### PR TITLE
Reject undeliverable waitlist emails (MX + disposable check)

### DIFF
--- a/web/app/[locale]/components/waitlist-dialog.tsx
+++ b/web/app/[locale]/components/waitlist-dialog.tsx
@@ -73,6 +73,33 @@ async function recordWaitlistSignup(
 }
 
 /**
+ * Asks the server whether the email's domain can receive mail (MX + disposable
+ * check) before we record the signup. Returns `"invalid"` only on a definitive
+ * rejection; network or server errors return `"ok"` so a transient failure never
+ * blocks a real signup (the server itself also fails open on DNS hiccups).
+ */
+async function verifyWaitlistEmail(
+  email: string,
+  platforms: WaitlistPlatform[],
+  location: string,
+): Promise<"ok" | "invalid"> {
+  try {
+    const res = await fetch("/api/waitlist", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, platforms, location, notify: false }),
+    });
+    if (!res.ok) return "ok";
+    const data = (await res.json().catch(() => null)) as {
+      valid?: boolean;
+    } | null;
+    return data?.valid === false ? "invalid" : "ok";
+  } catch {
+    return "ok";
+  }
+}
+
+/**
  * Pings our Slack channel about a signup via the `/api/waitlist` route.
  * Best-effort: the durable record is the PostHog capture above, so a failed
  * notification never blocks or fails the signup.
@@ -87,7 +114,7 @@ async function notifyWaitlistSlack(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       keepalive: true,
-      body: JSON.stringify({ email, platforms, location }),
+      body: JSON.stringify({ email, platforms, location, notify: true }),
     });
   } catch {
     // Notification only; ignore failures.
@@ -180,6 +207,19 @@ function WaitlistBody({
     }
     setStatus("submitting");
     const platforms = chosen;
+    // Start the pleasant-spinner clock now so the server round trips overlap it
+    // rather than stacking on top.
+    const minSpinner = new Promise<void>((resolve) => {
+      timerRef.current = setTimeout(resolve, SUBMIT_DELAY_MS);
+    });
+    // Gate on server-side deliverability (MX + disposable) before recording, so
+    // bogus addresses never enter the waitlist. Fails open on transient errors.
+    const verdict = await verifyWaitlistEmail(trimmed, platforms, location);
+    if (verdict === "invalid") {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setStatus("error");
+      return;
+    }
     // Record the signup with an awaited POST to PostHog's capture endpoint
     // (success only shows on confirmed delivery). The event carries
     // `distinct_id: email` and `$set`s the email + Early Access enrollment, so
@@ -190,9 +230,7 @@ function WaitlistBody({
     // spinner pleasant when the request is fast.
     const [ok] = await Promise.all([
       recordWaitlistSignup(trimmed, platforms, location),
-      new Promise<void>((resolve) => {
-        timerRef.current = setTimeout(resolve, SUBMIT_DELAY_MS);
-      }),
+      minSpinner,
     ]);
     // Ping Slack only after the signup was durably recorded, so the channel
     // never reports a signup that actually failed. Best-effort, not awaited.

--- a/web/app/api/waitlist/email-check.ts
+++ b/web/app/api/waitlist/email-check.ts
@@ -1,0 +1,147 @@
+import { promises as dns } from "node:dns";
+
+/**
+ * Result of checking whether an email address can plausibly receive mail.
+ * - `ok`: the domain publishes a usable MX (or an A/AAAA fallback per RFC 5321).
+ * - `invalid`: the domain definitively cannot receive mail (no such domain, or
+ *   an explicit "null MX" per RFC 7505), or it is a known disposable provider.
+ * - `unknown`: the lookup hit a transient DNS failure. Callers should fail open
+ *   (treat as deliverable) so a resolver hiccup never blocks a real signup.
+ */
+export type EmailCheck = "ok" | "invalid" | "unknown";
+
+/**
+ * Well-known disposable / single-use inbox providers. Deliberately conservative:
+ * it targets services whose entire purpose is throwaway inboxes, not privacy
+ * forwarders that real users rely on (e.g. passmail.com, duck.com, simplelogin).
+ * For a fuller (~3.5k domain) list, swap in the `disposable-email-domains`
+ * package; this hard-coded set avoids a dependency and stays predictable.
+ */
+export const DISPOSABLE_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  "mailinator.com",
+  "10minutemail.com",
+  "guerrillamail.com",
+  "guerrillamail.info",
+  "sharklasers.com",
+  "grr.la",
+  "yopmail.com",
+  "yopmail.fr",
+  "tempmail.com",
+  "temp-mail.org",
+  "trashmail.com",
+  "trashmail.de",
+  "getnada.com",
+  "nada.email",
+  "maildrop.cc",
+  "dispostable.com",
+  "fakeinbox.com",
+  "throwawaymail.com",
+  "mohmal.com",
+  "moakt.com",
+  "tempr.email",
+  "discard.email",
+  "33mail.com",
+  "spamgourmet.com",
+  "mailnesia.com",
+  "mintemail.com",
+  "emailondeck.com",
+  "tempmailo.com",
+  "mail7.io",
+  "inboxkitten.com",
+  "tmpmail.org",
+  "1secmail.com",
+  "1secmail.org",
+  "1secmail.net",
+  "vjuum.com",
+  "laafd.com",
+  "txcct.com",
+]);
+
+// Cache resolved domains so repeat submits and the two-phase validate/notify
+// round trips don't re-query DNS. Bounded so it can't grow without limit.
+const CACHE_TTL_MS = 10 * 60 * 1000;
+const CACHE_MAX = 2000;
+const cache = new Map<string, { status: EmailCheck; expires: number }>();
+
+function cacheGet(domain: string): EmailCheck | null {
+  const hit = cache.get(domain);
+  if (!hit) return null;
+  if (hit.expires < Date.now()) {
+    cache.delete(domain);
+    return null;
+  }
+  return hit.status;
+}
+
+function cacheSet(domain: string, status: EmailCheck): void {
+  if (cache.size >= CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(domain, { status, expires: Date.now() + CACHE_TTL_MS });
+}
+
+// ENOTFOUND/ENODATA are definitive "this record does not exist" answers; any
+// other DNS error (ETIMEOUT, ESERVFAIL, EREFUSED, …) is transient.
+function isNoSuchRecord(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | null)?.code;
+  return code === "ENOTFOUND" || code === "ENODATA";
+}
+
+// No MX record: RFC 5321 §5.1 treats the domain's A/AAAA address as an implicit
+// mail exchanger, so a domain with only an address record can still receive mail.
+async function hasAddressRecord(domain: string): Promise<EmailCheck> {
+  let transient = false;
+  try {
+    if ((await dns.resolve4(domain)).length > 0) return "ok";
+  } catch (err) {
+    if (!isNoSuchRecord(err)) transient = true;
+  }
+  try {
+    if ((await dns.resolve6(domain)).length > 0) return "ok";
+  } catch (err) {
+    if (!isNoSuchRecord(err)) transient = true;
+  }
+  return transient ? "unknown" : "invalid";
+}
+
+async function resolveDomain(domain: string): Promise<EmailCheck> {
+  try {
+    const mx = await dns.resolveMx(domain);
+    const usable = mx.filter((r) => r.exchange && r.exchange !== ".");
+    if (usable.length > 0) return "ok";
+    // Records exist but every one is a "null MX" (RFC 7505, exchange ".") — the
+    // domain is explicitly declaring it accepts no mail.
+    if (mx.length > 0) return "invalid";
+  } catch (err) {
+    // Transient resolver failure: fail open rather than reject a real address.
+    if (!isNoSuchRecord(err)) return "unknown";
+  }
+  return hasAddressRecord(domain);
+}
+
+/**
+ * Checks whether `email`'s domain can plausibly receive mail. Catches typos
+ * (`gmail.con`), nonexistent domains, null-MX domains, and known disposable
+ * providers, without proving inbox ownership. Returns `unknown` on transient
+ * DNS failures so callers can fail open.
+ */
+export async function checkEmailDeliverable(email: string): Promise<EmailCheck> {
+  const at = email.lastIndexOf("@");
+  if (at < 0) return "invalid";
+  const domain = email
+    .slice(at + 1)
+    .trim()
+    .toLowerCase()
+    .replace(/\.$/, "");
+  if (!domain || domain.includes("@")) return "invalid";
+  if (DISPOSABLE_EMAIL_DOMAINS.has(domain)) return "invalid";
+
+  const cached = cacheGet(domain);
+  if (cached) return cached;
+
+  const status = await resolveDomain(domain);
+  // Cache only stable answers; let `unknown` retry on the next submit.
+  if (status !== "unknown") cacheSet(domain, status);
+  return status;
+}

