### PR TITLE
web: add space above FAQ on home page

### DIFF
--- a/web/app/[locale]/components/spacing-control.tsx
+++ b/web/app/[locale]/components/spacing-control.tsx
@@ -28,7 +28,7 @@ const defaults: DevValues = {
   featuresPt: 12,
   featuresPb: 15,
   communityGap: 16,
-  faqPt: 0,
+  faqPt: 32,
   docsPt: 8,
 };
 

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -187,7 +187,7 @@ function HomeContent() {
         </div>
 
         {/* FAQ */}
-        <div data-dev="faq-top-spacer" style={{ height: 0 }} />
+        <div data-dev="faq-top-spacer" style={{ height: 32 }} />
         <section data-dev="faq" className="mb-10">
           <h2 className="text-xs font-medium text-muted tracking-tight mb-3">
             {t("faq")}


### PR DESCRIPTION
Adds 32px of breathing room above the FAQ section on the home page (the `faq-top-spacer` was at height 0). Default in the dev spacing control bumped to match.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784801374&installation_id=133855650&pr_number=6681&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6681&signature=3bf3f80e788bff74f92a031ac37d3847b6cbb423db4806c86766b6e60dce2bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only spacing tweak on the marketing home page with no logic, auth, or data changes.
> 
> **Overview**
> Adds **32px** of vertical space above the home page FAQ by changing the `faq-top-spacer` div from `height: 0` to `height: 32`.
> 
> The dev spacing control default for **FAQ pt** (`faqPt`) is updated from **0** to **32** so production layout matches what the FAQ spacing slider already drives in development.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8832346345672b7697005b2e57c4394a2e2cd39a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 32px of space above the home page FAQ to improve readability and match the surrounding layout. Updates the dev spacing control default (`faqPt`) to 32 so local overrides align with the new spacing.

<sup>Written for commit 8832346345672b7697005b2e57c4394a2e2cd39a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Increased vertical spacing at the top of the FAQ section to improve visual layout and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->