### PR TITLE
Fix OpenCode bunfs worker autoresume

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -27254,7 +27254,7 @@ function looksLikeOpenCodeScript(value) {
 function isOpenCodeInternalWorkerArg(value) {
   if (!value) return false;
   const normalized = String(value).replaceAll("\\", "/");
-  return normalized.includes("/$bunfs/") && normalized.includes("/src/cli/cmd/tui/worker.js");
+  return normalized.includes("/$bunfs/") && normalized.endsWith("/tui/worker.js");
 }
 
 function withoutOpenCodeInternalWorkerArgs(argv) {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -126,8 +126,8 @@ public enum AgentLaunchSanitizer {
             var tail = args
             while let first = tail.first {
                 let normalized = first.replacingOccurrences(of: "\\", with: "/")
-                let isInternalArgument = first == "tui-settings" || (normalized.contains("/$bunfs/") &&
-                    normalized.contains("/src/cli/cmd/tui/worker.js"))
+                let isInternalArgument = first == "tui-settings" ||
+                    (normalized.contains("/$bunfs/") && normalized.hasSuffix("/tui/worker.js"))
                 guard isInternalArgument else { break }
                 tail.removeFirst()
             }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/OpenCodeBunWorkerSanitizerTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/OpenCodeBunWorkerSanitizerTests.swift
@@ -1,0 +1,36 @@
+import CMUXAgentLaunch
+import Testing
+
+@Suite("OpenCode Bun worker sanitizer")
+struct OpenCodeBunWorkerSanitizerTests {
+    @Test("Drops internal TUI worker paths", arguments: [
+        "/$bunfs/root/src/cli/cmd/tui/worker.js",
+        "/$bunfs/root/src/cli/tui/worker.js",
+    ])
+    func dropsInternalTUIWorkerPaths(workerPath: String) {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "/Users/lawrence/.bun/bin/opencode",
+                    workerPath,
+                    "--model",
+                    "anthropic/claude-sonnet-4-6",
+                    "--session",
+                    "old-session",
+                    "--port",
+                    "4096",
+                    "/Users/lawrence/fun",
+                ],
+                launcher: "opencode",
+                fallbackKind: "opencode"
+            ) == [
+                "/Users/lawrence/.bun/bin/opencode",
+                "--model",
+                "anthropic/claude-sonnet-4-6",
+                "--port",
+                "4096",
+                "/Users/lawrence/fun",
+            ]
+        )
+    }
+}


### PR DESCRIPTION
Fixes #5787

## Summary
- Strip OpenCode internal Bun `$bunfs` TUI worker args when the virtual path ends in `/tui/worker.js`, covering both the old `/src/cli/cmd/tui/worker.js` layout and the new `/src/cli/tui/worker.js` layout.
- Keep the generated OpenCode hook predicate and the Swift replay sanitizer behaviorally aligned.
- Extend sanitizer/resume coverage for both old and new worker paths.

## Recovery note
The Swift replay sanitizer change also recovers already-persisted broken OpenCode sessions by stripping a captured `$bunfs` worker arg during resume, even if the session was captured before this fix.

## Testing
- Not run locally per issue instructions: do not build before explicit user go-ahead.
- Verified installed `opencode` embeds only `/$bunfs/root/src/cli/tui/worker.js` via `strings`.
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784798220&installation_id=133855650&pr_number=6680&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6680&signature=f8f4e9bb3a646732ef4542e10c2b496ccb3591dc426b9847fdee61d24026e7a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenCode auto-resume by stripping the internal Bun `/$bunfs/.../tui/worker.js` arg on launch and resume for both old (`/src/cli/cmd/tui/worker.js`) and new (`/src/cli/tui/worker.js`) layouts. Also recovers broken sessions by removing this arg during resume.

- **Bug Fixes**
  - In `cmux.swift` and `AgentLaunchSanitizer`, detect internal worker args with `includes("/$bunfs/")` and `endsWith("/tui/worker.js")`, then strip them on launch and resume.
  - Added a regression test to ensure the sanitizer drops both legacy and new `/$bunfs/.../tui/worker.js` paths.

<sup>Written for commit d62c44c9644407939ae05a5ff131a2d87cc140dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of internal worker path detection through stricter validation criteria.
  * Strengthened path matching requirements for more reliable worker identification in launch operations.

* **Tests**
  * Added comprehensive test suite to validate proper sanitization and filtering of internal worker launch arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->