### PR TITLE
iOS reload: auto sign-in + auto-pair the device by default

### DIFF
--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -603,7 +603,13 @@ reload_device() {
         echo "warning: installed but could not launch $BUNDLE_ID (device locked? unlock the iPhone and tap the app)" >&2
       fi
     elif ! auto_setup_launch device "$selected_device_install_id"; then
-      echo "warning: installed but signed launch failed (device locked? unlock the iPhone and tap the app)" >&2
+      # Auto sign-in/pair failed (e.g. missing dogfood creds, helper, or Mac).
+      # Fall back to a plain launch so the freshly installed app still opens,
+      # matching the simulator path and the previous device behavior.
+      echo "warning: signed launch failed; launching plain (sign in manually)" >&2
+      if ! xcrun devicectl device process launch --terminate-existing --device "$selected_device_install_id" "$BUNDLE_ID" >/dev/null 2>&1; then
+        echo "warning: installed but could not launch $BUNDLE_ID (device locked? unlock the iPhone and tap the app)" >&2
+      fi
     fi
   fi
 

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -156,6 +156,12 @@ IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # sanitize_tag call below.
 # shellcheck source=../../scripts/lib/mobile-attach.sh
 source "$IOS_DIR/../scripts/lib/mobile-attach.sh"
+# Fail closed on tags with no alphanumerics (their slug collapses onto the shared
+# fallback identity), matching the macOS reload's reject-empty behavior.
+if ! cmux_attach_tag_has_alnum "$TAG"; then
+  echo "error: --tag '$TAG' has no letters or digits; pick a tag with at least one alphanumeric character" >&2
+  exit 1
+fi
 WORKSPACE="$IOS_DIR/cmux.xcworkspace"
 SCHEME="cmux-ios"
 TAG_SLUG="$(sanitize_tag "$TAG")"

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -12,6 +12,12 @@ Build, install, and launch the cmux iOS app with an isolated tag.
 By default this reloads only the simulator. Use --device to also reload the
 first available paired iPhone/iPad, or --device-only to skip the simulator.
 
+After install, the app is launched signed in (dogfood creds) and auto-paired to
+the tagged Mac app. Opt out granularly:
+  --no-sign-in   plain launch, no auto sign-in (implies no auto-pair)
+  --no-attach    sign in, but do not auto-pair to the Mac
+  --no-setup     plain install + launch (today's behavior)
+
 Device signing uses the local Xcode account, or App Store Connect API
 credentials from ASC_API_KEY_ID, ASC_API_ISSUER_ID, ASC_API_KEY_PATH, or
 ios/Config/AppStoreConnect.local.plist. Set IOS_DEVELOPMENT_TEAM or pass
@@ -49,6 +55,11 @@ RELOAD_SIMULATOR=1
 RELOAD_DEVICE=0
 ALLOW_PROVISIONING_UPDATES=1
 ALLOW_DEVICE_REGISTRATION=0
+# Auto-setup: after install + launch, sign in (inject dogfood creds) and auto-pair
+# to the tagged Mac app. Default ON; opt out granularly.
+NO_SIGN_IN=0
+NO_ATTACH=0
+NO_SETUP=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -100,6 +111,18 @@ while [[ $# -gt 0 ]]; do
       LAUNCH=0
       shift
       ;;
+    --no-sign-in)
+      NO_SIGN_IN=1
+      shift
+      ;;
+    --no-attach)
+      NO_ATTACH=1
+      shift
+      ;;
+    --no-setup)
+      NO_SETUP=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -139,6 +162,32 @@ DISPLAY_NAME="cmux DEV $TAG"
 BUNDLE_ID="dev.cmux.ios.$TAG_SLUG"
 DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData/cmux-ios-$TAG_SLUG"
 DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME"
+MOBILE_DEV_LAUNCH="$IOS_DIR/../scripts/mobile-dev-launch.sh"
+
+# Auto-setup launch: relaunch the just-installed app signed in (dogfood creds
+# injected) and, unless --no-attach, auto-paired to the tagged Mac app. Delegates
+# to scripts/mobile-dev-launch.sh so there is ONE signed-launch path. Returns
+# non-zero on any failure so callers can warn + leave the app installed. $1 =
+# device|simulator, $2 = device install id (device only).
+auto_setup_launch() {
+  local kind="$1" dev_id="${2:-}"
+  local args=(--tag "$TAG")
+  if [[ "$kind" == "device" ]]; then
+    args+=(--device)
+    [[ -n "$dev_id" ]] && args+=(--device-id "$dev_id")
+  else
+    # --detach: do not attach the simulator console (would block this script).
+    args+=(--simulator "$SIMULATOR_NAME" --detach)
+  fi
+  # Auto-pair by default (--ensure-mac enables the pairing host + launches the
+  # tagged Mac app if down, then mints a ticket); --no-attach signs in only.
+  [[ "$NO_ATTACH" -eq 0 ]] && args+=(--ensure-mac)
+  if [[ ! -x "$MOBILE_DEV_LAUNCH" ]]; then
+    echo "warning: $MOBILE_DEV_LAUNCH not found/executable; cannot auto-sign-in" >&2
+    return 1
+  fi
+  "$MOBILE_DEV_LAUNCH" "${args[@]}"
+}
 
 # Dev-build identity baked into the app's Info.plist (CMUXGitSHA / CMUXDevTag),
 # surfaced in-app under Settings > About so a dogfood build is tellable. The
@@ -444,7 +493,12 @@ PY
 
   if [[ "$LAUNCH" -eq 1 ]]; then
     xcrun simctl terminate "$SIM_ID" "$BUNDLE_ID" >/dev/null 2>&1 || true
-    xcrun simctl launch "$SIM_ID" "$BUNDLE_ID" >/dev/null
+    if [[ "$NO_SETUP" -eq 1 || "$NO_SIGN_IN" -eq 1 ]]; then
+      xcrun simctl launch "$SIM_ID" "$BUNDLE_ID" >/dev/null
+    elif ! auto_setup_launch simulator; then
+      echo "warning: signed launch failed; launching plain (sign in manually)" >&2
+      xcrun simctl launch "$SIM_ID" "$BUNDLE_ID" >/dev/null
+    fi
   fi
 
   cat <<EOF
@@ -542,8 +596,14 @@ reload_device() {
     # Build + install already succeeded; a launch failure (most commonly a
     # LOCKED device — "could not be unlocked") must not fail the whole reload
     # or skip the QR marker update below. Warn and continue.
-    if ! xcrun devicectl device process launch --terminate-existing --device "$selected_device_install_id" "$BUNDLE_ID" >/dev/null 2>&1; then
-      echo "warning: installed but could not launch $BUNDLE_ID (device locked? unlock the iPhone and tap the app)" >&2
+    if [[ "$NO_SETUP" -eq 1 || "$NO_SIGN_IN" -eq 1 ]]; then
+      # Plain launch (no sign-in / no pair). --no-sign-in implies no auto-setup
+      # since attaching without a signed-in session is meaningless.
+      if ! xcrun devicectl device process launch --terminate-existing --device "$selected_device_install_id" "$BUNDLE_ID" >/dev/null 2>&1; then
+        echo "warning: installed but could not launch $BUNDLE_ID (device locked? unlock the iPhone and tap the app)" >&2
+      fi
+    elif ! auto_setup_launch device "$selected_device_install_id"; then
+      echo "warning: installed but signed launch failed (device locked? unlock the iPhone and tap the app)" >&2
     fi
   fi
 

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -170,14 +170,17 @@ MOBILE_DEV_LAUNCH="$IOS_DIR/../scripts/mobile-dev-launch.sh"
 # non-zero on any failure so callers can warn + leave the app installed. $1 =
 # device|simulator, $2 = device install id (device only).
 auto_setup_launch() {
-  local kind="$1" dev_id="${2:-}"
+  local kind="$1" id="${2:-}"
   local args=(--tag "$TAG")
   if [[ "$kind" == "device" ]]; then
     args+=(--device)
-    [[ -n "$dev_id" ]] && args+=(--device-id "$dev_id")
+    [[ -n "$id" ]] && args+=(--device-id "$id")
   else
     # --detach: do not attach the simulator console (would block this script).
+    # Pass the exact resolved UDID so the launch targets the sim we installed
+    # onto, not just the first booted sim sharing the name.
     args+=(--simulator "$SIMULATOR_NAME" --detach)
+    [[ -n "$id" ]] && args+=(--simulator-id "$id")
   fi
   # Auto-pair by default (--ensure-mac enables the pairing host + launches the
   # tagged Mac app if down, then mints a ticket); --no-attach signs in only.
@@ -495,7 +498,7 @@ PY
     xcrun simctl terminate "$SIM_ID" "$BUNDLE_ID" >/dev/null 2>&1 || true
     if [[ "$NO_SETUP" -eq 1 || "$NO_SIGN_IN" -eq 1 ]]; then
       xcrun simctl launch "$SIM_ID" "$BUNDLE_ID" >/dev/null
-    elif ! auto_setup_launch simulator; then
+    elif ! auto_setup_launch simulator "$SIM_ID"; then
       echo "warning: signed launch failed; launching plain (sign in manually)" >&2
       xcrun simctl launch "$SIM_ID" "$BUNDLE_ID" >/dev/null
     fi

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -25,15 +25,11 @@ ios/Config/AppStoreConnect.local.plist. Set IOS_DEVELOPMENT_TEAM or pass
 EOF
 }
 
-sanitize_tag() {
-  local raw="$1"
-  local cleaned
-  cleaned="$(echo "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
-  if [[ -z "$cleaned" ]]; then
-    cleaned="dev"
-  fi
-  echo "$cleaned"
-}
+# Tag -> slug. Delegates to the shared helper (scripts/lib/mobile-attach.sh,
+# sourced below) so the bundle id this builds/installs always matches the one
+# scripts/mobile-dev-launch.sh later signs in / pairs against, including for edge
+# tags that sanitize to empty. Do not reintroduce a local sanitizer here.
+sanitize_tag() { cmux_attach__slug "$1"; }
 
 require_option_value() {
   local option="$1"
@@ -155,6 +151,11 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Shared tag/identity + attach helpers; sanitize_tag() above delegates here so the
+# built bundle id matches the signed-launch bundle id. Sourced before any
+# sanitize_tag call below.
+# shellcheck source=../../scripts/lib/mobile-attach.sh
+source "$IOS_DIR/../scripts/lib/mobile-attach.sh"
 WORKSPACE="$IOS_DIR/cmux.xcworkspace"
 SCHEME="cmux-ios"
 TAG_SLUG="$(sanitize_tag "$TAG")"

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -87,6 +87,8 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROFILE_REPLAY="$SCRIPT_DIR/dev-profiles/replay-cli.mjs"
+# shellcheck source=scripts/lib/mobile-attach.sh
+source "$SCRIPT_DIR/lib/mobile-attach.sh"
 
 # --- profiles: validate up front (P3) ---------------------------------------
 # Fail fast on an unknown profile name BEFORE any heavy build/launch work, so a
@@ -116,14 +118,10 @@ if ! ( source "$SCRIPT_DIR/lib/dev-secrets.sh"; cmux_dev_secrets_load "${DEV_SEC
   exit 2
 fi
 
-# --- tag identity (must match reload.sh / cmux-debug-cli.sh exactly) ---------
-# slug -> socket path + DerivedData; tag-id -> bundle id.
-dev_setup__sanitize_path() {
-  local cleaned
-  cleaned="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
-  [[ -n "$cleaned" ]] || cleaned="agent"
-  printf '%s' "$cleaned"
-}
+# --- tag identity (delegated to scripts/lib/mobile-attach.sh) ----------------
+# slug -> socket path + DerivedData; tag-id -> bundle id. The shared lib owns the
+# exact derivation so it stays in sync with reload.sh / cmux-debug-cli.sh.
+dev_setup__sanitize_path() { cmux_attach__slug "$1"; }
 dev_setup__sanitize_bundle() {
   local cleaned
   cleaned="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/./g; s/^\.+//; s/\.+$//; s/\.+/./g')"
@@ -144,7 +142,7 @@ enable_pairing_host() {
   # the NWListener is bound. MobileHostService.start() reads this default at app
   # launch (applicationDidFinishLaunching), so it must be written BEFORE the
   # macOS launch below. The tagged bundle id is targeted, never the stable app.
-  defaults write "$BUNDLE_ID" mobile.iOSPairingHost.enabled -bool true
+  cmux_attach_enable_pairing_host "$TAG"
 }
 
 # --- macOS build + launch (P1 auto-sign-in) ---------------------------------
@@ -161,38 +159,7 @@ build_and_launch_mac() {
 # Echoes the URL on stdout. The URL is a bearer credential: callers must NOT
 # print it. Polls the mint RPC (real readiness signal) until routes are ready,
 # bounded so a never-binding listener fails instead of hanging.
-mint_attach_url() {
-  local payload _attempt
-  for _attempt in $(seq 1 20); do
-    if [[ ! -S "$SOCKET_PATH" ]]; then
-      sleep 0.5
-      continue
-    fi
-    # scope=mac mints a Mac-wide ticket; ttl bounded by the RPC (30..3600).
-    payload="$(CMUX_TAG="$TAG" "$REPO_ROOT/scripts/cmux-debug-cli.sh" rpc mobile.attach_ticket.create \
-      "{\"ttl_seconds\":${TTL_SECONDS},\"scope\":\"mac\"}" 2>/dev/null || true)"
-    if [[ -n "$payload" ]]; then
-      local url
-      url="$(REPO_ROOT="$REPO_ROOT" PAYLOAD="$payload" node --input-type=module <<'NODE' 2>/dev/null || true
-import path from "node:path";
-import { pathToFileURL } from "node:url";
-const { buildAttachURL } = await import(
-  pathToFileURL(path.join(process.env.REPO_ROOT, "scripts", "lib", "attach-url.mjs")).href
-);
-const { attachURL } = buildAttachURL(JSON.parse(process.env.PAYLOAD));
-process.stdout.write(attachURL);
-NODE
-)"
-      if [[ -n "$url" ]]; then
-        printf '%s' "$url"
-        return 0
-      fi
-    fi
-    # Listener not bound yet (routes unavailable) or app still starting; retry.
-    sleep 0.5
-  done
-  return 1
-}
+mint_attach_url() { cmux_attach_mint_url "$TAG" "$TTL_SECONDS" "$REPO_ROOT"; }
 
 # --- iOS build + launch (auto-pair via CMUX_DOGFOOD_ATTACH_URL) -------------
 build_and_launch_ios() {

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -182,6 +182,11 @@ build_and_launch_ios() {
 
   echo "==> launching iOS dev app${attach_url:+ (auto-pairing)}"
   local launch_args=(--tag "$TAG")
+  # Express attach intent so mobile-dev-launch.sh honors the pre-minted URL we
+  # pass via CMUX_DOGFOOD_ATTACH_URL (it ignores an ambient URL without --attach).
+  if [[ -n "$attach_url" ]]; then
+    launch_args+=(--attach)
+  fi
   if [[ "$AGENT" -eq 1 ]]; then
     launch_args+=(--agent)
   fi

--- a/scripts/lib/mobile-attach.sh
+++ b/scripts/lib/mobile-attach.sh
@@ -17,6 +17,15 @@ cmux_attach__slug() {
   printf '%s' "$cleaned"
 }
 
+# True iff the tag has at least one alphanumeric character, i.e. its slug is real
+# and not the empty-input fallback. Tag identity is correctness-critical (it
+# selects the bundle id / socket / Mac app), so entry points must reject tags
+# that would otherwise silently collapse onto the shared fallback identity and
+# target an unrelated app/socket. Callers should fail closed on a false result.
+cmux_attach_tag_has_alnum() {
+  [[ -n "$(printf '%s' "$1" | tr -cd '[:alnum:]')" ]]
+}
+
 # bundle id segment: lowercase, non-alnum -> '.', trimmed/collapsed.
 cmux_attach__bundle_seg() {
   local cleaned

--- a/scripts/lib/mobile-attach.sh
+++ b/scripts/lib/mobile-attach.sh
@@ -62,19 +62,40 @@ cmux_attach_mac_socket_ready() {
   [[ -S "$sock" ]]
 }
 
-# Best-effort: ensure the tagged Mac app is running so a ticket can be minted.
-# Enables the pairing host, then (if the socket is down and a local tagged build
-# exists) launches it and waits up to ~12s for the socket. Returns 0 if the
-# socket is ready, 1 otherwise (caller should degrade to signed-in-only). Never
-# fails the calling script.
+# Best-effort: ensure the tagged Mac app is running AND its iOS pairing listener
+# is actually bound, so a ticket can be minted. Enables the pairing host, then:
+#   - socket down  -> launch the local tagged build and wait for the socket.
+#   - socket up    -> the pairing default is only read at launch, so a live
+#                     socket does NOT prove the listener is bound. Probe by
+#                     minting; if it already works, done (no disruption). If not,
+#                     the running process predates the default — relaunch it so
+#                     the fresh process binds the listener.
+# Args: <tag> [<repo_root>] (repo_root enables the mint readiness probe). Returns
+# 0 if the Mac is ready to mint, 1 otherwise (caller degrades to signed-in-only).
+# Never fails the calling script.
 cmux_attach_ensure_mac() {
-  local tag="$1" sock app
+  local tag="$1" repo_root="${2:-}" sock app slug _i
   sock="$(cmux_attach_socket_path "$tag")"
-  cmux_attach_enable_pairing_host "$tag" || true
-  if [[ -S "$sock" ]]; then
-    return 0
-  fi
   app="$(cmux_attach_mac_app_path "$tag")"
+  slug="$(cmux_attach__slug "$tag")"
+  cmux_attach_enable_pairing_host "$tag" || true
+
+  if [[ -S "$sock" ]]; then
+    # Quick probe (2 attempts ~1s): if pairing already mints, leave the running
+    # app untouched.
+    if [[ -n "$repo_root" ]] && [[ -n "$(cmux_attach_mint_url "$tag" 60 "$repo_root" 2)" ]]; then
+      return 0
+    fi
+    if [[ ! -d "$app" ]]; then
+      echo "warning: tagged Mac app for '$tag' is running but its pairing listener is not ready, and there is no local build to relaunch; auto-pair unavailable (signing in only)." >&2
+      return 1
+    fi
+    echo "==> relaunching tagged Mac app to bind the pairing listener ($tag)" >&2
+    # Scoped to this tag's executable only (never the stable app or other tags).
+    pkill -f "cmux DEV ${slug}.app/Contents/MacOS/cmux DEV" 2>/dev/null || true
+    for _i in $(seq 1 25); do [[ -S "$sock" ]] || break; sleep 0.2; done
+  fi
+
   if [[ ! -d "$app" ]]; then
     echo "warning: tagged Mac app for '$tag' not found locally ($app); cannot auto-pair. Build it (scripts/reload-cloud.sh --tag $tag) then re-run, or pass --no-attach." >&2
     return 1
@@ -83,7 +104,6 @@ cmux_attach_ensure_mac() {
   # The tagged app derives its socket from its baked CMUXDevTag, so a plain launch
   # binds /tmp/cmux-debug-<slug>.sock without extra env.
   open -g "$app" >/dev/null 2>&1 || open "$app" >/dev/null 2>&1 || true
-  local _i
   for _i in $(seq 1 60); do
     [[ -S "$sock" ]] && return 0
     sleep 0.2
@@ -97,9 +117,9 @@ cmux_attach_ensure_mac() {
 # <repo_root>. Polls the mint RPC (the real readiness signal) until routes are
 # bound, bounded so a never-binding listener fails instead of hanging.
 cmux_attach_mint_url() {
-  local tag="$1" ttl="$2" repo_root="$3" sock payload url _i
+  local tag="$1" ttl="$2" repo_root="$3" max="${4:-20}" sock payload url _i
   sock="$(cmux_attach_socket_path "$tag")"
-  for _i in $(seq 1 20); do
+  for _i in $(seq 1 "$max"); do
     if [[ ! -S "$sock" ]]; then
       sleep 0.5
       continue

--- a/scripts/lib/mobile-attach.sh
+++ b/scripts/lib/mobile-attach.sh
@@ -117,14 +117,18 @@ cmux_attach_ensure_mac() {
 # <repo_root>. Polls the mint RPC (the real readiness signal) until routes are
 # bound, bounded so a never-binding listener fails instead of hanging.
 cmux_attach_mint_url() {
-  local tag="$1" ttl="$2" repo_root="$3" max="${4:-20}" sock payload url _i
+  local tag="$1" ttl="$2" repo_root="$3" max="${4:-20}" sock slug payload url _i
   sock="$(cmux_attach_socket_path "$tag")"
+  # cmux-debug-cli.sh rejects CMUX_TAG outside [A-Za-z0-9._-] and re-sanitizes it
+  # to the same slug used for the socket. Pass the slug so tags needing
+  # sanitization (e.g. "Fix Foo" -> "fix-foo") are not rejected before minting.
+  slug="$(cmux_attach__slug "$tag")"
   for _i in $(seq 1 "$max"); do
     if [[ ! -S "$sock" ]]; then
       sleep 0.5
       continue
     fi
-    payload="$(CMUX_TAG="$tag" "$repo_root/scripts/cmux-debug-cli.sh" rpc mobile.attach_ticket.create \
+    payload="$(CMUX_TAG="$slug" "$repo_root/scripts/cmux-debug-cli.sh" rpc mobile.attach_ticket.create \
       "{\"ttl_seconds\":${ttl},\"scope\":\"mac\"}" 2>/dev/null || true)"
     if [[ -n "$payload" ]]; then
       url="$(REPO_ROOT="$repo_root" PAYLOAD="$payload" node --input-type=module <<'NODE' 2>/dev/null || true

--- a/scripts/lib/mobile-attach.sh
+++ b/scripts/lib/mobile-attach.sh
@@ -8,22 +8,30 @@
 #
 # The attach URL is a bearer credential: callers must never print it.
 
-# slug: lowercase, non-alnum -> '-', trimmed/collapsed. Matches reload.sh +
-# cmux-debug-cli.sh socket/DerivedData naming.
+# Raw slug WITHOUT the empty-input fallback: lowercase, ASCII non-[a-z0-9] -> '-',
+# trimmed/collapsed. Empty when the tag has no ASCII alphanumerics. The ASCII
+# class is deliberate (matches reload.sh + cmux-debug-cli.sh socket/DerivedData
+# naming); a locale-sensitive class would keep non-ASCII letters the slug drops.
+cmux_attach__slug_raw() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+}
+
+# slug: raw slug, falling back to "agent" only for an otherwise-empty result.
 cmux_attach__slug() {
   local cleaned
-  cleaned="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+  cleaned="$(cmux_attach__slug_raw "$1")"
   [[ -n "$cleaned" ]] || cleaned="agent"
   printf '%s' "$cleaned"
 }
 
-# True iff the tag has at least one alphanumeric character, i.e. its slug is real
-# and not the empty-input fallback. Tag identity is correctness-critical (it
-# selects the bundle id / socket / Mac app), so entry points must reject tags
-# that would otherwise silently collapse onto the shared fallback identity and
-# target an unrelated app/socket. Callers should fail closed on a false result.
+# True iff the tag yields a real (non-empty) slug, i.e. it is not the empty-input
+# fallback. Uses the SAME ASCII transform as the slug (not locale-sensitive
+# [:alnum:], which would accept non-ASCII letters like "é" that the slug drops).
+# Tag identity is correctness-critical (it selects the bundle id / socket / Mac
+# app), so entry points must fail closed when this is false rather than let the
+# tag collapse onto the shared fallback identity and target an unrelated app.
 cmux_attach_tag_has_alnum() {
-  [[ -n "$(printf '%s' "$1" | tr -cd '[:alnum:]')" ]]
+  [[ -n "$(cmux_attach__slug_raw "$1")" ]]
 }
 
 # bundle id segment: lowercase, non-alnum -> '.', trimmed/collapsed.

--- a/scripts/lib/mobile-attach.sh
+++ b/scripts/lib/mobile-attach.sh
@@ -84,12 +84,14 @@ cmux_attach_mac_socket_ready() {
 #   - socket down  -> launch the local tagged build and wait for the socket.
 #   - socket up    -> the pairing default is only read at launch, so a live
 #                     socket does NOT prove the listener is bound. Probe by
-#                     minting; if it already works, done (no disruption). If not,
-#                     the running process predates the default — relaunch it so
-#                     the fresh process binds the listener.
+#                     minting; if it already works, done. If not, a tagged app is
+#                     already running — by default DO NOT disturb it (degrade to
+#                     signed-in-only with guidance to relaunch). Set
+#                     CMUX_ATTACH_ALLOW_RELAUNCH=1 to opt into auto-relaunching
+#                     the tagged app so it binds the listener.
 # Args: <tag> [<repo_root>] (repo_root enables the mint readiness probe). Returns
 # 0 if the Mac is ready to mint, 1 otherwise (caller degrades to signed-in-only).
-# Never fails the calling script.
+# Never fails the calling script and never force-kills a running app by default.
 cmux_attach_ensure_mac() {
   local tag="$1" repo_root="${2:-}" sock app slug _i
   sock="$(cmux_attach_socket_path "$tag")"
@@ -98,16 +100,22 @@ cmux_attach_ensure_mac() {
   cmux_attach_enable_pairing_host "$tag" || true
 
   if [[ -S "$sock" ]]; then
-    # Quick probe (2 attempts ~1s): if pairing already mints, leave the running
-    # app untouched.
+    # Quick probe (2 attempts ~1s): if pairing already mints, done.
     if [[ -n "$repo_root" ]] && [[ -n "$(cmux_attach_mint_url "$tag" 60 "$repo_root" 2)" ]]; then
       return 0
     fi
-    if [[ ! -d "$app" ]]; then
-      echo "warning: tagged Mac app for '$tag' is running but its pairing listener is not ready, and there is no local build to relaunch; auto-pair unavailable (signing in only)." >&2
+    # A tagged app is running but its pairing listener is not ready (launched
+    # before the default was set, prompt pending, or briefly busy). Protect the
+    # running instance: do NOT force-kill it unless explicitly opted in.
+    if [[ "${CMUX_ATTACH_ALLOW_RELAUNCH:-0}" != "1" ]]; then
+      echo "warning: tagged Mac app for '$tag' is running but its iOS pairing listener is not bound (it was likely launched before pairing was enabled, or the macOS Local Network prompt is pending). Relaunch it to enable auto-pair, or re-run with CMUX_ATTACH_ALLOW_RELAUNCH=1; signing in only for now." >&2
       return 1
     fi
-    echo "==> relaunching tagged Mac app to bind the pairing listener ($tag)" >&2
+    if [[ ! -d "$app" ]]; then
+      echo "warning: tagged Mac app for '$tag' is running but not ready, and there is no local build to relaunch; auto-pair unavailable (signing in only)." >&2
+      return 1
+    fi
+    echo "==> relaunching tagged Mac app to bind the pairing listener ($tag) [CMUX_ATTACH_ALLOW_RELAUNCH=1]" >&2
     # Scoped to this tag's executable only (never the stable app or other tags).
     pkill -f "cmux DEV ${slug}.app/Contents/MacOS/cmux DEV" 2>/dev/null || true
     for _i in $(seq 1 25); do [[ -S "$sock" ]] || break; sleep 0.2; done

--- a/scripts/lib/mobile-attach.sh
+++ b/scripts/lib/mobile-attach.sh
@@ -36,12 +36,14 @@ cmux_attach_socket_path() {
 }
 
 # The locally-built tagged macOS Debug .app bundle path (cloud/local reloads both
-# download/install here).
+# download/install here). Both the DerivedData dir AND the .app basename use the
+# sanitized slug, matching reload.sh (`APP_NAME="cmux DEV ${TAG_SLUG}"`); the raw
+# tag would miss for any tag whose slug differs (e.g. "Fix Foo" -> "fix-foo").
 cmux_attach_mac_app_path() {
-  local tag="$1" slug
-  slug="$(cmux_attach__slug "$tag")"
+  local slug
+  slug="$(cmux_attach__slug "$1")"
   printf '%s/Library/Developer/Xcode/DerivedData/cmux-%s/Build/Products/Debug/cmux DEV %s.app' \
-    "$HOME" "$slug" "$tag"
+    "$HOME" "$slug" "$slug"
 }
 
 # Enable the opt-in iOS pairing host on the tagged Mac bundle. Must be written

--- a/scripts/lib/mobile-attach.sh
+++ b/scripts/lib/mobile-attach.sh
@@ -1,0 +1,126 @@
+# shellcheck shell=bash
+# Shared helpers for the iOS dev auto-pair flow: tag -> identity, enabling the
+# tagged Mac app's iOS pairing host, and headlessly minting a short-TTL attach
+# URL against the tagged debug socket. Sourced by scripts/dev-setup.sh,
+# scripts/mobile-dev-launch.sh, and the reload scripts so the bundle-id / socket
+# derivation and the mint RPC live in exactly ONE place (they MUST match
+# reload.sh / cmux-debug-cli.sh exactly).
+#
+# The attach URL is a bearer credential: callers must never print it.
+
+# slug: lowercase, non-alnum -> '-', trimmed/collapsed. Matches reload.sh +
+# cmux-debug-cli.sh socket/DerivedData naming.
+cmux_attach__slug() {
+  local cleaned
+  cleaned="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+  [[ -n "$cleaned" ]] || cleaned="agent"
+  printf '%s' "$cleaned"
+}
+
+# bundle id segment: lowercase, non-alnum -> '.', trimmed/collapsed.
+cmux_attach__bundle_seg() {
+  local cleaned
+  cleaned="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/./g; s/^\.+//; s/\.+$//; s/\.+/./g')"
+  [[ -n "$cleaned" ]] || cleaned="agent"
+  printf '%s' "$cleaned"
+}
+
+# The tagged macOS Debug app's bundle id (the iOS pairing host lives on the Mac).
+cmux_attach_mac_bundle_id() {
+  printf 'com.cmuxterm.app.debug.%s' "$(cmux_attach__bundle_seg "$1")"
+}
+
+# The tagged Mac app's debug socket path.
+cmux_attach_socket_path() {
+  printf '/tmp/cmux-debug-%s.sock' "$(cmux_attach__slug "$1")"
+}
+
+# The locally-built tagged macOS Debug .app bundle path (cloud/local reloads both
+# download/install here).
+cmux_attach_mac_app_path() {
+  local tag="$1" slug
+  slug="$(cmux_attach__slug "$tag")"
+  printf '%s/Library/Developer/Xcode/DerivedData/cmux-%s/Build/Products/Debug/cmux DEV %s.app' \
+    "$HOME" "$slug" "$tag"
+}
+
+# Enable the opt-in iOS pairing host on the tagged Mac bundle. Must be written
+# BEFORE the Mac app launches (read in applicationDidFinishLaunching). The first
+# bind per bundle id triggers a one-time macOS "Local Network" prompt.
+cmux_attach_enable_pairing_host() {
+  local tag="$1" bundle_id
+  bundle_id="$(cmux_attach_mac_bundle_id "$tag")"
+  defaults write "$bundle_id" mobile.iOSPairingHost.enabled -bool true
+}
+
+# True if the tagged Mac app's debug socket is bound (app running + listening).
+cmux_attach_mac_socket_ready() {
+  local sock
+  sock="$(cmux_attach_socket_path "$1")"
+  [[ -S "$sock" ]]
+}
+
+# Best-effort: ensure the tagged Mac app is running so a ticket can be minted.
+# Enables the pairing host, then (if the socket is down and a local tagged build
+# exists) launches it and waits up to ~12s for the socket. Returns 0 if the
+# socket is ready, 1 otherwise (caller should degrade to signed-in-only). Never
+# fails the calling script.
+cmux_attach_ensure_mac() {
+  local tag="$1" sock app
+  sock="$(cmux_attach_socket_path "$tag")"
+  cmux_attach_enable_pairing_host "$tag" || true
+  if [[ -S "$sock" ]]; then
+    return 0
+  fi
+  app="$(cmux_attach_mac_app_path "$tag")"
+  if [[ ! -d "$app" ]]; then
+    echo "warning: tagged Mac app for '$tag' not found locally ($app); cannot auto-pair. Build it (scripts/reload-cloud.sh --tag $tag) then re-run, or pass --no-attach." >&2
+    return 1
+  fi
+  echo "==> launching tagged Mac app to arm pairing ($tag)" >&2
+  # The tagged app derives its socket from its baked CMUXDevTag, so a plain launch
+  # binds /tmp/cmux-debug-<slug>.sock without extra env.
+  open -g "$app" >/dev/null 2>&1 || open "$app" >/dev/null 2>&1 || true
+  local _i
+  for _i in $(seq 1 60); do
+    [[ -S "$sock" ]] && return 0
+    sleep 0.2
+  done
+  echo "warning: tagged Mac socket $sock did not appear after launch; auto-pair unavailable (signing in only)." >&2
+  return 1
+}
+
+# Mint a short-TTL Mac-scoped attach URL against the tagged socket. Echoes the
+# URL on stdout (bearer credential; do not log). Args: <tag> <ttl_seconds>
+# <repo_root>. Polls the mint RPC (the real readiness signal) until routes are
+# bound, bounded so a never-binding listener fails instead of hanging.
+cmux_attach_mint_url() {
+  local tag="$1" ttl="$2" repo_root="$3" sock payload url _i
+  sock="$(cmux_attach_socket_path "$tag")"
+  for _i in $(seq 1 20); do
+    if [[ ! -S "$sock" ]]; then
+      sleep 0.5
+      continue
+    fi
+    payload="$(CMUX_TAG="$tag" "$repo_root/scripts/cmux-debug-cli.sh" rpc mobile.attach_ticket.create \
+      "{\"ttl_seconds\":${ttl},\"scope\":\"mac\"}" 2>/dev/null || true)"
+    if [[ -n "$payload" ]]; then
+      url="$(REPO_ROOT="$repo_root" PAYLOAD="$payload" node --input-type=module <<'NODE' 2>/dev/null || true
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+const { buildAttachURL } = await import(
+  pathToFileURL(path.join(process.env.REPO_ROOT, "scripts", "lib", "attach-url.mjs")).href
+);
+const { attachURL } = buildAttachURL(JSON.parse(process.env.PAYLOAD));
+process.stdout.write(attachURL);
+NODE
+)"
+      if [[ -n "$url" ]]; then
+        printf '%s' "$url"
+        return 0
+      fi
+    fi
+    sleep 0.5
+  done
+  return 1
+}

--- a/scripts/mobile-dev-launch.sh
+++ b/scripts/mobile-dev-launch.sh
@@ -20,8 +20,12 @@
 #
 #   --attach   also pair to the running Mac. Uses CMUX_DOGFOOD_ATTACH_URL when it
 #              is already set (as dev-setup.sh passes it), else mints a fresh
-#              ticket from the mobile-attach QR server (default :17321). Requires
-#              that server + the tagged Mac app to be running.
+#              ticket: the mobile-attach QR server (default :17321) if up, else
+#              directly against the tagged Mac debug socket. Needs the tagged Mac
+#              app running with the pairing host enabled (see --ensure-mac).
+#   --ensure-mac  imply --attach and, before minting, enable the tagged Mac app's
+#              pairing host + launch it if its debug socket is down. Lets a device
+#              reload auto-pair with no separately-running Mac app or QR server.
 #   --agent    sign in with the shared agent account instead of the dogfood one.
 #   --detach   simulator only: launch without attaching stdio, so the app keeps
 #              running after this script exits.
@@ -33,9 +37,11 @@ TARGET="simulator"          # simulator | device
 SIMULATOR_NAME="iPhone 17"
 DEVICE_ID=""
 ATTACH=0
+ENSURE_MAC=0
 AGENT=0
 DETACH=0
 QR_PORT="${CMUX_QR_PORT:-17321}"
+ATTACH_TTL_SECONDS="${CMUX_ATTACH_TTL_SECONDS:-600}"
 
 usage() { sed -n '2,30p' "$0"; }
 
@@ -46,6 +52,10 @@ while [[ $# -gt 0 ]]; do
     --device) TARGET="device"; shift ;;
     --device-id) DEVICE_ID="${2:-}"; shift 2 ;;
     --attach) ATTACH=1; shift ;;
+    # --ensure-mac: before minting, enable the tagged Mac app's pairing host and
+    # launch it if its debug socket is down, so --attach can mint without a
+    # separately-running Mac app or QR server. Implies --attach.
+    --ensure-mac) ENSURE_MAC=1; ATTACH=1; shift ;;
     --agent) AGENT=1; shift ;;
     --detach) DETACH=1; shift ;;
     -h|--help) usage; exit 0 ;;
@@ -64,8 +74,11 @@ fi
 # Dogfood account wins over the agent account so iOS dev builds sign in as the
 # human dogfooder by default. Pass --agent for agent-driven flows.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=scripts/lib/dev-secrets.sh
 source "$SCRIPT_DIR/lib/dev-secrets.sh"
+# shellcheck source=scripts/lib/mobile-attach.sh
+source "$SCRIPT_DIR/lib/mobile-attach.sh"
 if [[ "$AGENT" -eq 1 ]]; then
   cmux_dev_secrets_load --agent || exit $?
 else
@@ -73,21 +86,36 @@ else
 fi
 
 # --- bundle id (matches ios/scripts/reload.sh sanitize_tag) ------------------
-slug="$(echo "$TAG" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
-[[ -n "$slug" ]] || slug="dev"
+slug="$(cmux_attach__slug "$TAG")"
 BUNDLE_ID="dev.cmux.ios.$slug"
 
 # --- attach ticket ----------------------------------------------------------
-# Prefer a pre-minted CMUX_DOGFOOD_ATTACH_URL (dev-setup.sh sets it directly,
-# so no QR server is needed). With --attach and no pre-set URL, mint a fresh one
-# from the mobile-attach QR server. Inject it as CMUX_DOGFOOD_ATTACH_URL, the
-# NOT-mock-gated env var the app reads with the real backend (CMUX_UITEST_MOCK_DATA=0).
+# Prefer a pre-minted CMUX_DOGFOOD_ATTACH_URL (dev-setup.sh sets it directly).
+# Otherwise, with --attach, mint one ourselves: first try the mobile-attach QR
+# server, then fall back to minting directly against the tagged Mac socket (no QR
+# server needed). With --ensure-mac we first enable the pairing host + launch the
+# tagged Mac app if its socket is down. The URL is injected as
+# CMUX_DOGFOOD_ATTACH_URL, the NOT-mock-gated var the app reads with the real
+# backend (CMUX_UITEST_MOCK_DATA=0).
 ATTACH_URL="${CMUX_DOGFOOD_ATTACH_URL:-}"
 if [[ -z "$ATTACH_URL" && "$ATTACH" -eq 1 ]]; then
+  if [[ "$ENSURE_MAC" -eq 1 ]]; then
+    cmux_attach_ensure_mac "$TAG" || true
+  fi
   ATTACH_URL="$(curl -fsS -m 8 "http://127.0.0.1:${QR_PORT}/ticket.json" 2>/dev/null \
     | python3 -c 'import sys,json; print(json.load(sys.stdin).get("attach_url",""))' 2>/dev/null || true)"
   if [[ -z "$ATTACH_URL" ]]; then
-    echo "warning: --attach requested but no ticket from :${QR_PORT} (is the QR server + tagged Mac app running?); launching signed-in only" >&2
+    # No QR server (or it had no ticket): mint straight from the tagged socket.
+    if cmux_attach_mac_socket_ready "$TAG"; then
+      ATTACH_URL="$(cmux_attach_mint_url "$TAG" "$ATTACH_TTL_SECONDS" "$REPO_ROOT" || true)"
+    fi
+  fi
+  if [[ -z "$ATTACH_URL" ]]; then
+    if [[ "$ENSURE_MAC" -eq 1 ]]; then
+      echo "warning: could not mint an attach ticket (the tagged Mac app's pairing listener may still be binding, or the macOS Local Network prompt is unanswered — click Allow, then re-run); launching signed-in only" >&2
+    else
+      echo "warning: --attach requested but no attach ticket could be minted (is the tagged Mac app for '$TAG' running with the pairing host enabled? try --ensure-mac); launching signed-in only" >&2
+    fi
   fi
 fi
 

--- a/scripts/mobile-dev-launch.sh
+++ b/scripts/mobile-dev-launch.sh
@@ -100,13 +100,20 @@ BUNDLE_ID="dev.cmux.ios.$slug"
 ATTACH_URL="${CMUX_DOGFOOD_ATTACH_URL:-}"
 if [[ -z "$ATTACH_URL" && "$ATTACH" -eq 1 ]]; then
   if [[ "$ENSURE_MAC" -eq 1 ]]; then
+    # We are pairing to THIS tag's Mac app: ensure it is up, then mint straight
+    # from its socket. Do NOT consult the QR server — its /ticket.json has no tag
+    # parameter and is served from whatever tag the QR server last set, so it
+    # could hand back a ticket for a DIFFERENT Mac and silently mispair.
     cmux_attach_ensure_mac "$TAG" || true
-  fi
-  ATTACH_URL="$(curl -fsS -m 8 "http://127.0.0.1:${QR_PORT}/ticket.json" 2>/dev/null \
-    | python3 -c 'import sys,json; print(json.load(sys.stdin).get("attach_url",""))' 2>/dev/null || true)"
-  if [[ -z "$ATTACH_URL" ]]; then
-    # No QR server (or it had no ticket): mint straight from the tagged socket.
     if cmux_attach_mac_socket_ready "$TAG"; then
+      ATTACH_URL="$(cmux_attach_mint_url "$TAG" "$ATTACH_TTL_SECONDS" "$REPO_ROOT" || true)"
+    fi
+  else
+    # Plain --attach (legacy dev flow): prefer a running QR server, else mint
+    # directly from the tagged socket when it is up.
+    ATTACH_URL="$(curl -fsS -m 8 "http://127.0.0.1:${QR_PORT}/ticket.json" 2>/dev/null \
+      | python3 -c 'import sys,json; print(json.load(sys.stdin).get("attach_url",""))' 2>/dev/null || true)"
+    if [[ -z "$ATTACH_URL" ]] && cmux_attach_mac_socket_ready "$TAG"; then
       ATTACH_URL="$(cmux_attach_mint_url "$TAG" "$ATTACH_TTL_SECONDS" "$REPO_ROOT" || true)"
     fi
   fi

--- a/scripts/mobile-dev-launch.sh
+++ b/scripts/mobile-dev-launch.sh
@@ -35,6 +35,7 @@ set -euo pipefail
 TAG=""
 TARGET="simulator"          # simulator | device
 SIMULATOR_NAME="iPhone 17"
+SIMULATOR_ID=""             # exact booted sim UDID (wins over name when set)
 DEVICE_ID=""
 ATTACH=0
 ENSURE_MAC=0
@@ -49,6 +50,9 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --tag) TAG="${2:-}"; shift 2 ;;
     --simulator) TARGET="simulator"; SIMULATOR_NAME="${2:-}"; shift 2 ;;
+    # Exact booted simulator UDID; wins over --simulator name so callers that
+    # already resolved/installed onto a specific sim launch on THAT one.
+    --simulator-id) TARGET="simulator"; SIMULATOR_ID="${2:-}"; shift 2 ;;
     --device) TARGET="device"; shift ;;
     --device-id) DEVICE_ID="${2:-}"; shift 2 ;;
     --attach) ATTACH=1; shift ;;
@@ -90,29 +94,32 @@ slug="$(cmux_attach__slug "$TAG")"
 BUNDLE_ID="dev.cmux.ios.$slug"
 
 # --- attach ticket ----------------------------------------------------------
-# Prefer a pre-minted CMUX_DOGFOOD_ATTACH_URL (dev-setup.sh sets it directly).
-# Otherwise, with --attach, mint one ourselves: first try the mobile-attach QR
-# server, then fall back to minting directly against the tagged Mac socket (no QR
-# server needed). With --ensure-mac we first enable the pairing host + launch the
-# tagged Mac app if its socket is down. The URL is injected as
-# CMUX_DOGFOOD_ATTACH_URL, the NOT-mock-gated var the app reads with the real
+# ATTACH_URL stays empty unless attach was explicitly requested, so a stale
+# ambient CMUX_DOGFOOD_ATTACH_URL can NEVER auto-pair an unrequested launch
+# (e.g. --no-attach from the reload scripts leaves ATTACH=0). The URL is injected
+# as CMUX_DOGFOOD_ATTACH_URL, the NOT-mock-gated var the app reads with the real
 # backend (CMUX_UITEST_MOCK_DATA=0).
-ATTACH_URL="${CMUX_DOGFOOD_ATTACH_URL:-}"
-if [[ -z "$ATTACH_URL" && "$ATTACH" -eq 1 ]]; then
+ATTACH_URL=""
+if [[ "$ATTACH" -eq 1 ]]; then
   if [[ "$ENSURE_MAC" -eq 1 ]]; then
     # We are pairing to THIS tag's Mac app: ensure it is up, then mint straight
-    # from its socket. Do NOT consult the QR server — its /ticket.json has no tag
-    # parameter and is served from whatever tag the QR server last set, so it
-    # could hand back a ticket for a DIFFERENT Mac and silently mispair.
+    # from its socket. Ignore any ambient CMUX_DOGFOOD_ATTACH_URL (it may be a
+    # stale ticket for another tag) and do NOT consult the QR server (its
+    # /ticket.json has no tag parameter and could hand back a different Mac's
+    # ticket and silently mispair).
     cmux_attach_ensure_mac "$TAG" "$REPO_ROOT" || true
     if cmux_attach_mac_socket_ready "$TAG"; then
       ATTACH_URL="$(cmux_attach_mint_url "$TAG" "$ATTACH_TTL_SECONDS" "$REPO_ROOT" || true)"
     fi
   else
-    # Plain --attach (legacy dev flow): prefer a running QR server, else mint
-    # directly from the tagged socket when it is up.
-    ATTACH_URL="$(curl -fsS -m 8 "http://127.0.0.1:${QR_PORT}/ticket.json" 2>/dev/null \
-      | python3 -c 'import sys,json; print(json.load(sys.stdin).get("attach_url",""))' 2>/dev/null || true)"
+    # Plain --attach: honor a pre-minted URL the caller deliberately passed
+    # (dev-setup.sh sets it + --attach), else prefer a running QR server, else
+    # mint directly from the tagged socket when it is up.
+    ATTACH_URL="${CMUX_DOGFOOD_ATTACH_URL:-}"
+    if [[ -z "$ATTACH_URL" ]]; then
+      ATTACH_URL="$(curl -fsS -m 8 "http://127.0.0.1:${QR_PORT}/ticket.json" 2>/dev/null \
+        | python3 -c 'import sys,json; print(json.load(sys.stdin).get("attach_url",""))' 2>/dev/null || true)"
+    fi
     if [[ -z "$ATTACH_URL" ]] && cmux_attach_mac_socket_ready "$TAG"; then
       ATTACH_URL="$(cmux_attach_mint_url "$TAG" "$ATTACH_TTL_SECONDS" "$REPO_ROOT" || true)"
     fi
