### PR TITLE
web: Slack notification on waitlist signup

### DIFF
--- a/web/app/[locale]/(legal)/privacy-policy/page.tsx
+++ b/web/app/[locale]/(legal)/privacy-policy/page.tsx
@@ -73,7 +73,8 @@ export default function PrivacyPolicyPage() {
         If you contact us via email or our contact page, we collect the
         information you provide such as your name and email address. If you join
         a platform waitlist, we collect the email address you submit so we can
-        email you when that platform launches.
+        email you when that platform launches, and we send a notification of the
+        signup (including that email address) to our internal Slack workspace.
       </p>
 
       <h3>3. Children&rsquo;s Privacy</h3>
@@ -112,6 +113,12 @@ export default function PrivacyPolicyPage() {
           <strong>Resend</strong> &mdash; transactional email delivery. Used to
           deliver feedback submissions from the Application. Your email address
           is transmitted to Resend only if you voluntarily submit feedback.
+        </li>
+        <li>
+          <strong>Slack</strong> &mdash; internal team notifications. If you join
+          a platform waitlist, the email address and platforms you submit are
+          sent to our private Slack workspace so the team is notified of the
+          signup.
         </li>
       </ul>
       <p>

--- a/web/app/[locale]/components/waitlist-dialog.tsx
+++ b/web/app/[locale]/components/waitlist-dialog.tsx
@@ -190,12 +190,15 @@ function WaitlistBody({
     // spinner pleasant when the request is fast.
     const [ok] = await Promise.all([
       recordWaitlistSignup(trimmed, platforms, location),
-      // Best-effort Slack ping in parallel; its result doesn't gate success.
-      notifyWaitlistSlack(trimmed, platforms, location),
       new Promise<void>((resolve) => {
         timerRef.current = setTimeout(resolve, SUBMIT_DELAY_MS);
       }),
     ]);
+    // Ping Slack only after the signup was durably recorded, so the channel
+    // never reports a signup that actually failed. Best-effort, not awaited.
+    if (ok) {
+      void notifyWaitlistSlack(trimmed, platforms, location);
+    }
     setStatus(ok ? "done" : "sendError");
   };
 

--- a/web/app/[locale]/components/waitlist-dialog.tsx
+++ b/web/app/[locale]/components/waitlist-dialog.tsx
@@ -72,6 +72,28 @@ async function recordWaitlistSignup(
   }
 }
 
+/**
+ * Pings our Slack channel about a signup via the `/api/waitlist` route.
+ * Best-effort: the durable record is the PostHog capture above, so a failed
+ * notification never blocks or fails the signup.
+ */
+async function notifyWaitlistSlack(
+  email: string,
+  platforms: WaitlistPlatform[],
+  location: string,
+): Promise<void> {
+  try {
+    await fetch("/api/waitlist", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      keepalive: true,
+      body: JSON.stringify({ email, platforms, location }),
+    });
+  } catch {
+    // Notification only; ignore failures.
+  }
+}
+
 export function WaitlistDialog({
   target,
   open,
@@ -168,6 +190,8 @@ function WaitlistBody({
     // spinner pleasant when the request is fast.
     const [ok] = await Promise.all([
       recordWaitlistSignup(trimmed, platforms, location),
+      // Best-effort Slack ping in parallel; its result doesn't gate success.
+      notifyWaitlistSlack(trimmed, platforms, location),
       new Promise<void>((resolve) => {
         timerRef.current = setTimeout(resolve, SUBMIT_DELAY_MS);
       }),

--- a/web/app/api/waitlist/route.ts
+++ b/web/app/api/waitlist/route.ts
@@ -79,15 +79,21 @@ export async function POST(request: Request) {
       }
 
       try {
+        // Platform labels come from a fixed enum; email + location are
+        // user-controlled, so escape Slack mrkdwn metacharacters (`&`, `<`, `>`)
+        // to keep `<!channel>`, `<@USER>`, and link syntax from rendering or
+        // notifying the channel.
         const platformList = platforms
           .map((p) => PLATFORM_LABELS[p])
           .join(", ");
-        const fromSuffix = location ? ` (from ${location})` : "";
+        const fromSuffix = location
+          ? ` (from ${escapeSlack(location)})`
+          : "";
         const res = await fetch(webhookUrl, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            text: `:tada: New waitlist signup: *${email}* for *${platformList}*${fromSuffix}`,
+            text: `:tada: New waitlist signup: *${escapeSlack(email)}* for *${platformList}*${fromSuffix}`,
           }),
         });
         if (!res.ok) {
@@ -102,6 +108,12 @@ export async function POST(request: Request) {
       return ok({ slack: "sent" });
     },
   );
+}
+
+// Escape the characters Slack treats specially in mrkdwn so user-controlled
+// text can't inject links, mentions, or channel broadcasts.
+function escapeSlack(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 function ok(extra: Record<string, unknown>) {

--- a/web/app/api/waitlist/route.ts
+++ b/web/app/api/waitlist/route.ts
@@ -1,0 +1,119 @@
+import { checkRateLimit } from "@vercel/firewall";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { env } from "@/app/env";
+import {
+  recordSpanError,
+  setSpanAttributes,
+  withApiRouteSpan,
+} from "../../../services/telemetry";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const WAITLIST_PLATFORMS = ["linux", "android", "windows"] as const;
+
+const PLATFORM_LABELS: Record<(typeof WAITLIST_PLATFORMS)[number], string> = {
+  linux: "Linux",
+  android: "Android",
+  windows: "Windows",
+};
+
+const waitlistSchema = z.object({
+  email: z.string().trim().email().max(320),
+  platforms: z
+    .array(z.enum(WAITLIST_PLATFORMS))
+    .min(1)
+    .max(WAITLIST_PLATFORMS.length),
+  location: z.string().trim().max(64).optional().default(""),
+});
+
+/**
+ * Notifies Slack when someone joins a platform waitlist. The durable signup
+ * record lives in PostHog (captured client-side); this route only fans out the
+ * team notification, so a Slack failure does not invalidate the signup.
+ */
+export async function POST(request: Request) {
+  return withApiRouteSpan(
+    request,
+    "/api/waitlist",
+    { "cmux.subsystem": "waitlist", "cmux.waitlist.operation": "notify" },
+    async (span): Promise<Response> => {
+      // Reuse the feedback rate-limit rule so a public POST that fans out to
+      // Slack can't be used to flood the channel. Only active on Vercel.
+      if (process.env.VERCEL === "1") {
+        const { error, rateLimited } = await checkRateLimit(
+          env.CMUX_FEEDBACK_RATE_LIMIT_ID,
+          { request },
+        );
+        setSpanAttributes(span, {
+          "cmux.rate_limited": rateLimited || error === "blocked",
+        });
+        if (rateLimited || error === "blocked") {
+          return jsonError("Rate limit exceeded", 429);
+        }
+      }
+
+      let payload: unknown;
+      try {
+        payload = await request.json();
+      } catch {
+        return jsonError("Invalid JSON payload", 400);
+      }
+
+      const parsed = waitlistSchema.safeParse(payload);
+      if (!parsed.success) {
+        return jsonError("Invalid waitlist payload", 400);
+      }
+      const { email, platforms, location } = parsed.data;
+      setSpanAttributes(span, {
+        "cmux.waitlist.platform_count": platforms.length,
+        "cmux.waitlist.location": location,
+      });
+
+      const webhookUrl = env.SLACK_WAITLIST_WEBHOOK_URL;
+      if (!webhookUrl) {
+        // Not configured: accept so the client signup flow still succeeds.
+        return ok({ slack: "skipped" });
+      }
+
+      try {
+        const platformList = platforms
+          .map((p) => PLATFORM_LABELS[p])
+          .join(", ");
+        const fromSuffix = location ? ` (from ${location})` : "";
+        const res = await fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            text: `:tada: New waitlist signup: *${email}* for *${platformList}*${fromSuffix}`,
+          }),
+        });
+        if (!res.ok) {
+          recordSpanError(span, new Error(`slack webhook ${res.status}`));
+          return jsonError("Failed to notify Slack", 502);
+        }
+      } catch (error) {
+        recordSpanError(span, error);
+        return jsonError("Failed to notify Slack", 502);
+      }
+
+      return ok({ slack: "sent" });
+    },
+  );
+}
+
+function ok(extra: Record<string, unknown>) {
+  return NextResponse.json(
+    { ok: true, ...extra },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+function jsonError(message: string, status: number) {
+  return NextResponse.json(
+    { error: message },
+    { status, headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -43,6 +43,9 @@ export const env = createEnv({
     // change without a code edit.
     STRIPE_FOUNDERS_WEBHOOK_SECRET: z.string().min(1).optional(),
     CMUX_FOUNDERS_FROM_EMAIL: z.string().email().optional(),
+    // Slack Incoming Webhook for the #website-waitlist channel. Optional: the
+    // /api/waitlist route silently skips the Slack ping when it is unset.
+    SLACK_WAITLIST_WEBHOOK_URL: z.string().url().optional(),
   },
   client: {
     NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),
@@ -58,6 +61,7 @@ export const env = createEnv({
     CMUX_PUSH_RATE_LIMIT_ID: trimEnv(process.env.CMUX_PUSH_RATE_LIMIT_ID),
     STRIPE_FOUNDERS_WEBHOOK_SECRET: trimEnv(process.env.STRIPE_FOUNDERS_WEBHOOK_SECRET),
     CMUX_FOUNDERS_FROM_EMAIL: trimEnv(process.env.CMUX_FOUNDERS_FROM_EMAIL),
+    SLACK_WAITLIST_WEBHOOK_URL: trimEnv(process.env.SLACK_WAITLIST_WEBHOOK_URL),
     NEXT_PUBLIC_STACK_PROJECT_ID: stackEnv(
       process.env.NEXT_PUBLIC_STACK_PROJECT_ID,
       "00000000-0000-4000-8000-000000000000"


### PR DESCRIPTION
Pings our Slack channel when someone joins a platform waitlist.

A new server route `POST /api/waitlist` posts a message to the **#website-waitlist** Slack channel via an Incoming Webhook (`SLACK_WAITLIST_WEBHOOK_URL`). The waitlist dialog calls it best-effort, in parallel with the existing durable PostHog capture, so a Slack failure never blocks or fails the signup. The route validates the payload (email + platforms), reuses the feedback rate-limit rule on Vercel, and silently no-ops when the webhook env is unset.

Setup done out-of-band:
- Created Slack channel **#website-waitlist** and an Incoming Webhook app ("Website Waitlist") in the Manaflow workspace.
- Set `SLACK_WAITLIST_WEBHOOK_URL` in Vercel **Production** only. Preview is intentionally left unset so preview/test deployments don't spam the real channel (the route returns a graceful `{ok:true, slack:"skipped"}`).
- Stored the webhook in `~/.secrets/cmuxterm-dev.env` for local dev.

Verified locally: `POST /api/waitlist` returns 200 `{slack:"sent"}` (Slack webhook returns `ok`) for valid payloads and 400 for invalid ones, and the full UI flow (submit → `notifyWaitlistSlack` → route → Slack) posts to the channel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784860190&installation_id=133855650&pr_number=6722&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6722&signature=5af3955c7901fede64f1ebb7f4f9b4e4947768ece896b1403a6065b945469ed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public POST endpoint is rate-limited and only forwards validated PII to an optional internal webhook; signup durability stays on PostHog and the UI does not depend on Slack.
> 
> **Overview**
> Adds **best-effort Slack alerts** when a platform waitlist signup succeeds in PostHog, without changing whether the user sees success.
> 
> A new **`POST /api/waitlist`** route validates `email`, `platforms`, and optional `location` with Zod, applies the existing Vercel firewall rate limit (`CMUX_FEEDBACK_RATE_LIMIT_ID`), posts to **`SLACK_WAITLIST_WEBHOOK_URL`** with mrkdwn escaping for user-controlled fields, and returns `{ ok: true, slack: "skipped" }` when the webhook is unset. The waitlist dialog calls this route **only after** a successful PostHog capture, **without awaiting** the response, so Slack errors never block the UI.
> 
> **Privacy policy** copy now discloses that waitlist email (and platforms) may be sent to the internal Slack workspace. **`env.ts`** wires the optional webhook URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2202715eebc7df0d5716b0705556ed7ddbff6bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send a Slack message when someone joins the platform waitlist after the signup is durably recorded; this never blocks the flow. Updates the privacy policy to disclose Slack notifications.

- **New Features**
  - New `POST /api/waitlist` posts to `#website-waitlist` via `SLACK_WAITLIST_WEBHOOK_URL`; validates `email`, `platforms`, and optional `location` with `zod`, escapes Slack mrkdwn, and returns 400 on invalid input.
  - Reuses `@vercel/firewall` rate limit (`CMUX_FEEDBACK_RATE_LIMIT_ID`) on Vercel to prevent spam.
  - Called from the waitlist dialog only after a successful PostHog capture; not awaited. If webhook is unset, returns `{ ok: true, slack: "skipped" }`.
  - Privacy policy updated to add Slack to third‑party services and note that waitlist emails are sent to our internal Slack.

- **Migration**
  - Set `SLACK_WAITLIST_WEBHOOK_URL` in Production. Leave unset in Preview to avoid channel noise.

<sup>Written for commit d2202715eebc7df0d5716b0705556ed7ddbff6bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waitlist signups can now trigger Slack notifications when a webhook is configured, without interrupting or failing the signup flow if notification delivery encounters issues.
  * Added a dedicated API endpoint to validate and record waitlist signups and fan out Slack alerts.

* **Documentation**
  * Updated the privacy policy to reflect that waitlist signup details may be forwarded to an internal Slack workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->