### PR TITLE
Security hardening: device-token ownership guard + 9 defense-in-depth fixes

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20416,10 +20416,12 @@ struct CMUXCLI {
             "--max-auto-depth",
             String(Self.codexTeamsMaxAutoDepth)
         ]
-        if let explicitPassword,
-           !explicitPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            watcherArguments.insert(contentsOf: ["--password", explicitPassword], at: 2)
-        }
+        // The socket password is handed to the watcher through its environment
+        // (CMUX_SOCKET_PASSWORD is set in launcherEnvironment above), not through
+        // argv. A `--password` argument would be visible to any local user via
+        // `ps`/proc_info; the watcher's SocketPasswordResolver reads the env var
+        // (falling back to the password file/keychain) when no explicit value is
+        // passed, so removing the argv copy does not change auth behavior.
         if let rootPid = rootCodex?.processIdentifier {
             watcherArguments += ["--owner-pid", String(rootPid)]
         }

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FileStackTokenStore.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FileStackTokenStore.swift
@@ -9,6 +9,13 @@ public import Foundation
 /// builds don't have). Atomic writes so a kill-during-reload can't drop the
 /// refresh token.
 ///
+/// Disk persistence is DEBUG-only. In Release builds the in-memory cache is
+/// still updated (so a Keychain failure does not drop the session mid-launch)
+/// but nothing is written to disk, so a live refresh token is never left in an
+/// unencrypted `credentials.json` on a real user's machine. A genuine Keychain
+/// failure in Release therefore surfaces as a re-auth on the next launch
+/// rather than a silent plaintext fallback.
+///
 /// ```swift
 /// let store = FileStackTokenStore(directory: appSupport
 ///     .appendingPathComponent("cmux", isDirectory: true)
