### PR TITLE
Pin Claude auto-resume binding to the launch cwd (#4256)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23086,6 +23086,7 @@ struct CMUXCLI {
                         displayName: String(localized: "cli.claude-hook.notification.title", defaultValue: "Claude Code"),
                         sessionId: sessionId,
                         cwd: parsedInput.cwd,
+                        transcriptPath: parsedInput.transcriptPath,
                         launchCommand: launchCommand
                     )
                 }
@@ -23211,6 +23212,7 @@ struct CMUXCLI {
                         displayName: String(localized: "cli.claude-hook.notification.title", defaultValue: "Claude Code"),
                         sessionId: sessionId,
                         cwd: parsedInput.cwd ?? mappedSession?.cwd,
+                        transcriptPath: parsedInput.transcriptPath ?? mappedSession?.transcriptPath,
                         launchCommand: mappedSession?.launchCommand
                     )
                 }
@@ -23334,6 +23336,7 @@ struct CMUXCLI {
                     displayName: String(localized: "cli.claude-hook.notification.title", defaultValue: "Claude Code"),
                     sessionId: sessionId,
                     cwd: parsedInput.cwd ?? mappedSession?.cwd,
+                    transcriptPath: parsedInput.transcriptPath ?? mappedSession?.transcriptPath,
                     launchCommand: mappedSession?.launchCommand ?? firstSightingLaunchCommand
                 )
             }
@@ -26721,6 +26724,7 @@ struct CMUXCLI {
         displayName: String,
         sessionId: String,
         cwd: String?,
+        transcriptPath: String?,
         launchCommand: AgentHookLaunchCommandRecord?
     ) {
         let resumeEnvironment = agentSurfaceResumeEnvironment(kind: kind, environment: launchCommand?.environment)
@@ -26728,11 +26732,26 @@ struct CMUXCLI {
         // runtime cwd: cwd-namespaced agents (Claude, Grok, Gemini, …) file their session under the
         // launch dir, so resuming from a worktree the agent later `cd`'d into fails with "No
         // conversation found".
-        let resumeWorkingDirectory = AgentResumeWorkingDirectory().resolve(
-            kind: kind,
-            runtimeCwd: cwd,
-            launchWorkingDirectory: launchCommand?.workingDirectory
-        )
+        //
+        // For Claude, the captured launch cwd can itself be the drifted runtime cwd when this hook
+        // process lacks a trusted `CMUX_AGENT_LAUNCH_CWD` (`agentLaunchCommandFromEnvironment` then
+        // falls back to the hook-reported cwd). So before the namespacing rule, verify against the
+        // transcript on disk which candidate directory actually holds the session — the same policy
+        // PR #5154 applied to the snapshot path, now shared via `ClaudeResumeWorkingDirectory`.
+        let verifiedClaudeWorkingDirectory: String? = kind == "claude"
+            ? ClaudeResumeWorkingDirectory().verifiedWorkingDirectory(
+                sessionId: sessionId,
+                transcriptPath: transcriptPath,
+                claudeConfigDir: launchCommand?.environment?["CLAUDE_CONFIG_DIR"],
+                candidateWorkingDirectories: [launchCommand?.workingDirectory, cwd].compactMap { $0 }
+            )
+            : nil
+        let resumeWorkingDirectory = verifiedClaudeWorkingDirectory
+            ?? AgentResumeWorkingDirectory().resolve(
+                kind: kind,
+                runtimeCwd: cwd,
+                launchWorkingDirectory: launchCommand?.workingDirectory
+            )
         guard let command = agentSurfaceResumeCommand(
             kind: kind,
             sessionId: sessionId,
@@ -29913,6 +29932,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                         displayName: def.displayName,
                         sessionId: sessionId,
                         cwd: hookCwd ?? mapped?.cwd,
+                        transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                         launchCommand: launchCommand
                     )
                 }
@@ -29980,6 +30000,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     displayName: def.displayName,
                     sessionId: sessionId,
                     cwd: latest.cwd,
+                    transcriptPath: latest.transcriptPath,
                     launchCommand: latest.launchCommand
                 )
                 if let lifecycle = latest.agentLifecycle {
@@ -30180,6 +30201,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     displayName: def.displayName,
                     sessionId: sessionId,
                     cwd: hookCwd ?? mapped?.cwd,
+                    transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                     launchCommand: launchCommand ?? mapped?.launchCommand
                 )
                 if codexPromptTurnWentTerminal() {
@@ -30454,6 +30476,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     displayName: def.displayName,
                     sessionId: sessionId,
                     cwd: cwd,
+                    transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                     launchCommand: launchCommand ?? mapped?.launchCommand
                 )
             }
@@ -30635,6 +30658,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     displayName: def.displayName,
                     sessionId: sessionId,
                     cwd: hookCwd ?? mapped?.cwd,
+                    transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                     launchCommand: launchCommand ?? mapped?.launchCommand
                 )
             }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeTranscriptResume.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeTranscriptResume.swift
