### PR TITLE
Hibernation: don't let an unknown lifecycle clobber a proven idle

### DIFF
--- a/Sources/AgentHibernation/AgentHibernationLifecycleState.swift
+++ b/Sources/AgentHibernation/AgentHibernationLifecycleState.swift
@@ -25,6 +25,30 @@ enum AgentHibernationLifecycleState: String, Codable, Sendable, Equatable, CaseI
         parse(rawValue)
     }
 
+    /// Resolve an `incoming` lifecycle against the currently stored one so an
+    /// indeterminate `.unknown` never erases a previously proven definitive state.
+    ///
+    /// An agent reports `.unknown` when it has no turn-state information: a
+    /// SessionStart right after a process restart, or a plugin agent that emits no
+    /// live lifecycle. That `.unknown` must not overwrite an earlier `.idle` /
+    /// `.running` / `.needsInput`, otherwise a restarted agent's status decays to
+    /// `.unknown` and it never becomes hibernation-eligible again (only codex,
+    /// which keeps reporting, would ever hibernate). A definitive incoming state
+    /// always wins, so this never *invents* idleness: eligibility stays
+    /// positive-evidence-only.
+    ///
+    /// - Returns: `incoming`, unless it is `.unknown` and `existing` is a definitive
+    ///   (non-`nil`, non-`.unknown`) state, in which case `existing` is kept.
+    static func preservingDefinitive(
+        existing: AgentHibernationLifecycleState?,
+        incoming: AgentHibernationLifecycleState
+    ) -> AgentHibernationLifecycleState {
+        guard incoming == .unknown, let existing, existing != .unknown else {
+            return incoming
+        }
+        return existing
+    }
+
     private static func parse(_ rawValue: String) -> AgentHibernationLifecycleState? {
         let normalized = rawValue
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -101,6 +101,16 @@ extension Workspace {
         if let panelId {
             didClearOtherStructuredAgentRuntime = clearOtherStructuredAgentRuntimes(onPanel: panelId, keeping: key)
         }
+        // A different PID for this key means a new agent runtime replaced the old one.
+        // The previous runtime's lifecycle (e.g. a stored `.idle`) is stale: it must
+        // not be preserved against the new runtime's reports, or the new process could
+        // be hibernated on the dead process's evidence. (`setAgentLifecycle` keeps a
+        // definitive state against an `.unknown` report; that is correct within one
+        // runtime, but wrong across a runtime boundary.) Clear it so the new process
+        // starts from no evidence and the idle countdown restarts.
+        if let panelId, let previousPID = agentPIDs[key], previousPID != pid {
+            _ = clearAgentLifecycle(key: agentStatusKey(forAgentPIDKey: key), panelId: panelId)
+        }
         agentPIDs[key] = pid
         if let panelId {
             recordAgentPIDOwnership(key: key, panelId: panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4591,8 +4591,20 @@ final class Workspace: Identifiable, ObservableObject {
     ) {
         let targetPanelId = panelId ?? focusedPanelId
         guard let targetPanelId, panels[targetPanelId] != nil else { return }
-        agentLifecycleStatesByPanelId[targetPanelId, default: [:]][key] = lifecycle
-        recordAgentLifecycleChange(panelId: targetPanelId)
+        // An incoming `.unknown` (process restart, or a plugin agent that emits no
+        // live lifecycle) must not clobber a proven definitive state: otherwise a
+        // non-codex agent's status decays to `.unknown` and it never hibernates.
+        let existing = agentLifecycleStatesByPanelId[targetPanelId]?[key]
+        agentLifecycleStatesByPanelId[targetPanelId, default: [:]][key] =
+            AgentHibernationLifecycleState.preservingDefinitive(existing: existing, incoming: lifecycle)
+        // `recordAgentLifecycleChange` resets the idle countdown (it records activity).
+        // An `.unknown` carries no turn-state information, so treating it as activity
+        // would let a periodic `.unknown` heartbeat keep a genuinely idle agent from
+        // ever accumulating enough idle time to hibernate. Only advance on a definitive
+        // report, which is real turn activity the user cares about.
+        if lifecycle != .unknown {
+            recordAgentLifecycleChange(panelId: targetPanelId)
+        }
     }
 
     @discardableResult

--- a/cmuxTests/AgentHibernationTests.swift
+++ b/cmuxTests/AgentHibernationTests.swift
@@ -345,6 +345,32 @@ final class AgentHibernationTests: XCTestCase {
         XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .running)
     }
 
+    @MainActor
+    func testNewAgentRuntimePIDClearsStalePriorLifecycle() throws {
+        // The preservingDefinitive guard is correct within one runtime, but a stored
+        // `.idle` must not survive across a runtime boundary: a new agent process
+        // (new PID) for the same key must start from no evidence so it is not
+        // hibernated based on the dead process's idle.
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        workspace.recordAgentPID(key: "claude_code", pid: 100, panelId: panelId, refreshPorts: false)
+        workspace.setAgentLifecycle(key: "claude_code", panelId: panelId, lifecycle: .idle)
+        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .idle)
+
+        // Same runtime re-registers (same PID): the idle must survive.
+        workspace.recordAgentPID(key: "claude_code", pid: 100, panelId: panelId, refreshPorts: false)
+        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .idle)
+
+        // A new runtime (different PID) replaces it: the stale idle must be cleared.
+        workspace.recordAgentPID(key: "claude_code", pid: 200, panelId: panelId, refreshPorts: false)
+        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .unknown)
+
+        // The new runtime's own `.unknown` report stays unknown (not preserved as idle).
+        workspace.setAgentLifecycle(key: "claude_code", panelId: panelId, lifecycle: .unknown)
+        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .unknown)
+    }
+
     func testSessionIndexLoadsAgentLifecycleFromHookStore() throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-agent-hibernation-index-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/AgentHibernationTests.swift
