### PR TITLE
ci(reload-build): build CmuxIrohFFI xcframework on the iOS lane

### DIFF
--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -107,6 +107,26 @@ jobs:
           mkdir -p artifact
           ( cd "$(dirname "$app_path")" && ditto -c -k --sequesterRsrc --keepParent "$(basename "$app_path")" "$GITHUB_WORKSPACE/artifact/app.zip" )
 
+      # iOS links the CmuxIrohFFI xcframework (gitignored, built from the Rust
+      # crate under Native/cmux-iroh). The macOS path builds it via
+      # reload.sh -> ensure-cmux-iroh.sh; the iOS archive below runs xcodebuild
+      # directly, so provision it here or SwiftPM fails with "local binary target
+      # 'CmuxIrohFFIBinary' ... does not contain a binary artifact". Guarded so
+      # source refs that predate the crate are a no-op (scripts come from
+      # inputs.ref, not this workflow's ref). install-rust-ci.sh is idempotent.
+      - name: Provision cmux-iroh FFI (iOS)
+        if: ${{ inputs.platform == 'ios' }}
+        run: |
+          set -euo pipefail
+          if [ -f scripts/ensure-cmux-iroh.sh ]; then
+            export PATH="$HOME/.cargo/bin:$PATH"
+            [ -f scripts/install-rust-ci.sh ] && ./scripts/install-rust-ci.sh
+            export PATH="$HOME/.cargo/bin:$PATH"
+            ./scripts/ensure-cmux-iroh.sh
+          else
+            echo "scripts/ensure-cmux-iroh.sh absent in source ref; skipping iroh FFI provisioning"
+          fi
+
       # --- iOS: build an UNSIGNED debug archive (signed locally by the caller) ---
       - name: Build unsigned iOS archive
         if: ${{ inputs.platform == 'ios' }}


### PR DESCRIPTION
## Problem

iOS reload/CI builds fail at SwiftPM resolution with:

```
local binary target 'CmuxIrohFFIBinary' at '.../CmuxIrohFFI.xcframework' does not contain a binary artifact.
```

`reload-build.yml`'s iOS job runs `xcodebuild archive` directly and only provisions GhosttyKit (`ensure-ghosttykit.sh`). It never builds the gitignored `CmuxIrohFFI.xcframework` (produced from the `Native/cmux-iroh` Rust crate by `scripts/ensure-cmux-iroh.sh`). The macOS job builds it implicitly via `reload.sh`, so only iOS is affected.

`reload-cloud*.sh` dispatch this workflow with `--ref main`, so the **workflow YAML is always read from main** while the source is checked out from `inputs.ref`. That means the iOS build of any iroh-linking branch (and the iroh iOS dogfood) is blocked until this step lands on main.

## Fix

Add a guarded `Provision cmux-iroh FFI (iOS)` step before the iOS archive that runs `ensure-cmux-iroh.sh` (with `install-rust-ci.sh` for the toolchain). Guarded on the script's presence so source refs predating the crate are a no-op. macOS path unchanged.

Workflow-only; no app/runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784855061&installation_id=133855650&pr_number=6716&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6716&signature=89317857fa5765c47e487f97b2142ea1ac0909e2c26d02b0e5bd55b3ad67f7c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to the dispatchable reload-build job; guarded skip on older refs and no production runtime behavior.
> 
> **Overview**
> **Fixes iOS reload/CI SwiftPM failures** when branches link `CmuxIrohFFIBinary` but the gitignored `CmuxIrohFFI.xcframework` was never built on that job.
> 
> Adds a **iOS-only** step before the unsigned archive that installs Rust (when `install-rust-ci.sh` exists) and runs `ensure-cmux-iroh.sh`, matching what macOS already gets indirectly through `reload.sh`. If the ensure script is missing on an older `inputs.ref`, the step **no-ops** instead of failing.
> 
> **macOS reload path is unchanged**; this is workflow-only with no app/runtime impact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b6a21c6e7a1d9760376e4e0d6f9d5457f5ac92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build `CmuxIrohFFI.xcframework` on the iOS CI lane before archiving to fix `SwiftPM` binary target errors and unblock reload builds on branches that link `cmux-iroh`. macOS path stays the same.

- **Bug Fixes**
  - Add a guarded “Provision cmux-iroh FFI (iOS)” step that runs `scripts/ensure-cmux-iroh.sh` (with `scripts/install-rust-ci.sh` when present).
  - Guarded on script presence so older source refs are a no-op; scripts come from `inputs.ref` while the workflow YAML is read from `main`. No app/runtime changes.

<sup>Written for commit b8b6a21c6e7a1d9760376e4e0d6f9d5457f5ac92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced iOS build process with improved provisioning for platform dependencies. The build workflow now conditionally ensures necessary components are available, making iOS builds more robust and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->