@@ -93,6 +100,7 @@ public actor FileStackTokenStore: StackAuthTokenStoreProtocol {
     }
 
     private func readFromDisk() -> Snapshot {
+        #if DEBUG
         let fm = FileManager.default
         guard fm.fileExists(atPath: fileURL.path) else { return Snapshot() }
         do {
@@ -103,10 +111,19 @@ public actor FileStackTokenStore: StackAuthTokenStoreProtocol {
             log.log("credentials read failed: \(error)")
             return Snapshot()
         }
+        #else
+        // Release never loads auth tokens from an unencrypted file. If a stale
+        // credentials.json is present (left by an older Debug build or a prior
+        // Release that wrote one), remove it so the plaintext does not persist
+        // and is not loaded later.
+        try? FileManager.default.removeItem(at: fileURL)
+        return Snapshot()
+        #endif
     }
 
     private func write(_ snapshot: Snapshot) {
         cache = snapshot
+        #if DEBUG
         let fm = FileManager.default
         let dir = fileURL.deletingLastPathComponent()
         do {
@@ -121,5 +138,11 @@ public actor FileStackTokenStore: StackAuthTokenStoreProtocol {
         } catch {
             log.log("credentials write failed: \(error)")
         }
+        #else
+        // Release: never persist auth tokens to an unencrypted file. The
+        // in-memory cache above keeps the current session working; the next
+        // launch re-uses Keychain (or surfaces the hard failure as re-auth).
+        log.log("file token write skipped in Release (no plaintext fallback)")
+        #endif
     }
 }

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/KeychainStackTokenStore.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/KeychainStackTokenStore.swift
@@ -147,17 +147,22 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
     private func keychainWrite(_ value: String, account: String) -> Bool {
         guard let data = value.data(using: .utf8) else { return false }
         let lookup = baseQuery(account: account)
-        let updateStatus = SecItemUpdate(
-            lookup as CFDictionary,
-            [kSecValueData as String: data] as CFDictionary
-        )
-        if updateStatus == errSecSuccess { return true }
-        if updateStatus != errSecItemNotFound {
-            log.log("keychain UPDATE status=\(updateStatus) account=\(account)")
-        }
+        // Delete any existing item first, then insert fresh. SecItemUpdate cannot
+        // reliably change `kSecAttrAccessible` on an existing item, so an item a
+        // prior build wrote with the syncable `AfterFirstUnlock` class would keep
+        // its old accessibility on update. Delete-then-add guarantees the
+        // device-only accessibility is applied on every write, migrating existing
+        // users on their next token refresh. Writes are infrequent, so the churn
+        // is acceptable.
+        SecItemDelete(lookup as CFDictionary)
         var insert = lookup
         insert[kSecValueData as String] = data
-        insert[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        // Device-only: long-lived OAuth refresh tokens must not be eligible for
+        // iCloud Keychain restore onto another device. `AfterFirstUnlock` is kept
+        // (rather than `WhenUnlocked`) so background token refresh and session
+        // resume while the screen is locked keep working; only the `*ThisDeviceOnly`
+        // suffix changes from the previous setting, removing the sync vector.
+        insert[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         let addStatus = SecItemAdd(insert as CFDictionary, nil)
         if addStatus != errSecSuccess {
             log.log("keychain ADD status=\(addStatus) account=\(account)")

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1260,15 +1260,18 @@ enum SurfaceResumeApprovalStore {
             kSecAttrAccount as String: keychainAccount,
             kSecUseDataProtectionKeychain as String: true,
         ]
-        let updateStatus = SecItemUpdate(
-            query as CFDictionary,
-            [kSecValueData as String: secret] as CFDictionary
-        )
-        if updateStatus == errSecSuccess { return true }
-        if updateStatus != errSecItemNotFound { return false }
+        // Delete-then-add: SecItemUpdate cannot reliably change
+        // kSecAttrAccessible on an existing item, so delete first and re-add to
+        // guarantee the device-only accessibility is applied (migrates items a
+        // prior build wrote with the syncable class).
+        SecItemDelete(query as CFDictionary)
         var insert = query
         insert[kSecValueData as String] = secret
-        insert[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        // Device-only so the session HMAC secret is not eligible for iCloud
+        // Keychain restore. `AfterFirstUnlock` timing is preserved so session
+        // resume at cold launch (which may run before the first unlock of a
+        // freshly booted session) is unaffected.
+        insert[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         return SecItemAdd(insert as CFDictionary, nil) == errSecSuccess
     }
 #else

--- a/docs/journals/2026-06-23-security-hardening-build-env-and-redgreen.md
+++ b/docs/journals/2026-06-23-security-hardening-build-env-and-redgreen.md
@@ -1,0 +1,44 @@
+# Local app build không khả thi + two-commit red/green: cái bẫy của "test pass" giả
+
+**Date**: 2026-06-23 20:03
+**Severity**: Medium
+**Component**: local build env / regression test workflow
+**Status**: Ongoing (CI-dependent)
+
+## What Happened
+
+Hai phát hiện về workflow hơn là code:
+
+1. **Môi trường dev này không build được cmux app local**: thiếu `zig` (cần cho GhosttyKit.xcframework) và chỉ có CommandLineTools (không full Xcode → `xcodebuild` refuse). `reload.sh` abort ngay trên missing zig. Chỉ SwiftPM package `CmuxAuthRuntime` build được qua `swift build`.
+2. **Two-commit red/green policy (CLAUDE.md) thật sự có giá trị**: cho device-token hijack fix (MEDIUM), commit 1 = failing test (POST cùng token cho user thứ 2 → expect 403), commit 2 = fix. Test fail làm bug visible trong PR CI check history.
+
+## The Brutal Truth
+
+Điều đau ở đây là **"test pass" không có nghĩa là "test chạy"**. Bẫy thật sự:
+
+- DB-gated test cần `CMUX_DB_TEST=1` + Postgres chạy. Local container không start được vì chỉ có `docker compose` v2, không có `docker-compose` v1. Red/green được chứng minh structural, defer sang CI.
+- Tương tự `cmuxTests/*.swift` phải wire vào `project.pbxproj` — file nằm trong worktree mà không có `PBXFileReference` + `PBXSourcesBuildPhase` thì Xcode silently ignore, CI báo "Executed 0 tests" không phân biệt được với green thật (đã có trong CLAUDE.md pitfalls, nhưng dễ quên).
+
+## Technical Details
+
+- `swift build` package `CmuxAuthRuntime`: OK. App-target `Sources/SessionPersistence.swift`, `CLI/cmux.swift`: không compile được local.
+- Workaround: `swift build` từng package cho token-store code; app-target Swift flag là "CI-verified".
+- Device-token hijack: fix ở backend route + DB test. Web suite 143 pass, worker suite 139 pass, `next build` OK, web typecheck 0 errors.
+
+## Root Cause Analysis
+
+- Giả định "local build luôn khả năng" sai — phụ thuộc zig + full Xcode.
+- Giả định "test pass = test chạy" sai khi có gate env (`CMUX_DB_TEST`) hoặc wiring requirement (pbxproj).
+
+## Lessons Learned
+
+- Đừng assume local app build khả thi. `swift build` package riêng; flag app-target Swift là CI-verified.
+- Two-commit red/green cho bug fix: commit 1 failing test, commit 2 fix. CI check history làm bug visible.
+- DB test cần Postgres chạy + `CMUX_DB_TEST=1`. Kiểm tra `docker compose` (v2) vs `docker-compose` (v1).
+- `cmuxTests/*.swift`: verify wiring vào `project.pbxproj`, hoặc sẽ thấy "Executed 0 tests" giả-green.
+
+## Next Steps
+
+- CI verify: (a) Swift app-target build, (b) DB test red→green cho device-token với `CMUX_DB_TEST=1`. Owner: CI. Khi: pre-merge.
+- Owner: squash/rebase nhánh `security-hardening` (14 commit, history churn) trước PR.
+- Unresolved: op cần provision `CMUX_ANALYTICS_RATE_LIMIT_ID` trên Vercel Firewall.

--- a/docs/journals/2026-06-23-security-hardening-csp-next16-keychain.md
+++ b/docs/journals/2026-06-23-security-hardening-csp-next16-keychain.md
@@ -1,0 +1,42 @@
+# Next 16 CSP nonce, `proxy.ts`, và Keychain accessibility: ba bẫy không hiển nhiên
+
+**Date**: 2026-06-23 20:03
+**Severity**: Medium
+**Component**: web CSP middleware / Swift Keychain (`SessionPersistence.swift`)
+**Status**: Resolved (CSP static; Keychain fix local, CI to verify app-target)
+
+## What Happened
+
+Ba pitfall rời rặc cùng nằm trong một nhánh security-hardening, mỗi cái đều đáng một entry nhưng gộp vì chung chủ đề "API contract không hiển nhiên":
+
+1. **Next 16 đổi tên `middleware.ts` → `proxy.ts`**. Tạo `web/middleware.ts` cạnh `web/proxy.ts` có sẵn → build error "Both middleware file and proxy file detected. Please use proxy.ts only."
+2. **CSP nonce qua response header không tới `headers()`** trong server component. `headers()` trả REQUEST headers; set `response.headers.set("x-nonce", ...)` chỉ gửi về client, layout đọc `headers().get("x-nonce")` = "" → inline theme script bị chính CSP block với `nonce=""`.
+3. **`SecItemUpdate` không đổi được `kSecAttrAccessible`** cho item đã tồn tại. Migration AfterFirstUnlock → AfterFirstUnlockThisDeviceOnly chỉ áp trên nhánh `SecItemAdd`; user cũ đi nhánh `SecItemUpdate` success → không bao giờ re-add → migration không có tác dụng.
+
+## The Brutal Truth
+
+Ba bug này đều giống nhau ở bản chất: **API có hai path (request/response header; add/update; middleware/proxy) và mình đoán sai path nào áp dụng**. CSP nonce đặc biệt đau vì không runtime-verify được local — một code review mới bắt được. Nếu không review, ta sẽ ship một CSP "có vẻ strict" mà thực ra hoàn toàn vô hiệu với inline script.
+
+## Technical Details
+
+- Next 16: file là `proxy.ts`. `middleware.ts` không còn tồn tại. cmux đã dùng `proxy.ts` (intl + redirects).
+- Nonce CSP đúng pattern: forward nonce qua REQUEST header bằng `NextResponse.next({ request: { headers } })`. Thread qua next-intl proxy phức tạp → không verify được local.
+- Quyết định: fallback **static restrictive CSP** (`script-src 'self' 'unsafe-inline'`...) áp qua `next.config.ts headers()` cho mọi route. Đơn giản, không cần threading runtime.
+- Keychain FIX: delete-then-add trên mỗi write → accessibility luôn re-apply (migrate trên lần refresh token kế tiếp).
+
+## Root Cause Analysis
+
+- Giả định "response header = headers()" sai về contract App Router. Static analysis không phát hiện vì type-check qua hết.
+- Giả định "SecItemUpdate cho mọi attribute" sai — accessibility class change unreliable qua update.
+- Giả định "middleware.ts vẫn hoạt động trên Next 16" sai — đã rename.
+
+## Lessons Learned
+
+- **Nonce CSP trong App Router**: cần request-header forwarding, KHÔNG phải response headers. Verify runtime, đừng tin static analysis.
+- **Keychain accessibility change**: delete + re-add; update unreliable.
+- **Next major version**: kiểm tra tên file middleware/proxy trước khi tạo. Trên Next 16 là `proxy.ts`.
+
+## Next Steps
+
+- CI verify app-target Swift build (`Sources/SessionPersistence.swift`, `CLI/cmux.swift`) — môi trường dev này không build được (xem entry build-env).
+- Squash/rebase nhánh trước PR (history churn: CSP nonce → proxy fixup → static CSP revert).

--- a/docs/journals/2026-06-23-security-hardening-test-cache-pitfalls.md
+++ b/docs/journals/2026-06-23-security-hardening-test-cache-pitfalls.md
@@ -1,0 +1,37 @@
+# t3-env singleton + bun mock.module: shared module cache sinkhole trong test suite
+
+**Date**: 2026-06-23 20:03
+**Severity**: High
+**Component**: web test suite (analytics + notifications-push routes)
+**Status**: Resolved (fix local, CI to verify)
+
+## What Happened
+
+Trong nhánh `security-hardening`, thêm rate-limit cho analytics route bỗng làm notifications-push test thất bại một cách bí ẩn: route trả 413 (đúng khi không có limiter id) thay vì 429. Nhìn的第一眼 giống `mock.module` collision giữa 2 file test.
+
+## The Brutal Truth
+
+Mất mấy vòng debug mới nhận ra thủ phạm không phải mock mà là module singleton cache của chính t3-env. Cảm giác bực mình vì test "pass" nhưng thực ra đang skip assertion vì route nhận sai env. Sai lầm nghiêm trọng: một test có vẻ green nhưng hoàn toàn không kiểm tra gì.
+
+## Technical Details
+
+- `web/app/api/notifications-push/route.ts` đọc `env.CMUX_PUSH_RATE_LIMIT_ID` qua `import { env }` (t3 createEnv singleton).
+- `web/app/api/analytics/route.ts` (theo thứ tự alphabet đứng trước) cũng import `env` → bun cache singleton TRƯỚC khi push test set `process.env.CMUX_PUSH_RATE_LIMIT_ID`.
+- Push test set env muộn → singleton đã cache giá trị rỗng → limiter id undefined → route SILENTLY bỏ qua rate limit → trả 413 thay vì 429.
+- Cùng loại bug thứ hai: analytics route `import { checkRateLimit } from "@vercel/firewall"` (static) cache module khi analytics test load route → mock.module của push test bị shadow.
+
+## Root Cause Analysis
+
+1. **t3-env là module singleton**: giá trị `process.env` được freeze tại lần import đầu tiên. Thứ tự import file test trong cùng process quyết định cache.
+2. **bun `mock.module` cross-file poisoning**: static import của một route kéo module vào cache trước khi test khác kịp mock. Dynamic import chỉ trong nhánh conditional tránh được.
+
+## Lessons Learned
+
+- **t3-env singleton**: route nào test import sớm nên đọc `process.env.X` trực tiếp (như `process.env.VERCEL`), không qua `env`.
+- **bun mock.module**: với module route chỉ conditionally cần, dùng `await import("...")` lazy trong nhánh cụ thể. Static import đầu độc cross-file module cache khi sibling test cũng mock cùng module.
+- **Debugging clue**: một rate-limited route trả sai status code trong suite nhưng đúng khi isolate → nghi ngờ shared singleton cache ngay lập tức.
+
+## Next Steps
+
+- CI chạy full web suite (143 tests) confirm 0 fail. Owner: CI. Khi: pre-merge.
+- Owner backend: provision Vercel Firewall rule id `CMUX_ANALYTICS_RATE_LIMIT_ID`.

--- a/plans/handoff-security-hardening.md
+++ b/plans/handoff-security-hardening.md
@@ -1,0 +1,34 @@
+# Handoff prompt — security-hardening (phiên tiếp theo)
+
+> Dán nguyên khối dưới đây làm tin nhắn đầu tiên của phiên tiếp theo (sau khi xoá ngữ cảnh). Memory + journal đã được ghi, sẽ auto-load.
+
+---
+
+## PROMPT (copy từ đây)
+
+Tiếp tục công việc security-hardening trên repo cmux (CWD: /Users/thailq/solo-dev/cmux). Ngữ cảnh đã bị xoá — đọc các tài liệu sau trước khi làm gì:
+
+1. **Memory** (đã auto-load qua MEMORY.md): `~/.claude/projects/-Users-thailq-solo-dev-cmux/memory/` — đặc biệt `cmux-security-hardening.md` (trạng thái nhánh), `cmux-build-env-constraints.md`, `cmux-nextjs16-conventions.md`, `cmux-test-isolation-pitfalls.md`.
+2. **Kế hoạch**: `~/.claude/plans/logical-forging-deer.md`.
+3. **Báo cáo scan**: `plans/reports/security-scan-260623-1708-cmux.md`.
+4. **Journal bài học**: `docs/journals/2026-06-23-security-hardening-*.md` (3 file).
+5. **Git**: `git log --oneline origin/main..security-hardening` và `git diff origin/main...security-hardening`.
+
+**Trạng thái**: nhánh `security-hardening`, 14 commit, CHƯA push. Đã implement xong 10 fix (1 MEDIUM device-token hijack + 9 LOW). Verify đã pass ở đây: web suite 143/0 fail, worker 139/0 fail, web typecheck 0 error, `next build` OK, SwiftPM `CmuxAuthRuntime` build OK. KHÔNG build được app macOS locally (thiếu zig + Xcode — xem memory).
+
+**Việc cần làm (theo thứ tự)**:
+1. **Squash/rebase** lịch sử nhánh (hiện có churn: CSP nonce → proxy.ts fixup → static CSP revert). Gộp thành commit sạch theo nhóm fix; GIỮ two-commit red/green cho device-token hijack (commit test fail trước, fix sau) theo policy CLAUDE.md.
+2. **Push + mở PR** tới `manaflow-ai/cmux` (dùng `gh`). CI sẽ verify: (a) Swift app-target build (SessionPersistence.swift, CLI/cmux.swift), (b) DB test red→green cho device-token với `CMUX_DB_TEST=1`.
+3. **Op/provisioning**: tạo Vercel Firewall rule `CMUX_ANALYTICS_RATE_LIMIT_ID` cho analytics rate-limit (route degrade OK khi thiếu).
+4. **Quyết định CSP**: hiện là static restrictive (`web/security-headers.ts`, script-src 'self' 'unsafe-inline'). Nếu muốn nonce-based mạnh hơn → phải forward nonce qua REQUEST headers (`NextResponse.next({request:{headers}})`), KHÔNG qua response headers, và runtime-verify (DevTools không CSP violation). Xem memory `cmux-nextjs16-conventions.md`.
+
+**Lưu ý quan trọng** (bẫy đã gặp, xem journal/memory): Next 16 dùng `proxy.ts` không phải `middleware.ts`; route nào test import sớm hãy đọc `process.env` thay vì singleton `env`; lazy-import module conditionally-needed; SecItemUpdate không đổi accessibility (phải delete-then-add); KHÔNG claim app build pass khi chưa build được.
+
+Bắt đầu bằng việc đọc 5 tài liệu trên, rồi báo cáo tóm tắt trạng thái + đề xuất kế hoạch squash trước khi thực hiện.
+
+## (hết prompt)
+
+## Ghi chú cho phiên hiện tại
+- Memory dir tạo mới: `~/.claude/projects/-Users-thailq-solo-dev-cmux/memory/` (5 file + MEMORY.md).
+- Journal: `docs/journals/` (3 file, ngày 2026-06-23).
+- Không push gì; không đổi code thêm.

--- a/plans/reports/security-scan-260623-1708-cmux.md
+++ b/plans/reports/security-scan-260623-1708-cmux.md
@@ -1,0 +1,331 @@
+# Báo cáo quét bảo mật — cmux
+
+**Dự án:** cmux | **Ngày quét:** 2026-06-23 | **Phạm vi:** Swift app + Next.js web + Cloud VM control plane + Cloudflare worker + webviews
+**Phương pháp:** Multi-dimensional scan (9 dimensions) song song + adversarial verification mỗi finding + synthesis. 26 agents, 6 false positives đã loại.
+
+## Tóm tắt kết quả
+
+Có **10 phát hiện đã xác nhận (confirmed): 1 medium, 9 low**. Không có critical/high. Phần lớn là lỗ hổng defense-in-depth (keychain accessibility, CSP thiếu `script-src`, plaintext fallback, cache-control) và 1 IDOR vừa (cross-user device-token hijack) có điều kiện khai thác. Không tìm thấy secret thật trong VCS, không SQL injection runtime, không command injection từ input người dùng.
+
+## Bảng tóm tắt
+
+| Severity | Số lượng | Category chính |
+|----------|----------|----------------|
+| Critical | 0 | — |
+| High | 0 | — |
+| Medium | 1 | authorization/IDOR |
+| Low | 9 | secrets-mgmt / credential storage / info-leak / injection / input-validation-abuse / xss-CSP / authz |
+
+| Category | Số lượng |
+|----------|----------|
+| authorization/IDOR | 1 |
+| input-validation/abuse | 2 |
+| info-leak | 1 |
+| injection (quota) | 1 |
+| secrets-mgmt | 1 |
+| credential storage | 2 |
+| xss/CSP | 1 |
+| authz | 1 |
+
+## Phát hiện (theo thứ tự severity giảm dần)
+
+---
+
+### [MEDIUM] device-tokens register ghi đè row APNs token của user khác (cross-user device-token hijack)
+
+**File:** `web/app/api/device-tokens/route.ts:54-88`
+
+**Mô tả + đường dẫn tấn công:**
+`POST /api/device-tokens` authenticate caller, nhưng khi gặp `deviceToken` trùng nó reassign row cho bất kỳ ai gọi. Advisory lock keyed trên `user.id` (line 52: `hashtextextended(${user.id}, 2)`), nên 2 user khác nhau không bao giờ serialize với nhau. Code đọc `userId` của row hiện có (line 54-58), nhận thấy thuộc user khác (line 60 `existingToken?.userId !== user.id`), nhưng branch đó chỉ dùng cho per-user cap check — không bao giờ refuse. Upsert tiếp theo (lines 70-88) làm `onConflictDoUpdate` trên bare `deviceToken` với `set: { userId: user.id, ... }`, reassign row từ A → B.
+
+**Tác động:**
+- Attacker biết APNs device token của nạn nhân (64-200 hex char secret, có thể leak qua logs/MITM/compromised device) → register nó vào account mình → `POST /api/notifications/push` từ session của attacker để deliver push notification tùy ý vào iPhone vật lý của nạn nhân.
+- Inverse: legitimate owner silently mất push delivery vì `/api/notifications/push` filter theo `userId`.
+- Bất đối xứng với `/api/devices` (route anh em) — route đó có ownership guard chính xác (returns 403 `device_not_owned`).
+
+**Bằng chứng:**
+```typescript
+const [existingToken] = await tx
+  .select({ userId: deviceTokens.userId })
+  .from(deviceTokens)
+  .where(eq(deviceTokens.deviceToken, deviceToken))
+  .limit(1);
+
+if (existingToken?.userId !== user.id) {
+  // ...chỉ dùng cho per-user cap check; falls through to overwrite
+}
+await tx
+  .insert(deviceTokens)
+  .values({ userId: user.id, deviceToken, ... })
+  .onConflictDoUpdate({
+    target: deviceTokens.deviceToken,
+    set: { userId: user.id, bundleId: bundle.bundleId, ... }, // unconditionally reassigns ownership
+  });
+```
+
+Schema (`web/db/schema.ts:131`): `uniqueIndex("device_tokens_device_token_unique").on(table.deviceToken)` là GLOBAL unique constraint (không `(userId, deviceToken)`), nên conflict path luôn fire. Peer route `/api/devices` (`web/app/api/devices/route.ts:217-219`): `if (existingDevice && existingDevice.userId !== user.id) { return { error: "device_not_owned" }; }` → 403.
+
+Downstream (`web/app/api/notifications/push/route.ts:88`): tokens select bằng `eq(deviceTokens.userId, user.id)`, payload từ body của caller authenticated, deliver qua `sendApnsNotification`.
+
+**Khuyến nghị sửa:**
+- Trong conflict branch, refuse take-over row của user khác: `if (existingToken && existingToken.userId !== user.id)` → return 403/409 (`token_not_owned`).
+- Nếu cần flow "re-claim from different account" (user reinstall, re-pair device), require prior DELETE bởi old owner hoặc explicit re-binding token.
+- Mở rộng advisory lock include `deviceToken` (`hashtextextended(deviceToken, 2)`) để concurrent claims serialize.
+
+---
+
+### [LOW] `/api/analytics/events` chấp nhận event batch unauthenticated, không rate-limit (PostHog quota/abuse amplifier)
+
+**File:** `web/app/api/analytics/events/route.ts:34-88`
+
+**Mô tả + đường dẫn tấn công:**
+`POST /api/analytics/events` không bao giờ reject unauthenticated request. `verifyRequest` gọi opportunistically (line 54), kết quả chỉ dùng để stamp `distinct_id` (line 83 `user?.id ?? null`); null user proceeds bình thường. Handler chỉ dựa vào shape gate (allowlist + 64KB body cap + per-batch/per-event bounds) để bound abuse. Comment defer rate limiting ("Rate limiting is deferred for Phase A", issue #5569).
+
+Route biến web app thành open reflector → PostHog: attacker fire batched POSTs unbounded, mỗi request forward lên tới `MAX_ANALYTICS_BATCH_EVENTS` events đến PostHog dùng server-side `api_key` rewrite → consume cmux function invocations VÀ PostHog project quota (events/billing) không có IP/user rate limiting.
+
+**Bằng chứng:**
+```typescript
+// Auth is read opportunistically, NOT required:
+const user = await verifyRequest(request, { allowCookie: false });
+// ...no `if (!user) return unauthorized()` follows...
+const forwarded = await forwardToPostHog(accepted, user?.id ?? null);
+```
+
+**Khuyến nghị sửa:** Thêm anonymous edge/IP rate limit (Vercel Firewall `checkRateLimit`, primitive đã dùng trong `feedback/route.ts` và `notifications/push/route.ts`) keyed trên request IP khi không có Stack session.
+
+---
+
+### [LOW] VM SSH/attach endpoints return live credentials trong JSON không có `Cache-Control: no-store`
+
+**File:** `web/services/vms/routeHelpers.ts:93-98`
+
+**Mô tả + đường dẫn tấn công:**
+`jsonResponse()` helper build response chỉ với `content-type` header, không có `Cache-Control: no-store` / `private`. Routes `POST /api/vm/[id]/ssh-endpoint` và `/api/vm/[id]/attach-endpoint` return short-lived nhưng live secrets trong JSON body: one-time Freestyle SSH password (`credential.value`), E2B `trafficAccessToken`, và đặc biệt Freestyle cmuxd RPC WebSocket lease token TTL 12 giờ (`CMUXD_WS_RPC_LEASE_TTL_SECONDS = 12 * 60 * 60` trong `freestyle.ts:40`).
+
+Shared/intermediate HTTP cache, CDN edge, reverse proxy key trên URL+method và treat `application/json` as cacheable có thể persist credentials beyond user session. 12-hour RPC token là leak surface highest-value (grants RPC access to cmuxd daemon inside user's sandbox).
+
+**Bằng chứng:**
+```typescript
+export function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+```
+
+Không có global Cache-Control: `web/security-headers.ts` apply CSP/Referrer-Policy/nosniff cho `/:path*` (không Cache-Control). `export const dynamic = "force-dynamic"` chỉ disable Next's own static/ISR caching — không emit no-store, không constrain fronting CDN. Revocation paths exist (`revokeActiveIdentities` tại `workflows.ts:315,350`).
+
+**Khuyến nghị sửa:** Thêm `Cache-Control: no-store, private` (+ ideally `Pragma: no-cache`) cho responses carrying credentials. Easiest: extend `jsonResponse` set header unconditionally, hoặc set explicit trong ssh-endpoint / attach-endpoint route handlers.
+
+---
+
+### [LOW] `vm/[id]/exec` forwards arbitrary shell đến provider sandbox không allowlist, chỉ gated bởi VM ownership
+
+**File:** `web/app/api/vm/[id]/exec/route.ts:43-74`
+
+**Mô tả + đường dẫn tấn công:**
+`POST /api/vm/[id]/exec` chỉ validate `command` là non-empty string và clamp `timeoutMs`; string forwarded verbatim đến provider's sandbox shell (freestyle `ref.exec({ command })`, e2b `sandbox.commands.run(command)`). By design (exec IS the feature), ownership enforced đúng qua `requireUserVm` → `findUserVm({ userId, providerVmId })`. Residual risk: abuse quota của caller — không có rate limit/concurrency cap, single command hold sandbox worker tới 15 phút (`MAX_EXEC_TIMEOUT_MS = 15 * 60 * 1000`). Malicious authenticated account tie up provider sandbox quota across `maxActiveVms` concurrent VMs.
+
+**Bằng chứng:**
+```typescript
+const command = typeof body.command === "string" ? body.command.trim() : "";
+if (command.length === 0) { ... }
+const MAX_EXEC_TIMEOUT_MS = 15 * 60 * 1000;
+const result = await runVmWorkflow(execVm({ userId: user.id, providerVmId: id, command, timeoutMs }));
+```
+
+Ownership filter: `repository.ts:363-378` `findUserVm` dùng Drizzle parameterized `eq(cloudVms.userId, input.userId) AND eq(cloudVms.providerVmId, ...)`. No rate-limiting middleware; chỉ `maxActiveVms` cap enforce tại create (default 5 free / 10 paid).
+
+**Khuyến nghị sửa:** Không cần sanitization change (sandbox user-owned). Quota hardening: thêm per-user/per-VM concurrency cap on in-flight execs + shorter default ceiling. Nếu exec metered, count trong billing gateway alongside create credits.
+
+---
+
+### [LOW] CLI passes socket password vào child process qua argv (visible trong `ps`)
+
+**File:** `CLI/cmux.swift:20419-20422` (cũng `3108-3115` accepting `--password`)
+
+**Mô tả + đường dẫn tấn công:**
+cmux CLI chấp nhận local control-socket password qua `--password <value>` argument, khi spawn codex-teams watcher forward password vào child Process's argv: `watcherArguments.insert(contentsOf: ["--password", explicitPassword], at: 2)`. Trên macOS argv visible với local users/processes khác qua `ps aux` / proc_info / Activity Monitor → local process đọc socket password. Doc advertise: "--password takes precedence, then CMUX_SOCKET_PASSWORD env var, then password saved in Settings." Preferred path là `CMUX_SOCKET_PASSWORD` env var + password file (0600 perms, constant-time verify). Defense-in-depth gap (local-only exposure), socket là unix domain socket protected bởi filesystem perms, password compare constant-time.
+
+**Bằng chứng:**
+```swift
+if let explicitPassword,
+   !explicitPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+    watcherArguments.insert(contentsOf: ["--password", explicitPassword], at: 2)
+}
+```
+
+Line `1502, 1516, 2886`: password file 0o600 perms. Line `20280` đã set `launcherEnvironment["CMUX_SOCKET_PASSWORD"] = explicitPassword` và env đó pass cho `startCodexTeamsProcess` (line 20431) → watcher đã nhận password qua env, có thể read qua `SocketPasswordResolver.resolve()` (line 1588-1598) không cần argv copy.
+
+**Khuyến nghị sửa:** Không pass socket password qua argv. Watcher inherit `CMUX_SOCKET_PASSWORD` từ parent environment (env-var path đã first-class). Consider deprecate `--password` flag (hoặc no-op read từ file/env) để không shipped path nào put credential vào argv.
+
+---
+
+### [LOW] Auth tokens lưu Keychain với `kSecAttrAccessibleAfterFirstUnlock` (không WhenUnlocked / không device-only)
+
+**File:** `Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/KeychainStackTokenStore.swift:160`
+
+**Mô tả + đường dẫn tấn công:**
+Stack Auth access + refresh tokens (secrets keep user signed in, let client refresh session) viết vào data-protection keychain với `kSecAttrAccessibleAfterFirstUnlock`. Accessibility class này (a) decrypt item sau first device unlock của boot và giữ readable khi device merely locked, (b) không phải `*ThisDeviceOnly` variant → item eligible cho Keychain restore onto new/other device qua iCloud Keychain backup. Cho long-lived OAuth-style session tokens đây là weaker-than-necessary protection class: thief/forensic tool obtain device sau khi đã unlock once (common state) → đọc valid refresh token. Best practice high-value bearer tokens: `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`. Cùng accessibility dùng cho SessionPersistence HMAC key (`Sources/SessionPersistence.swift:1271`).
+
+**Bằng chứng:**
+```swift
+var insert = lookup
+insert[kSecValueData as String] = data
+insert[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+let addStatus = SecItemAdd(insert as CFDictionary, nil)
+```
+
+`rg` over `*.swift`: chỉ 2 AfterFirstUnlock uses, không `WhenUnlocked` / `ThisDeviceOnly` / `kSecAttrSynchronizable`. Shared code consumed bởi cả macOS app và iOS app (CmuxAuthRuntime under `Packages/Shared/`).
+
+**Khuyến nghị sửa:** Dùng `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` cho access và refresh token items trong `KeychainStackTokenStore.keychainWrite`. Giữ `kSecUseDataProtectionKeychain`. Cho SessionPersistence HMAC secret (`Sources/SessionPersistence.swift:1271`), prefer `WhenUnlockedThisDeviceOnly` trừ khi surface-resume phải work trước first unlock.
+
+---
+
+### [LOW] FallbackTokenStore viết auth tokens (access + refresh) plaintext JSON khi Keychain failure thật
+
+**File:** `Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FileStackTokenStore.swift:108-124`
+
+**Mô tả + đường dẫn tấn công:**
+`MacAuthComposition` luôn wrap Keychain store trong `FallbackTokenStore` (`Sources/Auth/MacAuthComposition.swift:36-41`) — fallback path serialize access + refresh tokens ra JSON document (`credentials.json`) không encryption ngoài 0600 file perms và 0700 parent dir. Fallback reached khi keychain write/read signal failure thật: trên ad-hoc Debug builds là `errSecMissingEntitlement`, nhưng branch unconditional trong Release (`FallbackTokenStore.setTokens` line 58-61). Bất kỳ Keychain error path nào trên real user machine (corrupted keychain, profile issue, MDM restrictions, code-signing/entitlement regression sau rebuild) silently drop live refresh token vào `~/Library/Application Support/cmux/<bundleID>/credentials.json` cleartext. Refresh token alone đủ mint new access tokens; kết hợp với after-first-unlock keychain accessibility → widen at-rest exposure.
+
+**Bằng chứng:**
+```swift
+private func write(_ snapshot: Snapshot) {
+    cache = snapshot
+    let fm = FileManager.default
+    let dir = fileURL.deletingLastPathComponent()
+    do {
+        try fm.createDirectory(
+            at: dir,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let data = try JSONEncoder().encode(snapshot)
+        try data.write(to: fileURL, options: [.atomic])
+        try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+```
+
+`KeychainStackTokenStore.trySetTokens` (line 61-78) returns false trên bất kỳ `SecItemAdd`/`SecItemUpdate` failure.
+
+**Khuyến nghị sửa:**
+- Gate `FileStackTokenStore` fallback DEBUG only (hoặc `#if DEBUG`) → Release builds surface hard Keychain failure thay vì persist plaintext tokens.
+- HOẶC encrypt file payload với key derived từ Keychain-stored symmetric key.
+- Tối thiểu: Release log/metric fallback activation, surface state to user.
+
+---
+
+### [LOW] Web app CSP thiếu `script-src`/`default-src`/`style-src` — CSP gần như vô dụng chống XSS
+
+**File:** `web/security-headers.ts:4`
+
+**Mô tả + đường dẫn tấn công:**
+Content-Security-Policy header chỉ có 3 directives: `base-uri 'self'; object-src 'none'; frame-ancestors 'none'`. Không có `default-src`, `script-src`, hay `style-src`. Vì CSP fallback `default-src` không set, browser apply hành vi mặc định (allow all) cho script execution → CSP vô hiệu hoàn toàn chống XSS: bất kỳ inline script nào (qua unsanitized `dangerouslySetInnerHTML` hoặc future bug) execute mà không bị chặn, external scripts từ bất kỳ origin nào cũng load. Header apply cho mọi route `/:path*` qua `next.config.ts` `headers()`.
+
+**Bằng chứng:**
+```typescript
+export const securityHeaders = [
+  { key: "Content-Security-Policy", value: "base-uri 'self'; object-src 'none'; frame-ancestors 'none'" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  ...
+```
+
+Pinned bởi `web/tests/security-headers.test.ts` (deliberate design choice). Audited mọi `dangerouslySetInnerHTML` call site: `code-block.tsx:39` (Shiki HTML từ trusted source-code), `docs-search.tsx:278` (Pagefind `excerptHtml` từ static build-generated `/pagefind/` bundle), `page.tsx` (server-generated FAQ JSON-LD), `theme-bootstrap-script.tsx` (static theme script). Không ingest unsanitized attacker-controlled data → không current exploitable XSS path. Impact: FUTURE injection bug sẽ không có CSP safety net.
+
+**Khuyến nghị sửa:** Thêm `script-src` strict với nonce/hash-based whitelist (Next.js App Router hỗ trợ per-request nonce qua `headers()` + `Script` component). Ví dụ: `default-src 'self'; script-src 'self' 'nonce-<random>' 'strict-dynamic'; style-src 'self' 'unsafe-inline'`. Triển khai nonce generation trong middleware, inject vào script tags. Loại bỏ `'unsafe-inline'` cho `script-src`.
+
+---
+
+### [LOW] Unbounded Stack API subrequest amplification từ unique opaque tokens (worker)
+
+**File:** `workers/presence/src/auth.ts:191-225`
+
+**Mô tả + đường dẫn tấn công:**
+`verifyRequest` gọi Stack (`/api/v1/users/me` + `/api/v1/teams`) mỗi uncached token. Cache keyed trên SHA-256(token), negative-cached chỉ 10s (`AUTH_NEGATIVE_CACHE_TTL_MS`), capped 1024 entries với FIFO eviction. Unauthenticated attacker send stream of distinct opaque (non-JWT, nên client-side exp short-circuit line 197-198 không fire) strings trong Authorization header; mỗi distinct token hash miss cache → force HAI `fetch()` calls đến `api.stack-auth.com`. 1024-entry cap bound memory NHƯNG KHÔNG bound subrequest rate — khi full, mỗi new token vẫn perform network round trip (eviction lines 209-213 chỉ prevent memory growth, fetch line 207 đã happen). Heartbeats 15s/host, không per-IP/per-token rate limiting trong worker → single hostile client sustain unbounded traffic chống Stack backend (và Cloudflare subrequest daily quotas). Amplification factor constant 2:1.
+
+**Bằng chứng:**
+```typescript
+const cacheKey = await sha256Hex(token);
+  const cached = authCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) return cached.user;
+  authCache.delete(cacheKey);
+
+  const user = await fetchStackUser(env, token);
+
+  if (authCache.size >= AUTH_CACHE_MAX_ENTRIES) {
+    // Drop the oldest insertion; Map preserves insertion order.
+    const oldest = authCache.keys().next().value;
+    if (oldest !== undefined) authCache.delete(oldest);
+  }
+```
+
+`fetchStackUser` (lines 150-186): line 154 `fetch(/api/v1/users/me)`, line 172 `fetch(/api/v1/teams?user_id=me)`. Không `rate_limit`/`ratelimit` trong wrangler.toml/index.ts/auth.ts.
+
+**Khuyến nghị sửa:** Thêm per-isolate rate limit trên Stack subrequests (token-bucket counter, hoặc short negative-cache window keyed trên prefix token hash khi token opaque). Reject tokens không parseable JWT với valid `exp` shape trước bất kỳ network call. Fail fast trên malformed bearer (too short, no two dots).
+
+---
+
+### [LOW] Device ownership là first-authenticated-writer-wins (không registry attestation) — worker
+
+**File:** `workers/presence/src/core.ts:250-257`
+
+**Mô tả + đường dẫn tấn công:**
+`checkDeviceOwner` pin owner của device thành first authenticated team member announce `deviceId`. Device ids visible với toàn team, presence service không có synchronous dependency vào durable Aurora devices registry (by design, presence phải work khi web API down). Bất kỳ authenticated team member nào race claim not-yet-announced `deviceId` trước first heartbeat của legitimate owner, sau đó real owner locked out (403 `device_owner_mismatch`) đến khi manual intervention. Code document đây là accepted residual; blast radius presence-display only (attach routes và durable identity stay registry-owned).
+
+**Bằng chứng:**
+```typescript
+export function checkDeviceOwner(
+  existingOwner: string | undefined,
+  userId: string,
+): OwnerCheck {
+  if (existingOwner === undefined) return { ok: true, pin: true };
+  if (existingOwner === userId) return { ok: true, pin: false };
+  return { ok: false, error: "device_owner_mismatch" };
+}
+```
+
+Auth (`auth.ts#verifyRequest`) chỉ validate token + team membership, không device ownership. DO key durable sau pin, không re-claim sau timeout (`core.ts:240-241`). Attach/ssh endpoints auth qua VM workflow userId chống `web/db` registry, độc lập presence device ownership → impact presence-display only. Intentional/documented (`core.ts:232-248`), unit-tested.
+
+**Khuyến nghị sửa:** Khi available, cross-check first claim chống Aurora devices registry (pin registering userId) trước pin trong DO storage, hoặc have registry issue verifiable per-device credential mà presence validate trên first contact. Document race window to operators.
+
+---
+
+## Phụ thuộc (Dependencies)
+
+`bun audit` (web): phần lớn là transitive vulns kéo vào qua vercel build/dev toolchain (`@vercel/*` → `tar`, `undici`, `minimatch`, `path-to-regexp`, `ajv`, `brace-expansion`, `srvx`, `form-data`).
+
+**Đây là build-time/dev deps, KHÔNG phải production runtime request path.** Phân biệt rõ: các vuln này ảnh hưởng build pipeline/dev server, không reach được end-user request flow trong production. Khuyến nghị upgrade vercel toolchain khi có bản sửa, nhưng không phải vấn đề cấp bách về runtime security.
+
+## Đã loại trừ (False positives đã verify)
+
+| Tiêu đề | File | Lý do loại |
+|---------|------|------------|
+| `/api/feedback` unauthenticated | `web/app/api/feedback/route.ts` | Intentionally public feedback endpoint. Recipient hard-coded `feedback@manaflow.com` (không open spam relay). Content escape qua `escapeHtml`. Zod cap 4000 chars/10 attachments/4MB. Tự disable (503) khi `rateLimitId` unset, rate-limited trên Vercel deploy. Hardening note, không exploitable flaw. |
+| Cloud VM lease tokens stored unsalted SHA-256 | `web/services/vms/workflows.ts` | Tokens high-entropy (256-bit `randomBytes(32)`). SSH token từ Freestyle SDK, revoked trên destroy. Lease verify trên cmuxd daemon (nhận `token_sha256` trực tiếp), không re-read từ Postgres. Plain SHA-256 của high-entropy token là nice-to-have, không defect. |
+| Ownership model per-userId (per-user vs per-team split) | `web/services/vms/repository.ts` | Tự assert NO exploitable bypass. `listUserVms` luôn include `eq(userId)` cả 2 branches. Mọi mutate qua `requireUserVm` → `findUserVm` filter `userId` từ server-authenticated `user.id`. Design note, không security flaw. |
+| Bundled webview shells không có CSP meta | `Resources/agent-session-react/index.html` | WKWebView loads trusted bundled `file://` shell. Untrusted markdown qua `renderMarkdownHTML()`: `escapeMarkdownRawHTML()` + `marked.parse()` + `sanitizeRenderedHTML()` (remove script/iframe/on*/URL allowlist). Native bridge guard `isTrustedBridgeFrame`. Không demonstrable sanitizer bypass → missing CSP là hardening suggestion. |
+| Subscribe forwards all original client headers to DO | `workers/presence/src/index.ts` | `set()` override verified teamId/expiresAt → DO đọc chỉ 3 headers (`x-presence-team-id`, `x-presence-expires-at`, `upgrade`), không đọc Authorization/Cookie. Inert header pass-through, code-review nit. |
+| Stack error response bodies parsed as JSON before ok check | `workers/presence/src/auth.ts` | Guard `if (!meResponse.ok) return null;` chạy BEFORE `await meResponse.json()`. Không echo Stack response ra client. Operational observability concern, không adversarial impact. |
+
+## Khuyến nghị ưu tiên (top actions)
+
+1. **[MEDIUM — ưu tiên cao nhất]** Sửa cross-user device-token hijack (`web/app/api/device-tokens/route.ts:60-88`): thêm ownership guard `if (existingToken && existingToken.userId !== user.id) return 403/409` trước upsert; mở rộng advisory lock keyed thêm `deviceToken`. Đây là finding duy nhất có cross-user impact thật (push notification injection + silent push loss).
+
+2. **[LOW — Cluster auth token at-rest]** Gom 2 finding keychain accessibility (`KeychainStackTokenStore.swift:160`) + plaintext fallback (`FileStackTokenStore.swift:108-124`) thành 1 fix: `WhenUnlockedThisDeviceOnly` + gate fallback DEBUG-only hoặc encrypt payload. Combo này giảm significant at-rest exposure của live refresh token.
+
+3. **[LOW — CSP]** Thêm `default-src 'self'; script-src 'self' 'nonce-<random>' 'strict-dynamic'` vào `web/security-headers.ts` (cập nhật đồng thời test pin). Cheap defense-in-depth cho mọi future injection bug.
+
+4. **[LOW — Cache-Control credentials]** Extend `jsonResponse` (`routeHelpers.ts:93-98`) set `Cache-Control: no-store, private` — đặc biệt relevant cho 12-hour cmuxd RPC lease token.
+
+5. **[LOW — CLI argv leak]** Drop `--password` argv forwarding (`CLI/cmux.swift:20419-20422`), watcher đã nhận env var — fix 1-line, loại bỏ local password harvest path.
+
+6. **[LOW — Rate limiting cluster]** Thêm edge/IP rate limit cho `/api/analytics/events` + per-isolate Stack subrequest limit trong worker — bound quota/cost amplification từ unauthenticated callers.
+
+7. **[LOW — exec concurrency]** Per-user/per-VM concurrency cap cho `vm/[id]/exec` + shorter default timeout ceiling để chống quota tie-up.
+
+8. **[LOW — presence device race]** Cross-check Aurora registry trước pin first-owner; document race window.
+
+---
+
+**Câu hỏi chưa giải quyết:** Không. Tất cả 10 confirmed findings đã verify end-to-end với cited lines; 6 false positives đã loại với lý do rõ.

--- a/web/app/api/analytics/events/route.ts
+++ b/web/app/api/analytics/events/route.ts
@@ -40,17 +40,31 @@ export async function POST(request: Request): Promise<Response> {
   // gate, not auth. The PostHog key is already public (the web client posts to
   // r.cmux.com directly), so an anonymous proxy is no weaker than today.
   //
-  // Rate limiting is deferred for Phase A (tracked in
-  // https://github.com/manaflow-ai/cmux/issues/5569). The only reusable limiter in
-  // the codebase (`services/apns/rateLimit.ts`) is a per-`userId` Postgres-
-  // transaction gate, which does not fit an anonymous-first, high-volume telemetry
-  // ingest path (no user id pre-auth, and a DB write + advisory lock per analytics
-  // batch would defeat a lightweight proxy; in-memory limiting does not work on
-  // Vercel's per-instance stateless functions). The shape gate (allowlist + 64 KB
-  // body cap + per-batch/per-event bounds below) limits payload abuse; a dedicated
-  // anonymous IP/edge rate limit on cmux's own compute is the follow-up. The
-  // downstream PostHog quota risk is no worse than the already-public direct
-  // r.cmux.com path.
+  // Anonymous IP/edge rate limiting (Vercel Firewall, keyed on the request IP,
+  // mirroring /api/feedback) bounds PostHog quota and function-invocation abuse
+  // from unauthenticated callers. The per-`userId` Postgres limiter in
+  // `services/apns/rateLimit.ts` does not fit this anonymous-first path. When
+  // CMUX_ANALYTICS_RATE_LIMIT_ID is unset the route degrades to the shape gate
+  // (allowlist + 64 KB body cap + per-batch/per-event bounds below) only.
+  // Read the rate-limit id from process.env directly (not the t3 `env` singleton)
+  // so importing this route does not cache `env` before other test files set
+  // their own env vars — matching how `process.env.VERCEL` is read just below.
+  const analyticsRateLimitId = process.env.CMUX_ANALYTICS_RATE_LIMIT_ID;
+  if (process.env.VERCEL === "1" && analyticsRateLimitId) {
+    const { checkRateLimit } = await import("@vercel/firewall");
+    const { error, rateLimited } = await checkRateLimit(analyticsRateLimitId, {
+      request,
+    });
+    if (rateLimited || error === "blocked") {
+      return jsonResponse({ error: "rate_limited" }, 429);
+    }
+    if (error === "not-found") {
+      console.error("analytics.events.rate_limit_not_found", analyticsRateLimitId);
+    } else if (error) {
+      console.error("analytics.events.rate_limit_error", error);
+    }
+  }
+
   const user = await verifyRequest(request, { allowCookie: false });
 
   const body = await readBoundedJsonObject(request, MAX_ANALYTICS_REQUEST_BYTES);

--- a/web/app/api/device-tokens/route.ts
+++ b/web/app/api/device-tokens/route.ts
@@ -49,7 +49,15 @@ async function registerDeviceToken(request: Request): Promise<Response> {
   const db = cloudDb();
 
   const registered = await db.transaction(async (tx) => {
+    // Two advisory locks: one keyed on the user (serializes that user's
+    // registration-cap accounting across concurrent registrations) and one
+    // keyed on the token (serializes cross-user claims on the same device
+    // token). The global unique index on `deviceToken` makes a conflict
+    // reachable from a different user, so without the token-scoped lock two
+    // users racing to claim the same token would not serialize against each
+    // other. Different seeds (2 vs 3) keep the two lock namespaces disjoint.
     await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${user.id}, 2))`);
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${deviceToken}, 3))`);
 
     const [existingToken] = await tx
       .select({ userId: deviceTokens.userId })
@@ -57,13 +65,27 @@ async function registerDeviceToken(request: Request): Promise<Response> {
       .where(eq(deviceTokens.deviceToken, deviceToken))
       .limit(1);
 
-    if (existingToken?.userId !== user.id) {
+    // A device token pins its owning user. The unique index on `deviceToken`
+    // is global (by design, so a re-pairing device can move to a new account),
+    // which means an `onConflictDoUpdate` is reachable from a *different* user.
+    // Without this guard, anyone who learns another user's APNs token could
+    // reassign it to their own account and then either receive that user's
+    // pushes or silently drop them. Mirrors /api/devices: a token owned by
+    // someone else cannot be taken over. A genuine re-pair is initiated by the
+    // old owner deleting the row first.
+    if (existingToken && existingToken.userId !== user.id) {
+      return { error: "device_not_owned" as const };
+    }
+
+    // Only a brand-new token consumes a per-user registration slot; a
+    // same-user re-register updates the existing row in place.
+    if (!existingToken) {
       const [registrationCount] = await tx
         .select({ total: count() })
         .from(deviceTokens)
         .where(and(eq(deviceTokens.userId, user.id), ne(deviceTokens.deviceToken, deviceToken)));
       if (Number(registrationCount?.total ?? 0) >= MAX_DEVICE_TOKENS_PER_USER) {
-        return false;
+        return { error: "too_many_devices" as const };
       }
     }
 
@@ -87,10 +109,13 @@ async function registerDeviceToken(request: Request): Promise<Response> {
         },
       });
 
-    return true;
+    return { error: null };
   });
 
-  if (!registered) {
+  if (registered.error === "device_not_owned") {
+    return jsonResponse({ error: "device_not_owned" }, 403);
+  }
+  if (registered.error === "too_many_devices") {
     return jsonResponse({ error: "too_many_devices" }, 429);
   }
 

--- a/web/app/api/vm/[id]/exec/route.ts
+++ b/web/app/api/vm/[id]/exec/route.ts
@@ -50,10 +50,13 @@ export async function POST(
           details: { field: "command" },
         });
       }
-      // Clamp the timeout so a client can't tie up provider quota on a runaway exec. Upper
-      // bound matches the provider defaults (15 min on Freestyle); negative / non-number
-      // values fall back to 30s.
-      const MAX_EXEC_TIMEOUT_MS = 15 * 60 * 1000;
+      // Clamp the timeout so a client can't tie up provider quota on a runaway exec.
+      // Capped below the Freestyle provider default (15 min): a single exec can
+      // still run long enough for real builds, but the per-exec abuse window is
+      // bounded. Negative / non-number values fall back to 30s. A per-user/per-VM
+      // in-flight concurrency cap (needs shared state, e.g. a DB advisory lock or
+      // counter, since Vercel functions are stateless) is a separate follow-up.
+      const MAX_EXEC_TIMEOUT_MS = 10 * 60 * 1000;
       const rawTimeout = body.timeoutMs;
       const timeoutMs = typeof rawTimeout === "number" && Number.isFinite(rawTimeout) && rawTimeout > 0
         ? Math.min(Math.floor(rawTimeout), MAX_EXEC_TIMEOUT_MS)

--- a/web/security-headers.ts
+++ b/web/security-headers.ts
@@ -1,7 +1,36 @@
 export const poweredByHeader = false;
 
+/**
+ * Content-Security-Policy. Restrictive baseline applied to every route via
+ * `next.config.ts` `headers()` (so Stack Auth handler routes and all others are
+ * covered, not just proxied HTML).
+ *
+ * `script-src 'self' 'unsafe-inline'` blocks external-origin script injection
+ * (the primary XSS vector) while allowing the app's own inline scripts (Next
+ * hydration, the first-paint theme bootstrap). A per-request nonce would be
+ * stricter against inline injection, but there is no current inline-injection
+ * path and nonce threading through the next-intl proxy is unreliable, so this
+ * static policy is the robust baseline. `style-src 'unsafe-inline'` covers
+ * Shiki per-token color styles and Next-injected styles (not a script risk).
+ *
+ * `connect-src` is scoped to same-origin plus the PostHog ingest host
+ * (api_host https://r.cmux.com); the web client has no other cross-origin
+ * XHR/WS. `img-src` covers next/image (github.com) and GitHub avatars.
+ */
+export const contentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "connect-src 'self' https://r.cmux.com",
+  "img-src 'self' data: https://github.com https://avatars.githubusercontent.com",
+  "font-src 'self' data:",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
+
 export const securityHeaders = [
-  { key: "Content-Security-Policy", value: "base-uri 'self'; object-src 'none'; frame-ancestors 'none'" },
+  { key: "Content-Security-Policy", value: contentSecurityPolicy },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "X-Frame-Options", value: "DENY" },

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -89,11 +89,20 @@ export async function withAuthedVmApiRoute(
  * `Response.json(...)` misbehaves under Next.js 16's turbopack dev build (the handler's
  * promise settles but turbopack reports "No response is returned from route handler").
  * Use `new Response(JSON.stringify(...), { ... })` explicitly instead.
+ *
+ * Every consumer is dynamic and several return live credentials (VM SSH/attach
+ * endpoints hand out short-lived tokens and a long-lived cmuxd RPC lease), so
+ * responses are marked non-cacheable to keep shared/intermediary HTTP caches
+ * (CDN edge, reverse proxies) from persisting them. The one route that wants
+ * caching (github-stars, ISR) uses NextResponse directly and not this helper.
  */
 export function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store, private",
+    },
   });
 }
 

--- a/web/tests/analytics-events-route.test.ts
+++ b/web/tests/analytics-events-route.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+// Anonymous-first analytics ingest proxy. These tests cover the request shape
+// gate (batch/event bounds + allowlist) without touching @vercel/firewall or
+// PostHog, so they do not mock any module that sibling test files also mock.
+
+const envKeys = ["SKIP_ENV_VALIDATION"] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]])) as Record<
+  (typeof envKeys)[number],
+  string | undefined
+>;
+
+process.env.SKIP_ENV_VALIDATION = "1";
+
+const getUser = mock(async () => null);
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => true,
+}));
+
+const analyticsRoute = await import("../app/api/analytics/events/route");
+
+afterAll(() => {
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (typeof value === "undefined") {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+function post(body: unknown): Promise<Response> {
+  return analyticsRoute.POST(
+    new Request("https://cmux.test/api/analytics/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("analytics events route shape gate", () => {
+  test("rejects a missing batch with 400", async () => {
+    const response = await post({ notBatch: true });
+    expect(response.status).toBe(400);
+    expect(((await response.json()) as { error: string }).error).toBe("missing_batch");
+  });
+
+  test("accepts an empty batch as a no-op forward", async () => {
+    const response = await post({ batch: [] });
+    expect(response.status).toBe(200);
+    expect(((await response.json()) as { ok: boolean; forwarded: number })).toEqual({
+      ok: true,
+      forwarded: 0,
+    });
+  });
+});

--- a/web/tests/device-tokens-route.test.ts
+++ b/web/tests/device-tokens-route.test.ts
@@ -6,10 +6,13 @@ import { closeCloudDbForTests } from "../db/client";
 const runDbTests = process.env.CMUX_DB_TEST === "1";
 const dbTest = runDbTests ? test : test.skip;
 
+// `currentUserId` is switchable so a test can impersonate a second user and
+// attempt to hijack a token already owned by the first.
+let currentUserId = "push-user-1";
 const getUser = mock(async () => ({
-  id: "push-user-1",
+  id: currentUserId,
   displayName: null,
-  primaryEmail: "push@example.com",
+  primaryEmail: `${currentUserId}@example.com`,
   selectedTeam: null,
   listTeams: async () => [],
 }));
@@ -114,5 +117,45 @@ describe("device token route", () => {
       select count(*)::int as total from device_tokens where user_id = 'push-user-1'
     `;
     expect(remaining.total).toBe(0);
+  });
+
+  dbTest("refuses to let a second user take over a token owned by another user", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate device_tokens restart identity cascade`;
+    getUser.mockClear();
+
+    const sharedToken = "b".repeat(64);
+    const headers = {
+      authorization: "Bearer access-token",
+      "x-stack-refresh-token": "refresh-token",
+    };
+    const register = (deviceToken: string) =>
+      POST(
+        new Request("https://cmux.test/api/device-tokens", {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            deviceToken,
+            bundleId: "dev.cmux.ios.push1",
+            platform: "ios",
+          }),
+        }),
+      );
+
+    // user-1 registers the token legitimately.
+    currentUserId = "push-user-1";
+    expect((await register(sharedToken)).status).toBe(200);
+
+    // user-2 attempts to hijack the same token by re-registering it — must be
+    // refused, and the row must remain owned by user-1.
+    currentUserId = "push-user-2";
+    const attack = await register(sharedToken);
+    expect(attack.status).toBe(403);
+    expect(((await attack.json()) as { error: string }).error).toBe("device_not_owned");
+
+    const [owner] = await sql<{ user_id: string }[]>`
+      select user_id from device_tokens where device_token = ${sharedToken}
+    `;
+    expect(owner.user_id).toBe("push-user-1");
   });
 });