@@ -130,9 +137,15 @@ fi
 echo "==> launching $BUNDLE_ID on $TARGET (signed in as $CMUX_UITEST_STACK_EMAIL${ATTACH_URL:+, auto-pairing})"
 
 if [[ "$TARGET" == "simulator" ]]; then
-  SIM_UDID="$(xcrun simctl list devices booted 2>/dev/null | grep -F "$SIMULATOR_NAME" | grep -oE '[0-9A-F-]{36}' | head -1)"
+  if [[ -n "$SIMULATOR_ID" ]]; then
+    # Exact UDID the caller installed onto; do not re-resolve by name (multiple
+    # booted sims can share a name across runtimes).
+    SIM_UDID="$SIMULATOR_ID"
+  else
+    SIM_UDID="$(xcrun simctl list devices booted 2>/dev/null | grep -F "$SIMULATOR_NAME" | grep -oE '[0-9A-F-]{36}' | head -1)"
+  fi
   if [[ -z "$SIM_UDID" ]]; then
-    echo "error: simulator '$SIMULATOR_NAME' is not booted (boot it or pass --simulator <name>)" >&2
+    echo "error: simulator '${SIMULATOR_ID:-$SIMULATOR_NAME}' is not booted (boot it or pass --simulator <name>)" >&2
     exit 1
   fi
   xcrun simctl terminate "$SIM_UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true