@@ -30,10 +30,14 @@ public enum ClaudeProjectDirEncoding {
 public struct ClaudeResumeWorkingDirectory {
     private let fileManager: FileManager
     private let homeDirectory: String
+    // A reference-type cache so that reusing one instance across a session-index load loop shares the
+    // (expensive) config-root scan and per-project transcript probes instead of redoing them per call.
+    private let cache: TranscriptLookupCache
 
     public init(fileManager: FileManager = .default, homeDirectory: String = NSHomeDirectory()) {
         self.fileManager = fileManager
         self.homeDirectory = homeDirectory
+        self.cache = TranscriptLookupCache(homeDirectory: homeDirectory, fileManager: fileManager)
     }
 
     /// Returns the candidate working directory whose Claude project folder actually holds the
@@ -59,7 +63,6 @@ public struct ClaudeResumeWorkingDirectory {
         let candidates = candidateWorkingDirectories.compactMap { normalizedNonEmptyValue($0) }
         guard !candidates.isEmpty else { return nil }
 
-        let cache = TranscriptLookupCache(homeDirectory: homeDirectory, fileManager: fileManager)
         let roots = cache.configRoots(claudeConfigDir: claudeConfigDir)
 
         if let transcriptPath = normalizedNonEmptyValue(transcriptPath) {
@@ -67,27 +70,27 @@ public struct ClaudeResumeWorkingDirectory {
             // The transcript's own storage path names the project directory Claude looks in.
             let expectedProjectDirName = projectDirName(
                 containingTranscriptPath: expandedTranscriptPath,
+                sessionId: sessionId,
                 configRoots: roots
-            ) ?? (((expandedTranscriptPath as NSString).deletingLastPathComponent) as NSString)
-                .lastPathComponent
+            )
 
-            // (a) Prefer a candidate whose encoding matches that project directory.
-            if !expectedProjectDirName.isEmpty,
-               let matched = candidates.first(where: {
-                   ClaudeProjectDirEncoding.projectDirName(forPath: $0) == expectedProjectDirName
-               }) {
-                return matched
-            }
+            if let expectedProjectDirName, !expectedProjectDirName.isEmpty {
+                // (a) Prefer a candidate whose encoding matches that project directory.
+                if let matched = candidates.first(where: {
+                    ClaudeProjectDirEncoding.projectDirName(forPath: $0) == expectedProjectDirName
+                }) {
+                    return matched
+                }
 
-            // (b) No candidate matches — the true launch cwd is not among them (e.g. the launch
-            // capture itself collapsed to the drifted runtime cwd). Recover it directly from the
-            // transcript: every Claude record carries the session's launch cwd in a top-level "cwd".
-            // Only trust it when its re-encoding round-trips to the same project directory, so a
-            // lossy/foreign path can never be accepted.
-            if !expectedProjectDirName.isEmpty,
-               let recovered = recordedCwd(inTranscriptAtPath: expandedTranscriptPath),
-               ClaudeProjectDirEncoding.projectDirName(forPath: recovered) == expectedProjectDirName {
-                return recovered
+                // (b) No candidate matches — the true launch cwd is not among them (e.g. the launch
+                // capture itself collapsed to the drifted runtime cwd). Recover it directly from the
+                // transcript: every Claude record carries the session's launch cwd in a top-level
+                // "cwd". Only trust it when its re-encoding round-trips to the same project
+                // directory, so a lossy/foreign path can never be accepted.
+                if let recovered = recordedCwd(inTranscriptAtPath: expandedTranscriptPath),
+                   ClaudeProjectDirEncoding.projectDirName(forPath: recovered) == expectedProjectDirName {
+                    return recovered
+                }
             }
         }
 
@@ -135,7 +138,15 @@ public struct ClaudeResumeWorkingDirectory {
             && sessionId != ".."
     }
 
-    private func projectDirName(containingTranscriptPath path: String, configRoots: [String]) -> String? {
+    /// The project directory segment of a Claude transcript path. Resolves against a known config
+    /// root when possible; otherwise infers it from the known transcript shapes
+    /// `<project>/<id>.jsonl` and the nested `<project>/<id>/messages/<id>.jsonl`, so recovery works
+    /// even when the config root is unknown.
+    private func projectDirName(
+        containingTranscriptPath path: String,
+        sessionId: String,
+        configRoots: [String]
+    ) -> String? {
         let standardizedPath = (path as NSString).standardizingPath
         for root in configRoots {
             let projectsRoot = ((root as NSString).appendingPathComponent("projects") as NSString)
@@ -149,7 +160,18 @@ public struct ClaudeResumeWorkingDirectory {
             }
             return String(projectDirName)
         }
-        return nil
+
+        // Config root unknown — infer from the transcript shape. Walk up from the file: the nested
+        // layout puts `<id>/messages/` between the project dir and the file, so skip those segments.
+        var dir = (standardizedPath as NSString).deletingLastPathComponent
+        if (dir as NSString).lastPathComponent == "messages" {
+            dir = (dir as NSString).deletingLastPathComponent
+            if (dir as NSString).lastPathComponent == sessionId {
+                dir = (dir as NSString).deletingLastPathComponent
+            }
+        }
+        let name = (dir as NSString).lastPathComponent
+        return name.isEmpty ? nil : name
     }
 
     private func normalizedNonEmptyValue(_ value: String?) -> String? {
@@ -166,6 +188,7 @@ public struct ClaudeResumeWorkingDirectory {
         private let fileManager: FileManager
         private var transcriptPathByProjectRootAndSession: [String: String] = [:]
         private var missingTranscriptPathByProjectRootAndSession: Set<String> = []
+        private var configRootsByConfigDir: [String: [String]] = [:]
 
         init(homeDirectory: String, fileManager: FileManager) {
             self.homeDirectory = homeDirectory
@@ -173,6 +196,17 @@ public struct ClaudeResumeWorkingDirectory {
         }
 
         func configRoots(claudeConfigDir: String?) -> [String] {
+            // Memoize so reusing the cache across a load loop scans the account roots once.
+            let key = normalizedNonEmptyValue(claudeConfigDir) ?? ""
+            if let cached = configRootsByConfigDir[key] {
+                return cached
+            }
+            let resolved = computeConfigRoots(claudeConfigDir: claudeConfigDir)
+            configRootsByConfigDir[key] = resolved
+            return resolved
+        }
+
+        private func computeConfigRoots(claudeConfigDir: String?) -> [String] {
             if let configured = normalizedNonEmptyValue(claudeConfigDir) {
                 return [
                     ClaudeConfigDirectoryPath.preferredPath(

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeTranscriptResume.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeTranscriptResume.swift
@@ -1,0 +1,292 @@
+import Foundation
+
+/// Encodes a filesystem path into the project-directory name Claude derives from it.
+///
+/// Claude namespaces each session transcript under
+/// `<config>/projects/<encoded-cwd>/<session-id>.jsonl`, where the encoding replaces both `/` and
+/// `.` with `-` (e.g. `/Users/x/repo/.claude` -> `-Users-x-repo--claude`). This is the single
+/// source of truth for that encoding, shared by the app's session index and the CLI's resume-binding
+/// publisher so both look in the directory Claude actually stores the transcript in.
+public enum ClaudeProjectDirEncoding {
+    public static func projectDirName(forPath path: String) -> String {
+        path.replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+    }
+}
+
+/// Resolves which working directory a resumed Claude session must `cd` into so `claude --resume <id>`
+/// finds its transcript.
+///
+/// Claude addresses transcripts by the cwd the session was *created* in, not the runtime cwd the agent
+/// later `cd`'d into (e.g. a repo root drifting into a worktree). Given the candidate directories (the
+/// launch cwd and the last-reported runtime cwd), this returns the one whose encoded project directory
+/// actually holds the transcript on disk — matched first against the transcript's own storage path,
+/// then by probing the Claude config roots — or `nil` when neither can be verified, so the caller can
+/// fall back to the launch cwd instead of the drift-prone runtime cwd.
+///
+/// This mirrors the app-side snapshot resolver (`RestorableAgentSessionIndex`) and is shared with the
+/// CLI resume-binding publisher (`publishAgentSurfaceResumeBinding` in the `cmux-cli` target) so both
+/// the snapshot path and the `source: agent-hook` auto-resume binding path apply one policy.
+public struct ClaudeResumeWorkingDirectory {
+    private let fileManager: FileManager
+    private let homeDirectory: String
+
+    public init(fileManager: FileManager = .default, homeDirectory: String = NSHomeDirectory()) {
+        self.fileManager = fileManager
+        self.homeDirectory = homeDirectory
+    }
+
+    /// Returns the candidate working directory whose Claude project folder actually holds the
+    /// transcript for `sessionId`, or `nil` when neither candidate can be verified.
+    ///
+    /// - Parameters:
+    ///   - sessionId: the Claude session id (transcript file stem).
+    ///   - transcriptPath: the transcript path Claude reported, if any. Its parent project directory
+    ///     names the directory Claude resumes from.
+    ///   - claudeConfigDir: the session's `CLAUDE_CONFIG_DIR`, if it ran with a non-default config dir.
+    ///   - candidateWorkingDirectories: directories to verify, in priority order (typically
+    ///     `[launchCwd, runtimeCwd]`). Empty/blank entries are ignored.
+    public func verifiedWorkingDirectory(
+        sessionId: String,
+        transcriptPath: String?,
+        claudeConfigDir: String?,
+        candidateWorkingDirectories: [String]
+    ) -> String? {
+        guard let sessionId = normalizedNonEmptyValue(sessionId),
+              sessionIdIsSafeFilename(sessionId) else {
+            return nil
+        }
+        let candidates = candidateWorkingDirectories.compactMap { normalizedNonEmptyValue($0) }
+        guard !candidates.isEmpty else { return nil }
+
+        let cache = TranscriptLookupCache(homeDirectory: homeDirectory, fileManager: fileManager)
+        let roots = cache.configRoots(claudeConfigDir: claudeConfigDir)
+
+        if let transcriptPath = normalizedNonEmptyValue(transcriptPath) {
+            let expandedTranscriptPath = (transcriptPath as NSString).expandingTildeInPath
+            // The transcript's own storage path names the project directory Claude looks in.
+            let expectedProjectDirName = projectDirName(
+                containingTranscriptPath: expandedTranscriptPath,
+                configRoots: roots
+            ) ?? (((expandedTranscriptPath as NSString).deletingLastPathComponent) as NSString)
+                .lastPathComponent
+
+            // (a) Prefer a candidate whose encoding matches that project directory.
+            if !expectedProjectDirName.isEmpty,
+               let matched = candidates.first(where: {
+                   ClaudeProjectDirEncoding.projectDirName(forPath: $0) == expectedProjectDirName
+               }) {
+                return matched
+            }
+
+            // (b) No candidate matches — the true launch cwd is not among them (e.g. the launch
+            // capture itself collapsed to the drifted runtime cwd). Recover it directly from the
+            // transcript: every Claude record carries the session's launch cwd in a top-level "cwd".
+            // Only trust it when its re-encoding round-trips to the same project directory, so a
+            // lossy/foreign path can never be accepted.
+            if !expectedProjectDirName.isEmpty,
+               let recovered = recordedCwd(inTranscriptAtPath: expandedTranscriptPath),
+               ClaudeProjectDirEncoding.projectDirName(forPath: recovered) == expectedProjectDirName {
+                return recovered
+            }
+        }
+
+        // (c) Probe the config directory for the candidate that holds the transcript on disk.
+        if !roots.isEmpty {
+            for candidate in candidates {
+                let dirName = ClaudeProjectDirEncoding.projectDirName(forPath: candidate)
+                for root in roots where cache.transcriptPath(
+                    configRoot: root,
+                    projectDirName: dirName,
+                    sessionId: sessionId
+                ) != nil {
+                    return candidate
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Reads the launch cwd Claude records on every transcript record (top-level `"cwd"`). The read
+    /// is bounded so a huge or mid-write transcript never stalls the hook — the cwd appears on the
+    /// first record, so a head read suffices.
+    private func recordedCwd(inTranscriptAtPath path: String) -> String? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        guard let chunk = try? handle.read(upToCount: 64 * 1024), !chunk.isEmpty,
+              let text = String(data: chunk, encoding: .utf8) else {
+            return nil
+        }
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let data = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let cwd = normalizedNonEmptyValue(object["cwd"] as? String) else {
+                continue
+            }
+            return cwd
+        }
+        return nil
+    }
+
+    private func sessionIdIsSafeFilename(_ sessionId: String) -> Bool {
+        sessionId.range(of: #"[\\/]"#, options: .regularExpression) == nil
+            && !sessionId.isEmpty
+            && sessionId != "."
+            && sessionId != ".."
+    }
+
+    private func projectDirName(containingTranscriptPath path: String, configRoots: [String]) -> String? {
+        let standardizedPath = (path as NSString).standardizingPath
+        for root in configRoots {
+            let projectsRoot = ((root as NSString).appendingPathComponent("projects") as NSString)
+                .standardizingPath
+            let prefix = projectsRoot.hasSuffix("/") ? projectsRoot : projectsRoot + "/"
+            guard standardizedPath.hasPrefix(prefix) else { continue }
+            let relativePath = String(standardizedPath.dropFirst(prefix.count))
+            guard let projectDirName = relativePath.split(separator: "/", maxSplits: 1).first,
+                  !projectDirName.isEmpty else {
+                continue
+            }
+            return String(projectDirName)
+        }
+        return nil
+    }
+
+    private func normalizedNonEmptyValue(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    /// Caches config-root discovery and per-project transcript lookups for one resolution pass.
+    private final class TranscriptLookupCache {
+        private let homeDirectory: String
+        private let fileManager: FileManager
+        private var transcriptPathByProjectRootAndSession: [String: String] = [:]
+        private var missingTranscriptPathByProjectRootAndSession: Set<String> = []
+
+        init(homeDirectory: String, fileManager: FileManager) {
+            self.homeDirectory = homeDirectory
+            self.fileManager = fileManager
+        }
+
+        func configRoots(claudeConfigDir: String?) -> [String] {
+            if let configured = normalizedNonEmptyValue(claudeConfigDir) {
+                return [
+                    ClaudeConfigDirectoryPath.preferredPath(
+                        configured,
+                        fileManager: fileManager,
+                        homeDirectory: homeDirectory
+                    ),
+                ]
+            }
+
+            var roots: [String] = []
+            var seen: Set<String> = []
+            func appendRoot(_ path: String) {
+                let standardized = (path as NSString).standardizingPath
+                guard seen.insert(standardized).inserted else { return }
+                roots.append(standardized)
+            }
+
+            let accountRoot = (homeDirectory as NSString).appendingPathComponent(".codex-accounts/claude")
+            if directoryExists(atPath: accountRoot),
+               let accountDirs = try? fileManager.contentsOfDirectory(atPath: accountRoot) {
+                for accountDir in accountDirs.sorted() {
+                    appendRoot((accountRoot as NSString).appendingPathComponent(accountDir))
+                }
+            }
+            appendRoot((homeDirectory as NSString).appendingPathComponent(".claude"))
+            appendRoot(
+                ClaudeConfigDirectoryPath.preferredPath(
+                    (homeDirectory as NSString).appendingPathComponent(".subrouter/codex/claude"),
+                    fileManager: fileManager,
+                    homeDirectory: homeDirectory
+                )
+            )
+            return roots
+        }
+
+        func transcriptPath(configRoot: String, projectDirName: String, sessionId: String) -> String? {
+            let standardizedRoot = (configRoot as NSString).standardizingPath
+            let projectsRoot = (standardizedRoot as NSString).appendingPathComponent("projects")
+            let projectRoot = ((projectsRoot as NSString).appendingPathComponent(projectDirName) as NSString)
+                .standardizingPath
+            let key = cacheKey(projectRoot, sessionId)
+            if let cached = transcriptPathByProjectRootAndSession[key] {
+                return cached
+            }
+            if missingTranscriptPathByProjectRootAndSession.contains(key) {
+                return nil
+            }
+
+            let path = Self.transcriptPath(
+                inProjectRoot: projectRoot,
+                sessionId: sessionId,
+                fileManager: fileManager
+            )
+            if let path {
+                transcriptPathByProjectRootAndSession[key] = path
+            } else {
+                missingTranscriptPathByProjectRootAndSession.insert(key)
+            }
+            return path
+        }
+
+        private static func transcriptPath(
+            inProjectRoot projectRoot: String,
+            sessionId: String,
+            fileManager: FileManager
+        ) -> String? {
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: projectRoot, isDirectory: &isDirectory),
+                  isDirectory.boolValue else {
+                return nil
+            }
+
+            let directPath = (projectRoot as NSString).appendingPathComponent("\(sessionId).jsonl")
+            if regularNonEmptyFileExists(atPath: directPath, fileManager: fileManager) {
+                return directPath
+            }
+
+            let nestedMessagesPath = (((projectRoot as NSString)
+                .appendingPathComponent(sessionId) as NSString)
+                .appendingPathComponent("messages") as NSString)
+                .appendingPathComponent("\(sessionId).jsonl")
+            if regularNonEmptyFileExists(atPath: nestedMessagesPath, fileManager: fileManager) {
+                return nestedMessagesPath
+            }
+            return nil
+        }
+
+        private static func regularNonEmptyFileExists(atPath path: String, fileManager: FileManager) -> Bool {
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory),
+                  !isDirectory.boolValue,
+                  let attrs = try? fileManager.attributesOfItem(atPath: path),
+                  let size = attrs[.size] as? NSNumber else {
+                return false
+            }
+            return size.intValue > 0
+        }
+
+        private func directoryExists(atPath path: String) -> Bool {
+            var isDirectory: ObjCBool = false
+            return fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+        }
+
+        private func normalizedNonEmptyValue(_ value: String?) -> String? {
+            guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty else {
+                return nil
+            }
+            return trimmed
+        }
+
+        private func cacheKey(_ prefix: String, _ sessionId: String) -> String {
+            prefix + "\u{0}" + sessionId
+        }
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeWorkingDirectoryTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeWorkingDirectoryTests.swift
@@ -1,0 +1,181 @@
+import CMUXAgentLaunch
+import Foundation
+import Testing
+
+@Suite("ClaudeResumeWorkingDirectory")
+struct ClaudeResumeWorkingDirectoryTests {
+    /// Lays down `<home>/.claude/projects/<encoded launchCwd>/<sessionId>.jsonl` and returns the home.
+    /// When `recordCwd` is non-nil, the transcript carries a Claude record whose top-level `cwd` is
+    /// that value (mirroring real transcripts); otherwise it writes an empty record.
+    private func makeConfigWithTranscript(
+        launchCwd: String,
+        sessionId: String,
+        recordCwd: String? = nil
+    ) throws -> (home: String, transcriptPath: String) {
+        let home = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("cmux-claude-resume-\(UUID().uuidString)")
+        let projectDir = ((((home as NSString)
+            .appendingPathComponent(".claude") as NSString)
+            .appendingPathComponent("projects") as NSString)
+            .appendingPathComponent(ClaudeProjectDirEncoding.projectDirName(forPath: launchCwd)))
+        try FileManager.default.createDirectory(
+            atPath: projectDir, withIntermediateDirectories: true
+        )
+        let transcriptPath = (projectDir as NSString).appendingPathComponent("\(sessionId).jsonl")
+        let line: String
+        if let recordCwd {
+            line = #"{"type":"user","sessionId":"\#(sessionId)","cwd":"\#(recordCwd)","message":{"role":"user","content":"hello"}}"# + "\n"
+        } else {
+            line = "{}\n"
+        }
+        try line.write(toFile: transcriptPath, atomically: true, encoding: .utf8)
+        return (home, transcriptPath)
+    }
+
+    @Test("Verifies launch cwd via the transcript path when the agent drifted into a subdir")
+    func verifiesViaTranscriptPath() throws {
+        let sessionId = UUID().uuidString
+        let launchCwd = "/Users/x/repo"
+        let runtimeCwd = "/Users/x/repo/worktrees/feature"
+        let (home, transcriptPath) = try makeConfigWithTranscript(
+            launchCwd: launchCwd, sessionId: sessionId
+        )
+        defer { try? FileManager.default.removeItem(atPath: home) }
+
+        let resolved = ClaudeResumeWorkingDirectory(homeDirectory: home).verifiedWorkingDirectory(
+            sessionId: sessionId,
+            transcriptPath: transcriptPath,
+            claudeConfigDir: nil,
+            candidateWorkingDirectories: [runtimeCwd, launchCwd] // runtime first, yet launch must win
+        )
+        #expect(resolved == launchCwd)
+    }
+
+    @Test("Falls back to a config-dir scan when no transcript path is reported")
+    func verifiesViaConfigScanWhenTranscriptPathMissing() throws {
+        let sessionId = UUID().uuidString
+        let launchCwd = "/Users/x/repo"
+        let runtimeCwd = "/Users/x/repo/sub"
+        let (home, _) = try makeConfigWithTranscript(launchCwd: launchCwd, sessionId: sessionId)
+        defer { try? FileManager.default.removeItem(atPath: home) }
+
+        let resolved = ClaudeResumeWorkingDirectory(homeDirectory: home).verifiedWorkingDirectory(
+            sessionId: sessionId,
+            transcriptPath: nil,
+            claudeConfigDir: nil,
+            candidateWorkingDirectories: [runtimeCwd, launchCwd]
+        )
+        #expect(resolved == launchCwd)
+    }
+
+    @Test("Honors an explicit CLAUDE_CONFIG_DIR")
+    func verifiesUnderExplicitConfigDir() throws {
+        let sessionId = UUID().uuidString
+        let launchCwd = "/Users/x/repo"
+        let configDir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("cmux-claude-cfg-\(UUID().uuidString)")
+        let projectDir = (((configDir as NSString)
+            .appendingPathComponent("projects") as NSString)
+            .appendingPathComponent(ClaudeProjectDirEncoding.projectDirName(forPath: launchCwd)))
+        try FileManager.default.createDirectory(atPath: projectDir, withIntermediateDirectories: true)
+        let transcriptPath = (projectDir as NSString).appendingPathComponent("\(sessionId).jsonl")
+        try "{}\n".write(toFile: transcriptPath, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: configDir) }
+
+        let resolved = ClaudeResumeWorkingDirectory().verifiedWorkingDirectory(
+            sessionId: sessionId,
+            transcriptPath: nil,
+            claudeConfigDir: configDir,
+            candidateWorkingDirectories: ["/Users/x/repo/drift", launchCwd]
+        )
+        #expect(resolved == launchCwd)
+    }
+
+    @Test("Recovers the launch cwd from transcript content when no candidate matches")
+    func recoversLaunchCwdFromTranscriptContentWhenCandidatesAllDrifted() throws {
+        let sessionId = UUID().uuidString
+        let launchCwd = "/Users/x/repo"
+        // The real failure: both candidates are the drifted dir (the launch capture itself collapsed
+        // to the runtime cwd), so the true launch cwd is NOT among them — but the transcript lives
+        // under the launch cwd and records it in its content.
+        let driftedCwd = "/Users/x/repo/worktrees/feature"
+        let (home, transcriptPath) = try makeConfigWithTranscript(
+            launchCwd: launchCwd, sessionId: sessionId, recordCwd: launchCwd
+        )
+        defer { try? FileManager.default.removeItem(atPath: home) }
+
+        let resolved = ClaudeResumeWorkingDirectory(homeDirectory: home).verifiedWorkingDirectory(
+            sessionId: sessionId,
+            transcriptPath: transcriptPath,
+            claudeConfigDir: nil,
+            candidateWorkingDirectories: [driftedCwd, driftedCwd]
+        )
+        #expect(resolved == launchCwd)
+    }
+
+    @Test("Ignores a transcript-recorded cwd that does not round-trip to the project dir")
+    func ignoresRecordedCwdThatDoesNotRoundTrip() throws {
+        let sessionId = UUID().uuidString
+        let launchCwd = "/Users/x/repo"
+        // Transcript stored under launchCwd's project dir, but its recorded cwd claims a different
+        // path — the encoding guard must reject it rather than trust spoofed/foreign content.
+        let (home, transcriptPath) = try makeConfigWithTranscript(
+            launchCwd: launchCwd, sessionId: sessionId, recordCwd: "/Users/x/somewhere-else"
+        )
+        defer { try? FileManager.default.removeItem(atPath: home) }
+
+        let resolved = ClaudeResumeWorkingDirectory(homeDirectory: home).verifiedWorkingDirectory(
+            sessionId: sessionId,
+            transcriptPath: transcriptPath,
+            claudeConfigDir: nil,
+            candidateWorkingDirectories: ["/Users/x/drift", "/Users/x/drift"]
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test("Returns nil when neither candidate holds the transcript (caller falls back)")
+    func returnsNilWhenUnverifiable() throws {
+        let sessionId = UUID().uuidString
+        // Transcript lives under a directory that is NOT among the candidates.
+        let (home, transcriptPath) = try makeConfigWithTranscript(
+            launchCwd: "/Users/x/elsewhere", sessionId: sessionId
+        )
+        defer { try? FileManager.default.removeItem(atPath: home) }
+
+        let resolved = ClaudeResumeWorkingDirectory(homeDirectory: home).verifiedWorkingDirectory(
+            sessionId: sessionId,
+            transcriptPath: transcriptPath,
+            claudeConfigDir: nil,
+            candidateWorkingDirectories: ["/Users/x/repo", "/Users/x/repo/sub"]
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test("Returns nil for empty inputs")
+    func returnsNilForEmptyInputs() {
+        #expect(
+            ClaudeResumeWorkingDirectory().verifiedWorkingDirectory(
+                sessionId: "   ",
+                transcriptPath: nil,
+                claudeConfigDir: nil,
+                candidateWorkingDirectories: ["/Users/x/repo"]
+            ) == nil
+        )
+        #expect(
+            ClaudeResumeWorkingDirectory().verifiedWorkingDirectory(
+                sessionId: UUID().uuidString,
+                transcriptPath: nil,
+                claudeConfigDir: nil,
+                candidateWorkingDirectories: []
+            ) == nil
+        )
+    }
+
+    @Test("Encodes both slashes and dots like Claude's project dir naming")
+    func encodesDotsAndSlashes() {
+        #expect(
+            ClaudeProjectDirEncoding.projectDirName(forPath: "/Users/x/repo/.claude")
+                == "-Users-x-repo--claude"
+        )
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeWorkingDirectoryTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeWorkingDirectoryTests.swift
@@ -4,13 +4,15 @@ import Testing
 
 @Suite("ClaudeResumeWorkingDirectory")
 struct ClaudeResumeWorkingDirectoryTests {
-    /// Lays down `<home>/.claude/projects/<encoded launchCwd>/<sessionId>.jsonl` and returns the home.
-    /// When `recordCwd` is non-nil, the transcript carries a Claude record whose top-level `cwd` is
-    /// that value (mirroring real transcripts); otherwise it writes an empty record.
+    /// Lays down a transcript under `<home>/.claude/projects/<encoded launchCwd>/` and returns the
+    /// home. The `direct` layout writes `<project>/<sessionId>.jsonl`; the nested layout writes
+    /// `<project>/<sessionId>/messages/<sessionId>.jsonl` (both shapes Claude uses). When `recordCwd`
+    /// is non-nil the record carries a top-level `cwd` (mirroring real transcripts).
     private func makeConfigWithTranscript(
         launchCwd: String,
         sessionId: String,
-        recordCwd: String? = nil
+        recordCwd: String? = nil,
+        nested: Bool = false
     ) throws -> (home: String, transcriptPath: String) {
         let home = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("cmux-claude-resume-\(UUID().uuidString)")
@@ -18,10 +20,14 @@ struct ClaudeResumeWorkingDirectoryTests {
             .appendingPathComponent(".claude") as NSString)
             .appendingPathComponent("projects") as NSString)
             .appendingPathComponent(ClaudeProjectDirEncoding.projectDirName(forPath: launchCwd)))
+        let transcriptDir = nested
+            ? (((projectDir as NSString).appendingPathComponent(sessionId) as NSString)
+                .appendingPathComponent("messages"))
+            : projectDir
         try FileManager.default.createDirectory(
-            atPath: projectDir, withIntermediateDirectories: true
+            atPath: transcriptDir, withIntermediateDirectories: true
         )
-        let transcriptPath = (projectDir as NSString).appendingPathComponent("\(sessionId).jsonl")
+        let transcriptPath = (transcriptDir as NSString).appendingPathComponent("\(sessionId).jsonl")
         let line: String
         if let recordCwd {
             line = #"{"type":"user","sessionId":"\#(sessionId)","cwd":"\#(recordCwd)","message":{"role":"user","content":"hello"}}"# + "\n"
@@ -101,6 +107,25 @@ struct ClaudeResumeWorkingDirectoryTests {
         let driftedCwd = "/Users/x/repo/worktrees/feature"
         let (home, transcriptPath) = try makeConfigWithTranscript(
             launchCwd: launchCwd, sessionId: sessionId, recordCwd: launchCwd
+        )
+        defer { try? FileManager.default.removeItem(atPath: home) }
+
+        let resolved = ClaudeResumeWorkingDirectory(homeDirectory: home).verifiedWorkingDirectory(
+            sessionId: sessionId,
+            transcriptPath: transcriptPath,
+            claudeConfigDir: nil,
+            candidateWorkingDirectories: [driftedCwd, driftedCwd]
+        )
+        #expect(resolved == launchCwd)
+    }
+
+    @Test("Recovers via the nested <id>/messages/<id>.jsonl layout when candidates miss")
+    func recoversFromNestedTranscriptLayout() throws {
+        let sessionId = UUID().uuidString
+        let launchCwd = "/Users/x/repo"
+        let driftedCwd = "/Users/x/repo/worktrees/feature"
+        let (home, transcriptPath) = try makeConfigWithTranscript(
+            launchCwd: launchCwd, sessionId: sessionId, recordCwd: launchCwd, nested: true
         )
         defer { try? FileManager.default.removeItem(atPath: home) }
 

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1079,6 +1079,12 @@ struct RestorableAgentSessionIndex: Sendable {
             homeDirectory: homeDirectory,
             fileManager: fileManager
         )
+        // One resolver for the whole load pass so its config-root scan and transcript probes are
+        // shared across every session record instead of rebuilt per record.
+        let claudeResumeResolver = ClaudeResumeWorkingDirectory(
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        )
         let builtInKindIDs = Set(RestorableAgentKind.allCases.map(\.rawValue))
         let hookKinds: [(kind: RestorableAgentKind, registration: CmuxVaultAgentRegistration?)] =
             RestorableAgentKind.allCases.map { (kind: $0, registration: nil) }
@@ -1133,8 +1139,7 @@ struct RestorableAgentSessionIndex: Sendable {
                         for: effectiveRecord,
                         kind: kind,
                         registration: registration,
-                        fileManager: fileManager,
-                        homeDirectory: homeDirectory
+                        resumeResolver: claudeResumeResolver
                     ),
                     launchCommand: effectiveRecord.launchCommand,
                     registration: registration
@@ -1457,8 +1462,7 @@ struct RestorableAgentSessionIndex: Sendable {
         for record: RestorableAgentHookSessionRecord,
         kind: RestorableAgentKind,
         registration: CmuxVaultAgentRegistration?,
-        fileManager: FileManager,
-        homeDirectory: String
+        resumeResolver: ClaudeResumeWorkingDirectory
     ) -> String? {
         let recordedCwd = normalizedWorkingDirectory(record.cwd)
         let launchCwd = normalizedWorkingDirectory(record.launchCommand?.workingDirectory)
@@ -1479,12 +1483,11 @@ struct RestorableAgentSessionIndex: Sendable {
             return recordedCwd ?? launchCwd
         case .byDirectory:
             if kind == .claude,
-               let verified = claudeVerifiedRestorableWorkingDirectory(
-                   record: record,
-                   recordedCwd: recordedCwd,
-                   launchCwd: launchCwd,
-                   fileManager: fileManager,
-                   homeDirectory: homeDirectory
+               let verified = resumeResolver.verifiedWorkingDirectory(
+                   sessionId: record.sessionId,
+                   transcriptPath: record.transcriptPath,
+                   claudeConfigDir: record.launchCommand?.environment?["CLAUDE_CONFIG_DIR"],
+                   candidateWorkingDirectories: [launchCwd, recordedCwd].compactMap { $0 }
                ) {
                 return verified
             }
@@ -1494,50 +1497,10 @@ struct RestorableAgentSessionIndex: Sendable {
         }
     }
 
-    /// For Claude, returns the candidate directory whose project folder actually holds the
-    /// transcript — matched first against the transcript's known storage path, then against the
-    /// config directory on disk — or `nil` when neither can be verified (so the caller prefers the
-    /// launch cwd instead of the drift-prone recorded cwd).
-    ///
-    /// Delegates to the shared `ClaudeResumeWorkingDirectory` in `CMUXAgentLaunch`, which is the
-    /// single source of truth used by both this snapshot path and the CLI auto-resume binding path.
-    private static func claudeVerifiedRestorableWorkingDirectory(
-        record: RestorableAgentHookSessionRecord,
-        recordedCwd: String?,
-        launchCwd: String?,
-        fileManager: FileManager,
-        homeDirectory: String
-    ) -> String? {
-        ClaudeResumeWorkingDirectory(fileManager: fileManager, homeDirectory: homeDirectory)
-            .verifiedWorkingDirectory(
-                sessionId: record.sessionId ?? "",
-                transcriptPath: record.transcriptPath,
-                claudeConfigDir: record.launchCommand?.environment?["CLAUDE_CONFIG_DIR"],
-                candidateWorkingDirectories: [launchCwd, recordedCwd].compactMap { $0 }
-            )
-    }
-
     static func encodeClaudeProjectDir(_ path: String) -> String {
         // Thin shim over the shared encoder so the app and CLI agree on Claude's project-dir naming
         // (both "/" and "." map to "-", e.g. "/Users/x/repo/.claude" -> "-Users-x-repo--claude").
         ClaudeProjectDirEncoding.projectDirName(forPath: path)
-    }
-
-    private static func claudeProjectDirName(containingTranscriptPath path: String, configRoots: [String]) -> String? {
-        let standardizedPath = (path as NSString).standardizingPath
-        for root in configRoots {
-            let projectsRoot = ((root as NSString).appendingPathComponent("projects") as NSString)
-                .standardizingPath
-            let prefix = projectsRoot.hasSuffix("/") ? projectsRoot : projectsRoot + "/"
-            guard standardizedPath.hasPrefix(prefix) else { continue }
-            let relativePath = String(standardizedPath.dropFirst(prefix.count))
-            guard let projectDirName = relativePath.split(separator: "/", maxSplits: 1).first,
-                  !projectDirName.isEmpty else {
-                continue
-            }
-            return String(projectDirName)
-        }
-        return nil
     }
 
     private static func claudeTranscriptPath(

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1134,7 +1134,7 @@ struct RestorableAgentSessionIndex: Sendable {
                         kind: kind,
                         registration: registration,
                         fileManager: fileManager,
-                        lookup: claudeTranscriptLookup
+                        homeDirectory: homeDirectory
                     ),
                     launchCommand: effectiveRecord.launchCommand,
                     registration: registration
@@ -1458,7 +1458,7 @@ struct RestorableAgentSessionIndex: Sendable {
         kind: RestorableAgentKind,
         registration: CmuxVaultAgentRegistration?,
         fileManager: FileManager,
-        lookup: ClaudeTranscriptLookupCache
+        homeDirectory: String
     ) -> String? {
         let recordedCwd = normalizedWorkingDirectory(record.cwd)
         let launchCwd = normalizedWorkingDirectory(record.launchCommand?.workingDirectory)
@@ -1484,7 +1484,7 @@ struct RestorableAgentSessionIndex: Sendable {
                    recordedCwd: recordedCwd,
                    launchCwd: launchCwd,
                    fileManager: fileManager,
-                   lookup: lookup
+                   homeDirectory: homeDirectory
                ) {
                 return verified
             }
@@ -1498,67 +1498,29 @@ struct RestorableAgentSessionIndex: Sendable {
     /// transcript — matched first against the transcript's known storage path, then against the
     /// config directory on disk — or `nil` when neither can be verified (so the caller prefers the
     /// launch cwd instead of the drift-prone recorded cwd).
+    ///
+    /// Delegates to the shared `ClaudeResumeWorkingDirectory` in `CMUXAgentLaunch`, which is the
+    /// single source of truth used by both this snapshot path and the CLI auto-resume binding path.
     private static func claudeVerifiedRestorableWorkingDirectory(
         record: RestorableAgentHookSessionRecord,
         recordedCwd: String?,
         launchCwd: String?,
         fileManager: FileManager,
-        lookup: ClaudeTranscriptLookupCache
+        homeDirectory: String
     ) -> String? {
-        guard let sessionId = normalizedNonEmptyValue(record.sessionId),
-              claudeSessionIdIsSafeFilename(sessionId) else {
-            return nil
-        }
-        let candidates = [launchCwd, recordedCwd].compactMap { $0 }
-
-        // The transcript's own storage path names the project directory Claude will look in,
-        // so the candidate whose encoding matches it is the one Claude can resume from.
-        if let transcriptPath = normalizedNonEmptyValue(record.transcriptPath) {
-            let expandedTranscriptPath = (transcriptPath as NSString).expandingTildeInPath
-            let roots = lookup.configRoots(for: record)
-            let expectedProjectDirName = claudeProjectDirName(
-                containingTranscriptPath: expandedTranscriptPath,
-                configRoots: roots
-            ) ?? (((expandedTranscriptPath as NSString).deletingLastPathComponent) as NSString)
-                .lastPathComponent
-            if !expectedProjectDirName.isEmpty,
-               let matched = candidates.first(where: {
-                   encodeClaudeProjectDir($0) == expectedProjectDirName
-               }) {
-                return matched
-            }
-        }
-
-        // Probe the config directory for the candidate that holds the transcript on disk.
-        let roots = lookup.configRoots(for: record)
-        if !roots.isEmpty {
-            for candidate in candidates {
-                let projectDirName = encodeClaudeProjectDir(candidate)
-                for root in roots where lookup.transcriptPath(
-                    configRoot: root,
-                    projectDirName: projectDirName,
-                    sessionId: sessionId
-                ) != nil {
-                    return candidate
-                }
-            }
-        }
-        return nil
-    }
-
-    private static func claudeSessionIdIsSafeFilename(_ sessionId: String) -> Bool {
-        sessionId.range(of: #"[\\/]"#, options: .regularExpression) == nil
-            && !sessionId.isEmpty
-            && sessionId != "."
-            && sessionId != ".."
+        ClaudeResumeWorkingDirectory(fileManager: fileManager, homeDirectory: homeDirectory)
+            .verifiedWorkingDirectory(
+                sessionId: record.sessionId ?? "",
+                transcriptPath: record.transcriptPath,
+                claudeConfigDir: record.launchCommand?.environment?["CLAUDE_CONFIG_DIR"],
+                candidateWorkingDirectories: [launchCwd, recordedCwd].compactMap { $0 }
+            )
     }
 
     static func encodeClaudeProjectDir(_ path: String) -> String {
-        // Claude derives a project directory name by replacing both "/" and "." with "-"
-        // (e.g. "/Users/x/repo/.claude" -> "-Users-x-repo--claude"). Missing the "." case
-        // sent dotted paths to the wrong project directory.
-        path.replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: ".", with: "-")
+        // Thin shim over the shared encoder so the app and CLI agree on Claude's project-dir naming
+        // (both "/" and "." map to "-", e.g. "/Users/x/repo/.claude" -> "-Users-x-repo--claude").
+        ClaudeProjectDirEncoding.projectDirName(forPath: path)
     }
 
     private static func claudeProjectDirName(containingTranscriptPath path: String, configRoots: [String]) -> String? {

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3696,4 +3696,90 @@ extension CLINotifyProcessIntegrationRegressionTests {
             )
         }
     }
+
+    /// Issue #4256 / follow-up of PR #5154: the Claude auto-resume *binding* (source: agent-hook)
+    /// must `cd` into the directory the session was *created* in, not a runtime cwd the agent drifted
+    /// into mid-session. Claude files transcripts under `<config>/projects/<encoded launch cwd>/`, so a
+    /// binding pinned to a drifted subdir resumes from the wrong project dir and fails with
+    /// "No conversation found". PR #5154 fixed the snapshot path but explicitly left the binding path
+    /// as a follow-up; this covers that path.
+    ///
+    /// Reproduces the REAL failure: the SessionStart hook fires after the agent already drifted and
+    /// `CMUX_AGENT_LAUNCH_CWD` is the drift, so BOTH the captured launch cwd and the runtime cwd are
+    /// the drift — the true launch cwd is not available from env at all. The fix recovers it from the
+    /// transcript's recorded `cwd` (verified by re-encoding against the transcript's project dir).
+    func testClaudeResumeBindingPinsLaunchCwdRecoveredFromTranscript() throws {
+        let context = try makeClaudeHookContext(name: "claude-resume-binding-cwd")
+        defer { context.cleanup() }
+
+        let sessionId = "drifted-resume-session"
+        // The TRUE launch cwd Claude namespaced the transcript under.
+        let launchCwd = context.root.appendingPathComponent("repo.main", isDirectory: true).path
+        // The drifted cwd the agent moved into; the hook only ever sees this one.
+        let driftedCwd = context.root.appendingPathComponent("worktree", isDirectory: true).path
+        try FileManager.default.createDirectory(atPath: launchCwd, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: driftedCwd, withIntermediateDirectories: true)
+
+        // Lay the transcript where Claude actually stores it: under the launch cwd's project dir,
+        // with the launch cwd recorded inside (as real Claude transcripts do). Encode independently
+        // of the production helper so an encoder regression can't mask the bug.
+        let encodedLaunchDir = launchCwd
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+        let projectDir = context.root
+            .appendingPathComponent(".claude/projects/\(encodedLaunchDir)", isDirectory: true)
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        let transcriptPath = projectDir.appendingPathComponent("\(sessionId).jsonl").path
+        try (#"{"type":"user","sessionId":"\#(sessionId)","cwd":"\#(launchCwd)","message":{"role":"user","content":"hi"}}"# + "\n")
+            .write(toFile: transcriptPath, atomically: true, encoding: .utf8)
+
+        // The drift trap: the launch capture itself reports the drifted cwd (CMUX_AGENT_LAUNCH_CWD =
+        // drift), matching the real case where SessionStart fired after the agent had moved.
+        let driftedLaunchEnv: [String: String] = [
+            "CMUX_AGENT_LAUNCH_KIND": "claude",
+            "CMUX_AGENT_LAUNCH_EXECUTABLE": "/usr/local/bin/claude",
+            "CMUX_AGENT_LAUNCH_CWD": driftedCwd,
+            "CMUX_AGENT_LAUNCH_ARGV_B64": base64NULSeparated(["/usr/local/bin/claude"]),
+        ]
+
+        _ = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"\#(sessionId)","source":"clear","cwd":"\#(driftedCwd)","transcript_path":"\#(transcriptPath)","hook_event_name":"SessionStart"}"#,
+            extraEnvironment: driftedLaunchEnv
+        )
+        let prompt = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(driftedCwd)","transcript_path":"\#(transcriptPath)","hook_event_name":"UserPromptSubmit"}"#,
+            extraEnvironment: driftedLaunchEnv
+        )
+        XCTAssertFalse(prompt.timedOut, prompt.stderr)
+        XCTAssertEqual(prompt.status, 0, prompt.stderr)
+
+        let resumeSetParams = context.state.snapshot().compactMap { line -> [String: Any]? in
+            guard let payload = self.jsonObject(line),
+                  payload["method"] as? String == "surface.resume.set",
+                  let params = payload["params"] as? [String: Any],
+                  params["kind"] as? String == "claude" else {
+                return nil
+            }
+            return params
+        }
+        let params = try XCTUnwrap(
+            resumeSetParams.last,
+            "expected a claude surface.resume.set; saw \(context.state.snapshot())"
+        )
+
+        // The binding must target the launch cwd (where the transcript lives), NOT the drifted cwd.
+        XCTAssertEqual(
+            params["cwd"] as? String, launchCwd,
+            "resume binding cwd should pin the launch dir recovered from the transcript, not the drift"
+        )
+        let command = try XCTUnwrap(params["command"] as? String)
+        XCTAssertTrue(
+            command.contains(launchCwd) && !command.contains(driftedCwd),
+            "resume command should cd into the launch cwd, not the drifted cwd; command=\(command)"
+        )
+    }
 }

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3742,12 +3742,14 @@ extension CLINotifyProcessIntegrationRegressionTests {
             "CMUX_AGENT_LAUNCH_ARGV_B64": base64NULSeparated(["/usr/local/bin/claude"]),
         ]
 
-        _ = runClaudeHook(
+        let start = runClaudeHook(
             context: context,
             arguments: ["hooks", "claude", "session-start"],
             standardInput: #"{"session_id":"\#(sessionId)","source":"clear","cwd":"\#(driftedCwd)","transcript_path":"\#(transcriptPath)","hook_event_name":"SessionStart"}"#,
             extraEnvironment: driftedLaunchEnv
         )
+        XCTAssertFalse(start.timedOut, start.stderr)
+        XCTAssertEqual(start.status, 0, start.stderr)
         let prompt = runClaudeHook(
             context: context,
             arguments: ["hooks", "claude", "prompt-submit"],


### PR DESCRIPTION
## Summary

Fixes the Claude **auto-resume binding** path (`source: agent-hook`) so a restored session `cd`s into the directory Claude filed the transcript under, not a runtime cwd the agent drifted into mid-session. Resolves #4256.

Claude namespaces each transcript under `<config>/projects/<encoded launch cwd>/<id>.jsonl`, and `claude --resume <id>` only locates it from that same cwd. When a session starts in one dir and the agent later `cd`s elsewhere (repo root → worktree, or `$HOME` → a subdir), the persisted binding pinned the **drifted** cwd, so auto-resume ran `cd '<drift>' && claude --resume <id>` and failed with `No conversation found`.

This is the follow-up that #5154 explicitly deferred:

> The same root-cause drift also reaches the auto-resume binding path (`source: agent-hook`, `--resume`), whose cwd originates in the CLI hook (`CLI/cmux.swift`) … intentionally left as a focused follow-up.

#5154 fixed the snapshot fork/restore path (`Sources/RestorableAgentSession.swift`); the binding published by `publishAgentSurfaceResumeBinding` in `CLI/cmux.swift` was untouched.

## Why a candidate match isn't enough

In the real failure (captured from a live `0.64.9` session, see #4256) **both** inputs to `AgentResumeWorkingDirectory().resolve(...)` are the drift by the time the binding is published: the runtime `cwd` is the drift, and the captured `launchCommand.workingDirectory` *also* collapsed to the drift (SessionStart fired after the agent moved, and the hook process had no trusted `CMUX_AGENT_LAUNCH_CWD`, so `agentLaunchCommandFromEnvironment` fell back to `parsedInput.cwd`). The true launch cwd is therefore not among the candidates.

What is reliable: every Claude transcript record carries the launch cwd in a top-level `"cwd"`, and `transcript_path` is in the hook payload. So the launch cwd is recovered from the transcript content and accepted only when it re-encodes to the transcript's project dir (no lossy decode).

## Changes

- **New shared type** `ClaudeResumeWorkingDirectory` + `ClaudeProjectDirEncoding` in `CMUXAgentLaunch` (single source of truth for both targets). `verifiedWorkingDirectory(...)`:
  1. matches a candidate dir's encoding to the transcript path's project-dir segment;
  2. else recovers the launch cwd from the transcript file's top-level `"cwd"`, accepted only if it re-encodes to that same project dir;
  3. else probes the Claude config roots on disk.
- **CLI binding builder** `publishAgentSurfaceResumeBinding` resolves the Claude resume cwd through it before the existing namespacing fallback, gated to `kind == "claude"` (other agents unchanged). `transcriptPath` is threaded through all 8 call sites.
- **App snapshot resolver** delegates to the same shared type, removing the duplicated transcript-verification logic (no behavior change; the existing #5154 tests cover it).

## Testing

- `CMUXAgentLaunch` package: `swift test` green (added `ClaudeResumeWorkingDirectoryTests` — candidate match, transcript-content recovery, round-trip guard rejection, config scan, empty inputs; full suite 161 tests pass).
- Added a CLI hook integration test (`cmuxTests/CLIGenericHookPersistenceTests.swift`) that reproduces the drift (both candidates = drift, transcript under the launch dir) and asserts the published `surface.resume.set` cwd/command pin the launch dir.

> ⚠️ **Disclosure:** I could not run the full Xcode app/CLI build or the `cmuxTests` target locally (this machine is missing `CoreSimulator.framework`, so `xcodebuild` fails to load `IDESimulatorFoundation` before compiling). The shared-package logic and its unit tests are verified via `swift test`; the CLI/app integration compiles against the same shared API but its full build + the new integration test should be confirmed by CI.

## Residual notes for reviewers

- If Claude ever changes its project-dir encoding, `ClaudeProjectDirEncoding` is now the one place to update (used by both app and CLI).
- The round-trip guard is intentionally strict: it only accepts a recovered cwd that re-encodes to the transcript's project dir, so a foreign/spoofed `cwd` in transcript content can't be honored.
- The transcript read is a bounded 64 KB head read with per-line JSON parsing; a mid-codepoint UTF-8 cut yields `nil` and falls through safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784887225&installation_id=133855650&pr_number=6741&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6741&signature=ed26aaa0dd3fcaebb0e6c6da467f62633ed5eafe6fda5d61577e9fc0389ffcb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Claude auto-resume to the original launch directory and verifies it against the transcript to prevent “No conversation found” after mid-session `cd`. Resolves #4256.

- **Bug Fixes**
  - Verifies the resume cwd with `ClaudeResumeWorkingDirectory`: match the transcript’s project dir, else recover from transcript content with a round-trip check, else scan config roots; supports nested `<id>/messages/<id>.jsonl`.
  - Updates CLI `publishAgentSurfaceResumeBinding` (Claude only) to resolve via transcript before namespacing and threads `transcriptPath`; fixes non-optional `sessionId` handling.

- **Refactors**
  - Extracts `ClaudeProjectDirEncoding` and centralizes logic in `@macOS/CMUXAgentLaunch`.
  - App snapshot resolver now delegates to one shared resolver per index-load pass with memoized config-root/transcript lookups, removing duplicate verification code.

<sup>Written for commit daa09dd5aedf89aa20f147d97e0b8da5ec7754c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Claude resume handling by verifying and resolving the correct working directory from the session transcript, even when the current CWD has drifted.
  * Resume/session flows now better preserve and propagate transcript path context for more consistent continuation behavior.

* **Bug Fixes**
  * Fixed resume targeting the wrong folder by validating the expected project-dir encoding and, when needed, recovering the launch CWD from transcript JSONL records.
  * Added more reliable fallback behavior (including honoring `CLAUDE_CONFIG_DIR`) when transcript lookup isn’t provided.

* **Tests**
  * Added coverage for transcript-derived CWD recovery and Claude project directory encoding rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->