### PR TITLE
Hibernation: a plain Claude waiting notification reports idle, not needsInput

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,7 +1,7 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-34546	CLI/cmux.swift
+34598	CLI/cmux.swift
 17841	Sources/AppDelegate.swift
 16132	Sources/ContentView.swift
 13824	Sources/TerminalController.swift

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -25758,7 +25758,7 @@ struct CMUXCLI {
                 return (
                     classified.subtitle,
                     classified.body,
-                    Self.claudeNotificationLifecycle(signal: fallback, message: fallback)
+                    claudeNotificationLifecycle(signal: fallback, message: fallback)
                 )
             }
             // A bare "waiting for input" reminder is an idle agent, not a blocking prompt.
@@ -25784,7 +25784,7 @@ struct CMUXCLI {
         return (
             classified.subtitle,
             classified.body,
-            Self.claudeNotificationLifecycle(signal: signal, message: normalizedMessage)
+            claudeNotificationLifecycle(signal: signal, message: normalizedMessage)
         )
     }
 
@@ -25794,20 +25794,34 @@ struct CMUXCLI {
     /// prompts and as a plain "waiting for your input" reminder once it has gone
     /// idle after finishing a turn. The handler previously hard-set `.needsInput`
     /// for every notification, which clobbered the `.idle` that the Stop hook had
-    /// just recorded, so a Claude pane never became hibernation-eligible (only
-    /// codex, which keeps reporting idle, ever hibernated). Only a permission /
-    /// approval prompt is a real blocking state; everything else is the idle agent
-    /// waiting, so it resolves to `.idle`. This affects hibernation eligibility
-    /// only: the user-facing notification, bell, and sidebar status are unchanged.
-    static func claudeNotificationLifecycle(
+    /// just recorded, so a Claude pane never became hibernation-eligible off-screen
+    /// (only codex, which keeps reporting idle, ever hibernated).
+    ///
+    /// This fails closed: hibernation eligibility is positive-evidence-only. A
+    /// notification reports `.idle` only when it is a positively identified idle or
+    /// completion reminder; a permission/approval prompt, an error, or any
+    /// unrecognized attention-style notification stays `.needsInput` so a blocking
+    /// prompt phrased without a known cue is never hibernated mid-wait. This affects
+    /// hibernation eligibility only: the user notification, bell, and sidebar status
+    /// are unchanged.
+    private func claudeNotificationLifecycle(
         signal: String,
         message: String
     ) -> AgentHibernationLifecycleState {
         let lower = "\(signal) \(message)".lowercased()
-        if lower.contains("permission") || lower.contains("approve") || lower.contains("approval") {
+        // Blocking or error: keep the pane live so the user can act.
+        if lower.contains("permission") || lower.contains("approve") || lower.contains("approval")
+            || lower.contains("error") || lower.contains("failed") || lower.contains("exception") {
             return .needsInput
         }
-        return .idle
+        // Positively identified idle/completion reminders are the only idle case:
+        // Claude's routine "waiting for your input" reminder fires after it has gone
+        // idle, and a completion notice means the turn finished.
+        if containsCompletionCue(lower) || lower.contains("waiting") || lower.contains("idle") {
+            return .idle
+        }
+        // Fail closed: an unrecognized attention notification keeps the pane live.
+        return .needsInput
     }
 
     private func summarizeAgentHookNotification(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23393,7 +23393,11 @@ struct CMUXCLI {
             if let mappedSession,
                let savedBody = mappedSession.lastBody, !savedBody.isEmpty,
                summary.body.contains("needs your attention") || summary.body.contains("needs your input") {
-                summary = (subtitle: mappedSession.lastSubtitle ?? summary.subtitle, body: savedBody)
+                summary = (
+                    subtitle: mappedSession.lastSubtitle ?? summary.subtitle,
+                    body: savedBody,
+                    lifecycle: summary.lifecycle
+                )
             }
 
             let title = String(
@@ -23409,7 +23413,7 @@ struct CMUXCLI {
                     surfaceId: surfaceId,
                     cwd: parsedInput.cwd,
                     transcriptPath: parsedInput.transcriptPath,
-                    agentLifecycle: .needsInput,
+                    agentLifecycle: summary.lifecycle,
                     lastSubtitle: summary.subtitle,
                     lastBody: summary.body
                 )
@@ -23418,7 +23422,7 @@ struct CMUXCLI {
             setAgentLifecycle(
                 client: client,
                 key: Self.claudeCodeStatusKey,
-                lifecycle: .needsInput,
+                lifecycle: summary.lifecycle,
                 workspaceId: workspaceId,
                 surfaceId: surfaceId
             )
@@ -25739,12 +25743,20 @@ struct CMUXCLI {
         return nil
     }
 
-    private func summarizeClaudeHookNotification(parsedInput: ClaudeHookParsedInput) -> (subtitle: String, body: String) {
+    private func summarizeClaudeHookNotification(
+        parsedInput: ClaudeHookParsedInput
+    ) -> (subtitle: String, body: String, lifecycle: AgentHibernationLifecycleState) {
         guard let object = parsedInput.object else {
             if let fallback = parsedInput.rawFallback, !fallback.isEmpty {
-                return classifyClaudeNotification(signal: fallback, message: fallback)
+                let classified = classifyClaudeNotification(signal: fallback, message: fallback)
+                return (
+                    classified.subtitle,
+                    classified.body,
+                    Self.claudeNotificationLifecycle(signal: fallback, message: fallback)
+                )
             }
-            return ("Waiting", "Claude is waiting for your input")
+            // A bare "waiting for input" reminder is an idle agent, not a blocking prompt.
+            return ("Waiting", "Claude is waiting for your input", .idle)
         }
 
         let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
@@ -25763,7 +25775,33 @@ struct CMUXCLI {
         var classified = classifyClaudeNotification(signal: signal, message: normalizedMessage)
 
         classified.body = truncate(classified.body, maxLength: 180)
-        return classified
+        return (
+            classified.subtitle,
+            classified.body,
+            Self.claudeNotificationLifecycle(signal: signal, message: normalizedMessage)
+        )
+    }
+
+    /// Hibernation lifecycle implied by a Claude `Notification` hook.
+    ///
+    /// Claude fires the Notification hook both for genuine permission/approval
+    /// prompts and as a plain "waiting for your input" reminder once it has gone
+    /// idle after finishing a turn. The handler previously hard-set `.needsInput`
+    /// for every notification, which clobbered the `.idle` that the Stop hook had
+    /// just recorded, so a Claude pane never became hibernation-eligible (only
+    /// codex, which keeps reporting idle, ever hibernated). Only a permission /
+    /// approval prompt is a real blocking state; everything else is the idle agent
+    /// waiting, so it resolves to `.idle`. This affects hibernation eligibility
+    /// only: the user-facing notification, bell, and sidebar status are unchanged.
+    static func claudeNotificationLifecycle(
+        signal: String,
+        message: String
+    ) -> AgentHibernationLifecycleState {
+        let lower = "\(signal) \(message)".lowercased()
+        if lower.contains("permission") || lower.contains("approve") || lower.contains("approval") {
+            return .needsInput
+        }
+        return .idle
     }
 
     private func summarizeAgentHookNotification(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23396,15 +23396,11 @@ struct CMUXCLI {
                 // Reuse the specific body an earlier hook saved (e.g. a blocking
                 // AskUserQuestion/ExitPlanMode PreToolUse) in place of the generic
                 // "needs your attention" text. Only the display body/subtitle is reused;
-                // the lifecycle stays the freshly classified value. Because the
-                // classifier fails closed, a generic "needs your input/attention"
-                // notification is already `.needsInput`, so a deferred blocking prompt
-                // keeps its blocking state without inheriting a possibly stale
-                // `agentLifecycle` from the (sticky) session record.
+                // the blocking classification is unaffected.
                 summary = (
                     subtitle: mappedSession.lastSubtitle ?? summary.subtitle,
                     body: savedBody,
-                    lifecycle: summary.lifecycle
+                    isBlocking: summary.isBlocking
                 )
             }
 
@@ -23414,14 +23410,13 @@ struct CMUXCLI {
             )
             let payload = notificationPayload(title: title, subtitle: summary.subtitle, body: summary.body)
 
-            // Never let a notification downgrade an already-recorded blocking state to
-            // idle. AskUserQuestion / ExitPlanMode record `.needsInput` in PreToolUse and
-            // (outside bypass-permissions mode) defer the bell to a following Notification
-            // whose text may read "waiting for your response"; classifying that as idle
-            // would hibernate the pane mid-prompt. This only overrides toward the
-            // conservative `.needsInput`, so it cannot resurrect a stale idle.
-            let notificationLifecycle: AgentHibernationLifecycleState =
-                mappedSession?.agentLifecycle == .needsInput ? .needsInput : summary.lifecycle
+            // Only assert `.needsInput` for a genuinely blocking notification. For
+            // every other notification (the routine idle reminder, completion, generic
+            // attention) leave the lifecycle untouched so the Stop hook's `.idle` (or a
+            // PreToolUse `.needsInput`) stays authoritative. `nil` preserves the stored
+            // lifecycle, and the live mutation is skipped, so the pane hibernates after a
+            // turn instead of being clobbered back to needs-input by the reminder.
+            let blockingLifecycle: AgentHibernationLifecycleState? = summary.isBlocking ? .needsInput : nil
 
             if let sessionId = parsedInput.sessionId {
                 try? sessionStore.upsert(
@@ -23430,19 +23425,21 @@ struct CMUXCLI {
                     surfaceId: surfaceId,
                     cwd: parsedInput.cwd,
                     transcriptPath: parsedInput.transcriptPath,
-                    agentLifecycle: notificationLifecycle,
+                    agentLifecycle: blockingLifecycle,
                     lastSubtitle: summary.subtitle,
                     lastBody: summary.body
                 )
             }
 
-            setAgentLifecycle(
-                client: client,
-                key: Self.claudeCodeStatusKey,
-                lifecycle: notificationLifecycle,
-                workspaceId: workspaceId,
-                surfaceId: surfaceId
-            )
+            if let blockingLifecycle {
+                setAgentLifecycle(
+                    client: client,
+                    key: Self.claudeCodeStatusKey,
+                    lifecycle: blockingLifecycle,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId
+                )
+            }
             _ = try? setClaudeStatus(
                 client: client,
                 workspaceId: workspaceId,
@@ -25762,18 +25759,18 @@ struct CMUXCLI {
 
     private func summarizeClaudeHookNotification(
         parsedInput: ClaudeHookParsedInput
-    ) -> (subtitle: String, body: String, lifecycle: AgentHibernationLifecycleState) {
+    ) -> (subtitle: String, body: String, isBlocking: Bool) {
         guard let object = parsedInput.object else {
             if let fallback = parsedInput.rawFallback, !fallback.isEmpty {
                 let classified = classifyClaudeNotification(signal: fallback, message: fallback)
                 return (
                     classified.subtitle,
                     classified.body,
-                    claudeNotificationLifecycle(signal: fallback, message: fallback)
+                    claudeNotificationIsBlockingPrompt(signal: fallback, message: fallback)
                 )
             }
             // A bare "waiting for input" reminder is an idle agent, not a blocking prompt.
-            return ("Waiting", "Claude is waiting for your input", .idle)
+            return ("Waiting", "Claude is waiting for your input", false)
         }
 
         let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
@@ -25795,44 +25792,30 @@ struct CMUXCLI {
         return (
             classified.subtitle,
             classified.body,
-            claudeNotificationLifecycle(signal: signal, message: normalizedMessage)
+            claudeNotificationIsBlockingPrompt(signal: signal, message: normalizedMessage)
         )
     }
 
-    /// Hibernation lifecycle implied by a Claude `Notification` hook.
+    /// Whether a Claude `Notification` hook is a genuinely blocking prompt that the
+    /// user must act on (a permission/approval request, or an error).
     ///
-    /// Claude fires the Notification hook both for genuine permission/approval
-    /// prompts and as a plain "waiting for your input" reminder once it has gone
-    /// idle after finishing a turn. The handler previously hard-set `.needsInput`
-    /// for every notification, which clobbered the `.idle` that the Stop hook had
-    /// just recorded, so a Claude pane never became hibernation-eligible off-screen
-    /// (only codex, which keeps reporting idle, ever hibernated).
+    /// The hibernation lifecycle has a single authoritative idle source: the Stop
+    /// hook, which records `.idle` when a turn ends. The Notification hook previously
+    /// hard-set `.needsInput` for every notification, including the routine "waiting
+    /// for your input" reminder Claude fires once idle, which clobbered the Stop
+    /// hook's idle so a Claude pane never hibernated off-screen (only codex did).
     ///
-    /// This fails closed: hibernation eligibility is positive-evidence-only. A
-    /// notification reports `.idle` only when it is a positively identified idle or
-    /// completion reminder; a permission/approval prompt, an error, or any
-    /// unrecognized attention-style notification stays `.needsInput` so a blocking
-    /// prompt phrased without a known cue is never hibernated mid-wait. This affects
-    /// hibernation eligibility only: the user notification, bell, and sidebar status
-    /// are unchanged.
-    private func claudeNotificationLifecycle(
-        signal: String,
-        message: String
-    ) -> AgentHibernationLifecycleState {
+    /// Rather than make ambiguous notification prose authoritative for `.idle` (a
+    /// "waiting for your response" prompt and a "waiting for your input" idle reminder
+    /// read alike), the handler only *asserts* `.needsInput` when this returns true,
+    /// and otherwise leaves the lifecycle untouched. So the Stop hook's idle survives
+    /// (the pane hibernates) and an AskUserQuestion/ExitPlanMode `.needsInput` recorded
+    /// in PreToolUse survives (it is never downgraded). Matching on blocking/error
+    /// words is the conservative direction only; it never forces idle.
+    private func claudeNotificationIsBlockingPrompt(signal: String, message: String) -> Bool {
         let lower = "\(signal) \(message)".lowercased()
-        // Blocking or error: keep the pane live so the user can act.
-        if lower.contains("permission") || lower.contains("approve") || lower.contains("approval")
-            || lower.contains("error") || lower.contains("failed") || lower.contains("exception") {
-            return .needsInput
-        }
-        // Positively identified idle/completion reminders are the only idle case:
-        // Claude's routine "waiting for your input" reminder fires after it has gone
-        // idle, and a completion notice means the turn finished.
-        if containsCompletionCue(lower) || lower.contains("waiting") || lower.contains("idle") {
-            return .idle
-        }
-        // Fail closed: an unrecognized attention notification keeps the pane live.
-        return .needsInput
+        return lower.contains("permission") || lower.contains("approve") || lower.contains("approval")
+            || lower.contains("error") || lower.contains("failed") || lower.contains("exception")
     }
 
     private func summarizeAgentHookNotification(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23414,6 +23414,15 @@ struct CMUXCLI {
             )
             let payload = notificationPayload(title: title, subtitle: summary.subtitle, body: summary.body)
 
+            // Never let a notification downgrade an already-recorded blocking state to
+            // idle. AskUserQuestion / ExitPlanMode record `.needsInput` in PreToolUse and
+            // (outside bypass-permissions mode) defer the bell to a following Notification
+            // whose text may read "waiting for your response"; classifying that as idle
+            // would hibernate the pane mid-prompt. This only overrides toward the
+            // conservative `.needsInput`, so it cannot resurrect a stale idle.
+            let notificationLifecycle: AgentHibernationLifecycleState =
+                mappedSession?.agentLifecycle == .needsInput ? .needsInput : summary.lifecycle
+
             if let sessionId = parsedInput.sessionId {
                 try? sessionStore.upsert(
                     sessionId: sessionId,
@@ -23421,7 +23430,7 @@ struct CMUXCLI {
                     surfaceId: surfaceId,
                     cwd: parsedInput.cwd,
                     transcriptPath: parsedInput.transcriptPath,
-                    agentLifecycle: summary.lifecycle,
+                    agentLifecycle: notificationLifecycle,
                     lastSubtitle: summary.subtitle,
                     lastBody: summary.body
                 )
@@ -23430,7 +23439,7 @@ struct CMUXCLI {
             setAgentLifecycle(
                 client: client,
                 key: Self.claudeCodeStatusKey,
-                lifecycle: summary.lifecycle,
+                lifecycle: notificationLifecycle,
                 workspaceId: workspaceId,
                 surfaceId: surfaceId
             )

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23393,10 +23393,16 @@ struct CMUXCLI {
             if let mappedSession,
                let savedBody = mappedSession.lastBody, !savedBody.isEmpty,
                summary.body.contains("needs your attention") || summary.body.contains("needs your input") {
+                // This is a deferred notification reusing a body an earlier hook saved
+                // (e.g. a blocking AskUserQuestion/ExitPlanMode PreToolUse that recorded
+                // `.needsInput`, or an idle waiting reminder that recorded `.idle`). The
+                // generic notification text would otherwise reclassify to `.idle` and
+                // undo a real blocking state, so keep the lifecycle the session already
+                // recorded alongside that body.
                 summary = (
                     subtitle: mappedSession.lastSubtitle ?? summary.subtitle,
                     body: savedBody,
-                    lifecycle: summary.lifecycle
+                    lifecycle: mappedSession.agentLifecycle ?? summary.lifecycle
                 )
             }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23393,16 +23393,18 @@ struct CMUXCLI {
             if let mappedSession,
                let savedBody = mappedSession.lastBody, !savedBody.isEmpty,
                summary.body.contains("needs your attention") || summary.body.contains("needs your input") {
-                // This is a deferred notification reusing a body an earlier hook saved
-                // (e.g. a blocking AskUserQuestion/ExitPlanMode PreToolUse that recorded
-                // `.needsInput`, or an idle waiting reminder that recorded `.idle`). The
-                // generic notification text would otherwise reclassify to `.idle` and
-                // undo a real blocking state, so keep the lifecycle the session already
-                // recorded alongside that body.
+                // Reuse the specific body an earlier hook saved (e.g. a blocking
+                // AskUserQuestion/ExitPlanMode PreToolUse) in place of the generic
+                // "needs your attention" text. Only the display body/subtitle is reused;
+                // the lifecycle stays the freshly classified value. Because the
+                // classifier fails closed, a generic "needs your input/attention"
+                // notification is already `.needsInput`, so a deferred blocking prompt
+                // keeps its blocking state without inheriting a possibly stale
+                // `agentLifecycle` from the (sticky) session record.
                 summary = (
                     subtitle: mappedSession.lastSubtitle ?? summary.subtitle,
                     body: savedBody,
-                    lifecycle: mappedSession.agentLifecycle ?? summary.lifecycle
+                    lifecycle: summary.lifecycle
                 )
             }
 

--- a/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
+++ b/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
@@ -103,26 +103,27 @@ struct ClaudeNotificationStatusLifecycleTests {
         )
     }
 
-    @Test func deferredBlockingToolNotificationKeepsRecordedNeedsInput() throws {
-        // AskUserQuestion / ExitPlanMode (non-bypass) record `.needsInput` + a saved
-        // body in PreToolUse, then defer the bell to the following Notification, whose
-        // generic text ("needs your input") would otherwise reclassify to `.idle`. The
-        // handler must keep the session's already-recorded `.needsInput` so the pane is
-        // not hibernated while the user still owes an answer / plan approval.
+    @Test func savedBodyReusePathDoesNotInheritStaleIdle() throws {
+        // The saved-body reuse path fires for generic "needs your input/attention"
+        // notifications. A session record's `agentLifecycle` is sticky (an earlier
+        // Stop/idle can leave it `.idle`), so reusing it here would downgrade a fresh
+        // generic blocking notification to idle and hibernate the pane while Claude is
+        // waiting. The handler must keep the freshly classified lifecycle, which fails
+        // closed to `.needsInput` for this generic text.
         let snapshot = try runClaudeNotification(
-            name: "claude-notify-blocking-tool",
-            ttyName: "ttys-claude-notify-blocking-tool",
+            name: "claude-notify-stale-idle",
+            ttyName: "ttys-claude-notify-stale-idle",
             message: "Claude needs your input",
-            seededLifecycle: "needsInput",
+            seededLifecycle: "idle",
             seededBody: "Which option do you want?"
         )
         #expect(
             snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput ") },
-            "Expected a deferred blocking-tool notification to keep needsInput, saw \(snapshot)"
+            "Expected the saved-body reuse path to keep needsInput, not inherit stale idle, saw \(snapshot)"
         )
         #expect(
             !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
-            "A deferred blocking-tool notification must not downgrade to idle, saw \(snapshot)"
+            "The saved-body reuse path must not downgrade a generic blocking notification to idle, saw \(snapshot)"
         )
     }
 

--- a/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
+++ b/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
@@ -103,6 +103,28 @@ struct ClaudeNotificationStatusLifecycleTests {
         )
     }
 
+    @Test func deferredBlockingWaitingNotificationDoesNotDowngradeNeedsInput() throws {
+        // AskUserQuestion / ExitPlanMode record `.needsInput` in PreToolUse, then defer
+        // the bell to a Notification whose text can read "waiting for your response".
+        // The "waiting" cue would classify to idle, but the recorded blocking state must
+        // win so the pane is not hibernated while the user still owes an answer.
+        let snapshot = try runClaudeNotification(
+            name: "claude-notify-deferred-block",
+            ttyName: "ttys-claude-notify-deferred-block",
+            message: "Claude is waiting for your response",
+            seededLifecycle: "needsInput",
+            seededBody: "Which option do you want?"
+        )
+        #expect(
+            snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput ") },
+            "Expected a deferred blocking notification with waiting text to keep needsInput, saw \(snapshot)"
+        )
+        #expect(
+            !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
+            "A pending blocking prompt must not be downgraded to idle by waiting text, saw \(snapshot)"
+        )
+    }
+
     @Test func savedBodyReusePathDoesNotInheritStaleIdle() throws {
         // The saved-body reuse path fires for generic "needs your input/attention"
         // notifications. A session record's `agentLifecycle` is sticky (an earlier

--- a/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
+++ b/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
@@ -50,64 +50,63 @@ struct ClaudeNotificationStatusLifecycleTests {
         )
     }
 
-    @Test func plainWaitingNotificationResolvesToIdleLifecycle() throws {
+    @Test func plainWaitingNotificationLeavesLifecycleUntouched() throws {
+        // Regression for the original bug: the routine "waiting for input" reminder
+        // fires after Claude has gone idle. It must NOT clobber the Stop hook's `.idle`
+        // back to `.needsInput`. The notification is not an authoritative idle source
+        // either, so it emits no lifecycle command at all — the Stop hook's idle stays
+        // and the pane hibernates.
         let snapshot = try runClaudeNotification(
             name: "claude-notify-waiting",
             ttyName: "ttys-claude-notify-waiting",
             message: "Claude is waiting for your input"
         )
-        // Regression: a bare "waiting for input" reminder fires after Claude has gone
-        // idle. It must report `.idle` so the pane stays hibernation-eligible, not
-        // `.needsInput` (which clobbered the Stop hook's idle and blocked hibernation).
         #expect(
-            snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle ") },
-            "Expected a plain waiting notification to set idle lifecycle, saw \(snapshot)"
-        )
-        #expect(
-            !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput") },
-            "A plain waiting notification must not set needsInput, saw \(snapshot)"
+            !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code") },
+            "A plain waiting reminder must not emit any lifecycle command (leave Stop's idle), saw \(snapshot)"
         )
     }
 
-    @Test func permissionNotificationKeepsNeedsInputLifecycle() throws {
+    @Test func permissionNotificationSetsNeedsInput() throws {
+        // A genuine permission / approval prompt is a real blocking state the
+        // notification owns, so it asserts `.needsInput` to keep the pane live.
         let snapshot = try runClaudeNotification(
             name: "claude-notify-permission",
             ttyName: "ttys-claude-notify-permission",
             message: "Claude needs your permission to use Bash"
         )
-        // A genuine permission / approval prompt is a real blocking state and must
-        // stay `.needsInput` so the pane is not hibernated while the user is expected
-        // to respond.
         #expect(
             snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput ") },
             "Expected a permission notification to set needsInput lifecycle, saw \(snapshot)"
         )
     }
 
-    @Test func unrecognizedAttentionNotificationFailsClosedToNeedsInput() throws {
-        // Fail closed: a notification that is neither a recognized idle/completion
-        // reminder nor a permission prompt must keep the pane live, so a blocking
-        // prompt phrased without a known cue is never hibernated while Claude waits.
-        let snapshot = try runClaudeNotification(
-            name: "claude-notify-unrecognized",
-            ttyName: "ttys-claude-notify-unrecognized",
-            message: "Please confirm to continue"
-        )
-        #expect(
-            snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput ") },
-            "Expected an unrecognized attention notification to fail closed to needsInput, saw \(snapshot)"
-        )
-        #expect(
-            !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
-            "An unrecognized attention notification must not resolve to idle, saw \(snapshot)"
-        )
+    @Test func notificationNeverForcesIdleFromText() throws {
+        // Single source of truth: idle comes only from the Stop hook, never from
+        // ambiguous notification prose. No notification text may resolve to `.idle`.
+        for message in [
+            "Claude is waiting for your input",
+            "Claude is waiting for your response",
+            "Please confirm to continue",
+            "Task completed",
+        ] {
+            let snapshot = try runClaudeNotification(
+                name: "claude-notify-noidle",
+                ttyName: "ttys-claude-notify-noidle",
+                message: message
+            )
+            #expect(
+                !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
+                "Notification text \(message.debugDescription) must never force idle, saw \(snapshot)"
+            )
+        }
     }
 
-    @Test func deferredBlockingWaitingNotificationDoesNotDowngradeNeedsInput() throws {
+    @Test func deferredBlockingWaitingNotificationDoesNotDowngradeToIdle() throws {
         // AskUserQuestion / ExitPlanMode record `.needsInput` in PreToolUse, then defer
         // the bell to a Notification whose text can read "waiting for your response".
-        // The "waiting" cue would classify to idle, but the recorded blocking state must
-        // win so the pane is not hibernated while the user still owes an answer.
+        // Because the notification leaves the lifecycle untouched (it is not blocking
+        // text), the recorded `.needsInput` survives; it is never downgraded to idle.
         let snapshot = try runClaudeNotification(
             name: "claude-notify-deferred-block",
             ttyName: "ttys-claude-notify-deferred-block",
@@ -116,36 +115,8 @@ struct ClaudeNotificationStatusLifecycleTests {
             seededBody: "Which option do you want?"
         )
         #expect(
-            snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput ") },
-            "Expected a deferred blocking notification with waiting text to keep needsInput, saw \(snapshot)"
-        )
-        #expect(
             !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
             "A pending blocking prompt must not be downgraded to idle by waiting text, saw \(snapshot)"
-        )
-    }
-
-    @Test func savedBodyReusePathDoesNotInheritStaleIdle() throws {
-        // The saved-body reuse path fires for generic "needs your input/attention"
-        // notifications. A session record's `agentLifecycle` is sticky (an earlier
-        // Stop/idle can leave it `.idle`), so reusing it here would downgrade a fresh
-        // generic blocking notification to idle and hibernate the pane while Claude is
-        // waiting. The handler must keep the freshly classified lifecycle, which fails
-        // closed to `.needsInput` for this generic text.
-        let snapshot = try runClaudeNotification(
-            name: "claude-notify-stale-idle",
-            ttyName: "ttys-claude-notify-stale-idle",
-            message: "Claude needs your input",
-            seededLifecycle: "idle",
-            seededBody: "Which option do you want?"
-        )
-        #expect(
-            snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput ") },
-            "Expected the saved-body reuse path to keep needsInput, not inherit stale idle, saw \(snapshot)"
-        )
-        #expect(
-            !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
-            "The saved-body reuse path must not downgrade a generic blocking notification to idle, saw \(snapshot)"
         )
     }
 

--- a/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
+++ b/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
@@ -49,4 +49,77 @@ struct ClaudeNotificationStatusLifecycleTests {
             "Claude notification status must be PID-backed so the stale PID sweep can clear it after abrupt agent exit; command=\(statusCommand)"
         )
     }
+
+    @Test func plainWaitingNotificationResolvesToIdleLifecycle() throws {
+        let snapshot = try runClaudeNotification(
+            name: "claude-notify-waiting",
+            ttyName: "ttys-claude-notify-waiting",
+            message: "Claude is waiting for your input"
+        )
+        // Regression: a bare "waiting for input" reminder fires after Claude has gone
+        // idle. It must report `.idle` so the pane stays hibernation-eligible, not
+        // `.needsInput` (which clobbered the Stop hook's idle and blocked hibernation).
+        #expect(
+            snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle ") },
+            "Expected a plain waiting notification to set idle lifecycle, saw \(snapshot)"
+        )
+        #expect(
+            !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput") },
+            "A plain waiting notification must not set needsInput, saw \(snapshot)"
+        )
+    }
+
+    @Test func permissionNotificationKeepsNeedsInputLifecycle() throws {
+        let snapshot = try runClaudeNotification(
+            name: "claude-notify-permission",
+            ttyName: "ttys-claude-notify-permission",
+            message: "Claude needs your permission to use Bash"
+        )
+        // A genuine permission / approval prompt is a real blocking state and must
+        // stay `.needsInput` so the pane is not hibernated while the user is expected
+        // to respond.
+        #expect(
+            snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput ") },
+            "Expected a permission notification to set needsInput lifecycle, saw \(snapshot)"
+        )
+    }
+
+    /// Runs the Claude `notification` hook with a given message and returns the
+    /// socket commands it emitted.
+    private func runClaudeNotification(
+        name: String,
+        ttyName: String,
+        message: String
+    ) throws -> [String] {
+        let harness = ClaudeHookSurfaceResolutionSwiftTests()
+        let context = try harness.makeClaudeHookContext(name: name)
+        defer { context.cleanup() }
+
+        let serverHandled = harness.startClaudeSurfaceResolutionServer(
+            context: context,
+            surfaces: [(context.surfaceId, "surface:1", true)],
+            ttyName: ttyName,
+            ttySurfaceId: context.surfaceId
+        )
+
+        var environment = harness.claudeHookEnvironment(
+            context: context,
+            surfaceId: context.surfaceId,
+            ttyName: ttyName,
+            storeURL: context.root.appendingPathComponent("claude-hook-sessions.json")
+        )
+        environment["CMUX_CLAUDE_PID"] = "42424"
+
+        let result = harness.runProcess(
+            executablePath: context.cliPath,
+            arguments: ["hooks", "claude", "notification"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(name)-session","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"\#(message)"}"#,
+            timeout: 5
+        )
+
+        #expect(serverHandled.wait(timeout: .now() + 5) == .success)
+        harness.assertSuccessfulHook(result)
+        return context.state.snapshot()
+    }
 }

--- a/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
+++ b/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
@@ -84,6 +84,25 @@ struct ClaudeNotificationStatusLifecycleTests {
         )
     }
 
+    @Test func unrecognizedAttentionNotificationFailsClosedToNeedsInput() throws {
+        // Fail closed: a notification that is neither a recognized idle/completion
+        // reminder nor a permission prompt must keep the pane live, so a blocking
+        // prompt phrased without a known cue is never hibernated while Claude waits.
+        let snapshot = try runClaudeNotification(
+            name: "claude-notify-unrecognized",
+            ttyName: "ttys-claude-notify-unrecognized",
+            message: "Please confirm to continue"
+        )
+        #expect(
+            snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput ") },
+            "Expected an unrecognized attention notification to fail closed to needsInput, saw \(snapshot)"
+        )
+        #expect(
+            !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
+            "An unrecognized attention notification must not resolve to idle, saw \(snapshot)"
+        )
+    }
+
     @Test func deferredBlockingToolNotificationKeepsRecordedNeedsInput() throws {
         // AskUserQuestion / ExitPlanMode (non-bypass) record `.needsInput` + a saved
         // body in PreToolUse, then defer the bell to the following Notification, whose

--- a/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
+++ b/cmuxTests/ClaudeNotificationStatusLifecycleTests.swift
@@ -84,16 +84,58 @@ struct ClaudeNotificationStatusLifecycleTests {
         )
     }
 
+    @Test func deferredBlockingToolNotificationKeepsRecordedNeedsInput() throws {
+        // AskUserQuestion / ExitPlanMode (non-bypass) record `.needsInput` + a saved
+        // body in PreToolUse, then defer the bell to the following Notification, whose
+        // generic text ("needs your input") would otherwise reclassify to `.idle`. The
+        // handler must keep the session's already-recorded `.needsInput` so the pane is
+        // not hibernated while the user still owes an answer / plan approval.
+        let snapshot = try runClaudeNotification(
+            name: "claude-notify-blocking-tool",
+            ttyName: "ttys-claude-notify-blocking-tool",
+            message: "Claude needs your input",
+            seededLifecycle: "needsInput",
+            seededBody: "Which option do you want?"
+        )
+        #expect(
+            snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code needsInput ") },
+            "Expected a deferred blocking-tool notification to keep needsInput, saw \(snapshot)"
+        )
+        #expect(
+            !snapshot.contains { $0.hasPrefix("set_agent_lifecycle claude_code idle") },
+            "A deferred blocking-tool notification must not downgrade to idle, saw \(snapshot)"
+        )
+    }
+
     /// Runs the Claude `notification` hook with a given message and returns the
-    /// socket commands it emitted.
+    /// socket commands it emitted. When `seededLifecycle`/`seededBody` are provided,
+    /// a prior session record is written first so the handler's saved-body reuse path
+    /// is exercised (mirrors a blocking PreToolUse that recorded state then deferred
+    /// the notification).
     private func runClaudeNotification(
         name: String,
         ttyName: String,
-        message: String
+        message: String,
+        seededLifecycle: String? = nil,
+        seededBody: String? = nil
     ) throws -> [String] {
         let harness = ClaudeHookSurfaceResolutionSwiftTests()
         let context = try harness.makeClaudeHookContext(name: name)
         defer { context.cleanup() }
+
+        let sessionId = "\(name)-session"
+        let storeURL = context.root.appendingPathComponent("claude-hook-sessions.json")
+        if let seededLifecycle, let seededBody {
+            try seedClaudeSession(
+                storeURL: storeURL,
+                sessionId: sessionId,
+                workspaceId: context.workspaceId,
+                surfaceId: context.surfaceId,
+                cwd: context.root.path,
+                agentLifecycle: seededLifecycle,
+                lastBody: seededBody
+            )
+        }
 
         let serverHandled = harness.startClaudeSurfaceResolutionServer(
             context: context,
@@ -106,7 +148,7 @@ struct ClaudeNotificationStatusLifecycleTests {
             context: context,
             surfaceId: context.surfaceId,
             ttyName: ttyName,
-            storeURL: context.root.appendingPathComponent("claude-hook-sessions.json")
+            storeURL: storeURL
         )
         environment["CMUX_CLAUDE_PID"] = "42424"
 
@@ -114,12 +156,43 @@ struct ClaudeNotificationStatusLifecycleTests {
             executablePath: context.cliPath,
             arguments: ["hooks", "claude", "notification"],
             environment: environment,
-            standardInput: #"{"session_id":"\#(name)-session","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"\#(message)"}"#,
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"\#(message)"}"#,
             timeout: 5
         )
 
         #expect(serverHandled.wait(timeout: .now() + 5) == .success)
         harness.assertSuccessfulHook(result)
         return context.state.snapshot()
+    }
+
+    private func seedClaudeSession(
+        storeURL: URL,
+        sessionId: String,
+        workspaceId: String,
+        surfaceId: String,
+        cwd: String,
+        agentLifecycle: String,
+        lastBody: String
+    ) throws {
+        let now = Date().timeIntervalSince1970
+        let store: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionId: [
+                    "sessionId": sessionId,
+                    "workspaceId": workspaceId,
+                    "surfaceId": surfaceId,
+                    "cwd": cwd,
+                    "isRestorable": true,
+                    "startedAt": now,
+                    "updatedAt": now,
+                    "agentLifecycle": agentLifecycle,
+                    "lastSubtitle": "Permission",
+                    "lastBody": lastBody,
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: store, options: [.sortedKeys])
+        try data.write(to: storeURL)
     }
 }


