### PR TITLE
[codex] Smooth canvas scroll handling

### DIFF
--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasDocumentView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasDocumentView.swift
@@ -45,9 +45,10 @@ final class CanvasDocumentView: NSView {
 
         // Dots are aligned to canvas space so they stay put when the document
         // re-centers around content.
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
         let spacing = Self.gridSpacing
         let radius = Self.gridDotRadius
-        NSColor.tertiaryLabelColor.withAlphaComponent(0.18).setFill()
+        context.setFillColor(NSColor.tertiaryLabelColor.withAlphaComponent(0.18).cgColor)
         let phaseX = canvasToDocumentOffset.x.truncatingRemainder(dividingBy: spacing)
         let phaseY = canvasToDocumentOffset.y.truncatingRemainder(dividingBy: spacing)
         var x = (dirtyRect.minX - phaseX).rounded(.down) - (dirtyRect.minX - phaseX)
@@ -59,7 +60,7 @@ final class CanvasDocumentView: NSView {
             while y < dirtyRect.minY { y += spacing }
             while y <= dirtyRect.maxY {
                 let dot = CGRect(x: x - radius, y: y - radius, width: radius * 2, height: radius * 2)
-                NSBezierPath(ovalIn: dot).fill()
+                context.fillEllipse(in: dot)
                 y += spacing
             }
             x += spacing

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+CommandScroll.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+CommandScroll.swift
@@ -8,12 +8,18 @@ extension CanvasRootView {
     func installCommandScrollMonitor() {
         guard commandScrollMonitor == nil else { return }
         commandScrollMonitor = NSEvent.addLocalMonitorForEvents(
-            matching: [.scrollWheel, .magnify]
+            matching: [.scrollWheel, .magnify, .keyDown, .keyUp, .leftMouseDown, .leftMouseDragged, .leftMouseUp]
         ) { [weak self] event in
             guard let self,
                   let window = self.window,
                   event.window === window else {
                 return event
+            }
+            switch event.type {
+            case .keyDown, .keyUp, .leftMouseDown, .leftMouseDragged, .leftMouseUp:
+                return self.handleSpacePanEvent(event)
+            default:
+                break
             }
             let location = self.convert(event.locationInWindow, from: nil)
             guard self.bounds.contains(location) else { return event }

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+SpacePan.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+SpacePan.swift
@@ -1,0 +1,142 @@
+import AppKit
+
+/// Figma-style Space+click-drag panning for ``CanvasRootView``.
+extension CanvasRootView {
+    static let spacePanKeyCode: UInt16 = 49
+
+    struct SpacePanSession {
+        let startWindowPoint: CGPoint
+        let startClipOrigin: CGPoint
+    }
+
+    func handleSpacePanEvent(_ event: NSEvent) -> NSEvent? {
+        switch event.type {
+        case .keyDown:
+            guard isSpacePanKeyEvent(event) else { return event }
+            isSpacePanKeyDown = true
+            if shouldConsumeSpacePanKeyEvent() {
+                didConsumeSpacePanKeyDown = true
+                return nil
+            }
+            return event
+
+        case .keyUp:
+            guard isSpacePanKeyEvent(event) else { return event }
+            isSpacePanKeyDown = false
+            let shouldConsume = didConsumeSpacePanKeyDown || spacePanSession != nil
+            didConsumeSpacePanKeyDown = false
+            return shouldConsume ? nil : event
+
+        case .leftMouseDown:
+            guard isSpacePanArmed, bounds.contains(convert(event.locationInWindow, from: nil)) else {
+                return event
+            }
+            beginSpacePan(with: event)
+            return nil
+
+        case .leftMouseDragged:
+            guard spacePanSession != nil else { return event }
+            updateSpacePan(with: event)
+            return nil
+
+        case .leftMouseUp:
+            guard spacePanSession != nil else { return event }
+            finishSpacePan()
+            return nil
+
+        default:
+            return event
+        }
+    }
+
+    func cancelSpacePan() {
+        spacePanSession = nil
+        isSpacePanKeyDown = false
+        didConsumeSpacePanKeyDown = false
+        popSpacePanCursorIfNeeded()
+    }
+
+    private var isSpacePanArmed: Bool {
+        isSpacePanKeyDown || Self.isPhysicalSpaceKeyPressed
+    }
+
+    private static var isPhysicalSpaceKeyPressed: Bool {
+        CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(spacePanKeyCode))
+    }
+
+    private func isSpacePanKeyEvent(_ event: NSEvent) -> Bool {
+        guard event.keyCode == Self.spacePanKeyCode else { return false }
+        let reservedModifiers: NSEvent.ModifierFlags = [.command, .control, .option]
+        return event.modifierFlags.intersection(reservedModifiers).isEmpty
+    }
+
+    private func shouldConsumeSpacePanKeyEvent() -> Bool {
+        guard let window else { return false }
+        let location = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+        guard bounds.contains(location) else { return false }
+        // Preserve normal terminal/text entry when the pointer sits over pane
+        // content; the following mouse-down will still enter hand-pan mode if
+        // the user is intentionally holding Space and dragging.
+        return paneView(at: location) == nil || spacePanSession != nil
+    }
+
+    private func beginSpacePan(with event: NSEvent) {
+        spacePanSession = SpacePanSession(
+            startWindowPoint: event.locationInWindow,
+            startClipOrigin: scrollView.contentView.bounds.origin
+        )
+        overviewRestore = nil
+        pushSpacePanCursorIfNeeded()
+    }
+
+    private func updateSpacePan(with event: NSEvent) {
+        guard let session = spacePanSession else { return }
+        let origin = Self.spacePanClipOrigin(
+            startClipOrigin: session.startClipOrigin,
+            startWindowPoint: session.startWindowPoint,
+            currentWindowPoint: event.locationInWindow,
+            magnification: scrollView.magnification
+        )
+        let clipView = scrollView.contentView
+        let constrained = clipView.constrainBoundsRect(CGRect(origin: origin, size: clipView.bounds.size))
+        clipView.setBoundsOrigin(constrained.origin)
+        scrollView.reflectScrolledClipView(clipView)
+    }
+
+    private func finishSpacePan() {
+        guard spacePanSession != nil else { return }
+        spacePanSession = nil
+        popSpacePanCursorIfNeeded()
+        updateLifecycle()
+        saveViewportToModel()
+        callbacks.onViewportGeometryChanged(window)
+        callbacks.onViewportSettled(window)
+    }
+
+    private func pushSpacePanCursorIfNeeded() {
+        guard !didPushSpacePanCursor else { return }
+        NSCursor.closedHand.push()
+        didPushSpacePanCursor = true
+    }
+
+    private func popSpacePanCursorIfNeeded() {
+        guard didPushSpacePanCursor else { return }
+        NSCursor.pop()
+        didPushSpacePanCursor = false
+    }
+
+    static func spacePanClipOrigin(
+        startClipOrigin: CGPoint,
+        startWindowPoint: CGPoint,
+        currentWindowPoint: CGPoint,
+        magnification: CGFloat
+    ) -> CGPoint {
+        let scale = max(magnification, 0.0001)
+        let dx = (currentWindowPoint.x - startWindowPoint.x) / scale
+        let dy = (currentWindowPoint.y - startWindowPoint.y) / scale
+        return CGPoint(
+            x: startClipOrigin.x - dx,
+            y: startClipOrigin.y + dy
+        )
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+SpacePan.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+SpacePan.swift
@@ -10,12 +10,22 @@ extension CanvasRootView {
     }
 
     func handleSpacePanEvent(_ event: NSEvent) -> NSEvent? {
+        guard canvasSpacePanShouldHandleEvents(isWorkspaceVisible: isWorkspaceVisible) else {
+            cancelSpacePan()
+            return event
+        }
         switch event.type {
         case .keyDown:
             guard isSpacePanKeyEvent(event) else { return event }
             isSpacePanKeyDown = true
-            if shouldConsumeSpacePanKeyEvent() {
-                didConsumeSpacePanKeyDown = true
+            if event.isARepeat {
+                return canvasSpacePanShouldConsumeSpaceKeyRepeat(
+                    didConsumeSpaceKey: didConsumeSpacePanKeyDown,
+                    isPanning: spacePanSession != nil
+                ) ? nil : event
+            }
+            didConsumeSpacePanKeyDown = shouldConsumeSpacePanKeyEvent()
+            if didConsumeSpacePanKeyDown {
                 return nil
             }
             return event
@@ -28,7 +38,13 @@ extension CanvasRootView {
             return shouldConsume ? nil : event
 
         case .leftMouseDown:
-            guard isSpacePanArmed, bounds.contains(convert(event.locationInWindow, from: nil)) else {
+            refreshSpacePanKeyState()
+            let pointerInsideCanvas = bounds.contains(convert(event.locationInWindow, from: nil))
+            guard canvasSpacePanCanBegin(
+                didConsumeSpaceKey: didConsumeSpacePanKeyDown,
+                isPhysicalSpaceKeyPressed: Self.isPhysicalSpaceKeyPressed,
+                isPointerInsideCanvas: pointerInsideCanvas
+            ) else {
                 return event
             }
             beginSpacePan(with: event)
@@ -56,10 +72,6 @@ extension CanvasRootView {
         popSpacePanCursorIfNeeded()
     }
 
-    private var isSpacePanArmed: Bool {
-        isSpacePanKeyDown || Self.isPhysicalSpaceKeyPressed
-    }
-
     private static var isPhysicalSpaceKeyPressed: Bool {
         CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(spacePanKeyCode))
     }
@@ -74,10 +86,42 @@ extension CanvasRootView {
         guard let window else { return false }
         let location = convert(window.mouseLocationOutsideOfEventStream, from: nil)
         guard bounds.contains(location) else { return false }
-        // Preserve normal terminal/text entry when the pointer sits over pane
-        // content; the following mouse-down will still enter hand-pan mode if
-        // the user is intentionally holding Space and dragging.
-        return paneView(at: location) == nil || spacePanSession != nil
+        // Preserve normal terminal/text/control entry when keyboard focus is
+        // not owned by the canvas background. If the key was not swallowed, the
+        // later mouse-down must not start a pan because a literal Space may
+        // already have been delivered to that responder.
+        return canvasSpacePanShouldConsumeSpaceKey(
+            isPointerInsideCanvas: true,
+            canInterceptKeyboardTarget: canInterceptSpacePanKeyboardTarget(in: window),
+            isPanning: spacePanSession != nil
+        )
+    }
+
+    private func canInterceptSpacePanKeyboardTarget(in window: NSWindow) -> Bool {
+        guard let responder = window.firstResponder else { return true }
+        if responder === window {
+            return true
+        }
+        if canvasSpacePanIsTextInputOrControlResponder(responder) {
+            return false
+        }
+        guard let view = responder as? NSView else { return false }
+        if isPaneResponder(view) {
+            return false
+        }
+        return view === self || view.isDescendant(of: self)
+    }
+
+    private func isPaneResponder(_ responder: NSView) -> Bool {
+        return paneViews.values.contains { paneView in
+            responder === paneView || responder.isDescendant(of: paneView)
+        }
+    }
+
+    private func refreshSpacePanKeyState() {
+        guard !Self.isPhysicalSpaceKeyPressed else { return }
+        isSpacePanKeyDown = false
+        didConsumeSpacePanKeyDown = false
     }
 
     private func beginSpacePan(with event: NSEvent) {
@@ -91,7 +135,7 @@ extension CanvasRootView {
 
     private func updateSpacePan(with event: NSEvent) {
         guard let session = spacePanSession else { return }
-        let origin = Self.spacePanClipOrigin(
+        let origin = canvasSpacePanClipOrigin(
             startClipOrigin: session.startClipOrigin,
             startWindowPoint: session.startWindowPoint,
             currentWindowPoint: event.locationInWindow,
@@ -107,9 +151,7 @@ extension CanvasRootView {
         guard spacePanSession != nil else { return }
         spacePanSession = nil
         popSpacePanCursorIfNeeded()
-        updateLifecycle()
-        saveViewportToModel()
-        callbacks.onViewportGeometryChanged(window)
+        flushViewportDidScroll()
         callbacks.onViewportSettled(window)
     }
 
@@ -124,19 +166,53 @@ extension CanvasRootView {
         NSCursor.pop()
         didPushSpacePanCursor = false
     }
+}
 
-    static func spacePanClipOrigin(
-        startClipOrigin: CGPoint,
-        startWindowPoint: CGPoint,
-        currentWindowPoint: CGPoint,
-        magnification: CGFloat
-    ) -> CGPoint {
-        let scale = max(magnification, 0.0001)
-        let dx = (currentWindowPoint.x - startWindowPoint.x) / scale
-        let dy = (currentWindowPoint.y - startWindowPoint.y) / scale
-        return CGPoint(
-            x: startClipOrigin.x - dx,
-            y: startClipOrigin.y + dy
-        )
+func canvasSpacePanClipOrigin(
+    startClipOrigin: CGPoint,
+    startWindowPoint: CGPoint,
+    currentWindowPoint: CGPoint,
+    magnification: CGFloat
+) -> CGPoint {
+    let scale = max(magnification, 0.0001)
+    let dx = (currentWindowPoint.x - startWindowPoint.x) / scale
+    let dy = (currentWindowPoint.y - startWindowPoint.y) / scale
+    return CGPoint(
+        x: startClipOrigin.x - dx,
+        y: startClipOrigin.y + dy
+    )
+}
+
+func canvasSpacePanShouldConsumeSpaceKey(
+    isPointerInsideCanvas: Bool,
+    canInterceptKeyboardTarget: Bool,
+    isPanning: Bool
+) -> Bool {
+    isPanning || (isPointerInsideCanvas && canInterceptKeyboardTarget)
+}
+
+func canvasSpacePanShouldConsumeSpaceKeyRepeat(
+    didConsumeSpaceKey: Bool,
+    isPanning: Bool
+) -> Bool {
+    didConsumeSpaceKey || isPanning
+}
+
+func canvasSpacePanCanBegin(
+    didConsumeSpaceKey: Bool,
+    isPhysicalSpaceKeyPressed: Bool,
+    isPointerInsideCanvas: Bool
+) -> Bool {
+    didConsumeSpaceKey && isPhysicalSpaceKeyPressed && isPointerInsideCanvas
+}
+
+func canvasSpacePanShouldHandleEvents(isWorkspaceVisible: Bool) -> Bool {
+    isWorkspaceVisible
+}
+
+private func canvasSpacePanIsTextInputOrControlResponder(_ responder: NSResponder) -> Bool {
+    if responder is NSText || responder is any NSTextInputClient {
+        return true
     }
+    return responder is NSControl
 }

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
@@ -33,6 +33,8 @@ public final class CanvasRootView: NSView {
     /// Canvas coordinates of the document view's (0,0).
     var documentOriginInCanvas: CGPoint = .zero
     var dragSession: DragSession?
+    var spacePanSession: SpacePanSession?
+    var isSpacePanKeyDown = false, didConsumeSpacePanKeyDown = false, didPushSpacePanCursor = false
     var overviewRestore: (magnification: CGFloat, origin: CGPoint)?
     private var clipBoundsObserver: (any NSObjectProtocol)?
     private var scrollSettleObservers: [any NSObjectProtocol] = []
@@ -151,6 +153,7 @@ public final class CanvasRootView: NSView {
     public override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         if window == nil {
+            cancelSpacePan()
             removeCommandScrollMonitor()
         } else {
             installCommandScrollMonitor()
@@ -182,6 +185,7 @@ public final class CanvasRootView: NSView {
         commandScrollHintTask = nil
         zoomSettleTask?.cancel()
         zoomSettleTask = nil
+        cancelSpacePan()
         commandScrollHintHost?.removeFromSuperview()
         commandScrollHintHost = nil
         removeCommandScrollMonitor()

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
@@ -29,7 +29,7 @@ public final class CanvasRootView: NSView {
     /// The latest descriptors, by panel id, for mount/chrome lookups.
     private var descriptorsByPanelId: [UUID: CanvasPaneDescriptor] = [:]
     private var renderingByPane: [CanvasPaneID: Bool] = [:]
-    private var isWorkspaceVisible = true
+    var isWorkspaceVisible = true
     /// Canvas coordinates of the document view's (0,0).
     var documentOriginInCanvas: CGPoint = .zero
     var dragSession: DragSession?
@@ -202,6 +202,7 @@ public final class CanvasRootView: NSView {
     public func sync(descriptors: [CanvasPaneDescriptor], focusedPanelId: UUID?, isWorkspaceVisible: Bool) {
         let becameVisible = isWorkspaceVisible && !self.isWorkspaceVisible
         self.isWorkspaceVisible = isWorkspaceVisible
+        if !isWorkspaceVisible { cancelSpacePan() }
         let added = model.syncPanes(
             panelIds: descriptors.map(\.id),
             focusedPanelId: focusedPanelId
@@ -246,7 +247,6 @@ public final class CanvasRootView: NSView {
             revealPane(revealTarget, animated: true)
         }
     }
-
 
     /// Creates/removes pane views to match the model's pane set and brings
     /// each pane's mount and chrome up to date from the cached descriptors.
@@ -394,7 +394,8 @@ public final class CanvasRootView: NSView {
         }
     }
 
-    private func flushViewportDidScroll() {
+    func flushViewportDidScroll() {
+        guard viewportScrollUpdateScheduled else { return }
         viewportScrollUpdateScheduled = false
         updateLifecycle()
         saveViewportToModel()

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
@@ -46,6 +46,7 @@ public final class CanvasRootView: NSView {
     static var didShowCommandScrollHintThisSession = false
     var commandScrollHintTask: Task<Void, Never>?
     var commandScrollHintHost: NSHostingView<CanvasCommandScrollHint>?
+    private var viewportScrollUpdateScheduled = false
     /// A saved viewport waiting to be applied once the scroll view is laid
     /// out (contentSize settled). Cleared when successfully applied.
     private var pendingViewportRestore: (canvasCenter: CGPoint, magnification: CGFloat)?
@@ -377,6 +378,20 @@ public final class CanvasRootView: NSView {
     // MARK: Lifecycle
 
     private func viewportDidScroll() {
+        guard !viewportScrollUpdateScheduled else { return }
+        viewportScrollUpdateScheduled = true
+        // Stay in the active mode so live trackpad scrolls flush during event
+        // tracking without queueing duplicate work for other modes.
+        let mode = RunLoop.current.currentMode ?? .default
+        RunLoop.main.perform(inModes: [mode]) { [weak self] in
+            MainActor.assumeIsolated {
+                self?.flushViewportDidScroll()
+            }
+        }
+    }
+
+    private func flushViewportDidScroll() {
+        viewportScrollUpdateScheduled = false
         updateLifecycle()
         saveViewportToModel()
         callbacks.onViewportGeometryChanged(window)

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasSpacePanTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasSpacePanTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite("Canvas space pan")
 struct CanvasSpacePanTests {
     @Test func dragMovesViewportAsIfGrabbingCanvas() {
-        let origin = CanvasRootView.spacePanClipOrigin(
+        let origin = canvasSpacePanClipOrigin(
             startClipOrigin: CGPoint(x: 100, y: 200),
             startWindowPoint: CGPoint(x: 40, y: 50),
             currentWindowPoint: CGPoint(x: 70, y: 90),
@@ -18,7 +18,7 @@ struct CanvasSpacePanTests {
     }
 
     @Test func dragDeltaScalesWithMagnification() {
-        let origin = CanvasRootView.spacePanClipOrigin(
+        let origin = canvasSpacePanClipOrigin(
             startClipOrigin: CGPoint(x: 100, y: 200),
             startWindowPoint: CGPoint(x: 40, y: 50),
             currentWindowPoint: CGPoint(x: 70, y: 90),
@@ -27,5 +27,82 @@ struct CanvasSpacePanTests {
 
         #expect(origin.x == 40)
         #expect(origin.y == 280)
+    }
+
+    @Test func spaceKeyDoesNotArmPanWhilePaneOwnsKeyboardFocus() {
+        #expect(!canvasSpacePanShouldConsumeSpaceKey(
+            isPointerInsideCanvas: true,
+            canInterceptKeyboardTarget: false,
+            isPanning: false
+        ))
+    }
+
+    @Test func spaceKeyCanArmPanWhenCanvasOwnsKeyboardFocus() {
+        #expect(canvasSpacePanShouldConsumeSpaceKey(
+            isPointerInsideCanvas: true,
+            canInterceptKeyboardTarget: true,
+            isPanning: false
+        ))
+    }
+
+    @Test func activePanConsumesSpaceKeyUntilGestureEnds() {
+        #expect(canvasSpacePanShouldConsumeSpaceKey(
+            isPointerInsideCanvas: false,
+            canInterceptKeyboardTarget: false,
+            isPanning: true
+        ))
+    }
+
+    @Test func spaceKeyRepeatPreservesInitialConsumptionDecision() {
+        #expect(canvasSpacePanShouldConsumeSpaceKeyRepeat(
+            didConsumeSpaceKey: true,
+            isPanning: false
+        ))
+        #expect(!canvasSpacePanShouldConsumeSpaceKeyRepeat(
+            didConsumeSpaceKey: false,
+            isPanning: false
+        ))
+    }
+
+    @Test func spaceKeyDoesNotArmPanWhileTextOrControlOwnsKeyboardFocus() {
+        #expect(!canvasSpacePanShouldConsumeSpaceKey(
+            isPointerInsideCanvas: true,
+            canInterceptKeyboardTarget: false,
+            isPanning: false
+        ))
+    }
+
+    @Test func spaceKeyDoesNotArmPanWhileForeignViewOwnsKeyboardFocus() {
+        #expect(!canvasSpacePanShouldConsumeSpaceKey(
+            isPointerInsideCanvas: true,
+            canInterceptKeyboardTarget: false,
+            isPanning: false
+        ))
+    }
+
+    @Test func panBeginsOnlyWhenConsumedSpaceIsStillPhysicallyHeld() {
+        #expect(canvasSpacePanCanBegin(
+            didConsumeSpaceKey: true,
+            isPhysicalSpaceKeyPressed: true,
+            isPointerInsideCanvas: true
+        ))
+        #expect(!canvasSpacePanCanBegin(
+            didConsumeSpaceKey: true,
+            isPhysicalSpaceKeyPressed: false,
+            isPointerInsideCanvas: true
+        ))
+    }
+
+    @Test func panDoesNotBeginFromSpaceDeliveredToPane() {
+        #expect(!canvasSpacePanCanBegin(
+            didConsumeSpaceKey: false,
+            isPhysicalSpaceKeyPressed: true,
+            isPointerInsideCanvas: true
+        ))
+    }
+
+    @Test func hiddenCanvasDoesNotHandleSpacePanEvents() {
+        #expect(canvasSpacePanShouldHandleEvents(isWorkspaceVisible: true))
+        #expect(!canvasSpacePanShouldHandleEvents(isWorkspaceVisible: false))
     }
 }

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasSpacePanTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasSpacePanTests.swift
@@ -1,0 +1,31 @@
+import CoreGraphics
+import Testing
+@testable import CmuxCanvasUI
+
+@MainActor
+@Suite("Canvas space pan")
+struct CanvasSpacePanTests {
+    @Test func dragMovesViewportAsIfGrabbingCanvas() {
+        let origin = CanvasRootView.spacePanClipOrigin(
+            startClipOrigin: CGPoint(x: 100, y: 200),
+            startWindowPoint: CGPoint(x: 40, y: 50),
+            currentWindowPoint: CGPoint(x: 70, y: 90),
+            magnification: 1
+        )
+
+        #expect(origin.x == 70)
+        #expect(origin.y == 240)
+    }
+
+    @Test func dragDeltaScalesWithMagnification() {
+        let origin = CanvasRootView.spacePanClipOrigin(
+            startClipOrigin: CGPoint(x: 100, y: 200),
+            startWindowPoint: CGPoint(x: 40, y: 50),
+            currentWindowPoint: CGPoint(x: 70, y: 90),
+            magnification: 0.5
+        )
+
+        #expect(origin.x == 40)
+        #expect(origin.y == 280)
+    }
+}

--- a/Packages/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemotePlatformProbeScriptTests.swift
+++ b/Packages/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemotePlatformProbeScriptTests.swift
@@ -22,153 +22,157 @@ struct RemotePlatformProbeScriptTests {
 
     @Test("Probe works when tr lacks character classes (OpenWrt BusyBox)")
     func probeScriptWorksWhenTrLacksCharacterClasses() throws {
-        let fileManager = FileManager.default
-        let root = fileManager.temporaryDirectory.appendingPathComponent(
-            "cmux-remote-platform-probe-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        let home = root.appendingPathComponent("home", isDirectory: true)
-        let bin = root.appendingPathComponent("bin", isDirectory: true)
-        let daemonURL = home
-            .appendingPathComponent(".cmux/bin/cmuxd-remote/test-version/linux-amd64", isDirectory: true)
-            .appendingPathComponent("cmuxd-remote", isDirectory: false)
-        try fileManager.createDirectory(at: daemonURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try fileManager.createDirectory(at: bin, withIntermediateDirectories: true)
-        defer { try? fileManager.removeItem(at: root) }
+        try withRemoteSessionProcessTestLock {
+            let fileManager = FileManager.default
+            let root = fileManager.temporaryDirectory.appendingPathComponent(
+                "cmux-remote-platform-probe-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let home = root.appendingPathComponent("home", isDirectory: true)
+            let bin = root.appendingPathComponent("bin", isDirectory: true)
+            let daemonURL = home
+                .appendingPathComponent(".cmux/bin/cmuxd-remote/test-version/linux-amd64", isDirectory: true)
+                .appendingPathComponent("cmuxd-remote", isDirectory: false)
+            try fileManager.createDirectory(at: daemonURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try fileManager.createDirectory(at: bin, withIntermediateDirectories: true)
+            defer { try? fileManager.removeItem(at: root) }
 
-        try Self.writeExecutableShellFile(
-            at: daemonURL,
-            body: """
-            #!/bin/sh
-            exit 0
-            """
-        )
-        try Self.writeExecutableShellFile(
-            at: bin.appendingPathComponent("uname"),
-            body: """
-            #!/bin/sh
-            case "${1:-}" in
-              -s) printf '%s\\n' Linux ;;
-              -m) printf '%s\\n' x86_64 ;;
-              *) exit 1 ;;
-            esac
-            """
-        )
-        try Self.writeExecutableShellFile(
-            at: bin.appendingPathComponent("tr"),
-            body: """
-            #!/bin/sh
-            # OpenWrt BusyBox without FEATURE_TR_CLASSES maps these literal
-            # argument bytes positionally, so Linux becomes Linlx.
-            if [ "$#" -eq 2 ] && [ "$1" = '[:upper:]' ] && [ "$2" = '[:lower:]' ]; then
-              awk -v from="$1" -v to="$2" '
-                BEGIN {
-                  for (i = 1; i <= length(from); i++) {
-                    map[substr(from, i, 1)] = substr(to, i, 1)
-                  }
-                }
-                {
-                  if (NR > 1) {
-                    printf "\\n"
-                  }
-                  output = ""
-                  for (i = 1; i <= length($0); i++) {
-                    ch = substr($0, i, 1)
-                    output = output ((ch in map) ? map[ch] : ch)
-                  }
-                  printf "%s", output
-                }
-              '
-              exit 0
-            fi
-            exec /usr/bin/tr "$@"
-            """
-        )
+            try Self.writeExecutableShellFile(
+                at: daemonURL,
+                body: """
+                #!/bin/sh
+                exit 0
+                """
+            )
+            try Self.writeExecutableShellFile(
+                at: bin.appendingPathComponent("uname"),
+                body: """
+                #!/bin/sh
+                case "${1:-}" in
+                  -s) printf '%s\\n' Linux ;;
+                  -m) printf '%s\\n' x86_64 ;;
+                  *) exit 1 ;;
+                esac
+                """
+            )
+            try Self.writeExecutableShellFile(
+                at: bin.appendingPathComponent("tr"),
+                body: """
+                #!/bin/sh
+                # OpenWrt BusyBox without FEATURE_TR_CLASSES maps these literal
+                # argument bytes positionally, so Linux becomes Linlx.
+                if [ "$#" -eq 2 ] && [ "$1" = '[:upper:]' ] && [ "$2" = '[:lower:]' ]; then
+                  awk -v from="$1" -v to="$2" '
+                    BEGIN {
+                      for (i = 1; i <= length(from); i++) {
+                        map[substr(from, i, 1)] = substr(to, i, 1)
+                      }
+                    }
+                    {
+                      if (NR > 1) {
+                        printf "\\n"
+                      }
+                      output = ""
+                      for (i = 1; i <= length($0); i++) {
+                        ch = substr($0, i, 1)
+                        output = output ((ch in map) ? map[ch] : ch)
+                      }
+                      printf "%s", output
+                    }
+                  '
+                  exit 0
+                fi
+                exec /usr/bin/tr "$@"
+                """
+            )
 
-        let result = try Self.runProcess(
-            executablePath: "/usr/bin/env",
-            arguments: [
-                "HOME=\(home.path)",
-                "PATH=\(bin.path):/usr/bin:/bin",
-                "/bin/sh",
-                "-c",
-                RemoteSessionCoordinator.remotePlatformProbeScript(version: "test-version"),
-            ]
-        )
+            let result = try Self.runProcess(
+                executablePath: "/usr/bin/env",
+                arguments: [
+                    "HOME=\(home.path)",
+                    "PATH=\(bin.path):/usr/bin:/bin",
+                    "/bin/sh",
+                    "-c",
+                    RemoteSessionCoordinator.remotePlatformProbeScript(version: "test-version"),
+                ]
+            )
 
-        let outputComment = Comment(rawValue: result.stdout + result.stderr)
-        let stdoutComment = Comment(rawValue: result.stdout)
-        #expect(result.status == 0, outputComment)
-        #expect(
-            result.stdout.contains("\(RemoteSessionCoordinator.remotePlatformProbeOSMarker)Linux"),
-            stdoutComment
-        )
-        #expect(
-            result.stdout.contains("\(RemoteSessionCoordinator.remotePlatformProbeArchMarker)x86_64"),
-            stdoutComment
-        )
-        #expect(
-            result.stdout.contains("\(RemoteSessionCoordinator.remotePlatformProbeExistsMarker)yes"),
-            stdoutComment
-        )
+            let outputComment = Comment(rawValue: result.stdout + result.stderr)
+            let stdoutComment = Comment(rawValue: result.stdout)
+            #expect(result.status == 0, outputComment)
+            #expect(
+                result.stdout.contains("\(RemoteSessionCoordinator.remotePlatformProbeOSMarker)Linux"),
+                stdoutComment
+            )
+            #expect(
+                result.stdout.contains("\(RemoteSessionCoordinator.remotePlatformProbeArchMarker)x86_64"),
+                stdoutComment
+            )
+            #expect(
+                result.stdout.contains("\(RemoteSessionCoordinator.remotePlatformProbeExistsMarker)yes"),
+                stdoutComment
+            )
+        }
     }
 
     @Test("Probe sanitizes the version before shell interpolation")
     func probeScriptSanitizesVersionBeforeShellInterpolation() throws {
-        let fileManager = FileManager.default
-        let root = fileManager.temporaryDirectory.appendingPathComponent(
-            "cmux-remote-platform-probe-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        let home = root.appendingPathComponent("home", isDirectory: true)
-        let bin = root.appendingPathComponent("bin", isDirectory: true)
-        let daemonURL = home
-            .appendingPathComponent(".cmux/bin/cmuxd-remote/dev/linux-amd64", isDirectory: true)
-            .appendingPathComponent("cmuxd-remote", isDirectory: false)
-        try fileManager.createDirectory(at: daemonURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try fileManager.createDirectory(at: bin, withIntermediateDirectories: true)
-        defer { try? fileManager.removeItem(at: root) }
+        try withRemoteSessionProcessTestLock {
+            let fileManager = FileManager.default
+            let root = fileManager.temporaryDirectory.appendingPathComponent(
+                "cmux-remote-platform-probe-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let home = root.appendingPathComponent("home", isDirectory: true)
+            let bin = root.appendingPathComponent("bin", isDirectory: true)
+            let daemonURL = home
+                .appendingPathComponent(".cmux/bin/cmuxd-remote/dev/linux-amd64", isDirectory: true)
+                .appendingPathComponent("cmuxd-remote", isDirectory: false)
+            try fileManager.createDirectory(at: daemonURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try fileManager.createDirectory(at: bin, withIntermediateDirectories: true)
+            defer { try? fileManager.removeItem(at: root) }
 
-        try Self.writeExecutableShellFile(
-            at: daemonURL,
-            body: """
-            #!/bin/sh
-            exit 0
-            """
-        )
-        try Self.writeExecutableShellFile(
-            at: bin.appendingPathComponent("uname"),
-            body: """
-            #!/bin/sh
-            case "${1:-}" in
-              -s) printf '%s\\n' Linux ;;
-              -m) printf '%s\\n' x86_64 ;;
-              *) exit 1 ;;
-            esac
-            """
-        )
+            try Self.writeExecutableShellFile(
+                at: daemonURL,
+                body: """
+                #!/bin/sh
+                exit 0
+                """
+            )
+            try Self.writeExecutableShellFile(
+                at: bin.appendingPathComponent("uname"),
+                body: """
+                #!/bin/sh
+                case "${1:-}" in
+                  -s) printf '%s\\n' Linux ;;
+                  -m) printf '%s\\n' x86_64 ;;
+                  *) exit 1 ;;
+                esac
+                """
+            )
 
-        let result = try Self.runProcess(
-            executablePath: "/usr/bin/env",
-            arguments: [
-                "HOME=\(home.path)",
-                "PATH=\(bin.path):/usr/bin:/bin",
-                "/bin/sh",
-                "-c",
-                RemoteSessionCoordinator.remotePlatformProbeScript(
-                    version: #""; printf "__CMUX_INJECTED__\n"; #"#
-                ),
-            ]
-        )
+            let result = try Self.runProcess(
+                executablePath: "/usr/bin/env",
+                arguments: [
+                    "HOME=\(home.path)",
+                    "PATH=\(bin.path):/usr/bin:/bin",
+                    "/bin/sh",
+                    "-c",
+                    RemoteSessionCoordinator.remotePlatformProbeScript(
+                        version: #""; printf "__CMUX_INJECTED__\n"; #"#
+                    ),
+                ]
+            )
 
-        let outputComment = Comment(rawValue: result.stdout + result.stderr)
-        let stdoutComment = Comment(rawValue: result.stdout)
-        #expect(result.status == 0, outputComment)
-        #expect(!result.stdout.contains("__CMUX_INJECTED__"), stdoutComment)
-        #expect(
-            result.stdout.contains("\(RemoteSessionCoordinator.remotePlatformProbeExistsMarker)yes"),
-            stdoutComment
-        )
+            let outputComment = Comment(rawValue: result.stdout + result.stderr)
+            let stdoutComment = Comment(rawValue: result.stdout)
+            #expect(result.status == 0, outputComment)
+            #expect(!result.stdout.contains("__CMUX_INJECTED__"), stdoutComment)
+            #expect(
+                result.stdout.contains("\(RemoteSessionCoordinator.remotePlatformProbeExistsMarker)yes"),
+                stdoutComment
+            )
+        }
     }
 
     @Test("User-facing stdout omits internal probe markers")

--- a/Packages/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionProcessRunnerTests.swift
+++ b/Packages/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionProcessRunnerTests.swift
@@ -2,6 +2,15 @@ import Foundation
 import Testing
 @testable import CmuxRemoteSession
 
+let remoteSessionProcessTestLock = NSLock()
+
+@discardableResult
+func withRemoteSessionProcessTestLock<T>(_ body: () throws -> T) rethrows -> T {
+    remoteSessionProcessTestLock.lock()
+    defer { remoteSessionProcessTestLock.unlock() }
+    return try body()
+}
+
 // The blocking process runner behind the coordinator's ssh/scp execs.
 // The capture-survives-teardown case is retargeted from the app's
 // testARunProcessCaptureSurvivesPipeReadHandleTeardown (assertions
@@ -20,93 +29,103 @@ import Testing
 struct RemoteSessionProcessRunnerTests {
     @Test("Capture survives the pipe read handles being torn down mid-run")
     func captureSurvivesPipeReadHandleTeardown() throws {
-        let didCloseReadHandles = DispatchSemaphore(value: 0)
-        let runner = RemoteSessionProcessRunner(readHandlesDidInstall: { stdoutHandle, stderrHandle in
-            try? stdoutHandle.close()
-            try? stderrHandle.close()
-            didCloseReadHandles.signal()
-        })
+        try withRemoteSessionProcessTestLock {
+            let didCloseReadHandles = DispatchSemaphore(value: 0)
+            let runner = RemoteSessionProcessRunner(readHandlesDidInstall: { stdoutHandle, stderrHandle in
+                try? stdoutHandle.close()
+                try? stderrHandle.close()
+                didCloseReadHandles.signal()
+            })
 
-        let result = try runner.run(
-            RemoteProcessRequest(executable: "/usr/bin/true", arguments: [], timeout: 2),
-            operation: nil
-        )
+            let result = try runner.run(
+                RemoteProcessRequest(executable: "/usr/bin/true", arguments: [], timeout: 2),
+                operation: nil
+            )
 
-        #expect(didCloseReadHandles.wait(timeout: .now() + 2) == .success)
-        #expect(result.status == 0)
-        #expect(result.stdout == "")
-        #expect(result.stderr == "")
+            #expect(didCloseReadHandles.wait(timeout: .now() + 2) == .success)
+            #expect(result.status == 0)
+            #expect(result.stdout == "")
+            #expect(result.stderr == "")
+        }
     }
 
     @Test("Captures stdout, stderr, and the exit status")
     func capturesOutputAndStatus() throws {
-        let runner = RemoteSessionProcessRunner()
-        let result = try runner.run(
-            RemoteProcessRequest(
-                executable: "/bin/sh",
-                arguments: ["-c", "printf out; printf err 1>&2; exit 3"],
-                timeout: 5
-            ),
-            operation: nil
-        )
-        #expect(result.status == 3)
-        #expect(result.stdout == "out")
-        #expect(result.stderr == "err")
+        try withRemoteSessionProcessTestLock {
+            let runner = RemoteSessionProcessRunner()
+            let result = try runner.run(
+                RemoteProcessRequest(
+                    executable: "/bin/sh",
+                    arguments: ["-c", "printf out; printf err 1>&2; exit 3"],
+                    timeout: 5
+                ),
+                operation: nil
+            )
+            #expect(result.status == 3)
+            #expect(result.stdout == "out")
+            #expect(result.stderr == "err")
+        }
     }
 
     @Test("Delivers stdin and closes the write end")
     func deliversStdin() throws {
-        let runner = RemoteSessionProcessRunner()
-        let result = try runner.run(
-            RemoteProcessRequest(
-                executable: "/bin/cat",
-                arguments: [],
-                stdin: Data("hello-stdin".utf8),
-                timeout: 5
-            ),
-            operation: nil
-        )
-        #expect(result.status == 0)
-        #expect(result.stdout == "hello-stdin")
+        try withRemoteSessionProcessTestLock {
+            let runner = RemoteSessionProcessRunner()
+            let result = try runner.run(
+                RemoteProcessRequest(
+                    executable: "/bin/cat",
+                    arguments: [],
+                    stdin: Data("hello-stdin".utf8),
+                    timeout: 5
+                ),
+                operation: nil
+            )
+            #expect(result.status == 0)
+            #expect(result.stdout == "hello-stdin")
+        }
     }
 
     @Test("Launch failure throws the pinned cmux.remote.process code 1")
     func launchFailurePinsErrorCode() {
-        let runner = RemoteSessionProcessRunner()
-        #expect {
-            try runner.run(
-                RemoteProcessRequest(
-                    executable: "/nonexistent/cmux-no-such-binary",
-                    arguments: [],
-                    timeout: 2
-                ),
-                operation: nil
-            )
-        } throws: { error in
-            let nsError = error as NSError
-            return nsError.domain == "cmux.remote.process"
-                && nsError.code == 1
-                && nsError.localizedDescription.hasPrefix("Failed to launch cmux-no-such-binary:")
+        withRemoteSessionProcessTestLock {
+            let runner = RemoteSessionProcessRunner()
+            #expect {
+                try runner.run(
+                    RemoteProcessRequest(
+                        executable: "/nonexistent/cmux-no-such-binary",
+                        arguments: [],
+                        timeout: 2
+                    ),
+                    operation: nil
+                )
+            } throws: { error in
+                let nsError = error as NSError
+                return nsError.domain == "cmux.remote.process"
+                    && nsError.code == 1
+                    && nsError.localizedDescription.hasPrefix("Failed to launch cmux-no-such-binary:")
+            }
         }
     }
 
     @Test("Timeout terminates the process and throws the pinned code 2")
     func timeoutPinsErrorCode() {
-        let runner = RemoteSessionProcessRunner()
-        #expect {
-            try runner.run(
-                RemoteProcessRequest(
-                    executable: "/bin/sh",
-                    arguments: ["-c", "sleep 30"],
-                    timeout: 1
-                ),
-                operation: nil
-            )
-        } throws: { error in
-            let nsError = error as NSError
-            return nsError.domain == "cmux.remote.process"
-                && nsError.code == 2
-                && nsError.localizedDescription == "sh timed out after 1s"
+        withRemoteSessionProcessTestLock {
+            let runner = RemoteSessionProcessRunner()
+            #expect {
+                try runner.run(
+                    RemoteProcessRequest(
+                        executable: "/bin/sh",
+                        arguments: ["-c", "sleep 30"],
+                        timeout: 1
+                    ),
+                    operation: nil
+                )
+            } throws: { error in
+                let nsError = error as NSError
+                return nsError.domain == "cmux.remote.process"
+                    && nsError.code == 2
+                    && nsError.localizedDescription == "sh timed out after 1s"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Coalesce canvas viewport follow-up work from clip-view bounds notifications so high-rate scroll events do not synchronously run lifecycle, viewport persistence, and host geometry callbacks for every notification.
- Keep the coalesced flush in the active run-loop mode so live trackpad scrolling still updates during event tracking.
- Replace allocation-heavy per-dot `NSBezierPath(ovalIn:)` grid drawing with direct Core Graphics ellipse fills.

## Root cause

Fast diagonal/horizontal/vertical canvas scrolling was paying per-scroll main-thread work in two places: immediate viewport follow-up work on every clip bounds change, and allocation-heavy dot-grid redraws. Sampling the baseline scroll burst showed AppKit/SwiftUI layout work during scroll, `CanvasDocumentView.draw(_:)` with `NSBezierPath` allocation/fill stacks, and incidental terminal hit-test stacks. The fix keeps native AppKit scrolling but coalesces the follow-up work and removes the path allocation from grid drawing.

## Measurement

Benchmark workspace: 3x3 terminal canvas panes, viewport reset to `(-670, -420)`, then a 700-event pixel-wheel burst over the canvas: 260 diagonal, 220 horizontal, 220 vertical.

Before:
- Viewport: `(-670, -420)` -> `(1292, 976)`, delta `(+1962, +1396)`.
- Event burst file: `/tmp/canvas-scroll-before-events.json`, total `1420.36 ms`.
- Sample file: `/tmp/canvas-scroll-before.sample.txt`.
- Sample counters: `CanvasDocumentView.draw` 3, `NSBezierPath` 6, `WindowTerminalHostView.hitTest` 2.

After:
- Viewport: `(-670, -420)` -> `(1292, 976)`, delta `(+1962, +1396)`.
- Event burst file: `/tmp/canvas-scroll-after-command-events.json`, total `1055.03 ms`.
- Sample file: `/tmp/canvas-scroll-after-command.sample.txt`.
- Sample counters: `CanvasDocumentView.draw` 0, `NSBezierPath` 0, `WindowTerminalHostView.hitTest` 0.

The final after run used Command-scroll events so all phases stayed routed to the canvas after the cursor crossed pane content.

## Validation

- `swift test --package-path Packages/CmuxCanvasUI`
- `swift test --package-path Packages/CmuxCanvas`
- `./scripts/reload.sh --tag canvas-scroll --launch`
- `CMUX_TAG=canvas-scroll scripts/cmux-debug-cli.sh window display "LG HDR 4K"`
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-canvas-scroll-unit build`

## Localization

No user-facing strings were added or changed. Audited the changed Swift files for `Text`, `Button`, `Label`, `String(localized:)`, `defaultValue:`, `NSLocalizedString`, and new quoted UI strings; no localization catalog changes were needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784866084&installation_id=133855650&pr_number=6726&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6726&signature=122ffa759b752ed192028b421b5630ece47dddca247b2f195650845105021f7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces viewport updates in the active run-loop mode and switches dot-grid rendering to Core Graphics to keep trackpad scrolling responsive, cutting a 700‑event scroll burst ~26% (≈1420 ms → ≈1055 ms). Adds Figma-style Space+drag panning with a closed-hand cursor; zoom-scaled drag, only arms when Space was consumed by the canvas and is still physically held (never over pane content), cancels when the workspace is hidden, and serializes `CmuxRemoteSession` process tests to avoid flakiness.

<sup>Written for commit c081ff2311ba328970eee6d766168592ce10e83c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

