### PR TITLE
Smooth-fade home page typing caret

### DIFF
--- a/web/app/[locale]/typing.tsx
+++ b/web/app/[locale]/typing.tsx
@@ -71,12 +71,15 @@ export function TypingTagline() {
 
   const phrase = phrases[phraseIndex];
   const displayed = phrase.slice(0, charIndex);
+  // Like a macOS insertion point: solid while actively typing/deleting, only
+  // blink once the phrase is fully typed and we're idling before the next one.
+  const atRest = !deleting && charIndex === phrase.length;
 
   return (
     <span>
       <span>{displayed}</span>
       <span
-        className={`inline-block w-[2px] h-[1.1em] bg-foreground/70 ml-[1px] ${dev.cursorBlink ? "animate-blink" : ""}`}
+        className={`inline-block w-[2px] h-[1.1em] bg-foreground/70 ml-[1px] rounded-[0.5px] ${dev.cursorBlink && atRest ? "animate-blink" : ""}`}
         style={{ position: "relative", top: `${dev.cursorTop}px` }}
       />
     </span>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -72,7 +72,13 @@ body {
 }
 
 .animate-blink {
-  animation: blink 1s step-end infinite;
+  animation: blink 1.2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-blink {
+    animation: none;
+  }
 }
 
 @keyframes fade-in {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -66,13 +66,17 @@ body {
   }
 }
 
+/* macOS-style insertion point: visible most of the cycle, one quick soft
+   fade out, a short off, a quick fade back. ~1s period, visible longer than
+   hidden. Not a slow symmetric breathe and not a spring (carets never bounce). */
 @keyframes blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
+  0%, 55% { opacity: 1; }
+  65%, 90% { opacity: 0; }
+  100% { opacity: 1; }
 }
 
 .animate-blink {
-  animation: blink 1.2s ease-in-out infinite;
+  animation: blink 1.06s ease-in-out infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Replace the home page typing-tagline caret's hard `step-end` blink with a smooth `1.2s ease-in-out` fade so the cursor breathes in and out instead of snapping on/off.
- Add a `prefers-reduced-motion: reduce` rule that disables the caret animation.

`.animate-blink` is only used by the typing caret (`web/app/[locale]/typing.tsx`), so the change is scoped to the home page tagline.

## Testing
- CSS-only change; verified `.animate-blink` has no other consumers via grep.

## Issues
- Plain-text task: "make home page typing caret animated"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784804456&installation_id=133855650&pr_number=6688&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6688&signature=21cb2d3e695f09e14d4fa5af52949709d51fbc29654bb9530007caafc613d792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and presentational logic on the home typing tagline only; no auth, data, or API impact.
> 
> **Overview**
> Updates the home page **TypingTagline** caret so it behaves more like a macOS insertion point: **solid while characters are being typed or deleted**, and **only applies `animate-blink` when the phrase is fully typed and waiting** before delete (`atRest`). The caret bar also gets a slight `rounded-[0.5px]`.
> 
> **`globals.css`** replaces the old symmetric `step-end` blink with a **~1.06s ease-in-out** keyframe that stays visible most of the cycle and fades off briefly, plus **`prefers-reduced-motion: reduce`** turns off `.animate-blink`. `.animate-blink` is only used by this typing caret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f48b6cba62d8ffb250a70a34be2c5796dd7131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the home page typing caret to a macOS‑style blink (1.06s ease‑in‑out, visible longer than hidden) that only blinks when idle; it stays solid while typing or deleting.
Adds slight rounding to the caret and keeps the animation off with `prefers-reduced-motion: reduce`; change is scoped to the tagline via `typing.tsx` and `.animate-blink`.

<sup>Written for commit 57f48b6cba62d8ffb250a70a34be2c5796dd7131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

