### PR TITLE
iOS: fix View as Text showing empty

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
@@ -21,6 +21,16 @@ struct TerminalTextSheetView: View {
     /// workspace has no terminal; the sheet then shows its empty state.
     let surfaceID: String?
 
+    /// The capture started by `openTextSheetFromMenu` the instant the menu item
+    /// was tapped, while the terminal surface was still fully window-attached.
+    /// Preferred over re-resolving from the registry inside `.task`: by the time
+    /// the sheet's `.task` runs the presenter's window/alpha may have dropped,
+    /// and the registry pick is visibility-scoped, so a late resolve could miss
+    /// the live surface and show the empty state. The sheet just awaits this.
+    /// Nil falls back to a fresh resolve so the path still works if the capture
+    /// was never armed.
+    let capture: Task<String?, Never>?
+
     @Environment(\.dismiss) private var dismiss
 
     /// Loaded once per presentation in `.task`; nil while the off-main surface
@@ -107,11 +117,20 @@ struct TerminalTextSheetView: View {
     }
 
     private func loadSnapshot() async {
-        guard let surfaceID else {
-            isLoading = false
-            return
+        // Prefer the capture armed at tap time (surface still fully on screen).
+        // Only fall back to a fresh resolve when no capture was provided, which
+        // re-resolves from the registry and can miss the live surface if the
+        // sheet's presentation dropped the presenter's window/alpha.
+        let fullText: String?
+        if let capture {
+            fullText = await capture.value
+        } else {
+            guard let surfaceID else {
+                isLoading = false
+                return
+            }
+            fullText = await GhosttySurfaceView.copyableTerminalText(surfaceID: surfaceID)
         }
-        let fullText = await GhosttySurfaceView.copyableTerminalText(surfaceID: surfaceID)
         // Cap off the main actor: the capture is bounded by the iOS surface's
         // scrollback-limit (~2MB, see applyiOSDefaults), but splitting and
         // rejoining even that much text is O(content) string work that would

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -56,6 +56,15 @@ struct WorkspaceDetailView: View {
     /// workspace selection changes underneath it (e.g. Mac-side sync) while
     /// the sheet is open; the sheet loads its snapshot once per presentation.
     @State private var textSheetSurfaceID: String?
+    /// The "View as Text" capture, kicked off the instant the menu item is
+    /// tapped — while the terminal surface is still fully window-attached and
+    /// visible — rather than from the sheet's own `.task`. Presenting a sheet
+    /// can briefly drop the presenter's window/alpha, and the registry pick is
+    /// visibility-scoped, so re-resolving the surface after presentation could
+    /// miss the one live surface and show the empty state. Resolving at tap time
+    /// captures the surface (and FIFO-orders its queued read) before any of that
+    /// can happen; the sheet just awaits the result.
+    @State private var textSheetCapture: Task<String?, Never>?
     /// Chat-mode toggle: when on (and a session exists) the detail renders
     /// the agent chat inline in place of the terminal. The toolbar button
     /// flips this; there is no cover and no Done button.
@@ -441,8 +450,8 @@ struct WorkspaceDetailView: View {
         .sheet(isPresented: $isFeedbackComposerPresented) {
             feedbackComposer
         }
-        .sheet(isPresented: $isTextSheetPresented) {
-            TerminalTextSheetView(surfaceID: textSheetSurfaceID)
+        .sheet(isPresented: $isTextSheetPresented, onDismiss: { textSheetCapture = nil }) {
+            TerminalTextSheetView(surfaceID: textSheetSurfaceID, capture: textSheetCapture)
         }
         .workspaceRenameDialog(
             isPresented: $isRenamePresented,
@@ -649,7 +658,16 @@ struct WorkspaceDetailView: View {
     /// Opens the "View as Text" sheet: the terminal's content as selectable
     /// plain text, because the render surface itself has no copy affordance.
     private func openTextSheetFromMenu() {
-        textSheetSurfaceID = selectedTerminal?.id.rawValue
+        let surfaceID = selectedTerminal?.id.rawValue
+        textSheetSurfaceID = surfaceID
+        // Resolve + read NOW, on the main actor, while the terminal surface is
+        // still fully on screen. `copyableTerminalText` does its visibility-scoped
+        // registry pick and FIFO-enqueues the off-main read synchronously before
+        // returning the awaitable, so the surface can never be filtered out by a
+        // window/alpha drop that the sheet's own presentation would cause.
+        textSheetCapture = surfaceID.map { id in
+            Task { await GhosttySurfaceView.copyableTerminalText(surfaceID: id) }
+        }
         isTextSheetPresented = true
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceRegistry.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceRegistry.swift
@@ -1,3 +1,5 @@
+import CmuxMobileDiagnostics
+import CmuxMobileTerminalKit
 import GhosttyKit
 import UIKit
 
@@ -85,23 +87,60 @@ extension GhosttySurfaceView {
         // sheet's honest empty state over silently copying that stale text.
         // If the same terminal is mounted in several scenes the contents are
         // identical, so the lowest-keyed visible match keeps the pick
-        // deterministic.
-        let matchingView = registeredSurfaceViews
+        // deterministic. The eligibility rule itself lives in
+        // `CopyableTerminalTextSelection` so it is host-testable without UIKit;
+        // this just maps the live registry onto that pure predicate.
+        //
+        // The resolve happens on the main actor at the call site (the menu tap),
+        // BEFORE the sheet finishes presenting, so the surface is still
+        // window-attached and visible when the predicate runs — a sheet
+        // presentation that briefly drops the presenter's window/alpha can no
+        // longer turn the live surface into a miss.
+        let orderedViews = registeredSurfaceViews
             .sorted { $0.key < $1.key }
             .compactMap(\.value.value)
-            .first { candidate in
-                candidate.hostSurfaceID == surfaceID && candidate.surface != nil
-                    && candidate.window != nil && !candidate.isHidden
-                    && candidate.alpha > 0.01
-            }
-        guard let surface = matchingView?.surface else { return nil }
+        let candidates = orderedViews.map { view in
+            CopyableTerminalTextSelection.Candidate(
+                hostSurfaceID: view.hostSurfaceID,
+                hasSurface: view.surface != nil,
+                hasWindow: view.window != nil,
+                isHidden: view.isHidden,
+                alpha: Double(view.alpha)
+            )
+        }
+        let chosen = CopyableTerminalTextSelection.chosenIndex(from: candidates, for: surfaceID)
+            .map { orderedViews[$0] }
+
+        #if DEBUG
+        let candidateSummary = candidates
+            .map { "[id=\($0.hostSurfaceID ?? "nil") surf=\($0.hasSurface) win=\($0.hasWindow) hidden=\($0.isHidden) a=\(String(format: "%.2f", $0.alpha))]" }
+            .joined(separator: " ")
+        MobileDebugLog.anchormux(
+            "viewAsText.pick want=\(surfaceID) count=\(candidates.count) chosen=\(chosen == nil ? "none" : "yes") \(candidateSummary)"
+        )
+        #endif
+
+        guard let surface = chosen?.surface else { return nil }
         let handle = CopyableTextSurfaceHandle(surface: surface)
         return await withCheckedContinuation { continuation in
             outputQueue.async {
-                // SCREEN = scrollback + all written rows. Fall back to the
-                // viewport-only read if the screen read fails outright.
-                let text = surfaceText(handle.surface, pointTag: GHOSTTY_POINT_SCREEN)
-                    ?? surfaceText(handle.surface, pointTag: GHOSTTY_POINT_VIEWPORT)
+                // SCREEN = scrollback + all written rows. `surfaceText` returns a
+                // non-nil empty string for a zero-byte range, so a plain `??`
+                // never fell back when SCREEN read empty-but-ok. Route both reads
+                // through the pure decision so a nil OR empty SCREEN still tries
+                // VIEWPORT before the sheet gives up.
+                let screen = surfaceText(handle.surface, pointTag: GHOSTTY_POINT_SCREEN)
+                let viewport = surfaceText(handle.surface, pointTag: GHOSTTY_POINT_VIEWPORT)
+                let text = CopyableTerminalTextSelection.resolvedText(screen: screen, viewport: viewport)
+                #if DEBUG
+                func describe(_ value: String?) -> String {
+                    guard let value else { return "nil" }
+                    return value.isEmpty ? "empty" : "\(value.count)chars"
+                }
+                MobileDebugLog.anchormux(
+                    "viewAsText.read screen=\(describe(screen)) viewport=\(describe(viewport)) resolved=\(describe(text))"
+                )
+                #endif
                 continuation.resume(returning: text)
             }
         }

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/CopyableTerminalTextSelection.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/CopyableTerminalTextSelection.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Pure selection + fallback logic for the iOS "View as Text" capture, split
+/// out of `GhosttySurfaceRegistry` so the two decisions that actually decide
+/// whether the sheet shows text or its empty state are host-testable without
+/// libghostty, UIKit, or a live surface.
+///
+/// Two things were silently making the sheet show "No terminal text available"
+/// even with visible output:
+///
+/// 1. The candidate predicate is id-scoped AND visibility-scoped. If the chosen
+///    surface is re-resolved from the registry *after* the sheet has begun
+///    presenting, a transient `window == nil` / `isHidden` / `alpha` drop on the
+///    presenter can exclude the one live surface, yielding nil. The fix moves the
+///    resolve to tap time (see `GhosttySurfaceRegistry`), but the predicate is
+///    still the single source of truth and is unit-tested here.
+/// 2. `surfaceText` returns a non-nil empty string when the range has zero bytes,
+///    so `screen ?? viewport` never fell back when SCREEN read empty-but-ok. The
+///    `resolvedText` decision below treats nil OR empty SCREEN as "try VIEWPORT".
+public enum CopyableTerminalTextSelection {
+    /// Inputs describing a registered surface view for the eligibility decision.
+    /// Mirrors the runtime fields read off `GhosttySurfaceView` (`hostSurfaceID`,
+    /// `surface != nil`, `window != nil`, `isHidden`, `alpha`) as plain values so
+    /// the rule is testable without a UIKit view.
+    public struct Candidate: Equatable, Sendable {
+        public let hostSurfaceID: String?
+        public let hasSurface: Bool
+        public let hasWindow: Bool
+        public let isHidden: Bool
+        public let alpha: Double
+
+        public init(
+            hostSurfaceID: String?,
+            hasSurface: Bool,
+            hasWindow: Bool,
+            isHidden: Bool,
+            alpha: Double
+        ) {
+            self.hostSurfaceID = hostSurfaceID
+            self.hasSurface = hasSurface
+            self.hasWindow = hasWindow
+            self.isHidden = isHidden
+            self.alpha = alpha
+        }
+    }
+
+    /// Whether `candidate` is the live, on-screen surface for `surfaceID` and so
+    /// may back the "View as Text" capture.
+    ///
+    /// The id scoping keeps a second visible surface (another iPad scene, an
+    /// in-flight transition) from leaking a different workspace's terminal into
+    /// the capture; `hasSurface` keeps a dismantling view (registry-resident with
+    /// a non-nil pointer until its queued dispose runs) from contributing stale
+    /// text; the window/hidden/alpha gates keep an off-screen surface out.
+    public static func isEligible(_ candidate: Candidate, for surfaceID: String) -> Bool {
+        candidate.hostSurfaceID == surfaceID
+            && candidate.hasSurface
+            && candidate.hasWindow
+            && !candidate.isHidden
+            && candidate.alpha > 0.01
+    }
+
+    /// The deterministic pick from the registered candidates: the lowest-keyed
+    /// eligible match. When the same terminal is mounted in several scenes the
+    /// contents are identical, so the lowest-keyed visible match keeps the pick
+    /// stable. `candidates` must be supplied lowest-key-first.
+    ///
+    /// - Returns: The index of the chosen candidate in `candidates`, or nil when
+    ///   none is eligible.
+    public static func chosenIndex(
+        from candidates: [Candidate],
+        for surfaceID: String
+    ) -> Int? {
+        candidates.firstIndex { isEligible($0, for: surfaceID) }
+    }
+
+    /// The text the sheet should show given the SCREEN and VIEWPORT reads.
+    ///
+    /// `surfaceText` returns nil on a failed read and a non-nil empty string for
+    /// a zero-byte range, so a plain `screen ?? viewport` never fell back when
+    /// SCREEN read empty-but-ok. Here a SCREEN result that is nil OR empty falls
+    /// through to VIEWPORT, and only a VIEWPORT result that is also nil/empty
+    /// yields nil (the honest empty state).
+    ///
+    /// - Parameters:
+    ///   - screen: The SCREEN (scrollback + all rows) read, nil on failure.
+    ///   - viewport: The VIEWPORT (visible rows) read, nil on failure.
+    /// - Returns: The non-empty text to show, or nil when neither has content.
+    public static func resolvedText(screen: String?, viewport: String?) -> String? {
+        if let screen, !screen.isEmpty { return screen }
+        if let viewport, !viewport.isEmpty { return viewport }
+        return nil
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/CopyableTerminalTextSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/CopyableTerminalTextSelectionTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import CmuxMobileTerminalKit
+
+@Suite("CopyableTerminalTextSelection: View as Text pick + fallback")
+struct CopyableTerminalTextSelectionTests {
+    typealias Candidate = CopyableTerminalTextSelection.Candidate
+
+    private func visible(_ id: String?) -> Candidate {
+        Candidate(hostSurfaceID: id, hasSurface: true, hasWindow: true, isHidden: false, alpha: 1)
+    }
+
+    @Test("id-scoped, on-screen surface is eligible")
+    func eligibleMatch() {
+        #expect(CopyableTerminalTextSelection.isEligible(visible("surface:1"), for: "surface:1"))
+    }
+
+    @Test("a different id is never eligible")
+    func excludedByID() {
+        #expect(!CopyableTerminalTextSelection.isEligible(visible("surface:2"), for: "surface:1"))
+        #expect(!CopyableTerminalTextSelection.isEligible(visible(nil), for: "surface:1"))
+    }
+
+    @Test("a dismantling view with no surface is excluded")
+    func excludedWhenNoSurface() {
+        let dismantling = Candidate(
+            hostSurfaceID: "surface:1", hasSurface: false, hasWindow: true, isHidden: false, alpha: 1
+        )
+        #expect(!CopyableTerminalTextSelection.isEligible(dismantling, for: "surface:1"))
+    }
+
+    @Test("off-window / hidden / transparent surfaces are excluded")
+    func excludedWhenOffScreen() {
+        let detached = Candidate(
+            hostSurfaceID: "surface:1", hasSurface: true, hasWindow: false, isHidden: false, alpha: 1
+        )
+        let hidden = Candidate(
+            hostSurfaceID: "surface:1", hasSurface: true, hasWindow: true, isHidden: true, alpha: 1
+        )
+        let transparent = Candidate(
+            hostSurfaceID: "surface:1", hasSurface: true, hasWindow: true, isHidden: false, alpha: 0
+        )
+        #expect(!CopyableTerminalTextSelection.isEligible(detached, for: "surface:1"))
+        #expect(!CopyableTerminalTextSelection.isEligible(hidden, for: "surface:1"))
+        #expect(!CopyableTerminalTextSelection.isEligible(transparent, for: "surface:1"))
+    }
+
+    @Test("chosenIndex returns the first (lowest-keyed) eligible match")
+    func chosenIndexDeterministic() {
+        let candidates = [
+            visible("surface:2"),       // wrong id
+            visible("surface:1"),       // first eligible
+            visible("surface:1"),       // also eligible, but later
+        ]
+        #expect(CopyableTerminalTextSelection.chosenIndex(from: candidates, for: "surface:1") == 1)
+    }
+
+    @Test("chosenIndex is nil when nothing is eligible")
+    func chosenIndexNone() {
+        let candidates = [visible("surface:2"), visible(nil)]
+        #expect(CopyableTerminalTextSelection.chosenIndex(from: candidates, for: "surface:1") == nil)
+    }
+
+    @Test("non-empty SCREEN wins")
+    func screenWins() {
+        #expect(
+            CopyableTerminalTextSelection.resolvedText(screen: "scrollback", viewport: "visible")
+                == "scrollback"
+        )
+    }
+
+    @Test("empty-string SCREEN falls back to VIEWPORT")
+    func emptyScreenFallsBackToViewport() {
+        // The exact reported bug: SCREEN read OK but zero-byte (non-nil ""), so a
+        // plain `screen ?? viewport` would keep the empty string and the sheet
+        // showed its empty state even though the viewport had content.
+        #expect(
+            CopyableTerminalTextSelection.resolvedText(screen: "", viewport: "visible text")
+                == "visible text"
+        )
+    }
+
+    @Test("nil SCREEN falls back to VIEWPORT")
+    func nilScreenFallsBackToViewport() {
+        #expect(
+            CopyableTerminalTextSelection.resolvedText(screen: nil, viewport: "visible text")
+                == "visible text"
+        )
+    }
+
+    @Test("both empty/nil yields nil (honest empty state)")
+    func bothEmptyYieldsNil() {
+        #expect(CopyableTerminalTextSelection.resolvedText(screen: "", viewport: "") == nil)
+        #expect(CopyableTerminalTextSelection.resolvedText(screen: nil, viewport: nil) == nil)
+        #expect(CopyableTerminalTextSelection.resolvedText(screen: "", viewport: nil) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

On the iPhone, "View as Text" showed the empty state "No terminal text available" even when the terminal clearly had visible output. Two causes:

1. The capture's registry pick is visibility-scoped (it requires the surface to be window-attached, not hidden, and opaque). It ran from the sheet's own `.task`, i.e. after the sheet had begun presenting. Presenting a sheet can transiently drop the presenter's window/alpha, so the one live surface could be filtered out and the read returned nil. The resolve now happens in `openTextSheetFromMenu`, at tap time, while the terminal surface is still fully on screen. `copyableTerminalText` does its visibility-scoped pick and FIFO-enqueues the off-main read synchronously before returning the awaitable, so the surface can no longer be filtered out by a presentation-induced window/alpha drop. The sheet just awaits that capture.

2. `surfaceText` returns a non-nil empty string (`""`) for a zero-byte range, not nil. So `surfaceText(SCREEN) ?? surfaceText(VIEWPORT)` never fell back when the SCREEN read succeeded but came back empty. The new `resolvedText` treats a nil OR empty SCREEN as "try VIEWPORT", and only yields nil when neither has content.

Both decisions are extracted into `CopyableTerminalTextSelection` (pure, no UIKit/GhosttyKit) so the candidate predicate and the SCREEN-vs-viewport fallback are unit-testable. A concise DEBUG-only `anchormux` diagnostic records the requested id, every candidate's state (id / surface / window / hidden / alpha), and the SCREEN/VIEWPORT read outcomes, so the path is self-explaining in the dogfood log.

No new user-facing strings, so no localization changes.

## Testing

- `swift test` on `CmuxMobileTerminalKit` (host build): 103 tests pass, including the new `CopyableTerminalTextSelection` suite covering id-scoped match, excluded-when-no-surface, off-screen exclusion, deterministic lowest-keyed pick, and empty-SCREEN-falls-back-to-viewport.
- `xcodebuild build` for iOS Simulator on both `CmuxMobileTerminal` and `CmuxMobileShellUI`: BUILD SUCCEEDED.
- Not yet dogfooded on a real device; needs a live "View as Text" tap on a phone with terminal output.

## Issues

Plain-text bug (no GitHub issue): iPhone "View as Text" showed "No terminal text available" even when the terminal had visible output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784873877&installation_id=133855650&pr_number=6736&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6736&signature=085197bc3ddc703affa8182500872ea42a7df8f3095f955e7fb6a0a5e08200b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized iOS copy-sheet bugfix with preserved fallback path; no auth, networking, or data-model changes.
> 
> **Overview**
> Fixes iPhone **View as Text** incorrectly showing *No terminal text available* when the terminal clearly had visible output.
> 
> **Timing:** Terminal text capture now starts in `openTextSheetFromMenu` at menu tap (while the surface is still window-attached), and the sheet awaits that pre-started `Task` instead of calling `copyableTerminalText` from `.task` after presentation. Sheet presentation can briefly drop the presenter’s window/alpha; the visibility-scoped registry pick used to run too late and filter out the live surface.
> 
> **Read fallback:** SCREEN reads that succeed with `""` no longer block VIEWPORT fallback (`screen ?? viewport` treated empty SCREEN as success). `CopyableTerminalTextSelection.resolvedText` treats nil or empty SCREEN as “try VIEWPORT.”
> 
> **Testability:** Surface eligibility and SCREEN/VIEWPORT resolution move into pure `CopyableTerminalTextSelection` in `CmuxMobileTerminalKit`, wired from `GhosttySurfaceRegistry`, with unit tests. DEBUG `anchormux` logs record pick candidates and read outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23d3fea66124ca1e2b8b5bb9d9db5cbccbb0ae25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iPhone “View as Text” showing empty when the terminal has visible output. The capture now starts at tap time and empty SCREEN reads fall back to VIEWPORT, so text reliably loads.

- **Bug Fixes**
  - Start the capture in `openTextSheetFromMenu` and pass it to `TerminalTextSheetView`; avoids losing the visibility-scoped pick during sheet presentation.
  - Fall back when SCREEN is nil or empty using `CopyableTerminalTextSelection.resolvedText`; only show empty when both SCREEN and VIEWPORT have no content.

- **Refactors**
  - Extracted pick/fallback logic to `CopyableTerminalTextSelection` in `CmuxMobileTerminalKit` with unit tests; integrated into `GhosttySurfaceView` in `CmuxMobileTerminal`.
  - Added DEBUG `anchormux` logs for candidate states and read outcomes.

<sup>Written for commit 23d3fea66124ca1e2b8b5bb9d9db5cbccbb0ae25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “View as Text” now captures terminal text at the moment you tap it, helping preserve the text you intended to view.
  * The text sheet now shows a more reliable snapshot when the live terminal changes or disappears.

* **Bug Fixes**
  * Improved text selection so the app can fall back to a visible viewport capture when the main screen capture is empty.
  * Better handling of which terminal window is used for text capture, reducing missed or blank results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->