+++ b/cmuxTests/AgentHibernationTests.swift
@@ -284,6 +284,67 @@ final class AgentHibernationTests: XCTestCase {
         XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: secondPanelId, fallback: nil), .running)
     }
 
+    func testPreservingDefinitiveKeepsDefinitiveStateAgainstUnknown() {
+        // An `.unknown` report (process restart / no-emit plugin) must never erase a
+        // proven definitive state.
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: .idle, incoming: .unknown), .idle)
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: .running, incoming: .unknown), .running)
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: .needsInput, incoming: .unknown), .needsInput)
+    }
+
+    func testPreservingDefinitiveLetsDefinitiveIncomingWin() {
+        // A definitive incoming state always wins, so the function never invents idleness.
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: .idle, incoming: .running), .running)
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: .running, incoming: .idle), .idle)
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: .idle, incoming: .needsInput), .needsInput)
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: .needsInput, incoming: .idle), .idle)
+    }
+
+    func testPreservingDefinitivePassesThroughWhenNoDefinitiveExisting() {
+        // No prior state, or a prior `.unknown`, never blocks the incoming value.
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: nil, incoming: .unknown), .unknown)
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: nil, incoming: .idle), .idle)
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: .unknown, incoming: .unknown), .unknown)
+        XCTAssertEqual(
+            AgentHibernationLifecycleState.preservingDefinitive(existing: .unknown, incoming: .idle), .idle)
+    }
+
+    @MainActor
+    func testUnknownLifecycleDoesNotClobberStoredIdle() throws {
+        // Regression for non-codex hibernation: an agent reports `.idle` at turn end,
+        // then a SessionStart-style `.unknown` arrives. The idle must survive so the
+        // panel stays hibernation-eligible.
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        workspace.setAgentLifecycle(key: "claude_code", panelId: panelId, lifecycle: .idle)
+        workspace.setAgentLifecycle(key: "claude_code", panelId: panelId, lifecycle: .unknown)
+
+        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .idle)
+    }
+
+    @MainActor
+    func testDefinitiveLifecycleStillOverridesStoredIdle() throws {
+        // The preservation must not stick: a real `.running` after `.idle` still wins.
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        workspace.setAgentLifecycle(key: "claude_code", panelId: panelId, lifecycle: .idle)
+        workspace.setAgentLifecycle(key: "claude_code", panelId: panelId, lifecycle: .running)
+
+        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .running)
+    }
+
     func testSessionIndexLoadsAgentLifecycleFromHookStore() throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-agent-hibernation-index-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Problem

