### PR TITLE
iOS: make Computers searchable

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -29,6 +29,8 @@ struct DeviceTreeView: View {
 
     /// The computer pending a remove confirmation.
     @State private var pendingRemoval: MacComputerSnapshot?
+    /// Session-local search for narrowing the Computers management list.
+    @State private var searchText = ""
 
     /// The user's computers as immutable snapshots, sourced from the paired-Mac
     /// backup (`pairedMacs`) — this feature's source of truth, the same set that
@@ -64,14 +66,21 @@ struct DeviceTreeView: View {
         }
     }
 
+    private var filteredComputers: [MacComputerSnapshot] {
+        computers.filter { $0.matchesSearchQuery(searchText) }
+    }
+
     var body: some View {
         NavigationStack {
             List {
+                addComputerSection
                 if computers.isEmpty {
                     emptySection
+                } else if filteredComputers.isEmpty {
+                    noSearchResultsSection
                 } else {
                     Section {
-                        ForEach(computers) { computer in
+                        ForEach(filteredComputers) { computer in
                             NavigationLink(value: computer.deviceId) {
                                 MacComputerRow(computer: computer)
                             }
@@ -96,12 +105,15 @@ struct DeviceTreeView: View {
             }
             .navigationTitle(L10n.string("mobile.computers.title", defaultValue: "Computers"))
             .navigationBarTitleDisplayMode(.inline)
+            .searchable(
+                text: $searchText,
+                prompt: Text(L10n.string("mobile.computers.searchPrompt", defaultValue: "Search computers"))
+            )
             .toolbar {
                 if showAddDevice != nil {
                     ToolbarItem(placement: .topBarLeading) {
                         Button {
                             showAddDevice?()
-                            dismiss()
                         } label: {
                             Image(systemName: "plus")
                         }
@@ -177,11 +189,39 @@ struct DeviceTreeView: View {
     }
 
     @ViewBuilder
+    private var addComputerSection: some View {
+        if showAddDevice != nil {
+            Section {
+                Button {
+                    showAddDevice?()
+                } label: {
+                    Label(
+                        L10n.string("mobile.computers.add", defaultValue: "Add Computer"),
+                        systemImage: "plus"
+                    )
+                }
+                .accessibilityIdentifier("MobileComputersAddRowButton")
+            }
+        }
+    }
+
+    @ViewBuilder
     private var emptySection: some View {
         Section {
             Text(L10n.string(
                 "mobile.computers.empty",
                 defaultValue: "No computers yet. Add one to see its workspaces here."
+            ))
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var noSearchResultsSection: some View {
+        Section {
+            Text(L10n.string(
+                "mobile.computers.searchEmpty",
+                defaultValue: "No computers match your search."
             ))
             .foregroundStyle(.secondary)
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Search.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Search.swift
@@ -1,0 +1,54 @@
+import Foundation
+import CmuxMobileShellModel
+
+extension MacComputerSnapshot {
+    /// Returns whether this computer should remain visible for a Computers-screen
+    /// search query. Keep this value-only so the list rows stay below the
+    /// snapshot boundary without reaching back into the shell store.
+    func matchesSearchQuery(_ rawQuery: String) -> Bool {
+        let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return true }
+
+        return searchableTextFields.contains { field in
+            field.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    private var searchableTextFields: [String] {
+        [
+            title,
+            deviceId,
+            platform,
+            customColor,
+            customIcon,
+            buildLabel,
+            routeDescription,
+            connectionStatus?.searchToken,
+            presence?.searchToken,
+        ].compactMap { $0 }
+    }
+}
+
+private extension MobileMacConnectionStatus {
+    var searchToken: String {
+        switch self {
+        case .connected:
+            return "connected"
+        case .reconnecting:
+            return "reconnecting"
+        case .unavailable:
+            return "unavailable"
+        }
+    }
+}
+
+private extension DeviceTreePresence {
+    var searchToken: String {
+        switch self {
+        case .online:
+            return "online"
+        case .offline:
+            return "offline"
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -94,6 +94,7 @@ struct WorkspaceListView: View {
     @State private var showingShortcutsSettings = false
     @State private var showingSettings = false
     @State private var showingDeviceTree = false
+    @State private var shouldShowAddDeviceAfterDeviceTreeDismiss = false
     /// The active row filter (All / Unread), shared-model state behind the
     /// toolbar ``WorkspaceListFilterMenu``. Session-transient like a search.
     @State private var filter: MobileWorkspaceListFilter = .all
@@ -265,8 +266,17 @@ struct WorkspaceListView: View {
         // leaving a parent sheet covering it.
         .sheet(isPresented: $showingDeviceTree) {
             if let store {
-                DeviceTreeView(store: store, selectWorkspace: selectWorkspace, showAddDevice: showAddDevice)
+                DeviceTreeView(
+                    store: store,
+                    selectWorkspace: selectWorkspace,
+                    showAddDevice: showAddDevice.map { _ in requestAddDeviceFromDeviceTree }
+                )
             }
+        }
+        .onChange(of: showingDeviceTree) { _, isPresented in
+            guard !isPresented, shouldShowAddDeviceAfterDeviceTreeDismiss else { return }
+            shouldShowAddDeviceAfterDeviceTreeDismiss = false
+            showAddDevice?()
         }
         #endif
     }
@@ -293,6 +303,12 @@ struct WorkspaceListView: View {
         .accessibilityIdentifier("MobileWorkspaceDevicesButton")
     }
     #endif
+
+    private func requestAddDeviceFromDeviceTree() {
+        guard showAddDevice != nil else { return }
+        shouldShowAddDeviceAfterDeviceTreeDismiss = true
+        showingDeviceTree = false
+    }
 
     /// Flat presentation: a pinned-first list with no group headers. Used when the
     /// Mac has no groups (or lacks the capability) or while searching.

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MacComputerSearchTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MacComputerSearchTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import CmuxMobileShellModel
+import Testing
+@testable import CmuxMobileShellUI
+
+@Suite struct MacComputerSearchTests {
+    @Test func matchesIdentityRouteBuildAndStatusFields() {
+        let computer = makeComputer(
+            deviceId: "mac-mini-42",
+            title: "Kitchen Studio",
+            connectionStatus: .connected,
+            presence: .online,
+            buildLabel: "DEV ioscs",
+            routeDescription: "tailscale.local:17320"
+        )
+
+        #expect(computer.matchesSearchQuery("kitchen"))
+        #expect(computer.matchesSearchQuery("MINI-42"))
+        #expect(computer.matchesSearchQuery("ioscs"))
+        #expect(computer.matchesSearchQuery("tailscale"))
+        #expect(computer.matchesSearchQuery("connected"))
+        #expect(computer.matchesSearchQuery("online"))
+    }
+
+    @Test func rejectsUnmatchedQueryAndTreatsBlankQueryAsVisible() {
+        let computer = makeComputer(
+            deviceId: "work-mac",
+            title: "Desk Mac",
+            connectionStatus: .unavailable,
+            presence: .offline(lastSeenAt: Date(timeIntervalSince1970: 0)),
+            buildLabel: nil,
+            routeDescription: nil
+        )
+
+        #expect(computer.matchesSearchQuery("   "))
+        #expect(!computer.matchesSearchQuery("laptop"))
+    }
+
+    private func makeComputer(
+        deviceId: String,
+        title: String,
+        connectionStatus: MobileMacConnectionStatus?,
+        presence: DeviceTreePresence?,
+        buildLabel: String?,
+        routeDescription: String?
+    ) -> MacComputerSnapshot {
+        MacComputerSnapshot(
+            deviceId: deviceId,
+            title: title,
+            platform: "mac",
+            colorIndex: 1,
+            customColor: "blue",
+            customIcon: "desktopcomputer",
+            connectionStatus: connectionStatus,
+            presence: presence,
+            buildLabel: buildLabel,
+            routeDescription: routeDescription,
+            lastSeenAt: Date(timeIntervalSince1970: 0),
+            workspaceCount: 3
+        )
+    }
+}

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1106,6 +1106,40 @@
         }
       }
     },
+    "mobile.computers.searchEmpty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No computers match your search."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索に一致するコンピュータがありません。"
+          }
+        }
+      }
+    },
+    "mobile.computers.searchPrompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search computers"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンピュータを検索"
+          }
+        }
+      }
+    },
     "mobile.computers.field.build": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary
- add search to the iOS Computers screen using a value-only MacComputerSnapshot predicate
- add an Add Computer row inside Computers that reuses the existing root pairing flow
- localize the new search prompt and empty state

## Verification
- swift build --sdk "$SDK" --triple arm64-apple-ios18.0-simulator in Packages/iOS/CmuxMobileShellUI
- swift build --build-tests --sdk "$SDK" --triple arm64-apple-ios18.0-simulator in Packages/iOS/CmuxMobileShellUI
- ./scripts/lint-ios-package-conventions.sh
- git diff --check
- macOS tag ioscs reloaded, simulator tag ioscs reloaded, iPhone tag ioscs installed and launched

## Dogfood
Tag: ioscs
Mac: http://127.0.0.1:17320/ioscs
iOS bundle: dev.cmux.ios.ioscs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784811795&installation_id=133855650&pr_number=6701&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6701&signature=3d6b9002414376d49b24db9e71aa04af87a413dc455ccf12cc723f7acf05185e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only iOS shell changes with localized strings and unit-tested search logic; pairing flow timing is slightly adjusted but reuses existing callbacks.
> 
> **Overview**
> Adds **search** to the iOS **Computers** management sheet so users can narrow paired Macs by name, device id, route, build label, and connection/presence-style tokens, with a dedicated empty-search state and localized prompt strings.
> 
> Filtering uses a new value-only `MacComputerSnapshot.matchesSearchQuery` helper (plus unit tests) so list rows stay on snapshot data without touching the shell store.
> 
> The Computers list also gains an **Add Computer** row (alongside the existing toolbar **+**), both wired into the root pairing flow. **WorkspaceListView** dismisses the Computers sheet first, then presents add-device, avoiding nested-sheet issues; the toolbar **+** no longer dismisses Computers immediately when tapped from that sheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e42d7c587e43bed36b939a68e3ebe314eaf685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds search to the iOS Computers screen and an inline “Add Computer” row. Search is case-insensitive, fast, and localized, improving discoverability.

- **New Features**
  - Search bar filters computers using a value-only predicate on `MacComputerSnapshot`; matches name, device ID, route, build, connection status, and presence; blank query shows all; “no results” message shown.
  - Added “Add Computer” row (plus icon) when pairing is available; reuses the existing pairing flow and dismisses the Computers sheet before presenting pairing.
  - Localized search prompt and empty-state (en/ja).
  - New tests (`MacComputerSearchTests`) cover matching and blank-query behavior.

<sup>Written for commit e0e42d7c587e43bed36b939a68e3ebe314eaf685. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

