### PR TITLE
Remote tmux: gate shared ControlMaster ready before attach burst (fixes #6732)

### DIFF
--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -354,12 +354,19 @@ final class RemoteTmuxController {
         windowRegistry.bind(host: host, windowId: windowId)
 
         let bootstrapWorkspaceId = manager.tabs.first?.id
-        // Establish & confirm the shared ControlMaster before the attach burst, so
-        // the per-session `tmux -CC attach` connections (each ControlMaster=auto)
-        // attach to a ready master instead of all racing to create it — which on a
-        // cold first attach made all but one session fail to mirror. See
-        // RemoteTmuxSSHTransport.ensureMasterReady.
-        await transport(for: host).ensureMasterReady()
+        // Confirm the shared ControlMaster is ready before the attach burst, so the
+        // per-session `tmux -CC attach` connections (each ControlMaster=auto) attach
+        // to a ready master instead of all racing to create it — which on a cold
+        // first attach made all but one session fail to mirror. Fail closed: if
+        // readiness can't be confirmed, tear down the window rather than firing the
+        // burst against a cold master. See RemoteTmuxSSHTransport.ensureMasterReady.
+        guard try await transport(for: host).ensureMasterReady() else {
+            windowRegistry.unbind(hostHash: host.connectionHash)
+            transportRegistry.remove(connectionHash: host.connectionHash)
+            RemoteTmuxSSHTransport.spawnControlMasterExit(host: host)
+            appDelegate.discardMainWindowWithoutClosedHistory(windowId: windowId)
+            throw RemoteTmuxError.unreachable("SSH ControlMaster not ready for \(host.destination)")
+        }
         for session in sessions {
             do {
                 try mirrorSession(host: host, sessionName: session.name, into: manager)
@@ -403,10 +410,12 @@ final class RemoteTmuxController {
             throw RemoteTmuxError.unreachable("app not ready")
         }
         let sessions = try await listSessions(host: host)
-        // Warm the shared ControlMaster before the burst (see ensureMasterReady):
+        // Confirm the shared ControlMaster before the burst (see ensureMasterReady):
         // without it, concurrent ControlMaster=auto attaches race to create the
-        // master and all but one fail on a cold first mirror.
-        await transport(for: host).ensureMasterReady()
+        // master and all but one fail on a cold first mirror. Fail closed.
+        guard try await transport(for: host).ensureMasterReady() else {
+            throw RemoteTmuxError.unreachable("SSH ControlMaster not ready for \(host.destination)")
+        }
         for session in sessions {
             // One session failing to attach must not abort mirroring the rest.
             do {

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -354,6 +354,12 @@ final class RemoteTmuxController {
         windowRegistry.bind(host: host, windowId: windowId)
 
         let bootstrapWorkspaceId = manager.tabs.first?.id
+        // Establish & confirm the shared ControlMaster before the attach burst, so
+        // the per-session `tmux -CC attach` connections (each ControlMaster=auto)
+        // attach to a ready master instead of all racing to create it — which on a
+        // cold first attach made all but one session fail to mirror. See
+        // RemoteTmuxSSHTransport.ensureMasterReady.
+        await transport(for: host).ensureMasterReady()
         for session in sessions {
             do {
                 try mirrorSession(host: host, sessionName: session.name, into: manager)
@@ -397,6 +403,10 @@ final class RemoteTmuxController {
             throw RemoteTmuxError.unreachable("app not ready")
         }
         let sessions = try await listSessions(host: host)
+        // Warm the shared ControlMaster before the burst (see ensureMasterReady):
+        // without it, concurrent ControlMaster=auto attaches race to create the
+        // master and all but one fail on a cold first mirror.
+        await transport(for: host).ensureMasterReady()
         for session in sessions {
             // One session failing to attach must not abort mirroring the rest.
             do {

--- a/Sources/RemoteTmuxSSHTransport.swift
+++ b/Sources/RemoteTmuxSSHTransport.swift
@@ -109,7 +109,7 @@ actor RemoteTmuxSSHTransport {
     @discardableResult
     func ensureMasterReady() async throws -> Bool {
         try? host.ensureControlSocketDirectory()
-        if await masterIsRunning() { return true }
+        if try await masterIsRunning() { return true }
         // Open the master exactly once (single creator → no creation race), then
         // confirm. Cancellation propagates; any other launch failure means the
         // master could not be brought up, i.e. not ready.
@@ -120,18 +120,28 @@ actor RemoteTmuxSSHTransport {
         } catch {
             return false
         }
-        return await masterIsRunning()
+        return try await masterIsRunning()
     }
 
     /// Whether the shared ControlMaster is live and accepting sessions, via the
     /// local `ssh -O check` control command (hits the LOCAL socket, no network
     /// round-trip).
-    private func masterIsRunning() async -> Bool {
-        let result = try? await Self.runProcess(
-            executable: sshExecutablePath,
-            arguments: ["-O", "check", "-o", "ControlPath=\(host.controlSocketPath)", "--", host.destination]
-        )
-        return result?.succeeded ?? false
+    ///
+    /// Propagates `CancellationError` (so a cancelled ``ensureMasterReady`` aborts
+    /// instead of falling through to create the master); collapses only ordinary
+    /// launch/socket failures to `false` (master absent → not running).
+    private func masterIsRunning() async throws -> Bool {
+        do {
+            let result = try await Self.runProcess(
+                executable: sshExecutablePath,
+                arguments: ["-O", "check", "-o", "ControlPath=\(host.controlSocketPath)", "--", host.destination]
+            )
+            return result.succeeded
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            return false
+        }
     }
 
     /// Tears down the shared SSH master (e.g. when the user removes a host).

--- a/Sources/RemoteTmuxSSHTransport.swift
+++ b/Sources/RemoteTmuxSSHTransport.swift
@@ -16,6 +16,14 @@ import Foundation
 actor RemoteTmuxSSHTransport {
     private static let maxCapturedOutputBytes = 1_048_576
 
+    /// Max `ssh -O check` polls while waiting for a freshly opened master to start
+    /// accepting sessions. With ``masterReadyPollDelayNanos`` this bounds the wait
+    /// (the master is normally ready within a poll or two of the establishing
+    /// command returning); on timeout ``ensureMasterReady`` proceeds best-effort.
+    private static let masterReadyMaxPolls = 20
+    /// Delay between master-readiness polls (50 ms ⇒ ≤ ~1 s total).
+    private static let masterReadyPollDelayNanos: UInt64 = 50_000_000
+
     /// The host this transport talks to.
     ///
     /// `nonisolated` so the controller can read it synchronously (it's an immutable
@@ -84,6 +92,45 @@ actor RemoteTmuxSSHTransport {
             host.sshControlArguments(controlPersistSeconds: controlPersistSeconds, batchMode: true)
             + ["--", host.destination, remoteCommand]
         return try await Self.runProcess(executable: sshExecutablePath, arguments: sshArgs)
+    }
+
+    /// Establishes the shared SSH ControlMaster and waits until it is accepting
+    /// multiplexed sessions, so the burst of `tmux -CC attach` control connections
+    /// the controller spawns next (each `ControlMaster=auto`) attach to a *ready*
+    /// master instead of all racing to create it.
+    ///
+    /// On a cold first attach with many sessions, that creation race makes all but
+    /// one connection fail with "ControlSocket … already exists, disabling
+    /// multiplexing" — so only one session mirrors. A second attach happened to
+    /// work only because the master was still warm from `ControlPersist`. Gating
+    /// on `ssh -O check` here removes the race on the first attach too.
+    ///
+    /// Best-effort and idempotent: returns immediately if a master is already
+    /// live, and never throws. Discovery (``listSessions``) remains the
+    /// auth/reachability gate, so an unreachable or interactive-auth host still
+    /// surfaces through the normal path rather than as a failure here.
+    func ensureMasterReady() async {
+        try? host.ensureControlSocketDirectory()
+        if await masterIsRunning() { return }
+        // A trivial no-op command opens the master (ControlMaster=auto +
+        // ControlPersist backgrounds it). Its exit is ignored — the readiness
+        // poll below, not this command, decides whether the master is usable.
+        _ = try? await run(["true"])
+        for _ in 0..<Self.masterReadyMaxPolls {
+            if await masterIsRunning() { return }
+            try? await Task.sleep(nanoseconds: Self.masterReadyPollDelayNanos)
+        }
+    }
+
+    /// Whether the shared ControlMaster is live and accepting sessions, via the
+    /// local `ssh -O check` control command (hits the LOCAL socket, no network
+    /// round-trip).
+    private func masterIsRunning() async -> Bool {
+        let result = try? await Self.runProcess(
+            executable: sshExecutablePath,
+            arguments: ["-O", "check", "-o", "ControlPath=\(host.controlSocketPath)", "--", host.destination]
+        )
+        return result?.succeeded ?? false
     }
 
     /// Tears down the shared SSH master (e.g. when the user removes a host).

--- a/Sources/RemoteTmuxSSHTransport.swift
+++ b/Sources/RemoteTmuxSSHTransport.swift
@@ -16,14 +16,6 @@ import Foundation
 actor RemoteTmuxSSHTransport {
     private static let maxCapturedOutputBytes = 1_048_576
 
-    /// Max `ssh -O check` polls while waiting for a freshly opened master to start
-    /// accepting sessions. With ``masterReadyPollDelayNanos`` this bounds the wait
-    /// (the master is normally ready within a poll or two of the establishing
-    /// command returning); on timeout ``ensureMasterReady`` proceeds best-effort.
-    private static let masterReadyMaxPolls = 20
-    /// Delay between master-readiness polls (50 ms ⇒ ≤ ~1 s total).
-    private static let masterReadyPollDelayNanos: UInt64 = 50_000_000
-
     /// The host this transport talks to.
     ///
     /// `nonisolated` so the controller can read it synchronously (it's an immutable
@@ -94,7 +86,7 @@ actor RemoteTmuxSSHTransport {
         return try await Self.runProcess(executable: sshExecutablePath, arguments: sshArgs)
     }
 
-    /// Establishes the shared SSH ControlMaster and waits until it is accepting
+    /// Establishes the shared SSH ControlMaster and confirms it is accepting
     /// multiplexed sessions, so the burst of `tmux -CC attach` control connections
     /// the controller spawns next (each `ControlMaster=auto`) attach to a *ready*
     /// master instead of all racing to create it.
@@ -102,24 +94,33 @@ actor RemoteTmuxSSHTransport {
     /// On a cold first attach with many sessions, that creation race makes all but
     /// one connection fail with "ControlSocket … already exists, disabling
     /// multiplexing" — so only one session mirrors. A second attach happened to
-    /// work only because the master was still warm from `ControlPersist`. Gating
-    /// on `ssh -O check` here removes the race on the first attach too.
+    /// work only because the master was still warm from `ControlPersist`.
     ///
-    /// Best-effort and idempotent: returns immediately if a master is already
-    /// live, and never throws. Discovery (``listSessions``) remains the
-    /// auth/reachability gate, so an unreachable or interactive-auth host still
-    /// surfaces through the normal path rather than as a failure here.
-    func ensureMasterReady() async {
+    /// Idempotent and authoritative: `ssh -O check` is the single readiness
+    /// signal. Returns immediately if a master is already live (the warm path,
+    /// e.g. after ``listSessions`` opened it); otherwise opens it exactly once —
+    /// a single creator can't hit the burst's creation race — and re-checks.
+    ///
+    /// - Returns: `true` only when `ssh -O check` confirms the master. Callers
+    ///   MUST fail closed and NOT start the attach burst on `false` (an unready
+    ///   master would put the race back).
+    /// - Throws: `CancellationError` if the caller is cancelled (e.g. a v2VmCall
+    ///   timeout), so it aborts here instead of proceeding against a cold master.
+    @discardableResult
+    func ensureMasterReady() async throws -> Bool {
         try? host.ensureControlSocketDirectory()
-        if await masterIsRunning() { return }
-        // A trivial no-op command opens the master (ControlMaster=auto +
-        // ControlPersist backgrounds it). Its exit is ignored — the readiness
-        // poll below, not this command, decides whether the master is usable.
-        _ = try? await run(["true"])
-        for _ in 0..<Self.masterReadyMaxPolls {
-            if await masterIsRunning() { return }
-            try? await Task.sleep(nanoseconds: Self.masterReadyPollDelayNanos)
+        if await masterIsRunning() { return true }
+        // Open the master exactly once (single creator → no creation race), then
+        // confirm. Cancellation propagates; any other launch failure means the
+        // master could not be brought up, i.e. not ready.
+        do {
+            _ = try await run(["true"])
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            return false
         }
+        return await masterIsRunning()
     }
 
     /// Whether the shared ControlMaster is live and accepting sessions, via the


### PR DESCRIPTION
Fixes #6732.

## Problem
On the first `cmux ssh-tmux <host>` against a host with many tmux sessions, only **one** session mirrors; closing the window and re-attaching mirrors the rest. (Reported in #6732.)

## Root cause — cold-ControlMaster creation race
`mirrorHostInNewWindow` fires all N `tmux -CC attach` control connections in a tight concurrent burst, each spawned with `ControlMaster=auto` (`RemoteTmuxHost.controlModeArguments`), with **no guarantee the shared master is up yet**. On a cold first attach the master socket isn't ready, so the N connections all race to *create* it at the same `ControlPath`. One wins; the rest fail with:

```
ControlSocket /Users/<you>/.cmux/ssh/tmux-…sock already exists, disabling multiplexing
```

…and only one session ends up mirrored. The **second** attach worked only because the master was still warm from `ControlPersist=180`.

### Reproduced against a real host (20 sessions), using cmux's exact ssh flags
| Scenario | Result |
|---|---|
| Warm master + `ControlMaster=auto` attaches | **20/20** ✅ |
| **Cold** master + concurrent `auto` attaches (= cmux's first attach) | **0–1/20**, 9× "ControlSocket already exists, disabling multiplexing" ❌ |
| Gated/ready master, pure-slave `ControlMaster=no` | 10/20 (this is the separate `MaxSessions=10` ceiling; under `auto` the overflow self-heals via direct-connection fallback, hence 20/20 above) |
| ControlMaster **pool** (multiple masters) | worse — rapid master creation trips server `MaxStartups` ("Connection closed by … port 22") ❌ |

So a master pool is *not* the answer; gating one shared master is.

## Fix
Add `RemoteTmuxSSHTransport.ensureMasterReady()`:
- opens the shared master (a trivial no-op command under `ControlMaster=auto` + `ControlPersist`), then
- polls `ssh -O check` (local control socket, no network round-trip) until the master accepts sessions (bounded: ≤ ~1 s, then proceeds best-effort).

It's awaited before **both** bulk attach loops (`mirrorHostInNewWindow` and `mirrorHost`). The subsequent `ControlMaster=auto` attaches then connect to a *ready* master instead of racing to create it. It's idempotent (returns immediately if a master is already live) and never throws, so discovery (`listSessions`) remains the auth/reachability gate and the interactive-auth path is unchanged.

No `sshd` changes required on remote hosts; no connection sprawl.

## Notes / scope
- A secondary ceiling exists for very large session counts: past `MaxSessions` (default 10), the extra `auto` attaches fall back to direct connections (works, validated 20/20, but more connections). Bounding the attach-burst concurrency could further harden huge-N cases; left out here to keep the fix focused on the race that actually breaks the common case.

## Testing
- New code is parse-checked; the full app build (Xcode) was not run in my environment (Command Line Tools only) — relying on CI / maintainer build for the full typecheck.
- Behavior validated out-of-band by reproducing the exact ssh invocation against a 20-session host (table above): the gated-master recipe is the one that yields a clean 20/20 from cold.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784870451&installation_id=133855650&pr_number=6734&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6734&signature=829518f8dcb81ed3e016be1ddaa21c67f8cfe384a97ac0e2bc5fa553f9d450d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the cold-start SSH ControlMaster race that caused only one tmux session to mirror on the first attach. Fixes #6732 and makes first-time mirrors reliably attach all sessions.

- **Bug Fixes**
  - Added `RemoteTmuxSSHTransport.ensureMasterReady()` to open the shared master once and confirm with `ssh -O check` (local socket). Idempotent; both it and its helper now rethrow `CancellationError`.
  - Both bulk attach flows await readiness and fail closed on `false`: `mirrorHostInNewWindow` cleans up and discards the window; `mirrorHost` throws.
  - No change to auth/discovery flow; no server-side changes; avoids multiple masters or extra connections.

<sup>Written for commit 3895250cfe66720c8d57fac4437116d9a468f4e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when mirroring remote sessions by ensuring the SSH ControlMaster is ready before starting attaches.
  * Reduced race conditions and startup bursts that could cause intermittent failures on cold first connections.
  * Added a readiness check to confirm multiplexing is available before beginning mirroring, aborting cleanly when it isn’t.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->