--- a/scripts/mobile-dev-launch.sh
+++ b/scripts/mobile-dev-launch.sh
@@ -20,12 +20,13 @@
 #
 #   --attach   also pair to the running Mac. Uses CMUX_DOGFOOD_ATTACH_URL when it
 #              is already set (as dev-setup.sh passes it), else mints a fresh
-#              ticket: the mobile-attach QR server (default :17321) if up, else
-#              directly against the tagged Mac debug socket. Needs the tagged Mac
-#              app running with the pairing host enabled (see --ensure-mac).
+#              tag-scoped ticket directly against THIS tag's Mac debug socket
+#              (never an untagged QR-server ticket, which could pair the wrong
+#              Mac). Needs the tagged Mac app running with the pairing host
+#              enabled (see --ensure-mac).
 #   --ensure-mac  imply --attach and, before minting, enable the tagged Mac app's
 #              pairing host + launch it if its debug socket is down. Lets a device
-#              reload auto-pair with no separately-running Mac app or QR server.
+#              reload auto-pair with no separately-running Mac app.
 #   --agent    sign in with the shared agent account instead of the dogfood one.
 #   --detach   simulator only: launch without attaching stdio, so the app keeps
 #              running after this script exits.
@@ -41,7 +42,6 @@ ATTACH=0
 ENSURE_MAC=0
 AGENT=0
 DETACH=0
