### PR TITLE
Fix remote SSH workspace cwd tracking

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -49,10 +49,8 @@ extension ControlCommandCoordinator {
             return surfaceSendText(request.params)
         case "surface.send_key":
             return surfaceSendKey(request.params)
-        case "surface.report_tty":
-            return surfaceReportTTY(request.params)
-        case "surface.report_pwd":
-            return surfaceReportPWD(request.params)
+        case "surface.report_tty": return surfaceReportTTY(request.params)
+        case "surface.report_pwd": return surfaceReportPWD(request.params)
         case "surface.report_shell_state":
             return surfaceReportShellState(request.params)
         case "surface.ports_kick":

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -51,6 +51,8 @@ extension ControlCommandCoordinator {
             return surfaceSendKey(request.params)
         case "surface.report_tty":
             return surfaceReportTTY(request.params)
+        case "surface.report_pwd":
+            return surfaceReportPWD(request.params)
         case "surface.report_shell_state":
             return surfaceReportShellState(request.params)
         case "surface.ports_kick":

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface3.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface3.swift
@@ -220,11 +220,15 @@ extension ControlCommandCoordinator {
         if hasNonNull(params, "surface_id"), requestedSurfaceID == nil {
             return .err(code: "invalid_params", message: "Missing or invalid surface_id", data: nil)
         }
-        let rawPath = rawString(params, "path")
-            ?? rawString(params, "directory")
-            ?? rawString(params, "cwd")
-        guard let path = rawPath?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
+        // Accept compatibility aliases, but require one exact cwd value.
+        let candidatePaths = ["path", "directory", "cwd"]
+            .compactMap { rawString(params, $0) }
+            .filter { $0.rangeOfCharacter(from: .whitespacesAndNewlines.inverted) != nil }
+        guard let path = candidatePaths.first else {
             return .err(code: "invalid_params", message: "Missing path", data: nil)
+        }
+        guard candidatePaths.allSatisfy({ $0 == path }) else {
+            return .err(code: "invalid_params", message: "Conflicting path parameters", data: nil)
         }
 
         let resolution = context?.controlSurfaceReportPWD(

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface3.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface3.swift
@@ -1,8 +1,8 @@
 internal import Foundation
 
 /// The surface-domain resume (`surface.resume.*`) and reporting
-/// (`surface.report_tty` / `report_shell_state` / `ports_kick`) bodies, plus the
-/// shared resume-binding payload helper, split out of
+/// (`surface.report_tty` / `report_pwd` / `report_shell_state` / `ports_kick`)
+/// bodies, plus the shared resume-binding payload helper, split out of
 /// `ControlCommandCoordinator+Surface.swift` to keep each file under the 500-line
 /// budget. See that file's doc comment for the domain overview.
 extension ControlCommandCoordinator {
@@ -205,6 +205,54 @@ extension ControlCommandCoordinator {
                 "surface_id": .string(surfaceID.uuidString),
                 "surface_ref": ref(.surface, surfaceID),
                 "tty_name": .string(ttyName),
+            ]))
+        }
+    }
+
+    // MARK: - report_pwd
+
+    /// `surface.report_pwd` — record a surface's current working directory.
+    func surfaceReportPWD(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let workspaceID = uuid(params, "workspace_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
+        }
+        let requestedSurfaceID = uuid(params, "surface_id")
+        if hasNonNull(params, "surface_id"), requestedSurfaceID == nil {
+            return .err(code: "invalid_params", message: "Missing or invalid surface_id", data: nil)
+        }
+        let rawPath = rawString(params, "path")
+            ?? rawString(params, "directory")
+            ?? rawString(params, "cwd")
+        guard let path = rawPath?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
+            return .err(code: "invalid_params", message: "Missing path", data: nil)
+        }
+
+        let resolution = context?.controlSurfaceReportPWD(
+            workspaceID: workspaceID,
+            requestedSurfaceID: requestedSurfaceID,
+            path: path
+        ) ?? .workspaceNotFound
+        let requestedSurfaceData = surfaceReportSurfaceFields(
+            workspaceID: workspaceID,
+            requestedSurfaceID: requestedSurfaceID
+        )
+        switch resolution {
+        case .workspaceNotFound:
+            return .err(code: "not_found", message: "Workspace not found", data: .object(requestedSurfaceData))
+        case .surfaceNotFound:
+            return .err(code: "not_found", message: "Surface not found", data: .object(requestedSurfaceData))
+        case .pending:
+            var payload = requestedSurfaceData
+            payload["path"] = .string(path)
+            payload["pending"] = .bool(true)
+            return .ok(.object(payload))
+        case .recorded(let surfaceID):
+            return .ok(.object([
+                "workspace_id": .string(workspaceID.uuidString),
+                "workspace_ref": ref(.workspace, workspaceID),
+                "surface_id": .string(surfaceID.uuidString),
+                "surface_ref": ref(.surface, surfaceID),
+                "path": .string(path),
             ]))
         }
     }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
@@ -282,7 +282,7 @@ public protocol ControlSurfaceContext: AnyObject {
         expectedSource: String?
     ) -> ControlSurfaceResumeResolution
 
-    // MARK: - report_tty / report_shell_state / ports_kick
+    // MARK: - report_tty / report_pwd / report_shell_state / ports_kick
 
     /// Records a reported TTY name for `surface.report_tty`.
     ///
@@ -296,6 +296,19 @@ public protocol ControlSurfaceContext: AnyObject {
         requestedSurfaceID: UUID?,
         ttyName: String
     ) -> ControlSurfaceReportTTYResolution