Agent Hibernation only hibernated agents whose lifecycle resolved to `idle`, and in practice mostly only codex got there. A restarting/resuming agent (and plugin agents that emit no live lifecycle) reports `.unknown` on SessionStart, which overwrote the `.idle` the agent had recorded at its previous turn end. The hibernation reader intentionally ranks `unknown` above `idle` (an unclassified agent should block hibernation), so once the stored state decayed to `.unknown` the panel never became eligible again.

## Fix

Fix the write path, not the read priority. `Workspace.setAgentLifecycle` now applies `AgentHibernationLifecycleState.preservingDefinitive`: an incoming `.unknown` is kept only when there is no proven definitive state to preserve. A definitive incoming state (`idle`/`running`/`needsInput`) always wins, so eligibility stays positive-evidence-only and we never invent idleness.

It also stops treating an `.unknown` write as activity. `recordAgentLifecycleChange` resets the idle countdown, so a periodic `.unknown` heartbeat would otherwise keep a genuinely idle agent from ever accumulating enough idle time to hibernate.

This is the smallest, single-consumer slice of the broader hibernation work in https://github.com/manaflow-ai/cmux/pull/5500, split out so it can land independently.

## Tests

`cmuxTests/AgentHibernationTests.swift`: the pure `preservingDefinitive` resolution table, plus two Workspace behaviors (an `.unknown` write preserves a stored `.idle`; a real `.running` still overrides it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784806880&installation_id=133855650&pr_number=6693&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6693&signature=7fe7c5d1dc691949777f4a51ede45c4155a3a4976fc8fa211f7df9d673cd6707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hibernation eligibility and idle-timer semantics; wrong merging could hibernate live agents or block hibernation, but scope is limited to lifecycle write paths with strong test coverage.
> 
> **Overview**
> Fixes agent hibernation so **`.unknown` lifecycle writes no longer wipe a stored `.idle` / `.running` / `.needsInput`**, which had left many non-codex panels permanently ineligible after SessionStart or silent plugin agents.
> 
> **`AgentHibernationLifecycleState.preservingDefinitive`** merges incoming vs existing state: definitive incoming values still win; **`.unknown` only applies when there is no prior definitive state**. **`Workspace.setAgentLifecycle`** uses that merge and **skips `recordAgentLifecycleChange` for `.unknown`**, so idle heartbeats do not reset the hibernation idle timer.
> 
> When **`recordAgentPID` sees a new PID for the same agent key**, it **clears stored lifecycle** so a replacement process is not hibernated on the old process’s idle evidence (same-PID re-register keeps lifecycle).
> 
> Tests cover the merge table, workspace behavior, and PID-boundary clearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e943c7850ed002d28f9f87b3fcb78adb34e9e5ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `.unknown` lifecycle reports from wiping a proven `.idle`, and clear stale state when an agent runtime (PID) changes, so non-codex agents can hibernate again. Also stop `.unknown` heartbeats from resetting idle timers.

- **Bug Fixes**
  - Added `AgentHibernationLifecycleState.preservingDefinitive` and used it in `Workspace.setAgentLifecycle` to keep a definitive stored state when the incoming value is `.unknown`; definitive incoming values still override.
  - Stopped treating `.unknown` as activity in `Workspace.setAgentLifecycle`; only definitive states trigger `recordAgentLifecycleChange`, allowing genuine idle time to accrue.
  - Clear a key’s stored lifecycle in `recordAgentPID` when its PID changes, so a new runtime doesn’t inherit a prior runtime’s `.idle` and the idle countdown restarts.

<sup>Written for commit e943c7850ed002d28f9f87b3fcb78adb34e9e5ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