-QR_PORT="${CMUX_QR_PORT:-17321}"
 ATTACH_TTL_SECONDS="${CMUX_ATTACH_TTL_SECONDS:-600}"
 
 usage() { sed -n '2,30p' "$0"; }
@@ -58,7 +58,7 @@ while [[ $# -gt 0 ]]; do
     --attach) ATTACH=1; shift ;;
     # --ensure-mac: before minting, enable the tagged Mac app's pairing host and
     # launch it if its debug socket is down, so --attach can mint without a
-    # separately-running Mac app or QR server. Implies --attach.
+    # separately-running Mac app. Implies --attach.
     --ensure-mac) ENSURE_MAC=1; ATTACH=1; shift ;;
     --agent) AGENT=1; shift ;;
     --detach) DETACH=1; shift ;;
@@ -107,26 +107,21 @@ BUNDLE_ID="dev.cmux.ios.$slug"
 # backend (CMUX_UITEST_MOCK_DATA=0).
 ATTACH_URL=""
 if [[ "$ATTACH" -eq 1 ]]; then
-  if [[ "$ENSURE_MAC" -eq 1 ]]; then
-    # We are pairing to THIS tag's Mac app: ensure it is up, then mint straight
-    # from its socket. Ignore any ambient CMUX_DOGFOOD_ATTACH_URL (it may be a
-    # stale ticket for another tag) and do NOT consult the QR server (its
-    # /ticket.json has no tag parameter and could hand back a different Mac's
-    # ticket and silently mispair).
-    cmux_attach_ensure_mac "$TAG" "$REPO_ROOT" || true
-    if cmux_attach_mac_socket_ready "$TAG"; then
-      ATTACH_URL="$(cmux_attach_mint_url "$TAG" "$ATTACH_TTL_SECONDS" "$REPO_ROOT" || true)"
-    fi
-  else
-    # Plain --attach: honor a pre-minted URL the caller deliberately passed
-    # (dev-setup.sh sets it + --attach), else prefer a running QR server, else
-    # mint directly from the tagged socket when it is up.
+  # An attach URL the caller deliberately pre-minted (dev-setup.sh sets it +
+  # --attach) wins. Ignore it under --ensure-mac, which is an explicit "(re)pair
+  # to THIS tag's Mac" intent that must always mint fresh for this tag.
+  if [[ "$ENSURE_MAC" -eq 0 ]]; then
     ATTACH_URL="${CMUX_DOGFOOD_ATTACH_URL:-}"
