### PR TITLE
web: square the hero screenshot on mobile

### DIFF
--- a/web/app/[locale]/components/hero-screenshot.tsx
+++ b/web/app/[locale]/components/hero-screenshot.tsx
@@ -19,7 +19,7 @@ export function HeroScreenshot() {
         alt="cmux terminal app screenshot"
         priority
         onLoad={() => setLoaded(true)}
-        className="w-full rounded-xl shadow-[0_30px_80px_-20px_rgba(0,0,0,0.65)]"
+        className="w-full rounded-none sm:rounded-xl shadow-[0_30px_80px_-20px_rgba(0,0,0,0.65)]"
       />
       <HeroPhone />
     </div>


### PR DESCRIPTION
The big Mac hero image used `rounded-xl` at every breakpoint, which looked bad on phones (at the base breakpoint the image fills the padded container edge-to-edge). This drops the rounding on mobile and keeps `rounded-xl` from `sm` up, where the image floats out with negative margins.

`rounded-xl` → `rounded-none sm:rounded-xl` on the Mac screenshot in `hero-screenshot.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784796583&installation_id=133855650&pr_number=6676&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6676&signature=4f2e6d199ccd99f167e97c228bde3f0ed59d849b2954e9fe0768c419f08918d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on landing hero imagery with no logic, data, or auth impact.
> 
> **Overview**
> Updates the landing **Mac hero screenshot** in `hero-screenshot.tsx` so corner rounding is responsive: **`rounded-none` on mobile**, **`rounded-xl` from `sm` and up**.
> 
> On small viewports the image sits edge-to-edge in the padded container; removing rounding there avoids awkward clipped corners. Larger breakpoints keep the floating hero look (negative margins on the parent from `sm` up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da072021a1707dce35269b92166e05050251e5b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Square the hero screenshot on mobile to fix awkward rounded corners when the image sits edge-to-edge. Keep `rounded-xl` from `sm` and up.

Updated the image class in `hero-screenshot.tsx` from `rounded-xl` to `rounded-none sm:rounded-xl`.

<sup>Written for commit da072021a1707dce35269b92166e05050251e5b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

