### PR TITLE
Coalesce duplicate iOS paired Macs

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CmxAttachTicket+ConstrainingRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/CmxAttachTicket+ConstrainingRoutes.swift
@@ -1,0 +1,23 @@
+internal import CMUXMobileCore
+
+extension CmxAttachTicket {
+    func constrainingRoutes(
+        to routes: [CmxAttachRoute],
+        fallbackDisplayName: String
+    ) throws -> CmxAttachTicket {
+        try CmxAttachTicket(
+            workspaceID: workspaceID,
+            terminalID: terminalID,
+            macDeviceID: macDeviceID,
+            macDisplayName: macDisplayName ?? fallbackDisplayName,
+            macUserEmail: macUserEmail,
+            macUserID: macUserID,
+            macPairingCompatibilityVersion: macPairingCompatibilityVersion,
+            macAppVersion: macAppVersion,
+            macAppBuild: macAppBuild,
+            routes: routes,
+            expiresAt: expiresAt,
+            authToken: authToken
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileManualAttachTicketCreateResponse.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileManualAttachTicketCreateResponse.swift
@@ -1,0 +1,12 @@
+internal import CMUXMobileCore
+internal import Foundation
+
+struct MobileManualAttachTicketCreateResponse: Decodable, Sendable {
+    var ticket: CmxAttachTicket
+
+    static func decode(_ data: Data) throws -> MobileManualAttachTicketCreateResponse {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(MobileManualAttachTicketCreateResponse.self, from: data)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Helpers.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Helpers.swift
@@ -1,0 +1,41 @@
+internal import CMUXMobileCore
+internal import CmuxMobileShellModel
+internal import Foundation
+
+extension MobileShellComposite {
+    static func normalizedPairingURL(_ rawValue: String) -> String {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard CmxPairingURLScheme.hasPairingScheme(trimmed) else {
+            return trimmed
+        }
+        let scalars = trimmed.unicodeScalars.filter {
+            !CharacterSet.whitespacesAndNewlines.contains($0)
+        }
+        return String(String.UnicodeScalarView(scalars))
+    }
+
+    static func diagnosticSurfaceHandle(_ surfaceID: String) -> UInt32 {
+        var hash: UInt32 = 2_166_136_261
+        for byte in surfaceID.utf8 {
+            hash = (hash ^ UInt32(byte)) &* 16_777_619
+        }
+        return hash
+    }
+
+    static func workspaceActionCapabilities(
+        from supportedHostCapabilities: Set<String>
+    ) -> MobileWorkspaceActionCapabilities {
+        MobileWorkspaceActionCapabilities(
+            supportsWorkspaceActions: supportedHostCapabilities.contains("workspace.actions.v1"),
+            supportsReadStateActions: supportedHostCapabilities.contains("workspace.read_state.v1"),
+            supportsCloseActions: supportedHostCapabilities.contains("workspace.close.v1")
+        )
+    }
+
+    static func routeSortsBefore(_ left: CmxAttachRoute, _ right: CmxAttachRoute) -> Bool {
+        if left.priority == right.priority {
+            return left.id < right.id
+        }
+        return left.priority < right.priority
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacAliases.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacAliases.swift
@@ -1,0 +1,56 @@
+public import CmuxMobilePairedMac
+internal import CmuxMobileShellModel
+internal import Foundation
+
+extension MobileShellComposite {
+    /// Presentation-only duplicate collapse for the Computers screen.
+    public var displayPairedMacs: [MobilePairedMac] {
+        Self.coalescePairedMacsByDialEndpoint(
+            pairedMacs,
+            supportedKinds: runtime?.supportedRouteKinds ?? [],
+            preferNonLoopback: Self.prefersNonLoopbackRoutes
+        )
+    }
+
+    /// Stored ids represented by a visible paired-Mac row.
+    public func pairedMacAliasIDs(for macDeviceID: String) -> [String] {
+        pairedMacAliasIDsByRepresentativeID[macDeviceID] ?? [macDeviceID]
+    }
+
+    /// Presence rollup across every stored id represented by a visible paired-Mac row.
+    public func presenceSummary(for macDeviceID: String) -> PresenceMap.DeviceSummary? {
+        let summaries = pairedMacAliasIDs(for: macDeviceID).compactMap {
+            presenceMap.deviceSummary(deviceId: $0)
+        }
+        guard !summaries.isEmpty else { return nil }
+        let online = summaries.contains(where: \.online)
+        let freshest = summaries.max { $0.lastSeenAt < $1.lastSeenAt }
+        let label = summaries.first { $0.online && $0.buildLabel != nil }?.buildLabel
+            ?? freshest?.buildLabel
+        return PresenceMap.DeviceSummary(
+            online: online,
+            lastSeenAt: freshest?.lastSeenAt ?? Date(timeIntervalSince1970: 0),
+            buildLabel: label
+        )
+    }
+
+    /// Workspace count across every stored id represented by a visible paired-Mac row.
+    public func workspaceCount(for macDeviceID: String) -> Int {
+        let aliases = Set(pairedMacAliasIDs(for: macDeviceID))
+        return workspaces.filter { workspace in
+            guard let macDeviceID = workspace.macDeviceID else { return false }
+            return aliases.contains(macDeviceID)
+        }.count
+    }
+
+    /// User customization for every stored id represented by visible paired-Mac rows.
+    func pairedMacCustomizationsByAliasID() -> [String: MobilePairedMac] {
+        displayPairedMacs.reduce(into: [String: MobilePairedMac]()) { result, mac in
+            guard mac.customColor != nil || mac.customIcon != nil else { return }
+            for aliasID in pairedMacAliasIDs(for: mac.macDeviceID) {
+                result[aliasID] = mac
+            }
+        }
+    }
+
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
@@ -1,0 +1,107 @@
+internal import CMUXMobileCore
+internal import CmuxMobilePairedMac
+internal import CmuxMobileShellModel
+
+extension MobileShellComposite {
+    /// Collapse duplicate paired-Mac rows that have the same Mac-reported name
+    /// and dial the same host/port.
+    ///
+    /// A device can accumulate multiple Mac device ids for the same physical host
+    /// across debug/reload/pairing paths. The user's Computers screen is a list
+    /// of reachable computers, but a dial endpoint alone is not a durable
+    /// identity. Require the Mac-reported display name as the second signal
+    /// before treating rows as one logical computer. Prefer the active row, then
+    /// the freshest route record.
+    static func coalescePairedMacsByDialEndpoint(
+        _ macs: [MobilePairedMac],
+        supportedKinds: [CmxAttachTransportKind],
+        preferNonLoopback: Bool
+    ) -> [MobilePairedMac] {
+        var selectedByKey: [String: MobilePairedMac] = [:]
+        var orderByKey: [String: Int] = [:]
+
+        for (index, mac) in macs.enumerated() {
+            let key = mac.dialEndpointKey(
+                supportedKinds: supportedKinds,
+                preferNonLoopback: preferNonLoopback
+            ) ?? "device:\(mac.macDeviceID)"
+            orderByKey[key] = min(orderByKey[key] ?? index, index)
+            guard let existing = selectedByKey[key] else {
+                selectedByKey[key] = mac
+                continue
+            }
+            if mac.sortsBeforeDuplicate(existing) {
+                selectedByKey[key] = mac.mergingCustomization(from: existing)
+            } else {
+                selectedByKey[key] = existing.mergingCustomization(from: mac)
+            }
+        }
+
+        return selectedByKey
+            .sorted { lhs, rhs in
+                (orderByKey[lhs.key] ?? .max) < (orderByKey[rhs.key] ?? .max)
+            }
+            .map(\.value)
+    }
+
+    static func macDeviceIDsForLogicalPairedMac(
+        _ macDeviceID: String,
+        in macs: [MobilePairedMac],
+        supportedKinds: [CmxAttachTransportKind],
+        preferNonLoopback: Bool
+    ) -> [String] {
+        guard let target = macs.first(where: { $0.macDeviceID == macDeviceID }),
+              let key = target.dialEndpointKey(supportedKinds: supportedKinds, preferNonLoopback: preferNonLoopback) else {
+            return [macDeviceID]
+        }
+        let matching = macs.filter {
+            $0.dialEndpointKey(supportedKinds: supportedKinds, preferNonLoopback: preferNonLoopback) == key
+        }.map(\.macDeviceID)
+        return matching.isEmpty ? [macDeviceID] : matching
+    }
+}
+
+private extension MobilePairedMac {
+    @MainActor
+    func dialEndpointKey(
+        supportedKinds: [CmxAttachTransportKind],
+        preferNonLoopback: Bool
+    ) -> String? {
+        guard let displayName = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !displayName.isEmpty else {
+            return nil
+        }
+        guard let (host, port) = MobileShellComposite.firstReconnectHostPortRoute(
+            routes,
+            supportedKinds: supportedKinds,
+            preferNonLoopback: preferNonLoopback
+        ), let normalizedHost = MobileShellRouteAuthPolicy.normalizedManualHost(host) else {
+            return nil
+        }
+        return "host:\(normalizedHost.lowercased()):\(port):name:\(displayName.lowercased())"
+    }
+
+    func mergingCustomization(from other: MobilePairedMac) -> MobilePairedMac {
+        var merged = self
+        if merged.customName?.isEmpty ?? true {
+            merged.customName = other.customName
+        }
+        if merged.customColor?.isEmpty ?? true {
+            merged.customColor = other.customColor
+        }
+        if merged.customIcon?.isEmpty ?? true {
+            merged.customIcon = other.customIcon
+        }
+        return merged
+    }
+
+    func sortsBeforeDuplicate(_ other: MobilePairedMac) -> Bool {
+        if isActive != other.isActive {
+            return isActive
+        }
+        if lastSeenAt != other.lastSeenAt {
+            return lastSeenAt > other.lastSeenAt
+        }
+        return macDeviceID < other.macDeviceID
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -231,18 +231,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         workspaceAggregation.machineColorIndex(statesByMac: workspacesByMac)
     }
 
-    /// The PHONE'S OWN live connection status to each Mac (foreground or live
-    /// secondary subscription), keyed by `macDeviceID`. This is the source of
-    /// truth for "is the phone talking to this Mac right now" — distinct from
-    /// presence (the Mac's heartbeat to the Durable Object), which says whether the
-    /// Mac is online but not whether THIS phone can reach it. The Computers screen
-    /// drives its connection dot from this and shows presence separately, so a
-    /// mismatch (Mac online via presence, but phone not connected) is a visible
-    /// route/tailscale signal. Updates reactively as subscriptions connect/drop.
     public var macConnectionStatuses: [String: MobileMacConnectionStatus] {
-        var result: [String: MobileMacConnectionStatus] = [:]
-        for (macID, state) in workspacesByMac where !macID.isEmpty {
-            result[macID] = state.status
+        var result = workspacesByMac.reduce(into: [String: MobileMacConnectionStatus]()) { statuses, entry in
+            if !entry.key.isEmpty { statuses[entry.key] = entry.value.status }
+        }
+        for (representativeID, aliases) in pairedMacAliasIDsByRepresentativeID {
+            let aliasStatuses = aliases.compactMap { result[$0] }
+            if aliasStatuses.contains(.connected) {
+                result[representativeID] = .connected
+            } else if aliasStatuses.contains(.reconnecting) {
+                result[representativeID] = .reconnecting
+            } else if aliasStatuses.contains(.unavailable) {
+                result[representativeID] = .unavailable
+            }
         }
         return result
     }
@@ -608,6 +609,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Tail of the serialized paired-Mac store write chain; see
     /// ``performSerializedPairedMacWrite(ifStillCurrent:_:)``.
     private var pairedMacWriteChain: Task<Void, Never>?
+    private var pushedRouteSyncTask: Task<Void, Never>?
     /// The in-flight `mobile.events.subscribe` (reason `start`) ack for the
     /// current listener generation. It runs concurrently with the consumer
     /// loop (the ack is a server-side enable handshake, not a delivery
@@ -978,6 +980,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         activeRoute = nil
         // Drop the cached paired Macs so the next signed-in user never sees the
         // previous user's hosts in the switcher.
+        storedPairedMacs = []
+        pairedMacAliasIDsByRepresentativeID = [:]
         pairedMacs = []
         // Likewise drop the registry-backed device tree so a shared device never
         // shows the previous user's team devices after sign-out.
@@ -1087,6 +1091,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // loadRegistryDevices() (DeviceTreeView `.task`) repopulate scoped to the
         // new team. The foreground workspace list (derived from the kept entry) is
         // unaffected.
+        storedPairedMacs = []
+        pairedMacAliasIDsByRepresentativeID = [:]
         pairedMacs = []
         registryDevices = []
     }
@@ -1737,6 +1743,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
+    /// Full store rows for identity-sensitive paths; ``pairedMacs`` is display-coalesced.
+    private var storedPairedMacs: [MobilePairedMac] = []
+    /// Visible representative id to all stored ids for that logical paired Mac.
+    public private(set) var pairedMacAliasIDsByRepresentativeID: [String: [String]] = [:]
+
+    private var pairedMacsForIdentityMatching: [MobilePairedMac] {
+        storedPairedMacs.isEmpty ? pairedMacs : storedPairedMacs
+    }
     // MARK: - Device registry tree
 
     /// The team's registered devices and their cmux app instances (tags), for the
@@ -1955,7 +1969,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
-    private func applyPresenceUpdate(_ update: PresenceUpdate, scope: MobileShellScopeSnapshot) {
+    func applyPresenceUpdate(_ update: PresenceUpdate, scope: MobileShellScopeSnapshot) {
         presenceMap.apply(update)
         switch update {
         case .routes(let instance), .online(let instance):
@@ -1973,6 +1987,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         case .offline, .seen:
             break
         }
+    }
+
+    func waitForPushedRouteSyncForTesting() async {
+        await pushedRouteSyncTask?.value
     }
 
     /// Write presence-pushed attach routes through to the local paired-Mac
@@ -2006,13 +2024,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // pairedMacStore upserts and could each kick a reconnect. The chain
         // appends synchronously on the main actor, so deliveries execute
         // strictly in arrival order.
-        Task { @MainActor [weak self] in
+        let task = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.performSerializedPairedMacWrite(ifStillCurrent: nil) {
                 [weak self] in
                 guard let self else { return }
                 guard await self.isScopeCurrent(scope) else { return }
-                if self.pairedMacs.isEmpty {
+                if self.pairedMacsForIdentityMatching.isEmpty {
                     // A presence frame can land before the first paired-Mac
                     // load (snapshot arrives fast on launch); resolve the
                     // pairing list before deciding these devices are unknown.
@@ -2033,13 +2051,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 // ambiguity guard the stored last-known-good routes are
                 // deliberately kept and the reconnect uses those, the same
                 // outcome a manual Retry would have.
+                let knownMacs = self.pairedMacsForIdentityMatching
                 if self.connectionState != .connected,
                    let activeMacID = self.pairedMacs.first(where: { $0.isActive })?.macDeviceID,
-                   onlineDeviceIds.contains(activeMacID) {
+                   !onlineDeviceIds.isDisjoint(with: Self.macDeviceIDsForLogicalPairedMac(
+                        activeMacID,
+                        in: knownMacs,
+                        supportedKinds: self.runtime?.supportedRouteKinds ?? [],
+                        preferNonLoopback: Self.prefersNonLoopbackRoutes
+                   )) {
                     self.recoverMobileConnection(trigger: .presencePush)
                 }
             }
         }
+        pushedRouteSyncTask = task
     }
 
     /// Per-instance store/registry write-through for the batch sync above.
@@ -2049,7 +2074,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard let routes = instance.routes else { return }
         guard await isScopeCurrent(scope) else { return }
         let deviceId = instance.deviceId
-        guard let mac = pairedMacs.first(where: { $0.macDeviceID == deviceId }) else {
+        let knownMacs = pairedMacsForIdentityMatching
+        guard knownMacs.contains(where: { $0.macDeviceID == deviceId }) else {
             return
         }
         // Mirror the in-memory registry tree's Connect affordances first, so
@@ -2061,27 +2087,22 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                .firstIndex(where: { $0.tag == instance.tag }) {
             registryDevices[deviceIndex].instances[instanceIndex].routes = routes
         }
-        // The paired-Mac store keeps last-known-good reconnect routes, so only
-        // a non-empty push updates it (same merge the registry refresh uses).
-        // The store is device-level (no tag), so substitution must also stay
-        // unambiguous: persist only when this device has exactly one online
-        // route-advertising instance and it is the one that pushed, mirroring
-        // the registry refresh's multi-instance guard. With a stable build and
-        // a tagged debug build both live, keep the locally persisted routes
-        // rather than risk reconnecting the phone to the wrong build's
-        // workspaces.
+        // The paired-Mac store keeps last-known-good reconnect routes. The store
+        // is device-level (no tag), so substitution must stay unambiguous and
+        // scoped to the stored id that emitted the presence frame.
         guard !routes.isEmpty,
               let sole = presenceMap.soleRouteAdvertisingInstance(deviceId: deviceId),
               sole.tag == instance.tag,
-              let pairedMacStore,
-              await isScopeCurrent(scope),
+              let mac = knownMacs.first(where: { $0.macDeviceID == deviceId }),
               let updated = DeviceRegistryService.selectReconnectRoutes(
-                  local: mac.routes,
-                  registry: routes
-              ) else { return }
+                local: mac.routes,
+                registry: routes
+              ),
+              let pairedMacStore,
+              await isScopeCurrent(scope) else { return }
         do {
             try await pairedMacStore.upsert(
-                macDeviceID: deviceId,
+                macDeviceID: mac.macDeviceID,
                 displayName: mac.displayName,
                 routes: updated,
                 markActive: mac.isActive,
@@ -2199,6 +2220,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public func loadPairedMacs() async {
         guard let pairedMacStore,
               let scope = await currentScopeSnapshot() else {
+            storedPairedMacs = []
+            pairedMacAliasIDsByRepresentativeID = [:]
             pairedMacs = []
             return
         }
@@ -2214,6 +2237,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // captured account/team scope is still current.
         guard await isScopeCurrent(scope) else {
             return
+        }
+        storedPairedMacs = loaded
+        let coalesced = Self.coalescePairedMacsByDialEndpoint(loaded, supportedKinds: runtime?.supportedRouteKinds ?? [], preferNonLoopback: Self.prefersNonLoopbackRoutes)
+        pairedMacAliasIDsByRepresentativeID = coalesced.reduce(into: [String: [String]]()) { result, mac in
+            result[mac.macDeviceID] = Self.macDeviceIDsForLogicalPairedMac(
+                mac.macDeviceID,
+                in: loaded,
+                supportedKinds: runtime?.supportedRouteKinds ?? [],
+                preferNonLoopback: Self.prefersNonLoopbackRoutes
+            )
         }
         pairedMacs = loaded
     }
@@ -2383,13 +2416,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         return switched
     }
 
-    /// Forget `macDeviceID`. Always removes the selected stored row by its real
-    /// id, and additionally tears down the live connection when that row is the
-    /// active one (the live attach ticket can carry a transient manual id, so we
-    /// must not rely on it to identify the row being forgotten).
+    /// Forget one stored Mac id. Display coalescing is heuristic, so destructive
+    /// removal stays scoped to the exact stored identity.
     /// - Parameter macDeviceID: The stored Mac to forget.
     public func forgetMac(macDeviceID: String) async {
-        let isActiveMac = pairedMacs.first(where: { $0.macDeviceID == macDeviceID })?.isActive ?? false
+        guard let scope = await currentScopeSnapshot() else { return }
+        let isActiveMac = pairedMacsForIdentityMatching.first { $0.macDeviceID == macDeviceID }?.isActive == true
         if isActiveMac, connectionState == .connected {
             disconnectLiveConnection()
         }
@@ -2403,12 +2435,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             secondaryMacSubscriptions[macDeviceID] = nil
         }
         workspacesByMac[macDeviceID] = nil
-        let scope = await currentScopeSnapshot()
+        guard await isScopeCurrent(scope) else { return }
         do {
             try await pairedMacStore?.remove(
                 macDeviceID: macDeviceID,
-                stackUserID: scope?.userID,
-                teamID: scope?.teamID
+                stackUserID: scope.userID,
+                teamID: scope.teamID
             )
         } catch {
             mobileShellLog.error("paired mac store remove failed mac=\(macDeviceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
@@ -3106,10 +3138,23 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             await refresher.refreshFromBackup(stackUserID: scope.userID)
         }
         guard await isAggregationScopeValid(scope) else { return }
-        let macs = (try? await pairedMacStore.loadAll(stackUserID: scope.userID, teamID: scope.teamID)) ?? []
+        let loadedMacs = (try? await pairedMacStore.loadAll(stackUserID: scope.userID, teamID: scope.teamID)) ?? []
         guard await isAggregationScopeValid(scope) else { return }
+        let macs = Self.coalescePairedMacsByDialEndpoint(
+            loadedMacs,
+            supportedKinds: runtime?.supportedRouteKinds ?? [],
+            preferNonLoopback: Self.prefersNonLoopbackRoutes
+        )
+        let foregroundMacDeviceIDs = foregroundMacDeviceID.map {
+            Self.macDeviceIDsForLogicalPairedMac(
+                $0,
+                in: loadedMacs,
+                supportedKinds: runtime?.supportedRouteKinds ?? [],
+                preferNonLoopback: Self.prefersNonLoopbackRoutes
+            )
+        } ?? []
         let wanted = Set(macs.map(\.macDeviceID))
-            .subtracting(foregroundMacDeviceID.map { [$0] } ?? [])
+            .subtracting(foregroundMacDeviceIDs)
             .subtracting([""])
         // Tear down subscriptions for Macs that are gone or are now the foreground.
         for (macID, subscription) in secondaryMacSubscriptions where !wanted.contains(macID) {
@@ -3396,9 +3441,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // Stamp per-Mac user color/icon overrides from pairedMacs so every
         // workspace avatar matches its computer's customization (same place the
         // aggregation already assigned the automatic color index).
-        let customByMac = pairedMacs.reduce(into: [String: MobilePairedMac]()) { dict, mac in
-            if mac.customColor != nil || mac.customIcon != nil { dict[mac.macDeviceID] = mac }
-        }
+        let customByMac = pairedMacCustomizationsByAliasID()
         if !customByMac.isEmpty {
             derived = derived.map { workspace in
                 guard let macID = workspace.macDeviceID, let mac = customByMac[macID] else { return workspace }
@@ -3446,17 +3489,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             let t = s?.trimmingCharacters(in: .whitespacesAndNewlines)
             return (t?.isEmpty == false) ? t : nil
         }
-        let scope = await currentScopeSnapshot()
+        guard let scope = await currentScopeSnapshot() else { return }
+        let name = normalized(customName), color = normalized(customColor), icon = normalized(customIcon), now = Date()
         do {
-            try await pairedMacStore?.setCustomization(
-                macDeviceID: macDeviceID,
-                customName: normalized(customName),
-                customColor: normalized(customColor),
-                customIcon: normalized(customIcon),
-                stackUserID: scope?.userID,
-                teamID: scope?.teamID,
-                now: Date()
-            )
+            try await pairedMacStore?.setCustomization(macDeviceID: macDeviceID, customName: name, customColor: color, customIcon: icon, stackUserID: scope.userID, teamID: scope.teamID, now: now)
         } catch {
             mobileShellLog.error("setCustomization failed mac=\(macDeviceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
         }
@@ -6803,82 +6839,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         selectedWorkspaceID = workspaces.first?.id
         selectedTerminalID = workspaces.first?.terminals.first?.id
     }
-}
-
-private extension MobileShellComposite {
-    static func normalizedPairingURL(_ rawValue: String) -> String {
-        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard CmxPairingURLScheme.hasPairingScheme(trimmed) else {
-            return trimmed
-        }
-        let scalars = trimmed.unicodeScalars.filter {
-            !CharacterSet.whitespacesAndNewlines.contains($0)
-        }
-        return String(String.UnicodeScalarView(scalars))
-    }
-
-    static func diagnosticSurfaceHandle(_ surfaceID: String) -> UInt32 {
-        var hash: UInt32 = 2_166_136_261
-        for byte in surfaceID.utf8 {
-            hash = (hash ^ UInt32(byte)) &* 16_777_619
-        }
-        return hash
-    }
-
-    static func workspaceActionCapabilities(
-        from supportedHostCapabilities: Set<String>
-    ) -> MobileWorkspaceActionCapabilities {
-        MobileWorkspaceActionCapabilities(
-            supportsWorkspaceActions: supportedHostCapabilities.contains("workspace.actions.v1"),
-            supportsReadStateActions: supportedHostCapabilities.contains("workspace.read_state.v1"),
-            supportsCloseActions: supportedHostCapabilities.contains("workspace.close.v1")
-        )
-    }
-
-    static func routeSortsBefore(_ left: CmxAttachRoute, _ right: CmxAttachRoute) -> Bool {
-        if left.priority == right.priority {
-            return left.id < right.id
-        }
-        return left.priority < right.priority
-    }
-}
-
-private struct MobileTerminalViewportKey: Hashable, Sendable {
-    var workspaceID: MobileWorkspacePreview.ID
-    var terminalID: MobileTerminalPreview.ID
-}
-
-struct MobileManualAttachTicketCreateResponse: Decodable, Sendable {
-    var ticket: CmxAttachTicket
-
-    static func decode(_ data: Data) throws -> MobileManualAttachTicketCreateResponse {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        return try decoder.decode(MobileManualAttachTicketCreateResponse.self, from: data)
-    }
-}
-
-extension CmxAttachTicket {
-    func constrainingRoutes(
-        to routes: [CmxAttachRoute],
-        fallbackDisplayName: String
-    ) throws -> CmxAttachTicket {
-        try CmxAttachTicket(
-            workspaceID: workspaceID,
-            terminalID: terminalID,
-            macDeviceID: macDeviceID,
-            macDisplayName: macDisplayName ?? fallbackDisplayName,
-            macUserEmail: macUserEmail,
-            macUserID: macUserID,
-            macPairingCompatibilityVersion: macPairingCompatibilityVersion,
-            macAppVersion: macAppVersion,
-            macAppBuild: macAppBuild,
-            routes: routes,
-            expiresAt: expiresAt,
-            authToken: authToken
-        )
-    }
-
 }
 
 private extension MobileWorkspacePreview {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTerminalViewportKey.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTerminalViewportKey.swift
@@ -1,0 +1,6 @@
+internal import CmuxMobileShellModel
+
+struct MobileTerminalViewportKey: Hashable, Sendable {
+    var workspaceID: MobileWorkspacePreview.ID
+    var terminalID: MobileTerminalPreview.ID
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedTeamPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedTeamPairedMacStore.swift
@@ -3,11 +3,13 @@ import CmuxMobilePairedMac
 import Foundation
 
 actor DelayedTeamPairedMacStore: MobilePairedMacStoring {
-    private let recordsByTeam: [String: [MobilePairedMac]]
+    private var recordsByTeam: [String: [MobilePairedMac]]
     private let blockedTeams: Set<String>
     private var startedTeams: Set<String> = []
     private var startWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
     private var blockers: [String: CheckedContinuation<Void, Never>] = [:]
+    private var upsertCount = 0
+    private var upsertWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
 
     init(recordsByTeam: [String: [MobilePairedMac]], blockedTeams: Set<String>) {
         self.recordsByTeam = recordsByTeam
@@ -22,7 +24,35 @@ actor DelayedTeamPairedMacStore: MobilePairedMacStoring {
         stackUserID: String?,
         teamID: String?,
         now: Date
-    ) async throws {}
+    ) async throws {
+        let key = teamID ?? ""
+        if markActive {
+            recordsByTeam[key] = recordsByTeam[key]?.map { mac in
+                var copy = mac
+                copy.isActive = false
+                return copy
+            }
+        }
+        if let index = recordsByTeam[key]?.firstIndex(where: { $0.macDeviceID == macDeviceID }) {
+            recordsByTeam[key]?[index].displayName = displayName
+            recordsByTeam[key]?[index].routes = routes
+            recordsByTeam[key]?[index].lastSeenAt = now
+            recordsByTeam[key]?[index].isActive = markActive
+        } else {
+            recordsByTeam[key, default: []].append(MobilePairedMac(
+                macDeviceID: macDeviceID,
+                displayName: displayName,
+                routes: routes,
+                createdAt: now,
+                lastSeenAt: now,
+                isActive: markActive,
+                stackUserID: stackUserID,
+                teamID: teamID
+            ))
+        }
+        upsertCount += 1
+        resumeUpsertWaiters()
+    }
 
     func loadAll(stackUserID: String?, teamID: String?) async throws -> [MobilePairedMac] {
         let key = teamID ?? ""
@@ -46,8 +76,17 @@ actor DelayedTeamPairedMacStore: MobilePairedMacStoring {
         stackUserID: String?,
         teamID: String?,
         now: Date
-    ) async throws {}
-    func remove(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {}
+    ) async throws {
+        let key = teamID ?? ""
+        guard let index = recordsByTeam[key]?.firstIndex(where: { $0.macDeviceID == macDeviceID }) else { return }
+        recordsByTeam[key]?[index].customName = customName
+        recordsByTeam[key]?[index].customColor = customColor
+        recordsByTeam[key]?[index].customIcon = customIcon
+    }
+    func remove(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {
+        let key = teamID ?? ""
+        recordsByTeam[key]?.removeAll { $0.macDeviceID == macDeviceID }
+    }
     func removeAll() async throws {}
 
     func waitUntilLoadStarted(teamID: String?) async {
@@ -63,9 +102,26 @@ actor DelayedTeamPairedMacStore: MobilePairedMacStoring {
         blockers.removeValue(forKey: key)?.resume()
     }
 
+    func waitUntilUpsertCount(_ count: Int) async {
+        if upsertCount >= count { return }
+        await withCheckedContinuation { continuation in
+            upsertWaiters.append((count, continuation))
+        }
+    }
+
+    func currentUpsertCount() -> Int {
+        upsertCount
+    }
+
     private func markStarted(_ key: String) {
         startedTeams.insert(key)
         let waiters = startWaiters.removeValue(forKey: key) ?? []
         for waiter in waiters { waiter.resume() }
+    }
+
+    private func resumeUpsertWaiters() {
+        let ready = upsertWaiters.filter { upsertCount >= $0.0 }
+        upsertWaiters.removeAll { upsertCount >= $0.0 }
+        for (_, waiter) in ready { waiter.resume() }
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePairedMacCoalescingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePairedMacCoalescingTests.swift
@@ -1,0 +1,370 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+@Suite struct MobileShellCompositePairedMacCoalescingTests {
+    @Test func loadPairedMacsCoalescesDuplicateHostPortRows() async throws {
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "mac-old",
+                        displayName: "Lawrence Mac",
+                        host: " 100.82.214.112 ",
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false,
+                        customName: "Old custom",
+                        customColor: "palette:3",
+                        customIcon: "laptopcomputer"
+                    ),
+                    try Self.pairedMac(
+                        id: "mac-fresh",
+                        displayName: "Lawrence Mac",
+                        host: "100.82.214.112",
+                        lastSeenAt: Date(timeIntervalSince1970: 20),
+                        isActive: true
+                    ),
+                    try Self.pairedMac(
+                        id: "mac-other",
+                        displayName: "Other Mac",
+                        host: "100.82.214.113",
+                        lastSeenAt: Date(timeIntervalSince1970: 30),
+                        isActive: false
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" }
+        )
+
+        await store.loadPairedMacs()
+
+        #expect(store.pairedMacs.map(\.macDeviceID) == ["mac-old", "mac-fresh", "mac-other"])
+        #expect(store.displayPairedMacs.map(\.macDeviceID) == ["mac-fresh", "mac-other"])
+        #expect(Set(store.pairedMacAliasIDs(for: "mac-fresh")) == Set(["mac-old", "mac-fresh"]))
+        #expect(store.displayPairedMacs.first?.customName == "Old custom")
+        #expect(store.displayPairedMacs.first?.customColor == "palette:3")
+        #expect(store.displayPairedMacs.first?.customIcon == "laptopcomputer")
+        store.setWorkspaceStatesForTesting([
+            "mac-old": MacWorkspaceState(
+                macDeviceID: "mac-old",
+                workspaces: [
+                    MobileWorkspacePreview(
+                        id: "hidden-workspace",
+                        macDeviceID: "mac-old",
+                        name: "Hidden",
+                        terminals: []
+                    ),
+                ],
+                status: .connected
+            ),
+            "mac-fresh": MacWorkspaceState(
+                macDeviceID: "mac-fresh",
+                workspaces: [
+                    MobileWorkspacePreview(
+                        id: "visible-workspace",
+                        macDeviceID: "mac-fresh",
+                        name: "Visible",
+                        terminals: []
+                    ),
+                ],
+                status: .connected
+            ),
+        ], foregroundMacDeviceID: "mac-old")
+        let hiddenWorkspace = try #require(store.workspaces.first {
+            $0.rpcWorkspaceID.rawValue == "hidden-workspace"
+        })
+        let visibleWorkspace = try #require(store.workspaces.first {
+            $0.rpcWorkspaceID.rawValue == "visible-workspace"
+        })
+        #expect(hiddenWorkspace.machineCustomColor == "palette:3")
+        #expect(hiddenWorkspace.machineCustomIcon == "laptopcomputer")
+        #expect(visibleWorkspace.machineCustomColor == "palette:3")
+        #expect(visibleWorkspace.machineCustomIcon == "laptopcomputer")
+
+        await store.updateMacCustomization(macDeviceID: "mac-fresh", customName: "Desk setup", customColor: "palette:2", customIcon: "desktopcomputer")
+
+        #expect(store.displayPairedMacs.first?.customName == "Desk setup")
+        #expect(store.displayPairedMacs.first?.customColor == "palette:2")
+        #expect(store.displayPairedMacs.first?.customIcon == "desktopcomputer")
+        let customizedDuplicateRows = try await pairedStore.loadAll(stackUserID: "user-1", teamID: "team-a")
+            .filter { ["mac-old", "mac-fresh"].contains($0.macDeviceID) }
+        #expect(customizedDuplicateRows.first { $0.macDeviceID == "mac-old" }?.customName == "Old custom")
+        #expect(customizedDuplicateRows.first { $0.macDeviceID == "mac-fresh" }?.customName == "Desk setup")
+
+        await store.forgetMac(macDeviceID: "mac-fresh")
+
+        #expect(store.pairedMacs.map(\.macDeviceID) == ["mac-old", "mac-other"])
+        #expect(store.displayPairedMacs.map(\.macDeviceID) == ["mac-old", "mac-other"])
+        #expect(try await pairedStore.loadAll(stackUserID: "user-1", teamID: "team-a").map(\.macDeviceID) == ["mac-old", "mac-other"])
+    }
+
+    @Test func presenceRoutesForHiddenDuplicateRefreshOnlyTheEmittingRow() async throws {
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "mac-old",
+                        displayName: "Lawrence Mac",
+                        host: "100.82.214.112",
+                        port: 50922,
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false
+                    ),
+                    try Self.pairedMac(
+                        id: "mac-fresh",
+                        displayName: "Lawrence Mac",
+                        host: "100.82.214.112",
+                        port: 50922,
+                        lastSeenAt: Date(timeIntervalSince1970: 20),
+                        isActive: true
+                    ),
+                    try Self.pairedMac(
+                        id: "mac-other",
+                        displayName: "Other Mac",
+                        host: "100.82.214.113",
+                        port: 50922,
+                        lastSeenAt: Date(timeIntervalSince1970: 30),
+                        isActive: false
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" }
+        )
+        await store.loadPairedMacs()
+
+        let freshRoute = try CmxAttachRoute(
+            id: "fresh",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.82.214.112", port: 50922)
+        )
+        store.applyPresenceUpdate(
+            .online(PresenceInstance(
+                deviceId: "mac-old",
+                tag: "default",
+                platform: "mac",
+                online: true,
+                lastSeenAt: 1_000,
+                routes: [freshRoute]
+            )),
+            scope: MobileShellScopeSnapshot(userID: "user-1", teamID: "team-a", generation: 0)
+        )
+        await pairedStore.waitUntilUpsertCount(1)
+
+        #expect(store.presenceSummary(for: "mac-fresh")?.online == true)
+        let duplicateRows = try await pairedStore.loadAll(stackUserID: "user-1", teamID: "team-a")
+            .filter { ["mac-old", "mac-fresh"].contains($0.macDeviceID) }
+        #expect(duplicateRows.count == 2)
+        #expect(duplicateRows.first { $0.macDeviceID == "mac-old" }?.routes == [freshRoute])
+        #expect(duplicateRows.first { $0.macDeviceID == "mac-fresh" }?.routes != [freshRoute])
+        #expect(store.displayPairedMacs.map(\.macDeviceID) == ["mac-fresh", "mac-other"])
+    }
+
+    @Test func presenceRoutesDoNotFanOutWhenLogicalDuplicatesBothAdvertiseRoutes() async throws {
+        let oldRoute = try CmxAttachRoute(
+            id: "old",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.82.214.112", port: 50922)
+        )
+        let freshRoute = try CmxAttachRoute(
+            id: "fresh",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.82.214.112", port: 50923)
+        )
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "mac-old",
+                        displayName: "Lawrence Mac",
+                        host: "100.82.214.112",
+                        port: 50922,
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false,
+                        routes: [oldRoute]
+                    ),
+                    try Self.pairedMac(
+                        id: "mac-fresh",
+                        displayName: "Lawrence Mac",
+                        host: "100.82.214.112",
+                        port: 50922,
+                        lastSeenAt: Date(timeIntervalSince1970: 20),
+                        isActive: true,
+                        routes: [freshRoute]
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" }
+        )
+        await store.loadPairedMacs()
+
+        store.applyPresenceUpdate(
+            .snapshot(PresenceSnapshot(
+                teamId: "team-a",
+                now: 2_000,
+                heartbeatIntervalMs: 15_000,
+                offlineTimeoutMs: 45_000,
+                devices: [
+                    PresenceDevice(
+                        deviceId: "mac-old",
+                        platform: "mac",
+                        online: true,
+                        lastSeenAt: 1_000,
+                        instances: [
+                            PresenceInstance(
+                                deviceId: "mac-old",
+                                tag: "default",
+                                platform: "mac",
+                                online: true,
+                                lastSeenAt: 1_000,
+                                routes: [oldRoute]
+                            ),
+                        ]
+                    ),
+                    PresenceDevice(
+                        deviceId: "mac-fresh",
+                        platform: "mac",
+                        online: true,
+                        lastSeenAt: 2_000,
+                        instances: [
+                            PresenceInstance(
+                                deviceId: "mac-fresh",
+                                tag: "debug",
+                                platform: "mac",
+                                online: true,
+                                lastSeenAt: 2_000,
+                                routes: [freshRoute]
+                            ),
+                        ]
+                    ),
+                ]
+            )),
+            scope: MobileShellScopeSnapshot(userID: "user-1", teamID: "team-a", generation: 0)
+        )
+        await store.waitForPushedRouteSyncForTesting()
+
+        let duplicateRows = try await pairedStore.loadAll(stackUserID: "user-1", teamID: "team-a")
+            .filter { ["mac-old", "mac-fresh"].contains($0.macDeviceID) }
+        #expect(await pairedStore.currentUpsertCount() == 0)
+        #expect(duplicateRows.first { $0.macDeviceID == "mac-old" }?.routes == [oldRoute])
+        #expect(duplicateRows.first { $0.macDeviceID == "mac-fresh" }?.routes == [freshRoute])
+    }
+
+    @Test func sameEndpointWithDifferentDisplayNamesStaysSeparate() async throws {
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "mac-a",
+                        displayName: "Desk Mac",
+                        host: "100.82.214.112",
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false
+                    ),
+                    try Self.pairedMac(
+                        id: "mac-b",
+                        displayName: "Laptop Mac",
+                        host: "100.82.214.112",
+                        lastSeenAt: Date(timeIntervalSince1970: 20),
+                        isActive: false
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" }
+        )
+
+        await store.loadPairedMacs()
+
+        #expect(store.pairedMacs.map(\.macDeviceID) == ["mac-a", "mac-b"])
+        #expect(store.displayPairedMacs.map(\.macDeviceID) == ["mac-a", "mac-b"])
+    }
+
+    @Test func destructiveActionsDoNothingWithoutSignedInScope() async throws {
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "mac-a",
+                        displayName: "Lawrence Mac",
+                        host: "100.82.214.112",
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: true
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: false,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" }
+        )
+
+        await store.forgetMac(macDeviceID: "mac-a")
+        await store.updateMacCustomization(
+            macDeviceID: "mac-a",
+            customName: "Should not write",
+            customColor: nil,
+            customIcon: nil
+        )
+
+        let rows = try await pairedStore.loadAll(stackUserID: "user-1", teamID: "team-a")
+        #expect(rows.map(\.macDeviceID) == ["mac-a"])
+        #expect(rows.first?.customName == nil)
+    }
+
+    private static func pairedMac(
+        id: String,
+        displayName: String,
+        host: String,
+        port: Int = 50922,
+        lastSeenAt: Date,
+        isActive: Bool,
+        customName: String? = nil,
+        customColor: String? = nil,
+        customIcon: String? = nil,
+        routes: [CmxAttachRoute]? = nil
+    ) throws -> MobilePairedMac {
+        MobilePairedMac(
+            macDeviceID: id,
+            displayName: displayName,
+            routes: routes ?? [try CmxAttachRoute(id: "manual", kind: .tailscale, endpoint: .hostPort(host: host, port: port))],
+            createdAt: Date(timeIntervalSince1970: 1),
+            lastSeenAt: lastSeenAt,
+            isActive: isActive,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            customName: customName,
+            customColor: customColor,
+            customIcon: customIcon
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -38,20 +38,20 @@ struct DeviceTreeView: View {
     /// the next registry load.) Each is enriched with presence, live status, and how
     /// many aggregated workspaces it contributes.
     private var computers: [MacComputerSnapshot] {
-        let workspaces = store.workspaces
         let colorIndex = store.machineColorIndex
         // The PHONE's own per-Mac connection (foreground or live secondary) — the
         // source of truth for the dot, distinct from presence.
         let connectionStatuses = store.macConnectionStatuses
-        return store.pairedMacs.map { mac in
-            let summary = store.presenceMap.deviceSummary(deviceId: mac.macDeviceID)
+        return store.displayPairedMacs.map { mac in
+            let aliases = store.pairedMacAliasIDs(for: mac.macDeviceID)
+            let summary = store.presenceSummary(for: mac.macDeviceID)
             let presence: DeviceTreePresence? = summary
                 .map { $0.online ? .online : .offline(lastSeenAt: $0.lastSeenAt) }
             return MacComputerSnapshot(
                 deviceId: mac.macDeviceID,
                 title: mac.resolvedName,
                 platform: "mac",
-                colorIndex: colorIndex[mac.macDeviceID],
+                colorIndex: aliases.compactMap { colorIndex[$0] }.first,
                 customColor: mac.customColor,
                 customIcon: mac.customIcon,
                 connectionStatus: connectionStatuses[mac.macDeviceID],
@@ -59,7 +59,8 @@ struct DeviceTreeView: View {
                 buildLabel: summary?.buildLabel,
                 routeDescription: CmxAttachRoute.deviceTreeRouteDescription(for: mac.routes),
                 lastSeenAt: mac.lastSeenAt,
-                workspaceCount: workspaces.filter { $0.macDeviceID == mac.macDeviceID }.count
+                workspaceCount: store.workspaceCount(for: mac.macDeviceID),
+                aliasIDs: aliases
             )
         }
     }
@@ -154,10 +155,7 @@ struct DeviceTreeView: View {
                     pendingRemoval = nil
                 }
             } message: {
-                Text(L10n.string(
-                    "mobile.computers.removeMessage",
-                    defaultValue: "This computer and its workspaces stop appearing here. Pair it again to add it back."
-                ))
+                Text(removeMessage(pendingRemoval))
             }
         }
         .accessibilityIdentifier("MobileDeviceTree")
@@ -198,6 +196,22 @@ struct DeviceTreeView: View {
         String(
             format: L10n.string("mobile.computers.removeTitleFormat", defaultValue: "Remove %@?"),
             computer?.title ?? ""
+        )
+    }
+
+    private func removeMessage(_ computer: MacComputerSnapshot?) -> String {
+        guard let computer, computer.aliasIDs.count > 1 else {
+            return L10n.string(
+                "mobile.computers.removeMessage",
+                defaultValue: "This computer and its workspaces stop appearing here. Pair it again to add it back."
+            )
+        }
+        return String(
+            format: L10n.string(
+                "mobile.computers.removeMessageRepresentativeFormat",
+                defaultValue: "This removes paired record %@. Other matching records may still appear."
+            ),
+            computer.deviceId
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
@@ -44,17 +44,20 @@ struct MacComputerDetailView: View {
     private static let emojiChoices = ["💻", "🖥️", "⚡️", "🔥", "⭐️", "🚀", "🐧", "🍎", "🎮", "👾"]
 
     private var pairedMac: MobilePairedMac? {
-        store.pairedMacs.first { $0.macDeviceID == macDeviceID }
+        store.displayPairedMacs.first { $0.macDeviceID == macDeviceID }
     }
     private var connectionStatus: MobileMacConnectionStatus? {
         store.macConnectionStatuses[macDeviceID]
     }
     private var presence: PresenceMap.DeviceSummary? {
-        store.presenceMap.deviceSummary(deviceId: macDeviceID)
+        store.presenceSummary(for: macDeviceID)
     }
     private var isForeground: Bool { store.connectedMacDeviceID == macDeviceID }
     private var workspaceCount: Int {
-        store.workspaces.filter { $0.macDeviceID == macDeviceID }.count
+        store.workspaceCount(for: macDeviceID)
+    }
+    private var removalAliasIDs: [String] {
+        store.pairedMacAliasIDs(for: macDeviceID)
     }
 
     var body: some View {
@@ -92,8 +95,7 @@ struct MacComputerDetailView: View {
             }
             Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {}
         } message: {
-            Text(L10n.string("mobile.computers.removeMessage",
-                             defaultValue: "This computer and its workspaces stop appearing here. Pair it again to add it back."))
+            Text(removeMessage)
         }
     }
 
@@ -224,6 +226,20 @@ struct MacComputerDetailView: View {
                 customIcon: icon
             )
         }
+    }
+
+    private var removeMessage: String {
+        guard removalAliasIDs.count > 1 else {
+            return L10n.string("mobile.computers.removeMessage",
+                               defaultValue: "This computer and its workspaces stop appearing here. Pair it again to add it back.")
+        }
+        return String(
+            format: L10n.string(
+                "mobile.computers.removeMessageRepresentativeFormat",
+                defaultValue: "This removes paired record %@. Other matching records may still appear."
+            ),
+            macDeviceID
+        )
     }
 
     @ViewBuilder

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot.swift
@@ -24,6 +24,8 @@ struct MacComputerSnapshot: Equatable, Identifiable {
     let lastSeenAt: Date
     /// How many aggregated workspaces this computer contributes.
     let workspaceCount: Int
+    /// Stored paired-Mac ids represented by this visible row.
+    let aliasIDs: [String]
 
     var id: String { deviceId }
 }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1480,6 +1480,23 @@
         }
       }
     },
+    "mobile.computers.removeMessageRepresentativeFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This removes paired record %@. Other matching records may still appear."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペアリング済みレコード %@ を削除します。一致する他のレコードは引き続き表示される場合があります。"
+          }
+        }
+      }
+    },
     "mobile.computers.removeTitleFormat": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Summary
- Coalesce paired Mac rows that resolve to the same normalized host:port before publishing the iOS Computers list.
- Prefer active rows, then fresher lastSeenAt, so stale duplicate pairings do not win.
- Add a regression test that fails when two stored rows with the same IP and port both appear.

Tests
- swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileShellCompositePreviewTests/loadPairedMacsCoalescesDuplicateHostPortRows
- swift test --package-path Packages/iOS/CmuxMobileShell

Dogfood
- macOS tag: dupip
- iOS tag: dupip

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784881746&installation_id=133855650&pr_number=6737&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6737&signature=299abf284b5c4a2381e424f8f271cc36b8064af1a9102d36c0904e0cc3186260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reconnect triggers, secondary Mac subscriptions, and presence route persistence around duplicate device ids; wrong alias matching could mis-route or show stale connection state, though forget remains scoped to a single stored identity.
> 
> **Overview**
> **Collapses duplicate paired-Mac store rows** on the iOS Computers UI when they share the same normalized dial host/port and Mac-reported display name, picking a representative row (active first, then fresher `lastSeenAt`) and merging custom name/color/icon from duplicates.
> 
> **Adds alias-aware presentation** via `displayPairedMacs`, `pairedMacAliasIDs`, and rollups for presence, workspace counts, connection dots, and workspace avatar customization across every stored id behind one visible row. **Keeps full store rows** in `storedPairedMacs` for identity-sensitive paths (presence route writes, reconnect triggers).
> 
> **Presence-pushed routes** still upsert only the device id that emitted the frame; reconnect when the active logical Mac comes online considers all alias ids. **Forget/remove stays per stored id** (not bulk delete), with updated copy when multiple aliases exist.
> 
> Shell helpers and small types are split into dedicated files; **regression tests** cover coalescing, presence route isolation, and signed-in scope guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a81c3599bed9caa78cfc900890abe2477a31b3e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces duplicate paired Macs into one visible row by matching display name + normalized host:port, and rolls up presence, connection, and workspace counts across aliases. Forget now removes only the selected stored record; the UI clarifies when other matching records may remain.

- **Bug Fixes**
  - Coalescing uses the first reconnect host:port plus the Mac’s display name (normalized; honors supported kinds and non‑loopback). Falls back to device ID when no endpoint. Deterministic pick: prefer active, then newer lastSeenAt, then macDeviceID; preserves first-seen order. Merges missing custom name/color/icon from duplicates into the kept row.
  - Aggregations respect aliases: macConnectionStatuses, presenceSummary(for:), and workspaceCount(for:) roll up across all stored IDs represented by a visible row. Secondary-subscription wiring excludes the full alias set, not just the representative ID. Workspace avatars inherit customization across aliases for display.
  - Presence-pushed route updates are scoped to the exact stored device ID that emitted them (no fan-out to logical duplicates). Mobile connection recovery triggers if any alias is online. Added a test hook to await pushed-route sync.
  - Forget is identity-scoped: removes only the chosen stored macDeviceID, tears down its secondary subscription and workspaces, and disconnects if it was active. The Computers list and detail views now use coalesced rows and show a targeted removal message when duplicates exist. Updated tests and the delayed test store to support real upserts/removals and waiters.

<sup>Written for commit a81c3599bed9caa78cfc900890abe2477a31b3e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paired Macs that map to the same dial endpoint (including equivalent host/port values with different formatting) are now coalesced into a single logical entry, reducing duplicates.
  * When forgetting a paired Mac, the app now removes all related logical paired Macs across the coalesced endpoint set, keeping secondary workspaces in sync.
* **Tests**
  * Added new test coverage for paired-Mac dial-endpoint coalescing and the updated logical-forget behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->