--- a/web/tests/security-headers.test.ts
+++ b/web/tests/security-headers.test.ts
@@ -1,22 +1,37 @@
 import { describe, expect, test } from "bun:test";
-import { poweredByHeader, securityHeaderRules } from "../security-headers";
+import { contentSecurityPolicy, poweredByHeader, securityHeaderRules } from "../security-headers";
 
 describe("production security headers", () => {
   test("does not expose framework implementation details", () => {
     expect(poweredByHeader).toBe(false);
   });
 
-  test("applies baseline hardening headers to every route", async () => {
+  test("applies CSP + baseline hardening headers to every route", async () => {
     const allRoutes = securityHeaderRules.find((rule) => rule.source === "/:path*");
     expect(allRoutes).toBeDefined();
 
     const headers = Object.fromEntries(allRoutes!.headers.map((header) => [header.key, header.value]));
     expect(headers).toMatchObject({
-      "Content-Security-Policy": "base-uri 'self'; object-src 'none'; frame-ancestors 'none'",
+      "Content-Security-Policy": contentSecurityPolicy,
       "Referrer-Policy": "strict-origin-when-cross-origin",
       "X-Content-Type-Options": "nosniff",
       "X-Frame-Options": "DENY",
       "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
     });
+  });
+});
+
+describe("Content-Security-Policy", () => {
+  test("blocks external scripts and restricts connect/img origins", () => {
+    expect(contentSecurityPolicy).toContain("default-src 'self'");
+    // 'unsafe-inline' allows the app's own inline scripts (Next hydration,
+    // theme bootstrap) while 'self' blocks external-origin script injection.
+    expect(contentSecurityPolicy).toContain("script-src 'self' 'unsafe-inline'");
+    expect(contentSecurityPolicy).toContain("style-src 'self' 'unsafe-inline'");
+    expect(contentSecurityPolicy).toContain("connect-src 'self' https://r.cmux.com");
+    expect(contentSecurityPolicy).toContain("img-src 'self' data: https://github.com https://avatars.githubusercontent.com");
+    expect(contentSecurityPolicy).toContain("base-uri 'self'");
+    expect(contentSecurityPolicy).toContain("object-src 'none'");
+    expect(contentSecurityPolicy).toContain("frame-ancestors 'none'");
   });
 });

--- a/workers/presence/src/auth.ts
+++ b/workers/presence/src/auth.ts
@@ -77,6 +77,17 @@ export function tokenExpiryMs(token: string): number | null {
   }
 }
 
+/** Stack access tokens are JWTs (`header.payload.signature`). A bearer that is
+ * not exactly three non-empty dot-separated segments cannot be a legitimate
+ * token, so it is rejected before any Stack subrequest. Without this, a stream
+ * of distinct opaque values forces two Stack fetches per request (a quota/cost
+ * amplification vector), since the negative cache only de-duplicates a
+ * *repeated* token, not a flood of unique ones. Pure for tests. */
+export function isJwtShape(token: string): boolean {
+  const parts = token.split(".");
+  return parts.length === 3 && parts.every((part) => part.length > 0);
+}
+
 export type TeamResolution =
   | { ok: true; teamId: string }
   | { ok: false; error: "team_not_found" };
@@ -192,6 +203,7 @@ export async function verifyRequest(request: Request, env: AuthEnv): Promise<Aut
   if (!env.STACK_PROJECT_ID || !env.STACK_PUBLISHABLE_CLIENT_KEY) return null;
   const token = bearerToken(request);
   if (!token) return null;
+  if (!isJwtShape(token)) return null;
 
   const now = Date.now();
   const expMs = tokenExpiryMs(token);

--- a/workers/presence/src/core.ts
+++ b/workers/presence/src/core.ts
@@ -239,13 +239,20 @@ export type OwnerCheck =
  *
  * The pin lives in DO storage and is durable: it is never pruned with the
  * 24h presence tail, so an idle device cannot be re-claimed by a co-member.
- * Known residual (accepted until the registry's planned per-device
- * key-pinning phase, see the `devices` schema note): the very first claim of
- * a deviceId is first-authenticated-writer-wins, because the presence
- * service deliberately has no synchronous dependency on the Aurora registry
- * (presence must stay available when the web API is not) and the registry
- * does not yet issue verifiable device credentials. Blast radius is presence
- * display only; attach routes and durable identity stay registry-owned.
+ *
+ * TODO(security): Known residual — the very first claim of a deviceId is
+ * first-authenticated-writer-wins. Any authenticated team member can race the
+ * legitimate owner to claim an unannounced deviceId (device ids are visible to
+ * the whole team), after which the real owner is locked out (403
+ * device_owner_mismatch) until manual intervention. Accepted for now because
+ * the presence service deliberately has no synchronous dependency on the Aurora
+ * registry (presence must stay available when the web API is not) and the
+ * registry does not yet issue verifiable per-device credentials. The fix is the
+ * registry's planned per-device key-pinning phase (see the `devices` schema
+ * note): cross-check the first claim against the registry's pinned registering
+ * userId, or have the registry issue a verifiable credential presence validates
+ * on first contact. Blast radius is presence display only; attach routes and
+ * durable identity stay registry-owned.
  * Pure for tests. */
 export function checkDeviceOwner(
   existingOwner: string | undefined,

--- a/workers/presence/test/auth.test.ts
+++ b/workers/presence/test/auth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   AUTH_CACHE_TTL_MS,
   cacheDeadline,
+  isJwtShape,
   requestedTeamIdFromRequest,
   resolveTeamId,
   tokenExpiryMs,
@@ -95,21 +96,67 @@ describe("tokenExpiryMs", () => {
   });
 });
 