-    if [[ -z "$ATTACH_URL" ]]; then
-      ATTACH_URL="$(curl -fsS -m 8 "http://127.0.0.1:${QR_PORT}/ticket.json" 2>/dev/null \
-        | python3 -c 'import sys,json; print(json.load(sys.stdin).get("attach_url",""))' 2>/dev/null || true)"
+  fi
+  if [[ -z "$ATTACH_URL" ]]; then
+    if [[ "$ENSURE_MAC" -eq 1 ]]; then
+      cmux_attach_ensure_mac "$TAG" "$REPO_ROOT" || true
     fi
-    if [[ -z "$ATTACH_URL" ]] && cmux_attach_mac_socket_ready "$TAG"; then
+    # Always mint tag-scoped from THIS tag's socket. Never consult the
+    # tag-agnostic QR server: its /ticket.json has no tag parameter and is served
+    # from whatever tag the QR server last set, so it could hand back a different
+    # Mac's ticket and silently pair the phone to the wrong app.
+    if cmux_attach_mac_socket_ready "$TAG"; then
       ATTACH_URL="$(cmux_attach_mint_url "$TAG" "$ATTACH_TTL_SECONDS" "$REPO_ROOT" || true)"
     fi
   fi

--- a/scripts/mobile-dev-launch.sh
+++ b/scripts/mobile-dev-launch.sh
@@ -83,6 +83,12 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/lib/dev-secrets.sh"
 # shellcheck source=scripts/lib/mobile-attach.sh
 source "$SCRIPT_DIR/lib/mobile-attach.sh"
