### PR TITLE
Add React base UI review rule

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -31,6 +31,9 @@ reviews:
     - path: "**/*.{swift,ts,tsx,js,jsx,mjs,cjs}"
       instructions: |
         Apply `.github/review-bot-rules/reliability-single-source-of-truth.md` during review. For correctness-critical detection/identity (which agent is running, agent/session lifecycle and liveness, workspace/pane/surface identity, any value the UI trusts to enable controls or route input), flag deriving the value from a window/pane/terminal title, name, or process-argv heuristic; an "unreliable but better than nothing" fallback branch where a wrong value is a correctness bug; more than one disagreeing source of truth for the same fact; and a throttle/poll interval on the read that introduces a visible staleness window. Pass for reliable structured sources (session id, registered agent descriptor, typed lifecycle event), failing closed when the reliable signal is missing, genuinely cosmetic non-authoritative hints, and coalescing that does not delay the observable value.
+    - path: "web/**/*.{tsx,jsx}"
+      instructions: |
+        Apply `.github/review-bot-rules/react-base-ui-accessibility.md` during review. For custom React UI, require `@base-ui-components/react` or an existing local component when it provides the relevant dialog, popover, menu, checkbox, select, switch, tabs, tooltip, combobox, focus, or keyboard behavior. Pass for native semantic controls and for cases with no relevant primitive where the PR owns complete accessibility and keyboard behavior.
     - path: "**/Package.swift"
       instructions: |
         Apply the cmux custom Swift lint rules in `.github/review-bot-rules/`, especially the concurrency modernization, actor isolation, blocking runtime, file/package boundary, and architectural rethink rules.
@@ -191,6 +194,10 @@ reviews:
         mode: error
         instructions: |
           For production Swift, TypeScript, and JavaScript changes, fail when the diff violates `.github/review-bot-rules/reliability-single-source-of-truth.md`: a correctness-critical fact (which agent is running, agent/session lifecycle and liveness, workspace/pane/surface identity, or any value the UI trusts to enable controls or route input) derived from a window/pane/terminal title, name, or process-argv heuristic; an "unreliable but better than nothing" fallback branch where a wrong value is a correctness bug; more than one disagreeing source of truth for the same fact; or a throttle/poll interval on the read that introduces a visible staleness window. Require a single reliable structured source (session id, registered agent descriptor, typed lifecycle event) and failing closed when it is missing. Pass for genuinely cosmetic non-authoritative hints and coalescing that does not delay the observable value.
+      - name: "cmux React base UI"
+        mode: error
+        instructions: |
+          For React UI changes under `web/**/*.tsx` and `web/**/*.jsx`, fail when the diff violates `.github/review-bot-rules/react-base-ui-accessibility.md`: a custom dialog, popover, menu, context menu, checkbox, select, switch, tabs, tooltip, combobox, command menu, or other composite widget is built from raw elements, ad hoc ARIA, `tabIndex`, or hand-rolled keyboard handlers when `@base-ui-components/react` or an existing local component provides the relevant primitive. Pass for native semantic controls and for cases with no relevant primitive where the PR owns complete accessibility and keyboard behavior.
       - name: "cmux landing page registry parity"
         mode: error
         instructions: |

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -15,6 +15,7 @@ Current rules:
 - `hot-path-allocating-formatting.md`
 - `no-ambient-global-state.md`
 - `no-test-debug-seam-in-production-source.md`
+- `react-base-ui-accessibility.md`
 - `reliability-single-source-of-truth.md`
 - `runtime-no-hacky-sleeps.md`
 - `source-control-artifacts.md`

