### PR TITLE
ios: make workspace folder collapse device-local

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -20,7 +20,7 @@
 6084	Sources/TextBoxInput.swift
 5915	cmuxTests/TerminalAndGhosttyTests.swift
 5573	cmuxTests/BrowserConfigTests.swift
-5507	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+5534	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 4487	Sources/Panels/FilePreviewPanel.swift
 4478	Sources/cmuxApp.swift
 4401	cmuxTests/BrowserPanelTests.swift
@@ -92,8 +92,8 @@
 947	Sources/TerminalNotificationPolicy.swift
 945	Sources/SessionIndexRegisteredAgents.swift
 937	Sources/TextBoxMentionIndexStore.swift
-935	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
 934	Sources/App/ShortcutRoutingSupport.swift
+935	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
 926	Sources/DockPanelView.swift
 920	Sources/CommandPalette/CommandPaletteSettingsToggle.swift
 918	cmuxTests/WorkspaceGroupTests.swift

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -119,29 +119,22 @@ extension MobileShellComposite {
         return params
     }
 
-    /// Collapse or expand a workspace group on the Mac.
+    /// Collapse or expand a workspace group on THIS device only.
     ///
-    /// Fire-and-forget against the authoritative state, mirroring pin/rename: the
-    /// Mac toggles the group's `isCollapsed` and its workspace-list observer
-    /// (which watches `$workspaceGroups`) pushes `workspace.updated`, which
-    /// refreshes this list with the new collapse state. No local optimistic
-    /// mutation, so overlapping collapse/expand taps can never leave stale state.
+    /// Folder collapse is a per-device UI preference, not shared state: collapsing
+    /// a group on the phone must not collapse it on the Mac. So this records the
+    /// choice in the device-local `groupCollapseStore` and updates the in-memory
+    /// `workspaceGroups` for an immediate, authoritative render. Nothing is sent to
+    /// the Mac, and a later Mac `workspace.updated` will not override it (the
+    /// workspace-list ingest re-applies this store). The `async` signature is kept
+    /// for call-site compatibility; the work is synchronous on the main actor.
     /// - Parameters:
     ///   - id: The group to collapse or expand.
     ///   - collapsed: `true` to collapse (hide members), `false` to expand.
     public func setWorkspaceGroupCollapsed(id: MobileWorkspaceGroupPreview.ID, _ collapsed: Bool) async {
-        guard let client = remoteClient else { return }
-        do {
-            let request = try MobileCoreRPCClient.requestData(
-                method: collapsed ? "workspace.group.collapse" : "workspace.group.expand",
-                params: [
-                    "group_id": id.rawValue,
-                    "client_id": clientID,
-                ]
-            )
-            _ = try await client.sendRequest(request)
-        } catch {
-            mobileShellLog.error("workspace group collapse failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        groupCollapseStore.set(id.rawValue, collapsed: collapsed)
+        if let index = workspaceGroups.firstIndex(where: { $0.id == id }) {
+            workspaceGroups[index].isCollapsed = collapsed
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -213,7 +213,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// time this device sees it; thereafter the toggle writes here (no RPC to the
     /// Mac) and the workspace-list ingest reads from here. Excluded from
     /// observation: views read collapse through `workspaceGroups`, not this store.
-    @ObservationIgnored var groupCollapseStore = MobileWorkspaceGroupCollapseStore()
+    /// Injected at the composition root (`.standard`-backed) and overridable in
+    /// tests/previews with a suite-scoped `UserDefaults`.
+    @ObservationIgnored var groupCollapseStore: MobileWorkspaceGroupCollapseStore
     /// The connected Mac's `mobile.host.status` capabilities. Feature gates are
     /// computed from this set so version-skew checks cannot drift from the raw
     /// host payload.
@@ -673,10 +675,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         diagnosticLog: DiagnosticLog? = nil,
         feedbackEmailSubmitter: (any MobileFeedbackEmailSubmitting)? = nil,
         feedbackStampProvider: @escaping @MainActor () -> MobileFeedbackStamp = { MobileShellComposite.emptyFeedbackStamp },
-        draftStore: (any TerminalDraftStoring)? = nil
+        draftStore: (any TerminalDraftStoring)? = nil,
+        groupCollapseStore: MobileWorkspaceGroupCollapseStore = MobileWorkspaceGroupCollapseStore()
     ) {
         self.runtime = runtime
         self.draftStore = draftStore
+        self.groupCollapseStore = groupCollapseStore
         self.pairedMacStore = pairedMacStore
         self.deviceRegistry = deviceRegistry
         self.presence = presence

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -204,8 +204,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public private(set) var workspaceTopologyVersion: UInt64 = 0
     /// The Mac's workspace groups, in section order. Empty when the Mac reports no
     /// groups (or is old enough not to emit them). Drives the collapsible group
-    /// sections in the workspace list.
+    /// sections in the workspace list. Each group's `isCollapsed` reflects THIS
+    /// device's choice (see `groupCollapseStore`), not the Mac's live value.
     public var workspaceGroups: [MobileWorkspaceGroupPreview] = []
+    /// Device-local collapse state for workspace groups. Folder collapse is a
+    /// per-device UI preference: collapsing a group on the phone must not collapse
+    /// it on the Mac. The Mac's reported `isCollapsed` only seeds a group the first
+    /// time this device sees it; thereafter the toggle writes here (no RPC to the
+    /// Mac) and the workspace-list ingest reads from here. Excluded from
+    /// observation: views read collapse through `workspaceGroups`, not this store.
+    @ObservationIgnored var groupCollapseStore = MobileWorkspaceGroupCollapseStore()
     /// The connected Mac's `mobile.host.status` capabilities. Feature gates are
     /// computed from this set so version-skew checks cannot drift from the raw
     /// host payload.
@@ -5267,7 +5275,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // full-list response (the non-merge path, which the event-driven refresh
         // and initial sync use) carries authoritative group state.
         if !mergeExistingWorkspaces {
-            workspaceGroups = response.groups.map { MobileWorkspaceGroupPreview(remote: $0) }
+            // Apply this device's collapse state over the Mac's reported groups
+            // (seeding any group seen for the first time). Folder collapse is
+            // device-local, so the Mac's live `isCollapsed` never overrides a
+            // choice this phone already made.
+            workspaceGroups = groupCollapseStore.apply(
+                to: response.groups.map { MobileWorkspaceGroupPreview(remote: $0) }
+            )
         }
         if preferActiveTicketTarget, selectActiveTicketTargetIfAvailable() {
             return

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -207,14 +207,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// sections in the workspace list. Each group's `isCollapsed` reflects THIS
     /// device's choice (see `groupCollapseStore`), not the Mac's live value.
     public var workspaceGroups: [MobileWorkspaceGroupPreview] = []
-    /// Device-local collapse state for workspace groups. Folder collapse is a
-    /// per-device UI preference: collapsing a group on the phone must not collapse
-    /// it on the Mac. The Mac's reported `isCollapsed` only seeds a group the first
-    /// time this device sees it; thereafter the toggle writes here (no RPC to the
-    /// Mac) and the workspace-list ingest reads from here. Excluded from
-    /// observation: views read collapse through `workspaceGroups`, not this store.
-    /// Injected at the composition root (`.standard`-backed) and overridable in
-    /// tests/previews with a suite-scoped `UserDefaults`.
+    /// Device-local collapse state for workspace groups (per-device UI preference:
+    /// collapsing on the phone must not collapse on the Mac). Seeded once from the
+    /// Mac, then phone-owned. `@ObservationIgnored` (views read `workspaceGroups`);
+    /// injected so tests/previews can pass a suite-scoped `UserDefaults`.
     @ObservationIgnored var groupCollapseStore: MobileWorkspaceGroupCollapseStore
     /// The connected Mac's `mobile.host.status` capabilities. Feature gates are
     /// computed from this set so version-skew checks cannot drift from the raw
@@ -3312,7 +3308,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     }
                     clearPairingError()
                     await persistPairedMacFromTicket(ticket)
-                    applyRemoteWorkspaceList(response, preferActiveTicketTarget: workspaceListRequest.preferActiveTicketTarget)
+                    applyRemoteWorkspaceList(
+                        response,
+                        preferActiveTicketTarget: workspaceListRequest.preferActiveTicketTarget,
+                        // Scoped requests omit groups; only a non-scoped (full) list
+                        // is authoritative for the device-local collapse store.
+                        groupsAreAuthoritative: !workspaceListRequest.isScoped
+                    )
                     syncSelectedTerminalForWorkspace()
                     connectionState = .connected
                     markMacConnectionHealthy()
@@ -5257,7 +5259,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func applyRemoteWorkspaceList(
         _ response: MobileSyncWorkspaceListResponse,
         preferActiveTicketTarget: Bool = false,
-        mergeExistingWorkspaces: Bool = false
+        mergeExistingWorkspaces: Bool = false,
+        groupsAreAuthoritative: Bool = true
     ) {
         let remoteWorkspaces = remoteWorkspacesPreservingSnapshots(from: response)
         if mergeExistingWorkspaces {
@@ -5279,13 +5282,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // full-list response (the non-merge path, which the event-driven refresh
         // and initial sync use) carries authoritative group state.
         if !mergeExistingWorkspaces {
-            // Apply this device's collapse state over the Mac's reported groups
-            // (seeding any group seen for the first time). Folder collapse is
-            // device-local, so the Mac's live `isCollapsed` never overrides a
-            // choice this phone already made.
-            workspaceGroups = groupCollapseStore.apply(
-                to: response.groups.map { MobileWorkspaceGroupPreview(remote: $0) }
-            )
+            let mappedGroups = response.groups.map { MobileWorkspaceGroupPreview(remote: $0) }
+            if groupsAreAuthoritative {
+                // Apply this device's collapse state over the Mac's reported groups
+                // (seeding any group seen for the first time, pruning departed ones).
+                // Folder collapse is device-local, so the Mac's live `isCollapsed`
+                // never overrides a choice this phone already made.
+                workspaceGroups = groupCollapseStore.apply(to: mappedGroups)
+            } else {
+                // Scoped attach responses omit `groups`; feeding that empty list to
+                // the store would prune saved collapse choices. Leave it untouched —
+                // the full refresh that follows re-applies authoritatively.
+                workspaceGroups = mappedGroups
+            }
         }
         if preferActiveTicketTarget, selectActiveTicketTargetIfAvailable() {
             return

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -5281,20 +5281,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // applying its empty groups array would wrongly clear the sections. Only a
         // full-list response (the non-merge path, which the event-driven refresh
         // and initial sync use) carries authoritative group state.
-        if !mergeExistingWorkspaces {
-            let mappedGroups = response.groups.map { MobileWorkspaceGroupPreview(remote: $0) }
-            if groupsAreAuthoritative {
-                // Apply this device's collapse state over the Mac's reported groups
-                // (seeding any group seen for the first time, pruning departed ones).
-                // Folder collapse is device-local, so the Mac's live `isCollapsed`
-                // never overrides a choice this phone already made.
-                workspaceGroups = groupCollapseStore.apply(to: mappedGroups)
-            } else {
-                // Scoped attach responses omit `groups`; feeding that empty list to
-                // the store would prune saved collapse choices. Leave it untouched —
-                // the full refresh that follows re-applies authoritatively.
-                workspaceGroups = mappedGroups
-            }
+        if !mergeExistingWorkspaces, groupsAreAuthoritative {
+            // Apply this device's collapse state over the Mac's reported groups
+            // (seeding any group seen for the first time, pruning departed ones).
+            // Folder collapse is device-local, so the Mac's live `isCollapsed` never
+            // overrides a choice this phone already made.
+            //
+            // Only authoritative (full-list) responses reach here. A scoped attach
+            // response omits `groups`; it must neither prune the collapse store nor
+            // clear the visible group sections (which would flatten grouped
+            // workspaces until a full refresh that is not guaranteed for a tokenless
+            // ticket), so leave `workspaceGroups` untouched in that case.
+            workspaceGroups = groupCollapseStore.apply(
+                to: response.groups.map { MobileWorkspaceGroupPreview(remote: $0) }
+            )
         }
         if preferActiveTicketTarget, selectActiveTicketTargetIfAvailable() {
             return

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceGroupCollapseStore.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceGroupCollapseStore.swift
@@ -1,0 +1,100 @@
+public import Foundation
+
+/// Device-local collapse state for workspace groups, persisted in an injected
+/// `UserDefaults`.
+///
+/// Folder collapse is a per-device UI preference, not shared state: collapsing a
+/// group on the phone must not collapse it on the Mac, and vice versa. The Mac
+/// still owns the group model (name, membership, pin), and its workspace-list RPC
+/// reports an `isCollapsed`, but iOS treats that value only as the SEED for a
+/// group it has never seen. After first sight the group's collapse is whatever
+/// this device last chose; the Mac's value no longer overrides it, and a local
+/// toggle is never sent back to the Mac.
+///
+/// The backing `UserDefaults` is injected so the store is testable without
+/// touching `.standard` (mirroring `MobileOnboardingStore`); the app constructs it
+/// at the composition root with `UserDefaults.standard`.
+///
+/// ```swift
+/// var store = MobileWorkspaceGroupCollapseStore(defaults: .standard)
+/// let shown = store.apply(to: groupsFromMac)   // seeds unknown groups, applies local
+/// store.set(groupID, collapsed: true)          // device-local, not sent to the Mac
+/// ```
+public struct MobileWorkspaceGroupCollapseStore: Sendable {
+    /// The defaults key under which the `[groupID: collapsed]` map is stored.
+    public static let defaultsKey = "dev.cmux.mobile.workspaceGroup.collapse.v1"
+
+    // UserDefaults is Apple-documented thread-safe; OK to hold nonisolated.
+    private nonisolated(unsafe) let defaults: UserDefaults
+    /// groupID.rawValue -> this device's collapse decision. The map doubles as the
+    /// "have I seen this group?" set: a present key means the group's collapse is
+    /// device-owned; an absent key means it still inherits the Mac's seed.
+    private var map: [String: Bool]
+
+    /// Create a store backed by the given defaults.
+    /// - Parameter defaults: The persistence store for the collapse map. Inject a
+    ///   suite-scoped `UserDefaults` in tests; the app passes `.standard`.
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.defaultsKey),
+           let decoded = try? JSONDecoder().decode([String: Bool].self, from: data) {
+            map = decoded
+        } else {
+            map = [:]
+        }
+    }
+
+    /// This device's collapse decision for a group, or `nil` if the group has not
+    /// been seen yet (still inheriting the Mac's seed).
+    public func isCollapsed(_ id: String) -> Bool? { map[id] }
+
+    /// Record a device-local collapse decision for a group. Persists immediately
+    /// and never contacts the Mac.
+    public mutating func set(_ id: String, collapsed: Bool) {
+        guard map[id] != collapsed else { return }
+        map[id] = collapsed
+        persist()
+    }
+
+    /// Apply device-local collapse to a freshly received group list from the Mac.
+    ///
+    /// For each group: if this device already has a decision, override the group's
+    /// `isCollapsed` with it; otherwise seed the device decision from the Mac's
+    /// reported value (initial inheritance) and keep that. Entries for groups no
+    /// longer present are dropped so the map stays bounded by the live group count.
+    /// - Parameter groups: The groups as reported by the Mac.
+    /// - Returns: The same groups with `isCollapsed` reflecting this device.
+    public mutating func apply(to groups: [MobileWorkspaceGroupPreview]) -> [MobileWorkspaceGroupPreview] {
+        let liveIDs = Set(groups.map(\.id.rawValue))
+        var changed = false
+
+        // Prune decisions for groups that no longer exist (renamed-away/deleted),
+        // keeping the map bounded by the number of live groups.
+        for key in map.keys where !liveIDs.contains(key) {
+            map.removeValue(forKey: key)
+            changed = true
+        }
+
+        let resolved = groups.map { group -> MobileWorkspaceGroupPreview in
+            var group = group
+            let key = group.id.rawValue
+            if let local = map[key] {
+                group.isCollapsed = local
+            } else {
+                // First time this device sees the group: inherit the Mac's value.
+                map[key] = group.isCollapsed
+                changed = true
+            }
+            return group
+        }
+
+        if changed { persist() }
+        return resolved
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(map) {
+            defaults.set(data, forKey: Self.defaultsKey)
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceGroupCollapseStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceGroupCollapseStoreTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileShellModel
+
+/// Behavior tests for ``MobileWorkspaceGroupCollapseStore`` using a suite-scoped
+/// `UserDefaults` so they never touch `UserDefaults.standard`.
+///
+/// The store's contract is that folder collapse is device-local: the Mac's value
+/// only seeds a group the first time it is seen, after which this device's choice
+/// wins and is never overridden by the Mac. That independence is the whole point
+/// of the fix (collapsing on the phone must not collapse on the desktop), so these
+/// tests pin it down.
+@Suite struct MobileWorkspaceGroupCollapseStoreTests {
+    private func makeDefaults() -> UserDefaults {
+        let suite = "MobileWorkspaceGroupCollapseStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    private func group(
+        _ id: MobileWorkspaceGroupPreview.ID,
+        collapsed: Bool
+    ) -> MobileWorkspaceGroupPreview {
+        MobileWorkspaceGroupPreview(
+            id: id,
+            name: id.rawValue,
+            isCollapsed: collapsed,
+            isPinned: false,
+            anchorWorkspaceID: MobileWorkspacePreview.ID(rawValue: "anchor-\(id.rawValue)")
+        )
+    }
+
+    @Test func seedsUnknownGroupsFromTheMacValue() {
+        var store = MobileWorkspaceGroupCollapseStore(defaults: makeDefaults())
+        let resolved = store.apply(to: [group("a", collapsed: true), group("b", collapsed: false)])
+        #expect(resolved.first { $0.id == "a" }?.isCollapsed == true)
+        #expect(resolved.first { $0.id == "b" }?.isCollapsed == false)
+        // The seed is now device-owned.
+        #expect(store.isCollapsed("a") == true)
+        #expect(store.isCollapsed("b") == false)
+    }
+
+    @Test func localDecisionOverridesTheMacValue() {
+        var store = MobileWorkspaceGroupCollapseStore(defaults: makeDefaults())
+        _ = store.apply(to: [group("a", collapsed: false)]) // seed expanded
+        store.set("a", collapsed: true) // collapse on this device
+        // Mac still reports expanded; the device choice must win.
+        let resolved = store.apply(to: [group("a", collapsed: false)])
+        #expect(resolved.first { $0.id == "a" }?.isCollapsed == true)
+    }
+
+    @Test func macChangesNeverOverrideAfterFirstSight() {
+        var store = MobileWorkspaceGroupCollapseStore(defaults: makeDefaults())
+        _ = store.apply(to: [group("a", collapsed: false)]) // seed expanded, no local toggle
+        // Mac collapses the group; the phone must NOT follow (independence).
+        let resolved = store.apply(to: [group("a", collapsed: true)])
+        #expect(resolved.first { $0.id == "a" }?.isCollapsed == false)
+    }
+
+    @Test func persistsAcrossInstances() {
+        let defaults = makeDefaults()
+        var store = MobileWorkspaceGroupCollapseStore(defaults: defaults)
+        _ = store.apply(to: [group("a", collapsed: false)])
+        store.set("a", collapsed: true)
+
+        // A fresh store on the same defaults (app relaunch) reads the choice back.
+        let reloaded = MobileWorkspaceGroupCollapseStore(defaults: defaults)
+        #expect(reloaded.isCollapsed("a") == true)
+    }
+
+    @Test func prunesDecisionsForGroupsThatNoLongerExist() {
+        let defaults = makeDefaults()
+        var store = MobileWorkspaceGroupCollapseStore(defaults: defaults)
+        _ = store.apply(to: [group("a", collapsed: true), group("b", collapsed: true)])
+        #expect(store.isCollapsed("b") == true)
+
+        // "b" is gone in the next list; its decision is dropped so the map stays
+        // bounded by the live group count.
+        _ = store.apply(to: [group("a", collapsed: true)])
+        #expect(store.isCollapsed("b") == nil)
+        #expect(store.isCollapsed("a") == true)
+
+        let reloaded = MobileWorkspaceGroupCollapseStore(defaults: defaults)
+        #expect(reloaded.isCollapsed("b") == nil)
+    }
+}


### PR DESCRIPTION
## Problem

Collapsing a workspace folder/group on the iPhone also collapsed it on the Mac (and vice-versa). Folder collapse should be a per-device UI preference.

## Root cause

Collapse (`isCollapsed`) lived only on the Mac-authoritative `WorkspaceGroup` model. iOS had **no** local collapse state: the chevron sent a `workspace.group.collapse`/`expand` RPC that mutated the Mac's model, which the Mac UI reflected and re-broadcast to every connected client; iOS then rendered whatever `isCollapsed` the Mac reported. So a phone tap round-tripped through the desktop.

## Fix (iOS-only)

Add a device-local `MobileWorkspaceGroupCollapseStore` (UserDefaults-backed, injected for tests):
- The workspace-list ingest applies it over the Mac's groups, **seeding** a group from the Mac's value the first time this device sees it, then keeping the device's choice (the Mac's live value never overrides it afterward).
- The iOS toggle writes the store and updates `workspaceGroups` in place for an immediate render, sending **nothing** to the Mac.
- Stale entries are pruned to the live group set so the map stays bounded.

The Mac's group model and RPC handlers are untouched (no Mac behavior change). Initial state still inherits the Mac's value, then the two diverge independently.

## Tests

`MobileWorkspaceGroupCollapseStoreTests` (Swift Testing, suite-scoped UserDefaults), all passing locally via `swift test`: seed-from-Mac, local-override-wins, Mac-change-independence-after-first-sight, persistence across instances, and pruning.

## Verification

- `swift test --package-path Packages/iOS/CmuxMobileShellModel` green (5/5).
- `$autoreview` + cmux-policy clean (one P2 fixed: added a composite-init injection seam for the store).
- Localization: no new user-facing strings.

iOS runtime change; dogfooded on a tagged device build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784788824&installation_id=133855650&pr_number=6666&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6666&signature=fb2df7775a893ca838d919b84975ddf20f0ceb9bc0ac3cd4356ac2599e221246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iOS-only UI preference change with no Mac RPC or auth changes; behavior is covered by new unit tests.
> 
> **Overview**
> **Workspace folder collapse on iOS is now a per-device UI preference** instead of mutating shared Mac state.
> 
> `setWorkspaceGroupCollapsed` no longer sends `workspace.group.collapse` / `expand` RPCs. It writes to a new **`MobileWorkspaceGroupCollapseStore`** (`UserDefaults`) and updates `workspaceGroups` in memory for an immediate UI response.
> 
> On workspace-list ingest, **`applyRemoteWorkspaceList`** merges Mac group metadata with the store: first sight of a group seeds from the Mac’s `isCollapsed`, then the phone’s choice wins and Mac updates do not override it. **`groupsAreAuthoritative`** avoids applying or pruning groups when scoped list responses omit them.
> 
> The store is injectable on `MobileShellComposite` init for tests; **`MobileWorkspaceGroupCollapseStoreTests`** cover seeding, override, Mac-independence, persistence, and pruning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 199ed72ba23ddd84f75e15a687706c8509d1a45a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make workspace folder collapse on iOS device‑local. Collapsing on the phone no longer collapses it on the Mac, with immediate local updates; scoped attaches no longer wipe local choices or flatten groups.

- **Bug Fixes**
  - Added a device-local `MobileWorkspaceGroupCollapseStore` (UserDefaults-backed) for per-device folder collapse.
  - On full workspace lists, apply the store: seed from the Mac the first time, then keep the device’s choice; prune stale IDs. Scoped attach responses skip apply/pruning and leave `workspaceGroups` untouched so sections stay visible.
  - Tapping the chevron now updates `workspaceGroups` and writes the store locally; no RPC is sent to the Mac.

- **Refactors**
  - `groupCollapseStore` is injected via `MobileShellComposite` init (defaults to `.standard`) for testability.

<sup>Written for commit 199ed72ba23ddd84f75e15a687706c8509d1a45a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace group collapse/expand state is now saved locally on your device and restored when you reopen the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->