--- a/web/app/api/waitlist/email-check.ts
+++ b/web/app/api/waitlist/email-check.ts
@@ -88,21 +88,28 @@ function isNoSuchRecord(err: unknown): boolean {
   return code === "ENOTFOUND" || code === "ENODATA";
 }
 
+async function classifyAddress(
+  lookup: Promise<string[]>,
+): Promise<"ok" | "miss" | "transient"> {
+  try {
+    return (await lookup).length > 0 ? "ok" : "miss";
+  } catch (err) {
+    return isNoSuchRecord(err) ? "miss" : "transient";
+  }
+}
+
 // No MX record: RFC 5321 §5.1 treats the domain's A/AAAA address as an implicit
-// mail exchanger, so a domain with only an address record can still receive mail.
+// mail exchanger, so a domain with only an address record can still receive
+// mail. Run A and AAAA in parallel so this (rare, MX-less) fallback path never
+// pays two sequential lookups.
 async function hasAddressRecord(domain: string): Promise<EmailCheck> {
-  let transient = false;
-  try {
-    if ((await dns.resolve4(domain)).length > 0) return "ok";
-  } catch (err) {
-    if (!isNoSuchRecord(err)) transient = true;
-  }
-  try {
-    if ((await dns.resolve6(domain)).length > 0) return "ok";
-  } catch (err) {
-    if (!isNoSuchRecord(err)) transient = true;
-  }
-  return transient ? "unknown" : "invalid";
+  const [a, aaaa] = await Promise.all([
+    classifyAddress(dns.resolve4(domain)),
+    classifyAddress(dns.resolve6(domain)),
+  ]);
+  if (a === "ok" || aaaa === "ok") return "ok";
+  if (a === "transient" || aaaa === "transient") return "unknown";
+  return "invalid";
 }
 
 async function resolveDomain(domain: string): Promise<EmailCheck> {

--- a/web/app/api/waitlist/route.ts
+++ b/web/app/api/waitlist/route.ts
@@ -30,8 +30,10 @@ const waitlistSchema = z.object({
   location: z.string().trim().max(64).optional().default(""),
   // The client calls this route twice: first to validate the email before
   // recording the signup (`notify: false`), then to fan out the Slack ping
-  // after the durable PostHog capture succeeds (`notify: true`).
-  notify: z.boolean().optional().default(false),
+  // after the durable PostHog capture succeeds (`notify: true`). Defaults to
+  // `true` so a caller that omits the flag (e.g. a stale page bundle loaded
+  // before this change) keeps the original notify-on-valid behavior.
+  notify: z.boolean().optional().default(true),
 });
 
 /**

--- a/web/app/api/waitlist/route.ts
+++ b/web/app/api/waitlist/route.ts
@@ -48,21 +48,6 @@ export async function POST(request: Request) {
     "/api/waitlist",
     { "cmux.subsystem": "waitlist", "cmux.waitlist.operation": "notify" },
     async (span): Promise<Response> => {
-      // Reuse the feedback rate-limit rule so a public POST that fans out to
-      // Slack can't be used to flood the channel. Only active on Vercel.
-      if (process.env.VERCEL === "1") {
-        const { error, rateLimited } = await checkRateLimit(
-          env.CMUX_FEEDBACK_RATE_LIMIT_ID,
-          { request },
-        );
-        setSpanAttributes(span, {
-          "cmux.rate_limited": rateLimited || error === "blocked",
-        });
-        if (rateLimited || error === "blocked") {
-          return jsonError("Rate limit exceeded", 429);
-        }
-      }
-
       let payload: unknown;
       try {
         payload = await request.json();
@@ -94,6 +79,23 @@ export async function POST(request: Request) {
       // the post-record `notify` call fans out to Slack.
       if (!notify) {
         return ok({ valid: true, slack: "skipped" });
+      }
+
+      // Rate-limit the notify phase only (the one that posts to Slack) with the
+      // feedback rule, so a public POST can't flood the channel. The validate
+      // phase is deliberately un-throttled: it never touches Slack, and a
+      // rate-limit blip there would needlessly block a real signup.
+      if (process.env.VERCEL === "1") {
+        const { error, rateLimited } = await checkRateLimit(
+          env.CMUX_FEEDBACK_RATE_LIMIT_ID,
+          { request },
+        );
+        setSpanAttributes(span, {
+          "cmux.rate_limited": rateLimited || error === "blocked",
+        });
+        if (rateLimited || error === "blocked") {
+          return jsonError("Rate limit exceeded", 429);
+        }
       }
 
       const webhookUrl = env.SLACK_WAITLIST_WEBHOOK_URL;

--- a/web/app/api/waitlist/route.ts
+++ b/web/app/api/waitlist/route.ts
@@ -8,6 +8,7 @@ import {
   setSpanAttributes,
   withApiRouteSpan,
 } from "../../../services/telemetry";
+import { checkEmailDeliverable } from "./email-check";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -27,12 +28,19 @@ const waitlistSchema = z.object({
     .min(1)
     .max(WAITLIST_PLATFORMS.length),
   location: z.string().trim().max(64).optional().default(""),
+  // The client calls this route twice: first to validate the email before
+  // recording the signup (`notify: false`), then to fan out the Slack ping
+  // after the durable PostHog capture succeeds (`notify: true`).
+  notify: z.boolean().optional().default(false),
 });
 
 /**
- * Notifies Slack when someone joins a platform waitlist. The durable signup
- * record lives in PostHog (captured client-side); this route only fans out the
- * team notification, so a Slack failure does not invalidate the signup.
+ * Gates and announces waitlist signups. It (1) checks that the email's domain
+ * can plausibly receive mail (MX/disposable check) so bogus addresses never get
+ * recorded, and (2) when `notify` is set, pings Slack. The durable signup record
+ * itself lives in PostHog (captured client-side), so a Slack failure never
+ * invalidates the signup — but an undeliverable email is rejected before the
+ * client records it.
  */
 export async function POST(request: Request) {
   return withApiRouteSpan(
@@ -66,16 +74,32 @@ export async function POST(request: Request) {
       if (!parsed.success) {
         return jsonError("Invalid waitlist payload", 400);
       }
-      const { email, platforms, location } = parsed.data;
+      const { email, platforms, location, notify } = parsed.data;
       setSpanAttributes(span, {
         "cmux.waitlist.platform_count": platforms.length,
         "cmux.waitlist.location": location,
       });
 
+      // Reject addresses whose domain can't receive mail (typos, fake domains,
+      // disposable inboxes) before the client records the signup. Transient DNS
+      // failures resolve to "unknown" and fail open so a resolver hiccup never
+      // blocks a real signup.
+      const deliverable = await checkEmailDeliverable(email);
+      setSpanAttributes(span, { "cmux.waitlist.email_check": deliverable });
+      if (deliverable === "invalid") {
+        return ok({ valid: false });
+      }
+
+      // Email looks deliverable. The validate-only first phase stops here; only
+      // the post-record `notify` call fans out to Slack.
+      if (!notify) {
+        return ok({ valid: true, slack: "skipped" });
+      }
+
       const webhookUrl = env.SLACK_WAITLIST_WEBHOOK_URL;
       if (!webhookUrl) {
         // Not configured: accept so the client signup flow still succeeds.
-        return ok({ slack: "skipped" });
+        return ok({ valid: true, slack: "skipped" });
       }
 
       try {
@@ -105,7 +129,7 @@ export async function POST(request: Request) {
         return jsonError("Failed to notify Slack", 502);
       }
 
-      return ok({ slack: "sent" });
+      return ok({ valid: true, slack: "sent" });
     },
   );
 }

--- a/web/app/api/waitlist/route.ts
+++ b/web/app/api/waitlist/route.ts
@@ -48,6 +48,24 @@ export async function POST(request: Request) {
     "/api/waitlist",
     { "cmux.subsystem": "waitlist", "cmux.waitlist.operation": "notify" },
     async (span): Promise<Response> => {
+      // Rate-limit the whole public endpoint up front, before the DNS lookups
+      // below. The validate phase resolves a user-supplied domain (MX + A/AAAA),
+      // and unique domains miss the cache, so an unthrottled path would let a
+      // public POST flood the resolver as well as Slack. Reuses the feedback
+      // rule. Only active on Vercel.
+      if (process.env.VERCEL === "1") {
+        const { error, rateLimited } = await checkRateLimit(
+          env.CMUX_FEEDBACK_RATE_LIMIT_ID,
+          { request },
+        );
+        setSpanAttributes(span, {
+          "cmux.rate_limited": rateLimited || error === "blocked",
+        });
+        if (rateLimited || error === "blocked") {
+          return jsonError("Rate limit exceeded", 429);
+        }
+      }
+
       let payload: unknown;
       try {
         payload = await request.json();
@@ -79,23 +97,6 @@ export async function POST(request: Request) {
       // the post-record `notify` call fans out to Slack.
       if (!notify) {
         return ok({ valid: true, slack: "skipped" });
-      }
-
-      // Rate-limit the notify phase only (the one that posts to Slack) with the
-      // feedback rule, so a public POST can't flood the channel. The validate
-      // phase is deliberately un-throttled: it never touches Slack, and a
-      // rate-limit blip there would needlessly block a real signup.
-      if (process.env.VERCEL === "1") {
-        const { error, rateLimited } = await checkRateLimit(
-          env.CMUX_FEEDBACK_RATE_LIMIT_ID,
-          { request },
-        );
-        setSpanAttributes(span, {
-          "cmux.rate_limited": rateLimited || error === "blocked",
-        });
-        if (rateLimited || error === "blocked") {
-          return jsonError("Rate limit exceeded", 429);
-        }
       }
 
       const webhookUrl = env.SLACK_WAITLIST_WEBHOOK_URL;

--- a/web/tests/waitlist-email-check.test.ts
+++ b/web/tests/waitlist-email-check.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Controllable DNS responders; each test sets the behaviour it needs. Mocked
+// before importing the module under test so the import binds to these.
+let resolveMx: (
+  domain: string,
+) => Promise<{ exchange: string; priority: number }[]>;
+let resolve4: (domain: string) => Promise<string[]>;
+let resolve6: (domain: string) => Promise<string[]>;
+
+mock.module("node:dns", () => ({
+  promises: {
+    resolveMx: (d: string) => resolveMx(d),
+    resolve4: (d: string) => resolve4(d),
+    resolve6: (d: string) => resolve6(d),
+  },
+}));
+
+const { checkEmailDeliverable } = await import(
+  "../app/api/waitlist/email-check"
+);
+
+function dnsError(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+const noRecord = async (): Promise<never> => {
+  throw dnsError("ENOTFOUND");
+};
+
+describe("checkEmailDeliverable", () => {
+  test("accepts a domain with a usable MX record", async () => {
+    resolveMx = async () => [{ exchange: "mx.test", priority: 10 }];
+    resolve4 = noRecord;
+    resolve6 = noRecord;
+    expect(await checkEmailDeliverable("a@mx-ok.test")).toBe("ok");
+  });
+
+  test("rejects a domain with no MX and no address record", async () => {
+    resolveMx = noRecord;
+    resolve4 = noRecord;
+    resolve6 = noRecord;
+    expect(await checkEmailDeliverable("a@nope.test")).toBe("invalid");
+  });
+
+  test("falls back to an A record when there is no MX (RFC 5321)", async () => {
+    resolveMx = async () => {
+      throw dnsError("ENODATA");
+    };
+    resolve4 = async () => ["203.0.113.5"];
+    resolve6 = noRecord;
+    expect(await checkEmailDeliverable("a@a-only.test")).toBe("ok");
+  });
+
+  test("rejects an explicit null MX (RFC 7505)", async () => {
+    resolveMx = async () => [{ exchange: ".", priority: 0 }];
+    resolve4 = noRecord;
+    resolve6 = noRecord;
+    expect(await checkEmailDeliverable("a@null-mx.test")).toBe("invalid");
+  });
+
+  test("fails open (unknown) on a transient resolver error", async () => {
+    resolveMx = async () => {
+      throw dnsError("ETIMEOUT");
+    };
+    resolve4 = noRecord;
+    resolve6 = noRecord;
+    expect(await checkEmailDeliverable("a@flaky.test")).toBe("unknown");
+  });
+
+  test("rejects a known disposable domain without any DNS lookup", async () => {
+    const boom = async (): Promise<never> => {
+      throw new Error("DNS should not be queried for a disposable domain");
+    };
+    resolveMx = boom;
+    resolve4 = boom;
+    resolve6 = boom;
+    expect(await checkEmailDeliverable("a@mailinator.com")).toBe("invalid");
+  });
+
+  test("rejects malformed input with no @", async () => {
+    resolveMx = noRecord;
+    resolve4 = noRecord;
+    resolve6 = noRecord;
+    expect(await checkEmailDeliverable("not-an-email")).toBe("invalid");
+  });
+});

--- a/web/tests/waitlist-route.test.ts
+++ b/web/tests/waitlist-route.test.ts
@@ -1,0 +1,73 @@
+// Skip env validation so importing the route doesn't require server secrets.
+process.env.SKIP_ENV_VALIDATION = "1";
+
+import { describe, expect, mock, test } from "bun:test";
+
+function dnsError(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+// good.test has an MX; everything else has no records (undeliverable).
+mock.module("node:dns", () => ({
+  promises: {
+    resolveMx: async (domain: string) => {
+      if (domain === "good.test") {
+        return [{ exchange: "mx.good.test", priority: 10 }];
+      }
+      throw dnsError("ENOTFOUND");
+    },
+    resolve4: async () => {
+      throw dnsError("ENOTFOUND");
+    },
+    resolve6: async () => {
+      throw dnsError("ENOTFOUND");
+    },
+  },
+}));
+
+const { POST } = await import("../app/api/waitlist/route");
+
+function post(body: unknown): Request {
+  return new Request("https://cmux.test/api/waitlist", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("waitlist route", () => {
+  test("accepts a deliverable email in the validate phase", async () => {
+    const res = await POST(
+      post({ email: "a@good.test", platforms: ["linux"], notify: false }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      valid: true,
+      slack: "skipped",
+    });
+  });
+
+  test("rejects an undeliverable email without recording", async () => {
+    const res = await POST(
+      post({ email: "a@nope.test", platforms: ["linux"], notify: false }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, valid: false });
+  });
+
+  test("rejects a disposable email", async () => {
+    const res = await POST(
+      post({ email: "a@mailinator.com", platforms: ["windows"] }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, valid: false });
+  });
+
+  test("rejects a malformed payload with 400", async () => {
+    const res = await POST(post({ email: "not-an-email", platforms: [] }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/web/tests/waitlist-route.test.ts
+++ b/web/tests/waitlist-route.test.ts
@@ -1,7 +1,18 @@
 // Skip env validation so importing the route doesn't require server secrets.
+// Captured + restored in afterAll so the flag can't leak into other test files
+// sharing this process and silently suppress their env validation.
+const priorSkipEnvValidation = process.env.SKIP_ENV_VALIDATION;
 process.env.SKIP_ENV_VALIDATION = "1";
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+afterAll(() => {
+  if (priorSkipEnvValidation === undefined) {
+    delete process.env.SKIP_ENV_VALIDATION;
+  } else {
+    process.env.SKIP_ENV_VALIDATION = priorSkipEnvValidation;
+  }
+});
 
 function dnsError(code: string): NodeJS.ErrnoException {
   const err = new Error(code) as NodeJS.ErrnoException;


### PR DESCRIPTION
## What

Stops bogus emails from entering the waitlist. Previously the signup was recorded client-side straight to PostHog, so any syntactically-valid string (`gmail.con` typos, fake domains, throwaway inboxes) became a permanent signup with no reachability check.

Now the `/api/waitlist` route is the **gate**: the client validates the email there *before* recording, and only writes to PostHog when the domain can plausibly receive mail.

## How

- New `web/app/api/waitlist/email-check.ts` — `checkEmailDeliverable(email)`:
  - Resolves **MX** records; falls back to **A/AAAA** as an implicit mail exchanger (RFC 5321 §5.1).
  - Rejects explicit **null MX** (RFC 7505, `exchange "."`).
  - Blocks a small **curated disposable-domain list** (conservative: targets throwaway-inbox services, not privacy forwarders like passmail.com / duck.com that real users use).
  - **Fails open** (`unknown`) on transient DNS errors so a resolver hiccup never blocks a real signup.
  - In-memory cache (bounded, 10-min TTL) so repeat submits and the two-phase round trips don't re-query DNS.
- `route.ts` — validates first; returns `{ valid: false }` for undeliverable addresses (no Slack ping, no record). Slack notify is now opt-in via `notify: true`.
- `waitlist-dialog.tsx` — client calls the route to validate, shows the existing `invalidEmail` error on rejection, and records to PostHog only when valid. **Slack still pings only after the durable PostHog record succeeds** (`notify: true` second phase), preserving the invariant that the channel never reports a signup that did not persist.

## Why this design

This is a marketing waitlist, not an account system, so full Stack Auth / OTP verification would add friction that costs signups. MX + disposable filtering is free (Node `dns`, no vendor), invisible to honest users, and kills the obvious junk. It does not prove inbox ownership; a double opt-in (via the existing Resend integration) is the follow-up if provable ownership is ever needed.

## Tests

- `tests/waitlist-email-check.test.ts` — MX ok, no-records reject, A/AAAA fallback, null-MX reject, transient → fail-open, disposable reject, malformed input (mocks `node:dns`).
- `tests/waitlist-route.test.ts` — route returns `{valid:true}` for deliverable, `{valid:false}` for undeliverable/disposable, 400 for malformed.

11/11 pass locally; `tsc --noEmit` clean. No new localized strings (reuses `invalidEmail`, present in all 20 locales).

## Note

No Preview env change needed; the route's DNS check runs everywhere. Slack ping still requires the Production-only `SLACK_WAITLIST_WEBHOOK_URL` (unchanged).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784871184&installation_id=133855650&pr_number=6735&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6735&signature=da66d525066e349a02d59d1f9ea97dbb0da5db185b1e4fd757efdc8870443563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds user-supplied domain DNS lookups on a public route; mitigated by existing rate limits, caching, and fail-open on transient errors, but could still affect signup UX if DNS is slow or misclassified.
> 
> **Overview**
> Waitlist signups are **gated server-side** before PostHog capture: bogus domains no longer become permanent waitlist entries.
> 
> **`/api/waitlist`** now runs `checkEmailDeliverable` (new `email-check.ts`)—MX lookup with A/AAAA fallback, null-MX rejection, curated disposable blocklist, bounded DNS cache—and returns `{ valid: false }` for definitive rejects. Transient DNS errors **fail open**. A **`notify`** flag splits **validate-only** (`notify: false`) from **Slack** (`notify: true`, default for backward compatibility). Rate limiting applies **before** DNS so the public endpoint cannot flood the resolver.
> 
> **`waitlist-dialog`** calls the API to validate first (reuses `invalidEmail` on failure), records to PostHog only when valid, then best-effort Slack after a successful capture. The minimum submit spinner overlaps the validation round trip.
> 
> **Tests** cover deliverability edge cases and route validate/reject behavior (mocked `node:dns`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38664997e909a50993d609f98a5340b4bae906fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block undeliverable and disposable emails from the waitlist. Validation now happens server-side in `POST /api/waitlist` before PostHog or Slack; the endpoint is rate-limited up front to protect DNS and Slack.

- **New Features**
  - Added `checkEmailDeliverable(email)` (MX with parallel A/AAAA fallback, null‑MX reject, curated disposable list) with a bounded 10‑min cache; returns "unknown" on transient DNS errors to fail open.
  - Updated `POST /api/waitlist` to gate signups: returns `{ valid: false }` for undeliverable; on accept returns `{ valid: true, slack: "sent" | "skipped" }`. The `notify` flag now defaults to `true` for backward compatibility; the client sends `notify: false` to validate first, then `notify: true` after recording.
  - Updated `waitlist-dialog` to validate via the route, reuse the existing invalid email error, record to PostHog only when valid, then fire a best‑effort Slack notify.

<sup>Written for commit 38664997e909a50993d609f98a5340b4bae906fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DNS-based email deliverability validation before completing waitlist signup.
  * Introduced a two-step waitlist flow that captures signup separately from Slack notification.
* **Bug Fixes**
  * Undeliverable, disposable, or null-MX emails are rejected without recording.
  * DNS transient issues now fail open (treated as “unknown”) to avoid blocking valid users.
  * Slack notifications no longer block signups; missing Slack configuration results in a skipped notification.
* **Tests**
  * Added Bun test coverage for deliverability logic and waitlist route scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->