### PR TITLE
Bump Sparkle to 2.9.3 to fix auto-update agent kill on macOS 26

### DIFF
--- a/Packages/macOS/CmuxUpdater/Package.resolved
+++ b/Packages/macOS/CmuxUpdater/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
-        "version" : "2.8.1"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     }
   ],

--- a/Packages/macOS/CmuxUpdater/Package.swift
+++ b/Packages/macOS/CmuxUpdater/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.5.1"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
     ],
     targets: [
         .target(

--- a/Packages/macOS/CmuxUpdaterUI/Package.resolved
+++ b/Packages/macOS/CmuxUpdaterUI/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
-        "version" : "2.8.1"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     }
   ],

--- a/Packages/macOS/CmuxUpdaterUI/Package.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(path: "../CmuxFoundation"),
         .package(path: "../CmuxUpdater"),
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.5.1"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
     ],
     targets: [
         .target(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -5292,7 +5292,7 @@
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.5.1;
+				minimumVersion = 2.9.0;
 			};
 		};
 		A5001252 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
-        "version" : "2.8.1"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     },
     {


### PR DESCRIPTION
## Summary

Fixes in-app auto-update failing with `SUSparkleErrorDomain(4005)` / underlying `(10) "agent connection was never initiated"` on macOS 26 for a subset of users.

Root cause (full investigation in https://github.com/manaflow-ai/cmux/issues/5123): cmux ships the **Sparkle 2.8.1 prebuilt binary**, whose `Autoupdate`/`Updater.app` are built against the **macOS 15.5 SDK** (`Runtime Version 15.5.0`), while the cmux app is built against the **macOS 26 SDK** (`26.4.0`). On macOS 26 the kernel's `AppleSystemPolicy` rejects the SDK-mismatched progress agent at launch:

```
kernel (AppleSystemPolicy) ASP: Validation category (6) does not match top-level policy match (8)
   for process: .../Caches/com.cmuxterm.app/.../Launcher/<id>/Updater.app/Contents/MacOS/Updater
loginwindow ... appDeath for org.sparkle-project.Sparkle.Updater
launchd failed lookup: name = com.cmuxterm.app-spkp, requestor = Updater, error = 3: No such process
```

The progress agent dies, `-spkp` never registers, the host times out (~19s) and surfaces 4005. It is machine-state-gated, so it reproduces for some users and not others on the same OS. Controls: Helium ships the same Sparkle 2.8.1 but built from source against the 26 SDK (Updater RV 26.0.0) and is immune; Codex ships 2.9.1 (RV 26.2.0) and is immune.

## Fix

Bump Sparkle 2.8.1 -> 2.9.3. Sparkle 2.9.3's prebuilt helpers are built against the macOS 26.2 SDK (`Runtime Version 26.2.0`), matching the host, which clears the validation-category mismatch. Floor raised to 2.9.0 in both updater packages and the xcodeproj so resolution can't drop back below the SDK-fixed line; three lockfiles refreshed.

## Verification

- Confirmed the Sparkle 2.9.3 SPM artifact's `Updater.app`/`Autoupdate` report `Runtime Version=26.2.0` / `sdk 26.2` (vs 2.8.1's `15.5.0`).
- Local build resolves `Sparkle @ 2.9.3` and compiles/links cmux against it with no Sparkle errors (no API breakage 2.8 -> 2.9).
- Final artifact check: confirm the signed `cmux DEV` bundle's `Sparkle.framework/.../Updater.app` reports `Runtime Version 26.x` from the CI `release-build`.

Note: scope is the dependency bump only. Inside-out signing (https://github.com/manaflow-ai/cmux/pull/1962) is complementary hygiene but does not fix this on its own, since the failing helper is validly signed and `spctl`-accepts.

## Follow-up

Consider a post-sign guard that asserts the bundled Sparkle helpers' SDK major matches the host, to prevent a future Sparkle pin from re-introducing the mismatch.

Fixes https://github.com/manaflow-ai/cmux/issues/5123

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784797905&installation_id=133855650&pr_number=6678&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6678&signature=c47889326a971f7cc9b0a6478230a7d96d0ce2b33f3f2ac041daf85e3d0697b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the auto-update stack (Sparkle helpers bundled in releases); scope is dependency-only with no API changes in app code, but a bad pin could still break updates for all users.
> 
> **Overview**
> **Upgrades the Sparkle dependency from 2.8.1 to 2.9.3** so in-app auto-update ships updater helpers built against a macOS 26–compatible SDK, addressing failures where the progress agent never connects on macOS 26.
> 
> The SPM **minimum version floor** moves from `2.5.1` to **`2.9.0`** in `CmuxUpdater`, `CmuxUpdaterUI`, and the Xcode project’s remote package reference; **`Package.resolved`** pins are refreshed in those packages and the workspace lockfile to **2.9.3**. No application or updater source changes—only dependency metadata and lockfiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ff9f93c0c8a810faa30ad9a1034a025caec0c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `Sparkle` to 2.9.3 to fix macOS 26 auto‑update failures caused by the updater agent being killed at launch due to an SDK mismatch. Sets the minimum `Sparkle` requirement to 2.9.0 and refreshes lockfiles; fixes #5123.

- **Dependencies**
  - Update `Sparkle` 2.8.1 → 2.9.3; raise floor to 2.9.0 in `Packages/macOS/CmuxUpdater`, `Packages/macOS/CmuxUpdaterUI`, and `cmux.xcodeproj`; refresh related `Package.resolved` files.

<sup>Written for commit 2ff9f93c0c8a810faa30ad9a1034a025caec0c06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sparkle framework dependency from version 2.5.1 to 2.9.0 across all macOS packages and project configurations, with resolved version 2.9.3. This ensures improved framework compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->