--- a/.github/review-bot-rules/react-base-ui-accessibility.md
+++ b/.github/review-bot-rules/react-base-ui-accessibility.md
@@ -1,0 +1,19 @@
+# React Base UI Accessibility
+
+Apply this rule to React UI changes, especially custom interactive controls in `web/**/*.tsx` and `web/**/*.jsx`.
+
+## Fail
+
+- A custom dialog, popover, menu, context menu, checkbox, select, switch, tabs, tooltip, combobox, command menu, or other composite widget is built from raw `div`/`span` elements, ad hoc ARIA, `tabIndex`, or hand-rolled keyboard handlers when `@base-ui-components/react` or an existing local component already provides the relevant primitive.
+- A custom control reimplements focus trapping, roving focus, escape/outside-click dismissal, typeahead, arrow-key navigation, selection state, or checked/disabled semantics that Base UI or a shared local wrapper would own.
+- A new reusable React component wraps a Base UI primitive but drops required labels, keyboard behavior, controlled/uncontrolled state, focus restoration, or disabled/loading semantics.
+
+## Pass
+
+- Native semantic elements are sufficient, such as `button`, `a`, `input`, `select`, `textarea`, `details`, or `summary`, and the control does not need composite-widget behavior.
+- The repo has no relevant Base UI primitive or shared local component, and the PR includes the required semantics, keyboard behavior, focus management, and tests or a clear manual proof.
+- Existing custom UI is touched incidentally without worsening accessibility or keyboard behavior.
+
+## Report
+
+When this rule fails, name the exact file and line, identify the relevant Base UI primitive or local component, explain the missing accessibility or keyboard invariant, and suggest the smallest source-of-truth replacement.

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -212,6 +212,15 @@
       "severity": "high"
     },
     {
+      "id": "cmux-react-base-ui-accessibility",
+      "rule": "Flag custom React dialogs, popovers, menus, context menus, checkboxes, selects, switches, tabs, tooltips, comboboxes, command menus, or other composite widgets built from raw elements, ad hoc ARIA, tabIndex, or hand-rolled keyboard handlers when @base-ui-components/react or an existing local component provides the relevant primitive. Pass for native semantic controls and for cases with no relevant primitive where the PR owns complete accessibility, keyboard, focus, and disabled/loading behavior.",
+      "scope": [
+        "web/**/*.tsx",
+        "web/**/*.jsx"
+      ],
+      "severity": "high"
+    },
+    {
       "id": "cmux-source-control-artifacts",
       "rule": "Flag local tool output, generated logs, screenshots, recordings, temp folders, dependency checkouts, caches, build output, DerivedData, package-manager downloads, and broad scratch directories that enter source control without a deliberate product, docs, fixture, build, release, or test-system reason. Pass for intentional source files, configs, localization catalogs, review rules, durable docs assets, required fixtures, generated files that are already part of the repo's source-of-truth model, and PRs that only remove or ignore existing accidental artifacts.",
       "scope": [

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -173,6 +173,14 @@
       ]
     },
     {
+      "path": ".github/review-bot-rules/react-base-ui-accessibility.md",
+      "description": "Source-of-truth cmux review rule requiring relevant Base UI or local React primitives for custom interactive UI accessibility and keyboard behavior.",
+      "scope": [
+        "web/**/*.tsx",
+        "web/**/*.jsx"
+      ]
+    },
+    {
       "path": ".github/review-bot-rules/source-control-artifacts.md",
       "description": "Source-of-truth cmux review rule for local/generated artifacts that should not enter source control.",
       "scope": [

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -27,6 +27,7 @@ Review production Swift and runtime changes for:
 - Ambient global state: top-level free functions, global mutable vars, static-only namespace types, and new singletons that should be owned by a scoped type and injected.
 - Per-call allocating formatting (`String(format:)`, per-call formatters) on hot or concurrent paths instead of preallocated buffers or reused formatters.
 - Correctness-critical detection/identity derived from title/name heuristics or unreliable fallbacks instead of a single reliable source of truth.
+- Custom React composite UI built from raw elements when Base UI or an existing local component should own accessibility, focus, and keyboard behavior.
 
 ## Runtime No Hacky Sleeps
 
@@ -127,6 +128,14 @@ For production code that detects, identifies, or tracks correctness-critical sta
 Flag a correctness-critical value derived from a string/title/name heuristic (terminal title, window title, pane label, process-argv substring, display name) to decide agent type, session identity, liveness, or which conversation to show. Flag an "unreliable but better than nothing" fallback branch (a guess, a default, a best-effort branch) for state where a wrong value is a correctness bug. Flag more than one disagreeing source of truth for the same fact without one designated authority. Flag a throttle or polling interval placed on a correctness-critical read that introduces a visible staleness window when the consumer must reflect the change promptly.
 
 Pass for detection that uses a reliable structured source (explicit session id, registered agent descriptor, typed lifecycle event), a missing reliable signal that fails closed (no detection, control disabled, empty state) rather than guessing, a heuristic used only for a genuinely cosmetic non-authoritative hint, and coalescing/debouncing that does not delay the observable correctness-critical value.
+
+## React Base UI Accessibility
+
+For React UI changes under `web/**/*.tsx` and `web/**/*.jsx`, prefer `@base-ui-components/react` or an existing local component when building custom composite widgets.
+
+Flag custom dialogs, popovers, menus, context menus, checkboxes, selects, switches, tabs, tooltips, comboboxes, command menus, or similar interactive controls built from raw `div`/`span` elements, ad hoc ARIA, `tabIndex`, or hand-rolled keyboard handlers when Base UI or a shared component already provides the relevant primitive. Also flag wrappers around Base UI primitives that drop labels, focus restoration, controlled/uncontrolled state, keyboard support, or disabled/loading semantics.
+
+Pass for native semantic elements (`button`, `a`, `input`, `select`, `textarea`, `details`, `summary`) when they satisfy the behavior, cases with no relevant primitive where the PR owns complete semantics and keyboard/focus behavior, and existing custom UI not worsened by the PR.
 
 ## Landing Page Registry Parity
 


### PR DESCRIPTION
## Summary
- Add a React Base UI accessibility review rule for custom composite UI.
- Wire the rule into CodeRabbit and Greptile, with Base UI/local-component exceptions and native-control pass cases.

## Testing
- `jq -e . .greptile/config.json .greptile/files.json >/dev/null`
- `ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml"); puts "coderabbit yaml ok"'`\n- `git diff --check`\n- `/Users/lawrence/fun/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode branch --base origin/main`\n\n## Issues\n- Task: React custom UI should use relevant Base UI primitives for accessibility and keyboard behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784858927&installation_id=133855650&pr_number=6720&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6720&signature=752844c4a9c94adabb08a327b921913e337e8002de9e85f859b5d2e36fe3d314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and review-bot configuration only; no runtime web or app behavior changes.
> 
> **Overview**
> Introduces **`react-base-ui-accessibility.md`** as a shared review-bot rule so PRs that add custom composite React UI in `web/**/*.tsx` and `web/**/*.jsx` are checked for **Base UI** (`@base-ui-components/react`) or existing local wrappers instead of raw `div`/`span`, ad hoc ARIA, and hand-rolled keyboard/focus behavior.
> 
> **CodeRabbit** gets a scoped `path_instructions` entry and an error-mode pre-merge check **"cmux React base UI"**. **Greptile** gets a matching high-severity rule, `files.json` linkage to the rule file, and a **React Base UI Accessibility** section in `rules.md`. The rule index in `.github/review-bot-rules/README.md` is updated. Pass cases cover native semantic controls and PRs that fully own a11y when no primitive exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb4eeea40aad8e03627fcba22539a48c20700e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a React Base UI accessibility review rule that requires using `@base-ui-components/react` or existing local primitives for composite widgets. Integrated with CodeRabbit and Greptile to block ad hoc ARIA/keyboard implementations and aligns with the task to use Base UI for accessibility and keyboard behavior.

- New Features
  - Added `.github/review-bot-rules/react-base-ui-accessibility.md` with clear fail/pass criteria and reporting guidance.
  - CodeRabbit: new "cmux React base UI" check in error mode for `web/**/*.tsx,jsx` via `.coderabbit.yaml`.
  - Greptile: new high-severity rule `cmux-react-base-ui-accessibility`, scoped to `web/**/*.tsx,jsx`, with updates to `config.json`, `files.json`, `rules.md`, and `README.md`.

<sup>Written for commit dfb4eeea40aad8e03627fcba22539a48c20700e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added automated review rules and enforcement gates for React component accessibility, requiring use of Base UI primitives for interactive controls, focus management, and keyboard behavior in web React files.
* Updated code review documentation and configuration to reflect new accessibility compliance standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->