### PR TITLE
Fix stale diff viewer localhost URLs

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1286,7 +1286,7 @@ func browserIsTemporaryHistoryURL(_ url: URL?) -> Bool {
     if url.scheme?.lowercased() == CmuxDiffViewerURLSchemeHandler.scheme {
         return true
     }
-    guard url.fragment == "cmux-diff-viewer",
+    guard (url.fragment == "cmux-diff-viewer" || url.fragment == "/cmux-diff-viewer"),
           url.scheme?.lowercased() == "http",
           let host = url.host else {
         return false
@@ -2355,10 +2355,6 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
         }
     }
 
-    /// Loads the registered files for a token's on-disk manifest, or `nil` when
-    /// the manifest is missing, empty, or references remote patch entries
-    /// (`remote_url` / empty `file_path`) that the local-file scheme handler
-    /// cannot serve. Streamed remote PR diffs fall into the latter case.
     private func localManifestFiles(token: String) -> [RegisteredFile]? {
         guard Self.isValidToken(token) else { return nil }
         let manifestURL = trustedRootURL.appendingPathComponent(".manifest-\(token).json", isDirectory: false)
@@ -2380,13 +2376,6 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
         return files
     }
 
-    /// Whether a diff viewer surface can be restored through the custom scheme.
-    /// Requires a local-only manifest and an entry page that is neither a
-    /// pending placeholder nor a redirect stub. Pending pages poll a
-    /// deferred-load wait endpoint, and redirect pages bounce to the original
-    /// `http://127.0.0.1:<port>` URL; both only work against the local HTTP
-    /// server, which is gone after restart, so they would fail under the
-    /// custom scheme.
     func diffViewerRestorable(token: String, requestPath: String) -> Bool {
         guard let files = localManifestFiles(token: token),
               let entry = files.first(where: { $0.requestPath == requestPath }),
@@ -2402,9 +2391,15 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
         return true
     }
 
