### PR TITLE
web: broaden homepage positioning to multitasking, organization, programmability

### DIFF
--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -74,10 +74,7 @@ function HomeContent() {
 
         {/* Tagline */}
         <p className="text-lg leading-relaxed mb-3 text-foreground">
-          <span className="sr-only">
-            {t("taglinePrefix")}
-            {t("typingCodingAgents")}, {t("typingMultitasking")}
-          </span>
+          <span className="sr-only">{t("taglineStatic")}</span>
           <span aria-hidden="true">
             {t("taglinePrefix")}
             <TypingTagline />

--- a/web/app/[locale]/typing.tsx
+++ b/web/app/[locale]/typing.tsx
@@ -9,6 +9,8 @@ function usePhrases() {
   return [
     t("typingCodingAgents"),
     t("typingMultitasking"),
+    t("typingOrganization"),
+    t("typingProgrammability"),
     "Claude Code",
     "Codex",
     "OpenCode",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -27,7 +27,7 @@
     "backToMac": "cmux for Mac"
   },
   "meta": {
-    "title": "cmux — The terminal built for multitasking",
+    "title": "cmux — The terminal built for multitasking, organization, and programmability",
     "description": "Free and open source native macOS terminal built on Ghostty. Works with Claude Code, Codex, OpenCode, Gemini CLI, Kiro, Aider, and any CLI tool. Vertical tabs, notification rings, split panes, and a socket API.",
     "ogDescription": "Free and open source macOS terminal for AI coding agents. Works with Claude Code, Codex, OpenCode, Gemini CLI, Kiro, Aider, and any CLI tool."
   },
@@ -75,6 +75,9 @@
     "taglinePrefix": "The terminal built for ",
     "typingCodingAgents": "coding agents",
     "typingMultitasking": "multitasking",
+    "typingOrganization": "organization",
+    "typingProgrammability": "programmability",
+    "taglineStatic": "The terminal built for multitasking, organization, and programmability.",
     "subtitle": "Free and open source native macOS terminal built on Ghostty. Vertical tabs, notification rings when agents need attention, split panes, and a <cliLink>CLI</cliLink> for programmability.",
     "features": "Features",
     "faq": "FAQ",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -27,7 +27,7 @@
     "backToMac": "cmux for Mac"
   },
   "meta": {
-    "title": "cmux — マルチタスクのために作られたターミナル",
+    "title": "cmux — マルチタスク、整理、プログラマビリティのために作られたターミナル",
     "description": "無料・オープンソースのGhosttyベースのネイティブ macOS ターミナル。Claude Code、Codex、OpenCode、Gemini CLI、Kiro、Aider、あらゆるCLIツールに対応。垂直タブ、通知リング、分割ペイン、ソケットAPI搭載。",
     "ogDescription": "無料・オープンソースのAIコーディングエージェント向けネイティブ macOS ターミナル。Claude Code、Codex、OpenCode、Gemini CLI、Kiro、Aider、あらゆるCLIツールに対応。"
   },
@@ -75,6 +75,9 @@
     "taglinePrefix": "次のために作られたターミナル：",
     "typingCodingAgents": "コーディングエージェント",
     "typingMultitasking": "マルチタスク",
+    "typingOrganization": "整理",
+    "typingProgrammability": "プログラマビリティ",
+    "taglineStatic": "マルチタスク、整理、プログラマビリティのために作られたターミナル。",
     "subtitle": "無料・オープンソースのGhosttyベースのネイティブmacOSターミナル。縦タブ、エージェントが注意を必要とするときの通知リング、分割ペイン、プログラマビリティのための<cliLink>CLI</cliLink>を搭載。",
     "features": "機能",
     "faq": "FAQ",


### PR DESCRIPTION
Changes the homepage SEO/OG title from "The terminal built for multitasking" to "The terminal built for multitasking, organization, and programmability", matching the positioning already used on the comparison page.

Also adds `organization` and `programmability` as new cycling words in the hero typing animation (after `multitasking`), keeping the animation. The crawlable `sr-only` tagline now renders the full static phrase `The terminal built for multitasking, organization, and programmability.` so the cycling hero stays SEO-friendly (crawlers and screen readers get the complete positioning, not a partial cycle snapshot).

Localized in `en.json` and `ja.json`. The other 18 locales fall back to English for the new typing keys via `deepMergeMessages`, so no missing-key runtime errors; their existing localized meta titles are untouched.

Surfaces intentionally left unchanged: the static OG share image (`opengraph-image.tsx`) keeps its current text.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784797740&installation_id=133855650&pr_number=6677&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6677&signature=7151c4dd68c3cb5782ec6fe4a078f88719a8d04b8978107cd9627d7c4afeafcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy, i18n, and hero presentation only; no runtime logic, auth, or data handling changes.
> 
> **Overview**
> Broadens homepage positioning to **multitasking, organization, and programmability** (aligned with comparison-page messaging).
> 
> **SEO & metadata:** `meta.title` in **en** and **ja** now includes all three themes instead of multitasking alone.
> 
> **Hero typing:** `TypingTagline` adds **organization** and **programmability** to the rotation (after multitasking), alongside existing agent/tool names.
> 
> **Accessibility / crawlers:** The `sr-only` hero text switches from a stitched prefix + partial typing strings to a single **`taglineStatic`** string with the full positioning phrase, so screen readers and crawlers get the complete line while the animated hero stays `aria-hidden`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d6b9d6d957672e9a33857238f991c169e29a342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broadened the homepage positioning to “multitasking, organization, and programmability” and synced the hero typing + SEO for clearer messaging and better crawlability.

- **New Features**
  - Updated `meta.title` (en/ja) to “The terminal built for multitasking, organization, and programmability.”
  - Added `typingOrganization` and `typingProgrammability` to the hero cycle; `taglineStatic` provides the full phrase for screen readers and crawlers.
  - Other locales fall back to English for new typing keys via `deepMergeMessages`; existing localized meta titles remain unchanged.
  - OG share image text is unchanged.

<sup>Written for commit 8d6b9d6d957672e9a33857238f991c169e29a342. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Updated homepage content and page title to highlight organization and programmability features alongside multitasking capabilities.
  * Extended homepage typing animation with additional phrases.
  * Updated translations for English and Japanese language versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->