### PR TITLE
Avoid synchronous process scans before update relaunch

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
@@ -42,6 +42,10 @@ extension ControlCommandCoordinator {
             return debugTextBoxInteract(request.params)
         case "debug.app.activate":
             return debugActivateApp()
+        case "debug.update.attempt":
+            return debugAttemptUpdate()
+        case "debug.update.prepare_relaunch_benchmark":
+            return debugUpdatePrepareRelaunchBenchmark()
         case "debug.command_palette.toggle":
             return debugCommandPaletteEvent(.toggle, request.params)
         case "debug.command_palette.rename_tab.open":
@@ -165,6 +169,14 @@ extension ControlCommandCoordinator {
         guard let payload = debugContext?.controlDebugSessionSnapshotSeedScrollback(
             charactersPerTerminal: charactersPerTerminal
         ) else {
+            return .err(code: "unavailable", message: "AppDelegate not available", data: nil)
+        }
+        return .ok(payload)
+    }
+
+    /// `debug.update.prepare_relaunch_benchmark` — run the pre-quit update preparation path.
+    func debugUpdatePrepareRelaunchBenchmark() -> ControlCallResult {
+        guard let payload = debugContext?.controlDebugUpdatePrepareRelaunchBenchmark() else {
             return .err(code: "unavailable", message: "AppDelegate not available", data: nil)
         }
         return .ok(payload)
@@ -300,6 +312,15 @@ extension ControlCommandCoordinator {
         return resp == "OK"
             ? .ok(.object([:]))
             : .err(code: "internal_error", message: resp, data: nil)
+    }
+
+    /// `debug.update.attempt` — run the same host update action as the
+    /// command palette's "Attempt Update" entry.
+    func debugAttemptUpdate() -> ControlCallResult {
+        guard debugContext?.controlDebugAttemptUpdate() == true else {
+            return .err(code: "unavailable", message: "Update host unavailable", data: nil)
+        }
+        return .ok(.object([:]))
     }
 
     // MARK: - debug.command_palette.* (event posts)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugContext.swift
@@ -57,6 +57,17 @@ public protocol ControlDebugContext: AnyObject {
     /// - Returns: The raw v1 response.
     func controlDebugActivateApp() -> String
 
+    /// Runs the app's update attempt action for `debug.update.attempt`.
+    ///
+    /// - Returns: `true` when the host accepted the request.
+    func controlDebugAttemptUpdate() -> Bool
+
+    /// Runs the app's pre-quit update relaunch preparation path for
+    /// `debug.update.prepare_relaunch_benchmark`.
+    ///
+    /// - Returns: Phase timings and app shape, or `nil` when unavailable.
+    func controlDebugUpdatePrepareRelaunchBenchmark() -> JSONValue?
+
     /// Runs the shared v1 `is_terminal_focused` body for
     /// `debug.terminal.is_focused`.
     ///

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+Debug.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+Debug.swift
@@ -14,6 +14,8 @@ extension ControlDebugContext {
     func controlDebugSetShortcut(arguments: String) -> String { "ERROR: not implemented" }
     func controlDebugSimulateShortcut(combo: String) -> String { "ERROR: not implemented" }
     func controlDebugActivateApp() -> String { "ERROR: not implemented" }
+    func controlDebugAttemptUpdate() -> Bool { false }
+    func controlDebugUpdatePrepareRelaunchBenchmark() -> JSONValue? { nil }
     func controlDebugIsTerminalFocused(surfaceArgument: String) -> String { "ERROR: not implemented" }
     func controlDebugReadTerminalText(surfaceArgument: String) -> String { "ERROR: not implemented" }
     func controlDebugRenderStats(surfaceArgument: String) -> String { "ERROR: not implemented" }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1289,6 +1289,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // closedPanelHistoryEntry.
         if !isRunningUnderXCTest {
             SharedLiveAgentIndex.shared.scheduleRefreshIfStale()
+            SharedSurfaceResumeBindingIndex.shared.scheduleRefreshIfStale()
         }
 
         claimAuthCallbackURLSchemes()
@@ -4118,6 +4119,83 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             charactersPerTerminal: charactersPerTerminal
         )
     }
+
+    func debugBenchmarkUpdatePrepareRelaunch() -> [String: Any] {
+        let shape = debugUpdateRelaunchShape()
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        var resumeIndexesMs: Double = 0
+        var saveSnapshotMs: Double = 0
+        var closedHistoryFlushMs: Double = 0
+        var terminalStopMs: Double = 0
+        var restorableStateMs: Double = 0
+
+        isTerminatingApp = true
+
+        let resumeIndexesStart = ProcessInfo.processInfo.systemUptime
+        let resumeIndexes = cachedResumeIndexesForTerminatingSessionSave()
+        resumeIndexesMs = Self.debugElapsedMs(since: resumeIndexesStart)
+
+        let saveSnapshotStart = ProcessInfo.processInfo.systemUptime
+        _ = saveSessionSnapshot(
+            includeScrollback: true,
+            removeWhenEmpty: false,
+            restorableAgentIndex: resumeIndexes.restorableAgentIndex,
+            surfaceResumeBindingIndex: resumeIndexes.surfaceResumeBindingIndex
+        )
+        saveSnapshotMs = Self.debugElapsedMs(since: saveSnapshotStart)
+
+        let closedHistoryFlushStart = ProcessInfo.processInfo.systemUptime
+        ClosedItemHistoryStore.shared.flushPendingSaves()
+        closedHistoryFlushMs = Self.debugElapsedMs(since: closedHistoryFlushStart)
+
+        let terminalStopStart = ProcessInfo.processInfo.systemUptime
+        TerminalController.shared.stop()
+        terminalStopMs = Self.debugElapsedMs(since: terminalStopStart)
+
+        let restorableStateStart = ProcessInfo.processInfo.systemUptime
+        NSApp.invalidateRestorableState()
+        for window in NSApp.windows {
+            window.invalidateRestorableState()
+        }
+        restorableStateMs = Self.debugElapsedMs(since: restorableStateStart)
+
+        return [
+            "elapsed_ms": Self.debugElapsedMs(since: startedAt),
+            "resume_indexes_ms": resumeIndexesMs,
+            "resume_indexes_source": "cache",
+            "save_session_snapshot_ms": saveSnapshotMs,
+            "closed_history_flush_ms": closedHistoryFlushMs,
+            "terminal_stop_ms": terminalStopMs,
+            "restorable_state_ms": restorableStateMs,
+            "shape": shape
+        ]
+    }
+
+    private static func debugElapsedMs(since start: TimeInterval) -> Double {
+        ((ProcessInfo.processInfo.systemUptime - start) * 1000.0 * 100.0).rounded() / 100.0
+    }
+
+    private func debugUpdateRelaunchShape() -> [String: Any] {
+        let contexts = sortedMainWindowContextsForSessionSnapshot()
+        var workspaceCount = 0
+        var panelCount = 0
+        var terminalCount = 0
+        for context in contexts {
+            let workspaces = context.tabManager.tabs
+            workspaceCount += workspaces.count
+            for workspace in workspaces {
+                panelCount += workspace.panels.count
+                terminalCount += workspace.panels.values.filter { $0 is TerminalPanel }.count
+            }
+        }
+        return [
+            "windows": contexts.count,
+            "workspaces": workspaceCount,
+            "panels": panelCount,
+            "terminals": terminalCount,
+            "ns_windows": NSApp.windows.count
+        ]
+    }
 #endif
 
     nonisolated static func shouldPersistSnapshotOnWindowUnregister(isTerminatingApp: Bool) -> Bool {
@@ -4233,6 +4311,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
             return
         }
+        SharedSurfaceResumeBindingIndex.shared.replace(with: resumeIndexes.surfaceResumeBindingIndex)
         let autosaveFingerprint = sessionAutosaveFingerprint(
             includeScrollback: false,
             restorableAgentIndex: resumeIndexes.restorableAgentIndex,
@@ -4280,12 +4359,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         includeScrollback: Bool,
         removeWhenEmpty: Bool = false
     ) -> Bool {
-        let resumeIndexes = ProcessDetectedResumeIndexes.loadSynchronously()
+        let resumeIndexes: ProcessDetectedResumeIndexes
+        if isTerminatingApp {
+            resumeIndexes = cachedResumeIndexesForTerminatingSessionSave()
+        } else {
+            resumeIndexes = ProcessDetectedResumeIndexes.loadSynchronously()
+            SharedSurfaceResumeBindingIndex.shared.replace(with: resumeIndexes.surfaceResumeBindingIndex)
+        }
         return saveSessionSnapshot(
             includeScrollback: includeScrollback,
             removeWhenEmpty: removeWhenEmpty,
             restorableAgentIndex: resumeIndexes.restorableAgentIndex,
             surfaceResumeBindingIndex: resumeIndexes.surfaceResumeBindingIndex
+        )
+    }
+
+    private func cachedResumeIndexesForTerminatingSessionSave() -> ProcessDetectedResumeIndexes {
+        ProcessDetectedResumeIndexes(
+            restorableAgentIndex: SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh() ?? .empty,
+            surfaceResumeBindingIndex: SharedSurfaceResumeBindingIndex.shared.currentIndexSchedulingRefresh() ?? .empty
         )
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1289,7 +1289,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // closedPanelHistoryEntry.
         if !isRunningUnderXCTest {
             SharedLiveAgentIndex.shared.scheduleRefreshIfStale()
-            SharedSurfaceResumeBindingIndex.shared.scheduleRefreshIfStale()
         }
 
         claimAuthCallbackURLSchemes()
@@ -4138,13 +4137,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         var resumeIndexesMs: Double = 0
         var saveSnapshotMs: Double = 0
         var closedHistoryFlushMs: Double = 0
-        var terminalStopMs: Double = 0
-        var restorableStateMs: Double = 0
 
+        let previousIsTerminatingApp = isTerminatingApp
         isTerminatingApp = true
+        defer { isTerminatingApp = previousIsTerminatingApp }
 
         let resumeIndexesStart = ProcessInfo.processInfo.systemUptime
-        let resumeIndexes = cachedResumeIndexesForTerminatingSessionSave()
+        let (resumeIndexes, resumeIndexesSource) = resumeIndexesForTerminatingSessionSave()
         resumeIndexesMs = Self.debugElapsedMs(since: resumeIndexesStart)
 
         let saveSnapshotStart = ProcessInfo.processInfo.systemUptime
@@ -4160,25 +4159,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         ClosedItemHistoryStore.shared.flushPendingSaves()
         closedHistoryFlushMs = Self.debugElapsedMs(since: closedHistoryFlushStart)
 
-        let terminalStopStart = ProcessInfo.processInfo.systemUptime
-        TerminalController.shared.stop()
-        terminalStopMs = Self.debugElapsedMs(since: terminalStopStart)
-
-        let restorableStateStart = ProcessInfo.processInfo.systemUptime
-        NSApp.invalidateRestorableState()
-        for window in NSApp.windows {
-            window.invalidateRestorableState()
-        }
-        restorableStateMs = Self.debugElapsedMs(since: restorableStateStart)
-
         return [
+            "destructive": false,
             "elapsed_ms": Self.debugElapsedMs(since: startedAt),
             "resume_indexes_ms": resumeIndexesMs,
-            "resume_indexes_source": "cache",
+            "resume_indexes_source": resumeIndexesSource,
             "save_session_snapshot_ms": saveSnapshotMs,
             "closed_history_flush_ms": closedHistoryFlushMs,
-            "terminal_stop_ms": terminalStopMs,
-            "restorable_state_ms": restorableStateMs,
             "shape": shape
         ]
     }
@@ -4323,7 +4310,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
             return
         }
-        SharedSurfaceResumeBindingIndex.shared.replace(with: resumeIndexes.surfaceResumeBindingIndex)
         let autosaveFingerprint = sessionAutosaveFingerprint(
             includeScrollback: false,
             restorableAgentIndex: resumeIndexes.restorableAgentIndex,
@@ -4373,10 +4359,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     ) -> Bool {
         let resumeIndexes: ProcessDetectedResumeIndexes
         if isTerminatingApp {
-            resumeIndexes = cachedResumeIndexesForTerminatingSessionSave()
+            resumeIndexes = resumeIndexesForTerminatingSessionSave().indexes
         } else {
             resumeIndexes = ProcessDetectedResumeIndexes.loadSynchronously()
-            SharedSurfaceResumeBindingIndex.shared.replace(with: resumeIndexes.surfaceResumeBindingIndex)
         }
         return saveSessionSnapshot(
             includeScrollback: includeScrollback,
@@ -4386,11 +4371,43 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
-    private func cachedResumeIndexesForTerminatingSessionSave() -> ProcessDetectedResumeIndexes {
-        ProcessDetectedResumeIndexes(
-            restorableAgentIndex: SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh() ?? .empty,
-            surfaceResumeBindingIndex: SharedSurfaceResumeBindingIndex.shared.currentIndexSchedulingRefresh() ?? .empty
-        )
+    private func resumeIndexesForTerminatingSessionSave() -> (indexes: ProcessDetectedResumeIndexes, source: String) {
+        let ttyScope = liveSurfaceTTYNamesByPanelKeyForSessionSnapshot()
+        guard ttyScope.fullyVerified else {
+            let indexes = ProcessDetectedResumeIndexes.loadSynchronously()
+            return (indexes, "fresh_synchronous_scan_unverified_tty_fallback")
+        }
+        let indexes = ProcessDetectedResumeIndexes.loadSynchronously(panelTTYNamesByKey: ttyScope.panelTTYNamesByKey)
+        return (indexes, "fresh_tty_scoped_scan")
+    }
+
+    private func liveSurfaceTTYNamesByPanelKeyForSessionSnapshot()
+        -> (panelTTYNamesByKey: [RestorableAgentSessionIndex.PanelKey: String], fullyVerified: Bool) {
+        var ttyNamesByPanelKey: [RestorableAgentSessionIndex.PanelKey: String] = [:]
+        var seenTTYDevices = Set<Int64>()
+        for context in sortedMainWindowContextsForSessionSnapshot() {
+            for workspace in context.tabManager.tabs {
+                for panel in workspace.panels.values {
+                    guard let terminalPanel = panel as? TerminalPanel,
+                          terminalPanel.surface.hasLiveSurface else {
+                        continue
+                    }
+                    let trimmedTTYName = terminalPanel.surface.controllingTTYName()?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard let trimmedTTYName, !trimmedTTYName.isEmpty else {
+                        return (ttyNamesByPanelKey, false)
+                    }
+                    guard let ttyDevice = CmuxTopProcessSnapshot.deviceIdentifier(forTTYName: trimmedTTYName),
+                          seenTTYDevices.insert(ttyDevice).inserted else {
+                        return (ttyNamesByPanelKey, false)
+                    }
+                    ttyNamesByPanelKey[
+                        RestorableAgentSessionIndex.PanelKey(workspaceId: workspace.id, panelId: terminalPanel.id)
+                    ] = trimmedTTYName
+                }
+            }
+        }
+        return (ttyNamesByPanelKey, true)
     }
 
     private func saveSessionSnapshotAfterLoadingProcessDetectedIndexes(

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1905,27 +1905,47 @@ struct ProcessDetectedResumeIndexes: Sendable {
 
     static func loadSynchronously(
         homeDirectory: String = NSHomeDirectory(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        panelTTYNamesByKey: [RestorableAgentSessionIndex.PanelKey: String]? = nil
     ) -> ProcessDetectedResumeIndexes {
         let capturedAt = Date().timeIntervalSince1970
-        let processSnapshot = CmuxTopProcessSnapshot.capture(includeProcessDetails: true)
+        let processSnapshot = CmuxTopProcessSnapshot.capture(
+            includeProcessDetails: false,
+            includeCMUXScope: panelTTYNamesByKey == nil
+        )
+        var processArgumentsCache: [Int: CmuxTopProcessArguments] = [:]
+        let processArgumentsProvider: (Int) -> CmuxTopProcessArguments? = { pid in
+            if let cached = processArgumentsCache[pid] {
+                return cached
+            }
+            guard let arguments = CmuxTopProcessSnapshot.processArgumentsAndEnvironment(for: pid) else {
+                return nil
+            }
+            processArgumentsCache[pid] = arguments
+            return arguments
+        }
         let registry = CmuxVaultAgentRegistry.load(homeDirectory: homeDirectory, fileManager: fileManager)
         let detectedSnapshots = RestorableAgentSessionIndex.processDetectedSnapshots(
             registry: registry,
             fileManager: fileManager,
             processSnapshot: processSnapshot,
-            capturedAt: capturedAt
+            capturedAt: capturedAt,
+            processArgumentsProvider: processArgumentsProvider,
+            panelTTYNamesByKey: panelTTYNamesByKey
         )
         let restorableAgentIndex = RestorableAgentSessionIndex.load(
             homeDirectory: homeDirectory,
             fileManager: fileManager,
             registry: registry,
-            detectedSnapshots: detectedSnapshots
+            detectedSnapshots: detectedSnapshots,
+            processArgumentsProvider: processArgumentsProvider
         )
         let detectedBindings = SurfaceResumeBindingIndex.processDetectedTmuxBindings(
             fileManager: fileManager,
             processSnapshot: processSnapshot,
-            capturedAt: capturedAt
+            capturedAt: capturedAt,
+            processArgumentsProvider: processArgumentsProvider,
+            panelTTYNamesByKey: panelTTYNamesByKey
         )
         return ProcessDetectedResumeIndexes(
             restorableAgentIndex: restorableAgentIndex,

--- a/Sources/TerminalController+ControlDebugContext.swift
+++ b/Sources/TerminalController+ControlDebugContext.swift
@@ -74,6 +74,19 @@ extension TerminalController: ControlDebugContext {
 
     func controlDebugActivateApp() -> String { activateApp() }
 
+    func controlDebugAttemptUpdate() -> Bool {
+        guard let appDelegate = AppDelegate.shared else { return false }
+        appDelegate.attemptUpdate(nil)
+        return true
+    }
+
+    func controlDebugUpdatePrepareRelaunchBenchmark() -> JSONValue? {
+        guard let payload = AppDelegate.shared?.debugBenchmarkUpdatePrepareRelaunch() else {
+            return nil
+        }
+        return JSONValue(foundationObject: payload)
+    }
+
     func controlDebugIsTerminalFocused(surfaceArgument: String) -> String {
         isTerminalFocused(surfaceArgument)
     }

--- a/Sources/TerminalController+DebugMethodNames.swift
+++ b/Sources/TerminalController+DebugMethodNames.swift
@@ -7,6 +7,8 @@ extension TerminalController {
         "debug.textbox.inline_fixture",
         "debug.textbox.interact",
         "debug.app.activate",
+        "debug.update.attempt",
+        "debug.update.prepare_relaunch_benchmark",
         "debug.command_palette.toggle",
         "debug.command_palette.rename_tab.open",
         "debug.command_palette.visible",

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -63,14 +63,17 @@ extension RestorableAgentSessionIndex {
         fileManager: FileManager,
         processSnapshot: CmuxTopProcessSnapshot,
         capturedAt: TimeInterval,
-        processArgumentsProvider: (Int) -> CmuxTopProcessArguments?
+        processArgumentsProvider: (Int) -> CmuxTopProcessArguments?,
+        panelTTYNamesByKey: [PanelKey: String]? = nil
     ) -> [PanelKey: ProcessDetectedSnapshotEntry] {
-        let scopedProcessIDsByPanelKey = processSnapshot.cmuxScopedProcessIDsByPanelKey()
+        let scopedProcesses = processSnapshot.cmuxScopedProcesses(panelTTYNamesByKey: panelTTYNamesByKey)
+        let scopedProcessIDsByPanelKey = Self.scopedProcessIDsByPanelKey(scopedProcesses)
         var resolved = processDetectedOpenCodeSnapshots(
-            processSnapshot: processSnapshot,
+            scopedProcesses: scopedProcesses,
             capturedAt: capturedAt,
             fileManager: fileManager,
-            scopedProcessIDsByPanelKey: scopedProcessIDsByPanelKey
+            scopedProcessIDsByPanelKey: scopedProcessIDsByPanelKey,
+            processArgumentsProvider: processArgumentsProvider
         )
 
         guard !registry.registrations.isEmpty else { return resolved }
@@ -90,10 +93,9 @@ extension RestorableAgentSessionIndex {
             return resolved
         }
 
-        for process in processSnapshot.cmuxScopedProcesses() {
-            guard let workspaceId = process.cmuxWorkspaceID,
-                  let panelId = process.cmuxSurfaceID,
-                  let processArguments = processArgumentsProvider(process.pid) else {
+        for scopedProcess in scopedProcesses {
+            let process = scopedProcess.process
+            guard let processArguments = processArgumentsProvider(process.pid) else {
                 continue
             }
             let observed = VaultObservedAgentProcess(
@@ -129,7 +131,7 @@ extension RestorableAgentSessionIndex {
                 ),
                 registration: registration
             )
-            let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
+            let key = scopedProcess.panelKey
             resolved[key] = (
                 snapshot: snapshot,
                 updatedAt: capturedAt,
@@ -221,10 +223,11 @@ extension RestorableAgentSessionIndex {
     }
 
     private static func processDetectedOpenCodeSnapshots(
-        processSnapshot: CmuxTopProcessSnapshot,
+        scopedProcesses: [CmuxTopProcessSnapshot.ScopedPanelProcess],
         capturedAt: TimeInterval,
         fileManager: FileManager,
-        scopedProcessIDsByPanelKey: [PanelKey: Set<Int>]
+        scopedProcessIDsByPanelKey: [PanelKey: Set<Int>],
+        processArgumentsProvider: (Int) -> CmuxTopProcessArguments?
     ) -> [PanelKey: ProcessDetectedSnapshotEntry] {
         var resolved: [PanelKey: ProcessDetectedSnapshotEntry] = [:]
         var sessionByWorkingDirectoryAndParent: [String: String] = [:]
@@ -240,10 +243,9 @@ extension RestorableAgentSessionIndex {
         ] = []
         var panelKeysByWorkingDirectory: [String: Set<PanelKey>] = [:]
 
-        for process in processSnapshot.cmuxScopedProcesses() {
-            guard let workspaceId = process.cmuxWorkspaceID,
-                  let panelId = process.cmuxSurfaceID,
-                  let processArguments = CmuxTopProcessSnapshot.processArgumentsAndEnvironment(for: process.pid) else {
+        for scopedProcess in scopedProcesses {
+            let process = scopedProcess.process
+            guard let processArguments = processArgumentsProvider(process.pid) else {
                 continue
             }
             let observed = VaultObservedAgentProcess(
@@ -256,7 +258,7 @@ extension RestorableAgentSessionIndex {
 
             let cwd = openCodeWorkingDirectory(observed: observed)
             let cwdKey = cwd.map { ($0 as NSString).standardizingPath } ?? ""
-            let panelKey = PanelKey(workspaceId: workspaceId, panelId: panelId)
+            let panelKey = scopedProcess.panelKey
             openCodeProcesses.append((
                 panelKey: panelKey,
                 observed: observed,
@@ -596,14 +598,28 @@ extension SurfaceResumeBindingIndex {
         processSnapshot: CmuxTopProcessSnapshot,
         capturedAt: TimeInterval
     ) -> [PanelKey: (binding: SurfaceResumeBindingSnapshot, updatedAt: TimeInterval)] {
+        processDetectedTmuxBindings(
+            fileManager: fileManager,
+            processSnapshot: processSnapshot,
+            capturedAt: capturedAt,
+            processArgumentsProvider: { CmuxTopProcessSnapshot.processArgumentsAndEnvironment(for: $0) }
+        )
+    }
+
+    static func processDetectedTmuxBindings(
+        fileManager: FileManager,
+        processSnapshot: CmuxTopProcessSnapshot,
+        capturedAt: TimeInterval,
+        processArgumentsProvider: (Int) -> CmuxTopProcessArguments?,
+        panelTTYNamesByKey: [PanelKey: String]? = nil
+    ) -> [PanelKey: (binding: SurfaceResumeBindingSnapshot, updatedAt: TimeInterval)] {
         _ = fileManager
         var resolved: [PanelKey: (binding: SurfaceResumeBindingSnapshot, updatedAt: TimeInterval)] = [:]
 
-        for process in processSnapshot.cmuxScopedProcesses() {
-            guard let workspaceId = process.cmuxWorkspaceID,
-                  let panelId = process.cmuxSurfaceID,
-                  process.isTerminalForegroundProcessGroup,
-                  let processArguments = CmuxTopProcessSnapshot.processArgumentsAndEnvironment(for: process.pid) else {
+        for scopedProcess in processSnapshot.cmuxScopedProcesses(panelTTYNamesByKey: panelTTYNamesByKey) {
+            let process = scopedProcess.process
+            guard process.isTerminalForegroundProcessGroup,
+                  let processArguments = processArgumentsProvider(process.pid) else {
                 continue
             }
             guard let binding = TmuxResumeParser.binding(
@@ -615,7 +631,7 @@ extension SurfaceResumeBindingIndex {
             ) else {
                 continue
             }
-            resolved[PanelKey(workspaceId: workspaceId, panelId: panelId)] = (binding: binding, updatedAt: capturedAt)
+            resolved[scopedProcess.panelKey] = (binding: binding, updatedAt: capturedAt)
         }
 
         return resolved
@@ -903,15 +919,48 @@ private extension CmuxVaultAgentSessionIDSource {
 }
 
 private extension CmuxTopProcessSnapshot {
-    func cmuxScopedProcessIDsByPanelKey() -> [RestorableAgentSessionIndex.PanelKey: Set<Int>] {
-        var processIDsByPanelKey: [RestorableAgentSessionIndex.PanelKey: Set<Int>] = [:]
-        for process in cmuxScopedProcesses() {
+    typealias PanelKey = RestorableAgentSessionIndex.PanelKey
+    typealias ScopedPanelProcess = (panelKey: PanelKey, process: CmuxTopProcessInfo)
+
+    func cmuxScopedProcesses(panelTTYNamesByKey: [PanelKey: String]?) -> [ScopedPanelProcess] {
+        if let panelTTYNamesByKey {
+            return panelTTYNamesByKey.flatMap { panelKey, ttyName in
+                pids(forTTYName: ttyName).compactMap { pid in
+                    guard let process = process(pid: pid) else { return nil }
+                    return (panelKey: panelKey, process: process)
+                }
+            }
+            .sorted { lhs, rhs in
+                if lhs.panelKey.workspaceId != rhs.panelKey.workspaceId {
+                    return lhs.panelKey.workspaceId.uuidString < rhs.panelKey.workspaceId.uuidString
+                }
+                if lhs.panelKey.panelId != rhs.panelKey.panelId {
+                    return lhs.panelKey.panelId.uuidString < rhs.panelKey.panelId.uuidString
+                }
+                return lhs.process.pid < rhs.process.pid
+            }
+        }
+
+        return cmuxScopedProcesses().compactMap { process in
             guard let workspaceId = process.cmuxWorkspaceID,
                   let panelId = process.cmuxSurfaceID else {
-                continue
+                return nil
             }
-            let key = RestorableAgentSessionIndex.PanelKey(workspaceId: workspaceId, panelId: panelId)
-            processIDsByPanelKey[key, default: []].insert(process.pid)
+            return (
+                panelKey: PanelKey(workspaceId: workspaceId, panelId: panelId),
+                process: process
+            )
+        }
+    }
+}
+
+private extension RestorableAgentSessionIndex {
+    static func scopedProcessIDsByPanelKey(
+        _ scopedProcesses: [CmuxTopProcessSnapshot.ScopedPanelProcess]
+    ) -> [PanelKey: Set<Int>] {
+        var processIDsByPanelKey: [PanelKey: Set<Int>] = [:]
+        for scopedProcess in scopedProcesses {
+            processIDsByPanelKey[scopedProcess.panelKey, default: []].insert(scopedProcess.process.pid)
         }
         return processIDsByPanelKey
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2133,48 +2133,6 @@ final class SharedLiveAgentIndex: ObservableObject {
     }
 }
 
-/// Process-wide, off-main cache for tmux surface resume bindings. The update
-/// relaunch path reads this cache instead of synchronously scanning every
-/// cmux-scoped process while Sparkle is waiting to quit the old app.
-@MainActor
-final class SharedSurfaceResumeBindingIndex {
-    static let shared = SharedSurfaceResumeBindingIndex()
-
-    private var index: SurfaceResumeBindingIndex?
-    private var loadedAt: Date?
-    private var refreshTask: Task<Void, Never>?
-
-    private static let cacheTTL: TimeInterval = 10.0
-
-    private init() {}
-
-    func currentIndexSchedulingRefresh() -> SurfaceResumeBindingIndex? {
-        scheduleRefreshIfStale()
-        return index
-    }
-
-    func replace(with index: SurfaceResumeBindingIndex) {
-        self.index = index
-        loadedAt = Date()
-    }
-
-    func scheduleRefreshIfStale() {
-        guard refreshTask == nil else { return }
-        if let loadedAt, Date().timeIntervalSince(loadedAt) < Self.cacheTTL {
-            return
-        }
-        refreshTask = Task { @MainActor [weak self] in
-            let newIndex = await Task.detached(priority: .utility) {
-                SurfaceResumeBindingIndex.loadProcessDetectedBindingsSynchronously()
-            }.value
-            guard let self else { return }
-            self.index = newIndex
-            self.loadedAt = Date()
-            self.refreshTask = nil
-        }
-    }
-}
-
 /// Workspace represents a sidebar tab.
 /// Each workspace contains one BonsplitController that manages split panes and nested surfaces.
 @MainActor

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2133,6 +2133,48 @@ final class SharedLiveAgentIndex: ObservableObject {
     }
 }
 
+/// Process-wide, off-main cache for tmux surface resume bindings. The update
+/// relaunch path reads this cache instead of synchronously scanning every
+/// cmux-scoped process while Sparkle is waiting to quit the old app.
+@MainActor
+final class SharedSurfaceResumeBindingIndex {
+    static let shared = SharedSurfaceResumeBindingIndex()
+
+    private var index: SurfaceResumeBindingIndex?
+    private var loadedAt: Date?
+    private var refreshTask: Task<Void, Never>?
+
+    private static let cacheTTL: TimeInterval = 10.0
+
+    private init() {}
+
+    func currentIndexSchedulingRefresh() -> SurfaceResumeBindingIndex? {
+        scheduleRefreshIfStale()
+        return index
+    }
+
+    func replace(with index: SurfaceResumeBindingIndex) {
+        self.index = index
+        loadedAt = Date()
+    }
+
+    func scheduleRefreshIfStale() {
+        guard refreshTask == nil else { return }
+        if let loadedAt, Date().timeIntervalSince(loadedAt) < Self.cacheTTL {
+            return
+        }
+        refreshTask = Task { @MainActor [weak self] in
+            let newIndex = await Task.detached(priority: .utility) {
+                SurfaceResumeBindingIndex.loadProcessDetectedBindingsSynchronously()
+            }.value
+            guard let self else { return }
+            self.index = newIndex
+            self.loadedAt = Date()
+            self.refreshTask = nil
+        }
+    }
+}
+
 /// Workspace represents a sidebar tab.
 /// Each workspace contains one BonsplitController that manages split panes and nested surfaces.
 @MainActor


### PR DESCRIPTION
## Summary
- avoid fresh synchronous process-detected resume scans while Sparkle is waiting to relaunch
- add an off-main cache for tmux surface resume bindings, warmed at launch and from existing autosave scans
- add debug RPCs to reproduce and time the pre-quit update preparation path

## Repro / verification
- pre-fix `uhrq`, 126 workspaces / 501 terminals / 200 MB scrollback: `ProcessDetectedResumeIndexes.loadSynchronously()` took 1103.56 ms of a 1178.5 ms pre-quit callback
- fixed `uhrg`, 96 workspaces / 384 terminals / 153 MB scrollback: pre-quit callback took 70.0 ms, cached resume index phase 0.01 ms
- final merged cloud build: `./scripts/reload-cloud.sh --tag uhrj`
- final `uhrj` smoke: `debug.update.prepare_relaunch_benchmark` returned `resume_indexes_source: cache`, elapsed 4.62 ms on a fresh one-workspace app

## Notes
The fix is intended to remove the main-thread scan from the old process before Sparkle quits. It preserves recent tmux resume metadata through a cache; if the cache is cold, update relaunch prefers a fast snapshot over blocking on a fresh scan.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784789068&installation_id=133855650&pr_number=6667&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6667&signature=e5cb9bee94e9b01668355180c636f32fefce6f78ea045fa354e592759c076168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quit-time session snapshot resume metadata (agents/tmux bindings); incorrect TTY scoping or fallback behavior could weaken restore after updates, though unverified TTY state still uses the old full scan.
> 
> **Overview**
> Speeds up **pre-quit session saves** during update relaunch by changing how process-detected resume indexes are built when `isTerminatingApp` is set, instead of always running a full synchronous `ProcessDetectedResumeIndexes.loadSynchronously()` on the main thread.
> 
> On terminate, the app now collects **live terminal TTY names per panel** from the UI; when every live surface verifies uniquely, it loads indexes with a **TTY-scoped** scan (`panelTTYNamesByKey`) that maps panels to processes via TTY PIDs and uses a lighter process snapshot (`includeProcessDetails: false`, skips CMUX-scope enumeration when scoped). If TTY mapping is incomplete or ambiguous, it **falls back** to the previous full synchronous scan.
> 
> **DEBUG** control-socket methods `debug.update.attempt` and `debug.update.prepare_relaunch_benchmark` exercise the update path and return phase timings (resume indexes, snapshot save, closed-history flush) plus window/workspace shape.
> 
> Process scanning helpers in `VaultAgentProcessScanner` / `CmuxTopProcessSnapshot` are refactored around **`cmuxScopedProcesses(panelTTYNamesByKey:)`** and a shared cached `processArgumentsProvider` used by agent and tmux binding detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93babd91dbbb16bcdc4768229e0ba5f63ccc9481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops blocking update relaunch on broad synchronous process scans by switching terminating saves to a fast TTY‑scoped resume scan with a safe full‑scan fallback when TTYs can’t be verified. This removes the main‑thread stall in Sparkle’s pre‑quit path and speeds relaunch prep (~1.1s → ~70ms in large sessions).

- **New Features**
  - Terminating save: use TTY‑scoped resume index scan; fall back to full scan if live TTYs are missing/duplicated. Normal saves still use a full scan.
  - Scanner updates: `ProcessDetectedResumeIndexes.loadSynchronously(panelTTYNamesByKey:)`, lazy per‑PID argument fetch, and `cmuxScopedProcesses(panelTTYNamesByKey:)` for precise scoping (also used by tmux binding detection).
  - Debug RPCs: `debug.update.attempt` and `debug.update.prepare_relaunch_benchmark` (returns phase timings and app shape).

<sup>Written for commit 93babd91dbbb16bcdc4768229e0ba5f63ccc9481. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug update attempt verification and relaunch benchmark measurement capabilities.

* **Improvements**
  * Enhanced session restoration logic with improved terminal process detection and TTY-scoped filtering for more accurate panel tracking during relaunch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->