### PR TITLE
Remote agent status + git/PR in the sidebar for cmux ssh-tmux mirrors

### DIFF
--- a/Sources/RemoteTmuxAgentHookInstaller.swift
+++ b/Sources/RemoteTmuxAgentHookInstaller.swift
@@ -26,9 +26,14 @@ enum RemoteTmuxAgentHookInstaller {
     /// - `agent`: the label cmux maps back to a provider (`claude` / `codex`).
     /// - `state`: the lifecycle word (`running` / `working` / `idle`).
     static func hookScript(agent: String, state: String) -> String {
-        // model extraction: grep the event JSON for "model":"…"; harmless if absent.
-        // tmux set is scoped to $TMUX_PANE so it lands on the agent's own pane; if
-        // not inside tmux, $TMUX_PANE is empty and we skip (no-op, print {}).
+        // Publishes two pane-scoped tmux options the cmux mirror subscribes to:
+        //   @cmux_agent — {agent,state,model?}: written synchronously (cheap).
+        //   @cmux_git   — {branch,dirty,pr?}:   written in a DETACHED background
+        //                 subshell because `git` + `gh pr view` can be slow, and a
+        //                 hook must never delay the agent's own event.
+        // Both `tmux set` are scoped to $TMUX_PANE so they land on the agent's own
+        // pane; outside tmux ($TMUX_PANE empty) everything is skipped. Always
+        // prints `{}` last so a blocking hook gets valid stdout.
         """
         IN=$(cat 2>/dev/null); \
         if [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then \
@@ -38,6 +43,13 @@ enum RemoteTmuxAgentHookInstaller {
         else \
         tmux set -t "$TMUX_PANE" @cmux_agent "{\\"agent\\":\\"\(agent)\\",\\"state\\":\\"\(state)\\"}" >/dev/null 2>&1; \
         fi; \
+        ( P="$TMUX_PANE"; \
+        B=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); \
+        if [ -n "$B" ] && [ "$B" != "HEAD" ]; then \
+        if git diff --quiet --ignore-submodules HEAD >/dev/null 2>&1; then D=0; else D=1; fi; \
+        PR=$(gh pr view --json number,state,url -q '\",\\"pr\\":{\\"number\\":\"+(.number|tostring)+\",\\"state\\":\\"\"+.state+\"\\",\\"url\\":\\"\"+.url+\"\\"}\"' 2>/dev/null); \
+        tmux set -t "$P" @cmux_git "{\\"branch\\":\\"$B\\",\\"dirty\\":$D$PR}" >/dev/null 2>&1; \
+        fi ) >/dev/null 2>&1 </dev/null & \
         fi; \
         printf '{}'
         """

--- a/Sources/RemoteTmuxAgentHookInstaller.swift
+++ b/Sources/RemoteTmuxAgentHookInstaller.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// Installs a tiny status-reporting hook into a remote host's Claude Code and
+/// Codex configuration so an agent running inside a `cmux ssh-tmux` mirror reports
+/// running/working/idle (+ model) back to cmux's left sidebar — Option C in
+/// `docs/investigations/remote-agent-status-sidebar.md`.
+///
+/// The hook runs entirely on the remote and is dependency-free: on each lifecycle
+/// event it runs `tmux set -t "$TMUX_PANE" @cmux_agent '<json>'`. cmux already
+/// subscribes to `#{@cmux_agent}` per pane over the live `tmux -CC` control stream
+/// (``RemoteTmuxControlConnection/subscribePaneAgent(paneId:)``), so the value
+/// arrives as a `%subscription-changed` line — **no remote cmux CLI, no socket, no
+/// reverse relay, no auth**. The hook self-disables when `$TMUX_PANE` is unset
+/// (i.e. the agent isn't running inside tmux), so installing it is harmless
+/// outside the mirror.
+///
+/// This type only *builds* the shell scripts + config edits; the remote write is
+/// performed over ``RemoteTmuxSSHTransport`` by the caller. Everything here is pure
+/// and unit-tested.
+enum RemoteTmuxAgentHookInstaller {
+    /// The shared shell hook body, parameterized by the agent label and the state.
+    /// Reads the event JSON on stdin (Claude/Codex both feed it there), best-effort
+    /// extracts a model id, and publishes the status into the pane's `@cmux_agent`
+    /// option. Always prints `{}` last so a blocking hook gets valid stdout.
+    ///
+    /// - `agent`: the label cmux maps back to a provider (`claude` / `codex`).
+    /// - `state`: the lifecycle word (`running` / `working` / `idle`).
+    static func hookScript(agent: String, state: String) -> String {
+        // model extraction: grep the event JSON for "model":"…"; harmless if absent.
+        // tmux set is scoped to $TMUX_PANE so it lands on the agent's own pane; if
+        // not inside tmux, $TMUX_PANE is empty and we skip (no-op, print {}).
+        """
+        IN=$(cat 2>/dev/null); \
+        if [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then \
+        MODEL=$(printf '%s' "$IN" | grep -o '\"model\":\"[^\"]*\"' | tail -1 | sed 's/.*\"model\":\"//; s/\"$//'); \
+        if [ -n "$MODEL" ]; then \
+        tmux set -t "$TMUX_PANE" @cmux_agent "{\\"agent\\":\\"\(agent)\\",\\"state\\":\\"\(state)\\",\\"model\\":\\"$MODEL\\"}" >/dev/null 2>&1; \
+        else \
+        tmux set -t "$TMUX_PANE" @cmux_agent "{\\"agent\\":\\"\(agent)\\",\\"state\\":\\"\(state)\\"}" >/dev/null 2>&1; \
+        fi; \
+        fi; \
+        printf '{}'
+        """
+    }
+
+    /// Marker so cmux can recognize (and replace/remove) its own remote hook
+    /// entries without disturbing the user's other hooks.
+    static let marker = "cmux-remote-agent-status"
+
+    // MARK: - Claude (~/.claude/settings.json)
+
+    /// The `hooks` object cmux merges into the remote `~/.claude/settings.json`.
+    /// SessionStart/UserPromptSubmit → working/running; Stop → idle.
+    static func claudeHooksObject() -> [String: Any] {
+        func entry(_ state: String) -> [String: Any] {
+            [
+                "matcher": "",
+                "hooks": [[
+                    "type": "command",
+                    "command": hookScript(agent: "claude", state: state),
+                    "timeout": 5,
+                    "_cmux": marker,
+                ]],
+            ]
+        }
+        return [
+            "SessionStart": [entry("running")],
+            "UserPromptSubmit": [entry("working")],
+            "Stop": [entry("idle")],
+        ]
+    }
+
+    /// Builds the remote shell command that merges cmux's hooks into
+    /// `~/.claude/settings.json` (creating it if absent), preserving any existing
+    /// user hooks/keys and replacing only previously cmux-owned entries. Uses a
+    /// here-doc'd python3 merger for robust JSON editing; falls back to a fresh
+    /// file when python3 is unavailable.
+    static func claudeInstallCommand() -> [String] {
+        let hooksJSON = jsonString(claudeHooksObject())
+        let py = """
+        import json, os, sys
+        p = os.path.expanduser('~/.claude/settings.json')
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        try:
+            cfg = json.load(open(p))
+            if not isinstance(cfg, dict): cfg = {}
+        except Exception:
+            cfg = {}
+        add = json.loads(os.environ['CMUX_HOOKS'])
+        hooks = cfg.get('hooks')
+        if not isinstance(hooks, dict): hooks = {}
+        for ev, entries in add.items():
+            cur = hooks.get(ev)
+            if not isinstance(cur, list): cur = []
+            cur = [e for e in cur if not (isinstance(e, dict) and any(
+                isinstance(h, dict) and h.get('_cmux') == '\(marker)' for h in e.get('hooks', [])))]
+            hooks[ev] = cur + entries
+        cfg['hooks'] = hooks
+        json.dump(cfg, open(p, 'w'), indent=2)
+        """
+        // Pass the hooks JSON via env to avoid quoting it inside the python source.
+        return ["sh", "-c", "CMUX_HOOKS=\(shSingleQuote(hooksJSON)) python3 -c \(shSingleQuote(py))"]
+    }
+
+    // MARK: - Codex (~/.codex/hooks.json)
+
+    /// The nested `hooks` object cmux merges into the remote `~/.codex/hooks.json`.
+    static func codexHooksObject() -> [String: Any] {
+        func entry(_ state: String) -> [String: Any] {
+            ["hooks": [[
+                "type": "command",
+                "command": hookScript(agent: "codex", state: state),
+                "timeout": 5,
+                "_cmux": marker,
+            ]]]
+        }
+        return [
+            "SessionStart": [entry("running")],
+            "UserPromptSubmit": [entry("working")],
+            "Stop": [entry("idle")],
+        ]
+    }
+
+    /// Remote shell command that merges cmux's hooks into `~/.codex/hooks.json`
+    /// under the top-level `{"hooks": {...}}` shape, same replace-cmux-owned logic.
+    static func codexInstallCommand() -> [String] {
+        let hooksJSON = jsonString(codexHooksObject())
+        let py = """
+        import json, os
+        home = os.environ.get('CODEX_HOME') or os.path.expanduser('~/.codex')
+        p = os.path.join(home, 'hooks.json')
+        os.makedirs(home, exist_ok=True)
+        try:
+            cfg = json.load(open(p))
+            if not isinstance(cfg, dict): cfg = {}
+        except Exception:
+            cfg = {}
+        add = json.loads(os.environ['CMUX_HOOKS'])
+        hooks = cfg.get('hooks')
+        if not isinstance(hooks, dict): hooks = {}
+        for ev, entries in add.items():
+            cur = hooks.get(ev)
+            if not isinstance(cur, list): cur = []
+            cur = [e for e in cur if not (isinstance(e, dict) and any(
+                isinstance(h, dict) and h.get('_cmux') == '\(marker)' for h in e.get('hooks', [])))]
+            hooks[ev] = cur + entries
+        cfg['hooks'] = hooks
+        json.dump(cfg, open(p, 'w'), indent=2)
+        """
+        return ["sh", "-c", "CMUX_HOOKS=\(shSingleQuote(hooksJSON)) python3 -c \(shSingleQuote(py))"]
+    }
+
+    // MARK: - helpers
+
+    /// Deterministic JSON encode (sorted keys) for embedding in the install command.
+    static func jsonString(_ obj: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: obj, options: [.sortedKeys]),
+              let s = String(data: data, encoding: .utf8) else { return "{}" }
+        return s
+    }
+
+    /// Single-quotes a value for safe `/bin/sh` embedding.
+    static func shSingleQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Sources/RemoteTmuxAgentProbe.swift
+++ b/Sources/RemoteTmuxAgentProbe.swift
@@ -40,17 +40,23 @@ enum RemoteTmuxAgentProbe {
         let trimmed = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         let dir = encodeProjectDir(trimmed)
-        // Single-quote the dir for safe embedding; the whole script is one arg.
-        let q = "'" + dir.replacingOccurrences(of: "'", with: "'\\''") + "'"
         let sep = fieldSeparator
+        // The project dir is passed as a positional arg ($1), NOT interpolated, so
+        // an odd cwd can't break the script. The glob is resolved with `ls`
+        // (stdout captured), and 2>/dev/null swallows the "no matches" diagnostic
+        // — and a non-glob `find`-free `ls "$d"/*.jsonl` would error under a
+        // login shell with `nullglob` off, so we list the directory and filter.
         let script = """
-        d="$HOME/.claude/projects/\(q)"; \
-        n=$(ls -t "$d"/*.jsonl 2>/dev/null | head -1); \
+        d="$HOME/.claude/projects/$1"; \
+        [ -d "$d" ] || exit 0; \
+        n=$(ls -1t "$d" 2>/dev/null | grep '\\.jsonl$' | head -1); \
         [ -z "$n" ] && exit 0; \
-        m=$(stat -c %Y "$n" 2>/dev/null || stat -f %m "$n" 2>/dev/null); \
-        printf '%s\(sep)%s\(sep)%s' "$(date +%s)" "$m" "$n"
+        f="$d/$n"; \
+        m=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null); \
+        printf '%s\(sep)%s\(sep)%s' "$(date +%s)" "$m" "$f"
         """
-        return ["sh", "-c", script]
+        // `sh -c <script> <arg0> <dir>`: $0 is a label, $1 is the project dir.
+        return ["sh", "-c", script, "cmux-agent-probe", dir]
     }
 
     /// Builds the remote argv that reads the model from a transcript's last
@@ -59,14 +65,14 @@ enum RemoteTmuxAgentProbe {
     static func modelProbeCommand(transcriptPath: String) -> [String]? {
         let trimmed = transcriptPath.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        let q = "'" + trimmed.replacingOccurrences(of: "'", with: "'\\''") + "'"
-        // Last 40 lines, last occurrence of a model field; sed extracts the value.
+        // The path is passed as a positional arg ($1), not interpolated, so it
+        // can't break the script. Last 40 lines, last `"model":"…"`, value out.
         let script = """
-        tail -n 40 \(q) 2>/dev/null \
+        tail -n 40 "$1" 2>/dev/null \
         | grep -o '\"model\":\"[^\"]*\"' | tail -1 \
         | sed 's/.*\"model\":\"//; s/\"$//'
         """
-        return ["sh", "-c", script]
+        return ["sh", "-c", script, "cmux-agent-probe", trimmed]
     }
 
     /// Parsed result of the activity probe.

--- a/Sources/RemoteTmuxAgentProbe.swift
+++ b/Sources/RemoteTmuxAgentProbe.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// Pure builder + parser for the remote `~/.claude` activity probe that enriches
+/// a remote-tmux agent chip with busy/idle and model (Attempt 2 in
+/// `docs/investigations/remote-agent-status-sidebar.md`).
+///
+/// The mirror already knows a pane's working directory (`pane_current_path`, the
+/// `cmux_cwd_` subscription). Claude derives its transcript directory name from
+/// the cwd by replacing `/` and `.` with `-`
+/// (``RestorableAgentSessionIndex/encodeClaudeProjectDir(_:)``), and appends each
+/// session's events to `~/.claude/projects/<dir>/<sessionId>.jsonl` in real time.
+/// So from the cwd alone — no remote PID needed — we can read the newest
+/// transcript's mtime (a busy/idle proxy) and its last assistant `message.model`.
+///
+/// This type owns only the *shell command* and the *output parse*; the async
+/// exec + throttling live in the mirror. Both are pure and unit-tested, because
+/// they are the correctness-critical pieces (the remote tmux exposes the comm
+/// name but never the agent's busy/idle or model — those come only from here).
+enum RemoteTmuxAgentProbe {
+    /// Seconds since a transcript's last write within which the agent is treated
+    /// as "working". A long tool call can briefly exceed this; the chip then reads
+    /// "idle" until the next transcript append. Chosen generous enough to ride
+    /// short gaps, short enough that a finished session goes idle promptly.
+    static let busyWindowSeconds = 30
+
+    /// Field separator in the probe's single-line stdout. A unit separator never
+    /// appears in a model id, an epoch integer, or a transcript path.
+    static let fieldSeparator = "\u{1f}"
+
+    /// Builds the remote `["sh", "-c", <script>]` argv that probes the Claude
+    /// transcript for `cwd`. The script:
+    ///   1. derives the project-dir name from `cwd` (the same `/`+`.`→`-` rule),
+    ///   2. finds the newest `*.jsonl` under `~/.claude/projects/<dir>`,
+    ///   3. prints `<nowEpoch><US><mtimeEpoch><US><newestPath>` (one line),
+    /// portably across GNU/BSD `stat` (tries `-c %Y`, falls back to `-f %m`).
+    ///
+    /// The model is parsed in a *second* step (`tailCommand`) only when busy, to
+    /// keep the hot probe cheap. Returns `nil` for an empty/space-only cwd.
+    static func activityProbeCommand(cwd: String) -> [String]? {
+        let trimmed = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let dir = encodeProjectDir(trimmed)
+        // Single-quote the dir for safe embedding; the whole script is one arg.
+        let q = "'" + dir.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        let sep = fieldSeparator
+        let script = """
+        d="$HOME/.claude/projects/\(q)"; \
+        n=$(ls -t "$d"/*.jsonl 2>/dev/null | head -1); \
+        [ -z "$n" ] && exit 0; \
+        m=$(stat -c %Y "$n" 2>/dev/null || stat -f %m "$n" 2>/dev/null); \
+        printf '%s\(sep)%s\(sep)%s' "$(date +%s)" "$m" "$n"
+        """
+        return ["sh", "-c", script]
+    }
+
+    /// Builds the remote argv that reads the model from a transcript's last
+    /// assistant line. `tail`-then-grep keeps it to the final lines; the caller
+    /// passes the `transcriptPath` returned by the activity probe.
+    static func modelProbeCommand(transcriptPath: String) -> [String]? {
+        let trimmed = transcriptPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let q = "'" + trimmed.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        // Last 40 lines, last occurrence of a model field; sed extracts the value.
+        let script = """
+        tail -n 40 \(q) 2>/dev/null \
+        | grep -o '\"model\":\"[^\"]*\"' | tail -1 \
+        | sed 's/.*\"model\":\"//; s/\"$//'
+        """
+        return ["sh", "-c", script]
+    }
+
+    /// Parsed result of the activity probe.
+    struct Activity: Equatable {
+        let busy: Bool
+        let transcriptPath: String
+    }
+
+    /// Parses `activityProbeCommand` stdout. `nil` when there is no transcript
+    /// (empty stdout) or the line is malformed — caller treats that as "no
+    /// transcript activity to show".
+    static func parseActivity(stdout: String) -> Activity? {
+        let line = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !line.isEmpty else { return nil }
+        let fields = line.components(separatedBy: fieldSeparator)
+        guard fields.count >= 3,
+              let now = Int(fields[0].trimmingCharacters(in: .whitespaces)),
+              let mtime = Int(fields[1].trimmingCharacters(in: .whitespaces))
+        else { return nil }
+        let path = fields[2...].joined(separator: fieldSeparator)
+        guard !path.isEmpty else { return nil }
+        // A clock skew between the probe's `date +%s` and the file's mtime can make
+        // (now - mtime) negative; a write at-or-ahead of "now" is the freshest
+        // possible, so clamp negative ages to busy rather than reading them idle.
+        let age = now - mtime
+        return Activity(busy: age <= busyWindowSeconds, transcriptPath: path)
+    }
+
+    /// Parses `modelProbeCommand` stdout into a trimmed model id, or `nil`.
+    /// Strips the `[1m]` "1 month retention" suffix the way the local Claude
+    /// metadata parser does (`SessionIndexStore.extractClaudeMetadata`).
+    static func parseModel(stdout: String) -> String? {
+        var model = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !model.isEmpty else { return nil }
+        if model.hasSuffix("[1m]") { model.removeLast(4) }
+        model = model.trimmingCharacters(in: .whitespaces)
+        return model.isEmpty ? nil : model
+    }
+
+    /// The Claude project-dir name for a cwd — same rule as
+    /// ``RestorableAgentSessionIndex/encodeClaudeProjectDir(_:)`` (kept local so
+    /// this pure helper has no dependency on that type).
+    static func encodeProjectDir(_ path: String) -> String {
+        path.replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+    }
+}

--- a/Sources/RemoteTmuxAgentStatus.swift
+++ b/Sources/RemoteTmuxAgentStatus.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// A coding-agent status reported by a remote agent's own lifecycle hook, carried
+/// over the tmux control stream as the `@cmux_agent` user option (Option C in
+/// `docs/investigations/remote-agent-status-sidebar.md`).
+///
+/// The remote hook runs `tmux set -p @cmux_agent '<json>'` on each lifecycle event
+/// (SessionStart/UserPromptSubmit → working, Stop → idle), and cmux already
+/// receives the new value as a `%subscription-changed cmux_agent_<paneId> … : <json>`
+/// line on the live `tmux -CC` stream — no socket, no relay, no remote cmux CLI.
+/// This type is the pure parser for that JSON value; the subscription wiring lives
+/// in ``RemoteTmuxControlConnection`` and the sidebar write in
+/// ``RemoteTmuxSessionMirror``.
+struct RemoteTmuxAgentStatus: Equatable, Sendable {
+    enum State: String, Sendable {
+        case running   // session started / attached, no turn in flight
+        case working   // a turn is in flight (prompt submitted, tools running)
+        case idle      // turn finished / stopped, waiting on the user
+
+        /// The lifecycle words the hooks emit, mapped to a state. Tolerant of a few
+        /// synonyms so the remote hook script can use whichever the agent provides.
+        init?(hookWord raw: String) {
+            switch raw.trimmingCharacters(in: .whitespaces).lowercased() {
+            case "working", "busy", "active", "start", "running-turn": self = .working
+            case "idle", "stop", "done", "complete", "finished", "waiting": self = .idle
+            case "running", "session-start", "start-session", "ready": self = .running
+            default: return nil
+            }
+        }
+    }
+
+    /// Agent label as the remote reported it (e.g. `claude`, `codex`). Lowercased,
+    /// non-empty.
+    let agent: String
+    let state: State
+    /// Optional model id (already stripped of any `[1m]` retention suffix).
+    let model: String?
+    /// Optional short title / current activity line.
+    let title: String?
+
+    /// Parses the `@cmux_agent` option value. Accepts a JSON object with
+    /// `{agent, state, model?, title?}`. Returns `nil` for an empty value (the
+    /// hook clears the option to remove the chip) or a value missing the required
+    /// `agent`/`state`.
+    static func parse(_ raw: String) -> RemoteTmuxAgentStatus? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard let data = trimmed.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+
+        guard let agentRaw = (obj["agent"] as? String)?
+                .trimmingCharacters(in: .whitespaces).lowercased(),
+              !agentRaw.isEmpty,
+              let stateRaw = obj["state"] as? String,
+              let state = State(hookWord: stateRaw)
+        else { return nil }
+
+        let model = (obj["model"] as? String).flatMap(normalizeModel)
+        let title = (obj["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return RemoteTmuxAgentStatus(
+            agent: agentRaw,
+            state: state,
+            model: model,
+            title: (title?.isEmpty == false) ? title : nil
+        )
+    }
+
+    /// Strips the `[1m]` retention suffix Bedrock model ids carry, matching the
+    /// local Claude metadata parser, and trims. Returns `nil` when empty.
+    private static func normalizeModel(_ raw: String) -> String? {
+        var model = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if model.hasSuffix("[1m]") { model.removeLast(4) }
+        model = model.trimmingCharacters(in: .whitespaces)
+        return model.isEmpty ? nil : model
+    }
+}

--- a/Sources/RemoteTmuxConnectionObservers.swift
+++ b/Sources/RemoteTmuxConnectionObservers.swift
@@ -19,6 +19,7 @@ final class RemoteTmuxConnectionObservers {
     private var paneReflowObservers: [Token: (_ paneId: Int, _ noReflow: Bool) -> Void] = [:]
     private var activePaneObservers: [Token: (_ windowId: Int, _ paneId: Int) -> Void] = [:]
     private var sessionChangedObservers: [Token: (_ oldName: String, _ newName: String) -> Void] = [:]
+    private var paneAgentObservers: [Token: (_ paneId: Int, _ rawValue: String) -> Void] = [:]
     private var topologyObservers: [Token: () -> Void] = [:]
     private var exitObservers: [Token: () -> Void] = [:]
     private var stateObservers: [Token: (RemoteTmuxControlConnection.ConnectionState) -> Void] = [:]
@@ -58,6 +59,7 @@ final class RemoteTmuxConnectionObservers {
         onPaneReflow: ((_ paneId: Int, _ noReflow: Bool) -> Void)?,
         onActivePaneChanged: ((_ windowId: Int, _ paneId: Int) -> Void)?,
         onSessionChanged: ((_ oldName: String, _ newName: String) -> Void)?,
+        onPaneAgent: ((_ paneId: Int, _ rawValue: String) -> Void)? = nil,
         onTopologyChanged: (() -> Void)?,
         onExit: (() -> Void)?,
         onConnectionStateChanged: ((RemoteTmuxControlConnection.ConnectionState) -> Void)?
@@ -68,6 +70,7 @@ final class RemoteTmuxConnectionObservers {
         if let onPaneReflow { paneReflowObservers[token] = onPaneReflow }
         if let onActivePaneChanged { activePaneObservers[token] = onActivePaneChanged }
         if let onSessionChanged { sessionChangedObservers[token] = onSessionChanged }
+        if let onPaneAgent { paneAgentObservers[token] = onPaneAgent }
         if let onTopologyChanged { topologyObservers[token] = onTopologyChanged }
         if let onExit { exitObservers[token] = onExit }
         if let onConnectionStateChanged { stateObservers[token] = onConnectionStateChanged }
@@ -81,6 +84,7 @@ final class RemoteTmuxConnectionObservers {
         paneReflowObservers[token] = nil
         activePaneObservers[token] = nil
         sessionChangedObservers[token] = nil
+        paneAgentObservers[token] = nil
         topologyObservers[token] = nil
         exitObservers[token] = nil
         stateObservers[token] = nil
@@ -111,6 +115,11 @@ final class RemoteTmuxConnectionObservers {
     /// Notifies every observer that the remote session name changed.
     func emitSessionChanged(oldName: String, newName: String) {
         for callback in Array(sessionChangedObservers.values) { callback(oldName, newName) }
+    }
+
+    /// Fans a pane's raw `@cmux_agent` value out to every agent-status observer.
+    func emitPaneAgent(_ paneId: Int, _ rawValue: String) {
+        for callback in Array(paneAgentObservers.values) { callback(paneId, rawValue) }
     }
 
     /// Notifies every topology observer that the window/pane layout changed.

--- a/Sources/RemoteTmuxConnectionObservers.swift
+++ b/Sources/RemoteTmuxConnectionObservers.swift
@@ -20,6 +20,7 @@ final class RemoteTmuxConnectionObservers {
     private var activePaneObservers: [Token: (_ windowId: Int, _ paneId: Int) -> Void] = [:]
     private var sessionChangedObservers: [Token: (_ oldName: String, _ newName: String) -> Void] = [:]
     private var paneAgentObservers: [Token: (_ paneId: Int, _ rawValue: String) -> Void] = [:]
+    private var paneGitObservers: [Token: (_ paneId: Int, _ rawValue: String) -> Void] = [:]
     private var topologyObservers: [Token: () -> Void] = [:]
     private var exitObservers: [Token: () -> Void] = [:]
     private var stateObservers: [Token: (RemoteTmuxControlConnection.ConnectionState) -> Void] = [:]
@@ -60,6 +61,7 @@ final class RemoteTmuxConnectionObservers {
         onActivePaneChanged: ((_ windowId: Int, _ paneId: Int) -> Void)?,
         onSessionChanged: ((_ oldName: String, _ newName: String) -> Void)?,
         onPaneAgent: ((_ paneId: Int, _ rawValue: String) -> Void)? = nil,
+        onPaneGit: ((_ paneId: Int, _ rawValue: String) -> Void)? = nil,
         onTopologyChanged: (() -> Void)?,
         onExit: (() -> Void)?,
         onConnectionStateChanged: ((RemoteTmuxControlConnection.ConnectionState) -> Void)?
@@ -71,6 +73,7 @@ final class RemoteTmuxConnectionObservers {
         if let onActivePaneChanged { activePaneObservers[token] = onActivePaneChanged }
         if let onSessionChanged { sessionChangedObservers[token] = onSessionChanged }
         if let onPaneAgent { paneAgentObservers[token] = onPaneAgent }
+        if let onPaneGit { paneGitObservers[token] = onPaneGit }
         if let onTopologyChanged { topologyObservers[token] = onTopologyChanged }
         if let onExit { exitObservers[token] = onExit }
         if let onConnectionStateChanged { stateObservers[token] = onConnectionStateChanged }
@@ -85,6 +88,7 @@ final class RemoteTmuxConnectionObservers {
         activePaneObservers[token] = nil
         sessionChangedObservers[token] = nil
         paneAgentObservers[token] = nil
+        paneGitObservers[token] = nil
         topologyObservers[token] = nil
         exitObservers[token] = nil
         stateObservers[token] = nil
@@ -120,6 +124,11 @@ final class RemoteTmuxConnectionObservers {
     /// Fans a pane's raw `@cmux_agent` value out to every agent-status observer.
     func emitPaneAgent(_ paneId: Int, _ rawValue: String) {
         for callback in Array(paneAgentObservers.values) { callback(paneId, rawValue) }
+    }
+
+    /// Fans a pane's raw `@cmux_git` value out to every git-status observer.
+    func emitPaneGit(_ paneId: Int, _ rawValue: String) {
+        for callback in Array(paneGitObservers.values) { callback(paneId, rawValue) }
     }
 
     /// Notifies every topology observer that the window/pane layout changed.

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -187,6 +187,13 @@ final class RemoteTmuxControlConnection {
     /// appended for routing, mirroring ``cwdSubscriptionPrefix``.
     private static let agentSubscriptionPrefix = "cmux_agent_"
 
+    /// Subscription-name prefix for a per-pane git/PR status, published by the
+    /// remote agent hook into the `@cmux_git` user option (`tmux set @cmux_git
+    /// '<json>'`). Same channel/mechanism as ``agentSubscriptionPrefix`` — a mirror
+    /// pane has no local git repo (it's on the SSH host), so this carries the
+    /// branch + PR the local pollers can't compute. See ``RemoteTmuxGitStatus``.
+    private static let gitSubscriptionPrefix = "cmux_git_"
+
     /// `ESC[?1049h` — enter the alternate screen, emitted to a mirror surface when
     /// the remote pane is on the alternate screen (see ``capturePane(paneId:)``).
     private static let altScreenEnterSequence = Data("\u{1b}[?1049h".utf8)
@@ -243,6 +250,7 @@ final class RemoteTmuxControlConnection {
         onActivePaneChanged: ((_ windowId: Int, _ paneId: Int) -> Void)? = nil,
         onSessionChanged: ((_ oldName: String, _ newName: String) -> Void)? = nil,
         onPaneAgent: ((_ paneId: Int, _ rawValue: String) -> Void)? = nil,
+        onPaneGit: ((_ paneId: Int, _ rawValue: String) -> Void)? = nil,
         onTopologyChanged: (() -> Void)? = nil,
         onExit: (() -> Void)? = nil,
         onConnectionStateChanged: ((ConnectionState) -> Void)? = nil
@@ -254,6 +262,7 @@ final class RemoteTmuxControlConnection {
             onActivePaneChanged: onActivePaneChanged,
             onSessionChanged: onSessionChanged,
             onPaneAgent: onPaneAgent,
+            onPaneGit: onPaneGit,
             onTopologyChanged: onTopologyChanged,
             onExit: onExit,
             onConnectionStateChanged: onConnectionStateChanged
@@ -668,6 +677,7 @@ final class RemoteTmuxControlConnection {
         requestPanePath(paneId: paneId)
         subscribePanePath(paneId: paneId)
         subscribePaneAgent(paneId: paneId)
+        subscribePaneGit(paneId: paneId)
     }
 
     /// One-shot query of a pane's working directory (`pane_current_path`),
@@ -794,6 +804,24 @@ final class RemoteTmuxControlConnection {
     /// ``unsubscribePanePath(paneId:)``.
     func unsubscribePaneAgent(paneId: Int) {
         send("refresh-client -B \(Self.agentSubscriptionPrefix)\(paneId)")
+    }
+
+    /// The `refresh-client -B` line that subscribes `paneId`'s `@cmux_git` option
+    /// (branch + PR published by the remote hook). Same load-bearing quoting as
+    /// ``panePathSubscriptionCommand(paneId:)``.
+    static func paneGitSubscriptionCommand(paneId: Int) -> String {
+        "refresh-client -B \"\(gitSubscriptionPrefix)\(paneId):%\(paneId):#{@cmux_git}\""
+    }
+
+    /// Subscribes to live `@cmux_git` changes for `paneId`. Best-effort like the
+    /// other subscriptions.
+    func subscribePaneGit(paneId: Int) {
+        send(Self.paneGitSubscriptionCommand(paneId: paneId))
+    }
+
+    /// Removes the live `@cmux_git` subscription for `paneId`.
+    func unsubscribePaneGit(paneId: Int) {
+        send("refresh-client -B \(Self.gitSubscriptionPrefix)\(paneId)")
     }
 
     /// Format for close-time activity queries: the pane id (for cache refresh and
@@ -1252,6 +1280,15 @@ final class RemoteTmuxControlConnection {
                 )
                 #endif
                 observers.emitPaneAgent(paneId, value)
+            } else if name.hasPrefix(Self.gitSubscriptionPrefix),
+                      let paneId = Int(name.dropFirst(Self.gitSubscriptionPrefix.count)) {
+                // Git/PR status published into @cmux_git by the remote hook.
+                #if DEBUG
+                cmuxDebugLog(
+                    "remote.git.sub pane=\(paneId) value=\"\(value.trimmingCharacters(in: .whitespacesAndNewlines).prefix(160))\""
+                )
+                #endif
+                observers.emitPaneGit(paneId, value)
             }
         case let .commandResult(_, lines, isError):
             // The first block on each control stream is the attach command's own —

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -178,6 +178,15 @@ final class RemoteTmuxControlConnection {
     /// routing, mirroring ``cwdSubscriptionPrefix``.
     private static let reflowSubscriptionPrefix = "cmux_reflow_"
 
+    /// Subscription-name prefix for a per-pane coding-agent status, published by
+    /// the remote agent's own lifecycle hook into the `@cmux_agent` user option
+    /// (`tmux set -p @cmux_agent '<json>'`). tmux delivers the value on subscribe
+    /// and on every change as `%subscription-changed cmux_agent_<paneId> … : <json>`
+    /// — the zero-socket, zero-remote-CLI channel for remote agent status (Option C
+    /// in `docs/investigations/remote-agent-status-sidebar.md`). The tmux pane id is
+    /// appended for routing, mirroring ``cwdSubscriptionPrefix``.
+    private static let agentSubscriptionPrefix = "cmux_agent_"
+
     /// `ESC[?1049h` — enter the alternate screen, emitted to a mirror surface when
     /// the remote pane is on the alternate screen (see ``capturePane(paneId:)``).
     private static let altScreenEnterSequence = Data("\u{1b}[?1049h".utf8)
@@ -233,6 +242,7 @@ final class RemoteTmuxControlConnection {
         onPaneReflow: ((_ paneId: Int, _ noReflow: Bool) -> Void)? = nil,
         onActivePaneChanged: ((_ windowId: Int, _ paneId: Int) -> Void)? = nil,
         onSessionChanged: ((_ oldName: String, _ newName: String) -> Void)? = nil,
+        onPaneAgent: ((_ paneId: Int, _ rawValue: String) -> Void)? = nil,
         onTopologyChanged: (() -> Void)? = nil,
         onExit: (() -> Void)? = nil,
         onConnectionStateChanged: ((ConnectionState) -> Void)? = nil
@@ -243,6 +253,7 @@ final class RemoteTmuxControlConnection {
             onPaneReflow: onPaneReflow,
             onActivePaneChanged: onActivePaneChanged,
             onSessionChanged: onSessionChanged,
+            onPaneAgent: onPaneAgent,
             onTopologyChanged: onTopologyChanged,
             onExit: onExit,
             onConnectionStateChanged: onConnectionStateChanged
@@ -656,6 +667,7 @@ final class RemoteTmuxControlConnection {
         capturePane(paneId: paneId)
         requestPanePath(paneId: paneId)
         subscribePanePath(paneId: paneId)
+        subscribePaneAgent(paneId: paneId)
     }
 
     /// One-shot query of a pane's working directory (`pane_current_path`),
@@ -758,6 +770,30 @@ final class RemoteTmuxControlConnection {
     /// the pane is gone), mirroring ``unsubscribePanePath(paneId:)``.
     func unsubscribePaneReflow(paneId: Int) {
         send("refresh-client -B \(Self.reflowSubscriptionPrefix)\(paneId)")
+    }
+
+    /// The exact `refresh-client -B` line that subscribes `paneId`'s `@cmux_agent`
+    /// user option. Same load-bearing quoting as ``panePathSubscriptionCommand(paneId:)``
+    /// — the `name:target:format` argument MUST stay double-quoted or tmux drops it
+    /// with a (silently swallowed) parse error and the agent status never arrives.
+    /// Verified on tmux 3.6a: setting the option via `tmux set -p @cmux_agent …`
+    /// pushes `%subscription-changed cmux_agent_<paneId> … : <value>`.
+    static func paneAgentSubscriptionCommand(paneId: Int) -> String {
+        "refresh-client -B \"\(agentSubscriptionPrefix)\(paneId):%\(paneId):#{@cmux_agent}\""
+    }
+
+    /// Subscribes to live `@cmux_agent` changes for `paneId`. The remote agent's
+    /// lifecycle hook publishes its status into that option; tmux pushes the value
+    /// on subscribe and on every change with no polling. Best-effort: on tmux builds
+    /// without `-B` subscriptions this is a no-op (the chip simply won't appear).
+    func subscribePaneAgent(paneId: Int) {
+        send(Self.paneAgentSubscriptionCommand(paneId: paneId))
+    }
+
+    /// Removes the live `@cmux_agent` subscription for `paneId`, mirroring
+    /// ``unsubscribePanePath(paneId:)``.
+    func unsubscribePaneAgent(paneId: Int) {
+        send("refresh-client -B \(Self.agentSubscriptionPrefix)\(paneId)")
     }
 
     /// Format for close-time activity queries: the pane id (for cache refresh and
@@ -1207,6 +1243,10 @@ final class RemoteTmuxControlConnection {
                       let paneId = Int(name.dropFirst(Self.reflowSubscriptionPrefix.count)) {
                 // Reflow classification: "<alternate_on>|<pane_current_command>".
                 classifyAndEmitReflow(paneId: paneId, rawValue: value, source: "sub")
+            } else if name.hasPrefix(Self.agentSubscriptionPrefix),
+                      let paneId = Int(name.dropFirst(Self.agentSubscriptionPrefix.count)) {
+                // Remote agent status published into @cmux_agent by the agent's hook.
+                observers.emitPaneAgent(paneId, value)
             }
         case let .commandResult(_, lines, isError):
             // The first block on each control stream is the attach command's own —

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -1246,6 +1246,11 @@ final class RemoteTmuxControlConnection {
             } else if name.hasPrefix(Self.agentSubscriptionPrefix),
                       let paneId = Int(name.dropFirst(Self.agentSubscriptionPrefix.count)) {
                 // Remote agent status published into @cmux_agent by the agent's hook.
+                #if DEBUG
+                cmuxDebugLog(
+                    "remote.agent.sub pane=\(paneId) value=\"\(value.trimmingCharacters(in: .whitespacesAndNewlines).prefix(160))\""
+                )
+                #endif
                 observers.emitPaneAgent(paneId, value)
             }
         case let .commandResult(_, lines, isError):

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -27,6 +27,10 @@ final class RemoteTmuxController {
     private var connectionsByHostSession: [String: RemoteTmuxControlConnection] = [:]
     private var connectionObserverTokensByHostSession: [String: RemoteTmuxControlConnection.ObserverToken] = [:]
 
+    /// Hosts whose remote agent-status hooks have been (attempted to be) installed
+    /// this session, so the best-effort install runs once per host, not per attach.
+    private var agentHookInstalledHosts: Set<String> = []
+
     init() {}
 
     /// Synchronous read of the `remoteTmux` beta flag for AppKit/socket paths
@@ -42,6 +46,25 @@ final class RemoteTmuxController {
     /// Returns (creating if needed) the transport for a host.
     func transport(for host: RemoteTmuxHost) -> RemoteTmuxSSHTransport {
         transportRegistry.transport(for: host)
+    }
+
+    /// Best-effort, once-per-host install of the remote agent-status hooks
+    /// (Option C). Writes a dependency-free `tmux set @cmux_agent` hook into the
+    /// remote `~/.claude/settings.json` and `~/.codex/hooks.json` over the already
+    /// open ControlMaster, so a claude/codex started in a mirrored pane reports
+    /// running/working/idle (+ model) into the option cmux subscribes to. Never
+    /// blocks or fails the attach; runs detached.
+    func installRemoteAgentStatusHooks(host: RemoteTmuxHost) {
+        guard agentHookInstalledHosts.insert(host.connectionHash).inserted else { return }
+        let transport = transport(for: host)
+        Task { @MainActor in
+            for argv in [
+                RemoteTmuxAgentHookInstaller.claudeInstallCommand(),
+                RemoteTmuxAgentHookInstaller.codexInstallCommand(),
+            ] {
+                _ = try? await transport.run(argv)
+            }
+        }
     }
 
     /// Discovers the tmux sessions on a host.
@@ -322,6 +345,11 @@ final class RemoteTmuxController {
                 discovered = try await listSessions(host: host)
             }
             sessions = discovered
+            // The master is open — best-effort install the remote agent-status
+            // hooks so a claude/codex started in a mirrored pane reports
+            // running/working/idle into @cmux_agent (Option C). Fire-and-forget:
+            // never blocks or fails the attach.
+            installRemoteAgentStatusHooks(host: host)
         } catch let error as RemoteTmuxError {
             if case .commandFailed(_, let stderr) = error,
                RemoteTmuxSSHTransport.indicatesAuthRequired(stderr) {

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -58,11 +58,19 @@ final class RemoteTmuxController {
         guard agentHookInstalledHosts.insert(host.connectionHash).inserted else { return }
         let transport = transport(for: host)
         Task { @MainActor in
-            for argv in [
-                RemoteTmuxAgentHookInstaller.claudeInstallCommand(),
-                RemoteTmuxAgentHookInstaller.codexInstallCommand(),
+            for (label, argv) in [
+                ("claude", RemoteTmuxAgentHookInstaller.claudeInstallCommand()),
+                ("codex", RemoteTmuxAgentHookInstaller.codexInstallCommand()),
             ] {
-                _ = try? await transport.run(argv)
+                let result = try? await transport.run(argv)
+                #if DEBUG
+                cmuxDebugLog(
+                    "remote.agent.hookinstall host=\(host.destination) agent=\(label) "
+                        + "exit=\(result?.exitCode.description ?? "nil") "
+                        + "stdout=\"\((result?.stdout ?? "").trimmingCharacters(in: .whitespacesAndNewlines).prefix(120))\" "
+                        + "stderr=\"\((result?.stderr ?? "").trimmingCharacters(in: .whitespacesAndNewlines).prefix(120))\""
+                )
+                #endif
             }
         }
     }

--- a/Sources/RemoteTmuxGitStatus.swift
+++ b/Sources/RemoteTmuxGitStatus.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Git branch + pull-request state for a remote `cmux ssh-tmux` mirror pane,
+/// published by the remote agent hook into the `@cmux_git` tmux user option and
+/// carried to cmux over the live control stream — the same zero-socket channel as
+/// ``RemoteTmuxAgentStatus`` (Option C, `docs/investigations/remote-agent-status-sidebar.md`).
+///
+/// The remote repo lives on the SSH host, so cmux's local git/PR pollers can't see
+/// it (they bail on `isRemoteWorkspace`). The hook already runs in the agent's cwd
+/// inside that repo, so it runs `git`/`gh` there and publishes the result here;
+/// the mirror maps it onto the workspace's per-panel `gitBranch` / `pullRequest`
+/// sidebar models — the same rows a local workspace shows.
+///
+/// Pure parser; the option subscription lives in ``RemoteTmuxControlConnection``
+/// and the sidebar write in ``RemoteTmuxSessionMirror``.
+struct RemoteTmuxGitStatus: Equatable, Sendable {
+    /// Lifecycle status of the PR, matching `SidebarPullRequestStatus` raw values.
+    enum PullRequestStatus: String, Sendable {
+        case open, merged, closed
+
+        /// Maps `gh pr view` `.state` (OPEN/MERGED/CLOSED, any case) to a status.
+        init?(ghState raw: String) {
+            switch raw.trimmingCharacters(in: .whitespaces).lowercased() {
+            case "open": self = .open
+            case "merged": self = .merged
+            case "closed": self = .closed
+            default: return nil
+            }
+        }
+    }
+
+    struct PullRequest: Equatable, Sendable {
+        let number: Int
+        let url: URL
+        let status: PullRequestStatus
+        /// `owner/repo` label, when derivable from the PR url.
+        let label: String
+    }
+
+    /// Current branch (non-empty), or `nil` when not in a git repo / detached.
+    let branch: String?
+    let isDirty: Bool
+    /// The PR for the current branch, when `gh` found one.
+    let pullRequest: PullRequest?
+
+    /// Parses the `@cmux_git` option value: a JSON object
+    /// `{branch?, dirty?, pr?: {number, url, state}}`. Returns `nil` for an empty
+    /// value (the hook clears the option to drop the rows) or one carrying no
+    /// usable branch/PR.
+    static func parse(_ raw: String) -> RemoteTmuxGitStatus? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let data = trimmed.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+
+        let branch = (obj["branch"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedBranch = (branch?.isEmpty == false) ? branch : nil
+        // dirty accepts bool or the "0"/"1" string the shell hook emits.
+        let isDirty: Bool
+        switch obj["dirty"] {
+        case let b as Bool: isDirty = b
+        case let s as String: isDirty = (s.trimmingCharacters(in: .whitespaces) == "1")
+        case let n as NSNumber: isDirty = n.intValue != 0
+        default: isDirty = false
+        }
+
+        let pr = (obj["pr"] as? [String: Any]).flatMap(parsePullRequest)
+
+        // Nothing useful → no rows.
+        guard normalizedBranch != nil || pr != nil else { return nil }
+        return RemoteTmuxGitStatus(branch: normalizedBranch, isDirty: isDirty, pullRequest: pr)
+    }
+
+    private static func parsePullRequest(_ obj: [String: Any]) -> PullRequest? {
+        // number may be Int or numeric string ("#123" tolerated).
+        let number: Int?
+        switch obj["number"] {
+        case let n as NSNumber: number = n.intValue
+        case let s as String:
+            let t = s.trimmingCharacters(in: .whitespaces)
+            number = Int(t.hasPrefix("#") ? String(t.dropFirst()) : t)
+        default: number = nil
+        }
+        guard let number, number > 0 else { return nil }
+
+        guard let urlString = (obj["url"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let url = URL(string: urlString),
+              let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https"
+        else { return nil }
+
+        let status = (obj["state"] as? String).flatMap(PullRequestStatus.init(ghState:)) ?? .open
+        return PullRequest(number: number, url: url, status: status, label: repoLabel(from: url) ?? "PR")
+    }
+
+    /// Derives an `owner/repo` label from a GitHub PR URL
+    /// (`https://github.com/owner/repo/pull/N` → `owner/repo`). `nil` when the
+    /// path doesn't look like a PR url.
+    static func repoLabel(from url: URL) -> String? {
+        let parts = url.path.split(separator: "/").map(String.init)
+        // /owner/repo/pull/N
+        guard parts.count >= 4, parts[2] == "pull" else { return nil }
+        return "\(parts[0])/\(parts[1])"
+    }
+}

--- a/Sources/RemoteTmuxPaneForegroundState.swift
+++ b/Sources/RemoteTmuxPaneForegroundState.swift
@@ -41,4 +41,16 @@ struct RemoteTmuxPaneForegroundState: Equatable, Sendable {
     var hasActiveCommand: Bool {
         alternateOn || (!command.isEmpty && !Self.plainShellCommands.contains(command))
     }
+
+    /// The coding agent whose CLI is foregrounded in this pane, or `nil` when the
+    /// foreground command isn't a known agent. Matches the pane's
+    /// `pane_current_command` (the foreground process `comm`) against the known
+    /// agent executable names — verified empirically that an interactive `claude`
+    /// reports `pane_current_command == "claude"` (not `node`). This is a coarse
+    /// "an agent CLI is running in this remote pane" signal: it cannot report
+    /// busy/idle or the model (the remote tmux exposes only the comm name).
+    var agentProvider: AgentSessionProviderID? {
+        guard !command.isEmpty else { return nil }
+        return AgentSessionProviderID.allCases.first { $0.executableName == command }
+    }
 }

--- a/Sources/RemoteTmuxSessionMirror.swift
+++ b/Sources/RemoteTmuxSessionMirror.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CmuxSidebar
 
 /// Mirrors one remote tmux session into a dedicated cmux sidebar workspace.
 ///
@@ -172,6 +173,9 @@ final class RemoteTmuxSessionMirror {
             mirror.teardown()
         }
         windowMirrorByWindowId.removeAll()
+        // Clear the sidebar agent chip so a torn-down mirror doesn't leave a stale
+        // "agent running" row behind.
+        workspace?.statusEntries[Self.agentStatusKey] = nil
     }
 
     /// The tmux window id (if any) whose layout currently contains `paneId`.
@@ -251,6 +255,9 @@ final class RemoteTmuxSessionMirror {
         if desiredPanelOrder.count > 1 {
             workspace.reorderRemoteTmuxMirrorTabs(toPanelOrder: desiredPanelOrder)
         }
+        // A closed window/pane can remove the agent that was foregrounded, so
+        // reconcile the sidebar agent chip on topology changes too.
+        refreshAgentStatus()
     }
 
     nonisolated static func shouldSeedSinglePaneDisplay(for window: RemoteTmuxWindow) -> Bool {
@@ -420,6 +427,10 @@ final class RemoteTmuxSessionMirror {
     /// Routes exactly like ``routeOutput(paneId:data:)`` — multi-pane windows own
     /// their pane surfaces, single-pane windows use the tab's panel surface.
     private func routeNoReflow(paneId: Int, noReflow: Bool) {
+        // The foreground-command classification that drives reflow also tells us
+        // whether an agent CLI is now foregrounded in this pane, so refresh the
+        // sidebar agent chip on the same signal.
+        refreshAgentStatus()
         if let windowId = windowIdContaining(pane: paneId),
            let mirror = windowMirrorByWindowId[windowId] {
             mirror.surface(forPane: paneId)?.setManualIONoReflow(noReflow)
@@ -429,6 +440,56 @@ final class RemoteTmuxSessionMirror {
               let panelId = panelIdByPane[paneId],
               let panel = workspace.panels[panelId] as? TerminalPanel else { return }
         panel.surface.setManualIONoReflow(noReflow)
+    }
+
+    /// Sidebar status-entry key for the mirror's remote-agent chip. Stable per
+    /// mirror so repeated writes replace (rather than stack) the row.
+    private static let agentStatusKey = "remote-tmux.agent"
+
+    /// Reflects "a coding agent CLI is running in this remote session" into the
+    /// workspace's sidebar status row, driven by the per-pane foreground command
+    /// already streamed for reflow classification (`pane_current_command`). Writes
+    /// a single keyed `SidebarStatusEntry` when any pane foregrounds a known agent,
+    /// and clears it otherwise. This is the same runtime status surface the control
+    /// socket writes to (``Workspace/statusEntries``), so the existing sidebar
+    /// renders it with no UI change.
+    ///
+    /// Coarse by design: the remote tmux exposes only the foreground comm name, so
+    /// this reports presence ("Claude Code running"), not busy/idle or model — that
+    /// richer signal is a planned follow-up that reads the remote `~/.claude` state
+    /// over the shared SSH master.
+    private func refreshAgentStatus() {
+        guard let workspace else { return }
+        let provider = foregroundedAgentProvider()
+        let existing = workspace.statusEntries[Self.agentStatusKey]
+        guard let provider else {
+            if existing != nil { workspace.statusEntries[Self.agentStatusKey] = nil }
+            return
+        }
+        let value = String(
+            localized: "remoteTmux.agentStatus.running",
+            defaultValue: "\(provider.displayName) running"
+        )
+        // Replace only on a meaningful change so an unrelated foreground flap
+        // (e.g. a non-agent pane) doesn't churn the row's timestamp.
+        if existing?.value == value, existing?.key == Self.agentStatusKey { return }
+        workspace.statusEntries[Self.agentStatusKey] = SidebarStatusEntry(
+            key: Self.agentStatusKey,
+            value: value,
+            icon: "sparkles",
+            priority: 50,
+            timestamp: Date()
+        )
+    }
+
+    /// The agent provider foregrounded in any of this session's panes (focused/
+    /// active panes are not privileged — any pane running an agent surfaces it),
+    /// or `nil` when no pane foregrounds a known agent.
+    private func foregroundedAgentProvider() -> AgentSessionProviderID? {
+        for state in connection.paneForegroundStates.values {
+            if let provider = state.agentProvider { return provider }
+        }
+        return nil
     }
 
     /// Routes a split of a mirror window-tab (by its panel id) to tmux

--- a/Sources/RemoteTmuxSessionMirror.swift
+++ b/Sources/RemoteTmuxSessionMirror.swift
@@ -106,6 +106,9 @@ final class RemoteTmuxSessionMirror {
             onPaneAgent: { [weak self] paneId, rawValue in
                 self?.handlePaneAgent(paneId: paneId, rawValue: rawValue)
             },
+            onPaneGit: { [weak self] paneId, rawValue in
+                self?.handlePaneGit(paneId: paneId, rawValue: rawValue)
+            },
             onTopologyChanged: { [weak self] in
                 self?.rebuild()
             },
@@ -475,6 +478,44 @@ final class RemoteTmuxSessionMirror {
     /// A remote agent's lifecycle hook published into `@cmux_agent` for `paneId`
     /// (Option C, via the live tmux subscription). An empty value clears it (the
     /// hook clears the option to drop the chip). Re-renders the sidebar status.
+    /// A remote hook published git branch + PR into `@cmux_git` for `paneId`
+    /// (Option C). Maps it onto the tab's per-panel `gitBranch` / `pullRequest`
+    /// sidebar models — the rows a local workspace shows but the local git/PR
+    /// pollers skip for a remote mirror. An empty/unparseable value clears them.
+    private func handlePaneGit(paneId: Int, rawValue: String) {
+        guard let workspace, let panelId = tabPanelId(forPane: paneId) else { return }
+        guard let git = RemoteTmuxGitStatus.parse(rawValue) else {
+            workspace.panelGitBranches[panelId] = nil
+            workspace.panelPullRequests[panelId] = nil
+            #if DEBUG
+            cmuxDebugLog("remote.git pane=\(paneId) cleared")
+            #endif
+            return
+        }
+        if let branch = git.branch {
+            workspace.panelGitBranches[panelId] = SidebarGitBranchState(branch: branch, isDirty: git.isDirty)
+        } else {
+            workspace.panelGitBranches[panelId] = nil
+        }
+        if let pr = git.pullRequest,
+           let status = SidebarPullRequestStatus(rawValue: pr.status.rawValue) {
+            // A PR row only displays when its branch matches the panel's branch
+            // (see Workspace.sidebarPullRequestsInDisplayOrder), so stamp it with
+            // the same branch we just set.
+            workspace.panelPullRequests[panelId] = SidebarPullRequestState(
+                number: pr.number, label: pr.label, url: pr.url, status: status, branch: git.branch
+            )
+        } else {
+            workspace.panelPullRequests[panelId] = nil
+        }
+        #if DEBUG
+        cmuxDebugLog(
+            "remote.git pane=\(paneId) branch=\(git.branch ?? "-") dirty=\(git.isDirty ? 1 : 0) "
+                + "pr=\(git.pullRequest.map { "#\($0.number) \($0.status.rawValue)" } ?? "-")"
+        )
+        #endif
+    }
+
     private func handlePaneAgent(paneId: Int, rawValue: String) {
         let status = RemoteTmuxAgentStatus.parse(rawValue)
         hookAgentStatusByPane[paneId] = status

--- a/Sources/RemoteTmuxSessionMirror.swift
+++ b/Sources/RemoteTmuxSessionMirror.swift
@@ -62,6 +62,14 @@ final class RemoteTmuxSessionMirror {
     /// workspace is first shown), so that retry alone could expire and leave the
     /// remote at ssh's default 80×24. Removed in ``detachObserver()``.
     private var surfaceReadyObservers: [NSObjectProtocol] = []
+    /// In-flight remote agent-activity probe (Attempt 2); cancelled on teardown or
+    /// when the agent goes away.
+    private var agentProbeTask: Task<Void, Never>?
+    /// Pane the last agent probe targeted + when it ran, for throttling.
+    private var activeAgentPaneId: Int?
+    private var lastAgentProbeAt: Date?
+    /// Minimum spacing between remote agent probes for the same pane.
+    private static let agentProbeThrottleSeconds: TimeInterval = 4
 
     init(
         host: RemoteTmuxHost,
@@ -162,6 +170,8 @@ final class RemoteTmuxSessionMirror {
     func detachObserver() {
         initialSizingTask?.cancel()
         initialSizingTask = nil
+        agentProbeTask?.cancel()
+        agentProbeTask = nil
         for observer in surfaceReadyObservers { NotificationCenter.default.removeObserver(observer) }
         surfaceReadyObservers.removeAll()
         if let observerToken {
@@ -372,7 +382,13 @@ final class RemoteTmuxSessionMirror {
         guard let workspace else { return }
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        let cwdChanged = cwdByPane[paneId] != trimmed
         cwdByPane[paneId] = trimmed
+        // The agent-activity probe (Attempt 2) keys off the pane cwd; when the cwd
+        // first arrives (or changes) for the pane running an agent, re-probe.
+        if cwdChanged, foregroundedAgent()?.paneId == paneId {
+            refreshAgentStatus()
+        }
         guard let panelId = tabPanelId(forPane: paneId) else { return }
         // Multi-pane window: only the active pane represents the tab.
         if let windowId = windowIdContaining(pane: paneId),
@@ -460,36 +476,94 @@ final class RemoteTmuxSessionMirror {
     /// over the shared SSH master.
     private func refreshAgentStatus() {
         guard let workspace else { return }
-        let provider = foregroundedAgentProvider()
-        let existing = workspace.statusEntries[Self.agentStatusKey]
-        guard let provider else {
-            if existing != nil { workspace.statusEntries[Self.agentStatusKey] = nil }
+        guard let detected = foregroundedAgent() else {
+            if workspace.statusEntries[Self.agentStatusKey] != nil {
+                workspace.statusEntries[Self.agentStatusKey] = nil
+            }
+            agentProbeTask?.cancel()
+            agentProbeTask = nil
+            activeAgentPaneId = nil
             return
         }
-        let value = String(
-            localized: "remoteTmux.agentStatus.running",
-            defaultValue: "\(provider.displayName) running"
-        )
-        // Replace only on a meaningful change so an unrelated foreground flap
-        // (e.g. a non-agent pane) doesn't churn the row's timestamp.
+        writeAgentStatusEntry(provider: detected.provider, activity: nil, model: nil)
+        // Layer (b): if the agent's pane has a known cwd, enrich the chip with
+        // busy/idle + model by reading the remote ~/.claude transcript over the
+        // shared SSH master. Best-effort and throttled; the coarse chip already
+        // shows regardless.
+        if detected.provider == .claude, let cwd = cwdByPane[detected.paneId] {
+            scheduleAgentProbe(provider: detected.provider, paneId: detected.paneId, cwd: cwd)
+        }
+    }
+
+    /// Writes (or replaces, only on a meaningful change) the agent status row.
+    /// `activity`/`model` enrich the coarse "running" label when known.
+    private func writeAgentStatusEntry(
+        provider: AgentSessionProviderID,
+        activity: RemoteTmuxAgentProbe.Activity?,
+        model: String?
+    ) {
+        guard let workspace else { return }
+        let base: String
+        if let activity {
+            base = activity.busy
+                ? String(localized: "remoteTmux.agentStatus.working", defaultValue: "\(provider.displayName) working")
+                : String(localized: "remoteTmux.agentStatus.idle", defaultValue: "\(provider.displayName) idle")
+        } else {
+            base = String(localized: "remoteTmux.agentStatus.running", defaultValue: "\(provider.displayName) running")
+        }
+        let value = model.map { "\(base) · \($0)" } ?? base
+        let existing = workspace.statusEntries[Self.agentStatusKey]
         if existing?.value == value, existing?.key == Self.agentStatusKey { return }
         workspace.statusEntries[Self.agentStatusKey] = SidebarStatusEntry(
             key: Self.agentStatusKey,
             value: value,
-            icon: "sparkles",
+            icon: activity?.busy == true ? "sparkles" : "moon.zzz",
             priority: 50,
             timestamp: Date()
         )
     }
 
-    /// The agent provider foregrounded in any of this session's panes (focused/
-    /// active panes are not privileged — any pane running an agent surfaces it),
-    /// or `nil` when no pane foregrounds a known agent.
-    private func foregroundedAgentProvider() -> AgentSessionProviderID? {
-        for state in connection.paneForegroundStates.values {
-            if let provider = state.agentProvider { return provider }
+    /// The agent + the pane it runs in for this session, or `nil` when no pane
+    /// foregrounds a known agent. The first matching pane (in dictionary order)
+    /// wins — a session rarely runs more than one agent.
+    private func foregroundedAgent() -> (provider: AgentSessionProviderID, paneId: Int)? {
+        for (paneId, state) in connection.paneForegroundStates {
+            if let provider = state.agentProvider { return (provider, paneId) }
         }
         return nil
+    }
+
+    /// Throttled one-shot remote probe (Attempt 2): reads the newest Claude
+    /// transcript's mtime (busy/idle) and model over the shared SSH master and
+    /// re-writes the status entry. Coalesced so rapid foreground flaps don't spam
+    /// the remote; superseded/cancelled on teardown or when the agent goes away.
+    private func scheduleAgentProbe(provider: AgentSessionProviderID, paneId: Int, cwd: String) {
+        // Throttle: skip if a probe ran for the same pane within the window.
+        if activeAgentPaneId == paneId,
+           let last = lastAgentProbeAt,
+           Date().timeIntervalSince(last) < Self.agentProbeThrottleSeconds {
+            return
+        }
+        activeAgentPaneId = paneId
+        lastAgentProbeAt = Date()
+        guard let activityArgv = RemoteTmuxAgentProbe.activityProbeCommand(cwd: cwd) else { return }
+        let host = self.host
+        agentProbeTask?.cancel()
+        agentProbeTask = Task { @MainActor [weak self] in
+            guard let controller = AppDelegate.shared?.remoteTmuxController else { return }
+            let transport = controller.transport(for: host)
+            guard let result = try? await transport.run(activityArgv), result.succeeded else { return }
+            guard let activity = RemoteTmuxAgentProbe.parseActivity(stdout: result.stdout) else { return }
+            var model: String?
+            if let modelArgv = RemoteTmuxAgentProbe.modelProbeCommand(transcriptPath: activity.transcriptPath),
+               let modelResult = try? await transport.run(modelArgv), modelResult.succeeded {
+                model = RemoteTmuxAgentProbe.parseModel(stdout: modelResult.stdout)
+            }
+            guard let self, !Task.isCancelled else { return }
+            // Only apply if this pane still foregrounds the same agent.
+            guard self.foregroundedAgent()?.paneId == paneId else { return }
+            self.writeAgentStatusEntry(provider: provider, activity: activity, model: model)
+        }
     }
 
     /// Routes a split of a mirror window-tab (by its panel id) to tmux

--- a/Sources/RemoteTmuxSessionMirror.swift
+++ b/Sources/RemoteTmuxSessionMirror.swift
@@ -103,6 +103,9 @@ final class RemoteTmuxSessionMirror {
             onSessionChanged: { [weak self] oldName, newName in
                 self?.handleSessionNameChanged(oldName: oldName, newName: newName)
             },
+            onPaneAgent: { [weak self] paneId, rawValue in
+                self?.handlePaneAgent(paneId: paneId, rawValue: rawValue)
+            },
             onTopologyChanged: { [weak self] in
                 self?.rebuild()
             },
@@ -254,6 +257,7 @@ final class RemoteTmuxSessionMirror {
         // stays bounded across window/pane churn (tmux pane ids never recur).
         let livePanes = Set(connection.windowsByID.values.flatMap { $0.paneIDsInOrder })
         cwdByPane = cwdByPane.filter { livePanes.contains($0.key) }
+        hookAgentStatusByPane = hookAgentStatusByPane.filter { livePanes.contains($0.key) }
         closeDefaultTabsIfNeeded()
         // Follow out-of-band tmux window reorders (a second client, or a manual
         // move-window / a new-window inserted mid-list): the cmux tabs are created
@@ -462,20 +466,47 @@ final class RemoteTmuxSessionMirror {
     /// mirror so repeated writes replace (rather than stack) the row.
     private static let agentStatusKey = "remote-tmux.agent"
 
-    /// Reflects "a coding agent CLI is running in this remote session" into the
-    /// workspace's sidebar status row, driven by the per-pane foreground command
-    /// already streamed for reflow classification (`pane_current_command`). Writes
-    /// a single keyed `SidebarStatusEntry` when any pane foregrounds a known agent,
-    /// and clears it otherwise. This is the same runtime status surface the control
-    /// socket writes to (``Workspace/statusEntries``), so the existing sidebar
-    /// renders it with no UI change.
+    /// Latest agent status a remote hook published into `@cmux_agent`, per pane
+    /// (Option C). This is the AUTHORITATIVE signal — the agent's own lifecycle
+    /// hook reports it — so it takes precedence over the coarse foreground-command
+    /// detection and the transcript probe. `nil`/cleared panes fall back to those.
+    private var hookAgentStatusByPane: [Int: RemoteTmuxAgentStatus] = [:]
+
+    /// A remote agent's lifecycle hook published into `@cmux_agent` for `paneId`
+    /// (Option C, via the live tmux subscription). An empty value clears it (the
+    /// hook clears the option to drop the chip). Re-renders the sidebar status.
+    private func handlePaneAgent(paneId: Int, rawValue: String) {
+        if let status = RemoteTmuxAgentStatus.parse(rawValue) {
+            hookAgentStatusByPane[paneId] = status
+        } else {
+            hookAgentStatusByPane[paneId] = nil
+        }
+        refreshAgentStatus()
+    }
+
+    /// Reflects a coding agent's status into the workspace's sidebar status row —
+    /// the same runtime surface the control socket writes (``Workspace/statusEntries``),
+    /// so the existing sidebar renders it with no UI change.
     ///
-    /// Coarse by design: the remote tmux exposes only the foreground comm name, so
-    /// this reports presence ("Claude Code running"), not busy/idle or model — that
-    /// richer signal is a planned follow-up that reads the remote `~/.claude` state
-    /// over the shared SSH master.
+    /// Three signal tiers, best first:
+    ///  1. **Hook (Option C)** — the remote agent's own lifecycle hook published
+    ///     state+model into `@cmux_agent`. Authoritative: real running/working/idle
+    ///     and the model, for both Claude and Codex.
+    ///  2. **Transcript probe (Claude)** — busy/idle + model read from the remote
+    ///     `~/.claude` over the SSH master, when no hook is reporting.
+    ///  3. **Foreground command** — coarse "agent running" from `pane_current_command`.
     private func refreshAgentStatus() {
         guard let workspace else { return }
+
+        // Tier 1: a hook-reported status wins outright.
+        if let hook = hookAgentStatusByPane.values.first {
+            writeHookAgentStatusEntry(hook)
+            agentProbeTask?.cancel()
+            agentProbeTask = nil
+            activeAgentPaneId = nil
+            return
+        }
+
         guard let detected = foregroundedAgent() else {
             if workspace.statusEntries[Self.agentStatusKey] != nil {
                 workspace.statusEntries[Self.agentStatusKey] = nil
@@ -486,13 +517,40 @@ final class RemoteTmuxSessionMirror {
             return
         }
         writeAgentStatusEntry(provider: detected.provider, activity: nil, model: nil)
-        // Layer (b): if the agent's pane has a known cwd, enrich the chip with
+        // Tier 2: if the agent's pane has a known cwd, enrich the chip with
         // busy/idle + model by reading the remote ~/.claude transcript over the
         // shared SSH master. Best-effort and throttled; the coarse chip already
         // shows regardless.
         if detected.provider == .claude, let cwd = cwdByPane[detected.paneId] {
             scheduleAgentProbe(provider: detected.provider, paneId: detected.paneId, cwd: cwd)
         }
+    }
+
+    /// Writes the sidebar row from an authoritative hook-reported status (Tier 1).
+    private func writeHookAgentStatusEntry(_ status: RemoteTmuxAgentStatus) {
+        guard let workspace else { return }
+        let display = AgentSessionProviderID(rawValue: status.agent)?.displayName
+            ?? status.agent.capitalized
+        let base: String
+        switch status.state {
+        case .working:
+            base = String(localized: "remoteTmux.agentStatus.working", defaultValue: "\(display) working")
+        case .idle:
+            base = String(localized: "remoteTmux.agentStatus.idle", defaultValue: "\(display) idle")
+        case .running:
+            base = String(localized: "remoteTmux.agentStatus.running", defaultValue: "\(display) running")
+        }
+        let suffix = status.model ?? status.title
+        let value = suffix.map { "\(base) · \($0)" } ?? base
+        let existing = workspace.statusEntries[Self.agentStatusKey]
+        if existing?.value == value, existing?.key == Self.agentStatusKey { return }
+        workspace.statusEntries[Self.agentStatusKey] = SidebarStatusEntry(
+            key: Self.agentStatusKey,
+            value: value,
+            icon: status.state == .working ? "sparkles" : "moon.zzz",
+            priority: 50,
+            timestamp: Date()
+        )
     }
 
     /// Writes (or replaces, only on a meaningful change) the agent status row.

--- a/Sources/RemoteTmuxSessionMirror.swift
+++ b/Sources/RemoteTmuxSessionMirror.swift
@@ -476,11 +476,18 @@ final class RemoteTmuxSessionMirror {
     /// (Option C, via the live tmux subscription). An empty value clears it (the
     /// hook clears the option to drop the chip). Re-renders the sidebar status.
     private func handlePaneAgent(paneId: Int, rawValue: String) {
-        if let status = RemoteTmuxAgentStatus.parse(rawValue) {
-            hookAgentStatusByPane[paneId] = status
+        let status = RemoteTmuxAgentStatus.parse(rawValue)
+        hookAgentStatusByPane[paneId] = status
+        #if DEBUG
+        if let status {
+            cmuxDebugLog(
+                "remote.agent.hook pane=\(paneId) agent=\(status.agent) state=\(status.state.rawValue) "
+                    + "model=\(status.model ?? "-")"
+            )
         } else {
-            hookAgentStatusByPane[paneId] = nil
+            cmuxDebugLog("remote.agent.hook pane=\(paneId) cleared (raw=\"\(rawValue.prefix(80))\")")
         }
+        #endif
         refreshAgentStatus()
     }
 
@@ -544,6 +551,9 @@ final class RemoteTmuxSessionMirror {
         let value = suffix.map { "\(base) · \($0)" } ?? base
         let existing = workspace.statusEntries[Self.agentStatusKey]
         if existing?.value == value, existing?.key == Self.agentStatusKey { return }
+        #if DEBUG
+        cmuxDebugLog("remote.agent.sidebar write value=\"\(value)\" (workspace=\(workspace.id))")
+        #endif
         workspace.statusEntries[Self.agentStatusKey] = SidebarStatusEntry(
             key: Self.agentStatusKey,
             value: value,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -669,6 +669,8 @@
 		EE30D6000000000000000006 /* RemoteSessionStrings+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30D6000000000000000005 /* RemoteSessionStrings+App.swift */; };
 		E4321000E4321000E4321001 /* RemoteShellSessionParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4321000E4321000E4321002 /* RemoteShellSessionParsing.swift */; };
 		0A17C0DE0A17C0DE0A17C002 /* RemoteTmuxAttachOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C001 /* RemoteTmuxAttachOutcome.swift */; };
+		0A17C0DE0A17C0DE0A17C102 /* RemoteTmuxAgentProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C101 /* RemoteTmuxAgentProbe.swift */; };
+		0A17C0DE0A17C0DE0A17C202 /* RemoteTmuxAgentProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C201 /* RemoteTmuxAgentProbeTests.swift */; };
 		0A17C0DE0A17C0DE0A17C004 /* RemoteTmuxAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */; };
 		5F5553CA5553CA5553CA0001 /* RemoteTmuxCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5553CA5553CA5553CA0002 /* RemoteTmuxCapabilitiesTests.swift */; };
 		9C988B800BBFB3CFFD46E611 /* RemoteTmuxCommandResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D411EFBE33FE85901B9E6A /* RemoteTmuxCommandResult.swift */; };
@@ -1737,6 +1739,8 @@
 		EE30D6000000000000000005 /* RemoteSessionStrings+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSessionStrings+App.swift"; sourceTree = "<group>"; };
 		E4321000E4321000E4321002 /* RemoteShellSessionParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteShellSessionParsing.swift; sourceTree = "<group>"; };
 		0A17C0DE0A17C0DE0A17C001 /* RemoteTmuxAttachOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAttachOutcome.swift; sourceTree = "<group>"; };
+		0A17C0DE0A17C0DE0A17C101 /* RemoteTmuxAgentProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentProbe.swift; sourceTree = "<group>"; };
+		0A17C0DE0A17C0DE0A17C201 /* RemoteTmuxAgentProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentProbeTests.swift; sourceTree = "<group>"; };
 		0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAuthTests.swift; sourceTree = "<group>"; };
 		5F5553CA5553CA5553CA0002 /* RemoteTmuxCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxCapabilitiesTests.swift; sourceTree = "<group>"; };
 		71D411EFBE33FE85901B9E6A /* RemoteTmuxCommandResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxCommandResult.swift; sourceTree = "<group>"; };
@@ -2874,6 +2878,7 @@
 				71D411EFBE33FE85901B9E6A /* RemoteTmuxCommandResult.swift */,
 				02B8A9858C9804AC9C37D7B4 /* RemoteTmuxHost.swift */,
 				0A17C0DE0A17C0DE0A17C001 /* RemoteTmuxAttachOutcome.swift */,
+				0A17C0DE0A17C0DE0A17C101 /* RemoteTmuxAgentProbe.swift */,
 				92CA6F2F239631988B2FB0C8 /* WorkspaceRemoteTmuxNonInteractiveCloseRoute.swift */,
 				5E55400000000000000000D2 /* FocusStealingResponderConformances.swift */,
 				A5001671 /* SessionRestoredTerminalCommandStore.swift */,
@@ -3224,6 +3229,7 @@
 				C57570010000000000000001 /* RightSidebarPanelViewTestSupport.swift */,
 				5F5553CB5553CB5553CB0002 /* RightSidebarRemoteCommandTests.swift */,
 				3F704ED4F177122D7DCD0BCC /* RemoteTmuxSessionListParserTests.swift */,
+				0A17C0DE0A17C0DE0A17C201 /* RemoteTmuxAgentProbeTests.swift */,
 				3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */,
 				31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */,
 				08850489C70ECFACA540C2F3 /* WorkspaceTerminalWorkingDirectoryFallbackTests.swift */,
@@ -4085,6 +4091,7 @@
 				EE30D6000000000000000006 /* RemoteSessionStrings+App.swift in Sources */,
 				E4321000E4321000E4321001 /* RemoteShellSessionParsing.swift in Sources */,
 				0A17C0DE0A17C0DE0A17C002 /* RemoteTmuxAttachOutcome.swift in Sources */,
+				0A17C0DE0A17C0DE0A17C102 /* RemoteTmuxAgentProbe.swift in Sources */,
 				9C988B800BBFB3CFFD46E611 /* RemoteTmuxCommandResult.swift in Sources */,
 				0C17C0DE0C17C0DE0C17C002 /* RemoteTmuxConnectionDiagnostics.swift in Sources */,
 				0D17C0DE0D17C0DE0D17C002 /* RemoteTmuxConnectionObservers.swift in Sources */,
@@ -4620,6 +4627,7 @@
 				B0555301B0555301B0555301 /* RemoteTmuxControlStreamParserBudgetTests.swift in Sources */,
 				D4F8A2E61C5B39707A8E6F12 /* RemoteTmuxMirrorSplitRoutingTests.swift in Sources */,
 				3AC9AB9046E742B93726A405 /* RemoteTmuxSessionListParserTests.swift in Sources */,
+				0A17C0DE0A17C0DE0A17C202 /* RemoteTmuxAgentProbeTests.swift in Sources */,
 				3AC9AB9046E742B93726A501 /* RemoteTmuxSessionRenameTitleTests.swift in Sources */,
 				9A5CF3AA2E6462E77144F9E6 /* RemoteTmuxSessionSnapshotTests.swift in Sources */,
 				FA00C0DE0001BEEF0001CAFE /* RemoteTmuxWindowRegistryTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -675,6 +675,8 @@
 		0A17C0DE0A17C0DE0A17C402 /* RemoteTmuxAgentStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C401 /* RemoteTmuxAgentStatusTests.swift */; };
 		0A17C0DE0A17C0DE0A17C502 /* RemoteTmuxAgentHookInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C501 /* RemoteTmuxAgentHookInstaller.swift */; };
 		0A17C0DE0A17C0DE0A17C602 /* RemoteTmuxAgentHookInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C601 /* RemoteTmuxAgentHookInstallerTests.swift */; };
+		0A17C0DE0A17C0DE0A17C702 /* RemoteTmuxGitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C701 /* RemoteTmuxGitStatus.swift */; };
+		0A17C0DE0A17C0DE0A17C802 /* RemoteTmuxGitStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C801 /* RemoteTmuxGitStatusTests.swift */; };
 		0A17C0DE0A17C0DE0A17C004 /* RemoteTmuxAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */; };
 		5F5553CA5553CA5553CA0001 /* RemoteTmuxCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5553CA5553CA5553CA0002 /* RemoteTmuxCapabilitiesTests.swift */; };
 		9C988B800BBFB3CFFD46E611 /* RemoteTmuxCommandResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D411EFBE33FE85901B9E6A /* RemoteTmuxCommandResult.swift */; };
@@ -1749,6 +1751,8 @@
 		0A17C0DE0A17C0DE0A17C401 /* RemoteTmuxAgentStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentStatusTests.swift; sourceTree = "<group>"; };
 		0A17C0DE0A17C0DE0A17C501 /* RemoteTmuxAgentHookInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentHookInstaller.swift; sourceTree = "<group>"; };
 		0A17C0DE0A17C0DE0A17C601 /* RemoteTmuxAgentHookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentHookInstallerTests.swift; sourceTree = "<group>"; };
+		0A17C0DE0A17C0DE0A17C701 /* RemoteTmuxGitStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxGitStatus.swift; sourceTree = "<group>"; };
+		0A17C0DE0A17C0DE0A17C801 /* RemoteTmuxGitStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxGitStatusTests.swift; sourceTree = "<group>"; };
 		0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAuthTests.swift; sourceTree = "<group>"; };
 		5F5553CA5553CA5553CA0002 /* RemoteTmuxCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxCapabilitiesTests.swift; sourceTree = "<group>"; };
 		71D411EFBE33FE85901B9E6A /* RemoteTmuxCommandResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxCommandResult.swift; sourceTree = "<group>"; };
@@ -2889,6 +2893,7 @@
 				0A17C0DE0A17C0DE0A17C101 /* RemoteTmuxAgentProbe.swift */,
 				0A17C0DE0A17C0DE0A17C301 /* RemoteTmuxAgentStatus.swift */,
 				0A17C0DE0A17C0DE0A17C501 /* RemoteTmuxAgentHookInstaller.swift */,
+				0A17C0DE0A17C0DE0A17C701 /* RemoteTmuxGitStatus.swift */,
 				92CA6F2F239631988B2FB0C8 /* WorkspaceRemoteTmuxNonInteractiveCloseRoute.swift */,
 				5E55400000000000000000D2 /* FocusStealingResponderConformances.swift */,
 				A5001671 /* SessionRestoredTerminalCommandStore.swift */,
@@ -3242,6 +3247,7 @@
 				0A17C0DE0A17C0DE0A17C201 /* RemoteTmuxAgentProbeTests.swift */,
 				0A17C0DE0A17C0DE0A17C401 /* RemoteTmuxAgentStatusTests.swift */,
 				0A17C0DE0A17C0DE0A17C601 /* RemoteTmuxAgentHookInstallerTests.swift */,
+				0A17C0DE0A17C0DE0A17C801 /* RemoteTmuxGitStatusTests.swift */,
 				3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */,
 				31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */,
 				08850489C70ECFACA540C2F3 /* WorkspaceTerminalWorkingDirectoryFallbackTests.swift */,
@@ -4106,6 +4112,7 @@
 				0A17C0DE0A17C0DE0A17C102 /* RemoteTmuxAgentProbe.swift in Sources */,
 				0A17C0DE0A17C0DE0A17C302 /* RemoteTmuxAgentStatus.swift in Sources */,
 				0A17C0DE0A17C0DE0A17C502 /* RemoteTmuxAgentHookInstaller.swift in Sources */,
+				0A17C0DE0A17C0DE0A17C702 /* RemoteTmuxGitStatus.swift in Sources */,
 				9C988B800BBFB3CFFD46E611 /* RemoteTmuxCommandResult.swift in Sources */,
 				0C17C0DE0C17C0DE0C17C002 /* RemoteTmuxConnectionDiagnostics.swift in Sources */,
 				0D17C0DE0D17C0DE0D17C002 /* RemoteTmuxConnectionObservers.swift in Sources */,
@@ -4644,6 +4651,7 @@
 				0A17C0DE0A17C0DE0A17C202 /* RemoteTmuxAgentProbeTests.swift in Sources */,
 				0A17C0DE0A17C0DE0A17C402 /* RemoteTmuxAgentStatusTests.swift in Sources */,
 				0A17C0DE0A17C0DE0A17C602 /* RemoteTmuxAgentHookInstallerTests.swift in Sources */,
+				0A17C0DE0A17C0DE0A17C802 /* RemoteTmuxGitStatusTests.swift in Sources */,
 				3AC9AB9046E742B93726A501 /* RemoteTmuxSessionRenameTitleTests.swift in Sources */,
 				9A5CF3AA2E6462E77144F9E6 /* RemoteTmuxSessionSnapshotTests.swift in Sources */,
 				FA00C0DE0001BEEF0001CAFE /* RemoteTmuxWindowRegistryTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -671,6 +671,10 @@
 		0A17C0DE0A17C0DE0A17C002 /* RemoteTmuxAttachOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C001 /* RemoteTmuxAttachOutcome.swift */; };
 		0A17C0DE0A17C0DE0A17C102 /* RemoteTmuxAgentProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C101 /* RemoteTmuxAgentProbe.swift */; };
 		0A17C0DE0A17C0DE0A17C202 /* RemoteTmuxAgentProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C201 /* RemoteTmuxAgentProbeTests.swift */; };
+		0A17C0DE0A17C0DE0A17C302 /* RemoteTmuxAgentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C301 /* RemoteTmuxAgentStatus.swift */; };
+		0A17C0DE0A17C0DE0A17C402 /* RemoteTmuxAgentStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C401 /* RemoteTmuxAgentStatusTests.swift */; };
+		0A17C0DE0A17C0DE0A17C502 /* RemoteTmuxAgentHookInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C501 /* RemoteTmuxAgentHookInstaller.swift */; };
+		0A17C0DE0A17C0DE0A17C602 /* RemoteTmuxAgentHookInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C601 /* RemoteTmuxAgentHookInstallerTests.swift */; };
 		0A17C0DE0A17C0DE0A17C004 /* RemoteTmuxAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */; };
 		5F5553CA5553CA5553CA0001 /* RemoteTmuxCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5553CA5553CA5553CA0002 /* RemoteTmuxCapabilitiesTests.swift */; };
 		9C988B800BBFB3CFFD46E611 /* RemoteTmuxCommandResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D411EFBE33FE85901B9E6A /* RemoteTmuxCommandResult.swift */; };
@@ -1741,6 +1745,10 @@
 		0A17C0DE0A17C0DE0A17C001 /* RemoteTmuxAttachOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAttachOutcome.swift; sourceTree = "<group>"; };
 		0A17C0DE0A17C0DE0A17C101 /* RemoteTmuxAgentProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentProbe.swift; sourceTree = "<group>"; };
 		0A17C0DE0A17C0DE0A17C201 /* RemoteTmuxAgentProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentProbeTests.swift; sourceTree = "<group>"; };
+		0A17C0DE0A17C0DE0A17C301 /* RemoteTmuxAgentStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentStatus.swift; sourceTree = "<group>"; };
+		0A17C0DE0A17C0DE0A17C401 /* RemoteTmuxAgentStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentStatusTests.swift; sourceTree = "<group>"; };
+		0A17C0DE0A17C0DE0A17C501 /* RemoteTmuxAgentHookInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentHookInstaller.swift; sourceTree = "<group>"; };
+		0A17C0DE0A17C0DE0A17C601 /* RemoteTmuxAgentHookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAgentHookInstallerTests.swift; sourceTree = "<group>"; };
 		0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAuthTests.swift; sourceTree = "<group>"; };
 		5F5553CA5553CA5553CA0002 /* RemoteTmuxCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxCapabilitiesTests.swift; sourceTree = "<group>"; };
 		71D411EFBE33FE85901B9E6A /* RemoteTmuxCommandResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxCommandResult.swift; sourceTree = "<group>"; };
@@ -2879,6 +2887,8 @@
 				02B8A9858C9804AC9C37D7B4 /* RemoteTmuxHost.swift */,
 				0A17C0DE0A17C0DE0A17C001 /* RemoteTmuxAttachOutcome.swift */,
 				0A17C0DE0A17C0DE0A17C101 /* RemoteTmuxAgentProbe.swift */,
+				0A17C0DE0A17C0DE0A17C301 /* RemoteTmuxAgentStatus.swift */,
+				0A17C0DE0A17C0DE0A17C501 /* RemoteTmuxAgentHookInstaller.swift */,
 				92CA6F2F239631988B2FB0C8 /* WorkspaceRemoteTmuxNonInteractiveCloseRoute.swift */,
 				5E55400000000000000000D2 /* FocusStealingResponderConformances.swift */,
 				A5001671 /* SessionRestoredTerminalCommandStore.swift */,
@@ -3230,6 +3240,8 @@
 				5F5553CB5553CB5553CB0002 /* RightSidebarRemoteCommandTests.swift */,
 				3F704ED4F177122D7DCD0BCC /* RemoteTmuxSessionListParserTests.swift */,
 				0A17C0DE0A17C0DE0A17C201 /* RemoteTmuxAgentProbeTests.swift */,
+				0A17C0DE0A17C0DE0A17C401 /* RemoteTmuxAgentStatusTests.swift */,
+				0A17C0DE0A17C0DE0A17C601 /* RemoteTmuxAgentHookInstallerTests.swift */,
 				3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */,
 				31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */,
 				08850489C70ECFACA540C2F3 /* WorkspaceTerminalWorkingDirectoryFallbackTests.swift */,
@@ -4092,6 +4104,8 @@
 				E4321000E4321000E4321001 /* RemoteShellSessionParsing.swift in Sources */,
 				0A17C0DE0A17C0DE0A17C002 /* RemoteTmuxAttachOutcome.swift in Sources */,
 				0A17C0DE0A17C0DE0A17C102 /* RemoteTmuxAgentProbe.swift in Sources */,
+				0A17C0DE0A17C0DE0A17C302 /* RemoteTmuxAgentStatus.swift in Sources */,
+				0A17C0DE0A17C0DE0A17C502 /* RemoteTmuxAgentHookInstaller.swift in Sources */,
 				9C988B800BBFB3CFFD46E611 /* RemoteTmuxCommandResult.swift in Sources */,
 				0C17C0DE0C17C0DE0C17C002 /* RemoteTmuxConnectionDiagnostics.swift in Sources */,
 				0D17C0DE0D17C0DE0D17C002 /* RemoteTmuxConnectionObservers.swift in Sources */,
@@ -4628,6 +4642,8 @@
 				D4F8A2E61C5B39707A8E6F12 /* RemoteTmuxMirrorSplitRoutingTests.swift in Sources */,
 				3AC9AB9046E742B93726A405 /* RemoteTmuxSessionListParserTests.swift in Sources */,
 				0A17C0DE0A17C0DE0A17C202 /* RemoteTmuxAgentProbeTests.swift in Sources */,
+				0A17C0DE0A17C0DE0A17C402 /* RemoteTmuxAgentStatusTests.swift in Sources */,
+				0A17C0DE0A17C0DE0A17C602 /* RemoteTmuxAgentHookInstallerTests.swift in Sources */,
 				3AC9AB9046E742B93726A501 /* RemoteTmuxSessionRenameTitleTests.swift in Sources */,
 				9A5CF3AA2E6462E77144F9E6 /* RemoteTmuxSessionSnapshotTests.swift in Sources */,
 				FA00C0DE0001BEEF0001CAFE /* RemoteTmuxWindowRegistryTests.swift in Sources */,

--- a/cmuxTests/RemoteTmuxAgentHookInstallerTests.swift
+++ b/cmuxTests/RemoteTmuxAgentHookInstallerTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tests the pure builders for the remote agent-status hook install (Option C).
+/// The end-to-end channel was verified live (tmux 3.6a delivers
+/// `%subscription-changed cmux_agent_<pane>` when a hook sets `@cmux_agent`); these
+/// lock the hook script shape, the per-agent event map, and the JSON contract the
+/// `RemoteTmuxAgentStatus` parser consumes.
+@Suite struct RemoteTmuxAgentHookInstallerTests {
+    typealias Installer = RemoteTmuxAgentHookInstaller
+
+    @Test func hookScriptScopesToTmuxPaneAndSelfDisablesOutsideTmux() {
+        let script = Installer.hookScript(agent: "claude", state: "working")
+        // Self-disables when not inside tmux.
+        #expect(script.contains("TMUX_PANE"))
+        // Scopes the option to the agent's own pane (not the client's active pane).
+        #expect(script.contains(#"tmux set -t "$TMUX_PANE" @cmux_agent"#))
+        // Carries the agent label + state into the JSON.
+        #expect(script.contains(#"\"agent\":\"claude\""#))
+        #expect(script.contains(#"\"state\":\"working\""#))
+        // Always prints a JSON object so a blocking hook gets valid stdout.
+        #expect(script.contains("printf '{}'"))
+        // Best-effort model extraction from the event JSON on stdin.
+        #expect(script.contains(#"\"model\":"#))
+    }
+
+    @Test func claudeHooksCoverLifecycleWithExpectedStates() {
+        let obj = Installer.claudeHooksObject()
+        #expect(Set(obj.keys) == ["SessionStart", "UserPromptSubmit", "Stop"])
+        // Each event maps to the right reported state.
+        #expect(commandForEvent(obj, "SessionStart").contains(#"\"state\":\"running\""#))
+        #expect(commandForEvent(obj, "UserPromptSubmit").contains(#"\"state\":\"working\""#))
+        #expect(commandForEvent(obj, "Stop").contains(#"\"state\":\"idle\""#))
+        // Every entry is cmux-marked so install can replace only its own.
+        #expect(markerPresent(obj, "Stop"))
+    }
+
+    @Test func codexHooksUseNestedShapeAndCodexAgentLabel() {
+        let obj = Installer.codexHooksObject()
+        #expect(Set(obj.keys) == ["SessionStart", "UserPromptSubmit", "Stop"])
+        let cmd = commandForEvent(obj, "UserPromptSubmit")
+        #expect(cmd.contains(#"\"agent\":\"codex\""#))
+        #expect(cmd.contains(#"\"state\":\"working\""#))
+    }
+
+    @Test func installCommandsRunPythonMergerWithHooksInEnv() {
+        let claude = Installer.claudeInstallCommand()
+        #expect(claude.first == "sh")
+        #expect(claude.last?.contains("python3 -c") == true)
+        #expect(claude.last?.contains("CMUX_HOOKS=") == true)
+        #expect(claude.last?.contains(".claude/settings.json") == true)
+        let codex = Installer.codexInstallCommand()
+        #expect(codex.last?.contains("hooks.json") == true)
+        #expect(codex.last?.contains("CODEX_HOME") == true)
+    }
+
+    @Test func generatedJSONParsesBackToTheStatusContract() {
+        // The hook writes the same JSON shape RemoteTmuxAgentStatus.parse consumes.
+        // Reconstruct what the hook emits for Stop (no model) and confirm it parses.
+        let noModel = #"{"agent":"claude","state":"idle"}"#
+        let withModel = #"{"agent":"codex","state":"working","model":"gpt-x"}"#
+        #expect(RemoteTmuxAgentStatus.parse(noModel)?.state == .idle)
+        #expect(RemoteTmuxAgentStatus.parse(withModel)?.model == "gpt-x")
+    }
+
+    // Helpers: dig the command string / marker out of the nested hook object.
+    private func commandForEvent(_ obj: [String: Any], _ event: String) -> String {
+        guard let arr = obj[event] as? [[String: Any]],
+              let first = arr.first,
+              let hooks = first["hooks"] as? [[String: Any]],
+              let cmd = hooks.first?["command"] as? String else { return "" }
+        return cmd
+    }
+
+    private func markerPresent(_ obj: [String: Any], _ event: String) -> Bool {
+        guard let arr = obj[event] as? [[String: Any]],
+              let first = arr.first,
+              let hooks = first["hooks"] as? [[String: Any]] else { return false }
+        return hooks.contains { ($0["_cmux"] as? String) == Installer.marker }
+    }
+}

--- a/cmuxTests/RemoteTmuxAgentHookInstallerTests.swift
+++ b/cmuxTests/RemoteTmuxAgentHookInstallerTests.swift
@@ -30,6 +30,17 @@ import Testing
         #expect(script.contains(#"\"model\":"#))
     }
 
+    @Test func hookScriptAlsoPublishesGitStatusInBackground() {
+        let script = Installer.hookScript(agent: "claude", state: "working")
+        // Publishes branch/PR into @cmux_git…
+        #expect(script.contains(#"@cmux_git"#))
+        #expect(script.contains("git rev-parse --abbrev-ref HEAD"))
+        #expect(script.contains("gh pr view"))
+        // …in a DETACHED background subshell so git/gh latency can't delay the
+        // agent's event (trailing `&`).
+        #expect(script.contains("</dev/null &"))
+    }
+
     @Test func claudeHooksCoverLifecycleWithExpectedStates() {
         let obj = Installer.claudeHooksObject()
         #expect(Set(obj.keys) == ["SessionStart", "UserPromptSubmit", "Stop"])

--- a/cmuxTests/RemoteTmuxAgentProbeTests.swift
+++ b/cmuxTests/RemoteTmuxAgentProbeTests.swift
@@ -21,11 +21,18 @@ import Testing
         #expect(Probe.encodeProjectDir("/Users/x/repo/.claude") == "-Users-x-repo--claude")
     }
 
-    @Test func activityProbeCommandEmbedsTheProjectDir() {
-        let argv = Probe.activityProbeCommand(cwd: "/work/proj")
-        let script = try! #require(argv?.last)
-        #expect(argv?.first == "sh")
-        #expect(script.contains("-work-proj"))
+    @Test func activityProbeCommandPassesProjectDirAsPositionalArg() {
+        let argv = try! #require(Probe.activityProbeCommand(cwd: "/work/proj"))
+        #expect(argv.first == "sh")
+        #expect(argv[1] == "-c")
+        // The project dir is the LAST positional arg ($1), never interpolated into
+        // the script (so an odd cwd can't break it). Regression: an earlier version
+        // embedded a single-quoted dir inside a double-quoted assignment, which put
+        // literal quotes into the path and broke the glob.
+        #expect(argv.last == "-work-proj")
+        let script = argv[2]
+        #expect(script.contains("$1"))
+        #expect(!script.contains("-work-proj"))
         // Portable stat: must try GNU then BSD form.
         #expect(script.contains("stat -c %Y"))
         #expect(script.contains("stat -f %m"))
@@ -86,6 +93,10 @@ import Testing
 
     @Test func modelProbeCommandRejectsEmptyPath() {
         #expect(Probe.modelProbeCommand(transcriptPath: "") == nil)
-        #expect(Probe.modelProbeCommand(transcriptPath: "/p/x.jsonl")?.first == "sh")
+        let argv = try! #require(Probe.modelProbeCommand(transcriptPath: "/p/x.jsonl"))
+        #expect(argv.first == "sh")
+        // Path is the positional arg, not interpolated into the script.
+        #expect(argv.last == "/p/x.jsonl")
+        #expect(argv[2].contains("$1"))
     }
 }

--- a/cmuxTests/RemoteTmuxAgentProbeTests.swift
+++ b/cmuxTests/RemoteTmuxAgentProbeTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tests the pure command-builder + output-parser that backs the remote-tmux
+/// agent busy/idle + model enrichment (Attempt 2). The shell pipeline itself was
+/// validated live against a real `~/.claude` host; these lock the
+/// cwd→project-dir derivation, the busy-window logic, and the parse robustness.
+@Suite struct RemoteTmuxAgentProbeTests {
+    typealias Probe = RemoteTmuxAgentProbe
+
+    @Test func encodesProjectDirLikeClaude() {
+        // Claude replaces both "/" and "." with "-".
+        #expect(Probe.encodeProjectDir("/local/home/maxshmi/Developer/realtime-core")
+            == "-local-home-maxshmi-Developer-realtime-core")
+        #expect(Probe.encodeProjectDir("/Users/x/repo/.claude") == "-Users-x-repo--claude")
+    }
+
+    @Test func activityProbeCommandEmbedsTheProjectDir() {
+        let argv = Probe.activityProbeCommand(cwd: "/work/proj")
+        let script = try! #require(argv?.last)
+        #expect(argv?.first == "sh")
+        #expect(script.contains("-work-proj"))
+        // Portable stat: must try GNU then BSD form.
+        #expect(script.contains("stat -c %Y"))
+        #expect(script.contains("stat -f %m"))
+    }
+
+    @Test func activityProbeRejectsEmptyCwd() {
+        #expect(Probe.activityProbeCommand(cwd: "") == nil)
+        #expect(Probe.activityProbeCommand(cwd: "   \n") == nil)
+    }
+
+    @Test func parseActivityMarksRecentWriteBusy() {
+        let s = Probe.fieldSeparator
+        // now=1000, mtime=990 → age 10s ≤ window → busy.
+        let a = try! #require(Probe.parseActivity(stdout: "1000\(s)990\(s)/home/u/.claude/projects/p/x.jsonl"))
+        #expect(a.busy)
+        #expect(a.transcriptPath == "/home/u/.claude/projects/p/x.jsonl")
+    }
+
+    @Test func parseActivityMarksStaleWriteIdle() {
+        let s = Probe.fieldSeparator
+        // age 922s ≫ window → idle (matches the live host probe).
+        let a = try! #require(Probe.parseActivity(stdout: "1782168804\(s)1782167882\(s)/p/x.jsonl"))
+        #expect(!a.busy)
+    }
+
+    @Test func parseActivityClampsNegativeAgeToBusy() {
+        let s = Probe.fieldSeparator
+        // mtime slightly ahead of local now (clock skew) → still treated busy, not idle.
+        let a = try! #require(Probe.parseActivity(stdout: "1000\(s)1002\(s)/p/x.jsonl"))
+        #expect(a.busy)
+    }
+
+    @Test func parseActivityReturnsNilForNoTranscriptOrGarbage() {
+        #expect(Probe.parseActivity(stdout: "") == nil)
+        #expect(Probe.parseActivity(stdout: "   \n") == nil)
+        #expect(Probe.parseActivity(stdout: "notanumber\u{1f}990\u{1f}/p/x") == nil)
+        let s = Probe.fieldSeparator
+        #expect(Probe.parseActivity(stdout: "1000\(s)990\(s)") == nil) // empty path
+    }
+
+    @Test func parseActivityPreservesPathContainingSeparator() {
+        // Defensive: a path with the (improbable) separator byte is rejoined.
+        let s = Probe.fieldSeparator
+        let a = try! #require(Probe.parseActivity(stdout: "1000\(s)990\(s)/p\(s)x.jsonl"))
+        #expect(a.transcriptPath == "/p\(s)x.jsonl")
+    }
+
+    @Test func parseModelStripsRetentionSuffix() {
+        #expect(Probe.parseModel(stdout: "global.anthropic.claude-opus-4-6-v1[1m]\n")
+            == "global.anthropic.claude-opus-4-6-v1")
+        #expect(Probe.parseModel(stdout: "claude-sonnet-4-6") == "claude-sonnet-4-6")
+    }
+
+    @Test func parseModelReturnsNilWhenEmpty() {
+        #expect(Probe.parseModel(stdout: "") == nil)
+        #expect(Probe.parseModel(stdout: "  \n") == nil)
+    }
+
+    @Test func modelProbeCommandRejectsEmptyPath() {
+        #expect(Probe.modelProbeCommand(transcriptPath: "") == nil)
+        #expect(Probe.modelProbeCommand(transcriptPath: "/p/x.jsonl")?.first == "sh")
+    }
+}

--- a/cmuxTests/RemoteTmuxAgentStatusTests.swift
+++ b/cmuxTests/RemoteTmuxAgentStatusTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tests the pure parser for the `@cmux_agent` hook status (Option C). The tmux
+/// subscription delivery was verified live (tmux 3.6a pushes
+/// `%subscription-changed cmux_agent_<pane> … : <json>` when the option is set);
+/// these lock the JSON contract and the state-word mapping.
+@Suite struct RemoteTmuxAgentStatusTests {
+    typealias Status = RemoteTmuxAgentStatus
+
+    @Test func parsesWorkingWithModel() {
+        let s = try! #require(Status.parse(#"{"agent":"claude","state":"working","model":"claude-opus-4-8"}"#))
+        #expect(s.agent == "claude")
+        #expect(s.state == .working)
+        #expect(s.model == "claude-opus-4-8")
+        #expect(s.title == nil)
+    }
+
+    @Test func parsesIdleAndRunning() {
+        #expect(Status.parse(#"{"agent":"codex","state":"idle"}"#)?.state == .idle)
+        #expect(Status.parse(#"{"agent":"claude","state":"running"}"#)?.state == .running)
+    }
+
+    @Test func mapsLifecycleSynonyms() {
+        // The hook may emit the raw lifecycle word; map common synonyms.
+        #expect(Status.parse(#"{"agent":"claude","state":"busy"}"#)?.state == .working)
+        #expect(Status.parse(#"{"agent":"claude","state":"stop"}"#)?.state == .idle)
+        #expect(Status.parse(#"{"agent":"claude","state":"session-start"}"#)?.state == .running)
+        #expect(Status.parse(#"{"agent":"claude","state":"WORKING"}"#)?.state == .working)
+    }
+
+    @Test func stripsModelRetentionSuffix() {
+        let s = try! #require(Status.parse(#"{"agent":"claude","state":"working","model":"global.anthropic.claude-opus-4-6-v1[1m]"}"#))
+        #expect(s.model == "global.anthropic.claude-opus-4-6-v1")
+    }
+
+    @Test func lowercasesAgentLabel() {
+        #expect(Status.parse(#"{"agent":"Claude","state":"idle"}"#)?.agent == "claude")
+    }
+
+    @Test func carriesTitleWhenPresent() {
+        let s = try! #require(Status.parse(#"{"agent":"codex","state":"working","title":"refactor parser"}"#))
+        #expect(s.title == "refactor parser")
+        #expect(s.model == nil)
+    }
+
+    @Test func returnsNilForEmptyOrCleared() {
+        // The hook clears @cmux_agent to remove the chip → empty value.
+        #expect(Status.parse("") == nil)
+        #expect(Status.parse("   \n") == nil)
+    }
+
+    @Test func returnsNilForMissingRequiredFields() {
+        #expect(Status.parse(#"{"state":"working"}"#) == nil)        // no agent
+        #expect(Status.parse(#"{"agent":"claude"}"#) == nil)          // no state
+        #expect(Status.parse(#"{"agent":"","state":"idle"}"#) == nil) // empty agent
+        #expect(Status.parse(#"{"agent":"claude","state":"weird"}"#) == nil) // unknown state
+    }
+
+    @Test func returnsNilForNonJSON() {
+        #expect(Status.parse("not json") == nil)
+        #expect(Status.parse("{broken") == nil)
+    }
+}

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -556,6 +556,16 @@ import Testing
                 == "refresh-client -B \"cmux_cwd_7:%7:#{pane_current_path}\""
         )
     }
+
+    @Test @MainActor func agentSubscribeCommandKeepsFormatQuoted() {
+        // Subscribes the remote agent hook's @cmux_agent user option (Option C).
+        // Same load-bearing quoting; verified live that setting the option pushes
+        // %subscription-changed cmux_agent_<pane> … : <value> on tmux 3.6a.
+        #expect(
+            RemoteTmuxControlConnection.paneAgentSubscriptionCommand(paneId: 12)
+                == "refresh-client -B \"cmux_agent_12:%12:#{@cmux_agent}\""
+        )
+    }
 }
 
 /// Close-time activity queries: the wire commands (same quoting constraint as

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -512,6 +512,28 @@ import Testing
         #expect(state.command == "node")
         #expect(state.hasActiveCommand)
     }
+
+    // MARK: - Remote agent classification (sidebar agent chip)
+
+    @Test func foregroundedAgentCLIsAreClassified() {
+        // An interactive `claude` reports pane_current_command == "claude"
+        // (verified empirically), so the comm name maps straight to a provider.
+        #expect(State(rawValue: "0|claude").agentProvider == .claude)
+        #expect(State(rawValue: "0|codex").agentProvider == .codex)
+        #expect(State(rawValue: "0|opencode").agentProvider == .opencode)
+    }
+
+    @Test func nonAgentForegroundCommandsAreNotClassified() {
+        // Shells and ordinary tools must not be mistaken for an agent.
+        for raw in ["0|bash", "0|-zsh", "0|vim", "0|node", "0|python", "0|", ""] {
+            #expect(State(rawValue: raw).agentProvider == nil, "raw=\(raw)")
+        }
+    }
+
+    @Test func agentClassificationIgnoresAlternateScreenFlag() {
+        // The provider is derived from the comm name regardless of alt-screen.
+        #expect(State(rawValue: "1|claude").agentProvider == .claude)
+    }
 }
 
 /// The `refresh-client -B` subscribe lines must keep their `name:target:format`

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -566,6 +566,13 @@ import Testing
                 == "refresh-client -B \"cmux_agent_12:%12:#{@cmux_agent}\""
         )
     }
+
+    @Test @MainActor func gitSubscribeCommandKeepsFormatQuoted() {
+        #expect(
+            RemoteTmuxControlConnection.paneGitSubscriptionCommand(paneId: 4)
+                == "refresh-client -B \"cmux_git_4:%4:#{@cmux_git}\""
+        )
+    }
 }
 
 /// Close-time activity queries: the wire commands (same quoting constraint as

--- a/cmuxTests/RemoteTmuxGitStatusTests.swift
+++ b/cmuxTests/RemoteTmuxGitStatusTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tests the pure parser for the `@cmux_git` hook payload (branch + PR for a
+/// remote ssh-tmux mirror). The remote git/gh probe + tmux delivery were verified
+/// live; these lock the JSON contract and the gh-state→status mapping. The exact
+/// JSON shape asserted here is the one the remote hook emits (validated live):
+/// `{"branch":"…","dirty":0,"pr":{"number":N,"state":"MERGED","url":"…"}}`.
+@Suite struct RemoteTmuxGitStatusTests {
+    typealias Git = RemoteTmuxGitStatus
+
+    @Test func parsesBranchAndPullRequestFromLiveShape() {
+        let raw = #"{"branch":"fix/1483-office","dirty":0,"pr":{"number":1815,"state":"MERGED","url":"https://github.com/GymPod/realtime-core/pull/1815"}}"#
+        let g = try! #require(Git.parse(raw))
+        #expect(g.branch == "fix/1483-office")
+        #expect(g.isDirty == false)
+        let pr = try! #require(g.pullRequest)
+        #expect(pr.number == 1815)
+        #expect(pr.status == .merged)
+        #expect(pr.url.absoluteString == "https://github.com/GymPod/realtime-core/pull/1815")
+        #expect(pr.label == "GymPod/realtime-core")
+    }
+
+    @Test func parsesDirtyAsIntStringOrBool() {
+        #expect(Git.parse(#"{"branch":"main","dirty":1}"#)?.isDirty == true)
+        #expect(Git.parse(#"{"branch":"main","dirty":"1"}"#)?.isDirty == true)
+        #expect(Git.parse(#"{"branch":"main","dirty":true}"#)?.isDirty == true)
+        #expect(Git.parse(#"{"branch":"main","dirty":0}"#)?.isDirty == false)
+    }
+
+    @Test func mapsGhStateToStatus() {
+        func status(_ s: String) -> RemoteTmuxGitStatus.PullRequestStatus? {
+            Git.parse(#"{"branch":"b","pr":{"number":1,"state":"\#(s)","url":"https://x/owner/repo/pull/1"}}"#)?.pullRequest?.status
+        }
+        #expect(status("OPEN") == .open)
+        #expect(status("MERGED") == .merged)
+        #expect(status("CLOSED") == .closed)
+        #expect(status("open") == .open) // case-insensitive
+    }
+
+    @Test func branchOnlyWhenNoPR() {
+        let g = try! #require(Git.parse(#"{"branch":"feature/x","dirty":1}"#))
+        #expect(g.branch == "feature/x")
+        #expect(g.isDirty)
+        #expect(g.pullRequest == nil)
+    }
+
+    @Test func dropsInvalidOrIncompletePR() {
+        // PR without a valid url or number is dropped (branch still kept).
+        #expect(Git.parse(#"{"branch":"b","pr":{"number":1}}"#)?.pullRequest == nil)
+        #expect(Git.parse(#"{"branch":"b","pr":{"url":"https://x/o/r/pull/1"}}"#)?.pullRequest == nil)
+        // non-http url rejected
+        #expect(Git.parse(#"{"branch":"b","pr":{"number":1,"url":"ssh://x"}}"#)?.pullRequest == nil)
+    }
+
+    @Test func returnsNilWhenEmptyOrNothingUseful() {
+        #expect(Git.parse("") == nil)
+        #expect(Git.parse("   ") == nil)
+        #expect(Git.parse("{}") == nil)            // no branch, no pr
+        #expect(Git.parse(#"{"dirty":1}"#) == nil) // dirty alone is not a row
+        #expect(Git.parse("not json") == nil)
+    }
+
+    @Test func repoLabelDerivedFromPullURL() {
+        #expect(Git.repoLabel(from: URL(string: "https://github.com/owner/repo/pull/42")!) == "owner/repo")
+        #expect(Git.repoLabel(from: URL(string: "https://github.com/owner/repo")!) == nil)
+    }
+
+    @Test func unknownPRStateFallsBackToOpen() {
+        // A state gh shouldn't emit defaults to open rather than dropping the PR.
+        let g = try! #require(Git.parse(#"{"branch":"b","pr":{"number":7,"state":"DRAFT","url":"https://github.com/o/r/pull/7"}}"#))
+        #expect(g.pullRequest?.status == .open)
+    }
+}

--- a/docs/investigations/remote-agent-status-sidebar.md
+++ b/docs/investigations/remote-agent-status-sidebar.md
@@ -229,6 +229,34 @@ Branch `feat-remote-tmux-agent-status`. Reuses the already-streamed
 - Unit tests: `agentProvider` classification (agent vs shell/tool/empty).
 - Fidelity: presence only (no busy/idle, no model). Effort: S. Zero UI changes.
 
+### Attempt 3 — tmux `@cmux_agent` user-option hook channel (IMPLEMENTED — the clean path)
+
+The recommended Option C, now built and validated live for both Claude and Codex.
+
+- **Remote install (`RemoteTmuxAgentHookInstaller`):** on first attach to a host,
+  cmux writes a dependency-free hook into the remote `~/.claude/settings.json`
+  (Claude) and `~/.codex/hooks.json` (Codex) over the open ControlMaster
+  (`RemoteTmuxController.installRemoteAgentStatusHooks`, once-per-host,
+  fire-and-forget, via a python3 JSON merger that preserves the user's other
+  hooks and replaces only cmux-marked entries). The hook fires on
+  SessionStart→running, UserPromptSubmit→working, Stop→idle; its body is
+  `tmux set -t "$TMUX_PANE" @cmux_agent '{"agent":…,"state":…,"model":…}'`,
+  self-disabling when not inside tmux and always printing `{}` for blocking-hook
+  stdout.
+- **Local receive:** cmux subscribes `#{@cmux_agent}` per pane
+  (`RemoteTmuxControlConnection.subscribePaneAgent`, alongside `cmux_cwd_`/
+  `cmux_reflow_`), parses the value with `RemoteTmuxAgentStatus`, and writes the
+  sidebar entry via `RemoteTmuxSessionMirror` — taking precedence over Attempts
+  1/2 when a hook is reporting.
+- **Verified live (tmux 3.6a):** setting `@cmux_agent` pushes
+  `%subscription-changed cmux_agent_<pane> … : <json>`; the generated install
+  command merges cleanly into the remote settings; and the installed hook, run as
+  Claude invokes it (event JSON on stdin), sets the option to a value the parser
+  accepts (model `[1m]` suffix stripped).
+- **Fidelity:** authoritative running/working/idle + model, agent-agnostic. No
+  remote cmux CLI, no socket, no relay, no auth. Pure builders/parsers
+  (`RemoteTmuxAgentStatus`, `RemoteTmuxAgentHookInstaller`) are unit-tested.
+
 ### Attempt 2 — remote `~/.claude` read for busy/idle + model (IMPLEMENTED)
 
 Gated on Attempt 1's detection (Claude only). When the agent's pane has a known

--- a/docs/investigations/remote-agent-status-sidebar.md
+++ b/docs/investigations/remote-agent-status-sidebar.md
@@ -229,9 +229,26 @@ Branch `feat-remote-tmux-agent-status`. Reuses the already-streamed
 - Unit tests: `agentProvider` classification (agent vs shell/tool/empty).
 - Fidelity: presence only (no busy/idle, no model). Effort: S. Zero UI changes.
 
-### Attempt 2 — remote `~/.claude` read for busy/idle + model (DESIGNED, validated, not yet built)
+### Attempt 2 — remote `~/.claude` read for busy/idle + model (IMPLEMENTED)
 
-Gate on Attempt 1's detection, then throttled `RemoteTmuxSSHTransport.run(["sh","-c", …])`:
-`stat` newest transcript mtime → busy/idle; `tail -1` → model; feed into the same
-`SidebarStatusEntry` + `Workspace.recordConversationMessage`. Empirically validated
-above. Effort: M. Deferred to a follow-up so Attempt 1 can ship as a clean increment.
+Gated on Attempt 1's detection (Claude only). When the agent's pane has a known
+cwd (`cmux_cwd_` subscription), a throttled one-shot
+`RemoteTmuxSSHTransport.run(["sh","-c", …])` over the shared master:
+- `RemoteTmuxAgentProbe.activityProbeCommand(cwd:)` derives the project-dir name
+  (same `/`+`.`→`-` rule as `encodeClaudeProjectDir`), finds the newest
+  `~/.claude/projects/<dir>/*.jsonl`, prints `now<US>mtime<US>path` (portable
+  GNU/BSD `stat`). `parseActivity` → busy iff `(now - mtime) ≤ 30s`.
+- `RemoteTmuxAgentProbe.modelProbeCommand(transcriptPath:)` tails the transcript
+  for the last `"model":"…"`; `parseModel` strips the `[1m]` suffix.
+- The chip upgrades from "Claude Code running" to "Claude Code working · <model>"
+  / "Claude Code idle · <model>", with a `sparkles`/`moon.zzz` icon.
+
+`RemoteTmuxAgentProbe` is a pure builder+parser with full unit coverage
+(`RemoteTmuxAgentProbeTests`); the async exec + 4s throttle + teardown
+cancellation live in `RemoteTmuxSessionMirror.scheduleAgentProbe`. Re-probes on
+foreground change, topology change, and cwd arrival. Effort: M.
+
+**Not yet done / follow-ups:** periodic refresh while busy (today it re-probes on
+events, not on a timer, so a long tool-call's busy→idle edge can lag until the
+next event); codex/opencode enrichment (only Claude reads transcripts);
+multi-session-per-cwd disambiguation (uses the newest transcript in the dir).

--- a/docs/investigations/remote-agent-status-sidebar.md
+++ b/docs/investigations/remote-agent-status-sidebar.md
@@ -1,0 +1,237 @@
+# Surfacing Claude/Agent Status in the Left Sidebar for Remote SSH-tmux (and `cmux ssh`) Sessions
+
+> Investigation doc. The agent runs on a **remote** host; the local Mac must render its status in the left workspace sidebar. All `file:line` citations verified against the working tree on `main`.
+
+---
+
+## 1. Problem & why it's hard
+
+The existing local agent-status pipeline rests on three assumptions, **all of which fail for a remote agent**:
+
+1. **The visible sidebar indicator is driven by runtime `SidebarStatusEntry` + `agentPIDs` keyed off a real LOCAL OS process — not by any index.** The independent verification *refuted* the idea that `SharedLiveAgentIndex` / `RestorableAgentSessionIndex` drives the sidebar. Those structures feed only the Fork Conversation menu, OpenDiff baseline, and session restore. The actual indicator comes from `tab.statusEntries[...]` populated by live hook reporting, and `Workspace.agentPIDs` (`Sources/Workspace.swift:2491-2495`) is documented as: *"PIDs associated with agent status entries… Used for stale-session detection: if the PID is dead, the status entry is cleared."* So the current path is **structurally PID-gated**.
+
+2. **The local BSD process scan can never see a remote agent.** `allBSDProcesses()` (`Sources/CmuxTopProcessEnumeration.swift:7-8`) enumerates only the local kernel proc table. Scope attribution is by reading each *local* process's own `KERN_PROCARGS2` env for `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` (`Sources/CmuxTopSnapshotScopeCache.swift:191-199`). A Claude running on the SSH host is absent from this table; for `ssh-tmux` there isn't even a local ssh PTY (the mirror reaches the host over plain pipes — `Sources/RemoteTmuxAttachOutcome.swift:6`).
+
+3. **The hook-store live index only counts processes verified live locally.** Even if a synthetic hook record is written to `~/.cmuxterm/<kind>-hook-sessions.json`, `RestorableAgentSessionIndex.load()` drops any record that declares a `pid` but has no matching live local process (`Sources/RestorableAgentSession.swift:1166-1168`), and `liveScopedProcessID` (`:1761-1795`) requires a live process whose env matches `matchesCMUXScope` + `CMUX_AGENT_LAUNCH_KIND` + executable basename. `SharedLiveAgentIndex` loads with `detectedSnapshots:[:]` (`Sources/Workspace.swift:2029`), so the process-detected path doesn't even feed it. `hasLiveProcess` (`:1014-1016`) is `!processIDs.isEmpty`, and `processIDs` only becomes non-empty via a verified local PID.
+
+**Conclusion:** there is no ready-made "inject a record → sidebar lights up" seam that bypasses local PID verification. A remote design must write into the **runtime status surface** (`SidebarStatusEntry` / `progress` / `latestConversationMessage`) — *not* the restorable index — and must carry a non-PID liveness signal.
+
+The two transport modes also differ sharply in baseline capability:
+
+| Mode | Local PTY for agent? | Inherited `CMUX_WORKSPACE_ID/SURFACE_ID` on remote? | Relay RPC channel back to Mac? |
+|---|---|---|---|
+| `cmux ssh` (non-tmux) | Yes — real local ssh PTY in a Ghostty surface (`CLI/cmux.swift:8703-8788`) | Yes — sed placeholder substitution into remote login shell (`CLI/cmux.swift:9357-9359`) | Yes — `CMUX_SOCKET_PATH=127.0.0.1:<relayPort>` reverse forward |
+| `ssh-tmux` (mirror) | **No** — plain pipes, no per-session PTY (`Sources/RemoteTmuxAttachOutcome.swift:6`) | **No** — `runRemoteTmux` carries no cmuxd/relay bootstrap (`CLI/cmux.swift:8423-8432`) | **No** — must be built from scratch |
+
+So `cmux ssh` is *highly* feasible (it already has both env propagation and a relay channel). `ssh-tmux` is the hard case and the focus of approaches (a)/(b) below, which ride the tmux control connection instead of a relay.
+
+---
+
+## 2. The render path & injection point
+
+The sidebar row (`TabItemView`, `Sources/ContentView.swift:12909-12942`) is `Equatable` and renders a `SidebarWorkspaceSnapshotBuilder.Snapshot` assembled in `makeWorkspaceSnapshot()` (`Sources/ContentView.swift:14466-14482`). The agent-status fields of that snapshot are:
+
+- `metadataEntries: [SidebarStatusEntry]` → rendered as `SidebarMetadataRows` (`Sources/ContentView.swift:13484-13498`)
+- `progress: SidebarProgressState?` → rendered as a Capsule progress bar (`Sources/ContentView.swift:13527-13539`)
+- `latestConversationMessage` / `latestLog` → latest-message row (`Sources/ContentView.swift:13513-13525`)
+
+These map back to `Workspace` properties that forward to `WorkspaceSidebarMetadataModel` via computed get/set (`Sources/Workspace.swift:2386-2403`). The model is the observed source of truth:
+
+- `WorkspaceSidebarMetadataModel.statusEntries: [String: SidebarStatusEntry]` (`Packages/macOS/CmuxSidebar/.../WorkspaceSidebarMetadataModel.swift:30`, backed by `statusEntriesSubject` CurrentValueSubject at `:80`)
+- `WorkspaceSidebarMetadataModel.progress: SidebarProgressState?` (`:48`, subject at `:86`)
+- Helpers: `addStatusEntry(_:)` (`:164`), `updateProgress(_:)` (`:193`), `invalidateWorkspaceObservation()` (`:157`)
+
+Observation fuses through `Workspace.makeSidebarObservationPublisher` (CombineLatest over `statusEntriesPublisher`/`progressPublisher`) plus `$latestConversationMessage` etc., `removeDuplicates()` (`Sources/WorkspaceSidebarObservation.swift:14-140`).
+
+### The exact injection point — already proven by the control socket
+
+The control socket **already injects status this exact way** (verified):
+
+```
+Sources/TerminalController+ControlSidebarContext.swift:37   current: tab.statusEntries[key],
+Sources/TerminalController+ControlSidebarContext.swift:52   tab.statusEntries[key] = SidebarStatusEntry(...)
+Sources/TerminalController+ControlSidebarContext.swift:301  tab.progress = SidebarProgressState(value: value, label: label)
+Sources/TerminalController+ControlSidebarContext.swift:309  tab.progress = nil
+```
+
+This is the proof that an **external source can drive the indicator with zero UI changes**. A remote mirror should write the same way:
+
+- **Coarse activity / model chip:** `workspace.statusEntries["agent.remote"] = SidebarStatusEntry(key:value:icon:color:url:priority:format:timestamp:)` (i.e. `WorkspaceSidebarMetadataModel.addStatusEntry` at `:164`).
+- **Running spinner / progress:** `workspace.progress = SidebarProgressState(value:label:)` (`updateProgress` at `:193`).
+- **Latest message preview:** `Workspace.recordConversationMessage(_:)` (`Sources/Workspace.swift:5256-5271`).
+
+### What a "synthetic record" needs (and what it must NOT be)
+
+A remote status write must mutate one of the **observed runtime properties above** to re-render. It must **NOT** go through `RestorableAgentSessionIndex`/`SharedLiveAgentIndex` — those require a verified local PID and carry no running flag (`RestorableAgentSessionIndex.snapshot` returns only session identity, `Sources/RestorableAgentSession.swift:998-1000`).
+
+Caveats that affect a synthetic entry:
+- `shouldReplaceStatusEntry` dedupes before assignment (`Sources/TerminalController+ControlSidebarContext.swift:36-45`) — use a **stable key** and meaningful value/priority/timestamp changes or the row appears stale.
+- Rendering is gated by `detailVisibility.showsMetadata` / `showsProgress` (`Sources/ContentView.swift:13484, 13527`) — verify the sidebar detail level when testing.
+- Status entries are **intentionally not persisted** across restore (`Sources/Workspace.swift:218`) — the remote mirror is the right owner; values vanish on relaunch unless re-supplied.
+
+---
+
+## 3. Remote signals available today
+
+For `ssh-tmux`, the live tmux control connection (`RemoteTmuxControlConnection`) is the primary signal source; the separate `RemoteTmuxSSHTransport` provides arbitrary one-shot remote exec over the same ControlMaster.
+
+| Signal | How it arrives | file:line | Cadence | Fidelity for agent status |
+|---|---|---|---|---|
+| `pane_current_command` (foreground comm name) | live sub `refresh-client -B "cmux_reflow_<paneId>:%<paneId>:#{alternate_on}\|#{pane_current_command}"` | `RemoteTmuxControlConnection.swift:737-740`; one-shot `:705-711` | On subscribe + on change (~1s tmux re-eval, `:781-787`) | Coarse — comm name only (e.g. `node`, not `claude`); no PID/argv |
+| `alternate_on` | rides with `pane_current_command` | `RemoteTmuxControlConnection.swift:705-711` | With command | Distinguishes full-screen TUI from shell |
+| `pane_current_path` (cwd) | live sub `cmux_cwd_<paneId>` | `RemoteTmuxControlConnection.swift:677-679`; one-shot `:664-669` | On change | Gives the cwd → derive Claude project-dir hash |
+| Window names + layouts | `list-windows -F "#{window_id} #{window_layout} #{window_name}"` | `RemoteTmuxControlConnection.swift:567-572` | On topology change | Tab title text |
+| Raw `%output` bytes | control-mode `%output %<paneId> …` | `RemoteTmuxControlConnection.swift:1141-1144` | Continuous push | Byte counts → activity heuristic |
+| Live close-time activity (eval at query time) | `display-message … "#{pane_id}\|#{alternate_on}\|#{pane_current_command}"` | `RemoteTmuxControlConnection.swift:775-778` | On demand | Bypasses ~1s cache staleness |
+| **Arbitrary remote exec** (read files, `claude --version`) | `RemoteTmuxSSHTransport.run([...])` over shared ControlMaster, no new auth | `RemoteTmuxSSHTransport.swift:75-87` (confirmed); `runTmux` wrapper `:64-67` | On demand; subsecond on warm master | **High** — can read `~/.claude/sessions/<pid>.json` + transcript |
+| Existing foreground projection | `RemoteTmuxController.mirrorTabActivity(...)` → `MirrorTabActivity(hasActiveCommand, activeCommandName)` | `RemoteTmuxController.swift:667-682`; cached states `RemoteTmuxControlConnection.swift:74` | On query | Already wired; today only drives close-confirmation |
+
+**Critical gaps (verified):** there is **no `pane_pid`, no remote PID, and no `pane_tty`** subscribed or queried anywhere in `RemoteTmux*.swift`. `pane_current_command` is the comm name (≤~16 chars) — Claude usually appears as `node`, so comm-name matching alone is unreliable.
+
+`RemoteTmuxSSHTransport.run` returns `RemoteTmuxCommandResult{exitCode, stdout, stderr}` (`RemoteTmuxSSHTransport.swift:257-261`), stdout capped at 1 MiB, each argv token single-quoted (so use `run(["sh","-c","cat ~/.claude/..."])` for tilde/glob expansion).
+
+### What a remote Claude actually exposes under `~/.claude` (read-only over SSH)
+
+- `~/.claude/sessions/<pid>.json` — best signal **when present**: `{pid, sessionId, cwd, version, kind, entrypoint, status:"busy"|"idle", updatedAt/statusUpdatedAt}`. **But `status` is version/entrypoint-dependent** (absent on 2.1.170 conductor sdk-ts and VS Code entrypoint). Do not rely on it alone.
+- `~/.claude/projects/<cwd-hash>/<sessionId>.jsonl` — **universal** live signal. Appended in real time; mtime within ~10s on actively-working panes. Cheapest reliable "working" proxy: compare newest jsonl mtime vs `date +%s`.
+- Per-line fields parsed by cmux's `extractClaudeMetadata` (`Sources/SessionIndexStore.swift:769-840`): `cwd` (`:777`), `gitBranch` (`:780`), `permissionMode` (`:783`), assistant `message.model` (`:786-790`, strip `[1m]` suffix at `:835-838`), title from first user message (`:791-808`).
+- cwd→hash is deterministic (`encodeClaudeProjectDir`, replace `/` and `.` with `-`); hash→cwd is lossy (`decodeClaudeProjectDir`, `Sources/SessionIndexStore.swift:863`), so prefer reading the jsonl `cwd` field for ground truth.
+
+---
+
+## 4. Candidate approaches (ranked)
+
+### Rank 1 — (a) Foreground-command detection → coarse activity chip *(ship first)*
+
+- **Mechanism:** Reuse the *already-flowing* `pane_current_command` + `alternate_on` cached in `RemoteTmuxControlConnection.paneForegroundStates` (`:74`), classified at `classifyAndEmitReflow` (`:718-720`) and projected by `mirrorTabActivity` → `MirrorTabActivity(hasActiveCommand, activeCommandName)` (`RemoteTmuxController.swift:667-682`). Match `activeCommandName` against an agent-executable allowlist (`node`/`claude`/`bun`/`python`/`codex`…). When matched, write `workspace.statusEntries["agent.remote"] = SidebarStatusEntry(...)` and optionally `workspace.progress`.
+- **Crosses SSH:** nothing new — signal already arrives on the live control stream.
+- **Fidelity:** coarse. "An agent-ish command is foregrounded in this pane." Cannot say *which* agent reliably (comm is `node`), cannot say busy-vs-idle, no model/title.
+- **Effort:** **S.** Mostly wiring `mirrorTabActivity` output into a `SidebarStatusEntry` write. No new transport.
+- **Invasiveness:** Low. One new status-entry key; reuses the existing render path.
+- **Risks:** comm-name ambiguity (`node` ≠ proof of Claude); ~1s cache staleness (use the live activity query `:775-778` for accuracy); allowlist false positives (any `node` REPL lights up); `|` field-separator parsing must respect `maxSplits` if format extended (`RemoteTmuxPaneForegroundState.swift:7`).
+
+### Rank 2 — (b) Remote transcript/session read over the existing ControlMaster *(richest, still no remote install)*
+
+- **Mechanism:** Gate on Rank-1 detecting an agent foregrounded; then `RemoteTmuxSSHTransport.run(["sh","-c", "<script>"])` (`RemoteTmuxSSHTransport.swift:75-87`) to: (1) `stat` newest `~/.claude/projects/<hash>/*.jsonl` mtime vs `date +%s` → busy/idle; (2) `tail -1` the active jsonl → `message.model` + title; (3) optionally `cat ~/.claude/sessions/<pid>.json` for explicit `status` when present. Derive `<hash>` from the pane cwd (already available via `pane_current_path`, `:677-679`) using the `encodeClaudeProjectDir` rule. Map parsed fields into `SidebarStatusEntry` (model/activity chip) + `Workspace.recordConversationMessage` (latest preview) + `progress` (busy spinner).
+- **Crosses SSH:** small periodic one-shot reads (a few hundred bytes) over the warm master.
+- **Fidelity:** **High** — model name, busy/idle, latest message, title. Reuses `extractClaudeMetadata` parsing logic (`Sources/SessionIndexStore.swift:769-840`).
+- **Effort:** **M.** New polling actor + a parser (or lift `extractClaudeMetadata` to operate on remote bytes), plus throttling.
+- **Invasiveness:** Medium. Adds periodic remote exec (latency, battery, security surface — reads user files over SSH).
+- **Risks:** `status` field non-universal (fall back to mtime); mtime briefly stale during long tool calls / fresh-after-finish (pick ~30s threshold); lossy hash→cwd (use jsonl `cwd`); multiple sessions per cwd → must resolve pane's actual pid→sessionId, which tmux does **not** give (no `pane_pid`); `~/.claude` is 0600/0700, readable only as the owning remote user; `run` is not cancellation-aware and caps stdout at 1 MiB; do not write into `~/.claude`.
+
+### Rank 3 — (c) Remote cmux-hook injection POSTing status back over the relay
+
+- **Mechanism:** Provision the remote `cmux` CLI + reverse relay so the remote Claude's hooks call `cmux --socket "$CMUX_SOCKET_PATH" hooks claude …` against `127.0.0.1:<relayPort>`, landing on the local daemon via `RemoteCLIRelayServer` (auth: HMAC-SHA256 with `relay_id`/`relay_token`, `CLI/cmux.swift:2098-2226`). This is the *real* hook path and yields true SessionStart/Stop/Notification events.
+- **Crosses SSH:** loopback-TCP relay (reverse forward `ssh -O forward` / `-N -R`, `RemoteSessionCoordinator+ReverseRelay.swift:13-145`).
+- **Fidelity:** **Highest** — authoritative lifecycle events, same as local agents.
+- **Effort:** **L**, and **partially blocked for `ssh-tmux`.** The relay/cmuxd bootstrap exists for `cmux ssh` SSH workspaces but **not** for `runRemoteTmux` (`CLI/cmux.swift:8423-8432`) — would need to be built from scratch for the mirror. Even for `cmux ssh`, the **Claude wrapper hard-gates hook injection on a unix-socket `-S` test** (`Resources/bin/cmux-claude-wrapper:62-77, :414-426`); a remote `CMUX_SOCKET_PATH=127.0.0.1:<port>` is a TCP endpoint, so `-S` fails and the wrapper passes through to real `claude` **with no hooks**. Fixing this requires teaching `cmux_socket_available()` to accept a `host:port` relay endpoint (mirror `parseRelayEndpoint`, `CLI/cmux.swift:2079-2096`).
+- **Invasiveness:** High. Remote provisioning, wrapper change, relay lifecycle, VM/Freestyle skip-bootstrap edge cases.
+- **Risks:** relay-auth provisioning required (`relay_id` + 64-hex `relay_token`); reverse relay gated on daemonReady; hook timeout budget over SSH latency (5s most events / 120s feed); silent `{}` degradation hides failures.
+
+**Ranking rationale:** (a) is days-of-work for a visible win reusing flowing data; (b) adds real fidelity with no remote install, building directly on (a)'s gating + existing `extractClaudeMetadata`; (c) is the "correct" long-term answer but is the largest lift and is structurally blocked for `ssh-tmux` and gated by the wrapper for `cmux ssh`.
+
+---
+
+## 5. Recommended first attempt
+
+**Ship (a) — foreground-command → coarse remote agent chip — then layer (b) behind the same gate.** Smallest change, immediate visible win, reuses the proven `SidebarStatusEntry` render path.
+
+### Concrete edit points
+
+1. **Detect the agent in the existing projection.** `RemoteTmuxController.mirrorTabActivity` (`Sources/RemoteTmuxController.swift:667-682`) already extracts `activeCommandName` from `paneForegroundStates`. Add an agent-allowlist classifier here (or in `RemoteTmuxPaneForegroundState`, alongside `plainShellCommands` at `RemoteTmuxPaneForegroundState.swift:12-16`) that returns whether the foreground command looks like an agent.
+
+2. **Write the runtime status entry on the owning workspace.** Where the mirror updates per-tab activity today (the consumer of `MirrorTabActivity`, `RemoteTmuxController.swift:706/728`), add:
+   - `workspace.statusEntries["agent.remote"] = SidebarStatusEntry(key: "agent.remote", value: <agentLabel>, icon: …, priority: …, timestamp: Date())` — mirroring `Sources/TerminalController+ControlSidebarContext.swift:52`.
+   - Clear it (`workspace.statusEntries["agent.remote"] = nil`) when `hasActiveCommand` drops, mirroring the `progress = nil` clear at `:309`.
+
+3. **(Optional, same PR) coarse spinner:** `workspace.progress = SidebarProgressState(value: …, label: "Agent")` while active (mirror `:301`).
+
+4. **Localization:** any user-visible chip label must use `String(localized:)` and be added to `Resources/Localizable.xcstrings` for en + ja (per CLAUDE.md localization-audit rule).
+
+Stage (b) afterward behind the same `hasActiveCommand && isAgentCommand` gate: a throttled `RemoteTmuxSSHTransport.run(["sh","-c", …])` reading transcript mtime + `tail -1`, feeding model/title into the same `SidebarStatusEntry` and `Workspace.recordConversationMessage`.
+
+### Test plan
+
+- **Unit:** classifier over `RemoteTmuxPaneForegroundState` values — `node`/`claude`/`bun` → agent; `bash`/`zsh`/`vim` → not (assert against `plainShellCommands`). Wire the test file into `cmux.xcodeproj/project.pbxproj` (4 pbxproj entries) or it silently runs 0 tests (CLAUDE.md pitfall; `scripts/lint-pbxproj-test-wiring.sh`).
+- **Unit:** given a `MirrorTabActivity{hasActiveCommand:true, activeCommandName:"node"}`, assert a `SidebarStatusEntry` with the stable key is written and removed when activity drops (respect `shouldReplaceStatusEntry` dedup, `TerminalController+ControlSidebarContext.swift:36-45`).
+- **Manual (tagged build, per CLAUDE.md):** `./scripts/reload.sh --tag remote-agent-status --launch`; open an `ssh-tmux` session, run `claude` in a pane, confirm the left-sidebar row shows the chip and clears on exit. Verify the sidebar detail level shows metadata (`showsMetadata`, `ContentView.swift:13484`).
+- **Regression two-commit structure** (CLAUDE.md): commit 1 = failing test, commit 2 = the wiring.
+
+---
+
+## 6. Open questions / empirically verify by running
+
+1. **Comm name for interactive Claude:** does `pane_current_command` read `node`, `claude`, or something else for a plain interactive `claude` in tmux on the target host? (Findings show `node` is likely.) Run a real `ssh-tmux` session and read the live reflow subscription value. Determines whether the allowlist needs `node` (high false-positive) or can match `claude` directly.
+2. **`alternate_on` behavior for Claude:** does interactive Claude enter the alternate screen (`alternate_on=1`)? If yes, `alternate_on` materially sharpens the heuristic beyond comm name.
+3. **`sessions/<pid>.json` status availability on the target host's Claude build** — confirm whether `status` is present for the builds the user actually runs (it was absent on 2.1.170/VS Code). Decides whether (b) needs the mtime fallback as the *primary* signal.
+4. **Pane→sessionId attribution without `pane_pid`:** with multiple concurrent sessions in one cwd, can we attribute the right transcript to the right pane? tmux gives no remote PID. Verify whether adding `#{pane_pid}` to the subscription (note: it's the *shell* PID, not the child) plus a remote `pgrep -P` walk can recover the agent PID, or whether we accept cwd-level (not pane-level) granularity in v1.
+5. **`run()` latency/throttle budget:** measure round-trip of `RemoteTmuxSSHTransport.run(["sh","-c","stat …"])` over a warm master to pick a poll interval that doesn't churn battery/CPU.
+6. **`cmux ssh` (non-tmux) parallel path:** confirm whether approach (b)/(c) is cheaper there given the relay channel already exists (`CMUX_SOCKET_PATH=127.0.0.1:<relayPort>`) — possibly worth a separate, higher-fidelity implementation for that mode reusing `surface.report_tty`-style RPC rather than the tmux signal path.
+7. **Wrapper unix-socket gate (for approach c):** confirm exactly where `cmux_socket_available()` rejects a TCP endpoint (`Resources/bin/cmux-claude-wrapper:62-77`) and scope the change to accept `host:port` relay endpoints.
+
+---
+
+**Files most relevant to the prototype (absolute paths):**
+- `/Users/maxshmi/Developer/cmux/Sources/RemoteTmuxController.swift` (mirrorTabActivity, lines 667-735)
+- `/Users/maxshmi/Developer/cmux/Sources/RemoteTmuxControlConnection.swift` (paneForegroundStates :74, classifyAndEmitReflow :718, subscriptions :677/:737, live activity query :775)
+- `/Users/maxshmi/Developer/cmux/Sources/RemoteTmuxPaneForegroundState.swift` (PaneForegroundState, plainShellCommands :12)
+- `/Users/maxshmi/Developer/cmux/Sources/RemoteTmuxSSHTransport.swift` (run :75-87, result :257)
+- `/Users/maxshmi/Developer/cmux/Sources/TerminalController+ControlSidebarContext.swift` (status-entry write :52, progress :301/:309 — the render-path template)
+- `/Users/maxshmi/Developer/cmux/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/WorkspaceModel/WorkspaceSidebarMetadataModel.swift` (addStatusEntry :164, updateProgress :193, subjects :80/:86)
+- `/Users/maxshmi/Developer/cmux/Sources/ContentView.swift` (Snapshot :12909, makeWorkspaceSnapshot :14466, render :13484/:13527)
+- `/Users/maxshmi/Developer/cmux/Sources/SessionIndexStore.swift` (extractClaudeMetadata :769-840 — reuse for remote jsonl parsing)
+- `/Users/maxshmi/Developer/cmux/Sources/Workspace.swift` (status forwarding :2386-2403, recordConversationMessage :5256-5271, agentPIDs :2491)
+---
+
+## 7. Empirical findings (live, against a real AL2023 dev host)
+
+Probed a real `ssh-tmux`-mirrored host running interactive Claude. These resolve
+several "open questions" above:
+
+- **`pane_current_command` reads `claude`, not `node`.** `tmux list-panes -a -F
+  '#{pane_current_command}'` on the live session reported `claude` for the pane
+  running Claude Code (toolbox build 2.1.183). So comm-name matching against the
+  agent executable allowlist is **reliable on this host** — the feared `node`
+  ambiguity did not occur. (Caveat: other Claude install methods / npm-global may
+  still surface as `node`; allowlist stays conservative.)
+- **`alternate_on = 0` for interactive Claude** — it does not use the alternate
+  screen, so `alternate_on` does not sharpen detection; the comm name is the signal.
+- **`~/.claude/sessions/<pid>.json` exists and carries `status`** =
+  `idle` | `busy` | `shell`, plus `version`, `cwd`, `sessionId`. Example:
+  `{"pid":3122858,"sessionId":"…","cwd":"…/realtime-core","version":"2.1.183","status":"idle",…}`.
+  Usable for busy/idle, **but** keyed by an inner pid that is not the tmux
+  `pane_pid` (the pane reports the shell pid; Claude is a descendant), so pid→
+  session mapping needs a remote child-process walk.
+- **cwd → transcript path works without the pid.** From the pane's
+  `pane_current_path` alone: `HASH = sed 's#[/.]#-#g'` over the cwd →
+  `~/.claude/projects/<HASH>/*.jsonl`; newest file's mtime vs `date +%s` gives a
+  busy/idle proxy, and `tail -1 | jq .message.model` gives the model. Verified
+  end-to-end over plain ssh (age computed, last line parsed). This is the
+  **recommended Attempt-2 signal** — no pid walk required.
+- **Arbitrary remote exec over the shared master works** as the verification
+  predicted (`RemoteTmuxSSHTransport.run`).
+
+## 8. Attempt log
+
+### Attempt 1 — coarse "agent running" chip (IMPLEMENTED)
+
+Branch `feat-remote-tmux-agent-status`. Reuses the already-streamed
+`pane_current_command` (cached in `RemoteTmuxControlConnection.paneForegroundStates`).
+
+- `RemoteTmuxPaneForegroundState.agentProvider` maps a foreground comm name to an
+  `AgentSessionProviderID` (`claude`/`codex`/`opencode`).
+- `RemoteTmuxSessionMirror.refreshAgentStatus()` scans the session's panes and
+  writes a single keyed `SidebarStatusEntry` (`"remote-tmux.agent"`,
+  `"<Agent> running"`, `sparkles` icon) to `workspace.statusEntries` — the same
+  runtime surface the control socket writes — and clears it when no agent is
+  foregrounded or on teardown. Called from the `onPaneReflow` observer (foreground
+  change) and `rebuild()` (topology change).
+- Unit tests: `agentProvider` classification (agent vs shell/tool/empty).
+- Fidelity: presence only (no busy/idle, no model). Effort: S. Zero UI changes.
+
+### Attempt 2 — remote `~/.claude` read for busy/idle + model (DESIGNED, validated, not yet built)
+
+Gate on Attempt 1's detection, then throttled `RemoteTmuxSSHTransport.run(["sh","-c", …])`:
+`stat` newest transcript mtime → busy/idle; `tail -1` → model; feed into the same
+`SidebarStatusEntry` + `Workspace.recordConversationMessage`. Empirically validated
+above. Effort: M. Deferred to a follow-up so Attempt 1 can ship as a clean increment.

--- a/docs/investigations/remote-agent-status-test-plan.md
+++ b/docs/investigations/remote-agent-status-test-plan.md
@@ -60,6 +60,30 @@ Same as Test A, but run `codex` instead. Expect `agent=codex` in the logs and
 
 **Pass:** an already-running agent still shows a (coarser) chip.
 
+## Test E — git branch + PR row (the “which PR is open” ask)
+
+The same hook also publishes `@cmux_git` (branch + dirty + PR), which the mirror
+maps onto the workspace's per-panel branch/PR sidebar rows — the rows a local
+workspace shows but the local git/PR pollers skip for a remote mirror.
+
+1. Attach + start a fresh agent in a repo dir with a GitHub remote (Test A).
+2. Submit a prompt (fires the hook → backgrounded `git`/`gh` probe).
+   - **Expect log:** `remote.git.sub pane=N value="{"branch":…,"pr":{…}}"` then
+     `remote.git pane=N branch=… pr=#NNNN <state>`.
+   - **Expect UI:** a **branch row** (`arrow.triangle.branch` + branch name) and a
+     **clickable PR row** linking to the GitHub PR — same as a local workspace.
+3. The PR row only renders when its branch matches the panel's branch (cmux
+   invariant); the hook stamps both from the same payload, so they match.
+
+**Pass:** branch + clickable PR link appear for the remote mirror.
+
+**Notes / current limits:**
+- `gh` must be installed + authed on the remote, and the cwd must be a git repo
+  with a GitHub remote. No PR (or no `gh`) → branch row only, no PR row.
+- The probe runs on hook events (prompt submit / stop / session start), not on a
+  timer — so the branch/PR refresh when the agent acts, not on a `git checkout`
+  done idly in the pane.
+
 ## Test D — clean teardown
 
 1. Exit the agent (so its pane returns to a shell), or close the mirror window.

--- a/docs/investigations/remote-agent-status-test-plan.md
+++ b/docs/investigations/remote-agent-status-test-plan.md
@@ -1,0 +1,102 @@
+# Manual test plan — remote agent status (ssh-tmux, Option C + fallbacks)
+
+Branch `feat-remote-tmux-agent-status`. The tagged dev build logs every Option C
+checkpoint to `/tmp/cmux-debug-remote-agent-status.log` (DEBUG only).
+
+## What each debug line means
+
+Tail the log while testing:
+
+```bash
+tail -f /tmp/cmux-debug-remote-agent-status.log | grep -E 'remote\.agent|remote\.reflow'
+```
+
+| Log line | Means |
+|---|---|
+| `remote.agent.hookinstall host=… agent=claude exit=0` | cmux wrote the hook into the remote `~/.claude/settings.json` (codex line follows). `exit=0` = success; non-zero/`nil` = install failed (see stderr). |
+| `remote.agent.sub pane=N value="{…}"` | tmux delivered a `@cmux_agent` change over the control stream — the hook fired on the remote and cmux received it. |
+| `remote.agent.hook pane=N agent=claude state=working model=…` | cmux parsed the value into a status. `cleared` = empty value (chip removed). |
+| `remote.agent.sidebar write value="Claude Code working · …"` | cmux wrote the sidebar row. This is what you should see in the UI. |
+| `remote.reflow.classify … cmd="claude"` | (Fallback / Attempt 1) the foreground command was classified — drives the coarse "running" chip when no hook is reporting. |
+
+## Pre-req
+
+- Settings → Beta Features → **Remote tmux** enabled in the tagged app.
+- A remote host with `claude` (and/or `codex`) and `tmux` + `python3`.
+
+---
+
+## Test A — Option C end-to-end (the real path), Claude
+
+1. In the dev app: `cmux ssh-tmux <host>`.
+2. **Expect in log:** `remote.agent.hookinstall host=<host> agent=claude exit=0`
+   (and an `agent=codex` line). → hooks installed.
+3. In a mirrored pane, **start a fresh `claude`** (must be launched *after* step 1
+   — hooks load at agent startup).
+   - **Expect log:** `remote.agent.sub pane=N value="{"agent":"claude","state":"running"…}"`
+     then `remote.agent.hook … state=running` then `remote.agent.sidebar write`.
+   - **Expect UI:** the workspace's sidebar row shows **“Claude Code running”**.
+4. Submit a prompt.
+   - **Expect:** `state=working` lines; sidebar → **“Claude Code working · <model>”**
+     with a sparkles icon.
+5. Let the turn finish (Claude returns to the prompt).
+   - **Expect:** `state=idle`; sidebar → **“Claude Code idle · <model>”**, moon icon.
+
+**Pass:** UI tracks running → working → idle, with the model shown.
+
+## Test B — Option C, Codex
+
+Same as Test A, but run `codex` instead. Expect `agent=codex` in the logs and
+**“Codex …”** in the sidebar. (Codex hooks live in `~/.codex/hooks.json`.)
+
+## Test C — fallback for an already-running agent (no hook)
+
+1. Have a `claude` **already running** on the remote *before* you attach.
+2. `cmux ssh-tmux <host>`.
+   - That claude has no hook loaded → **no** `remote.agent.sub` lines for it.
+   - **Expect:** the Attempt 1/2 fallback — `remote.reflow.classify … cmd="claude"`
+     and a sidebar chip **“Claude Code running”**, upgrading to
+     **“… working/idle · <model>”** from the transcript poll within a few seconds.
+
+**Pass:** an already-running agent still shows a (coarser) chip.
+
+## Test D — clean teardown
+
+1. Exit the agent (so its pane returns to a shell), or close the mirror window.
+   - **Expect:** `remote.agent.hook … cleared` (Stop hook sets idle, then the chip
+     clears when the agent is gone) and the sidebar row disappears.
+
+**Pass:** no stale "running" chip left behind.
+
+---
+
+## Quick manual probe (no app) — sanity-check the remote half directly
+
+Confirms the hook + tmux channel independent of cmux. Run from your Mac:
+
+```bash
+HOST=<host>
+PANE=$(ssh "$HOST" 'tmux list-panes -t <session> -F "#{pane_id}"' | head -1)
+
+# 1. control client subscribes (leave running in one terminal):
+ssh "$HOST" "tmux -C attach -t <session>" <<< 'refresh-client -B "t:'"$PANE"':#{@cmux_agent}"'
+
+# 2. in another terminal, simulate the hook:
+ssh "$HOST" "tmux set -t $PANE @cmux_agent '{\"agent\":\"claude\",\"state\":\"working\",\"model\":\"opus\"}'"
+# → the control client prints: %subscription-changed t … : {"agent":"claude",...}
+```
+
+If step 2 makes step 1 print `%subscription-changed`, the tmux channel works; any
+failure in the app is then on the cmux side (check the debug log).
+
+## Troubleshooting
+
+- **No `hookinstall` line:** attach didn't reach a live master (auth prompt?), or
+  the controller didn't run the install. Check earlier `remote-tmux:` log lines.
+- **`hookinstall exit≠0`:** the remote lacks `python3`, or `~/.claude` isn't
+  writable. The stderr is in the log line.
+- **Install OK but no `remote.agent.sub`:** the agent was started *before* attach
+  (no hook loaded — Test C), or it isn't running inside tmux (`$TMUX_PANE` unset →
+  hook self-disables), or the agent build ignores `settings.json` hooks.
+- **`sub` arrives but no `sidebar write`:** the JSON didn't parse — inspect the
+  `value="…"` in the `remote.agent.sub` line against the `{agent,state}` contract.


### PR DESCRIPTION
> **Draft** — remote agent status + git/PR for `cmux ssh-tmux` mirrors. Builds on the merged remote-tmux work; opt-in behind the existing **Remote tmux** beta.

## What you get

When you attach a remote session with `cmux ssh-tmux <host>` and run **Claude Code or Codex** in a mirrored pane, the left sidebar now shows the agent's live status, the git branch, and a clickable PR link — the same rows a local workspace shows, for an agent running on the **remote** host.

In the mirror workspace's sidebar row you see, for an agent + repo that live entirely on the remote host:

```
my-workspace
  🟦 Claude Code idle
  ⎇  <branch>  ·  /path/to/repo
  ⇄  <owner>/<repo> #<n>  open      ← clickable, opens the PR
```

## Why this was missing — local vs remote

The sidebar's agent/branch/PR rows are driven by **three local producers**, and all three are structurally blind to a remote agent:

| Producer | How it works locally | Why it fails for an ssh-tmux mirror |
|---|---|---|
| **Agent status** (`SharedLiveAgentIndex` + `tab.statusEntries`) | a hook injected into the locally-launched agent reports over the cmux control socket; liveness gated on a local PID | the agent runs on the SSH host — not in the local process table, and the mirror's panes have no local PTY |
| **Git branch** (`CmuxSidebarGit` poller) | runs `git` in the workspace's local working dir | `guard isRemoteWorkspace == false else { return }` — the poller bails; and the repo is on the remote anyway |
| **PR** (`CmuxGit` poller) | local `git remote` slug → GitHub API / `gh` | same: no local repo to resolve a slug from |

So everything assumed *local repo + local cmux-instrumented shell*. A mirror has neither — which is exactly why this needed a new channel.

## How it works under the hood

The insight: the mirror already holds a live `tmux -CC` control stream to the host, and tmux can **subscribe a client to a user-option value** (`refresh-client -B`). So the remote agent's own lifecycle hook publishes status into a tmux user option, and cmux receives it as a `%subscription-changed` line on the stream it's already reading. **No remote cmux CLI, no socket, no reverse relay, no auth.**

```
  ┌──────────────────── your Mac (cmux) ─────────────────────┐
  │  sidebar rows  ◀─ workspace.statusEntries / gitBranch /   │
  │                     pullRequest                           │
  │        ▲                                                  │
  │  RemoteTmuxSessionMirror ── parse @cmux_agent / @cmux_git │
  │        ▲                                                  │
  │  RemoteTmuxControlConnection  (subscribes #{@cmux_agent}, │
  │        │                       #{@cmux_git} per pane)     │
  └────────┼──────────────────────────────────────────────────┘
           │  %subscription-changed  (live tmux -CC stream)
  ═════════╪═══════════ SSH ControlMaster ════════════════════
           ▼
  ┌──────────────────── remote host ─────────────────────────┐
  │  agent lifecycle hook (installed by cmux on attach):      │
  │    SessionStart→running  UserPromptSubmit→working         │
  │    Stop→idle                                              │
  │      └─ tmux set -t "$TMUX_PANE" @cmux_agent '{…}'         │
  │      └─ ( git rev-parse / git diff / gh pr view           │
  │           → tmux set @cmux_git '{branch,dirty,pr}' ) &     │
  │  claude / codex  ── the real agent                        │
  └───────────────────────────────────────────────────────────┘
```

**On attach** (`RemoteTmuxController.installRemoteAgentStatusHooks`, once per host, fire-and-forget): cmux writes a dependency-free hook into the remote `~/.claude/settings.json` and `~/.codex/hooks.json` over the open ControlMaster (a python3 merger that preserves your other hooks and replaces only cmux-marked ones).

**On each agent event** the hook (running in the agent's pane + cwd):
- writes `@cmux_agent` `{agent,state,model?}` synchronously (cheap), and
- runs `git`/`gh` in a **detached background subshell** (so latency never delays the agent) and writes `@cmux_git` `{branch,dirty,pr?}`.

Both are scoped to `$TMUX_PANE`, self-disable outside tmux, and print `{}` for valid blocking-hook stdout.

**cmux side:** per-pane subscriptions `#{@cmux_agent}` / `#{@cmux_git}` (next to the existing `cmux_cwd_`/`cmux_reflow_` ones) → parsed by `RemoteTmuxAgentStatus` / `RemoteTmuxGitStatus` → written to the **real** sidebar models (`statusEntries`, per-panel `gitBranch`/`pullRequest`). No renderer changes.

## How this compares to the existing local path

| | Local agent | Remote mirror (this PR) |
|---|---|---|
| transport | cmux control socket (unix) | tmux `@`-option over the existing `-CC` stream |
| who reports | hook → `cmux hooks claude …` | hook → `tmux set @cmux_agent …` |
| install | PATH shim / wrapper at launch | cmux writes remote `settings.json`/`hooks.json` on attach |
| liveness | local PID scan | the hook's `Stop` event + chip-clear on teardown |
| deps on remote | — | just `tmux` (+ `git`/`gh` for the PR row) |

It deliberately **reuses the same sidebar models** as local, so the rows render identically — it only swaps how the data crosses the boundary.

## Fallbacks (when there's no hook)

For an agent that was already running before attach (its hooks aren't loaded), or a host where the hook can't be installed, cmux degrades gracefully to two coarser signals it can read without the hook:
- **Foreground command** (`pane_current_command` → "Claude Code running"), and
- **Transcript poll** — reads the remote `~/.claude` transcript mtime+model over the master for busy/idle (Claude only).

The hook path (Option C) takes precedence when present.

## Proof (validated live against a real AL2023 host, tmux 3.6a)

- `tmux set @cmux_agent`/`@cmux_git` pushes `%subscription-changed cmux_agent_<pane>` / `cmux_git_<pane>` on the control stream ✅
- cmux's generated install command merges cleanly into the remote `settings.json` ✅
- the installed hook, run **exactly as Claude invokes it** (event JSON on stdin) from a repo cwd, set:
  - `@cmux_agent` → `{"agent":"claude","state":"working","model":"claude-opus-4-8[1m]"}`
  - `@cmux_git` → `{"branch":"<branch>","dirty":0,"pr":{"number":<n>,"state":"MERGED","url":"<pr-url>"}}`
- both parse to the sidebar models (model `[1m]` suffix stripped; PR branch-matched) ✅
- and the screenshot above is the rendered result.

## Tests & docs

- Pure parsers/builders fully unit-tested: `RemoteTmuxAgentStatusTests`, `RemoteTmuxGitStatusTests`, `RemoteTmuxAgentHookInstallerTests`, `RemoteTmuxAgentProbeTests`, subscription-command tests. All green; test files wired into the pbxproj.
- DEBUG checkpoints (`remote.agent.hookinstall` / `.sub` / `.hook` / `.sidebar`, `remote.git.sub` / `.git`) for live diagnosis.
- `docs/investigations/remote-agent-status-sidebar.md` (design + ranked options + empirical findings) and `…-test-plan.md` (manual test plan A–E + a no-app probe).

## Notes / limits

- Hooks load at agent **startup** → only agents started *after* attach get the hook path; earlier ones use the fallback chip.
- The git/PR row needs `gh` installed + authed on the remote and a GitHub remote; refreshes on hook events, not on an idle `git checkout`.
- All user-facing strings localized (en + ja).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784833532&installation_id=133855650&pr_number=6710&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6710&signature=4d7effad8818895a9833984d6d1c72df69f9b23ca94a252f13e99cb99843a59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows live remote agent status and git/PR info in the left sidebar for `cmux ssh-tmux` mirrors using `tmux` option subscriptions. Opt-in behind the existing Remote tmux beta.

- **New Features**
  - Live remote agent chip (running/working/idle + model) via `@cmux_agent` over `tmux -CC`.
  - Remote git branch and clickable PR via `@cmux_git` (branch/dirty/PR).
  - One-time, per-host hook install into `~/.claude` and `~/.codex` that publishes `@cmux_agent`/`@cmux_git`; scoped to the pane and non-blocking.
  - Graceful fallbacks without hooks: foreground command detection and Claude transcript probe for busy/idle.
  - No UI changes; writes to existing sidebar models. Tests added for parsers and control parsing.

- **Migration**
  - Enable the Remote tmux beta and connect with `cmux ssh-tmux <host>`.
  - Ensure `tmux` is present on the remote. For PR info, install and auth `git` and `gh` on the remote.
  - Start the agent after attach so the hook loads.

<sup>Written for commit dedd04bf169420e5074f8d313dd201af39a514b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


