### PR TITLE
Fix iOS auth error handling

### DIFF
--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthConfig.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthConfig.swift
@@ -54,8 +54,8 @@ public struct AuthConfig: Equatable, Sendable {
             callbackURL = "http://localhost:3000/auth/callback"
             defaultAPIBaseURL = "http://localhost:3000"
         case .production:
-            callbackURL = "https://cmux.dev/auth/callback"
-            defaultAPIBaseURL = "https://cmux.dev"
+            callbackURL = "https://cmux.com/auth/callback"
+            defaultAPIBaseURL = "https://cmux.com"
         }
 
         let override = overrides["ApiBaseURL"]

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthError+DisplaySafe.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthError+DisplaySafe.swift
@@ -41,6 +41,7 @@ extension AuthError {
                 "INVALID_OTP",
                 "OTP_EXPIRED",
                 "RATE_LIMIT",
+                "RATE_LIMITED",
                 "EMAIL_PASSWORD_MISMATCH",
                 "USER_NOT_FOUND",
                 "PASSKEY_AUTHENTICATION_FAILED",
@@ -48,7 +49,18 @@ extension AuthError {
                 "INVALID_TOTP_CODE",
                 "REDIRECT_URL_NOT_WHITELISTED",
                 "OAUTH_PROVIDER_ACCOUNT_ID_ALREADY_USED_FOR_SIGN_IN",
-                "INVALID_APPLE_CREDENTIALS":
+                "INVALID_APPLE_CREDENTIALS",
+                "APPLE_SIGNIN_NOT_CONFIGURED",
+                "APPLE_SIGNIN_NOT_HANDLED",
+                "APPLE_SIGNIN_INVALID_RESPONSE",
+                "APPLE_SIGNIN_FAILED",
+                "APPLE_SIGNIN_NOT_INTERACTIVE",
+                "APPLE_SIGNIN_ERROR",
+                "OAUTH_ERROR",
+                "MISSING_CODE",
+                "PARSE_ERROR",
+                "INVALID_RESPONSE",
+                "INVALID_URL":
                 // Already display-safe; the sign-in UI renders these codes.
                 return nil
             case "UNAUTHORIZED", "INVALID_TOKEN", "TOKEN_EXPIRED":

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthConfigTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthConfigTests.swift
@@ -1,0 +1,12 @@
+import CMUXAuthCore
+import Testing
+@testable import CmuxAuthRuntime
+
+@Suite struct AuthConfigTests {
+    @Test func productionUsesStackWhitelistedCmuxDomain() {
+        let config = AuthConfig(environment: .production)
+
+        #expect(config.magicLinkCallbackURL == "https://cmux.com/auth/callback")
+        #expect(config.apiBaseURL == "https://cmux.com")
+    }
+}

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthErrorDisplaySafeTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthErrorDisplaySafeTests.swift
@@ -8,7 +8,12 @@ import Testing
         let preserved = [
             "SCHEMA_ERROR", "USER_EMAIL_ALREADY_EXISTS", "VERIFICATION_CODE_ERROR",
             "INVALID_OTP", "OTP_EXPIRED", "RATE_LIMIT", "RATE_LIMITED",
-            "EMAIL_PASSWORD_MISMATCH", "USER_NOT_FOUND", "INVALID_TOTP_CODE",
+            "EMAIL_PASSWORD_MISMATCH", "USER_NOT_FOUND",
+            "PASSKEY_AUTHENTICATION_FAILED", "PASSKEY_WEBAUTHN_ERROR",
+            "INVALID_TOTP_CODE", "REDIRECT_URL_NOT_WHITELISTED",
+            "OAUTH_PROVIDER_ACCOUNT_ID_ALREADY_USED_FOR_SIGN_IN",
+            "INVALID_APPLE_CREDENTIALS", "OAUTH_ERROR", "MISSING_CODE",
+            "PARSE_ERROR", "INVALID_RESPONSE", "INVALID_URL",
             "apple_signin_not_configured", "apple_signin_not_handled",
             "apple_signin_invalid_response", "apple_signin_failed",
             "apple_signin_not_interactive", "apple_signin_error",

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthErrorDisplaySafeTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthErrorDisplaySafeTests.swift
@@ -7,8 +7,11 @@ import Testing
     @Test func preservesRenderableStackCodes() {
         let preserved = [
             "SCHEMA_ERROR", "USER_EMAIL_ALREADY_EXISTS", "VERIFICATION_CODE_ERROR",
-            "INVALID_OTP", "OTP_EXPIRED", "RATE_LIMIT", "EMAIL_PASSWORD_MISMATCH",
-            "USER_NOT_FOUND", "INVALID_TOTP_CODE",
+            "INVALID_OTP", "OTP_EXPIRED", "RATE_LIMIT", "RATE_LIMITED",
+            "EMAIL_PASSWORD_MISMATCH", "USER_NOT_FOUND", "INVALID_TOTP_CODE",
+            "apple_signin_not_configured", "apple_signin_not_handled",
+            "apple_signin_invalid_response", "apple_signin_failed",
+            "apple_signin_not_interactive", "apple_signin_error",
         ]
         for code in preserved {
             // nil means "surface the original error unchanged".

--- a/Packages/iOS/CmuxMobileShellUI/Package.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Package.swift
@@ -61,6 +61,7 @@ let package = Package(
                 "CmuxMobileShellUI",
                 "CmuxMobileShell",
                 "CmuxMobileWorkspace",
+                .product(name: "StackAuth", package: "stack-auth-swift-sdk-prerelease"),
             ],
             swiftSettings: [
                 .define("CMUX_DEV_AUTH", .when(configuration: .debug)),

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInErrorPresentation.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInErrorPresentation.swift
@@ -4,11 +4,9 @@ import Foundation
 import StackAuth
 
 struct SignInErrorPresentation {
-    private init() {}
-
     /// Maps a sign-in error to the `ios_sign_in_failed` `failure_reason` enum
     /// (enums only, never the error text or the user's email).
-    static func failureReason(for error: Error) -> String {
+    func failureReason(for error: Error) -> String {
         if let authError = error as? AuthError {
             switch authError {
             case .timedOut:
@@ -40,7 +38,7 @@ struct SignInErrorPresentation {
         return "other"
     }
 
-    static func message(for error: Error) -> String {
+    func message(for error: Error) -> String {
         let displayError = AuthError(displaySafe: error) ?? error
         if let stackError = displayError as? StackAuthErrorProtocol {
             switch stackError.code.uppercased() {
@@ -77,8 +75,6 @@ struct SignInErrorPresentation {
                 return L10n.string("auth.error.apple_config", defaultValue: "Apple Sign In is not available yet. Please use another sign-in method.")
             case "OAUTH_ERROR", "MISSING_CODE", "PARSE_ERROR", "INVALID_RESPONSE":
                 return L10n.string("auth.error.browser_sign_in_failed", defaultValue: "Could not complete browser sign-in. Try again or open sign-in in your browser.")
-            case "OAUTH_CANCELLED":
-                return ""
             default:
                 break
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInErrorPresentation.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInErrorPresentation.swift
@@ -1,0 +1,109 @@
+import CmuxAuthRuntime
+import CmuxMobileSupport
+import Foundation
+import StackAuth
+
+struct SignInErrorPresentation {
+    private init() {}
+
+    /// Maps a sign-in error to the `ios_sign_in_failed` `failure_reason` enum
+    /// (enums only, never the error text or the user's email).
+    static func failureReason(for error: Error) -> String {
+        if let authError = error as? AuthError {
+            switch authError {
+            case .timedOut:
+                return "timeout"
+            case .offline:
+                return "offline"
+            case .networkError:
+                return "network"
+            default:
+                break
+            }
+        }
+        if let stackError = error as? StackAuthErrorProtocol {
+            switch stackError.code.uppercased() {
+            case "VERIFICATION_CODE_ERROR", "INVALID_OTP", "INVALID_TOTP_CODE":
+                return "invalid_code"
+            case "OTP_EXPIRED":
+                return "code_expired"
+            case "RATE_LIMIT", "RATE_LIMITED":
+                return "rate_limit"
+            default:
+                return "oauth_error"
+            }
+        }
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            return "network"
+        }
+        return "other"
+    }
+
+    static func message(for error: Error) -> String {
+        let displayError = AuthError(displaySafe: error) ?? error
+        if let stackError = displayError as? StackAuthErrorProtocol {
+            switch stackError.code.uppercased() {
+            case "SCHEMA_ERROR":
+                return L10n.string("auth.error.invalid_email", defaultValue: "Please enter a valid email address.")
+            case "USER_EMAIL_ALREADY_EXISTS":
+                return L10n.string("auth.error.email_exists", defaultValue: "An account with this email already exists. Try signing in instead.")
+            case "VERIFICATION_CODE_ERROR", "INVALID_OTP":
+                return L10n.string("auth.error.invalid_code", defaultValue: "Invalid code. Please check and try again.")
+            case "OTP_EXPIRED":
+                return L10n.string("auth.error.code_expired", defaultValue: "Code expired. Please request a new one.")
+            case "RATE_LIMIT", "RATE_LIMITED":
+                return L10n.string("auth.error.rate_limit", defaultValue: "Too many attempts. Please wait a moment and try again.")
+            case "EMAIL_PASSWORD_MISMATCH":
+                return L10n.string("auth.error.wrong_password", defaultValue: "Incorrect email or password.")
+            case "USER_NOT_FOUND":
+                return L10n.string("auth.error.user_not_found", defaultValue: "No account found with this email.")
+            case "PASSKEY_AUTHENTICATION_FAILED", "PASSKEY_WEBAUTHN_ERROR":
+                return L10n.string("auth.error.passkey_failed", defaultValue: "Passkey authentication failed. Please try again.")
+            case "INVALID_TOTP_CODE":
+                return L10n.string("auth.error.invalid_mfa", defaultValue: "Incorrect verification code. Please try again.")
+            case "REDIRECT_URL_NOT_WHITELISTED", "INVALID_URL":
+                return L10n.string("auth.error.config", defaultValue: "Sign in is temporarily unavailable. Please try again later.")
+            case "OAUTH_PROVIDER_ACCOUNT_ID_ALREADY_USED_FOR_SIGN_IN":
+                return L10n.string("auth.error.oauth_linked", defaultValue: "This account is already linked to another sign-in method.")
+            case
+                "INVALID_APPLE_CREDENTIALS",
+                "APPLE_SIGNIN_NOT_CONFIGURED",
+                "APPLE_SIGNIN_NOT_HANDLED",
+                "APPLE_SIGNIN_INVALID_RESPONSE",
+                "APPLE_SIGNIN_FAILED",
+                "APPLE_SIGNIN_NOT_INTERACTIVE",
+                "APPLE_SIGNIN_ERROR":
+                return L10n.string("auth.error.apple_config", defaultValue: "Apple Sign In is not available yet. Please use another sign-in method.")
+            case "OAUTH_ERROR", "MISSING_CODE", "PARSE_ERROR", "INVALID_RESPONSE":
+                return L10n.string("auth.error.browser_sign_in_failed", defaultValue: "Could not complete browser sign-in. Try again or open sign-in in your browser.")
+            case "OAUTH_CANCELLED":
+                return ""
+            default:
+                break
+            }
+        }
+
+        if let authError = displayError as? AuthError {
+            return authError.localizedDescription
+        }
+
+        let nsError = displayError as NSError
+        if nsError.domain == NSURLErrorDomain {
+            return L10n.string("auth.error.network", defaultValue: "Could not connect to the server. Check your internet connection and try again.")
+        }
+
+        #if DEBUG
+        var debug = "\(displayError.localizedDescription)\n\(String(reflecting: type(of: displayError)))"
+        if let stackError = displayError as? StackAuthErrorProtocol {
+            debug += "\ncode: \(stackError.code)\nmessage: \(stackError.message)"
+            if let details = stackError.details {
+                debug += "\ndetails: \(details)"
+            }
+        }
+        return debug
+        #else
+        return L10n.string("auth.error.generic", defaultValue: "Something went wrong. Please try again.")
+        #endif
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
@@ -363,35 +363,7 @@ struct SignInView: View {
     /// Maps a sign-in error to the `ios_sign_in_failed` `failure_reason` enum
     /// (enums only, never the error text or the user's email).
     private static func signInFailureReason(_ error: Error) -> String {
-        if let authError = error as? AuthError {
-            switch authError {
-            case .timedOut:
-                return "timeout"
-            case .offline:
-                return "offline"
-            case .networkError:
-                return "network"
-            default:
-                break
-            }
-        }
-        if let stackError = error as? StackAuthErrorProtocol {
-            switch stackError.code {
-            case "VERIFICATION_CODE_ERROR", "INVALID_OTP", "INVALID_TOTP_CODE":
-                return "invalid_code"
-            case "OTP_EXPIRED":
-                return "code_expired"
-            case "RATE_LIMIT":
-                return "rate_limit"
-            default:
-                return "oauth_error"
-            }
-        }
-        let nsError = error as NSError
-        if nsError.domain == NSURLErrorDomain {
-            return "network"
-        }
-        return "other"
+        SignInErrorPresentation.failureReason(for: error)
     }
 
     private func errorText(_ message: String) -> some View {
@@ -405,61 +377,7 @@ struct SignInView: View {
     }
 
     private func detailedErrorMessage(_ error: Error) -> String {
-        let displayError = AuthError(displaySafe: error) ?? error
-        if let stackError = displayError as? StackAuthErrorProtocol {
-            switch stackError.code {
-            case "SCHEMA_ERROR":
-                return L10n.string("auth.error.invalid_email", defaultValue: "Please enter a valid email address.")
-            case "USER_EMAIL_ALREADY_EXISTS":
-                return L10n.string("auth.error.email_exists", defaultValue: "An account with this email already exists. Try signing in instead.")
-            case "VERIFICATION_CODE_ERROR", "INVALID_OTP":
-                return L10n.string("auth.error.invalid_code", defaultValue: "Invalid code. Please check and try again.")
-            case "OTP_EXPIRED":
-                return L10n.string("auth.error.code_expired", defaultValue: "Code expired. Please request a new one.")
-            case "RATE_LIMIT":
-                return L10n.string("auth.error.rate_limit", defaultValue: "Too many attempts. Please wait a moment and try again.")
-            case "EMAIL_PASSWORD_MISMATCH":
-                return L10n.string("auth.error.wrong_password", defaultValue: "Incorrect email or password.")
-            case "USER_NOT_FOUND":
-                return L10n.string("auth.error.user_not_found", defaultValue: "No account found with this email.")
-            case "PASSKEY_AUTHENTICATION_FAILED", "PASSKEY_WEBAUTHN_ERROR":
-                return L10n.string("auth.error.passkey_failed", defaultValue: "Passkey authentication failed. Please try again.")
-            case "INVALID_TOTP_CODE":
-                return L10n.string("auth.error.invalid_mfa", defaultValue: "Incorrect verification code. Please try again.")
-            case "REDIRECT_URL_NOT_WHITELISTED":
-                return L10n.string("auth.error.config", defaultValue: "Sign in is temporarily unavailable. Please try again later.")
-            case "OAUTH_PROVIDER_ACCOUNT_ID_ALREADY_USED_FOR_SIGN_IN":
-                return L10n.string("auth.error.oauth_linked", defaultValue: "This account is already linked to another sign-in method.")
-            case "INVALID_APPLE_CREDENTIALS":
-                return L10n.string("auth.error.apple_config", defaultValue: "Apple Sign In is not available yet. Please use another sign-in method.")
-            case "oauth_cancelled":
-                return ""
-            default:
-                break
-            }
-        }
-
-        if let authError = displayError as? AuthError {
-            return authError.localizedDescription
-        }
-
-        let nsError = displayError as NSError
-        if nsError.domain == NSURLErrorDomain {
-            return L10n.string("auth.error.network", defaultValue: "Could not connect to the server. Check your internet connection and try again.")
-        }
-
-        #if DEBUG
-        var debug = "\(displayError.localizedDescription)\n\(String(reflecting: type(of: displayError)))"
-        if let stackError = displayError as? StackAuthErrorProtocol {
-            debug += "\ncode: \(stackError.code)\nmessage: \(stackError.message)"
-            if let details = stackError.details {
-                debug += "\ndetails: \(details)"
-            }
-        }
-        return debug
-        #else
-        return L10n.string("auth.error.generic", defaultValue: "Something went wrong. Please try again.")
-        #endif
+        SignInErrorPresentation.message(for: error)
     }
 
     private func authCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
@@ -22,6 +22,7 @@ struct SignInView: View {
     @State private var shouldAutofocusCode = false
     @State private var shouldAutofocusEmail = false
     @State private var signInTask: Task<Void, Never>?
+    private let errorPresentation = SignInErrorPresentation()
     @FocusState private var isEmailFocused: Bool
     @FocusState private var isCodeFocused: Bool
     var body: some View {
@@ -289,7 +290,7 @@ struct SignInView: View {
             self.error = detailedErrorMessage(error)
             analytics.capture("ios_sign_in_failed", [
                 "method": .string("email_code"),
-                "failure_reason": .string(Self.signInFailureReason(error)),
+                "failure_reason": .string(signInFailureReason(error)),
             ])
         }
     }
@@ -307,7 +308,7 @@ struct SignInView: View {
             code = ""
             analytics.capture("ios_sign_in_failed", [
                 "method": .string("email_code"),
-                "failure_reason": .string(Self.signInFailureReason(error)),
+                "failure_reason": .string(signInFailureReason(error)),
             ])
         }
     }
@@ -331,7 +332,7 @@ struct SignInView: View {
             self.error = detailedErrorMessage(error)
             analytics.capture("ios_sign_in_failed", [
                 "method": .string("apple"),
-                "failure_reason": .string(Self.signInFailureReason(error)),
+                "failure_reason": .string(signInFailureReason(error)),
             ])
         }
     }
@@ -355,15 +356,15 @@ struct SignInView: View {
             self.error = detailedErrorMessage(error)
             analytics.capture("ios_sign_in_failed", [
                 "method": .string("google"),
-                "failure_reason": .string(Self.signInFailureReason(error)),
+                "failure_reason": .string(signInFailureReason(error)),
             ])
         }
     }
 
     /// Maps a sign-in error to the `ios_sign_in_failed` `failure_reason` enum
     /// (enums only, never the error text or the user's email).
-    private static func signInFailureReason(_ error: Error) -> String {
-        SignInErrorPresentation.failureReason(for: error)
+    private func signInFailureReason(_ error: Error) -> String {
+        errorPresentation.failureReason(for: error)
     }
 
     private func errorText(_ message: String) -> some View {
@@ -377,7 +378,7 @@ struct SignInView: View {
     }
 
     private func detailedErrorMessage(_ error: Error) -> String {
-        SignInErrorPresentation.message(for: error)
+        errorPresentation.message(for: error)
     }
 
     private func authCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/SignInErrorPresentationTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/SignInErrorPresentationTests.swift
@@ -4,16 +4,18 @@ import Testing
 
 @Suite struct SignInErrorPresentationTests {
     @Test func rateLimitedStackCodeUsesRateLimitMessageAndReason() {
+        let presentation = SignInErrorPresentation()
         let error = StackAuthError(code: "RATE_LIMITED", message: "too many requests")
 
-        #expect(SignInErrorPresentation.failureReason(for: error) == "rate_limit")
+        #expect(presentation.failureReason(for: error) == "rate_limit")
         #expect(
-            SignInErrorPresentation.message(for: error)
+            presentation.message(for: error)
                 == "Too many attempts. Please wait a moment and try again."
         )
     }
 
     @Test func appleSignInSdkCodesUseAppleUnavailableMessage() {
+        let presentation = SignInErrorPresentation()
         let codes = [
             "apple_signin_not_configured",
             "apple_signin_not_handled",
@@ -25,9 +27,9 @@ import Testing
 
         for code in codes {
             let error = StackAuthError(code: code, message: "apple failed")
-            #expect(SignInErrorPresentation.failureReason(for: error) == "oauth_error")
+            #expect(presentation.failureReason(for: error) == "oauth_error")
             #expect(
-                SignInErrorPresentation.message(for: error)
+                presentation.message(for: error)
                     == "Apple Sign In is not available yet. Please use another sign-in method."
             )
         }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/SignInErrorPresentationTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/SignInErrorPresentationTests.swift
@@ -1,0 +1,35 @@
+import StackAuth
+import Testing
+@testable import CmuxMobileShellUI
+
+@Suite struct SignInErrorPresentationTests {
+    @Test func rateLimitedStackCodeUsesRateLimitMessageAndReason() {
+        let error = StackAuthError(code: "RATE_LIMITED", message: "too many requests")
+
+        #expect(SignInErrorPresentation.failureReason(for: error) == "rate_limit")
+        #expect(
+            SignInErrorPresentation.message(for: error)
+                == "Too many attempts. Please wait a moment and try again."
+        )
+    }
+
+    @Test func appleSignInSdkCodesUseAppleUnavailableMessage() {
+        let codes = [
+            "apple_signin_not_configured",
+            "apple_signin_not_handled",
+            "apple_signin_invalid_response",
+            "apple_signin_failed",
+            "apple_signin_not_interactive",
+            "apple_signin_error",
+        ]
+
+        for code in codes {
+            let error = StackAuthError(code: code, message: "apple failed")
+            #expect(SignInErrorPresentation.failureReason(for: error) == "oauth_error")
+            #expect(
+                SignInErrorPresentation.message(for: error)
+                    == "Apple Sign In is not available yet. Please use another sign-in method."
+            )
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6750

## Summary
- preserve Stack Auth rate-limit, OAuth, and Apple Sign In SDK error codes through the shared auth display-safe layer
- move iOS sign-in error presentation into a testable helper
- map RATE_LIMITED and Apple Sign In SDK failures to existing localized messages instead of the generic fallback
- fix the Release/TestFlight production auth callback/API defaults from cmux.dev to cmux.com so they match the production Stack project's whitelisted domains

## Root cause
- Debug simulator builds use the development Stack project and localhost callback, so email sign-in could work there.
- Release/TestFlight uses the production Stack project, but the app was sending `https://cmux.dev/auth/callback`; that host redirects to `https://cmux.com`, but the production Stack project whitelist contains `https://cmux.com`/related domains, not `https://cmux.dev`. Stack can reject the original callback URL before any web redirect helps.
- Several SDK errors were also collapsed to `auth_failed`, so the iOS UI showed a generic/unavailable message instead of the actionable auth/config error.

## Validation
- Reproduced iOS email code entry in the iPhone 17 simulator: email input and send-code advanced to code entry; real code completion was limited by inbox access, then the session later completed for `austin+issue6750@manaflow.com`.
- Reproduced Apple Sign In immediate failure in the simulator showing the generic error before this fix.
- Queried public Stack project metadata: development allows localhost; production whitelists `cmux.com`/`action.new`/`devbox.new` domains and does not list `cmux.dev`.
- Built and launched the iOS simulator app with `CMUX_SKIP_ZIG_BUILD=1 ./ios/scripts/reload.sh --tag issue-6750-ios-email-signin`.
- Did not run local tests per issue instructions; iOS/unit coverage is left to CI.

## Localization
- No new user-facing string keys; reused existing iOS auth error strings already localized in English and Japanese.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized sign-in error presentation to deliver clearer analytics and user-facing failure reasons/messages across Apple sign-in, OAuth, rate limiting, MFA/passkey issues, and URL/response problems.

* **Bug Fixes**
  * Expanded the set of authentication errors treated as safe to display, reducing generic or unclear sign-in feedback.

* **Tests**
  * Added coverage for sign-in error mapping and updated configuration checks to match the new behavior.

* **Chores**
  * Switched production magic-link callback and API base URLs to the `cmux.com` domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->