+
+    /// Records a reported current working directory for `surface.report_pwd`.
+    ///
+    /// - Parameters:
+    ///   - workspaceID: The target workspace.
+    ///   - requestedSurfaceID: The explicit `surface_id`, or `nil` to resolve.
+    ///   - path: The reported (trimmed, non-empty) current working directory.
+    /// - Returns: The report resolution.
+    func controlSurfaceReportPWD(
+        workspaceID: UUID,
+        requestedSurfaceID: UUID?,
+        path: String
+    ) -> ControlSurfaceReportPWDResolution
 
     /// Parses a raw shell-activity token via the app's
     /// `parseReportedShellActivityState`, returning the state's raw value (the

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceReportPWDResolution.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceReportPWDResolution.swift
@@ -1,0 +1,23 @@
+public import Foundation
+
+/// The outcome of `surface.report_pwd`, preserving the report commands'
+/// distinct failures and recorded identity.
+///
+/// The coordinator validates the params (workspace required, surface-if-present
+/// must parse, path required) and mints refs; every case echoes the workspace id
+/// plus the requested-or-resolved surface id and the path. The app records the
+/// current working directory against the resolved surface and returns this.
+public enum ControlSurfaceReportPWDResolution: Sendable, Equatable {
+    /// The workspace did not resolve (`not_found` / "Workspace not found",
+    /// `data` echoes the workspace + requested surface).
+    case workspaceNotFound
+    /// The surface did not resolve (`not_found` / "Surface not found", `data`
+    /// echoes the workspace + requested surface).
+    case surfaceNotFound
+    /// The workspace is a remote workspace with no surfaces yet, so the path was
+    /// remembered (`ok` with `pending: true`, echoing the requested surface).
+    case pending
+    /// The path was recorded. Carries the resolved surface id (the `.ok` payload
+    /// echoes the resolved surface, not the requested one).
+    case recorded(surfaceID: UUID)
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -468,6 +468,12 @@ extension ControlSurfaceContext {
         ttyName: String
     ) -> ControlSurfaceReportTTYResolution { .workspaceNotFound }
 
+    func controlSurfaceReportPWD(
+        workspaceID: UUID,
+        requestedSurfaceID: UUID?,
+        path: String
+    ) -> ControlSurfaceReportPWDResolution { .workspaceNotFound }
+
     func controlSurfaceReportShellState(
         workspaceID: UUID,
         requestedSurfaceID: UUID?,

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -462,17 +462,10 @@ extension ControlSurfaceContext {
     func controlSurfaceParseShellActivityState(_ rawState: String) -> String? { nil }
     func controlSurfaceParsePortScanKickReason(_ rawReason: String) -> String? { nil }
 
-    func controlSurfaceReportTTY(
-        workspaceID: UUID,
-        requestedSurfaceID: UUID?,
-        ttyName: String
-    ) -> ControlSurfaceReportTTYResolution { .workspaceNotFound }
-
-    func controlSurfaceReportPWD(
-        workspaceID: UUID,
-        requestedSurfaceID: UUID?,
-        path: String
-    ) -> ControlSurfaceReportPWDResolution { .workspaceNotFound }
+    func controlSurfaceReportTTY(workspaceID: UUID, requestedSurfaceID: UUID?, ttyName: String)
+        -> ControlSurfaceReportTTYResolution { .workspaceNotFound }
+    func controlSurfaceReportPWD(workspaceID: UUID, requestedSurfaceID: UUID?, path: String)
+        -> ControlSurfaceReportPWDResolution { .workspaceNotFound }
 
     func controlSurfaceReportShellState(
         workspaceID: UUID,

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+@MainActor
+private final class FakeSurfaceControlCommandContext: ControlCommandContext {
+    var reportPWDResolution: ControlSurfaceReportPWDResolution = .recorded(surfaceID: UUID())
+    var reportedPWD: (workspaceID: UUID, requestedSurfaceID: UUID?, path: String)?
+
+    func controlSurfaceReportPWD(
+        workspaceID: UUID,
+        requestedSurfaceID: UUID?,
+        path: String
+    ) -> ControlSurfaceReportPWDResolution {
+        reportedPWD = (workspaceID, requestedSurfaceID, path)
+        return reportPWDResolution
+    }
+}
+
+@MainActor
+@Suite("ControlCommandCoordinator surface domain")
+struct ControlCommandCoordinatorSurfaceTests {
+    private func makeCoordinator() -> (ControlCommandCoordinator, FakeSurfaceControlCommandContext) {
+        let context = FakeSurfaceControlCommandContext()
+        return (ControlCommandCoordinator(context: context), context)
+    }
+
+    private func request(_ params: [String: JSONValue]) -> ControlRequest {
+        ControlRequest(id: .int(1), method: "surface.report_pwd", params: params)
+    }
+
+    @Test func reportPWDRejectsConflictingPathAliases() {
+        let (coordinator, context) = makeCoordinator()
+        let workspaceID = UUID()
+        let result = coordinator.handle(request([
+            "workspace_id": .string(workspaceID.uuidString),
+            "path": .string("/srv/work/bar"),
+            "cwd": .string("/srv/work/other"),
+        ]))
+
+        #expect(result == .err(code: "invalid_params", message: "Conflicting path parameters", data: nil))
+        #expect(context.reportedPWD?.path == nil)
+    }
+
+    @Test func reportPWDPreservesExactPathWhitespace() {
+        let (coordinator, context) = makeCoordinator()
+        let workspaceID = UUID()
+        _ = coordinator.handle(request([
+            "workspace_id": .string(workspaceID.uuidString),
+            "path": .string("/srv/work/bar "),
+        ]))
+
+        #expect(context.reportedPWD?.path == "/srv/work/bar ")
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
@@ -3,21 +3,6 @@ import Testing
 @testable import CmuxControlSocket
 
 @MainActor
-private final class FakeSurfaceControlCommandContext: ControlCommandContext {
-    var reportPWDResolution: ControlSurfaceReportPWDResolution = .recorded(surfaceID: UUID())
-    var reportedPWD: (workspaceID: UUID, requestedSurfaceID: UUID?, path: String)?
-
-    func controlSurfaceReportPWD(
-        workspaceID: UUID,
-        requestedSurfaceID: UUID?,
-        path: String
-    ) -> ControlSurfaceReportPWDResolution {
-        reportedPWD = (workspaceID, requestedSurfaceID, path)
-        return reportPWDResolution
-    }
-}
-
-@MainActor
 @Suite("ControlCommandCoordinator surface domain")
 struct ControlCommandCoordinatorSurfaceTests {
     private func makeCoordinator() -> (ControlCommandCoordinator, FakeSurfaceControlCommandContext) {

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
@@ -1,0 +1,17 @@
+import Foundation
+@testable import CmuxControlSocket
+
+@MainActor
+final class FakeSurfaceControlCommandContext: ControlCommandContext {
+    var reportPWDResolution: ControlSurfaceReportPWDResolution = .recorded(surfaceID: UUID())
+    var reportedPWD: (workspaceID: UUID, requestedSurfaceID: UUID?, path: String)?
+
+    func controlSurfaceReportPWD(
+        workspaceID: UUID,
+        requestedSurfaceID: UUID?,
+        path: String
+    ) -> ControlSurfaceReportPWDResolution {
+        reportedPWD = (workspaceID, requestedSurfaceID, path)
+        return reportPWDResolution
+    }
+}

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1522,8 +1522,7 @@ _cmux_prompt_command() {
     local pwd="$PWD"
     if (( ! cmux_has_unix_socket )); then
         if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
-            _CMUX_PWD_LAST_PWD="$pwd"
-            _cmux_report_pwd_via_relay "$pwd"
+            _cmux_report_pwd_via_relay "$pwd" && _CMUX_PWD_LAST_PWD="$pwd"
         fi
         if (( now - _CMUX_PORTS_LAST_RUN >= 10 )); then
             _cmux_ports_kick refresh

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -149,6 +149,23 @@ _cmux_report_tty_via_relay() {
     _cmux_relay_rpc "surface.report_tty" "$params"
 }
 
+_cmux_report_pwd_via_relay() {
+    local pwd="$1"
+    _cmux_socket_uses_remote_relay || return 1
+    [[ -n "$pwd" ]] || return 1
+    local workspace_id=""
+    workspace_id="$(_cmux_relay_workspace_id)" || return 1
+
+    local pwd_json params
+    pwd_json="$(_cmux_json_escape "$pwd")"
+    params="{\"workspace_id\":\"$workspace_id\",\"path\":\"$pwd_json\""
+    if [[ -n "$CMUX_PANEL_ID" ]]; then
+        params+=",\"surface_id\":\"$CMUX_PANEL_ID\""
+    fi
+    params+="}"
+    _cmux_relay_rpc_bg "surface.report_pwd" "$params"
+}
+
 _cmux_ports_kick_via_relay() {
     local reason="${1:-command}"
     _cmux_socket_uses_remote_relay || return 1
@@ -1502,7 +1519,12 @@ _cmux_prompt_command() {
 
     local now
     now="$(_cmux_now)"
+    local pwd="$PWD"
     if (( ! cmux_has_unix_socket )); then
+        if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
+            _CMUX_PWD_LAST_PWD="$pwd"
+            _cmux_report_pwd_via_relay "$pwd"
+        fi
         if (( now - _CMUX_PORTS_LAST_RUN >= 10 )); then
             _cmux_ports_kick refresh
         fi
@@ -1510,7 +1532,6 @@ _cmux_prompt_command() {
     fi
 
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
-    local pwd="$PWD"
     _cmux_set_git_active_pwd "$pwd"
 
     # Post-wake socket writes can occasionally leave a probe process wedged.

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1714,8 +1714,7 @@ _cmux_precmd() {
 
     if (( ! cmux_has_unix_socket )); then
         if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
-            _CMUX_PWD_LAST_PWD="$pwd"
-            _cmux_report_pwd_via_relay "$pwd"
+            _cmux_report_pwd_via_relay "$pwd" && _CMUX_PWD_LAST_PWD="$pwd"
         fi
         if (( cmd_dur >= 2 || now - _CMUX_PORTS_LAST_RUN >= 10 )); then
             _cmux_ports_kick refresh

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -151,6 +151,23 @@ _cmux_report_tty_via_relay() {
     _cmux_relay_rpc "surface.report_tty" "$params"
 }
 
+_cmux_report_pwd_via_relay() {
+    local pwd="$1"
+    _cmux_socket_uses_remote_relay || return 1
+    [[ -n "$pwd" ]] || return 1
+    local workspace_id=""
+    workspace_id="$(_cmux_relay_workspace_id)" || return 1
+
+    local pwd_json params
+    pwd_json="$(_cmux_json_escape "$pwd")"
+    params="{\"workspace_id\":\"$workspace_id\",\"path\":\"$pwd_json\""
+    if [[ -n "$CMUX_PANEL_ID" ]]; then
+        params+=",\"surface_id\":\"$CMUX_PANEL_ID\""
+    fi
+    params+="}"
+    _cmux_relay_rpc_bg "surface.report_pwd" "$params"
+}
+
 _cmux_ports_kick_via_relay() {
     local reason="${1:-command}"
     _cmux_socket_uses_remote_relay || return 1
@@ -1689,12 +1706,17 @@ _cmux_precmd() {
     local now="$(_cmux_now)"
     local cmd_start="$_CMUX_CMD_START"
     _CMUX_CMD_START=0
+    local pwd="$PWD"
     local cmd_dur=0
     if [[ -n "$cmd_start" && "$cmd_start" != 0 ]]; then
         cmd_dur=$(( now - cmd_start ))
     fi
 
     if (( ! cmux_has_unix_socket )); then
+        if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
+            _CMUX_PWD_LAST_PWD="$pwd"
+            _cmux_report_pwd_via_relay "$pwd"
+        fi
         if (( cmd_dur >= 2 || now - _CMUX_PORTS_LAST_RUN >= 10 )); then
             _cmux_ports_kick refresh
         fi
@@ -1702,7 +1724,6 @@ _cmux_precmd() {
     fi
 
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
-    local pwd="$PWD"
     _cmux_set_git_active_pwd "$pwd"
 
     _cmux_prompt_wrap_guard "$cmd_start" "$pwd"

--- a/Resources/shell-integration/fish/config.fish
+++ b/Resources/shell-integration/fish/config.fish
@@ -300,7 +300,7 @@ if test "$_cmux_integration_enabled" != 0
             set -g _CMUX_PWD_LAST_PWD "$pwd"
             if _cmux_socket_is_unix
                 if test -n "$CMUX_TAB_ID"; and test -n "$CMUX_PANEL_ID"
-                    set -l qpwd (string replace -a '"' '\"' -- "$pwd")
+                    set -l qpwd (_cmux_json_escape "$pwd")
                     _cmux_send_bg "report_pwd \"$qpwd\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
                 end
             else

--- a/Resources/shell-integration/fish/config.fish
+++ b/Resources/shell-integration/fish/config.fish
@@ -20,6 +20,7 @@ if test "$_cmux_integration_enabled" != 0
     set -g _CMUX_PORTS_LAST_RUN 0
     set -g _CMUX_TTY_NAME ""
     set -g _CMUX_TTY_REPORTED 0
+    set -g _CMUX_PWD_LAST_PWD ""
 
     function _cmux_now
         if test -n "$EPOCHSECONDS"
@@ -105,6 +106,19 @@ if test "$_cmux_integration_enabled" != 0
         end
         set params "$params}"
         _cmux_relay_rpc_bg surface.report_tty "$params"
+    end
+
+    function _cmux_report_pwd_via_relay --argument-names pwd
+        _cmux_socket_uses_remote_relay; or return 1
+        test -n "$pwd"; or return 1
+        set -l workspace_id (_cmux_relay_workspace_id); or return 1
+        set -l pwd_json (_cmux_json_escape "$pwd")
+        set -l params "{\"workspace_id\":\"$workspace_id\",\"path\":\"$pwd_json\""
+        if test -n "$CMUX_PANEL_ID"
+            set params "$params,\"surface_id\":\"$CMUX_PANEL_ID\""
+        end
+        set params "$params}"
+        _cmux_relay_rpc_bg surface.report_pwd "$params"
     end
 
     function _cmux_ports_kick_via_relay --argument-names reason
@@ -281,6 +295,18 @@ if test "$_cmux_integration_enabled" != 0
         _cmux_reset_terminal_keyboard_protocols
         _cmux_report_tty_once
         _cmux_report_shell_activity_state prompt
+        set -l pwd "$PWD"
+        if test "$pwd" != "$_CMUX_PWD_LAST_PWD"
+            set -g _CMUX_PWD_LAST_PWD "$pwd"
+            if _cmux_socket_is_unix
+                if test -n "$CMUX_TAB_ID"; and test -n "$CMUX_PANEL_ID"
+                    set -l qpwd (string replace -a '"' '\"' -- "$pwd")
+                    _cmux_send_bg "report_pwd \"$qpwd\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+                end
+            else
+                _cmux_report_pwd_via_relay "$pwd"
+            end
+        end
         set -l now (_cmux_now)
         if test (math "$now - $_CMUX_PORTS_LAST_RUN") -ge 5
             _cmux_ports_kick refresh

--- a/Resources/shell-integration/fish/config.fish
+++ b/Resources/shell-integration/fish/config.fish
@@ -297,14 +297,15 @@ if test "$_cmux_integration_enabled" != 0
         _cmux_report_shell_activity_state prompt
         set -l pwd "$PWD"
         if test "$pwd" != "$_CMUX_PWD_LAST_PWD"
-            set -g _CMUX_PWD_LAST_PWD "$pwd"
             if _cmux_socket_is_unix
                 if test -n "$CMUX_TAB_ID"; and test -n "$CMUX_PANEL_ID"
                     set -l qpwd (_cmux_json_escape "$pwd")
-                    _cmux_send_bg "report_pwd \"$qpwd\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+                    if _cmux_send_bg "report_pwd \"$qpwd\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+                        set -g _CMUX_PWD_LAST_PWD "$pwd"
+                    end
                 end
-            else
-                _cmux_report_pwd_via_relay "$pwd"
+            else if _cmux_report_pwd_via_relay "$pwd"
+                set -g _CMUX_PWD_LAST_PWD "$pwd"
             end
         end
         set -l now (_cmux_now)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6259,7 +6259,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             arguments.append(contentsOf: ["--session", sessionId])
         }
         process.arguments = arguments
-        process.currentDirectoryURL = URL(fileURLWithPath: cwd, isDirectory: true)
         var environment = ProcessInfo.processInfo.environment
         environment["CMUX_SOCKET_PATH"] = socketPath
         environment["CMUX_BUNDLED_CLI_PATH"] = cliURL.path

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -1078,7 +1078,7 @@ private func makeFeedNotificationPolicyContext(
             ),
             effects: effects
         ),
-        hooks: context?.cmuxConfigStore?.notificationHooks(startingFrom: workspace?.isRemoteWorkspace == true ? workspace?.surfaceTabBarDirectory : (normalizedFeedNotificationCWD(event.cwd) ?? workspace?.surfaceTabBarDirectory)) ?? [],
+        hooks: context?.cmuxConfigStore?.notificationHooks(startingFrom: workspace?.isRemoteWorkspace == true ? nil : (normalizedFeedNotificationCWD(event.cwd) ?? workspace?.surfaceTabBarDirectory)) ?? [],
         globalConfigPath: context?.cmuxConfigStore?.globalConfigPath
     )
 }

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -1078,7 +1078,7 @@ private func makeFeedNotificationPolicyContext(
             ),
             effects: effects
         ),
-        hooks: context?.cmuxConfigStore?.notificationHooks(startingFrom: cwd) ?? [],
+        hooks: context?.cmuxConfigStore?.notificationHooks(startingFrom: workspace?.isRemoteWorkspace == true ? workspace?.surfaceTabBarDirectory : (normalizedFeedNotificationCWD(event.cwd) ?? workspace?.surfaceTabBarDirectory)) ?? [],
         globalConfigPath: context?.cmuxConfigStore?.globalConfigPath
     )
 }

--- a/Sources/TerminalController+ControlSurfaceContext4.swift
+++ b/Sources/TerminalController+ControlSurfaceContext4.swift
@@ -6,11 +6,11 @@ import Foundation
 import CmuxWorkspaces
 
 /// The surface-domain resume (`resume.set` / `.get` / `.clear`) and reporting
-/// (`report_tty` / `report_shell_state` / `ports_kick`) witnesses, plus the token
-/// parsers. Split out of `TerminalController+ControlSurfaceContext` to keep the
-/// conformance readable; see that file's doc comment for the overview. The blocking
-/// approval `NSAlert` and its `String(localized:)` calls resolve here, in the app
-/// bundle, so translations survive.
+/// (`report_tty` / `report_pwd` / `report_shell_state` / `ports_kick`) witnesses,
+/// plus the token parsers. Split out of `TerminalController+ControlSurfaceContext`
+/// to keep the conformance readable; see that file's doc comment for the overview.
+/// The blocking approval `NSAlert` and its `String(localized:)` calls resolve
+/// here, in the app bundle, so translations survive.
 extension TerminalController {
 
     // MARK: - resume target resolution (twin of v2ResolveSurfaceResumeTarget)
@@ -311,6 +311,42 @@ extension TerminalController {
             _ = tab.applyPendingRemoteSurfacePortKickIfNeeded(to: surfaceId)
         } else {
             PortScanner.shared.registerTTY(workspaceId: workspaceID, panelId: surfaceId, ttyName: ttyName)
+        }
+        return .recorded(surfaceID: surfaceId)
+    }
+
+    // MARK: - report_pwd
+
+    func controlSurfaceReportPWD(
+        workspaceID: UUID,
+        requestedSurfaceID: UUID?,
+        path: String
+    ) -> ControlSurfaceReportPWDResolution {
+        guard let tab = controlTabForSidebarMutation(id: workspaceID) else {
+            return .workspaceNotFound
+        }
+        let validSurfaceIds = Set(tab.panels.keys)
+        tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
+
+        let surfaceId = controlResolveReportedSurfaceId(
+            in: tab,
+            requestedSurfaceId: requestedSurfaceID,
+            validSurfaceIds: validSurfaceIds
+        )
+        guard let surfaceId, validSurfaceIds.contains(surfaceId) else {
+            if tab.isRemoteWorkspace, validSurfaceIds.isEmpty {
+                tab.rememberPendingRemoteSurfacePWD(path, requestedSurfaceId: requestedSurfaceID)
+                return .pending
+            }
+            return .surfaceNotFound
+        }
+
+        if tab.isRemoteWorkspace {
+            _ = tab.updatePanelDirectory(panelId: surfaceId, directory: path)
+        } else if let tabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceID) ?? tabManager {
+            tabManager.updateSurfaceDirectory(tabId: workspaceID, surfaceId: surfaceId, directory: path)
+        } else {
+            _ = tab.updatePanelDirectory(panelId: surfaceId, directory: path)
         }
         return .recorded(surfaceID: surfaceId)
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1837,10 +1837,9 @@ class TerminalController {
         // still-shared v2SurfaceMove). surface.action/tab.action and
         // surface.drag_to_split/surface.split_off (the latter forwarding to the
         // still-shared v2SurfaceSplitOff) handled by ControlCommandCoordinator too.
-        // surface.refresh/health/resume.set/get/clear, debug.terminals (forwards to the
-        // still-shared v2DebugTerminals), surface.send_text/send_key/report_tty/
-        // report_pwd/report_shell_state/ports_kick/clear_history/trigger_flash, and
-        // surface.read_text handled by ControlCommandCoordinator.
+        // surface.refresh/health/resume.set/get/clear, debug.terminals, surface.send_text/
+        // send_key/report_tty/report_pwd/report_shell_state/ports_kick/clear_history/
+        // trigger_flash/read_text handled by ControlCommandCoordinator.
 
         // Panes
         // pane.* handled by ControlCommandCoordinator.

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1839,8 +1839,8 @@ class TerminalController {
         // still-shared v2SurfaceSplitOff) handled by ControlCommandCoordinator too.
         // surface.refresh/health/resume.set/get/clear, debug.terminals (forwards to the
         // still-shared v2DebugTerminals), surface.send_text/send_key/report_tty/
-        // report_shell_state/ports_kick/clear_history/trigger_flash, and surface.read_text
-        // handled by ControlCommandCoordinator.
+        // report_pwd/report_shell_state/ports_kick/clear_history/trigger_flash, and
+        // surface.read_text handled by ControlCommandCoordinator.
 
         // Panes
         // pane.* handled by ControlCommandCoordinator.
@@ -2059,6 +2059,7 @@ class TerminalController {
             "surface.send_text",
             "surface.send_key",
             "surface.report_tty",
+            "surface.report_pwd",
             "surface.report_shell_state",
             "surface.ports_kick",
             "surface.read_text",

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1054,7 +1054,7 @@ final class TerminalNotificationStore: ObservableObject {
                 isAppFocused: isAppFocused,
                 isFocusedPanel: isFocusedPanel
             ),
-            hooks: cmuxConfigStore?.notificationHooks(startingFrom: cwd) ?? [],
+            hooks: cmuxConfigStore?.notificationHooks(startingFrom: workspace?.isRemoteWorkspace == true ? workspace?.surfaceTabBarDirectory : (workspace?.surfaceTabBarDirectory ?? cwd)) ?? [],
             globalConfigPath: cmuxConfigStore?.globalConfigPath
         )
     }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1054,7 +1054,7 @@ final class TerminalNotificationStore: ObservableObject {
                 isAppFocused: isAppFocused,
                 isFocusedPanel: isFocusedPanel
             ),
-            hooks: cmuxConfigStore?.notificationHooks(startingFrom: workspace?.isRemoteWorkspace == true ? workspace?.surfaceTabBarDirectory : (workspace?.surfaceTabBarDirectory ?? cwd)) ?? [],
+            hooks: cmuxConfigStore?.notificationHooks(startingFrom: workspace?.isRemoteWorkspace == true ? nil : cwd) ?? [],
             globalConfigPath: cmuxConfigStore?.globalConfigPath
         )
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3431,6 +3431,8 @@ final class Workspace: Identifiable, ObservableObject {
     private var pendingRemoteSurfaceTTYSurfaceId: UUID?
     private var pendingRemoteSurfacePortKickReason: PortScanKickReason?
     private var pendingRemoteSurfacePortKickSurfaceId: UUID?
+    private var pendingRemoteSurfacePWD: String?
+    private var pendingRemoteSurfacePWDSurfaceId: UUID?
     // When the last live remote terminal is detached out, the source workspace may be
     // closed immediately after the move succeeds. That teardown must not shut down the
     // shared SSH control master that is still serving the moved terminal.
@@ -5730,6 +5732,8 @@ final class Workspace: Identifiable, ObservableObject {
         pendingRemoteSurfaceTTYSurfaceId = nil
         pendingRemoteSurfacePortKickReason = nil
         pendingRemoteSurfacePortKickSurfaceId = nil
+        pendingRemoteSurfacePWD = nil
+        pendingRemoteSurfacePWDSurfaceId = nil
         clearRemoteDetectedSurfacePorts()
         remoteDetectedPorts = []
         remoteForwardedPorts = []
@@ -5801,6 +5805,7 @@ final class Workspace: Identifiable, ObservableObject {
         }
         guard activeRemoteTerminalSurfaceIds.insert(panelId).inserted else { return }
         activeRemoteTerminalSessionCount = activeRemoteTerminalSurfaceIds.count
+        _ = applyPendingRemoteSurfacePWDIfNeeded(to: panelId)
         applyPendingRemoteSurfaceTTYIfNeeded(to: panelId)
         _ = applyPendingRemoteSurfacePortKickIfNeeded(to: panelId)
     }
@@ -6268,6 +6273,30 @@ final class Workspace: Identifiable, ObservableObject {
     ) {
         pendingRemoteSurfacePortKickReason = reason
         pendingRemoteSurfacePortKickSurfaceId = requestedSurfaceId
+    }
+
+    @MainActor
+    func rememberPendingRemoteSurfacePWD(_ path: String, requestedSurfaceId: UUID?) {
+        let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else { return }
+        pendingRemoteSurfacePWD = trimmedPath
+        pendingRemoteSurfacePWDSurfaceId = requestedSurfaceId
+    }
+
+    @MainActor
+    @discardableResult
+    private func applyPendingRemoteSurfacePWDIfNeeded(to panelId: UUID) -> Bool {
+        guard let path = pendingRemoteSurfacePWD?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !path.isEmpty else {
+            return false
+        }
+        if let requestedSurfaceId = pendingRemoteSurfacePWDSurfaceId,
+           requestedSurfaceId != panelId {
+            return false
+        }
+        pendingRemoteSurfacePWD = nil
+        pendingRemoteSurfacePWDSurfaceId = nil
+        return updatePanelDirectory(panelId: panelId, directory: path)
     }
 
     @MainActor

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6282,17 +6282,16 @@ final class Workspace: Identifiable, ObservableObject {
 
     @MainActor
     func rememberPendingRemoteSurfacePWD(_ path: String, requestedSurfaceId: UUID?) {
-        let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedPath.isEmpty else { return }
-        pendingRemoteSurfacePWD = trimmedPath
+        guard path.rangeOfCharacter(from: .whitespacesAndNewlines.inverted) != nil else { return }
+        pendingRemoteSurfacePWD = path
         pendingRemoteSurfacePWDSurfaceId = requestedSurfaceId
     }
 
     @MainActor
     @discardableResult
     private func applyPendingRemoteSurfacePWDIfNeeded(to panelId: UUID) -> Bool {
-        guard let path = pendingRemoteSurfacePWD?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !path.isEmpty else {
+        guard let path = pendingRemoteSurfacePWD,
+              path.rangeOfCharacter(from: .whitespacesAndNewlines.inverted) != nil else {
             return false
         }
         if let requestedSurfaceId = pendingRemoteSurfacePWDSurfaceId,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2545,6 +2545,10 @@ final class Workspace: Identifiable, ObservableObject {
     private func scheduleExtensionSidebarProjectRootRefresh(for directory: String) {
         extensionSidebarProjectRootRefreshID &+= 1
         let refreshID = extensionSidebarProjectRootRefreshID
+        guard !isRemoteWorkspace else {
+            extensionSidebarProjectRootPath = nil
+            return
+        }
         let trimmedDirectory = directory.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedDirectory.isEmpty else {
             extensionSidebarProjectRootPath = nil
@@ -4459,13 +4463,13 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     private func configTrackingDirectory(for panelId: UUID?) -> String? {
-        // A remote tmux mirror's directories are paths on the REMOTE host.
+        // A remote workspace's directories are paths on the REMOTE host.
         // Feeding one into local cmux.json tracking makes CmuxConfigStore walk
         // the ancestor chain with FileManager.fileExists on the main thread,
         // and stat'ing e.g. /home/… locally blocks on the autofs automounter
         // for hundreds of ms (measured via sample during tab-reveal stalls).
         // No local per-directory config can apply to a remote path — track none.
-        if isRemoteTmuxMirror { return nil }
+        if isRemoteWorkspace { return nil }
         if let panelId {
             for candidate in [
                 panelDirectories[panelId],
@@ -4504,8 +4508,9 @@ final class Workspace: Identifiable, ObservableObject {
         }
         // Update current directory if this is the focused panel
         if panelId == focusedPanelId {
-            if surfaceTabBarDirectory != trimmed {
-                surfaceTabBarDirectory = trimmed
+            let nextSurfaceTabBarDirectory = configTrackingDirectory(for: panelId)
+            if surfaceTabBarDirectory != nextSurfaceTabBarDirectory {
+                surfaceTabBarDirectory = nextSurfaceTabBarDirectory
             }
             if currentDirectory != trimmed {
                 currentDirectory = trimmed

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -675,6 +675,7 @@
 		REE0CA0000000000000000A2 /* RemotesClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = REE0CA0000000000000000A1 /* RemotesClient.swift */; };
 		REE0CA0000000000000000B2 /* RemotesClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = REE0CA0000000000000000B1 /* RemotesClientTests.swift */; };
 		EE30D6000000000000000006 /* RemoteSessionStrings+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30D6000000000000000005 /* RemoteSessionStrings+App.swift */; };
+		C0F674600000000000000001 /* RemoteShellCWDRelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F674600000000000000002 /* RemoteShellCWDRelayTests.swift */; };
 		E4321000E4321000E4321001 /* RemoteShellSessionParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4321000E4321000E4321002 /* RemoteShellSessionParsing.swift */; };
 		0A17C0DE0A17C0DE0A17C002 /* RemoteTmuxAttachOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C001 /* RemoteTmuxAttachOutcome.swift */; };
 		0A17C0DE0A17C0DE0A17C004 /* RemoteTmuxAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */; };
@@ -1756,6 +1757,7 @@
 		REE0CA0000000000000000A1 /* RemotesClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemotesClient.swift; sourceTree = "<group>"; };
 		REE0CA0000000000000000B1 /* RemotesClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotesClientTests.swift; sourceTree = "<group>"; };
 		EE30D6000000000000000005 /* RemoteSessionStrings+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSessionStrings+App.swift"; sourceTree = "<group>"; };
+		C0F674600000000000000002 /* RemoteShellCWDRelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteShellCWDRelayTests.swift; sourceTree = "<group>"; };
 		E4321000E4321000E4321002 /* RemoteShellSessionParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteShellSessionParsing.swift; sourceTree = "<group>"; };
 		0A17C0DE0A17C0DE0A17C001 /* RemoteTmuxAttachOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAttachOutcome.swift; sourceTree = "<group>"; };
 		0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxAuthTests.swift; sourceTree = "<group>"; };
@@ -3060,6 +3062,7 @@
 				C0F15A000000000000000002 /* FishShellIntegrationTests.swift */,
 				C0F16A000000000000000002 /* ShellStartupMatrixTests.swift */,
 				C0F16C000000000000000002 /* ShellStartupMissingBundleTests.swift */,
+				C0F674600000000000000002 /* RemoteShellCWDRelayTests.swift */,
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */,
 				B8E9500A0000000000000002 /* PostHogAnalyticsPropertiesTests.swift */,
 				604100010000000000000002 /* GhosttyDrawableSizeRetryTests.swift */,
@@ -4664,6 +4667,7 @@
 				A64610020000000000000001 /* QuitConfirmationAlertPresenterTests.swift in Sources */,
 				A6D1F0400000000000000002 /* ReleasingWindowControllerTests.swift in Sources */,
 				REE0CA0000000000000000B2 /* RemotesClientTests.swift in Sources */,
+				C0F674600000000000000001 /* RemoteShellCWDRelayTests.swift in Sources */,
 				0A17C0DE0A17C0DE0A17C004 /* RemoteTmuxAuthTests.swift in Sources */,
 				5F5553CA5553CA5553CA0001 /* RemoteTmuxCapabilitiesTests.swift in Sources */,
 				B2FDE62450514C4C27FBD8F1 /* RemoteTmuxControlParserTests.swift in Sources */,

--- a/cmuxTests/FishShellIntegrationTests.swift
+++ b/cmuxTests/FishShellIntegrationTests.swift
@@ -162,6 +162,58 @@ struct FishShellIntegrationTests {
         )
     }
 
+    @Test(.enabled(if: fishExecutablePath != nil))
+    func testFishIntegrationRelayPromptReportsPWD() throws {
+        _ = try requireFishExecutable()
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-fish-relay-pwd-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let remoteDirectory = root.appendingPathComponent("remote-cwd", isDirectory: true)
+        let logPath = root.appendingPathComponent("relay.log", isDirectory: false)
+        let cmuxPath = binDir.appendingPathComponent("cmux", isDirectory: false)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableShellFile(
+            at: cmuxPath,
+            body: """
+            #!/bin/sh
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            """
+        )
+
+        let result = try runInteractiveFish(
+            command: """
+            printf '' > "\(logPath.path)"
+            cd "\(remoteDirectory.path)"
+            set -g _CMUX_TTY_REPORTED 1
+            set -g _CMUX_PORTS_LAST_RUN (_cmux_now)
+            set -g _CMUX_PWD_LAST_PWD /tmp/local-launch
+            _cmux_prompt
+            for _cmux_i in (seq 1 20)
+                test -s "\(logPath.path)"; and break
+                sleep 0.05
+            end
+            cat "\(logPath.path)"
+            """,
+            extraEnvironment: [
+                "CMUX_SOCKET_PATH": "127.0.0.1:64011",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "22222222-2222-2222-2222-222222222222",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+                "CMUX_BUNDLED_CLI_PATH": cmuxPath.path,
+            ]
+        )
+
+        expectTrue(
+            result.stdout.contains(#"rpc surface.report_pwd {"workspace_id":"11111111-1111-1111-1111-111111111111","path":"\#(remoteDirectory.path)","surface_id":"22222222-2222-2222-2222-222222222222"}"#),
+            result.stdout
+        )
+    }
+
     @Test
     func testGeneratedFishBootstrapStagesIntegrationAndPreservesUserConfigHome() throws {
         let fileManager = FileManager.default

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -5161,58 +5161,6 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
         )
     }
 
-    func testShellIntegrationRelayPromptReportsPWDInZsh() throws {
-        let fileManager = FileManager.default
-        let root = fileManager.temporaryDirectory
-            .appendingPathComponent("cmux-zsh-relay-pwd-\(UUID().uuidString)")
-        let binDir = root.appendingPathComponent("bin", isDirectory: true)
-        let remoteDirectory = root.appendingPathComponent("remote-cwd", isDirectory: true)
-        let logPath = root.appendingPathComponent("relay.log", isDirectory: false)
-
-        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
-        try fileManager.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
-        defer { try? fileManager.removeItem(at: root) }
-
-        try writeExecutableScript(
-            at: binDir.appendingPathComponent("cmux", isDirectory: false),
-            contents: """
-            #!/bin/sh
-            printf '%s\\n' "$*" >> "\(logPath.path)"
-            exit 0
-            """
-        )
-
-        let output = try runInteractiveZsh(
-            cmuxLoadGhosttyIntegration: false,
-            cmuxLoadShellIntegration: true,
-            command: """
-            : > "\(logPath.path)"
-            cd "\(remoteDirectory.path)"
-            _CMUX_TTY_REPORTED=1
-            _CMUX_PORTS_LAST_RUN=$(_cmux_now)
-            _CMUX_PWD_LAST_PWD="/tmp/local-launch"
-            _cmux_precmd
-            repeat 20; do
-              [[ -s "\(logPath.path)" ]] && break
-              sleep 0.05
-            done
-            cat "\(logPath.path)"
-            """,
-            extraEnvironment: [
-                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
-                "CMUX_SOCKET_PATH": "127.0.0.1:64011",
-                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
-                "CMUX_TAB_ID": "22222222-2222-2222-2222-222222222222",
-                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
-            ]
-        )
-
-        XCTAssertTrue(
-            output.contains(#"rpc surface.report_pwd {"workspace_id":"11111111-1111-1111-1111-111111111111","path":"\#(remoteDirectory.path)","surface_id":"22222222-2222-2222-2222-222222222222"}"#),
-            output
-        )
-    }
-
     func testShellIntegrationRelayReportTTYUsesWorkspaceIDInBash() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
@@ -5251,57 +5199,6 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
 
         XCTAssertTrue(
             result.stdout.contains(#"rpc surface.report_tty {"workspace_id":"11111111-1111-1111-1111-111111111111","tty_name":"ttys888","surface_id":"22222222-2222-2222-2222-222222222222"}"#),
-            result.stdout
-        )
-    }
-
-    func testShellIntegrationRelayPromptReportsPWDInBash() throws {
-        let fileManager = FileManager.default
-        let root = fileManager.temporaryDirectory
-            .appendingPathComponent("cmux-bash-relay-pwd-\(UUID().uuidString)")
-        let binDir = root.appendingPathComponent("bin", isDirectory: true)
-        let remoteDirectory = root.appendingPathComponent("remote-cwd", isDirectory: true)
-        let logPath = root.appendingPathComponent("relay.log", isDirectory: false)
-
-        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
-        try fileManager.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
-        defer { try? fileManager.removeItem(at: root) }
-
-        try writeExecutableScript(
-            at: binDir.appendingPathComponent("cmux", isDirectory: false),
-            contents: """
-            #!/bin/sh
-            printf '%s\\n' "$*" >> "\(logPath.path)"
-            exit 0
-            """
-        )
-
-        let result = try runInteractiveBash(
-            cmuxLoadShellIntegration: true,
-            command: """
-            : > "\(logPath.path)"
-            cd "\(remoteDirectory.path)"
-            _CMUX_TTY_REPORTED=1
-            _CMUX_PORTS_LAST_RUN=$(_cmux_now)
-            _CMUX_PWD_LAST_PWD="/tmp/local-launch"
-            _cmux_prompt_command
-            for _cmux_i in $(seq 1 20); do
-              [ -s "\(logPath.path)" ] && break
-              sleep 0.05
-            done
-            cat "\(logPath.path)"
-            """,
-            extraEnvironment: [
-                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
-                "CMUX_SOCKET_PATH": "127.0.0.1:64011",
-                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
-                "CMUX_TAB_ID": "22222222-2222-2222-2222-222222222222",
-                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
-            ]
-        )
-
-        XCTAssertTrue(
-            result.stdout.contains(#"rpc surface.report_pwd {"workspace_id":"11111111-1111-1111-1111-111111111111","path":"\#(remoteDirectory.path)","surface_id":"22222222-2222-2222-2222-222222222222"}"#),
             result.stdout
         )
     }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -5161,6 +5161,58 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
         )
     }
 
+    func testShellIntegrationRelayPromptReportsPWDInZsh() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-relay-pwd-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let remoteDirectory = root.appendingPathComponent("remote-cwd", isDirectory: true)
+        let logPath = root.appendingPathComponent("relay.log", isDirectory: false)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("cmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+
+        let output = try runInteractiveZsh(
+            cmuxLoadGhosttyIntegration: false,
+            cmuxLoadShellIntegration: true,
+            command: """
+            : > "\(logPath.path)"
+            cd "\(remoteDirectory.path)"
+            _CMUX_TTY_REPORTED=1
+            _CMUX_PORTS_LAST_RUN=$(_cmux_now)
+            _CMUX_PWD_LAST_PWD="/tmp/local-launch"
+            _cmux_precmd
+            repeat 20; do
+              [[ -s "\(logPath.path)" ]] && break
+              sleep 0.05
+            done
+            cat "\(logPath.path)"
+            """,
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": "127.0.0.1:64011",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "22222222-2222-2222-2222-222222222222",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        XCTAssertTrue(
+            output.contains(#"rpc surface.report_pwd {"workspace_id":"11111111-1111-1111-1111-111111111111","path":"\#(remoteDirectory.path)","surface_id":"22222222-2222-2222-2222-222222222222"}"#),
+            output
+        )
+    }
+
     func testShellIntegrationRelayReportTTYUsesWorkspaceIDInBash() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
@@ -5199,6 +5251,57 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
 
         XCTAssertTrue(
             result.stdout.contains(#"rpc surface.report_tty {"workspace_id":"11111111-1111-1111-1111-111111111111","tty_name":"ttys888","surface_id":"22222222-2222-2222-2222-222222222222"}"#),
+            result.stdout
+        )
+    }
+
+    func testShellIntegrationRelayPromptReportsPWDInBash() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-bash-relay-pwd-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let remoteDirectory = root.appendingPathComponent("remote-cwd", isDirectory: true)
+        let logPath = root.appendingPathComponent("relay.log", isDirectory: false)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("cmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+
+        let result = try runInteractiveBash(
+            cmuxLoadShellIntegration: true,
+            command: """
+            : > "\(logPath.path)"
+            cd "\(remoteDirectory.path)"
+            _CMUX_TTY_REPORTED=1
+            _CMUX_PORTS_LAST_RUN=$(_cmux_now)
+            _CMUX_PWD_LAST_PWD="/tmp/local-launch"
+            _cmux_prompt_command
+            for _cmux_i in $(seq 1 20); do
+              [ -s "\(logPath.path)" ] && break
+              sleep 0.05
+            done
+            cat "\(logPath.path)"
+            """,
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": "127.0.0.1:64011",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "22222222-2222-2222-2222-222222222222",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        XCTAssertTrue(
+            result.stdout.contains(#"rpc surface.report_pwd {"workspace_id":"11111111-1111-1111-1111-111111111111","path":"\#(remoteDirectory.path)","surface_id":"22222222-2222-2222-2222-222222222222"}"#),
             result.stdout
         )
     }

--- a/cmuxTests/RemoteShellCWDRelayTests.swift
+++ b/cmuxTests/RemoteShellCWDRelayTests.swift
@@ -1,0 +1,226 @@
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct RemoteShellCWDRelayTests {
+    @Test
+    func zshRelayPromptReportsRemotePWD() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-relay-pwd-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let remoteDirectory = root.appendingPathComponent("remote-cwd", isDirectory: true)
+        let logPath = root.appendingPathComponent("relay.log", isDirectory: false)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("cmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+
+        let output = try runInteractiveZsh(
+            command: """
+            : > "\(logPath.path)"
+            cd "\(remoteDirectory.path)"
+            _CMUX_TTY_REPORTED=1
+            _CMUX_PORTS_LAST_RUN=$(_cmux_now)
+            _CMUX_PWD_LAST_PWD="/tmp/local-launch"
+            _cmux_precmd
+            repeat 20; do
+              [[ -s "\(logPath.path)" ]] && break
+              sleep 0.05
+            done
+            cat "\(logPath.path)"
+            """,
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": "127.0.0.1:64011",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "22222222-2222-2222-2222-222222222222",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        let expected = #"rpc surface.report_pwd {"workspace_id":"11111111-1111-1111-1111-111111111111","path":"\#(remoteDirectory.path)","surface_id":"22222222-2222-2222-2222-222222222222"}"#
+        #expect(output.contains(expected), output)
+    }
+
+    @Test
+    func bashRelayPromptReportsRemotePWD() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-bash-relay-pwd-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let remoteDirectory = root.appendingPathComponent("remote-cwd", isDirectory: true)
+        let logPath = root.appendingPathComponent("relay.log", isDirectory: false)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: remoteDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("cmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+
+        let result = try runInteractiveBash(
+            command: """
+            : > "\(logPath.path)"
+            cd "\(remoteDirectory.path)"
+            _CMUX_TTY_REPORTED=1
+            _CMUX_PORTS_LAST_RUN=$(_cmux_now)
+            _CMUX_PWD_LAST_PWD="/tmp/local-launch"
+            _cmux_prompt_command
+            for _cmux_i in $(seq 1 20); do
+              [ -s "\(logPath.path)" ] && break
+              sleep 0.05
+            done
+            cat "\(logPath.path)"
+            """,
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": "127.0.0.1:64011",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "22222222-2222-2222-2222-222222222222",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        let expected = #"rpc surface.report_pwd {"workspace_id":"11111111-1111-1111-1111-111111111111","path":"\#(remoteDirectory.path)","surface_id":"22222222-2222-2222-2222-222222222222"}"#
+        #expect(result.stdout.contains(expected), result.stdout)
+    }
+
+    private func runInteractiveZsh(
+        command: String,
+        extraEnvironment: [String: String]
+    ) throws -> String {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-shell-integration-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let userZdotdir = root.appendingPathComponent("zdotdir")
+        try fileManager.createDirectory(at: userZdotdir, withIntermediateDirectories: true)
+        var userZshEnvFileContents = "\n"
+        if let path = extraEnvironment["PATH"] {
+            let escaped = path.replacingOccurrences(of: "\"", with: "\\\"")
+            userZshEnvFileContents = "export PATH=\"\(escaped)\"\n"
+        }
+        try userZshEnvFileContents.write(
+            to: userZdotdir.appendingPathComponent(".zshenv"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let cmuxZdotdir = repoRoot.appendingPathComponent("Resources/shell-integration")
+        let ghosttyResources = repoRoot.appendingPathComponent("ghostty/src")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-i", "-c", command]
+        process.environment = [
+            "HOME": root.path,
+            "TERM": "xterm-256color",
+            "SHELL": "/bin/zsh",
+            "USER": NSUserName(),
+            "ZDOTDIR": cmuxZdotdir.path,
+            "CMUX_ZSH_ZDOTDIR": userZdotdir.path,
+            "CMUX_SHELL_INTEGRATION": "1",
+            "CMUX_SHELL_INTEGRATION_DIR": cmuxZdotdir.path,
+            "GHOSTTY_RESOURCES_DIR": ghosttyResources.path,
+        ]
+        for (key, value) in extraEnvironment {
+            process.environment?[key] = value
+        }
+
+        let output = try runProcess(process)
+        #expect(output.status == 0, output.stderr)
+        return output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func runInteractiveBash(
+        command: String,
+        extraEnvironment: [String: String]
+    ) throws -> (stdout: String, stderr: String) {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-bash-shell-integration-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let integrationPath = repoRoot.appendingPathComponent("Resources/shell-integration/cmux-bash-integration.bash")
+        let rcfilePath = root.appendingPathComponent(".bashrc")
+        try ". \"\(integrationPath.path)\"\n".write(to: rcfilePath, atomically: true, encoding: .utf8)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["--noprofile", "--rcfile", rcfilePath.path, "-i", "-c", command]
+        process.environment = [
+            "HOME": root.path,
+            "TERM": "xterm-256color",
+            "SHELL": "/bin/bash",
+            "USER": NSUserName(),
+        ]
+        for (key, value) in extraEnvironment {
+            process.environment?[key] = value
+        }
+
+        let output = try runProcess(process)
+        #expect(output.status == 0, output.stderr)
+        return (
+            stdout: output.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+            stderr: output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    private func runProcess(_ process: Process) throws -> (status: Int32, stdout: String, stderr: String) {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        let deadline = Date.now.addingTimeInterval(5)
+        while process.isRunning && Date.now < deadline {
+            _ = RunLoop.current.run(mode: .default, before: Date.now.addingTimeInterval(0.01))
+        }
+        if process.isRunning {
+            process.terminate()
+            process.waitUntilExit()
+            throw NSError(
+                domain: "RemoteShellCWDRelayTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for shell to exit"]
+            )
+        }
+
+        return (
+            status: process.terminationStatus,
+            stdout: String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
+            stderr: String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        )
+    }
+
+    private func writeExecutableScript(at url: URL, contents: String) throws {
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+}

--- a/cmuxTests/RemoteShellCWDRelayTests.swift
+++ b/cmuxTests/RemoteShellCWDRelayTests.swift
@@ -49,7 +49,7 @@ struct RemoteShellCWDRelayTests {
         )
 
         let expected = #"rpc surface.report_pwd {"workspace_id":"11111111-1111-1111-1111-111111111111","path":"\#(remoteDirectory.path)","surface_id":"22222222-2222-2222-2222-222222222222"}"#
-        #expect(output.contains(expected), output)
+        #expect(output.contains(expected), Comment(rawValue: output))
     }
 
     @Test
@@ -98,7 +98,7 @@ struct RemoteShellCWDRelayTests {
         )
 
         let expected = #"rpc surface.report_pwd {"workspace_id":"11111111-1111-1111-1111-111111111111","path":"\#(remoteDirectory.path)","surface_id":"22222222-2222-2222-2222-222222222222"}"#
-        #expect(result.stdout.contains(expected), result.stdout)
+        #expect(result.stdout.contains(expected), Comment(rawValue: result.stdout))
     }
 
     private func runInteractiveZsh(
@@ -149,7 +149,7 @@ struct RemoteShellCWDRelayTests {
         }
 
         let output = try runProcess(process)
-        #expect(output.status == 0, output.stderr)
+        #expect(output.status == 0, Comment(rawValue: output.stderr))
         return output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
@@ -184,7 +184,7 @@ struct RemoteShellCWDRelayTests {
         }
 
         let output = try runProcess(process)
-        #expect(output.status == 0, output.stderr)
+        #expect(output.status == 0, Comment(rawValue: output.stderr))
         return (
             stdout: output.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
             stderr: output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
## Summary
- add regression coverage for remote zsh, bash, and fish prompt cwd relay
- add `surface.report_pwd` so remote shell integrations can update the shared workspace panel directory
- preserve early remote cwd reports until the remote terminal surface is registered

## Testing
- Not run locally per issue instructions; CI/PR workflows only.

Issue: https://github.com/manaflow-ai/cmux/issues/6746

Closes https://github.com/manaflow-ai/cmux/issues/6746

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784928418&installation_id=133855650&pr_number=6747&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6747&signature=f7f58b120d3a07a765efe3018177497bd1973ca301fa9fd7a5a95212597c9476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remote SSH workspace CWD tracking from the first prompt and stops local config/hook scans on remote paths. Adds and advertises the `surface.report_pwd` RPC; bash/zsh/fish now report CWD via socket or the remote relay. Addresses #6746.

- **Bug Fixes**
  - Implemented `surface.report_pwd` end-to-end with alias support (`path`/`directory`/`cwd`), conflict checks, and clear not_found errors; capability is now advertised.
  - Updated `cmux-{bash,zsh}` and fish prompts to report CWD (UNIX socket when present, relay otherwise) with last-PWD dedupe; added relay helpers and regression tests for bash/zsh/fish.
  - Queues early remote CWD reports and applies them when the first remote surface registers; preserves exact path whitespace.
  - No local config or hook scans for remote paths: disables project-root refresh for remote workspaces and passes no starting path to notification hooks in `FeedCoordinator` and `TerminalNotificationStore`.

<sup>Written for commit af708de64f5b6ed01092a2c11dd4b08a071df403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reporting the current working directory from remote shell sessions (including relay-based reporting when no local UNIX socket is available).
  * Expanded V2 socket/RPC support with the new `surface.report_pwd` command so the app can process directory reports.

* **Bug Fixes**
  * Added validation for `path`/`cwd` inputs, rejecting conflicting or missing values.
  * Improved remote surface handling by introducing a pending remote directory (PWD) flow and clearing it on disconnect.

* **Tests**
  * Added/updated integration and coordinator tests to cover `surface.report_pwd` for bash/zsh relay scenarios and parameter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->