### PR TITLE
iOS: optimistic UI for closing a workspace

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -72,19 +72,83 @@ extension MobileShellComposite {
         )
     }
 
-    /// Close a workspace on the Mac.
+    /// Close a workspace on the Mac with an optimistic UI update.
     ///
-    /// Sends the mutation to the Mac, then re-syncs from the authoritative
-    /// workspace list. If the Mac rejects the close, for example because it is
-    /// the last workspace, the refresh restores the row state on iOS.
+    /// The row is removed from the local list immediately so the close feels
+    /// instant, then the mutation is sent and the authoritative list re-synced.
+    /// While the close is unconfirmed the id is filtered out of every applied
+    /// snapshot (see ``optimisticallyClosedWorkspaces``), so a stale list fetched
+    /// before the Mac processed the close cannot resurrect the row, and the real
+    /// confirmation cannot double-remove it. If the transport call fails (offline
+    /// or a rejected close, e.g. the last workspace) the row is restored before
+    /// the re-sync so iOS snaps back to the Mac's real state.
     /// - Parameter id: The workspace to close.
     public func closeWorkspace(id: MobileWorkspacePreview.ID) async {
-        await sendWorkspaceMutation(
-            method: "workspace.close",
-            params: workspaceMutationParams(id: id),
-            id: id,
-            actionName: "close"
-        )
+        let params = workspaceMutationParams(id: id)
+        let removed = applyOptimisticWorkspaceClose(id: id)
+        guard let client = remoteClient else {
+            // No transport to send to: undo the optimistic removal immediately so
+            // the row does not vanish without a backing request.
+            if removed { rollbackOptimisticWorkspaceClose(id: id) }
+            return
+        }
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: "workspace.close",
+                params: params
+            )
+            _ = try await client.sendRequest(request)
+        } catch {
+            if removed { rollbackOptimisticWorkspaceClose(id: id) }
+            guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
+            markMacConnectionUnavailableIfNeeded(after: error)
+            mobileShellLog.error("workspace mutation failed action=close id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        }
+        await refreshWorkspaces()
+    }
+
+    /// Remove a workspace from the local list immediately and record its snapshot
+    /// for rollback. Returns `true` when a row was actually removed (so the caller
+    /// only rolls back what it removed). Reselects a neighbor if the closed
+    /// workspace was selected, matching the Mac's "select an adjacent tab" behavior.
+    /// - Parameter id: The workspace to remove optimistically.
+    /// - Returns: Whether a workspace was present and removed.
+    @discardableResult
+    func applyOptimisticWorkspaceClose(id: MobileWorkspacePreview.ID) -> Bool {
+        guard let index = workspaces.firstIndex(where: { $0.id == id }) else {
+            return false
+        }
+        let snapshot = workspaces[index]
+        optimisticallyClosedWorkspaces[id] = snapshot
+        let wasSelected = selectedWorkspaceID == id
+        workspaces.remove(at: index)
+        if wasSelected {
+            // Prefer the workspace that slid into the closed row's position, then
+            // the previous neighbor, then any remaining workspace.
+            let next: MobileWorkspacePreview?
+            if index < workspaces.count {
+                next = workspaces[index]
+            } else if index - 1 >= 0, index - 1 < workspaces.count {
+                next = workspaces[index - 1]
+            } else {
+                next = workspaces.first
+            }
+            selectedWorkspaceID = next?.id
+        }
+        return true
+    }
+
+    /// Restore an optimistically-closed workspace after a failed close, and drop
+    /// its pending entry so future snapshots stop filtering the id. Inserts the
+    /// snapshot back at its original position when known, so the row reappears in
+    /// place; the next authoritative refresh then reconciles exact ordering.
+    /// - Parameter id: The workspace whose close failed.
+    func rollbackOptimisticWorkspaceClose(id: MobileWorkspacePreview.ID) {
+        guard let snapshot = optimisticallyClosedWorkspaces.removeValue(forKey: id) else {
+            return
+        }
+        guard !workspaces.contains(where: { $0.id == id }) else { return }
+        workspaces.append(snapshot)
     }
 
     private func sendWorkspaceMutation(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -202,6 +202,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Bumped on every ``workspaces`` mutation: a cheap "lists may have
     /// changed" signal (e.g. for retrying a parked notification deep link).
     public private(set) var workspaceTopologyVersion: UInt64 = 0
+    /// Workspaces removed optimistically on close, keyed by id, with the snapshot
+    /// captured at removal so a rejected close can roll back the row.
+    ///
+    /// An id stays here only while its close is unconfirmed: every applied remote
+    /// list filters these ids out (so a stale snapshot fetched before the Mac
+    /// processed the close can never re-add the row), and the id is dropped the
+    /// moment an authoritative list confirms the workspace is gone or the close
+    /// fails (then the snapshot is restored). See
+    /// ``MobileShellComposite/applyOptimisticWorkspaceClose(id:)`` and
+    /// ``MobileShellComposite/reconcileOptimisticClosures(against:)``.
+    var optimisticallyClosedWorkspaces: [MobileWorkspacePreview.ID: MobileWorkspacePreview] = [:]
     /// The Mac's workspace groups, in section order. Empty when the Mac reports no
     /// groups (or is old enough not to emit them). Drives the collapsible group
     /// sections in the workspace list.
@@ -5285,11 +5296,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         syncSelectedTerminalForWorkspace()
     }
 
-    private func remoteWorkspacesPreservingSnapshots(
+    func remoteWorkspacesPreservingSnapshots(
         from response: MobileSyncWorkspaceListResponse
     ) -> [MobileWorkspacePreview] {
-        response.workspaces.map { remoteWorkspace in
+        // Reconcile pending optimistic closes against this authoritative list
+        // first: any id the Mac no longer reports is genuinely closed, so its
+        // pending entry is retired (it no longer needs to be filtered). Ids the
+        // Mac still reports stay pending and get filtered below, so a snapshot
+        // fetched before the Mac processed the close cannot resurrect the row.
+        reconcileOptimisticClosures(against: response)
+        return response.workspaces.compactMap { remoteWorkspace in
             var workspace = MobileWorkspacePreview(remote: remoteWorkspace)
+            guard optimisticallyClosedWorkspaces[workspace.id] == nil else {
+                return nil
+            }
             guard let existingWorkspace = workspaces.first(where: { $0.id == workspace.id }) else {
                 return workspace
             }
@@ -5302,6 +5322,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 return terminal
             }
             return workspace
+        }
+    }
+
+    /// Retire pending optimistic closes that the Mac's authoritative list confirms
+    /// are gone, so a real server confirmation never stays filtered. Ids still
+    /// present in the response remain pending (the close has not landed yet) and
+    /// keep being filtered out of the applied list.
+    func reconcileOptimisticClosures(against response: MobileSyncWorkspaceListResponse) {
+        guard !optimisticallyClosedWorkspaces.isEmpty else { return }
+        let remoteIDs = Set(response.workspaces.map { MobileWorkspacePreview.ID(rawValue: $0.id) })
+        for id in optimisticallyClosedWorkspaces.keys where !remoteIDs.contains(id) {
+            optimisticallyClosedWorkspaces.removeValue(forKey: id)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/OptimisticWorkspaceCloseTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/OptimisticWorkspaceCloseTests.swift
@@ -1,0 +1,104 @@
+import CmuxMobileRPC
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for the optimistic close path on ``MobileShellComposite``.
+///
+/// These exercise the in-memory state machine that makes a workspace close feel
+/// instant: the row leaves the list immediately, a rejected close restores it,
+/// and the reconciliation against an authoritative list keeps a stale snapshot
+/// from resurrecting an in-flight close while still retiring a confirmed one.
+@MainActor
+@Suite struct OptimisticWorkspaceCloseTests {
+    /// The optimistic removal drops the row from the local list right away and
+    /// records its snapshot so a later rollback has something to restore.
+    @Test func optimisticCloseRemovesRowImmediately() {
+        let store = MobileShellComposite.preview()
+
+        let removed = store.applyOptimisticWorkspaceClose(id: "workspace-docs")
+
+        #expect(removed)
+        #expect(store.workspaces.map(\.id.rawValue) == ["workspace-main"])
+        #expect(store.optimisticallyClosedWorkspaces.keys.contains("workspace-docs"))
+    }
+
+    /// Closing the selected workspace reselects a remaining one so the detail view
+    /// never points at a vanished id.
+    @Test func optimisticCloseOfSelectedReselectsNeighbor() {
+        let store = MobileShellComposite.preview()
+        store.selectedWorkspaceID = "workspace-main"
+
+        store.applyOptimisticWorkspaceClose(id: "workspace-main")
+
+        #expect(store.selectedWorkspaceID == "workspace-docs")
+    }
+
+    /// Closing a workspace that is not present is a no-op and records nothing.
+    @Test func optimisticCloseOfMissingWorkspaceIsNoop() {
+        let store = MobileShellComposite.preview()
+
+        let removed = store.applyOptimisticWorkspaceClose(id: "workspace-missing")
+
+        #expect(!removed)
+        #expect(store.workspaces.count == 2)
+        #expect(store.optimisticallyClosedWorkspaces.isEmpty)
+    }
+
+    /// A failed close restores the removed row and clears the pending entry, so
+    /// the next authoritative refresh treats the workspace as live again.
+    @Test func rollbackRestoresRemovedRow() {
+        let store = MobileShellComposite.preview()
+        store.applyOptimisticWorkspaceClose(id: "workspace-docs")
+
+        store.rollbackOptimisticWorkspaceClose(id: "workspace-docs")
+
+        #expect(store.workspaces.contains { $0.id == "workspace-docs" })
+        #expect(store.optimisticallyClosedWorkspaces.isEmpty)
+    }
+
+    /// While a close is unconfirmed, a stale authoritative snapshot that still
+    /// lists the workspace must not resurrect the row.
+    @Test func staleSnapshotDoesNotResurrectPendingClose() throws {
+        let store = MobileShellComposite.preview()
+        store.applyOptimisticWorkspaceClose(id: "workspace-docs")
+
+        // Mac has not yet processed the close, so its list still includes the row.
+        let response = try makeListResponse(ids: ["workspace-main", "workspace-docs"])
+        let reconciled = store.remoteWorkspacesPreservingSnapshots(from: response)
+
+        #expect(reconciled.map(\.id.rawValue) == ["workspace-main"])
+        // Still pending: the close has not been confirmed by the Mac.
+        #expect(store.optimisticallyClosedWorkspaces.keys.contains("workspace-docs"))
+    }
+
+    /// An authoritative snapshot that omits the workspace confirms the close, so
+    /// the pending entry is retired and the id no longer needs filtering.
+    @Test func confirmingSnapshotRetiresPendingClose() throws {
+        let store = MobileShellComposite.preview()
+        store.applyOptimisticWorkspaceClose(id: "workspace-docs")
+
+        let response = try makeListResponse(ids: ["workspace-main"])
+        let reconciled = store.remoteWorkspacesPreservingSnapshots(from: response)
+
+        #expect(reconciled.map(\.id.rawValue) == ["workspace-main"])
+        #expect(store.optimisticallyClosedWorkspaces.isEmpty)
+    }
+
+    private func makeListResponse(ids: [String]) throws -> MobileSyncWorkspaceListResponse {
+        let workspaceObjects = ids.enumerated().map { index, id -> [String: Any] in
+            [
+                "id": id,
+                "title": id,
+                "is_selected": index == 0,
+                "terminals": [
+                    ["id": "\(id)-terminal", "title": "Term", "is_focused": true],
+                ],
+            ]
+        }
+        let payload: [String: Any] = ["workspaces": workspaceObjects]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        return try MobileSyncWorkspaceListResponse.decode(data)
+    }
+}


### PR DESCRIPTION
## Summary

Closing a workspace in the iOS app waited on the backend round-trip before the row left the list, so it felt laggy. Now the row is removed from the local list immediately on close, the close RPC fires, and the list reconciles against the Mac's authoritative state.

The mechanism: `closeWorkspace(id:)` records the row's snapshot, removes it from `workspaces` right away (reselecting a neighbor if it was selected), then sends `workspace.close`. While the close is unconfirmed the id is held in `optimisticallyClosedWorkspaces` and filtered out of every applied workspace-list snapshot, so a list fetched before the Mac processed the close cannot resurrect the row, and the real confirmation cannot double-remove it. When an authoritative list omits the id, the close is confirmed and the pending entry is retired. If the transport call fails (offline, or a rejected close such as the last workspace) the row is restored before the re-sync, so iOS snaps back to the Mac's real state.

This keeps a single mutation path with pending-state tracking, authoritative reconciliation, and explicit rollback, per the repo's optimistic-update policy. Rename/pin/unread keep their existing wait-then-resync behavior.

## Testing

`swift test` in `Packages/iOS/CmuxMobileShell` (193 tests pass), including a new `OptimisticWorkspaceCloseTests` suite covering: immediate removal, neighbor reselection of the selected workspace, no-op on a missing id, rollback restoring the row, a stale snapshot not resurrecting an in-flight close, and a confirming snapshot retiring the pending entry. `swift build` clean.

Not run: tagged Xcode build/reload and `xcodebuild test` (out of scope for this change; per repo policy not run locally).

## Issues

None. Plain-text feature task, no GitHub issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784787401&installation_id=133855650&pr_number=6663&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6663&signature=b7fbaaa498178996cdc6b881a3c6dba07049775247d8c70d32b0e8ea4a4da244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace list sync and selection during an in-flight close; logic is localized and covered by tests, but race/stale-snapshot behavior is worth a quick UI pass.
> 
> **Overview**
> **Workspace close** no longer waits on the Mac round-trip before the list updates: `closeWorkspace` removes the row immediately, sends `workspace.close`, then refreshes. Pending closes live in `optimisticallyClosedWorkspaces`; `remoteWorkspacesPreservingSnapshots` filters those ids so stale lists cannot bring the row back, and `reconcileOptimisticClosures` drops entries once the Mac omits the workspace. Failed or offline closes roll back via `rollbackOptimisticWorkspaceClose` (including when there is no `remoteClient`); closing the selected tab reselects a neighbor like the Mac.
> 
> Adds **`OptimisticWorkspaceCloseTests`** for removal, reselection, rollback, stale vs confirming snapshots. Rename/pin/unread still use wait-then-resync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit defd8a37431b5611987fa2ff189fb84444983c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make closing a workspace on iOS feel instant with an optimistic UI. The row disappears immediately, `workspace.close` is sent, the list reconciles with the Mac, and failures restore the row.

- **New Features**
  - Track pending closes in `optimisticallyClosedWorkspaces` and filter these ids from applied lists.
  - Confirm and retire pending closes via `reconcileOptimisticClosures(against:)` when the Mac omits the id.
  - Roll back on transport/server failure by restoring the saved snapshot before re-sync.
  - Reselect a neighbor when the closed workspace was selected.

<sup>Written for commit defd8a37431b5611987fa2ff189fb84444983c78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