### PR DESCRIPTION
## Problem

Claude fires its `Notification` hook both for genuine permission/approval prompts and as a plain "waiting for your input" reminder once it has gone idle after finishing a turn. The notification handler hard-set `.needsInput` for every notification, which clobbered the `.idle` the Stop hook had just recorded. So a Claude pane never became hibernation-eligible off-screen (only codex, which keeps reporting idle, ever hibernated).

`needsInput` outranks `idle` in the hibernation reader regardless of ordering, so the companion write-path fix (https://github.com/manaflow-ai/cmux/pull/6693) does not help Claude on its own. This is the Claude-specific half.

## Fix

Classify the notification. Only a permission/approval prompt is a real blocking state and stays `.needsInput`; every other notification (the idle waiting reminder, completion, generic attention) resolves to `.idle` so the agent stays hibernation-eligible.

This affects hibernation eligibility only. The user-facing notification, bell, and the "Needs input" sidebar status are unchanged (the lifecycle pipeline and the notification/status badges are separate consumers).

Split out of the broader hibernation work in https://github.com/manaflow-ai/cmux/pull/5500.

## Tests

`cmuxTests/ClaudeNotificationStatusLifecycleTests.swift`: behavior tests that run the real Claude `notification` hook and assert the emitted `set_agent_lifecycle` — a waiting message sets `idle`, a permission message keeps `needsInput`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784806894&installation_id=133855650&pr_number=6694&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6694&signature=4f0622b00636d819ae5be61c6f2a9dbfba43523b05caa138990730b4a1064e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent hibernation lifecycle wiring for Claude notifications; misclassification could leave panes hibernating during real prompts or stay live when idle, though blocking detection is conservative and tests exercise key paths.
> 
> **Overview**
> Fixes Claude panes staying **non-hibernatable** because every `Notification` hook used to force **`needsInput`**, overwriting the Stop hook’s **`.idle`** after routine “waiting for your input” reminders.
> 
> The notification path now classifies messages with **`isBlocking`** (permission/approval/error cues via `claudeNotificationIsBlockingPrompt`). **Only blocking** notifications upsert **`needsInput`** and call **`set_agent_lifecycle`**; otherwise **`agentLifecycle` is `nil`** so stored lifecycle is preserved and live mutation is skipped. User-facing notify/status behavior is unchanged.
> 
> Saved-body reuse for generic “needs your attention/input” text still swaps subtitle/body only and keeps the fresh blocking flag. Tests in **`ClaudeNotificationStatusLifecycleTests`** cover plain waiting (no lifecycle command), permission (needsInput), never forcing idle from text, and deferred blocking with seeded session state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f422031af1547201db20365c10c616dfeb2e4f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only blocking Claude notifications now assert needsInput; routine waiting reminders no longer change lifecycle so the Stop hook’s idle persists and panes can hibernate. User-facing notifications and badges are unchanged; refreshed file-length budget for `CLI/cmux.swift` to keep CI green.

- **Bug Fixes**
  - Assert `.needsInput` only for permission/approval/error cues; otherwise skip lifecycle mutation (`set_agent_lifecycle` and session upsert use `nil` to preserve the stored value). Saved-body reuse keeps the fresh classification and only reuses subtitle/body.
  - Tests cover: plain waiting emits no lifecycle command; permission sets needsInput; no notification text ever forces idle; deferred blocking “waiting” notifications do not downgrade a recorded needsInput.

<sup>Written for commit f422031af1547201db20365c10c616dfeb2e4f3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude notification handling so the agent’s lifecycle is classified more accurately between “needs your input” and “idle/waiting,” including correct handling of approval/error cues and blocking state.
  * Updated notification processing to reuse the right previously displayed content when appropriate, while keeping lifecycle consistent with the latest classification.

* **Tests**
  * Added comprehensive test coverage for Claude notification lifecycle classification scenarios, including edge cases around idle cues, permission-like messages, and seeded blocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->