### PR TITLE
Fix zsh shim rewrite with noclobber

### DIFF
--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -275,7 +275,7 @@ _cmux_install_cli_command_shim() {
         else
             printf 'exec "%s" "$@"\n' "$escaped_wrapper"
         fi
-    } >"$shim_path" 2>/dev/null || return 0
+    } >|"$shim_path" 2>/dev/null || return 0
     /bin/chmod 0700 "$shim_path" >/dev/null 2>&1 || return 0
 
     if [[ "$command_name" == "claude" ]]; then

--- a/tests/test_issue_2448_shell_claude_wrapper_dispatch.py
+++ b/tests/test_issue_2448_shell_claude_wrapper_dispatch.py
@@ -127,6 +127,39 @@ def run_zsh_with_late_user_function(shell_dir: Path, real_bin: Path, log_path: P
     return result.returncode, combined, read_lines(log_path)
 
 
+def run_zsh_with_noclobber_existing_shim(
+    shell_dir: Path,
+    real_bin: Path,
+    log_path: Path,
+    tmp_root: Path,
+) -> tuple[int, str, list[str]]:
+    env = dict(os.environ)
+    env["CMUX_SHELL_INTEGRATION_DIR"] = str(shell_dir)
+    env["CMUX_TEST_LOG"] = str(log_path)
+    env["CMUX_TEST_REAL_BIN"] = str(real_bin)
+    env["CMUX_SURFACE_ID"] = "cmux-noclobber-existing-shim"
+    env["TMPDIR"] = str(tmp_root)
+    env["PATH"] = f"{real_bin}:/usr/bin:/bin"
+    env.pop("GHOSTTY_BIN_DIR", None)
+
+    result = subprocess.run(
+        [
+            "zsh",
+            "-fic",
+            f'setopt noclobber; source "{shell_dir / "cmux-zsh-integration.zsh"}"; '
+            f'source "{shell_dir / "cmux-zsh-integration.zsh"}"; '
+            'PATH="$CMUX_TEST_REAL_BIN:$PATH"; claude zsh-noclobber-case',
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    combined = ((result.stdout or "") + (result.stderr or "")).strip()
+    return result.returncode, combined, read_lines(log_path)
+
+
 def run_bash(shell_dir: Path, real_bin: Path, log_path: Path) -> tuple[int, str, list[str]]:
     env = dict(os.environ)
     env["CMUX_SHELL_INTEGRATION_DIR"] = str(shell_dir)
@@ -399,6 +432,20 @@ printf 'current-wrapper:%s\n' "$*" >> "$CMUX_TEST_LOG"
             failures.append(f"zsh late function case exited non-zero rc={rc}: {output}")
         elif lines != ["wrapper:zsh-late-function-case"]:
             failures.append(f"zsh late function case expected wrapper dispatch, saw {lines!r}")
+
+        zsh_noclobber_log = tmp / "zsh-noclobber.log"
+        rc, output, lines = run_zsh_with_noclobber_existing_shim(
+            shell_dir,
+            real_bin,
+            zsh_noclobber_log,
+            tmp,
+        )
+        if rc != 0:
+            failures.append(f"zsh noclobber case exited non-zero rc={rc}: {output}")
+        elif "file exists:" in output:
+            failures.append(f"zsh noclobber case should not emit file exists, saw {output!r}")
+        elif lines != ["wrapper:zsh-noclobber-case"]:
+            failures.append(f"zsh noclobber case expected wrapper dispatch, saw {lines!r}")
 
         bash_alias_log = tmp / "bash-alias.log"
         rc, output, lines = run_bash_with_alias(shell_dir, real_bin, bash_alias_log)


### PR DESCRIPTION
## Summary

Fix the zsh shell integration so cmux can refresh its generated CLI shim when the user's shell has `noclobber` enabled.

## Root Cause

`_cmux_install_cli_command_shim` writes the generated shim with normal zsh redirection:

```zsh
} >"$shim_path" 2>/dev/null || return 0
```

When the per-surface shim file already exists and `noclobber` is set, zsh rejects the overwrite and prints a startup error like:

```text
_cmux_install_cli_command_shim:13: file exists: .../cmux-cli-shims/<surface-id>/claude
```

## Change

Use zsh's explicit clobber redirection for this cmux-owned generated temp file:

```zsh
>|"$shim_path"
```

This keeps the user's global `noclobber` setting intact while allowing cmux to overwrite the shim it generated.

Fixes #6714

## Test

Added a regression case in `tests/test_issue_2448_shell_claude_wrapper_dispatch.py` that:

- enables zsh `noclobber`
- sources `cmux-zsh-integration.zsh` twice for the same `CMUX_SURFACE_ID`
- verifies no `file exists:` startup noise is emitted
- verifies `claude` still dispatches through the cmux wrapper

Validated locally with:

```sh
python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py
git diff --check HEAD~1 HEAD
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Zsh shell integration to properly handle file overwriting when `noclobber` is enabled, preventing errors during wrapper shim initialization.

* **Tests**
  * Added regression test to verify Zsh wrapper functionality with `noclobber` enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->