-    /// Extracts the diff viewer `(token, requestPath)` from a live diff viewer
-    /// URL, accepting both the custom scheme (`cmux-diff-viewer://<token>/<path>`)
-    /// and the local HTTP server form (`http://127.0.0.1:<port>/<token>/<path>#cmux-diff-viewer`).
+    func restorableSchemeURL(for url: URL?) -> URL? {
+        guard let components = Self.diffViewerComponents(from: url),
+              diffViewerRestorable(token: components.token, requestPath: components.requestPath),
+              registerFromManifest(token: components.token) else {
+            return nil
+        }
+        return Self.diffViewerURL(token: components.token, requestPath: components.requestPath)
+    }
+
     static func diffViewerComponents(from url: URL?) -> (token: String, requestPath: String)? {
         guard let url else { return nil }
         if url.scheme == scheme, let token = url.host, isValidToken(token) {
@@ -2413,7 +2408,7 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
         }
         if (url.scheme == "http" || url.scheme == "https"),
            url.host == "127.0.0.1",
-           url.fragment == Self.scheme {
+           (url.fragment == Self.scheme || url.fragment == "/\(Self.scheme)") {
             let rawPath = URLComponents(url: url, resolvingAgainstBaseURL: false)?.percentEncodedPath ?? url.path
             let parts = rawPath.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
             guard parts.count >= 2, isValidToken(parts[0]) else { return nil }
@@ -2424,9 +2419,6 @@ final class CmuxDiffViewerURLSchemeHandler: NSObject, WKURLSchemeHandler {
         return nil
     }
 
-    /// Builds the app-owned custom-scheme URL used to restore a diff viewer
-    /// surface, decoupled from the local HTTP server. No fragment, so
-    /// `registeredFile(for:)` serves it.
     static func diffViewerURL(token: String, requestPath: String) -> URL? {
         guard isValidToken(token), isValidRequestPath(requestPath) else { return nil }
         var components = URLComponents()
@@ -3793,7 +3785,8 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         navigationDelegate.didFailNavigation = { [weak self] failedWebView, failedURL in
             MainActor.assumeIsolated {
-                guard let self, self.isCurrentWebView(failedWebView, instanceID: boundWebViewInstanceID) else { return }
+                guard let self, self.isCurrentWebView(failedWebView, instanceID: boundWebViewInstanceID) else { return false }
+                if self.recoverFailedDiffViewerNavigation(failedURL: failedURL, in: failedWebView) { return true }
                 self.isMainFrameProvisionalNavigationActive = false
                 if let url = URL(string: failedURL) {
                     self.currentURL = Self.remoteProxyDisplayURL(for: url) ?? url
@@ -3806,6 +3799,7 @@ final class BrowserPanel: Panel, ObservableObject {
                 self.applyMuteState(to: failedWebView, reason: "navigationFail")
                 // Keep find-in-page open and clear stale counters on failed loads.
                 self.restoreFindStateAfterNavigation(replaySearch: false)
+                return false
             }
         }
         navigationDelegate.didCancelProvisionalNavigation = { [weak self] webView in
@@ -3816,6 +3810,16 @@ final class BrowserPanel: Panel, ObservableObject {
                 self.refreshBackgroundAppearance()
             }
         }
+    }
+
+    private func recoverFailedDiffViewerNavigation(failedURL: String, in webView: WKWebView) -> Bool {
+        guard let recoveredURL = CmuxDiffViewerURLSchemeHandler.shared.restorableSchemeURL(for: URL(string: failedURL)) else { return false }
+        isMainFrameProvisionalNavigationActive = false
+        currentURL = recoveredURL
+        navigationDelegate?.lastAttemptedURL = recoveredURL
+        refreshBackgroundAppearance()
+        webView.load(URLRequest(url: recoveredURL))
+        return true
     }
 
     private func publishCommittedURL(from webView: WKWebView) {
@@ -4536,7 +4540,7 @@ final class BrowserPanel: Panel, ObservableObject {
             return
         }
 
-        let restoredURL = Self.sanitizedSessionHistoryURL(snapshot.urlString)
+        let restoredURL = snapshot.urlString.flatMap { CmuxDiffViewerURLSchemeHandler.shared.restorableSchemeURL(for: URL(string: $0)) } ?? Self.sanitizedSessionHistoryURL(snapshot.urlString)
         let shouldRenderRestoredWebView = snapshot.shouldRenderWebView && BrowserAvailabilitySettings.isEnabled()
         hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(snapshot.shouldRenderWebView)
         setMuted(snapshot.isMuted)
@@ -5618,11 +5622,14 @@ final class BrowserPanel: Panel, ObservableObject {
         if !preserveRestoredSessionHistory {
             abandonRestoredSessionHistoryIfNeeded()
         }
-        let effectiveRequest = remoteProxyPreparedRequest(from: request, logScope: "rewrite")
+        let loadURL = CmuxDiffViewerURLSchemeHandler.shared.restorableSchemeURL(for: originalURL) ?? originalURL
+        var loadRequest = request
+        if loadURL != originalURL { loadRequest.url = loadURL; currentURL = loadURL }
+        let effectiveRequest = remoteProxyPreparedRequest(from: loadRequest, logScope: "rewrite")
         // Some installs can end up with a legacy Chrome UA override; keep this pinned.
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
         hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
-        navigationDelegate?.lastAttemptedURL = originalURL
+        navigationDelegate?.lastAttemptedURL = loadURL
         refreshBackgroundAppearance()
         shouldRenderWebView = true
         if shouldPreloadInitialNavigationInBackground {
@@ -5630,7 +5637,7 @@ final class BrowserPanel: Panel, ObservableObject {
             ensureBackgroundPreloadHostIfNeeded(reason: "initial-navigation")
         }
         if recordTypedNavigation {
-            historyStore.recordTypedNavigation(url: originalURL)
+            historyStore.recordTypedNavigation(url: loadURL)
         }
         browserLoadRequest(effectiveRequest, in: webView)
     }
@@ -8583,7 +8590,7 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
     var didStartProvisionalNavigation: ((WKWebView) -> Void)?
     var didCommit: ((WKWebView) -> Void)?
     var didFinish: ((WKWebView) -> Void)?
-    var didFailNavigation: ((WKWebView, String) -> Void)?
+    var didFailNavigation: ((WKWebView, String) -> Bool)?
     var didCancelProvisionalNavigation: ((WKWebView) -> Void)?
     var didTerminateWebContentProcess: ((WKWebView) -> Void)?
     var openInNewTab: ((URL) -> Void)?
@@ -8615,7 +8622,7 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
         // Treat committed-navigation failures the same as provisional ones so
         // stale favicon/title state from the prior page gets cleared.
         let failedURL = webView.url?.absoluteString ?? ""
-        didFailNavigation?(webView, failedURL)
+        _ = didFailNavigation?(webView, failedURL)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
@@ -8639,7 +8646,9 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
         let failedURL = nsError.userInfo[NSURLErrorFailingURLStringErrorKey] as? String
             ?? lastAttemptedURL?.absoluteString
             ?? ""
-        didFailNavigation?(webView, failedURL)
+        if didFailNavigation?(webView, failedURL) == true {
+            return
+        }
         loadErrorPage(in: webView, failedURL: failedURL, error: nsError)
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6054,6 +6054,7 @@ class TerminalController {
         if let error = v2RegisterDiffViewerURLIfNeeded(params: params, url: url) {
             return error
         }
+        let browserURL = CmuxDiffViewerURLSchemeHandler.shared.restorableSchemeURL(for: url) ?? url
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create browser", data: nil)
         v2MainSync {
@@ -6061,14 +6062,14 @@ class TerminalController {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
             }
-            if let url,
+            if let browserURL,
                respectExternalOpenRules,
-               BrowserLinkOpenSettings.shouldOpenExternally(url) {
-                guard NSWorkspace.shared.open(url) else {
+               BrowserLinkOpenSettings.shouldOpenExternally(browserURL) {
+                guard NSWorkspace.shared.open(browserURL) else {
                     result = .err(
                         code: "external_open_failed",
                         message: "Failed to open URL externally",
-                        data: ["url": url.absoluteString]
+                        data: ["url": browserURL.absoluteString]
                     )
                     return
                 }
@@ -6085,7 +6086,7 @@ class TerminalController {
                     "created_split": false,
                     "placement_strategy": "external",
                     "opened_externally": true,
-                    "url": url.absoluteString
+                    "url": browserURL.absoluteString
                 ])
                 return
             }
@@ -6106,7 +6107,7 @@ class TerminalController {
             let focus = v2FocusAllowed(requested: v2Bool(params, "focus") ?? false)
             let omnibarVisible = v2Bool(params, "show_omnibar") ?? true
             let transparentBackground = v2Bool(params, "transparent_background") ?? false
-            let bypassRemoteProxy = v2Bool(params, "bypass_remote_proxy") ?? v2IsDiffViewerURL(url)
+            let bypassRemoteProxy = v2Bool(params, "bypass_remote_proxy") ?? v2IsDiffViewerURL(browserURL)
 
             var createdSplit = true
             var placementStrategy = "split_right"
@@ -6114,7 +6115,7 @@ class TerminalController {
             if let targetPane = ws.preferredRightSideTargetPane(fromPanelId: sourceSurfaceId) {
                 createdPanel = ws.newBrowserSurface(
                     inPane: targetPane,
-                    url: url,
+                    url: browserURL,
                     focus: focus,
                     selectWhenNotFocused: true,
                     creationPolicy: .automationPreload,
@@ -6128,7 +6129,7 @@ class TerminalController {
                 createdPanel = ws.newBrowserSplit(
                     from: sourceSurfaceId,
                     orientation: .horizontal,
-                    url: url,
+                    url: browserURL,
                     focus: focus,
                     creationPolicy: .automationPreload,
                     omnibarVisible: omnibarVisible,
@@ -6163,7 +6164,8 @@ class TerminalController {
                 "placement_strategy": placementStrategy,
                 "show_omnibar": createdPanel?.isOmnibarVisible ?? omnibarVisible,
                 "transparent_background": transparentBackground,
-                "bypass_remote_proxy": bypassRemoteProxy
+                "bypass_remote_proxy": bypassRemoteProxy,
+                "url": v2OrNull(browserURL?.absoluteString)
             ])
         }
         return result
@@ -6174,9 +6176,7 @@ class TerminalController {
         if url.scheme?.lowercased() == CmuxDiffViewerURLSchemeHandler.scheme {
             return true
         }
-        return url.scheme?.lowercased() == "http" &&
-            url.host == "127.0.0.1" &&
-            url.fragment == "cmux-diff-viewer"
+        return CmuxDiffViewerURLSchemeHandler.diffViewerComponents(from: url) != nil
     }
 
     private func v2RegisterDiffViewerURLIfNeeded(params: [String: Any], url: URL?) -> V2CallResult? {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		A500MX01 /* BrowserPanel+MediaPlayback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500MX00 /* BrowserPanel+MediaPlayback.swift */; };
 		D7AB00000000000000000007 /* BrowserPanel+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */; };
 		A5001402 /* BrowserPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001412 /* BrowserPanel.swift */; };
+		DFD1FF001782223300000002 /* BrowserPanelDiffViewerRehydrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD1FF001782223300000001 /* BrowserPanelDiffViewerRehydrationTests.swift */; };
 		C62530010000000000000001 /* BrowserPanelReloadMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62530010000000000000002 /* BrowserPanelReloadMode.swift */; };
 		B65060010000000000000002 /* BrowserPanelSessionRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65060010000000000000001 /* BrowserPanelSessionRestoreTests.swift */; };
 		1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */; };
@@ -1258,6 +1259,7 @@
 		A500MX00 /* BrowserPanel+MediaPlayback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+MediaPlayback.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		A5001412 /* BrowserPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPanel.swift; sourceTree = "<group>"; };
+		DFD1FF001782223300000001 /* BrowserPanelDiffViewerRehydrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPanelDiffViewerRehydrationTests.swift; sourceTree = "<group>"; };
 		C62530010000000000000002 /* BrowserPanelReloadMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPanelReloadMode.swift; sourceTree = "<group>"; };
 		B65060010000000000000001 /* BrowserPanelSessionRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPanelSessionRestoreTests.swift; sourceTree = "<group>"; };
 		58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPanelTests.swift; sourceTree = "<group>"; };
@@ -3129,6 +3131,7 @@
 				D3622101A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift */,
 				B65060010000000000000001 /* BrowserPanelSessionRestoreTests.swift */,
 				B6585002B6585002B6585002 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift */,
+				DFD1FF001782223300000001 /* BrowserPanelDiffViewerRehydrationTests.swift */,
 				58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */,
 				C0DE62600000000000000002 /* BrowserWindowPortalRegistryNotificationTests.swift */,
 				19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */,
@@ -4496,6 +4499,7 @@
 				BCBC0A0E0000000000000E21 /* BrowserMediaPlaybackAudioActivityTests.swift in Sources */,
 				C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */,
 				D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */,
+				DFD1FF001782223300000002 /* BrowserPanelDiffViewerRehydrationTests.swift in Sources */,
 				B65060010000000000000002 /* BrowserPanelSessionRestoreTests.swift in Sources */,
 				1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */,
 				C7B800062D4202A13C962D2D /* BrowserSystemProxyMirrorTests.swift in Sources */,

--- a/cmuxTests/BrowserPanelDiffViewerRehydrationTests.swift
+++ b/cmuxTests/BrowserPanelDiffViewerRehydrationTests.swift
@@ -1,0 +1,45 @@
+import Darwin
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite(.serialized)
+struct BrowserPanelDiffViewerRehydrationTests {
+    @Test func routerHTTPURLIsTemporaryHistoryURL() throws {
+        let url = try #require(URL(string: "http://127.0.0.1:49152/token/diff.html#/cmux-diff-viewer"))
+        #expect(browserIsTemporaryHistoryURL(url))
+    }
+
+    @Test func completedHTTPURLRehydratesToSchemeURLFromManifest() throws {
+        let token = UUID().uuidString.lowercased()
+        let rootURL = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("cmux-diff-viewer-\(Darwin.getuid())", isDirectory: true)
+        let htmlURL = rootURL.appendingPathComponent("diff-\(token).html", isDirectory: false)
+        let manifestURL = rootURL.appendingPathComponent(".manifest-\(token).json", isDirectory: false)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: htmlURL)
+            try? FileManager.default.removeItem(at: manifestURL)
+        }
+
+        try "<!doctype html><html><body>ready diff</body></html>".write(to: htmlURL, atomically: true, encoding: .utf8)
+        let files = [["request_path": "/\(htmlURL.lastPathComponent)", "file_path": htmlURL.path, "mime_type": "text/html"]]
+        try JSONSerialization.data(withJSONObject: ["token": token, "files": files], options: [.sortedKeys])
+            .write(to: manifestURL, options: .atomic)
+
+        for fragment in ["cmux-diff-viewer", "/cmux-diff-viewer"] {
+            let staleURL = try #require(URL(string: "http://127.0.0.1:49152/\(token)/\(htmlURL.lastPathComponent)#\(fragment)"))
+            let rehydratedURL = try #require(CmuxDiffViewerURLSchemeHandler.shared.restorableSchemeURL(for: staleURL))
+            #expect(rehydratedURL.scheme == CmuxDiffViewerURLSchemeHandler.scheme)
+            #expect(rehydratedURL.host == token)
+            #expect(rehydratedURL.path == "/\(htmlURL.lastPathComponent)")
+            #expect(CmuxDiffViewerURLSchemeHandler.shared.registeredFile(for: rehydratedURL) != nil)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- rehydrate completed local diff-viewer localhost URLs to the durable cmux-diff-viewer scheme before opening browser surfaces
- recover restorable stale diff-viewer navigations instead of showing WebKit connection errors
- add Swift Testing coverage for browser.open_split URL rehydration

## Tests
- git diff --check origin/main..HEAD
- ./scripts/lint-pbxproj-test-wiring.sh
- python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv
- /Users/lawrence/fun/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- ./scripts/reload-cloud.sh --tag dfurl

## Dogfood
Open a diff viewer in the tagged build, then confirm it uses a cmux-diff-viewer:// URL and does not become a dead 127.0.0.1 tab when the helper server is unavailable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784812785&installation_id=133855650&pr_number=6702&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6702&signature=74170eb49ae26bf0251fc1cbed137ceef4cd33b7dc3bba1ddfe9faed28c397ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WKWebView navigation failure handling and session restore URL rewriting; behavior is gated on local manifest restorability, but incorrect matching could change which URLs load or recover.
> 
> **Overview**
> Completed diff viewer tabs that still point at **`http://127.0.0.1:…`** (including fragments **`#cmux-diff-viewer`** and **`#/cmux-diff-viewer`**) are now upgraded to durable **`cmux-diff-viewer://`** URLs when a local manifest can serve the page, instead of failing once the ephemeral helper server is gone.
> 
> **`restorableSchemeURL(for:)`** centralizes parsing, restorability checks, manifest registration, and scheme URL construction. **BrowserPanel** uses it on load, session restore, and on provisional navigation failure (via **`recoverFailedDiffViewerNavigation`**, which skips the WebKit error page when recovery succeeds). **`browser.open_split`** rehydrates before opening splits and returns the resolved URL in the RPC result. **`v2IsDiffViewerURL`** now delegates to **`diffViewerComponents`**.
> 
> New **`BrowserPanelDiffViewerRehydrationTests`** cover temporary-history detection and manifest-based rehydration for both fragment forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d2e24055b40949719a121d76c897dab35649b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale diff viewer tabs by rehydrating `127.0.0.1` URLs to `cmux-diff-viewer://` and auto-recovering failed loads to avoid WebKit errors. Also rehydrates during session restore and initial navigations; `browser.open_split` prefers and returns the restorable scheme URL.

- **Bug Fixes**
  - Browser: on navigation failure, recover restorable diff viewer loads and suppress the error page; rehydrate URLs during session restore and initial loads.
  - Diff viewer handler: `restorableSchemeURL(for:)` validates against local manifests, registers files, and builds the durable URL; accepts both `#cmux-diff-viewer` and `#/cmux-diff-viewer` fragments.
  - Terminal controller: rehydrate the input URL before opening, apply external-open rules using it, include it in the JSON-RPC result, and detect diff viewers via `diffViewerComponents`.
  - Tests: add `BrowserPanelDiffViewerRehydrationTests` and project wiring to cover temporary-history detection and URL rehydration.

<sup>Written for commit a6d2e24055b40949719a121d76c897dab35649b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic diff-viewer recovery that attempts to restore sessions when navigation fails, improving reliability of diff-viewer workflows
  * Implemented custom URL scheme support for persistent diff-viewer state
  * Enhanced navigation handling to recognize multiple diff-viewer URL formats

* **Tests**
  * Added comprehensive test coverage for diff-viewer rehydration and recovery scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->