### PR TITLE
Fix macOS 27 symbol launch crash

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11362,8 +11362,11 @@ struct VerticalTabsSidebar: View {
 
             Button(action: onNewTab) {
                 HStack(spacing: 9) {
-                    Image(systemName: "plus")
-                        .cmuxFont(size: 15, weight: .regular)
+                    CmuxSystemSymbolImage(
+                        systemName: "plus",
+                        pointSize: 15,
+                        weight: .regular
+                    )
                         .frame(width: 22, height: 22)
                     Text(String(localized: "sidebar.browserStack.newTab", defaultValue: "New Tab"))
                         .cmuxFont(size: 13, weight: .regular)
@@ -11399,15 +11402,21 @@ struct VerticalTabsSidebar: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
-                Image(systemName: "folder.fill")
-                    .cmuxFont(size: 14, weight: .regular)
+                CmuxSystemSymbolImage(
+                    systemName: "folder.fill",
+                    pointSize: 14,
+                    weight: .regular
+                )
                     .foregroundColor(.secondary)
                 Text(extensionSidebarTreeSectionTitle(section.treeSection))
                     .cmuxFont(size: 13, weight: .semibold)
                     .foregroundColor(.primary.opacity(0.86))
                     .lineLimit(1)
-                Image(systemName: "chevron.down")
-                    .cmuxFont(size: 11, weight: .medium)
+                CmuxSystemSymbolImage(
+                    systemName: "chevron.down",
+                    pointSize: 11,
+                    weight: .medium
+                )
                     .foregroundColor(.secondary)
                 Spacer(minLength: 0)
             }
@@ -11699,8 +11708,11 @@ struct VerticalTabsSidebar: View {
                 RoundedRectangle(cornerRadius: size * 0.24, style: .continuous).fill(background)
             }
             if let systemImageName = icon?.systemImageName {
-                Image(systemName: systemImageName)
-                    .cmuxFont(size: size * 0.58, weight: .semibold)
+                CmuxSystemSymbolImage(
+                    systemName: systemImageName,
+                    pointSize: size * 0.58,
+                    weight: .semibold
+                )
                     .foregroundColor(foreground)
             } else {
                 Text(icon?.text ?? ".")
@@ -11758,8 +11770,11 @@ struct VerticalTabsSidebar: View {
                         }
                     }
                 } label: {
-                    Image(systemName: isCollapsed ? "folder" : "folder.fill")
-                        .cmuxFont(size: 13, weight: .regular)
+                    CmuxSystemSymbolImage(
+                        systemName: isCollapsed ? "folder" : "folder.fill",
+                        pointSize: 13,
+                        weight: .regular
+                    )
                         .offset(y: -0.5)
                 }
                 .buttonStyle(.plain)
@@ -11774,11 +11789,17 @@ struct VerticalTabsSidebar: View {
                 Spacer(minLength: 0)
 
                 if canCreateWorktree {
+                    let worktreeButtonSymbol = extensionSidebarWorktreeCreationInFlightSectionIds.contains(section.id)
+                        ? "clock"
+                        : "plus"
                     Button {
                         createExtensionWorktreeWorkspace(for: section.treeSection)
                     } label: {
-                        Image(systemName: extensionSidebarWorktreeCreationInFlightSectionIds.contains(section.id) ? "clock" : "plus")
-                            .cmuxFont(size: 11, weight: .regular)
+                        CmuxSystemSymbolImage(
+                            systemName: worktreeButtonSymbol,
+                            pointSize: 11,
+                            weight: .regular
+                        )
                             .frame(width: 18, height: 18)
                     }
                     .buttonStyle(.plain)
@@ -12435,9 +12456,11 @@ private struct SidebarFooterButtons: View {
                         title: String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
                     )
                 } label: {
-                    Image(systemName: "puzzlepiece.extension")
-                        .symbolRenderingMode(.monochrome)
-                        .cmuxFont(size: 12, weight: .medium)
+                    CmuxSystemSymbolImage(
+                        systemName: "puzzlepiece.extension",
+                        pointSize: 12,
+                        weight: .medium
+                    )
                         .foregroundStyle(Color(nsColor: .secondaryLabelColor))
                         .frame(width: 22, height: 22, alignment: .center)
                 }
@@ -12493,9 +12516,11 @@ private struct SidebarHelpMenuButton: View {
         Button {
             isPopoverPresented.toggle()
         } label: {
-            Image(systemName: "questionmark.circle")
-                .symbolRenderingMode(.monochrome)
-                .cmuxSymbolRasterSize(iconSize, weight: .medium)
+            CmuxSystemSymbolImage(
+                systemName: "questionmark.circle",
+                pointSize: iconSize,
+                weight: .medium
+            )
                 .foregroundStyle(Color(nsColor: .secondaryLabelColor))
                 .frame(width: buttonSize, height: buttonSize, alignment: .center)
         }
@@ -12637,8 +12662,7 @@ private struct SidebarHelpMenuButton: View {
     }
 
     private func helpOptionTrailingIcon(systemName: String, size: CGFloat = 13) -> some View {
-        Image(systemName: systemName)
-            .cmuxSymbolRasterSize(size)
+        CmuxSystemSymbolImage(systemName: systemName, pointSize: size)
             .foregroundStyle(Color(nsColor: .secondaryLabelColor))
     }
 
@@ -13417,8 +13441,11 @@ struct TabItemView: View, Equatable {
                 }
 
                 if workspaceSnapshot.isPinned {
-                    Image(systemName: "pin.fill")
-                        .font(magnifiedFont(scaledFontSize(9), weight: .semibold))
+                    CmuxSystemSymbolImage(
+                        systemName: "pin.fill",
+                        pointSize: scaledFontSize(9),
+                        weight: .semibold
+                    )
                         .foregroundColor(activeSecondaryColor(0.8))
                         .safeHelp(protectedWorkspaceTooltip)
                 }
@@ -13432,8 +13459,11 @@ struct TabItemView: View, Equatable {
                         localized: "sidebar.mediaActivity.audio.tooltip",
                         defaultValue: "Playing audio"
                     )
-                    Image(systemName: "speaker.wave.2.fill")
-                        .font(.system(size: scaledFontSize(9), weight: .semibold))
+                    CmuxSystemSymbolImage(
+                        systemName: "speaker.wave.2.fill",
+                        pointSize: scaledFontSize(9),
+                        weight: .semibold
+                    )
                         .foregroundColor(activeSecondaryColor(0.8))
                         .safeHelp(audioPlayingTooltip)
                         .accessibilityLabel(audioPlayingTooltip)
@@ -13444,8 +13474,11 @@ struct TabItemView: View, Equatable {
                         localized: "sidebar.mediaActivity.microphone.tooltip",
                         defaultValue: "Microphone in use"
                     )
-                    Image(systemName: "mic.fill")
-                        .font(.system(size: scaledFontSize(9), weight: .semibold))
+                    CmuxSystemSymbolImage(
+                        systemName: "mic.fill",
+                        pointSize: scaledFontSize(9),
+                        weight: .semibold
+                    )
                         .foregroundColor(.orange)
                         .safeHelp(microphoneInUseTooltip)
                         .accessibilityLabel(microphoneInUseTooltip)
@@ -13456,8 +13489,11 @@ struct TabItemView: View, Equatable {
                         localized: "sidebar.mediaActivity.camera.tooltip",
                         defaultValue: "Camera in use"
                     )
-                    Image(systemName: "video.fill")
-                        .font(.system(size: scaledFontSize(9), weight: .semibold))
+                    CmuxSystemSymbolImage(
+                        systemName: "video.fill",
+                        pointSize: scaledFontSize(9),
+                        weight: .semibold
+                    )
                         .foregroundColor(.green)
                         .safeHelp(cameraInUseTooltip)
                         .accessibilityLabel(cameraInUseTooltip)
@@ -13484,8 +13520,11 @@ struct TabItemView: View, Equatable {
                         #endif
                         tabManager.closeWorkspaceWithConfirmation(tab)
                     }) {
-                        Image(systemName: "xmark")
-                            .cmuxSymbolRasterSize(scaledFontSize(9), weight: .medium)
+                        CmuxSystemSymbolImage(
+                            systemName: "xmark",
+                            pointSize: scaledFontSize(9),
+                            weight: .medium
+                        )
                             .foregroundColor(activeSecondaryColor(0.7))
                             .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
                             .contentShape(Rectangle())
@@ -13547,8 +13586,10 @@ struct TabItemView: View, Equatable {
 
             if detailVisibility.showsLog, let latestLog = workspaceSnapshot.latestLog {
                 HStack(spacing: 4) {
-                    Image(systemName: logLevelIcon(latestLog.level))
-                        .font(magnifiedFont(scaledFontSize(8)))
+                    CmuxSystemSymbolImage(
+                        systemName: logLevelIcon(latestLog.level),
+                        pointSize: scaledFontSize(8)
+                    )
                         .foregroundColor(logLevelColor(latestLog.level, isActive: usesInvertedActiveForeground))
                     Text(latestLog.message)
                         .font(magnifiedFont(scaledFontSize(10)))
@@ -13588,8 +13629,10 @@ struct TabItemView: View, Equatable {
                     if !workspaceSnapshot.branchDirectoryLines.isEmpty {
                         HStack(alignment: .top, spacing: 3) {
                             if sidebarShowGitBranchIcon, workspaceSnapshot.branchLinesContainBranch {
-                                Image(systemName: "arrow.triangle.branch")
-                                    .font(magnifiedFont(scaledFontSize(9)))
+                                CmuxSystemSymbolImage(
+                                    systemName: "arrow.triangle.branch",
+                                    pointSize: scaledFontSize(9)
+                                )
                                     .foregroundColor(activeSecondaryColor(0.6))
                             }
                             VStack(alignment: .leading, spacing: 1) {
@@ -13619,8 +13662,10 @@ struct TabItemView: View, Equatable {
                                                     .truncationMode(.tail)
                                             }
                                             if line.branch != nil, !line.directoryCandidates.isEmpty {
-                                                Image(systemName: "circle.fill")
-                                                    .font(magnifiedFont(scaledFontSize(3)))
+                                                CmuxSystemSymbolImage(
+                                                    systemName: "circle.fill",
+                                                    pointSize: scaledFontSize(3)
+                                                )
                                                     .foregroundColor(activeSecondaryColor(0.6))
                                                     .padding(.horizontal, 1)
                                             }
@@ -13642,8 +13687,10 @@ struct TabItemView: View, Equatable {
                            || !workspaceSnapshot.compactDirectoryCandidates.isEmpty) {
                     HStack(alignment: .top, spacing: 3) {
                         if sidebarShowGitBranchIcon, workspaceSnapshot.compactGitBranchSummaryText != nil {
-                            Image(systemName: "arrow.triangle.branch")
-                                .font(magnifiedFont(scaledFontSize(9)))
+                            CmuxSystemSymbolImage(
+                                systemName: "arrow.triangle.branch",
+                                pointSize: scaledFontSize(9)
+                            )
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
                         VStack(alignment: .leading, spacing: 1) {
@@ -13666,8 +13713,10 @@ struct TabItemView: View, Equatable {
                 } else if !workspaceSnapshot.compactBranchDirectoryCandidates.isEmpty {
                     HStack(spacing: 3) {
                         if sidebarShowGitBranchIcon, workspaceSnapshot.compactGitBranchSummaryText != nil {
-                            Image(systemName: "arrow.triangle.branch")
-                                .font(magnifiedFont(scaledFontSize(9)))
+                            CmuxSystemSymbolImage(
+                                systemName: "arrow.triangle.branch",
+                                pointSize: scaledFontSize(9)
+                            )
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
                         SidebarDirectoryText(
@@ -14807,8 +14856,11 @@ struct TabItemView: View, Equatable {
                     .scaleEffect(fontScale)
                     .frame(width: customFrameSize, height: customFrameSize)
             case .closed:
-                Image(systemName: "xmark.circle")
-                    .cmuxFont(size: 7 * fontScale, weight: .regular)
+                CmuxSystemSymbolImage(
+                    systemName: "xmark.circle",
+                    pointSize: 7 * fontScale,
+                    weight: .regular
+                )
                     .foregroundColor(color)
                     .frame(width: closedFrameSize, height: closedFrameSize)
             }
@@ -15200,7 +15252,7 @@ private struct SidebarMetadataEntryRow: View {
             symbolName = iconRaw
         }
         guard !symbolName.isEmpty else { return nil }
-        return AnyView(Image(systemName: symbolName).cmuxSymbolRasterSize(8 * fontScale, weight: .medium))
+        return AnyView(CmuxSystemSymbolImage(systemName: symbolName, pointSize: 8 * fontScale, weight: .medium))
     }
 
     @ViewBuilder

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11365,7 +11365,8 @@ struct VerticalTabsSidebar: View {
                     CmuxSystemSymbolImage(
                         systemName: "plus",
                         pointSize: 15,
-                        weight: .regular
+                        weight: .regular,
+                        appliesGlobalFontMagnification: true
                     )
                         .frame(width: 22, height: 22)
                     Text(String(localized: "sidebar.browserStack.newTab", defaultValue: "New Tab"))
@@ -11405,7 +11406,8 @@ struct VerticalTabsSidebar: View {
                 CmuxSystemSymbolImage(
                     systemName: "folder.fill",
                     pointSize: 14,
-                    weight: .regular
+                    weight: .regular,
+                    appliesGlobalFontMagnification: true
                 )
                     .foregroundColor(.secondary)
                 Text(extensionSidebarTreeSectionTitle(section.treeSection))
@@ -11415,7 +11417,8 @@ struct VerticalTabsSidebar: View {
                 CmuxSystemSymbolImage(
                     systemName: "chevron.down",
                     pointSize: 11,
-                    weight: .medium
+                    weight: .medium,
+                    appliesGlobalFontMagnification: true
                 )
                     .foregroundColor(.secondary)
                 Spacer(minLength: 0)
@@ -11711,7 +11714,8 @@ struct VerticalTabsSidebar: View {
                 CmuxSystemSymbolImage(
                     systemName: systemImageName,
                     pointSize: size * 0.58,
-                    weight: .semibold
+                    weight: .semibold,
+                    appliesGlobalFontMagnification: true
                 )
                     .foregroundColor(foreground)
             } else {
@@ -11773,7 +11777,8 @@ struct VerticalTabsSidebar: View {
                     CmuxSystemSymbolImage(
                         systemName: isCollapsed ? "folder" : "folder.fill",
                         pointSize: 13,
-                        weight: .regular
+                        weight: .regular,
+                        appliesGlobalFontMagnification: true
                     )
                         .offset(y: -0.5)
                 }
@@ -11798,7 +11803,8 @@ struct VerticalTabsSidebar: View {
                         CmuxSystemSymbolImage(
                             systemName: worktreeButtonSymbol,
                             pointSize: 11,
-                            weight: .regular
+                            weight: .regular,
+                            appliesGlobalFontMagnification: true
                         )
                             .frame(width: 18, height: 18)
                     }
@@ -12459,7 +12465,8 @@ private struct SidebarFooterButtons: View {
                     CmuxSystemSymbolImage(
                         systemName: "puzzlepiece.extension",
                         pointSize: 12,
-                        weight: .medium
+                        weight: .medium,
+                        appliesGlobalFontMagnification: true
                     )
                         .foregroundStyle(Color(nsColor: .secondaryLabelColor))
                         .frame(width: 22, height: 22, alignment: .center)
@@ -13444,7 +13451,8 @@ struct TabItemView: View, Equatable {
                     CmuxSystemSymbolImage(
                         systemName: "pin.fill",
                         pointSize: scaledFontSize(9),
-                        weight: .semibold
+                        weight: .semibold,
+                        appliesGlobalFontMagnification: true
                     )
                         .foregroundColor(activeSecondaryColor(0.8))
                         .safeHelp(protectedWorkspaceTooltip)
@@ -13462,7 +13470,8 @@ struct TabItemView: View, Equatable {
                     CmuxSystemSymbolImage(
                         systemName: "speaker.wave.2.fill",
                         pointSize: scaledFontSize(9),
-                        weight: .semibold
+                        weight: .semibold,
+                        appliesGlobalFontMagnification: true
                     )
                         .foregroundColor(activeSecondaryColor(0.8))
                         .safeHelp(audioPlayingTooltip)
@@ -13477,7 +13486,8 @@ struct TabItemView: View, Equatable {
                     CmuxSystemSymbolImage(
                         systemName: "mic.fill",
                         pointSize: scaledFontSize(9),
-                        weight: .semibold
+                        weight: .semibold,
+                        appliesGlobalFontMagnification: true
                     )
                         .foregroundColor(.orange)
                         .safeHelp(microphoneInUseTooltip)
@@ -13492,7 +13502,8 @@ struct TabItemView: View, Equatable {
                     CmuxSystemSymbolImage(
                         systemName: "video.fill",
                         pointSize: scaledFontSize(9),
-                        weight: .semibold
+                        weight: .semibold,
+                        appliesGlobalFontMagnification: true
                     )
                         .foregroundColor(.green)
                         .safeHelp(cameraInUseTooltip)
@@ -13523,7 +13534,8 @@ struct TabItemView: View, Equatable {
                         CmuxSystemSymbolImage(
                             systemName: "xmark",
                             pointSize: scaledFontSize(9),
-                            weight: .medium
+                            weight: .medium,
+                            appliesGlobalFontMagnification: true
                         )
                             .foregroundColor(activeSecondaryColor(0.7))
                             .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
@@ -13588,7 +13600,8 @@ struct TabItemView: View, Equatable {
                 HStack(spacing: 4) {
                     CmuxSystemSymbolImage(
                         systemName: logLevelIcon(latestLog.level),
-                        pointSize: scaledFontSize(8)
+                        pointSize: scaledFontSize(8),
+                        appliesGlobalFontMagnification: true
                     )
                         .foregroundColor(logLevelColor(latestLog.level, isActive: usesInvertedActiveForeground))
                     Text(latestLog.message)
@@ -13631,7 +13644,8 @@ struct TabItemView: View, Equatable {
                             if sidebarShowGitBranchIcon, workspaceSnapshot.branchLinesContainBranch {
                                 CmuxSystemSymbolImage(
                                     systemName: "arrow.triangle.branch",
-                                    pointSize: scaledFontSize(9)
+                                    pointSize: scaledFontSize(9),
+                                    appliesGlobalFontMagnification: true
                                 )
                                     .foregroundColor(activeSecondaryColor(0.6))
                             }
@@ -13664,7 +13678,8 @@ struct TabItemView: View, Equatable {
                                             if line.branch != nil, !line.directoryCandidates.isEmpty {
                                                 CmuxSystemSymbolImage(
                                                     systemName: "circle.fill",
-                                                    pointSize: scaledFontSize(3)
+                                                    pointSize: scaledFontSize(3),
+                                                    appliesGlobalFontMagnification: true
                                                 )
                                                     .foregroundColor(activeSecondaryColor(0.6))
                                                     .padding(.horizontal, 1)
@@ -13689,7 +13704,8 @@ struct TabItemView: View, Equatable {
                         if sidebarShowGitBranchIcon, workspaceSnapshot.compactGitBranchSummaryText != nil {
                             CmuxSystemSymbolImage(
                                 systemName: "arrow.triangle.branch",
-                                pointSize: scaledFontSize(9)
+                                pointSize: scaledFontSize(9),
+                                appliesGlobalFontMagnification: true
                             )
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
@@ -13715,7 +13731,8 @@ struct TabItemView: View, Equatable {
                         if sidebarShowGitBranchIcon, workspaceSnapshot.compactGitBranchSummaryText != nil {
                             CmuxSystemSymbolImage(
                                 systemName: "arrow.triangle.branch",
-                                pointSize: scaledFontSize(9)
+                                pointSize: scaledFontSize(9),
+                                appliesGlobalFontMagnification: true
                             )
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
@@ -14859,7 +14876,8 @@ struct TabItemView: View, Equatable {
                 CmuxSystemSymbolImage(
                     systemName: "xmark.circle",
                     pointSize: 7 * fontScale,
-                    weight: .regular
+                    weight: .regular,
+                    appliesGlobalFontMagnification: true
                 )
                     .foregroundColor(color)
                     .frame(width: closedFrameSize, height: closedFrameSize)
@@ -15252,7 +15270,12 @@ private struct SidebarMetadataEntryRow: View {
             symbolName = iconRaw
         }
         guard !symbolName.isEmpty else { return nil }
-        return AnyView(CmuxSystemSymbolImage(systemName: symbolName, pointSize: 8 * fontScale, weight: .medium))
+        return AnyView(CmuxSystemSymbolImage(
+            systemName: symbolName,
+            pointSize: 8 * fontScale,
+            weight: .medium,
+            appliesGlobalFontMagnification: true
+        ))
     }
 
     @ViewBuilder

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11362,12 +11362,7 @@ struct VerticalTabsSidebar: View {
 
             Button(action: onNewTab) {
                 HStack(spacing: 9) {
-                    CmuxSystemSymbolImage(
-                        systemName: "plus",
-                        pointSize: 15,
-                        weight: .regular,
-                        appliesGlobalFontMagnification: true
-                    )
+                    CmuxSystemSymbolImage(magnified: "plus", pointSize: 15, weight: .regular)
                         .frame(width: 22, height: 22)
                     Text(String(localized: "sidebar.browserStack.newTab", defaultValue: "New Tab"))
                         .cmuxFont(size: 13, weight: .regular)
@@ -11403,23 +11398,13 @@ struct VerticalTabsSidebar: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
-                CmuxSystemSymbolImage(
-                    systemName: "folder.fill",
-                    pointSize: 14,
-                    weight: .regular,
-                    appliesGlobalFontMagnification: true
-                )
+                CmuxSystemSymbolImage(magnified: "folder.fill", pointSize: 14, weight: .regular)
                     .foregroundColor(.secondary)
                 Text(extensionSidebarTreeSectionTitle(section.treeSection))
                     .cmuxFont(size: 13, weight: .semibold)
                     .foregroundColor(.primary.opacity(0.86))
                     .lineLimit(1)
-                CmuxSystemSymbolImage(
-                    systemName: "chevron.down",
-                    pointSize: 11,
-                    weight: .medium,
-                    appliesGlobalFontMagnification: true
-                )
+                CmuxSystemSymbolImage(magnified: "chevron.down", pointSize: 11, weight: .medium)
                     .foregroundColor(.secondary)
                 Spacer(minLength: 0)
             }
@@ -11711,12 +11696,7 @@ struct VerticalTabsSidebar: View {
                 RoundedRectangle(cornerRadius: size * 0.24, style: .continuous).fill(background)
             }
             if let systemImageName = icon?.systemImageName {
-                CmuxSystemSymbolImage(
-                    systemName: systemImageName,
-                    pointSize: size * 0.58,
-                    weight: .semibold,
-                    appliesGlobalFontMagnification: true
-                )
+                CmuxSystemSymbolImage(magnified: systemImageName, pointSize: size * 0.58, weight: .semibold)
                     .foregroundColor(foreground)
             } else {
                 Text(icon?.text ?? ".")
@@ -11774,12 +11754,7 @@ struct VerticalTabsSidebar: View {
                         }
                     }
                 } label: {
-                    CmuxSystemSymbolImage(
-                        systemName: isCollapsed ? "folder" : "folder.fill",
-                        pointSize: 13,
-                        weight: .regular,
-                        appliesGlobalFontMagnification: true
-                    )
+                    CmuxSystemSymbolImage(magnified: isCollapsed ? "folder" : "folder.fill", pointSize: 13, weight: .regular)
                         .offset(y: -0.5)
                 }
                 .buttonStyle(.plain)
@@ -11800,12 +11775,7 @@ struct VerticalTabsSidebar: View {
                     Button {
                         createExtensionWorktreeWorkspace(for: section.treeSection)
                     } label: {
-                        CmuxSystemSymbolImage(
-                            systemName: worktreeButtonSymbol,
-                            pointSize: 11,
-                            weight: .regular,
-                            appliesGlobalFontMagnification: true
-                        )
+                        CmuxSystemSymbolImage(magnified: worktreeButtonSymbol, pointSize: 11, weight: .regular)
                             .frame(width: 18, height: 18)
                     }
                     .buttonStyle(.plain)
@@ -12462,12 +12432,7 @@ private struct SidebarFooterButtons: View {
                         title: String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
                     )
                 } label: {
-                    CmuxSystemSymbolImage(
-                        systemName: "puzzlepiece.extension",
-                        pointSize: 12,
-                        weight: .medium,
-                        appliesGlobalFontMagnification: true
-                    )
+                    CmuxSystemSymbolImage(magnified: "puzzlepiece.extension", pointSize: 12, weight: .medium)
                         .foregroundStyle(Color(nsColor: .secondaryLabelColor))
                         .frame(width: 22, height: 22, alignment: .center)
                 }
@@ -12523,11 +12488,7 @@ private struct SidebarHelpMenuButton: View {
         Button {
             isPopoverPresented.toggle()
         } label: {
-            CmuxSystemSymbolImage(
-                systemName: "questionmark.circle",
-                pointSize: iconSize,
-                weight: .medium
-            )
+            CmuxSystemSymbolImage(systemName: "questionmark.circle", pointSize: iconSize, weight: .medium)
                 .foregroundStyle(Color(nsColor: .secondaryLabelColor))
                 .frame(width: buttonSize, height: buttonSize, alignment: .center)
         }
@@ -13448,12 +13409,7 @@ struct TabItemView: View, Equatable {
                 }
 
                 if workspaceSnapshot.isPinned {
-                    CmuxSystemSymbolImage(
-                        systemName: "pin.fill",
-                        pointSize: scaledFontSize(9),
-                        weight: .semibold,
-                        appliesGlobalFontMagnification: true
-                    )
+                    CmuxSystemSymbolImage(magnified: "pin.fill", pointSize: scaledFontSize(9), weight: .semibold)
                         .foregroundColor(activeSecondaryColor(0.8))
                         .safeHelp(protectedWorkspaceTooltip)
                 }
@@ -13467,12 +13423,7 @@ struct TabItemView: View, Equatable {
                         localized: "sidebar.mediaActivity.audio.tooltip",
                         defaultValue: "Playing audio"
                     )
-                    CmuxSystemSymbolImage(
-                        systemName: "speaker.wave.2.fill",
-                        pointSize: scaledFontSize(9),
-                        weight: .semibold,
-                        appliesGlobalFontMagnification: true
-                    )
+                    CmuxSystemSymbolImage(magnified: "speaker.wave.2.fill", pointSize: scaledFontSize(9), weight: .semibold)
                         .foregroundColor(activeSecondaryColor(0.8))
                         .safeHelp(audioPlayingTooltip)
                         .accessibilityLabel(audioPlayingTooltip)
@@ -13483,12 +13434,7 @@ struct TabItemView: View, Equatable {
                         localized: "sidebar.mediaActivity.microphone.tooltip",
                         defaultValue: "Microphone in use"
                     )
-                    CmuxSystemSymbolImage(
-                        systemName: "mic.fill",
-                        pointSize: scaledFontSize(9),
-                        weight: .semibold,
-                        appliesGlobalFontMagnification: true
-                    )
+                    CmuxSystemSymbolImage(magnified: "mic.fill", pointSize: scaledFontSize(9), weight: .semibold)
                         .foregroundColor(.orange)
                         .safeHelp(microphoneInUseTooltip)
                         .accessibilityLabel(microphoneInUseTooltip)
@@ -13499,12 +13445,7 @@ struct TabItemView: View, Equatable {
                         localized: "sidebar.mediaActivity.camera.tooltip",
                         defaultValue: "Camera in use"
                     )
-                    CmuxSystemSymbolImage(
-                        systemName: "video.fill",
-                        pointSize: scaledFontSize(9),
-                        weight: .semibold,
-                        appliesGlobalFontMagnification: true
-                    )
+                    CmuxSystemSymbolImage(magnified: "video.fill", pointSize: scaledFontSize(9), weight: .semibold)
                         .foregroundColor(.green)
                         .safeHelp(cameraInUseTooltip)
                         .accessibilityLabel(cameraInUseTooltip)
@@ -13531,12 +13472,7 @@ struct TabItemView: View, Equatable {
                         #endif
                         tabManager.closeWorkspaceWithConfirmation(tab)
                     }) {
-                        CmuxSystemSymbolImage(
-                            systemName: "xmark",
-                            pointSize: scaledFontSize(9),
-                            weight: .medium,
-                            appliesGlobalFontMagnification: true
-                        )
+                        CmuxSystemSymbolImage(magnified: "xmark", pointSize: scaledFontSize(9), weight: .medium)
                             .foregroundColor(activeSecondaryColor(0.7))
                             .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
                             .contentShape(Rectangle())
@@ -13598,11 +13534,7 @@ struct TabItemView: View, Equatable {
 
             if detailVisibility.showsLog, let latestLog = workspaceSnapshot.latestLog {
                 HStack(spacing: 4) {
-                    CmuxSystemSymbolImage(
-                        systemName: logLevelIcon(latestLog.level),
-                        pointSize: scaledFontSize(8),
-                        appliesGlobalFontMagnification: true
-                    )
+                    CmuxSystemSymbolImage(magnified: logLevelIcon(latestLog.level), pointSize: scaledFontSize(8))
                         .foregroundColor(logLevelColor(latestLog.level, isActive: usesInvertedActiveForeground))
                     Text(latestLog.message)
                         .font(magnifiedFont(scaledFontSize(10)))
@@ -13642,11 +13574,7 @@ struct TabItemView: View, Equatable {
                     if !workspaceSnapshot.branchDirectoryLines.isEmpty {
                         HStack(alignment: .top, spacing: 3) {
                             if sidebarShowGitBranchIcon, workspaceSnapshot.branchLinesContainBranch {
-                                CmuxSystemSymbolImage(
-                                    systemName: "arrow.triangle.branch",
-                                    pointSize: scaledFontSize(9),
-                                    appliesGlobalFontMagnification: true
-                                )
+                                CmuxSystemSymbolImage(magnified: "arrow.triangle.branch", pointSize: scaledFontSize(9))
                                     .foregroundColor(activeSecondaryColor(0.6))
                             }
                             VStack(alignment: .leading, spacing: 1) {
@@ -13676,11 +13604,7 @@ struct TabItemView: View, Equatable {
                                                     .truncationMode(.tail)
                                             }
                                             if line.branch != nil, !line.directoryCandidates.isEmpty {
-                                                CmuxSystemSymbolImage(
-                                                    systemName: "circle.fill",
-                                                    pointSize: scaledFontSize(3),
-                                                    appliesGlobalFontMagnification: true
-                                                )
+                                                CmuxSystemSymbolImage(magnified: "circle.fill", pointSize: scaledFontSize(3))
                                                     .foregroundColor(activeSecondaryColor(0.6))
                                                     .padding(.horizontal, 1)
                                             }
@@ -13702,11 +13626,7 @@ struct TabItemView: View, Equatable {
                            || !workspaceSnapshot.compactDirectoryCandidates.isEmpty) {
                     HStack(alignment: .top, spacing: 3) {
                         if sidebarShowGitBranchIcon, workspaceSnapshot.compactGitBranchSummaryText != nil {
-                            CmuxSystemSymbolImage(
-                                systemName: "arrow.triangle.branch",
-                                pointSize: scaledFontSize(9),
-                                appliesGlobalFontMagnification: true
-                            )
+                            CmuxSystemSymbolImage(magnified: "arrow.triangle.branch", pointSize: scaledFontSize(9))
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
                         VStack(alignment: .leading, spacing: 1) {
@@ -13729,11 +13649,7 @@ struct TabItemView: View, Equatable {
                 } else if !workspaceSnapshot.compactBranchDirectoryCandidates.isEmpty {
                     HStack(spacing: 3) {
                         if sidebarShowGitBranchIcon, workspaceSnapshot.compactGitBranchSummaryText != nil {
-                            CmuxSystemSymbolImage(
-                                systemName: "arrow.triangle.branch",
-                                pointSize: scaledFontSize(9),
-                                appliesGlobalFontMagnification: true
-                            )
+                            CmuxSystemSymbolImage(magnified: "arrow.triangle.branch", pointSize: scaledFontSize(9))
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
                         SidebarDirectoryText(
@@ -14873,12 +14789,7 @@ struct TabItemView: View, Equatable {
                     .scaleEffect(fontScale)
                     .frame(width: customFrameSize, height: customFrameSize)
             case .closed:
-                CmuxSystemSymbolImage(
-                    systemName: "xmark.circle",
-                    pointSize: 7 * fontScale,
-                    weight: .regular,
-                    appliesGlobalFontMagnification: true
-                )
+                CmuxSystemSymbolImage(magnified: "xmark.circle", pointSize: 7 * fontScale, weight: .regular)
                     .foregroundColor(color)
                     .frame(width: closedFrameSize, height: closedFrameSize)
             }
@@ -15270,12 +15181,7 @@ private struct SidebarMetadataEntryRow: View {
             symbolName = iconRaw
         }
         guard !symbolName.isEmpty else { return nil }
-        return AnyView(CmuxSystemSymbolImage(
-            systemName: symbolName,
-            pointSize: 8 * fontScale,
-            weight: .medium,
-            appliesGlobalFontMagnification: true
-        ))
+        return AnyView(CmuxSystemSymbolImage(magnified: symbolName, pointSize: 8 * fontScale, weight: .medium))
     }
 
     @ViewBuilder

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -329,14 +329,6 @@ private struct OmnibarAddressButtonStyleBody: View {
     }
 }
 
-private extension Image {
-    func cmuxFlatSymbolColorRendering() -> Image {
-        // `symbolColorRenderingMode(.flat)` is not available in the current SDK
-        // used by CI/local builds. Keep this modifier as a compatibility no-op.
-        self
-    }
-}
-
 func resolvedBrowserChromeBackgroundColor(
     for colorScheme: ColorScheme,
     themeBackgroundColor: NSColor,
@@ -1329,8 +1321,11 @@ struct BrowserPanelView: View {
                 #endif
                 panel.goBack()
             }) {
-                Image(systemName: "chevron.left")
-                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconFontSize, weight: .medium)
+                CmuxSystemSymbolImage(
+                    systemName: "chevron.left",
+                    pointSize: chromeMetrics.navigationIconFontSize,
+                    weight: .medium
+                )
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1345,8 +1340,11 @@ struct BrowserPanelView: View {
                 #endif
                 panel.goForward()
             }) {
-                Image(systemName: "chevron.right")
-                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconFontSize, weight: .medium)
+                CmuxSystemSymbolImage(
+                    systemName: "chevron.right",
+                    pointSize: chromeMetrics.navigationIconFontSize,
+                    weight: .medium
+                )
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1356,8 +1354,11 @@ struct BrowserPanelView: View {
             .safeHelp(String(localized: "browser.goForward", defaultValue: "Go Forward"))
 
             Button(action: handleReloadOrStopButtonAction) {
-                Image(systemName: panel.isLoading ? "xmark" : "arrow.clockwise")
-                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconFontSize, weight: .medium)
+                CmuxSystemSymbolImage(
+                    systemName: panel.isLoading ? "xmark" : "arrow.clockwise",
+                    pointSize: chromeMetrics.navigationIconFontSize,
+                    weight: .medium
+                )
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1388,10 +1389,11 @@ struct BrowserPanelView: View {
 
     private var screenshotPageButton: some View {
         Button(action: handleScreenshotPageButtonAction) {
-            Image(systemName: screenshotPageCopied ? "checkmark" : "camera")
-                .symbolRenderingMode(.monochrome)
-                .cmuxFlatSymbolColorRendering()
-                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
+            CmuxSystemSymbolImage(
+                systemName: screenshotPageCopied ? "checkmark" : "camera",
+                pointSize: devToolsButtonIconSize,
+                weight: .medium
+            )
                 .foregroundStyle(screenshotPageButtonColor)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1444,8 +1446,11 @@ struct BrowserPanelView: View {
     private var browserFocusModeButton: some View {
         Button(action: handleBrowserFocusModeButtonAction) {
             HStack(spacing: 5) {
-                Image(systemName: "keyboard")
-                    .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
+                CmuxSystemSymbolImage(
+                    systemName: "keyboard",
+                    pointSize: devToolsButtonIconSize,
+                    weight: .medium
+                )
                     .scaleEffect(panel.isBrowserFocusModeActive ? 1.08 : 1.0)
                     .animation(.spring(response: 0.18, dampingFraction: 0.82), value: panel.isBrowserFocusModeActive)
                 if panel.isBrowserFocusModeActive {
@@ -1490,10 +1495,11 @@ struct BrowserPanelView: View {
             panel.clearReactGrabRoundTrip(reason: "toolbarButton.manualStart")
             Task { await panel.toggleOrInjectReactGrab() }
         }) {
-            Image(systemName: "cursorarrow.click.2")
-                .symbolRenderingMode(.monochrome)
-                .cmuxFlatSymbolColorRendering()
-                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
+            CmuxSystemSymbolImage(
+                systemName: "cursorarrow.click.2",
+                pointSize: devToolsButtonIconSize,
+                weight: .medium
+            )
                 .foregroundStyle(panel.isReactGrabActive ? Color.accentColor : Color.secondary)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1507,10 +1513,11 @@ struct BrowserPanelView: View {
         Button(action: {
             openDevTools()
         }) {
-            Image(systemName: devToolsIconOption.rawValue)
-                .symbolRenderingMode(.monochrome)
-                .cmuxFlatSymbolColorRendering()
-                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
+            CmuxSystemSymbolImage(
+                systemName: devToolsIconOption.rawValue,
+                pointSize: devToolsButtonIconSize,
+                weight: .medium
+            )
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1524,10 +1531,11 @@ struct BrowserPanelView: View {
         Button(action: {
             isBrowserProfileMenuPresented.toggle()
         }) {
-            Image(systemName: "person.crop.circle")
-                .symbolRenderingMode(.monochrome)
-                .cmuxFlatSymbolColorRendering()
-                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
+            CmuxSystemSymbolImage(
+                systemName: "person.crop.circle",
+                pointSize: devToolsButtonIconSize,
+                weight: .medium
+            )
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1585,10 +1593,11 @@ struct BrowserPanelView: View {
                 Label(developerToolsButtonHelp, systemImage: devToolsIconOption.rawValue)
             }
         } label: {
-            Image(systemName: "ellipsis")
-                .symbolRenderingMode(.monochrome)
-                .cmuxFlatSymbolColorRendering()
-                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
+            CmuxSystemSymbolImage(
+                systemName: "ellipsis",
+                pointSize: devToolsButtonIconSize,
+                weight: .medium
+            )
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1603,10 +1612,11 @@ struct BrowserPanelView: View {
         Button(action: {
             isBrowserThemeMenuPresented.toggle()
         }) {
-            Image(systemName: browserThemeMode.iconName)
-                .symbolRenderingMode(.monochrome)
-                .cmuxFlatSymbolColorRendering()
-                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
+            CmuxSystemSymbolImage(
+                systemName: browserThemeMode.iconName,
+                pointSize: devToolsButtonIconSize,
+                weight: .medium
+            )
                 .foregroundStyle(browserThemeModeIconColor)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1632,8 +1642,11 @@ struct BrowserPanelView: View {
             isBrowserImportHintPopoverPresented.toggle()
         }) {
             HStack(spacing: 4) {
-                Image(systemName: "square.and.arrow.down.on.square")
-                    .cmuxSymbolRasterSize(10, weight: .medium)
+                CmuxSystemSymbolImage(
+                    systemName: "square.and.arrow.down.on.square",
+                    pointSize: 10,
+                    weight: .medium
+                )
                 Text(String(localized: "browser.import.hint.toolbar", defaultValue: "Import"))
                     .cmuxFont(size: 11, weight: .medium)
                     .lineLimit(1)
@@ -1662,8 +1675,11 @@ struct BrowserPanelView: View {
                         applyBrowserProfileSelection(profile.id)
                     } label: {
                         HStack(spacing: 8) {
-                            Image(systemName: profile.id == panel.profileID ? "checkmark" : "circle")
-                                .cmuxSymbolRasterSize(10, weight: .semibold)
+                            CmuxSystemSymbolImage(
+                                systemName: profile.id == panel.profileID ? "checkmark" : "circle",
+                                pointSize: 10,
+                                weight: .semibold
+                            )
                                 .opacity(profile.id == panel.profileID ? 1.0 : 0.0)
                                 .frame(width: 12, alignment: .center)
                             Text(profile.displayName)
@@ -1725,8 +1741,11 @@ struct BrowserPanelView: View {
                     isBrowserThemeMenuPresented = false
                 } label: {
                     HStack(spacing: 8) {
-                        Image(systemName: mode == browserThemeMode ? "checkmark" : "circle")
-                            .cmuxSymbolRasterSize(10, weight: .semibold)
+                        CmuxSystemSymbolImage(
+                            systemName: mode == browserThemeMode ? "checkmark" : "circle",
+                            pointSize: 10,
+                            weight: .semibold
+                        )
                             .opacity(mode == browserThemeMode ? 1.0 : 0.0)
                             .frame(width: 12, alignment: .center)
                         Text(mode.displayName)
@@ -1758,8 +1777,10 @@ struct BrowserPanelView: View {
 
         return HStack(spacing: 4) {
             if showSecureBadge {
-                Image(systemName: "lock.fill")
-                    .cmuxSymbolRasterSize(chromeMetrics.secureBadgeFontSize)
+                CmuxSystemSymbolImage(
+                    systemName: "lock.fill",
+                    pointSize: chromeMetrics.secureBadgeFontSize
+                )
                     .foregroundColor(.secondary)
             }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1321,11 +1321,7 @@ struct BrowserPanelView: View {
                 #endif
                 panel.goBack()
             }) {
-                CmuxSystemSymbolImage(
-                    systemName: "chevron.left",
-                    pointSize: chromeMetrics.navigationIconFontSize,
-                    weight: .medium
-                )
+                CmuxSystemSymbolImage(systemName: "chevron.left", pointSize: chromeMetrics.navigationIconFontSize, weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1340,11 +1336,7 @@ struct BrowserPanelView: View {
                 #endif
                 panel.goForward()
             }) {
-                CmuxSystemSymbolImage(
-                    systemName: "chevron.right",
-                    pointSize: chromeMetrics.navigationIconFontSize,
-                    weight: .medium
-                )
+                CmuxSystemSymbolImage(systemName: "chevron.right", pointSize: chromeMetrics.navigationIconFontSize, weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1354,11 +1346,7 @@ struct BrowserPanelView: View {
             .safeHelp(String(localized: "browser.goForward", defaultValue: "Go Forward"))
 
             Button(action: handleReloadOrStopButtonAction) {
-                CmuxSystemSymbolImage(
-                    systemName: panel.isLoading ? "xmark" : "arrow.clockwise",
-                    pointSize: chromeMetrics.navigationIconFontSize,
-                    weight: .medium
-                )
+                CmuxSystemSymbolImage(systemName: panel.isLoading ? "xmark" : "arrow.clockwise", pointSize: chromeMetrics.navigationIconFontSize, weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1389,11 +1377,7 @@ struct BrowserPanelView: View {
 
     private var screenshotPageButton: some View {
         Button(action: handleScreenshotPageButtonAction) {
-            CmuxSystemSymbolImage(
-                systemName: screenshotPageCopied ? "checkmark" : "camera",
-                pointSize: devToolsButtonIconSize,
-                weight: .medium
-            )
+            CmuxSystemSymbolImage(systemName: screenshotPageCopied ? "checkmark" : "camera", pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(screenshotPageButtonColor)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1446,11 +1430,7 @@ struct BrowserPanelView: View {
     private var browserFocusModeButton: some View {
         Button(action: handleBrowserFocusModeButtonAction) {
             HStack(spacing: 5) {
-                CmuxSystemSymbolImage(
-                    systemName: "keyboard",
-                    pointSize: devToolsButtonIconSize,
-                    weight: .medium
-                )
+                CmuxSystemSymbolImage(systemName: "keyboard", pointSize: devToolsButtonIconSize, weight: .medium)
                     .scaleEffect(panel.isBrowserFocusModeActive ? 1.08 : 1.0)
                     .animation(.spring(response: 0.18, dampingFraction: 0.82), value: panel.isBrowserFocusModeActive)
                 if panel.isBrowserFocusModeActive {
@@ -1495,11 +1475,7 @@ struct BrowserPanelView: View {
             panel.clearReactGrabRoundTrip(reason: "toolbarButton.manualStart")
             Task { await panel.toggleOrInjectReactGrab() }
         }) {
-            CmuxSystemSymbolImage(
-                systemName: "cursorarrow.click.2",
-                pointSize: devToolsButtonIconSize,
-                weight: .medium
-            )
+            CmuxSystemSymbolImage(systemName: "cursorarrow.click.2", pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(panel.isReactGrabActive ? Color.accentColor : Color.secondary)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1513,11 +1489,7 @@ struct BrowserPanelView: View {
         Button(action: {
             openDevTools()
         }) {
-            CmuxSystemSymbolImage(
-                systemName: devToolsIconOption.rawValue,
-                pointSize: devToolsButtonIconSize,
-                weight: .medium
-            )
+            CmuxSystemSymbolImage(systemName: devToolsIconOption.rawValue, pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1531,11 +1503,7 @@ struct BrowserPanelView: View {
         Button(action: {
             isBrowserProfileMenuPresented.toggle()
         }) {
-            CmuxSystemSymbolImage(
-                systemName: "person.crop.circle",
-                pointSize: devToolsButtonIconSize,
-                weight: .medium
-            )
+            CmuxSystemSymbolImage(systemName: "person.crop.circle", pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1593,11 +1561,7 @@ struct BrowserPanelView: View {
                 Label(developerToolsButtonHelp, systemImage: devToolsIconOption.rawValue)
             }
         } label: {
-            CmuxSystemSymbolImage(
-                systemName: "ellipsis",
-                pointSize: devToolsButtonIconSize,
-                weight: .medium
-            )
+            CmuxSystemSymbolImage(systemName: "ellipsis", pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1612,11 +1576,7 @@ struct BrowserPanelView: View {
         Button(action: {
             isBrowserThemeMenuPresented.toggle()
         }) {
-            CmuxSystemSymbolImage(
-                systemName: browserThemeMode.iconName,
-                pointSize: devToolsButtonIconSize,
-                weight: .medium
-            )
+            CmuxSystemSymbolImage(systemName: browserThemeMode.iconName, pointSize: devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(browserThemeModeIconColor)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1642,11 +1602,7 @@ struct BrowserPanelView: View {
             isBrowserImportHintPopoverPresented.toggle()
         }) {
             HStack(spacing: 4) {
-                CmuxSystemSymbolImage(
-                    systemName: "square.and.arrow.down.on.square",
-                    pointSize: 10,
-                    weight: .medium
-                )
+                CmuxSystemSymbolImage(systemName: "square.and.arrow.down.on.square", pointSize: 10, weight: .medium)
                 Text(String(localized: "browser.import.hint.toolbar", defaultValue: "Import"))
                     .cmuxFont(size: 11, weight: .medium)
                     .lineLimit(1)
@@ -1675,11 +1631,7 @@ struct BrowserPanelView: View {
                         applyBrowserProfileSelection(profile.id)
                     } label: {
                         HStack(spacing: 8) {
-                            CmuxSystemSymbolImage(
-                                systemName: profile.id == panel.profileID ? "checkmark" : "circle",
-                                pointSize: 10,
-                                weight: .semibold
-                            )
+                            CmuxSystemSymbolImage(systemName: profile.id == panel.profileID ? "checkmark" : "circle", pointSize: 10, weight: .semibold)
                                 .opacity(profile.id == panel.profileID ? 1.0 : 0.0)
                                 .frame(width: 12, alignment: .center)
                             Text(profile.displayName)
@@ -1741,11 +1693,7 @@ struct BrowserPanelView: View {
                     isBrowserThemeMenuPresented = false
                 } label: {
                     HStack(spacing: 8) {
-                        CmuxSystemSymbolImage(
-                            systemName: mode == browserThemeMode ? "checkmark" : "circle",
-                            pointSize: 10,
-                            weight: .semibold
-                        )
+                        CmuxSystemSymbolImage(systemName: mode == browserThemeMode ? "checkmark" : "circle", pointSize: 10, weight: .semibold)
                             .opacity(mode == browserThemeMode ? 1.0 : 0.0)
                             .frame(width: 12, alignment: .center)
                         Text(mode.displayName)
@@ -1777,10 +1725,7 @@ struct BrowserPanelView: View {
 
         return HStack(spacing: 4) {
             if showSecureBadge {
-                CmuxSystemSymbolImage(
-                    systemName: "lock.fill",
-                    pointSize: chromeMetrics.secureBadgeFontSize
-                )
+                CmuxSystemSymbolImage(systemName: "lock.fill", pointSize: chromeMetrics.secureBadgeFontSize)
                     .foregroundColor(.secondary)
             }
 

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -173,7 +173,7 @@ struct PanelFilePathHeader<TrailingContent: View>: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: iconSystemName)
+            CmuxSystemSymbolImage(systemName: iconSystemName, pointSize: 16)
                 .foregroundStyle(.secondary)
                 .frame(width: 16)
             Text(filePath)
@@ -213,8 +213,7 @@ struct PanelHeaderIconGlyph: View {
     let systemName: String
 
     var body: some View {
-        Image(systemName: systemName)
-            .cmuxSymbolRasterSize(13)
+        CmuxSystemSymbolImage(systemName: systemName, pointSize: 13)
             .frame(width: 20, height: 20, alignment: .center)
             .contentShape(Rectangle())
     }

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -98,9 +98,14 @@ enum RenderableSystemSymbol {
         if let cached = appKitImageCache[cacheKey] {
             return cached
         }
-        guard let baseImage = NSImage(systemSymbolName: systemName, accessibilityDescription: nil) else {
+        if renderabilityCache[systemName] == false {
             return nil
         }
+        guard let baseImage = NSImage(systemSymbolName: systemName, accessibilityDescription: nil) else {
+            renderabilityCache[systemName] = false
+            return nil
+        }
+        renderabilityCache[systemName] = true
         let configuration = NSImage.SymbolConfiguration(
             pointSize: rasterSize,
             weight: fontWeight

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -6,9 +6,12 @@ enum RenderableSystemSymbol {
     static let defaultWorkspaceGroupIcon = "folder.fill"
     static let defaultSurfaceTabIcon = "doc.text"
     private static let minimumRasterPointSize: CGFloat = 1
+    private static let renderabilityCacheLimit = 512
     private static let appKitImageCacheLimit = 256
     @MainActor
     private static var renderabilityCache: [String: Bool] = [:]
+    @MainActor
+    private static var renderabilityCacheInsertionOrder: [String] = []
     @MainActor
     private static var appKitImageCache: [AppKitImageCacheKey: NSImage] = [:]
     @MainActor
@@ -59,7 +62,7 @@ enum RenderableSystemSymbol {
             return cached
         }
         let resolved = NSImage(systemSymbolName: symbol, accessibilityDescription: nil) != nil
-        renderabilityCache[symbol] = resolved
+        cacheRenderability(resolved, for: symbol)
         return resolved
     }
 
@@ -102,10 +105,10 @@ enum RenderableSystemSymbol {
             return nil
         }
         guard let baseImage = NSImage(systemSymbolName: systemName, accessibilityDescription: nil) else {
-            renderabilityCache[systemName] = false
+            cacheRenderability(false, for: systemName)
             return nil
         }
-        renderabilityCache[systemName] = true
+        cacheRenderability(true, for: systemName)
         let configuration = NSImage.SymbolConfiguration(
             pointSize: rasterSize,
             weight: fontWeight
@@ -121,6 +124,18 @@ enum RenderableSystemSymbol {
             appKitImageCache.removeValue(forKey: evictedKey)
         }
         return image
+    }
+
+    @MainActor
+    private static func cacheRenderability(_ isRenderable: Bool, for symbol: String) {
+        if renderabilityCache[symbol] == nil {
+            renderabilityCacheInsertionOrder.append(symbol)
+        }
+        renderabilityCache[symbol] = isRenderable
+        while renderabilityCacheInsertionOrder.count > renderabilityCacheLimit {
+            let evictedSymbol = renderabilityCacheInsertionOrder.removeFirst()
+            renderabilityCache.removeValue(forKey: evictedSymbol)
+        }
     }
 
     static func fittedSymbolSize(_ naturalSize: NSSize, maximumDimension: CGFloat) -> NSSize {
@@ -152,6 +167,7 @@ enum RenderableSystemSymbol {
     @MainActor
     static func resetRenderabilityCacheForTesting() {
         renderabilityCache.removeAll()
+        renderabilityCacheInsertionOrder.removeAll()
         appKitImageCache.removeAll()
         appKitImageCacheInsertionOrder.removeAll()
     }

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -162,6 +162,35 @@ struct CmuxSystemSymbolImage: View {
     var alignment: Alignment = .center
     var appliesGlobalFontMagnification = false
 
+    init(
+        systemName: String,
+        pointSize: CGFloat,
+        weight: Font.Weight? = nil,
+        alignment: Alignment = .center,
+        appliesGlobalFontMagnification: Bool = false
+    ) {
+        self.systemName = systemName
+        self.pointSize = pointSize
+        self.weight = weight
+        self.alignment = alignment
+        self.appliesGlobalFontMagnification = appliesGlobalFontMagnification
+    }
+
+    init(
+        magnified systemName: String,
+        pointSize: CGFloat,
+        weight: Font.Weight? = nil,
+        alignment: Alignment = .center
+    ) {
+        self.init(
+            systemName: systemName,
+            pointSize: pointSize,
+            weight: weight,
+            alignment: alignment,
+            appliesGlobalFontMagnification: true
+        )
+    }
+
     var body: some View {
         let rasterSize = RenderableSystemSymbol.resolvedRasterPointSize(
             pointSize,

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -108,7 +108,7 @@ enum RenderableSystemSymbol {
         let configuredImage = baseImage.withSymbolConfiguration(configuration) ?? baseImage
         let image = (configuredImage.copy() as? NSImage) ?? configuredImage
         image.isTemplate = true
-        image.size = NSSize(width: rasterSize, height: rasterSize)
+        image.size = fittedSymbolSize(configuredImage.size, maximumDimension: rasterSize)
         appKitImageCache[cacheKey] = image
         appKitImageCacheInsertionOrder.append(cacheKey)
         while appKitImageCacheInsertionOrder.count > appKitImageCacheLimit {
@@ -116,6 +116,18 @@ enum RenderableSystemSymbol {
             appKitImageCache.removeValue(forKey: evictedKey)
         }
         return image
+    }
+
+    static func fittedSymbolSize(_ naturalSize: NSSize, maximumDimension: CGFloat) -> NSSize {
+        let maximumDimension = clampedRasterPointSize(maximumDimension)
+        guard naturalSize.width.isFinite,
+              naturalSize.height.isFinite,
+              naturalSize.width > 0,
+              naturalSize.height > 0 else {
+            return NSSize(width: maximumDimension, height: maximumDimension)
+        }
+        let scale = maximumDimension / max(naturalSize.width, naturalSize.height)
+        return NSSize(width: naturalSize.width * scale, height: naturalSize.height * scale)
     }
 
     private static func nsFontWeight(for weight: Font.Weight?) -> NSFont.Weight {

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxFoundation
 import SwiftUI
 
 enum RenderableSystemSymbol {
@@ -69,6 +70,18 @@ enum RenderableSystemSymbol {
         return max(minimumRasterPointSize, pointSize)
     }
 
+    static func resolvedRasterPointSize(
+        _ pointSize: CGFloat,
+        globalFontPercent: Int,
+        appliesGlobalFontMagnification: Bool
+    ) -> CGFloat {
+        let rasterSize = clampedRasterPointSize(pointSize)
+        guard appliesGlobalFontMagnification else {
+            return rasterSize
+        }
+        return GlobalFontMagnification.scaledSize(rasterSize, percent: globalFontPercent)
+    }
+
     @MainActor
     static func configuredAppKitImage(
         systemName: String,
@@ -129,13 +142,20 @@ enum RenderableSystemSymbol {
 }
 
 struct CmuxSystemSymbolImage: View {
+    @Environment(\.cmuxGlobalFontMagnificationPercent) private var globalFontPercent
+
     let systemName: String
     let pointSize: CGFloat
     var weight: Font.Weight?
     var alignment: Alignment = .center
+    var appliesGlobalFontMagnification = false
 
     var body: some View {
-        let rasterSize = RenderableSystemSymbol.clampedRasterPointSize(pointSize)
+        let rasterSize = RenderableSystemSymbol.resolvedRasterPointSize(
+            pointSize,
+            globalFontPercent: globalFontPercent,
+            appliesGlobalFontMagnification: appliesGlobalFontMagnification
+        )
         if let image = RenderableSystemSymbol.configuredAppKitImage(
             systemName: systemName,
             pointSize: rasterSize,

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -58,6 +58,40 @@ enum RenderableSystemSymbol {
         return max(minimumRasterPointSize, pointSize)
     }
 
+    @MainActor
+    static func configuredAppKitImage(
+        systemName: String,
+        pointSize: CGFloat,
+        weight: Font.Weight? = nil
+    ) -> NSImage? {
+        let rasterSize = clampedRasterPointSize(pointSize)
+        guard let baseImage = NSImage(systemSymbolName: systemName, accessibilityDescription: nil) else {
+            return nil
+        }
+        let configuration = NSImage.SymbolConfiguration(
+            pointSize: rasterSize,
+            weight: nsFontWeight(for: weight)
+        )
+        let configuredImage = baseImage.withSymbolConfiguration(configuration) ?? baseImage
+        let image = (configuredImage.copy() as? NSImage) ?? configuredImage
+        image.isTemplate = true
+        image.size = NSSize(width: rasterSize, height: rasterSize)
+        return image
+    }
+
+    private static func nsFontWeight(for weight: Font.Weight?) -> NSFont.Weight {
+        guard let weight else { return .regular }
+        if weight == .ultraLight { return .ultraLight }
+        if weight == .thin { return .thin }
+        if weight == .light { return .light }
+        if weight == .medium { return .medium }
+        if weight == .semibold { return .semibold }
+        if weight == .bold { return .bold }
+        if weight == .heavy { return .heavy }
+        if weight == .black { return .black }
+        return .regular
+    }
+
     #if DEBUG
     @MainActor
     static func resetRenderabilityCacheForTesting() {
@@ -66,16 +100,26 @@ enum RenderableSystemSymbol {
     #endif
 }
 
-extension Image {
-    /// Keeps a positive symbol frame while avoiding the blank-prone resizable SF Symbol rasterizer.
-    func cmuxSymbolRasterSize(
-        _ pointSize: CGFloat,
-        weight: Font.Weight? = nil,
-        alignment: Alignment = .center
-    ) -> some View {
+struct CmuxSystemSymbolImage: View {
+    let systemName: String
+    let pointSize: CGFloat
+    var weight: Font.Weight?
+    var alignment: Alignment = .center
+
+    var body: some View {
         let rasterSize = RenderableSystemSymbol.clampedRasterPointSize(pointSize)
-        let systemFont: Font = weight.map { .system(size: rasterSize, weight: $0) } ?? .system(size: rasterSize)
-        return font(systemFont)
-            .frame(width: rasterSize, height: rasterSize, alignment: alignment)
+        if let image = RenderableSystemSymbol.configuredAppKitImage(
+            systemName: systemName,
+            pointSize: rasterSize,
+            weight: weight
+        ) {
+            Image(nsImage: image)
+                .renderingMode(.template)
+                .frame(width: rasterSize, height: rasterSize, alignment: alignment)
+        } else {
+            Color.clear
+                .frame(width: rasterSize, height: rasterSize, alignment: alignment)
+                .accessibilityHidden(true)
+        }
     }
 }

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -5,8 +5,19 @@ enum RenderableSystemSymbol {
     static let defaultWorkspaceGroupIcon = "folder.fill"
     static let defaultSurfaceTabIcon = "doc.text"
     private static let minimumRasterPointSize: CGFloat = 1
+    private static let appKitImageCacheLimit = 256
     @MainActor
     private static var renderabilityCache: [String: Bool] = [:]
+    @MainActor
+    private static var appKitImageCache: [AppKitImageCacheKey: NSImage] = [:]
+    @MainActor
+    private static var appKitImageCacheInsertionOrder: [AppKitImageCacheKey] = []
+
+    private struct AppKitImageCacheKey: Hashable {
+        let systemName: String
+        let rasterSize: CGFloat
+        let weightRawValue: CGFloat
+    }
 
     static func trimmed(_ raw: String?) -> String? {
         guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -65,17 +76,32 @@ enum RenderableSystemSymbol {
         weight: Font.Weight? = nil
     ) -> NSImage? {
         let rasterSize = clampedRasterPointSize(pointSize)
+        let fontWeight = nsFontWeight(for: weight)
+        let cacheKey = AppKitImageCacheKey(
+            systemName: systemName,
+            rasterSize: rasterSize,
+            weightRawValue: fontWeight.rawValue
+        )
+        if let cached = appKitImageCache[cacheKey] {
+            return cached
+        }
         guard let baseImage = NSImage(systemSymbolName: systemName, accessibilityDescription: nil) else {
             return nil
         }
         let configuration = NSImage.SymbolConfiguration(
             pointSize: rasterSize,
-            weight: nsFontWeight(for: weight)
+            weight: fontWeight
         )
         let configuredImage = baseImage.withSymbolConfiguration(configuration) ?? baseImage
         let image = (configuredImage.copy() as? NSImage) ?? configuredImage
         image.isTemplate = true
         image.size = NSSize(width: rasterSize, height: rasterSize)
+        appKitImageCache[cacheKey] = image
+        appKitImageCacheInsertionOrder.append(cacheKey)
+        while appKitImageCacheInsertionOrder.count > appKitImageCacheLimit {
+            let evictedKey = appKitImageCacheInsertionOrder.removeFirst()
+            appKitImageCache.removeValue(forKey: evictedKey)
+        }
         return image
     }
 
@@ -96,6 +122,8 @@ enum RenderableSystemSymbol {
     @MainActor
     static func resetRenderabilityCacheForTesting() {
         renderabilityCache.removeAll()
+        appKitImageCache.removeAll()
+        appKitImageCacheInsertionOrder.removeAll()
     }
     #endif
 }

--- a/Sources/RightSidebarChromeStyle.swift
+++ b/Sources/RightSidebarChromeStyle.swift
@@ -351,7 +351,8 @@ struct ModeBarButton: View {
                 CmuxSystemSymbolImage(
                     systemName: item.symbolName,
                     pointSize: RightSidebarChromeControlStyle.modeIconSize,
-                    weight: RightSidebarChromeControlStyle.iconWeight
+                    weight: RightSidebarChromeControlStyle.iconWeight,
+                    appliesGlobalFontMagnification: true
                 )
                     .reportRightSidebarChromeNamedGeometryForBonsplitUITest(
                         keyPrefix: "rightSidebarModeIcon_\(item.id)",

--- a/Sources/RightSidebarChromeStyle.swift
+++ b/Sources/RightSidebarChromeStyle.swift
@@ -25,8 +25,11 @@ enum HeaderChromeIconStyle {
     }
 
     static func symbol(_ systemName: String) -> some View {
-        Image(systemName: systemName)
-            .cmuxSymbolRasterSize(RightSidebarChromeMetrics.headerIconSize, weight: weight)
+        CmuxSystemSymbolImage(
+            systemName: systemName,
+            pointSize: RightSidebarChromeMetrics.headerIconSize,
+            weight: weight
+        )
     }
 
     static func foregroundOpacity(isHovering: Bool, isPressed: Bool, isEnabled: Bool = true) -> Double {
@@ -345,12 +348,11 @@ struct ModeBarButton: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 4) {
-                Image(systemName: item.symbolName)
-                    .symbolRenderingMode(.monochrome)
-                    .cmuxFont(
-                        size: RightSidebarChromeControlStyle.modeIconSize,
-                        weight: RightSidebarChromeControlStyle.iconWeight
-                    )
+                CmuxSystemSymbolImage(
+                    systemName: item.symbolName,
+                    pointSize: RightSidebarChromeControlStyle.modeIconSize,
+                    weight: RightSidebarChromeControlStyle.iconWeight
+                )
                     .reportRightSidebarChromeNamedGeometryForBonsplitUITest(
                         keyPrefix: "rightSidebarModeIcon_\(item.id)",
                         isVisible: true

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -127,7 +127,8 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             CmuxSystemSymbolImage(
                 systemName: isCollapsed ? "chevron.right" : "chevron.down",
                 pointSize: metrics.chevronFontSize,
-                weight: .semibold
+                weight: .semibold,
+                appliesGlobalFontMagnification: true
             )
                 .foregroundStyle(.secondary)
                 .frame(width: metrics.chevronFrame, height: metrics.chevronFrame)
@@ -146,7 +147,8 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 CmuxSystemSymbolImage(
                     systemName: displayedIconSymbol,
                     pointSize: metrics.iconFontSize,
-                    weight: .semibold
+                    weight: .semibold,
+                    appliesGlobalFontMagnification: true
                 )
                     .foregroundStyle(iconColor)
                     .frame(width: metrics.iconFrame, height: metrics.iconFrame)
@@ -187,7 +189,8 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 CmuxSystemSymbolImage(
                     systemName: "plus",
                     pointSize: metrics.plusFontSize,
-                    weight: .medium
+                    weight: .medium,
+                    appliesGlobalFontMagnification: true
                 )
                     .foregroundStyle(.secondary)
                     .frame(width: metrics.plusFrame, height: metrics.plusFrame)

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -124,8 +124,11 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
 
     var body: some View {
         HStack(spacing: 4) {
-            Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
-                .cmuxFont(size: metrics.chevronFontSize, weight: .semibold)
+            CmuxSystemSymbolImage(
+                systemName: isCollapsed ? "chevron.right" : "chevron.down",
+                pointSize: metrics.chevronFontSize,
+                weight: .semibold
+            )
                 .foregroundStyle(.secondary)
                 .frame(width: metrics.chevronFrame, height: metrics.chevronFrame)
                 .contentShape(Rectangle())
@@ -140,8 +143,11 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 )
 
             HStack(spacing: 6) {
-                Image(systemName: displayedIconSymbol)
-                    .cmuxFont(size: metrics.iconFontSize, weight: .semibold)
+                CmuxSystemSymbolImage(
+                    systemName: displayedIconSymbol,
+                    pointSize: metrics.iconFontSize,
+                    weight: .semibold
+                )
                     .foregroundStyle(iconColor)
                     .frame(width: metrics.iconFrame, height: metrics.iconFrame)
                     .accessibilityHidden(true)
@@ -178,8 +184,11 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 shortcutHintModeActive: showsShortcutHint
             )
             Button(action: onTapPlus) {
-                Image(systemName: "plus")
-                    .cmuxFont(size: metrics.plusFontSize, weight: .medium)
+                CmuxSystemSymbolImage(
+                    systemName: "plus",
+                    pointSize: metrics.plusFontSize,
+                    weight: .medium
+                )
                     .foregroundStyle(.secondary)
                     .frame(width: metrics.plusFrame, height: metrics.plusFrame)
                     .contentShape(Rectangle())

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1075,8 +1075,11 @@ private struct TextBoxAttachmentPreviewPopoverView: View {
                 .background(Color.black.opacity(0.82))
         } else {
             VStack(spacing: 10) {
-                Image(systemName: "doc")
-                    .cmuxFont(size: 42, weight: .regular)
+                CmuxSystemSymbolImage(
+                    systemName: "doc",
+                    pointSize: 42,
+                    weight: .regular
+                )
                 Text(attachment.displayName)
                     .cmuxFont(size: 13, weight: .medium)
                     .lineLimit(2)
@@ -1157,8 +1160,11 @@ private struct TextBoxAttachmentChip: View {
                     )
                     .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
             } else {
-                Image(systemName: "doc")
-                    .cmuxFont(size: 12, weight: .medium)
+                CmuxSystemSymbolImage(
+                    systemName: "doc",
+                    pointSize: 12,
+                    weight: .medium
+                )
                     .frame(
                         width: TextBoxLayout.attachmentImageSize,
                         height: TextBoxLayout.attachmentImageSize
@@ -1172,8 +1178,11 @@ private struct TextBoxAttachmentChip: View {
                 .frame(maxWidth: 118, alignment: .leading)
 
             Button(action: onRemove) {
-                Image(systemName: "xmark")
-                    .cmuxFont(size: 8, weight: .bold)
+                CmuxSystemSymbolImage(
+                    systemName: "xmark",
+                    pointSize: 8,
+                    weight: .bold
+                )
                     .frame(width: 14, height: 14)
             }
             .buttonStyle(.plain)
@@ -2811,8 +2820,11 @@ struct TextBoxInputContainer: View {
 
     private func addFilesButton(foreground: Color) -> some View {
         Button(action: chooseFiles) {
-            Image(systemName: "plus")
-                .cmuxFont(size: TextBoxLayout.iconSymbolSize, weight: .semibold)
+            CmuxSystemSymbolImage(
+                systemName: "plus",
+                pointSize: TextBoxLayout.iconSymbolSize,
+                weight: .semibold
+            )
                 .frame(width: TextBoxLayout.iconButtonSize, height: TextBoxLayout.iconButtonSize)
                 .background(
                     Circle()
@@ -2850,8 +2862,11 @@ struct TextBoxInputContainer: View {
 
     private func sendButton(canSend: Bool, foreground: Color) -> some View {
         Button(action: submit) {
-            Image(systemName: "arrow.up")
-                .cmuxFont(size: TextBoxLayout.sendSymbolSize, weight: .bold)
+            CmuxSystemSymbolImage(
+                systemName: "arrow.up",
+                pointSize: TextBoxLayout.sendSymbolSize,
+                weight: .bold
+            )
                 .frame(width: TextBoxLayout.iconButtonSize, height: TextBoxLayout.iconButtonSize)
         }
         .buttonStyle(TextBoxSendButtonStyle(canSend: canSend))
@@ -2870,8 +2885,11 @@ struct TextBoxInputContainer: View {
                 showPendingCommentsPreview.toggle()
             } label: {
                 HStack(spacing: 5) {
-                    Image(systemName: "text.bubble")
-                        .cmuxFont(size: 11, weight: .medium)
+                    CmuxSystemSymbolImage(
+                        systemName: "text.bubble",
+                        pointSize: 11,
+                        weight: .medium
+                    )
                     Text(pendingCommentsLabel(count))
                         .cmuxFont(size: 12, weight: .medium)
                         .lineLimit(1)
@@ -2885,8 +2903,11 @@ struct TextBoxInputContainer: View {
             Button {
                 dismissPendingComments()
             } label: {
-                Image(systemName: "xmark")
-                    .cmuxFont(size: 9, weight: .bold)
+                CmuxSystemSymbolImage(
+                    systemName: "xmark",
+                    pointSize: 9,
+                    weight: .bold
+                )
                     .frame(width: 16, height: 16)
                     .background(Circle().fill(foreground.opacity(0.12)))
             }

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1075,12 +1075,7 @@ private struct TextBoxAttachmentPreviewPopoverView: View {
                 .background(Color.black.opacity(0.82))
         } else {
             VStack(spacing: 10) {
-                CmuxSystemSymbolImage(
-                    systemName: "doc",
-                    pointSize: 42,
-                    weight: .regular,
-                    appliesGlobalFontMagnification: true
-                )
+                CmuxSystemSymbolImage(magnified: "doc", pointSize: 42, weight: .regular)
                 Text(attachment.displayName)
                     .cmuxFont(size: 13, weight: .medium)
                     .lineLimit(2)
@@ -1161,12 +1156,7 @@ private struct TextBoxAttachmentChip: View {
                     )
                     .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
             } else {
-                CmuxSystemSymbolImage(
-                    systemName: "doc",
-                    pointSize: 12,
-                    weight: .medium,
-                    appliesGlobalFontMagnification: true
-                )
+                CmuxSystemSymbolImage(magnified: "doc", pointSize: 12, weight: .medium)
                     .frame(
                         width: TextBoxLayout.attachmentImageSize,
                         height: TextBoxLayout.attachmentImageSize
@@ -1180,12 +1170,7 @@ private struct TextBoxAttachmentChip: View {
                 .frame(maxWidth: 118, alignment: .leading)
 
             Button(action: onRemove) {
-                CmuxSystemSymbolImage(
-                    systemName: "xmark",
-                    pointSize: 8,
-                    weight: .bold,
-                    appliesGlobalFontMagnification: true
-                )
+                CmuxSystemSymbolImage(magnified: "xmark", pointSize: 8, weight: .bold)
                     .frame(width: 14, height: 14)
             }
             .buttonStyle(.plain)
@@ -2823,12 +2808,7 @@ struct TextBoxInputContainer: View {
 
     private func addFilesButton(foreground: Color) -> some View {
         Button(action: chooseFiles) {
-            CmuxSystemSymbolImage(
-                systemName: "plus",
-                pointSize: TextBoxLayout.iconSymbolSize,
-                weight: .semibold,
-                appliesGlobalFontMagnification: true
-            )
+            CmuxSystemSymbolImage(magnified: "plus", pointSize: TextBoxLayout.iconSymbolSize, weight: .semibold)
                 .frame(width: TextBoxLayout.iconButtonSize, height: TextBoxLayout.iconButtonSize)
                 .background(
                     Circle()
@@ -2866,12 +2846,7 @@ struct TextBoxInputContainer: View {
 
     private func sendButton(canSend: Bool, foreground: Color) -> some View {
         Button(action: submit) {
-            CmuxSystemSymbolImage(
-                systemName: "arrow.up",
-                pointSize: TextBoxLayout.sendSymbolSize,
-                weight: .bold,
-                appliesGlobalFontMagnification: true
-            )
+            CmuxSystemSymbolImage(magnified: "arrow.up", pointSize: TextBoxLayout.sendSymbolSize, weight: .bold)
                 .frame(width: TextBoxLayout.iconButtonSize, height: TextBoxLayout.iconButtonSize)
         }
         .buttonStyle(TextBoxSendButtonStyle(canSend: canSend))
@@ -2890,12 +2865,7 @@ struct TextBoxInputContainer: View {
                 showPendingCommentsPreview.toggle()
             } label: {
                 HStack(spacing: 5) {
-                    CmuxSystemSymbolImage(
-                        systemName: "text.bubble",
-                        pointSize: 11,
-                        weight: .medium,
-                        appliesGlobalFontMagnification: true
-                    )
+                    CmuxSystemSymbolImage(magnified: "text.bubble", pointSize: 11, weight: .medium)
                     Text(pendingCommentsLabel(count))
                         .cmuxFont(size: 12, weight: .medium)
                         .lineLimit(1)
@@ -2909,12 +2879,7 @@ struct TextBoxInputContainer: View {
             Button {
                 dismissPendingComments()
             } label: {
-                CmuxSystemSymbolImage(
-                    systemName: "xmark",
-                    pointSize: 9,
-                    weight: .bold,
-                    appliesGlobalFontMagnification: true
-                )
+                CmuxSystemSymbolImage(magnified: "xmark", pointSize: 9, weight: .bold)
                     .frame(width: 16, height: 16)
                     .background(Circle().fill(foreground.opacity(0.12)))
             }

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1078,7 +1078,8 @@ private struct TextBoxAttachmentPreviewPopoverView: View {
                 CmuxSystemSymbolImage(
                     systemName: "doc",
                     pointSize: 42,
-                    weight: .regular
+                    weight: .regular,
+                    appliesGlobalFontMagnification: true
                 )
                 Text(attachment.displayName)
                     .cmuxFont(size: 13, weight: .medium)
@@ -1163,7 +1164,8 @@ private struct TextBoxAttachmentChip: View {
                 CmuxSystemSymbolImage(
                     systemName: "doc",
                     pointSize: 12,
-                    weight: .medium
+                    weight: .medium,
+                    appliesGlobalFontMagnification: true
                 )
                     .frame(
                         width: TextBoxLayout.attachmentImageSize,
@@ -1181,7 +1183,8 @@ private struct TextBoxAttachmentChip: View {
                 CmuxSystemSymbolImage(
                     systemName: "xmark",
                     pointSize: 8,
-                    weight: .bold
+                    weight: .bold,
+                    appliesGlobalFontMagnification: true
                 )
                     .frame(width: 14, height: 14)
             }
@@ -2823,7 +2826,8 @@ struct TextBoxInputContainer: View {
             CmuxSystemSymbolImage(
                 systemName: "plus",
                 pointSize: TextBoxLayout.iconSymbolSize,
-                weight: .semibold
+                weight: .semibold,
+                appliesGlobalFontMagnification: true
             )
                 .frame(width: TextBoxLayout.iconButtonSize, height: TextBoxLayout.iconButtonSize)
                 .background(
@@ -2865,7 +2869,8 @@ struct TextBoxInputContainer: View {
             CmuxSystemSymbolImage(
                 systemName: "arrow.up",
                 pointSize: TextBoxLayout.sendSymbolSize,
-                weight: .bold
+                weight: .bold,
+                appliesGlobalFontMagnification: true
             )
                 .frame(width: TextBoxLayout.iconButtonSize, height: TextBoxLayout.iconButtonSize)
         }
@@ -2888,7 +2893,8 @@ struct TextBoxInputContainer: View {
                     CmuxSystemSymbolImage(
                         systemName: "text.bubble",
                         pointSize: 11,
-                        weight: .medium
+                        weight: .medium,
+                        appliesGlobalFontMagnification: true
                     )
                     Text(pendingCommentsLabel(count))
                         .cmuxFont(size: 12, weight: .medium)
@@ -2906,7 +2912,8 @@ struct TextBoxInputContainer: View {
                 CmuxSystemSymbolImage(
                     systemName: "xmark",
                     pointSize: 9,
-                    weight: .bold
+                    weight: .bold,
+                    appliesGlobalFontMagnification: true
                 )
                     .frame(width: 16, height: 16)
                     .background(Circle().fill(foreground.opacity(0.12)))

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1179,9 +1179,11 @@ struct TitlebarControlsView: View {
         iconGeometryKeyPrefix: String? = nil
     ) -> some View {
         titlebarIconChrome(config: config, iconGeometryKeyPrefix: iconGeometryKeyPrefix) {
-            Image(systemName: systemName)
-                .symbolRenderingMode(.monochrome)
-                .cmuxSymbolRasterSize(config.iconSize, weight: TitlebarControlIconStyle.weight)
+            CmuxSystemSymbolImage(
+                systemName: systemName,
+                pointSize: config.iconSize,
+                weight: TitlebarControlIconStyle.weight
+            )
         }
     }
 
@@ -2199,8 +2201,11 @@ private struct NotificationsPopoverView: View {
             Spacer()
             Button(action: jumpToLatestUnread) {
                 HStack(spacing: 5) {
-                    Image(systemName: "arrow.down.to.line")
-                        .cmuxSymbolRasterSize(10, weight: .semibold)
+                    CmuxSystemSymbolImage(
+                        systemName: "arrow.down.to.line",
+                        pointSize: 10,
+                        weight: .semibold
+                    )
                     Text(String(localized: "notifications.jumpToLatest", defaultValue: "Jump to Latest"))
                         .cmuxFont(size: 11)
                     if !jumpToUnreadShortcut.displayString.isEmpty {
@@ -2323,8 +2328,11 @@ private struct NotificationsPopoverView: View {
 
     private func emptyState(systemImage: String, title: String, subtitle: String?) -> some View {
         VStack(spacing: 10) {
-            Image(systemName: systemImage)
-                .cmuxSymbolRasterSize(30, weight: .light)
+            CmuxSystemSymbolImage(
+                systemName: systemImage,
+                pointSize: 30,
+                weight: .light
+            )
                 .foregroundColor(.secondary.opacity(0.7))
             Text(title)
                 .cmuxFont(size: 14, weight: .medium)
@@ -2507,8 +2515,11 @@ private struct NotificationPopoverRow: View {
             ZStack {
                 Circle()
                     .fill(Color.primary.opacity(0.1))
-                Image(systemName: "xmark")
-                    .cmuxSymbolRasterSize(9, weight: .bold)
+                CmuxSystemSymbolImage(
+                    systemName: "xmark",
+                    pointSize: 9,
+                    weight: .bold
+                )
                     .foregroundColor(.primary.opacity(0.7))
             }
             .frame(width: 20, height: 20)

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1179,11 +1179,7 @@ struct TitlebarControlsView: View {
         iconGeometryKeyPrefix: String? = nil
     ) -> some View {
         titlebarIconChrome(config: config, iconGeometryKeyPrefix: iconGeometryKeyPrefix) {
-            CmuxSystemSymbolImage(
-                systemName: systemName,
-                pointSize: config.iconSize,
-                weight: TitlebarControlIconStyle.weight
-            )
+            CmuxSystemSymbolImage(systemName: systemName, pointSize: config.iconSize, weight: TitlebarControlIconStyle.weight)
         }
     }
 
@@ -2201,11 +2197,7 @@ private struct NotificationsPopoverView: View {
             Spacer()
             Button(action: jumpToLatestUnread) {
                 HStack(spacing: 5) {
-                    CmuxSystemSymbolImage(
-                        systemName: "arrow.down.to.line",
-                        pointSize: 10,
-                        weight: .semibold
-                    )
+                    CmuxSystemSymbolImage(systemName: "arrow.down.to.line", pointSize: 10, weight: .semibold)
                     Text(String(localized: "notifications.jumpToLatest", defaultValue: "Jump to Latest"))
                         .cmuxFont(size: 11)
                     if !jumpToUnreadShortcut.displayString.isEmpty {
@@ -2328,11 +2320,7 @@ private struct NotificationsPopoverView: View {
 
     private func emptyState(systemImage: String, title: String, subtitle: String?) -> some View {
         VStack(spacing: 10) {
-            CmuxSystemSymbolImage(
-                systemName: systemImage,
-                pointSize: 30,
-                weight: .light
-            )
+            CmuxSystemSymbolImage(systemName: systemImage, pointSize: 30, weight: .light)
                 .foregroundColor(.secondary.opacity(0.7))
             Text(title)
                 .cmuxFont(size: 14, weight: .medium)
@@ -2515,11 +2503,7 @@ private struct NotificationPopoverRow: View {
             ZStack {
                 Circle()
                     .fill(Color.primary.opacity(0.1))
-                CmuxSystemSymbolImage(
-                    systemName: "xmark",
-                    pointSize: 9,
-                    weight: .bold
-                )
+                CmuxSystemSymbolImage(systemName: "xmark", pointSize: 9, weight: .bold)
                     .foregroundColor(.primary.opacity(0.7))
             }
             .frame(width: 20, height: 20)

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 
@@ -16,5 +17,23 @@ struct RenderableSystemSymbolTests {
         #expect(RenderableSystemSymbol.clampedRasterPointSize(.nan) == 1)
         #expect(RenderableSystemSymbol.clampedRasterPointSize(.infinity) == 1)
         #expect(RenderableSystemSymbol.clampedRasterPointSize(-.infinity) == 1)
+    }
+
+    @Test @MainActor func configuredAppKitImageUsesTemplateImageWithClampedSize() throws {
+        let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: "questionmark.circle",
+            pointSize: 0,
+            weight: .medium
+        ))
+        #expect(image.isTemplate)
+        #expect(image.size == NSSize(width: 1, height: 1))
+    }
+
+    @Test @MainActor func configuredAppKitImageRejectsUnknownSymbols() {
+        #expect(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: "not.an.sf.symbol",
+            pointSize: 11,
+            weight: .regular
+        ) == nil)
     }
 }

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -48,6 +48,28 @@ struct RenderableSystemSymbolTests {
         #expect(image.size == NSSize(width: 1, height: 1))
     }
 
+    @Test @MainActor func configuredAppKitImagePreservesNonSquareSymbolAspectRatio() throws {
+        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+        let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: "arrow.right",
+            pointSize: 16,
+            weight: .regular
+        ))
+        #expect(abs(image.size.width - 16) < 0.001)
+        #expect(image.size.height < 16)
+    }
+
+    @Test func fittedSymbolSizeScalesLongerDimensionToRasterSize() {
+        #expect(RenderableSystemSymbol.fittedSymbolSize(
+            NSSize(width: 20, height: 10),
+            maximumDimension: 16
+        ) == NSSize(width: 16, height: 8))
+        #expect(RenderableSystemSymbol.fittedSymbolSize(
+            NSSize(width: 0, height: 10),
+            maximumDimension: 16
+        ) == NSSize(width: 16, height: 16))
+    }
+
     @Test @MainActor func configuredAppKitImageReusesCachedImage() throws {
         RenderableSystemSymbol.resetRenderabilityCacheForTesting()
         let first = try #require(RenderableSystemSymbol.configuredAppKitImage(

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -20,6 +20,7 @@ struct RenderableSystemSymbolTests {
     }
 
     @Test @MainActor func configuredAppKitImageUsesTemplateImageWithClampedSize() throws {
+        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
         let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
             systemName: "questionmark.circle",
             pointSize: 0,
@@ -27,6 +28,21 @@ struct RenderableSystemSymbolTests {
         ))
         #expect(image.isTemplate)
         #expect(image.size == NSSize(width: 1, height: 1))
+    }
+
+    @Test @MainActor func configuredAppKitImageReusesCachedImage() throws {
+        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+        let first = try #require(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: "questionmark.circle",
+            pointSize: 11,
+            weight: .medium
+        ))
+        let second = try #require(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: "questionmark.circle",
+            pointSize: 11,
+            weight: .medium
+        ))
+        #expect(first === second)
     }
 
     @Test @MainActor func configuredAppKitImageRejectsUnknownSymbols() {

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -86,10 +86,12 @@ struct RenderableSystemSymbolTests {
     }
 
     @Test @MainActor func configuredAppKitImageRejectsUnknownSymbols() {
+        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
         #expect(RenderableSystemSymbol.configuredAppKitImage(
             systemName: "not.an.sf.symbol",
             pointSize: 11,
             weight: .regular
         ) == nil)
+        #expect(RenderableSystemSymbol.isRenderable("not.an.sf.symbol") == false)
     }
 }

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -19,6 +19,24 @@ struct RenderableSystemSymbolTests {
         #expect(RenderableSystemSymbol.clampedRasterPointSize(-.infinity) == 1)
     }
 
+    @Test func resolvedRasterPointSizeAppliesGlobalFontMagnificationWhenRequested() {
+        #expect(RenderableSystemSymbol.resolvedRasterPointSize(
+            10,
+            globalFontPercent: 150,
+            appliesGlobalFontMagnification: true
+        ) == 15)
+        #expect(RenderableSystemSymbol.resolvedRasterPointSize(
+            10,
+            globalFontPercent: 150,
+            appliesGlobalFontMagnification: false
+        ) == 10)
+        #expect(RenderableSystemSymbol.resolvedRasterPointSize(
+            0,
+            globalFontPercent: 200,
+            appliesGlobalFontMagnification: true
+        ) == 2)
+    }
+
     @Test @MainActor func configuredAppKitImageUsesTemplateImageWithClampedSize() throws {
         RenderableSystemSymbol.resetRenderabilityCacheForTesting()
         let image = try #require(RenderableSystemSymbol.configuredAppKitImage(


### PR DESCRIPTION
## Summary
- Add an AppKit-backed CmuxSystemSymbolImage that resolves SF Symbols through NSImage.SymbolConfiguration, clamps invalid point sizes, and renders a template NSImage from SwiftUI.
- Move launch and restored main-window chrome symbols in the sidebar, browser toolbar, titlebar, text box, and right sidebar off SwiftUI Image(systemName:) so first layout avoids SwiftUICore renderVectorGlyph and CoreUI CUINamedVectorGlyph.

## Testing
- ./scripts/lint-pbxproj-test-wiring.sh
- xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-sf27unit build-for-testing\n\n## Issues\n- Closes https://github.com/manaflow-ai/cmux/issues/6703

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784867156&installation_id=133855650&pr_number=6728&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6728&signature=3207c3b101a51f6829592fa80ab47b8882f45b74fe3d0f6ee814d9f15d48d8ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a macOS 27 launch crash by routing SF Symbol rendering through an AppKit-backed path with consistent template rasterization, aspect‑ratio‑preserving fitting, and caching, while preserving global font magnification where expected. Closes #6703.

- **Bug Fixes**
  - Added `CmuxSystemSymbolImage` using `NSImage.SymbolConfiguration`; clamps sizes, preserves aspect ratio, returns template images, caches AppKit symbols (256 max, FIFO), and bounds the renderability cache for unknown symbols (512 max, FIFO).
  - Preserved global font magnification via a new resolver and `appliesGlobalFontMagnification`, applied across sidebar, tabs, browser toolbar, titlebar, right sidebar, text box, and headers.
  - Replaced SwiftUI symbol rendering with `CmuxSystemSymbolImage` across chrome, removed the no‑op flat color helper, and kept call sites short via `magnified:` and explicit magnification flags.
  - Expanded tests to cover magnification scaling, clamping, template output, aspect‑ratio fitting, cache reuse, and unknown‑symbol rejection with negative‑lookup caching.

<sup>Written for commit a3e7c20b3167640838bbb20096b73cb13d9eaf2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Refactor
* Unified SF Symbol rendering across the app using a shared system-symbol image helper with explicit `systemName`, `pointSize`, and `weight`, replacing ad-hoc font/raster sizing approaches.
* Improved consistency by centralizing AppKit symbol rasterization with clamped sizing, aspect-preserving fits, and cached template images across navigation, toolbars, sidebars, workspace controls, browser panels, and various inputs/popovers.

## Tests
* Added AppKit-backed tests for point-size magnification rules, size clamping, cache reuse, non-square aspect behavior, fitted-symbol scaling, and unknown-symbol handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->