### PR TITLE
Recover stale iOS Ghostty renders

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -590,16 +590,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// settled layer size rather than leaving a stale mid-animation surface.
     /// Bounded to avoid a perpetual main-queue present flood.
     private var pendingRenderFrames: Int = 0
-    /// At most one `render_now` is in flight on `outputQueue` at a time. The
-    /// display link can fire at 120Hz and previously enqueued a render every
-    /// frame with no guard, so during a continuous pinch renders piled up
-    /// faster than the serial queue drained them. Each op stayed fast, but the
-    /// DISPLAYED frame fell seconds behind the live font and only caught up
-    /// when zoom stopped and the backlog drained — the "frozen, no updates"
-    /// symptom. Coalescing caps the backlog: while a render is in flight, mark
-    /// `needsAnotherRender` and re-enqueue exactly one when it completes.
-    private var renderInFlight: Bool = false
-    private var needsAnotherRender: Bool = false
+    /// Coalesces display-link `render_now` calls and reopens if a render wedges.
+    private var renderFlightState = TerminalRenderFlightState()
     /// True while the app is inactive/backgrounded. On iOS `render_now`
     /// produces a frame synchronously on `outputQueue` and acquires a
     /// swap-chain frame slot from libghostty; if the app is backgrounded while
@@ -611,6 +603,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// GPU is available so any in-flight render drains — and gate dispatch so
     /// no `render_now` is sent into the background.
     private var renderingSuspended: Bool = false
+    private static let renderFlightTimeout: CFTimeInterval = 3.0
     #if DEBUG
     /// Last time the display-link heartbeat logged (DEBUG diagnostic). The
     /// per-frame callback runs on the main thread, so a steady heartbeat proves
@@ -642,6 +635,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     static let outputQueue = DispatchQueue(
         label: "dev.cmux.GhosttySurfaceView.output",
         qos: .userInitiated
+    )
+    private static let renderQueue = DispatchQueue(
+        label: "dev.cmux.GhosttySurfaceView.render",
+        qos: .userInteractive,
+        attributes: .concurrent
     )
     private static let scrollMechanicsContentHeight: CGFloat = 1_000_000
     private var scrollMechanicsIsRecentering = false