+# Fail closed on tags that have no alphanumerics: their slug would collapse onto
+# the shared fallback identity and target an unrelated app/socket.
+if ! cmux_attach_tag_has_alnum "$TAG"; then
+  echo "error: --tag '$TAG' has no letters or digits; pick a tag with at least one alphanumeric character" >&2
+  exit 2
+fi
 if [[ "$AGENT" -eq 1 ]]; then
   cmux_dev_secrets_load --agent || exit $?
 else

--- a/scripts/mobile-dev-launch.sh
+++ b/scripts/mobile-dev-launch.sh
@@ -104,7 +104,7 @@ if [[ -z "$ATTACH_URL" && "$ATTACH" -eq 1 ]]; then
     # from its socket. Do NOT consult the QR server — its /ticket.json has no tag
     # parameter and is served from whatever tag the QR server last set, so it
     # could hand back a ticket for a DIFFERENT Mac and silently mispair.
-    cmux_attach_ensure_mac "$TAG" || true
+    cmux_attach_ensure_mac "$TAG" "$REPO_ROOT" || true
     if cmux_attach_mac_socket_ready "$TAG"; then
       ATTACH_URL="$(cmux_attach_mint_url "$TAG" "$ATTACH_TTL_SECONDS" "$REPO_ROOT" || true)"
     fi


