### PR TITLE
Animate iOS page images in on scroll like the home page

### DIFF
--- a/web/app/[locale]/components/reveal-image.tsx
+++ b/web/app/[locale]/components/reveal-image.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Image, { type ImageProps } from "next/image";
+import { useCallback, useState } from "react";
+
+type RevealImageProps = ImageProps & {
+  /** Upward travel distance while hidden, in pixels. Set 0 for fade-only. */
+  rise?: number;
+  /** Stagger offset in ms, e.g. index * 60 for a grid cascade. */
+  delay?: number;
+  /** Fade/rise duration in ms. */
+  duration?: number;
+};
+
+// Image that fades and gently rises in when it scrolls into view, the reveal
+// the marketing home page uses for its screenshots. An IntersectionObserver
+// drives it rather than the image load event: next/image routes its onLoad
+// through an effect-populated ref, so lazily-loaded gallery images regularly
+// finished loading without ever firing onLoad and stayed stuck invisible. The
+// observer is reliable for any count of below-the-fold images, and because its
+// callback runs after the first paint, the opacity/transform transition always
+// plays (above-the-fold images included) instead of snapping to visible.
+export function RevealImage({
+  rise = 12,
+  delay = 0,
+  duration = 700,
+  className,
+  style,
+  alt,
+  ...imageProps
+}: RevealImageProps) {
+  const [revealed, setRevealed] = useState(false);
+
+  // Callback ref (no useEffect). Runs on the client only; refs are not invoked
+  // during SSR. Disconnects after the first intersection so it fires once.
+  const observeRef = useCallback((node: HTMLImageElement | null) => {
+    if (!node || typeof IntersectionObserver === "undefined") {
+      // No observer support: reveal immediately so the image is never stuck.
+      if (node) setRevealed(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setRevealed(true);
+          observer.disconnect();
+        }
+      },
+      // Trigger once the image is a little way into the viewport, not at the
+      // very first pixel, so the rise reads as a deliberate entrance.
+      { rootMargin: "0px 0px -10% 0px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Image
+      {...imageProps}
+      alt={alt}
+      ref={observeRef}
+      style={{
+        transitionProperty: "opacity, transform",
+        transitionTimingFunction: "ease-out",
+        transitionDuration: `${duration}ms`,
+        transitionDelay: `${delay}ms`,
+        opacity: revealed ? 1 : 0,
+        transform: revealed ? "none" : `translateY(${rise}px)`,
+        ...style,
+      }}
+      // Users who prefer reduced motion see the image immediately, no movement.
+      className={`motion-reduce:opacity-100! motion-reduce:translate-y-0! motion-reduce:transition-none! ${className ?? ""}`}
+    />
+  );
+}

--- a/web/app/[locale]/ios/page.tsx
+++ b/web/app/[locale]/ios/page.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import Image from "next/image";
 import { Link } from "../../../i18n/navigation";
+import { RevealImage } from "../components/reveal-image";
 import { buildAlternates } from "../../../i18n/seo";
 import { SiteHeader } from "../components/site-header";
 import { BrandLogoLink } from "../components/brand-logo-link";
@@ -102,17 +102,18 @@ export default function IosLanding() {
           data-dev="ios-screenshot"
           className="my-14 grid grid-cols-2 gap-5 sm:gap-10 max-w-lg mx-auto"
         >
-          <Image
+          <RevealImage
             src={iosWorkspaces}
             alt={t("screenshotAlt")}
             priority
             sizes="(max-width: 640px) 42vw, 240px"
             className="w-full h-auto drop-shadow-[0_24px_56px_rgba(0,0,0,0.5)]"
           />
-          <Image
+          <RevealImage
             src={iosClaude}
             alt={t("screenshotAlt")}
             priority
+            delay={90}
             sizes="(max-width: 640px) 42vw, 240px"
             className="w-full h-auto drop-shadow-[0_24px_56px_rgba(0,0,0,0.5)]"
           />
@@ -135,11 +136,14 @@ export default function IosLanding() {
                 [iosHtop, "htop"],
                 [iosBtop, "btop"],
               ] as const
-            ).map(([src, name]) => (
+            ).map(([src, name], i) => (
               <figure key={name} className="m-0">
-                <Image
+                <RevealImage
                   src={src}
                   alt={t("galleryItemAlt", { name })}
+                  // Cascade within each row pair so the grid reveals as a wave
+                  // rather than all at once.
+                  delay={(i % 2) * 90}
                   sizes="(max-width: 640px) 90vw, 336px"
                   className="w-full h-auto drop-shadow-[0_18px_40px_rgba(0,0,0,0.45)]"
                 />


### PR DESCRIPTION
Adds a reusable `RevealImage` component and uses it on the `/ios` landing page so the screenshots fade and rise into view, matching the home page's reveal.

`RevealImage` (drop-in for `next/image`) starts each image at `opacity:0 translateY(12px)` and transitions it in. Props: `rise`, `delay` (for staggered cascades), `duration`. Reduced-motion users see images immediately.

It reveals via `IntersectionObserver` rather than `next/image`'s `onLoad`. `onLoad` regularly never fired for lazily-loaded gallery images (next/image routes it through an effect-set ref), leaving them stuck invisible; the observer is reliable for any number of below-the-fold images and animates after first paint. Implemented as a callback ref, no `useEffect`.

Applied to the two hero phones and all eight gallery screenshots with a light per-row stagger.

Verified locally: page serves 200, eslint clean on the new component, all ten images reach the revealed state after scrolling through.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784867346&installation_id=133855650&pr_number=6729&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6729&signature=abe7b74b90662cd745c6342160f07d61f3bf1de23b6206d7c6d3c5687f5cc17e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 31180cafb52df8f2b4702c357e3545d28211f3cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable `RevealImage` to animate `/ios` screenshots on scroll, matching the home page. Also fixes lazily-loaded images getting stuck invisible by using IntersectionObserver instead of `next/image`’s onLoad.

- **New Features**
  - New `RevealImage` (drop-in for `next/image`) that fades and rises images into view; props: `rise`, `delay`, `duration`; respects reduced motion.
  - Applied to `/ios`: two hero images and eight gallery screenshots with a light per-row stagger.

- **Bug Fixes**
  - Replaces unreliable `onLoad` with IntersectionObserver so below-the-fold images reveal reliably after first paint.

<sup>Written for commit 31180cafb52df8f2b4702c357e3545d28211f3cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth reveal animations for images that trigger as you scroll into view
  * Implemented on the iOS landing page with staggered timing across screenshots and gallery images for enhanced visual presentation
  * Respects user accessibility preferences and disables animations for users with reduced motion settings enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->