@@ -1102,8 +1100,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// re-mark the surface visible, and restart the frame pump. Idempotent.
     private func resumeRendering() {
         renderingSuspended = false
-        renderInFlight = false
-        needsAnotherRender = false
+        renderFlightState.reset()
         guard let surface, window != nil else { return }
         ghostty_surface_set_occlusion(surface, true)  // true = visible
         setFocus(true)
@@ -2588,7 +2585,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 : -1
             MobileDebugLog.anchormux(
                 "tick.alive win=\(window != nil) suspended=\(renderingSuspended) "
-                + "renderInFlight=\(renderInFlight) "
+                + "renderInFlight=\(renderFlightState.isInFlight) "
                 + "needsDraw=\(needsDraw) contents=\(renderLayer?.contents != nil) "
                 + "surf=\(Int(renderSize.width))x\(Int(renderSize.height)) "
                 + "sinceOutput=\(sinceOutputMs)ms"
@@ -2623,6 +2620,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             syncSurfaceGeometry(shouldReassertNaturalSize: reassert)
         }
         let now = CACurrentMediaTime()
+        if renderFlightState.isStale(now: now, timeout: Self.renderFlightTimeout) {
+            MobileDebugLog.anchormux(
+                "render.stale reopening elapsedMs=\(Int((now - (renderFlightState.startedAt ?? now)) * 1000))"
+            )
+            needsDraw = true
+        }
         let blinkChanged = cursorBlinkState.advance(now: now)
         // Draw on content/cursor changes, and for a short bounded burst after
         // any geometry change. iOS has no renderer-side vsync, so a frame is
@@ -2679,8 +2682,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
-    /// Drive a full render cycle via `ghostty_surface_render_now`, dispatched
-    /// to the off-main surface queue.
+    /// Drive a full render cycle via `ghostty_surface_render_now`, off main.
     ///
     /// On iOS libghostty's renderer-thread event loop does not pump frames
     /// (it's a platform-display-driven embedder), so `ghostty_surface_refresh`
@@ -2688,13 +2690,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// doesn't run, the cell grid stays 0x0, and the surface renders blank
     /// (uninitialized buffer shows as garbled). `render_now` instead runs
     /// `applyPendingResizeIfNeeded` + drainMailbox + `updateFrame` + drawFrame
-    /// directly on the calling thread, so the terminal grid is sized and the
-    /// cells are rebuilt from real content. We run it on `outputQueue` so the
-    /// GPU encode/swap-chain wait stays OFF the main thread (calling it on main
-    /// is what tripped the scene-update watchdog under fast zoom). The present
-    /// still hops to main inside libghostty (`setSurface`). The display link
-    /// gates this on `needsDraw`/`pendingRenderFrames`, so it is not a
-    /// per-frame loop that would flood the main queue with present blocks.
+    /// directly on the calling thread, so the terminal grid is sized and cells
+    /// are rebuilt from real content. Rendering is separate from `outputQueue`
+    /// so a wedged GPU frame wait cannot block later `process_output`.
     private func requestRender() {
         // Never dispatch a render into the background: a backgrounded
         // `render_now` can stall acquiring a swap-chain frame slot from
@@ -2703,15 +2701,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // skipped frame the display link re-drives), but we still gate on
         // suspension; `resumeRendering` clears it on the next active transition.
         guard !renderingSuspended, let surface, !isDismantled else { return }
-        // Coalesce: never let more than one render_now sit on the serial queue.
-        // (Called on main from the display link.)
-        if renderInFlight {
-            needsAnotherRender = true
-            return
+        let now = CACurrentMediaTime()
+        let decision = renderFlightState.request(now: now, staleTimeout: Self.renderFlightTimeout)
+        guard case let .enqueue(generation, replacedStale) = decision else { return }
+        if replacedStale {
+            MobileDebugLog.anchormux("render.stale replaced generation=\(generation)")
         }
-        renderInFlight = true
         let enqueuedAt = CACurrentMediaTime()
-        Self.outputQueue.async { [weak self] in
+        Self.renderQueue.async { [weak self] in
             // Queue LAG = how long this render waited behind other ops. If this
             // climbs into hundreds of ms the queue is backlogged (the freeze).
             let lagMs = (CACurrentMediaTime() - enqueuedAt) * 1000
@@ -2719,14 +2716,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             ghostty_surface_render_now(surface)
             DispatchQueue.main.async {
                 guard let self else { return }
-                self.renderInFlight = false
+                let completion = self.renderFlightState.complete(generation: generation)
                 guard !self.isDismantled else {
-                    self.needsAnotherRender = false
                     return
                 }
-                if self.needsAnotherRender {
-                    self.needsAnotherRender = false
+                if completion == .enqueueCoalesced {
                     self.requestRender()
+                } else if completion == .ignoredStaleCompletion {
+                    MobileDebugLog.anchormux("render.stale late_completion generation=\(generation)")
                 }
             }
         }

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalRenderFlightState.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalRenderFlightState.swift
@@ -1,0 +1,67 @@
+public enum TerminalRenderRequestDecision: Equatable, Sendable {
+    case enqueue(generation: UInt64, replacedStale: Bool)
+    case coalesced
+}
+
+public enum TerminalRenderCompletionDecision: Equatable, Sendable {
+    case ignoredStaleCompletion
+    case idle
+    case enqueueCoalesced
+}
+
+public struct TerminalRenderFlightState: Equatable, Sendable {
+    public private(set) var isInFlight = false
+    public private(set) var needsCoalescedRender = false
+    public private(set) var generation: UInt64 = 0
+    public private(set) var startedAt: Double?
+
+    public init() {}
+
+    public func isStale(now: Double, timeout: Double) -> Bool {
+        guard isInFlight, let startedAt else { return false }
+        return now - startedAt >= timeout
+    }
+
+    public mutating func request(
+        now: Double,
+        staleTimeout: Double
+    ) -> TerminalRenderRequestDecision {
+        if isInFlight {
+            if isStale(now: now, timeout: staleTimeout) {
+                generation &+= 1
+                startedAt = now
+                needsCoalescedRender = false
+                return .enqueue(generation: generation, replacedStale: true)
+            }
+            needsCoalescedRender = true
+            return .coalesced
+        }
+
+        isInFlight = true
+        needsCoalescedRender = false
+        generation &+= 1
+        startedAt = now
+        return .enqueue(generation: generation, replacedStale: false)
+    }
+
+    public mutating func complete(generation completedGeneration: UInt64) -> TerminalRenderCompletionDecision {
+        guard isInFlight, completedGeneration == generation else {
+            return .ignoredStaleCompletion
+        }
+
+        isInFlight = false
+        startedAt = nil
+        if needsCoalescedRender {
+            needsCoalescedRender = false
+            return .enqueueCoalesced
+        }
+        return .idle
+    }
+
+    public mutating func reset() {
+        isInFlight = false
+        needsCoalescedRender = false
+        startedAt = nil
+        generation &+= 1
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalRenderFlightStateTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalRenderFlightStateTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import CmuxMobileTerminalKit
+
+@Suite("Terminal render flight state")
+struct TerminalRenderFlightStateTests {
+    @Test("coalesces while a render is in flight")
+    func coalescesWhileInFlight() {
+        var state = TerminalRenderFlightState()
+
+        #expect(state.request(now: 1, staleTimeout: 3) == .enqueue(generation: 1, replacedStale: false))
+        #expect(state.request(now: 2, staleTimeout: 3) == .coalesced)
+
+        #expect(state.complete(generation: 1) == .enqueueCoalesced)
+        #expect(state.request(now: 2.1, staleTimeout: 3) == .enqueue(generation: 2, replacedStale: false))
+    }
+
+    @Test("reopens the latch when an in-flight render becomes stale")
+    func replacesStaleRender() {
+        var state = TerminalRenderFlightState()
+
+        #expect(state.request(now: 10, staleTimeout: 3) == .enqueue(generation: 1, replacedStale: false))
+        #expect(state.request(now: 14, staleTimeout: 3) == .enqueue(generation: 2, replacedStale: true))
+
+        #expect(state.complete(generation: 1) == .ignoredStaleCompletion)
+        #expect(state.complete(generation: 2) == .idle)
+    }
+
+    @Test("reset invalidates late completions")
+    func resetInvalidatesLateCompletion() {
+        var state = TerminalRenderFlightState()
+
+        #expect(state.request(now: 1, staleTimeout: 3) == .enqueue(generation: 1, replacedStale: false))
+        state.reset()
+
+        #expect(state.complete(generation: 1) == .ignoredStaleCompletion)
+        #expect(state.request(now: 2, staleTimeout: 3) == .enqueue(generation: 3, replacedStale: false))
+    }
+}


### PR DESCRIPTION
## Summary
- recover the iOS Ghostty render latch when an in-flight render becomes stale
- move `render_now` off the serial terminal output queue so fresh output is not blocked behind a wedged render
- add Swift Testing coverage for coalesced, stale, and reset render-flight states

## Validation
- `swift test --package-path Packages/iOS/CmuxMobileTerminalKit --filter TerminalRenderFlightStateTests`
- Mac tagged build: `CMUX_PORT=4381 CMUX_PORT_RANGE=1 CMUX_PORT_END=4381 ./scripts/reload-cloud.sh --tag irend`
- Web API warmed on port 4381: `/` 200, `/handler/sign-in` 200, `/handler/after-sign-in` final 200 after redirect
- iPhone reload: `CMUX_PORT=4381 CMUX_PORT_RANGE=1 CMUX_PORT_END=4381 ./ios/scripts/reload-cloud.sh --tag irend --device-id E4058DA9-F4C7-52DD-951D-0354061B8E89 --wait`
- Simulator reload attempted with `./ios/scripts/reload.sh --tag irend`, blocked by hq local-build guard

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784794268&installation_id=133855650&pr_number=6672&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6672&signature=303ce6095bd302ac125187c09fd2982733231279a282a2b79f2e67346f49d1d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core iOS terminal render/output threading path; mis-handling could cause duplicate presents, dropped frames, or races with surface teardown, though generation guards and existing dismantle checks mitigate that.
> 
> **Overview**
> Fixes iOS terminal freezes when **`ghostty_surface_render_now`** wedges on GPU work by **moving renders off the serial `outputQueue`** onto a dedicated concurrent **`renderQueue`**, so **`process_output`** can keep draining while a render is stuck.
> 
> Replaces ad-hoc **`renderInFlight` / `needsAnotherRender`** flags with **`TerminalRenderFlightState`** in **CmuxMobileTerminalKit**: coalesces display-link render requests, tracks a **generation** so late completions are ignored after a stale reopen, and **re-enqueues** after a **3s** timeout (display link also forces **`needsDraw`** when stale). **`resumeRendering`** resets flight state on foreground return.
> 
> Adds **Swift Testing** coverage for coalescing, stale replacement, and reset invalidating late completions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0a173a5702d06dc586db55799d874ae293c699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes frozen or lagging iOS Ghostty frames by coalescing render requests and recovering when a render wedges. Addresses the render‑on‑connect issue and keeps output responsive by moving rendering to its own queue.

- **Bug Fixes**
  - Coalesce display‑link `render_now` calls via `TerminalRenderFlightState`; if a render is in flight for >3s, replace it and drive a new frame.
  - Run `ghostty_surface_render_now` on a dedicated concurrent render queue (separate from `outputQueue`) so GPU waits don’t block terminal output.
  - Reset the latch on resume and gate renders while backgrounded; add Swift tests for coalescing, stale replacement, and reset behavior.

<sup>Written for commit 9b0a173a5702d06dc586db55799d874ae293c699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rendering system to prevent GPU frame waits from blocking terminal output processing.
  * Added recovery mechanism for stuck or stalled renders that exceed timeout thresholds.

* **Tests**
  * Added test coverage for render request handling and completion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->