### PR DESCRIPTION
## Summary
- A cloud/local iOS **device** reload installed the app but launched it with a plain `devicectl` launch, so the app came up on the **login screen** and unpaired. Sign-in only happens when the DEBUG build is launched with dogfood creds injected as `DEVICECTL_CHILD_*` env vars, which the reload path never did.
- Reloads now leave the phone **dogfood-ready by default**: launched signed in (dogfood creds) and auto-paired to the tagged Mac app.

## What changed
- **New `scripts/lib/mobile-attach.sh`** centralizes tag→identity (slug / bundle id / socket), enabling the tagged Mac app's iOS pairing host, ensuring it is running, and minting a short-TTL attach URL directly from its debug socket (no QR server). `scripts/dev-setup.sh` now delegates to it instead of duplicating the mint / pairing-host / sanitizer logic (these must stay byte-for-byte in sync with `reload.sh`).
- **`scripts/mobile-dev-launch.sh`**: `--attach` mints from the Mac socket when there is no pre-set `CMUX_DOGFOOD_ATTACH_URL` / QR server; new `--ensure-mac` enables the pairing host and launches the tagged Mac app if its socket is down.
- **`ios/scripts/reload.sh`**: after install, launches via `mobile-dev-launch.sh` (signed in + auto-paired) by default. Granular opt-out: `--no-sign-in` (plain launch), `--no-attach` (sign in only), `--no-setup` (previous install + plain launch). A launch failure warns and leaves the app installed; it never fails the build.