-describe("verifyRequest negative cache", () => {
+describe("isJwtShape", () => {
+  it("accepts a three-segment JWT-shaped bearer", () => {
+    expect(isJwtShape("header.payload.sig")).toBe(true);
+  });
+
+  it("rejects opaque tokens", () => {
+    expect(isJwtShape("opaque-rejected-token")).toBe(false);
+  });
+
+  it("rejects tokens without exactly three segments", () => {
+    expect(isJwtShape("a.b")).toBe(false);
+    expect(isJwtShape("a.b.c.d")).toBe(false);
+    expect(isJwtShape("")).toBe(false);
+    // Three segments but one or more empty (e.g. ".." or "a..c") is not a JWT.
+    expect(isJwtShape("..")).toBe(false);
+    expect(isJwtShape("a..c")).toBe(false);
+    expect(isJwtShape(".b.")).toBe(false);
+  });
+});
+
+describe("verifyRequest", () => {
   const env = {
     STACK_PROJECT_ID: "proj",
     STACK_PUBLISHABLE_CLIENT_KEY: "pk",
     STACK_API_URL: "https://stack.test",
   };
 
-  it("does not re-hit Stack for a token it already rejected", async () => {
+  it("rejects an opaque bearer before any Stack subrequest", async () => {
     const { verifyRequest } = await import("../src/auth");
     const realFetch = globalThis.fetch;
     let calls = 0;
-    // Opaque (non-JWT) bearer: tokenExpiryMs is null, so the cheap expiry
-    // short-circuit cannot help and only the negative cache prevents the
-    // per-request Stack subrequest amplification.
-    const token = "opaque-rejected-token-" + Math.random().toString(36).slice(2);
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response("unauthorized", { status: 401 });
+    }) as unknown as typeof fetch;
+    try {
+      const make = () =>
+        new Request("https://presence.test/v1/presence/snapshot", {
+          headers: { authorization: "Bearer opaque-rejected-token" },
+        });
+      // Opaque (non-JWT) bearers are rejected by shape, so a flood of distinct
+      // opaque values cannot amplify into 2 Stack subrequests per request.
+      expect(await verifyRequest(make(), env)).toBeNull();
+      expect(calls).toBe(0);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("does not re-hit Stack for a JWT it already rejected (negative cache)", async () => {
+    const { verifyRequest } = await import("../src/auth");
+    const realFetch = globalThis.fetch;
+    let calls = 0;
+    // JWT-shaped but Stack-rejected: the negative cache de-duplicates repeat
+    // verifications so a hostile client replaying the same token only costs one
+    // Stack round trip per TTL window.
+    const payload = btoa(JSON.stringify({}))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const token = `header.${payload}.sig`;
     globalThis.fetch = (async () => {
       calls += 1;
       return new Response("unauthorized", { status: 401 });
@@ -127,4 +174,4 @@ describe("verifyRequest negative cache", () => {
       globalThis.fetch = realFetch;
     }
   });
-})
+});


### PR DESCRIPTION
## Summary

Addresses all **10 confirmed findings** from the 2026-06-23 multi-dimensional security scan (1 MEDIUM cross-user device-token hijack + 9 LOW defense-in-depth). No critical/high. Full scan report: `plans/reports/security-scan-260623-1708-cmux.md`.

## Changes

| Sev | Area | Fix |
|-----|------|-----|
| **MEDIUM** | device-tokens | Refuse to overwrite a token owned by another user (403 `device_not_owned` before upsert; token-scoped advisory lock, seed 3). Mirrors `/api/devices`. |
| LOW | web API | `jsonResponse` now sets `Cache-Control: no-store, private` — VM SSH/attach responses carry live credentials (one-time SSH password, E2B traffic token, 12h cmuxd RPC lease token). |
| LOW | auth (Swift) | Stack tokens + session HMAC key → `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` (device-only, no iCloud Keychain restore); delete-then-add on every write (migrates existing items); plaintext file fallback compiles out under `#if DEBUG`. |
| LOW | CLI | Stop forwarding the socket password through the watcher argv (already inherited via `CMUX_SOCKET_PASSWORD`, resolved via `SocketPasswordResolver`). |
| LOW | analytics | IP-keyed Vercel Firewall rate limit on anonymous event ingest when on Vercel + `CMUX_ANALYTICS_RATE_LIMIT_ID` set; reads id from `process.env` (not the t3 env singleton) and lazy-imports `@vercel/firewall`. |
| LOW | presence worker | Reject non-JWT bearers before any Stack subrequest (closes unbounded subrequest amplification from distinct opaque tokens). |
| LOW | web CSP | Static restrictive CSP (`default-src 'self'`, `script-src 'self' 'unsafe-inline'`, scoped `connect-src`/`img-src`/`font-src`) applied to every route via `next.config.ts` `headers()`. |
| LOW | cloud VM exec | Tighten `MAX_EXEC_TIMEOUT_MS` ceiling 15 → 10 minutes. |
| LOW | presence worker | Surface the first-writer-wins device-owner race as a tracked TODO (accepted residual; blast radius is presence-display only). |

## Device-token fix — two-commit red/green

Per the regression-test policy, `test(device-tokens): cover cross-user token takeover attempt` lands first and fails on `main` (route overwrites the owner); `fix(device-tokens): refuse to overwrite a token owned by another user` then makes it green.

## Verification

- **Web:** 143 pass / 0 fail (47 DB-gated skips), `tsc --noEmit` clean.
- **Worker presence:** 139 pass / 0 fail.
- **Swift:** `CmuxAuthRuntime` package compiles locally. The macOS app target (`Sources/SessionPersistence.swift`, `CLI/cmux.swift`) could not be compiled in the dev environment — CI should confirm.
- **DB test (device-token red→green):** gated on `CMUX_DB_TEST=1` + Postgres; needs CI to demonstrate the red→green transition.

## Follow-up (operator)

- Provision the Vercel Firewall rule referenced by `CMUX_ANALYTICS_RATE_LIMIT_ID`. The analytics route degrades gracefully (no rate limiting) until it exists.
- A per-user/per-VM concurrency cap for `vm/[id]/exec` is tracked as follow-up (this PR only tightens the timeout ceiling).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784815358&installation_id=133855650&pr_number=6705&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6705&signature=32e486e44158c76893a0bece4d77c2dc8bf3e1a10fefad4e457c17f85b933871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks cross‑user device‑token hijacks and adds nine defense‑in‑depth improvements across web, workers, CLI, and Swift. Stronger ownership checks, safer headers and CSP, anonymous analytics rate limiting, device‑only Keychain storage, and a shorter VM exec ceiling.

- **Bug Fixes**
  - Device tokens: refuse takeovers (403 `device_not_owned`) and serialize claims with a token‑scoped advisory lock; adds a regression test.
  - Web API: set `Cache-Control: no-store, private` in `jsonResponse()` to protect SSH/attach/RPC lease tokens; tighten `vm/[id]/exec` max timeout to 10m.
  - Analytics: add optional IP/edge rate limit via `@vercel/firewall` when `CMUX_ANALYTICS_RATE_LIMIT_ID` is set; lazy‑import and read the id from `process.env`.
  - CSP: apply a static restrictive policy for all routes (`default-src 'self'`, `script-src 'self' 'unsafe-inline'`, scoped `connect/img/font`).
  - Presence worker: reject non‑JWT bearers before any Stack subrequest to prevent amplification.
  - CLI: stop passing the socket password via argv; rely on `CMUX_SOCKET_PASSWORD` env/secret resolver.
  - Swift auth: store stack tokens and the session HMAC secret as `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` with delete‑then‑add writes; disable plaintext file fallback in Release builds.

- **Migration**
  - Provision the Vercel Firewall rule referenced by `CMUX_ANALYTICS_RATE_LIMIT_ID`; analytics ingest degrades gracefully if absent.

<sup>Written for commit 109b1e030e5a50b9934034d661276a39fb9a57a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Enhancements**
  * Added rate limiting for anonymous analytics event submissions.
  * Prevented device token hijacking through improved registration checks.
  * Strengthened Content Security Policy with expanded directives.
  * Enhanced keychain storage to use device-only accessibility.
  * Reduced VM execution timeout to 10 minutes for abuse prevention.
  * Improved JWT validation in authentication flows.
  * Added cache-control headers to sensitive credential responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->