The companion change in the `cmuxterm-hq` control-center `scripts/reload-cloud-ios.sh` wires the same flags + post-install signed launch into the cloud builder path (not in this repo).

## Testing
- `bash -n` on all changed scripts.
- Unit-checked `scripts/lib/mobile-attach.sh` derivations (slug / mac bundle id / socket path / app path).
- End-to-end on a physical iPhone: `mobile-dev-launch.sh --tag <t> --device --ensure-mac` enabled the pairing host, launched the tagged Mac app, and minted a real attach ticket (routes present) from the socket; the signed-launch path injects creds for auto sign-in. Verified graceful degradation to signed-in-only when the Mac pairing listener isn't bound yet.

## Notes
- No user-facing app strings changed (shell only), so no localization impact.
- Full auto-pair requires the macOS "Local Network" permission to be allowed once per tagged bundle id (first listener bind); until then it degrades to signed-in-only with a clear message.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784784989&installation_id=133855650&pr_number=6661&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6661&signature=29a08b763663c6a92bd396b4c925ab60f03bf017dfacf14a84e424add41606f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shell-only dev tooling, but attach URLs are bearer credentials and auto-pair can launch or relaunch the tagged Mac app; wrong-tag pairing is mitigated by shared slug derivation and rejecting empty slugs.
> 
> **Overview**
> **iOS reload** no longer plain-launches after install; by default it runs **`mobile-dev-launch.sh`** so the app starts **signed in** (dogfood creds) and **auto-paired** to the tagged Mac (`--ensure-mac`). Opt out with **`--no-setup`**, **`--no-sign-in`**, or **`--no-attach`**; failures warn and fall back to a plain launch so install still succeeds.
> 
> Adds **`scripts/lib/mobile-attach.sh`** as the single place for tag→slug/bundle/socket, enabling the Mac pairing host, **`cmux_attach_ensure_mac`**, and minting attach URLs from the **tagged debug socket** (not the QR server). **`dev-setup.sh`** delegates mint/pairing-host logic to it; **`mobile-dev-launch.sh`** gains **`--ensure-mac`**, **`--simulator-id`**, requires **`--attach`** before honoring ambient **`CMUX_DOGFOOD_ATTACH_URL`**, and mints only from the correct tag’s socket. Tags with **no ASCII alphanumerics** are rejected so identities don’t collapse onto the shared fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f82ee3734a1b46fd6b1df76844bcaddd02fca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
iOS reloads now launch signed in and auto‑paired to the tagged Mac by default, with tag‑scoped attach (no QR server), exact simulator targeting, and hardened tag validation. Tags with no ASCII letters or digits are rejected to avoid wrong‑tag bundle IDs and pairing.

- **New Features**
  - `ios/scripts/reload.sh`: post‑install signed launch via `scripts/mobile-dev-launch.sh`; auto‑pair by default; opt out with `--no-sign-in`, `--no-attach`, or `--no-setup`; passes `--simulator-id` to launch the exact installed sim.
  - `scripts/mobile-dev-launch.sh` + `scripts/lib/mobile-attach.sh`: `--ensure-mac` enables the pairing host, starts the tagged Mac app if needed, and mints a short‑TTL ticket from THIS tag’s debug socket; `--attach` is required before honoring `CMUX_DOGFOOD_ATTACH_URL`; tag→slug/bundle/socket/app path and minting are centralized.

- **Bug Fixes**
  - Tag validation uses the exact ASCII slug transform and rejects empty‑slug tags to prevent identity collisions.
  - Safer attach: ambient attach URLs are ignored unless `--attach`; attach is tag‑scoped only (QR server removed); `--ensure-mac` won’t kill a running Mac app by default and can optionally relaunch with `CMUX_ATTACH_ALLOW_RELAUNCH=1`.
  - Launch resilience: if a signed launch fails, warn and fall back to a plain launch; exact simulator targeting via `--simulator-id`; `scripts/dev-setup.sh` now passes `--attach` when providing `CMUX_DOGFOOD_ATTACH_URL`.

<sup>Written for commit e0f82ee3734a1b46fd6b1df76844bcaddd02fca2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an iOS auto-setup flow after install + first launch, including default sign-in and automatic macOS pairing/attachment.
  * Added `--no-sign-in`, `--no-attach`, and `--no-setup` flags to opt out of parts of the setup.
  * Added `--ensure-mac` for mobile dev launch to ensure the macOS pairing host is ready before attaching.

* **Improvements**
  * Improved simulator/device launch behavior with graceful fallbacks when auto sign-in/pairing isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->