### PR TITLE
fix(cli): default workspace-scoped commands to the caller's workspace, not the focused one

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,7 +1,7 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-34590	CLI/cmux.swift
+34629	CLI/cmux.swift
 17841	Sources/AppDelegate.swift
 16132	Sources/ContentView.swift
 13832	Sources/TerminalController.swift

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5955,6 +5955,12 @@ struct CMUXCLI {
     ) throws -> String? {
         guard let raw else {
             if !allowCurrent { return nil }
+            // Prefer the caller's own workspace before the focused one (see
+            // resolveWorkspaceId). Placed after the !allowCurrent guard so explicit-surface
+            // routing, which passes allowCurrent: false to resolve globally, is unaffected.
+            if let callerWorkspaceId = callerWorkspaceIdFromEnvironment(windowHandle: windowHandle) {
+                return callerWorkspaceId
+            }
             let current: [String: Any]
             if let windowHandle {
                 current = try client.sendV2(method: "workspace.current", params: ["window_id": windowHandle])
@@ -13934,6 +13940,18 @@ struct CMUXCLI {
             .replacingOccurrences(of: "%25", with: "%")
     }
 
+    /// The caller's own workspace, taken from the `CMUX_WORKSPACE_ID` the app injects
+    /// into every terminal surface. Returns nil when the value is unset, blank, not a
+    /// UUID, or when an explicit window is targeted (the caller's workspace may live in a
+    /// different window). Resolvers use this to default to the workspace the command was
+    /// invoked from, falling back to the focused workspace only when there is no caller.
+    private func callerWorkspaceIdFromEnvironment(windowHandle: String?) -> String? {
+        guard windowHandle == nil else { return nil }
+        let value = (ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return isUUID(value) ? value : nil
+    }
+
     private func resolveWorkspaceId(_ raw: String?, client: SocketClient, windowHandle: String? = nil) throws -> String {
         if let raw, isUUID(raw) {
             return raw
@@ -13970,6 +13988,15 @@ struct CMUXCLI {
                 if let id = item["id"] as? String { return id }
             }
             throw CLIError(message: "Workspace index not found")
+        }
+
+        // No explicit workspace handle (nil, blank, or unparseable). Prefer the caller's
+        // own workspace over the focused one, so a background agent whose command omits or
+        // empties --workspace never silently acts on whatever workspace is selected in the
+        // foreground. Only when there is no caller (env unset, or an explicit --window was
+        // targeted) do we fall back to the window's selected workspace.
+        if let callerWorkspaceId = callerWorkspaceIdFromEnvironment(windowHandle: windowHandle) {
+            return callerWorkspaceId
         }
 
         var currentParams: [String: Any] = [:]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5956,8 +5956,8 @@ struct CMUXCLI {
         guard let raw else {
             if !allowCurrent { return nil }
             // Prefer the caller's own workspace before the focused one (see
-            // resolveWorkspaceId). Placed after the !allowCurrent guard so explicit-surface
-            // routing, which passes allowCurrent: false to resolve globally, is unaffected.
+            // resolveWorkspaceId). After the !allowCurrent guard, so explicit-surface
+            // routing (allowCurrent: false, resolves globally) is unaffected.
             if let callerWorkspaceId = callerWorkspaceIdFromEnvironment(windowHandle: windowHandle) {
                 return callerWorkspaceId
             }
@@ -13940,11 +13940,10 @@ struct CMUXCLI {
             .replacingOccurrences(of: "%25", with: "%")
     }
 
-    /// The caller's own workspace, taken from the `CMUX_WORKSPACE_ID` the app injects
-    /// into every terminal surface. Returns nil when the value is unset, blank, not a
-    /// UUID, or when an explicit window is targeted (the caller's workspace may live in a
-    /// different window). Resolvers use this to default to the workspace the command was
-    /// invoked from, falling back to the focused workspace only when there is no caller.
+    /// The caller's own workspace, from the `CMUX_WORKSPACE_ID` the app injects into every
+    /// terminal surface. Nil when unset/blank/non-UUID, or when an explicit window is
+    /// targeted (the caller's workspace may live in another window). Resolvers prefer this
+    /// over the focused workspace so a command defaults to where it was invoked from.
     private func callerWorkspaceIdFromEnvironment(windowHandle: String?) -> String? {
         guard windowHandle == nil else { return nil }
         let value = (ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] ?? "")
@@ -13991,27 +13990,23 @@ struct CMUXCLI {
         }
 
         // Reached only when `raw` was nil, blank, or nonblank-but-unrecognized (valid
-        // UUID/ref/index selectors returned or threw above).
-        //
-        // An explicit, nonblank, unrecognized selector (e.g. a typo) must fail closed
-        // regardless of caller env or window, so a malformed user-supplied workspace name
-        // never silently resolves to — and mutates — a different workspace.
+        // UUID/ref/index selectors returned or threw above). An explicit, nonblank,
+        // unrecognized selector (e.g. a typo) fails closed regardless of caller/window, so a
+        // malformed name never silently resolves to — and mutates — a different workspace.
         if let raw, !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             throw CLIError(message: "Workspace not found: \(raw)")
         }
 
-        // `raw` is nil (omitted) or explicitly blank. Prefer the caller's own workspace
-        // over the focused one, so a background agent whose command omits or empties
-        // --workspace never silently acts on whatever workspace is selected in the
-        // foreground.
+        // `raw` is nil (omitted) or blank. Prefer the caller's own workspace over the
+        // focused one, so a background agent that omits/empties --workspace never silently
+        // acts on whatever workspace is selected in the foreground.
         if let callerWorkspaceId = callerWorkspaceIdFromEnvironment(windowHandle: windowHandle) {
             return callerWorkspaceId
         }
 
         // No caller workspace. An explicit but blank selector (the dangerous
-        // `--workspace "${CMUX_WORKSPACE_ID:-}"`-expands-to-empty case) fails closed rather
-        // than retargeting the foreground workspace. Only a truly omitted selector, or an
-        // explicit --window, falls back to the window's selected workspace.
+        // `--workspace "${CMUX_WORKSPACE_ID:-}"`-expands-to-empty case) fails closed; only a
+        // truly omitted selector, or an explicit --window, uses the window's selection.
         if windowHandle == nil, raw != nil {
             throw CLIError(message: "No workspace selected: --workspace was blank and CMUX_WORKSPACE_ID is unset")
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13990,23 +13990,30 @@ struct CMUXCLI {
             throw CLIError(message: "Workspace index not found")
         }
 
-        // No usable workspace handle. Prefer the caller's own workspace over the focused
-        // one, so a background agent whose command omits or empties --workspace never
-        // silently acts on whatever workspace is selected in the foreground.
+        // Reached only when `raw` was nil, blank, or nonblank-but-unrecognized (valid
+        // UUID/ref/index selectors returned or threw above).
+        //
+        // An explicit, nonblank, unrecognized selector (e.g. a typo) must fail closed
+        // regardless of caller env or window, so a malformed user-supplied workspace name
+        // never silently resolves to — and mutates — a different workspace.
+        if let raw, !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw CLIError(message: "Workspace not found: \(raw)")
+        }
+
+        // `raw` is nil (omitted) or explicitly blank. Prefer the caller's own workspace
+        // over the focused one, so a background agent whose command omits or empties
+        // --workspace never silently acts on whatever workspace is selected in the
+        // foreground.
         if let callerWorkspaceId = callerWorkspaceIdFromEnvironment(windowHandle: windowHandle) {
             return callerWorkspaceId
         }
 
-        // An *explicit* but blank/unparseable selector must fail closed when there is no
-        // caller workspace, rather than silently retargeting the foreground workspace. This
-        // is the dangerous case: `--workspace "${CMUX_WORKSPACE_ID:-}"` expands to an empty
-        // argument when the caller environment is thin. Only a truly omitted selector (raw
-        // == nil), or an explicit --window, falls back to the window's selected workspace.
-        if windowHandle == nil, let raw {
-            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            throw CLIError(message: trimmed.isEmpty
-                ? "No workspace selected: --workspace was blank and CMUX_WORKSPACE_ID is unset"
-                : "Workspace not found: \(raw)")
+        // No caller workspace. An explicit but blank selector (the dangerous
+        // `--workspace "${CMUX_WORKSPACE_ID:-}"`-expands-to-empty case) fails closed rather
+        // than retargeting the foreground workspace. Only a truly omitted selector, or an
+        // explicit --window, falls back to the window's selected workspace.
+        if windowHandle == nil, raw != nil {
+            throw CLIError(message: "No workspace selected: --workspace was blank and CMUX_WORKSPACE_ID is unset")
         }
 
         var currentParams: [String: Any] = [:]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13990,13 +13990,23 @@ struct CMUXCLI {
             throw CLIError(message: "Workspace index not found")
         }
 
-        // No explicit workspace handle (nil, blank, or unparseable). Prefer the caller's
-        // own workspace over the focused one, so a background agent whose command omits or
-        // empties --workspace never silently acts on whatever workspace is selected in the
-        // foreground. Only when there is no caller (env unset, or an explicit --window was
-        // targeted) do we fall back to the window's selected workspace.
+        // No usable workspace handle. Prefer the caller's own workspace over the focused
+        // one, so a background agent whose command omits or empties --workspace never
+        // silently acts on whatever workspace is selected in the foreground.
         if let callerWorkspaceId = callerWorkspaceIdFromEnvironment(windowHandle: windowHandle) {
             return callerWorkspaceId
+        }
+
+        // An *explicit* but blank/unparseable selector must fail closed when there is no
+        // caller workspace, rather than silently retargeting the foreground workspace. This
+        // is the dangerous case: `--workspace "${CMUX_WORKSPACE_ID:-}"` expands to an empty
+        // argument when the caller environment is thin. Only a truly omitted selector (raw
+        // == nil), or an explicit --window, falls back to the window's selected workspace.
+        if windowHandle == nil, let raw {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw CLIError(message: trimmed.isEmpty
+                ? "No workspace selected: --workspace was blank and CMUX_WORKSPACE_ID is unset"
+                : "Workspace not found: \(raw)")
         }
 
         var currentParams: [String: Any] = [:]

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		A5D41222A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */; };
 		A9F200000000000000000015 /* ClaudeStreamJSONAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000015 /* ClaudeStreamJSONAccumulator.swift */; };
 		A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */; };
+		CA11E4D0FA017DE500000B101 /* CLICallerWorkspaceDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */; };
 		C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */; };
 		E295EA3753206FE3FFCA6C0A /* CLIExplicitSurfaceRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */; };
 		C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */; };
@@ -1304,6 +1305,7 @@
 		A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeNotificationStatusLifecycleTests.swift; sourceTree = "<group>"; };
 		A9F100000000000000000015 /* ClaudeStreamJSONAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ClaudeStreamJSONAccumulator.swift; sourceTree = "<group>"; };
 		A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAuthAliasTests.swift; sourceTree = "<group>"; };
+		CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICallerWorkspaceDefaultTests.swift; sourceTree = "<group>"; };
 		C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexHookTimeoutRegressionTests.swift; sourceTree = "<group>"; };
 		1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIExplicitSurfaceRoutingTests.swift; sourceTree = "<group>"; };
 		C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIForwardingLaunchArgumentTests.swift; sourceTree = "<group>"; };
@@ -3205,6 +3207,7 @@
 					C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */,
 					C0DE31390000000000000112 /* CMUXOpenHTMLFocusTests.swift */,
 					1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */,
+					CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */,
 					C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */,
 					C0DE64950000000000000006 /* CMUXCLISessionsListTests.swift */,
 					C0DE64950000000000000004 /* CMUXCLITestAssertions.swift */,
@@ -4544,6 +4547,7 @@
 				A5D41220A1B2C3D4E5F60718 /* ClaudeHookSurfaceResolutionSwiftTests.swift in Sources */,
 				A5D41222A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift in Sources */,
 				A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */,
+					CA11E4D0FA017DE500000B101 /* CLICallerWorkspaceDefaultTests.swift in Sources */,
 				C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */,
 					E295EA3753206FE3FFCA6C0A /* CLIExplicitSurfaceRoutingTests.swift in Sources */,
 				C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */,

--- a/cmuxTests/CLICallerWorkspaceDefaultTests.swift
+++ b/cmuxTests/CLICallerWorkspaceDefaultTests.swift
@@ -49,6 +49,22 @@ struct CLICallerWorkspaceDefaultTests {
         #expect(!methods.contains("notification.mark_read"), Comment(rawValue: methods.joined(separator: ",")))
     }
 
+    /// An explicit but unrecognized `--workspace` (e.g. a typo) must fail closed even when
+    /// a caller workspace is present, so a malformed name never silently resolves to — and
+    /// mutates — the caller's workspace.
+    @Test func invalidWorkspaceArgFailsClosedEvenWithCaller() throws {
+        let (requests, result) = try runMarkNotificationRead(
+            workspaceArgument: "not-a-real-workspace",
+            focusedWorkspaceId: Self.focusedWorkspaceId,
+            callerWorkspaceId: Self.callerWorkspaceId
+        )
+
+        #expect(result.status != 0, Comment(rawValue: "expected nonzero exit, got \(result.status)"))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(!methods.contains("notification.mark_read"), Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("workspace.current"), Comment(rawValue: methods.joined(separator: ",")))
+    }
+
     /// An explicit `--workspace <uuid>` must still win over the caller's environment, so
     /// the caller default never hijacks a command that names another workspace.
     @Test func explicitWorkspaceArgStillWins() throws {

--- a/cmuxTests/CLICallerWorkspaceDefaultTests.swift
+++ b/cmuxTests/CLICallerWorkspaceDefaultTests.swift
@@ -1,0 +1,333 @@
+import Darwin
+import Foundation
+import Testing
+
+/// Regression coverage for workspace-scoped CLI commands defaulting to the *caller's*
+/// workspace (the `CMUX_WORKSPACE_ID` the app injects into every terminal surface)
+/// instead of silently falling back to the focused workspace.
+///
+/// The regression: `resolveWorkspaceId` treated a missing/blank `--workspace` as
+/// "no handle" and fell through to `workspace.current`, i.e. whatever workspace is
+/// selected in the foreground. The skill-recommended pattern
+/// `--workspace "${CMUX_WORKSPACE_ID:-}"` expands to an empty value whenever a
+/// background agent's environment is thin, so the command would act on the user's
+/// visible workspace rather than the agent's own.
+@Suite(.serialized)
+struct CLICallerWorkspaceDefaultTests {
+    /// A blank `--workspace` from a caller pane must target the caller's workspace and
+    /// must never consult `workspace.current` (the focused workspace).
+    @Test func blankWorkspaceArgDefaultsToCallerWorkspace() throws {
+        let requests = try runMarkNotificationRead(
+            workspaceArgument: "   ",
+            focusedWorkspaceId: Self.focusedWorkspaceId
+        )
+
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(methods == ["notification.mark_read"], Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("workspace.current"))
+
+        let params = try #require(requests.first?["params"] as? [String: Any])
+        #expect(params["tab_id"] as? String == Self.callerWorkspaceId)
+    }
+
+    /// An explicit `--workspace <uuid>` must still win over the caller's environment, so
+    /// the caller default never hijacks a command that names another workspace.
+    @Test func explicitWorkspaceArgStillWins() throws {
+        let requests = try runMarkNotificationRead(
+            workspaceArgument: Self.otherWorkspaceId,
+            focusedWorkspaceId: Self.focusedWorkspaceId
+        )
+
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(methods == ["notification.mark_read"], Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("workspace.current"))
+
+        let params = try #require(requests.first?["params"] as? [String: Any])
+        #expect(params["tab_id"] as? String == Self.otherWorkspaceId)
+    }
+
+    /// Drives `mark-notification-read --workspace <argument>` against a mock socket and
+    /// returns the recorded JSON-RPC requests. The mock answers `workspace.current` with
+    /// `focusedWorkspaceId` so that, pre-fix, the command would visibly retarget there.
+    private func runMarkNotificationRead(
+        workspaceArgument: String,
+        focusedWorkspaceId: String
+    ) throws -> [[String: Any]] {
+        let socketPath = Self.makeSocketPath("caller-ws")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let state = ServerState()
+        let handled = Self.startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return Self.malformedRequestResponse(raw: line)
+            }
+            switch method {
+            case "workspace.current":
+                return Self.v2Response(id: id, ok: true, result: ["workspace_id": focusedWorkspaceId])
+            case "notification.mark_read":
+                return Self.v2Response(id: id, ok: true, result: ["ok": true])
+            default:
+                return Self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected_method", "message": method]
+                )
+            }
+        }
+
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: ["mark-notification-read", "--workspace", workspaceArgument],
+            environment: cliEnvironment(socketPath: socketPath),
+            timeout: 5
+        )
+
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+
+        return try state.requestObjects()
+    }
+
+    private func cliEnvironment(socketPath: String) -> [String: String] {
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = Self.callerWorkspaceId
+        environment["CMUX_SURFACE_ID"] = Self.callerSurfaceId
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+        // Clear any ambient window targeting inherited from the test host's own pane.
+        environment["CMUX_WINDOW_ID"] = nil
+        return environment
+    }
+
+    private static let callerWorkspaceId = "11111111-1111-1111-1111-111111111111"
+    private static let callerSurfaceId = "22222222-2222-2222-2222-222222222222"
+    private static let focusedWorkspaceId = "99999999-9999-9999-9999-999999999999"
+    private static let otherWorkspaceId = "44444444-4444-4444-4444-444444444444"
+
+    private final class CLICallerWorkspaceDefaultBundleToken {}
+
+    // Records socket callbacks from a background queue; `lock` guards both arrays.
+    private final class ServerState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var requestLines: [String] = []
+        private var errors: [String] = []
+
+        func record(_ line: String) {
+            lock.lock()
+            requestLines.append(line)
+            lock.unlock()
+        }
+
+        func recordError(_ message: String) {
+            lock.lock()
+            errors.append(message)
+            lock.unlock()
+        }
+
+        func errorsSnapshot() -> [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return errors
+        }
+
+        func requestObjects() throws -> [[String: Any]] {
+            lock.lock()
+            let lines = requestLines
+            lock.unlock()
+            return try lines.map { line in
+                try #require(CLICallerWorkspaceDefaultTests.jsonObject(line))
+            }
+        }
+    }
+
+    private struct ProcessRunResult {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+        let timedOut: Bool
+    }
+
+    private static func bundledCLIPath() throws -> String {
+        try BundledCLITestSupport.bundledCLIPath(for: CLICallerWorkspaceDefaultBundleToken.self)
+    }
+
+    private static func makeSocketPath(_ name: String) -> String {
+        let shortID = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-\(name.prefix(6))-\(shortID).sock")
+            .path
+    }
+
+    private static func bindUnixSocket(at path: String) throws -> Int32 {
+        unlink(path)
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxPathLength = MemoryLayout.size(ofValue: addr.sun_path)
+        let utf8 = Array(path.utf8)
+        guard utf8.count < maxPathLength else {
+            Darwin.close(fd)
+            throw NSError(domain: "cmux.tests", code: Int(ENAMETOOLONG), userInfo: [
+                NSLocalizedDescriptionKey: "Unix socket path is too long: \(path)",
+            ])
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: maxPathLength) { buffer in
+                for index in 0..<utf8.count {
+                    buffer[index] = CChar(bitPattern: utf8[index])
+                }
+                buffer[utf8.count] = 0
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.bind(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard Darwin.listen(fd, 1) == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return fd
+    }
+
+    private static func startMockServer(
+        listenerFD: Int32,
+        state: ServerState,
+        handler: @escaping @Sendable (String) -> String
+    ) -> DispatchSemaphore {
+        let handled = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { handled.signal() }
+
+            var clientAddr = sockaddr_un()
+            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                }
+            }
+            guard clientFD >= 0 else {
+                state.recordError("mock socket server failed to accept a client")
+                return
+            }
+            defer { Darwin.close(clientFD) }
+
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            while true {
+                let count = Darwin.read(clientFD, &buffer, buffer.count)
+                if count < 0 {
+                    if errno == EINTR { continue }
+                    state.recordError("mock socket server read failed with errno \(errno)")
+                    return
+                }
+                if count == 0 { return }
+                pending.append(buffer, count: count)
+
+                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                    pending.removeSubrange(0...newlineRange.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                    state.record(line)
+                    let response = handler(line) + "\n"
+                    _ = response.withCString { pointer in
+                        Darwin.write(clientFD, pointer, strlen(pointer))
+                    }
+                }
+            }
+        }
+        return handled
+    }
+
+    private static func v2Response(
+        id: String,
+        ok: Bool,
+        result: [String: Any]? = nil,
+        error: [String: Any]? = nil
+    ) -> String {
+        var payload: [String: Any] = ["id": id, "ok": ok]
+        if let result { payload["result"] = result }
+        if let error { payload["error"] = error }
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
+        return String(data: data ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+    }
+
+    private static func malformedRequestResponse(id: String? = nil, raw: String) -> String {
+        v2Response(
+            id: id ?? "unknown",
+            ok: false,
+            error: ["code": "malformed_request", "message": "invalid or non-JSON payload", "raw": raw]
+        )
+    }
+
+    private static func jsonObject(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+    }
+
+    private static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessRunResult(status: -1, stdout: "", stderr: String(describing: error), timedOut: false)
+        }
+
+        let exitSignal = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            exitSignal.signal()
+        }
+
+        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
+        if timedOut {
+            process.terminate()
+            if exitSignal.wait(timeout: .now() + 1) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = exitSignal.wait(timeout: .now() + 1)
+            }
+        }
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return ProcessRunResult(
+            status: process.isRunning ? SIGKILL : process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr,
+            timedOut: timedOut
+        )
+    }
+}

--- a/cmuxTests/CLICallerWorkspaceDefaultTests.swift
+++ b/cmuxTests/CLICallerWorkspaceDefaultTests.swift
@@ -17,10 +17,12 @@ struct CLICallerWorkspaceDefaultTests {
     /// A blank `--workspace` from a caller pane must target the caller's workspace and
     /// must never consult `workspace.current` (the focused workspace).
     @Test func blankWorkspaceArgDefaultsToCallerWorkspace() throws {
-        let requests = try runMarkNotificationRead(
+        let (requests, result) = try runMarkNotificationRead(
             workspaceArgument: "   ",
-            focusedWorkspaceId: Self.focusedWorkspaceId
+            focusedWorkspaceId: Self.focusedWorkspaceId,
+            callerWorkspaceId: Self.callerWorkspaceId
         )
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
 
         let methods = requests.compactMap { $0["method"] as? String }
         #expect(methods == ["notification.mark_read"], Comment(rawValue: methods.joined(separator: ",")))
@@ -30,13 +32,32 @@ struct CLICallerWorkspaceDefaultTests {
         #expect(params["tab_id"] as? String == Self.callerWorkspaceId)
     }
 
+    /// A blank `--workspace` with no caller workspace in the environment must fail closed
+    /// (nonzero exit) rather than silently retargeting the focused workspace. This is the
+    /// dangerous case where `--workspace "${CMUX_WORKSPACE_ID:-}"` expands to an empty
+    /// argument because the caller environment is thin.
+    @Test func blankWorkspaceArgWithoutCallerFailsClosed() throws {
+        let (requests, result) = try runMarkNotificationRead(
+            workspaceArgument: "   ",
+            focusedWorkspaceId: Self.focusedWorkspaceId,
+            callerWorkspaceId: nil
+        )
+
+        #expect(result.status != 0, Comment(rawValue: "expected nonzero exit, got \(result.status)"))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(!methods.contains("workspace.current"), Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("notification.mark_read"), Comment(rawValue: methods.joined(separator: ",")))
+    }
+
     /// An explicit `--workspace <uuid>` must still win over the caller's environment, so
     /// the caller default never hijacks a command that names another workspace.
     @Test func explicitWorkspaceArgStillWins() throws {
-        let requests = try runMarkNotificationRead(
+        let (requests, result) = try runMarkNotificationRead(
             workspaceArgument: Self.otherWorkspaceId,
-            focusedWorkspaceId: Self.focusedWorkspaceId
+            focusedWorkspaceId: Self.focusedWorkspaceId,
+            callerWorkspaceId: Self.callerWorkspaceId
         )
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
 
         let methods = requests.compactMap { $0["method"] as? String }
         #expect(methods == ["notification.mark_read"], Comment(rawValue: methods.joined(separator: ",")))
@@ -47,12 +68,14 @@ struct CLICallerWorkspaceDefaultTests {
     }
 
     /// Drives `mark-notification-read --workspace <argument>` against a mock socket and
-    /// returns the recorded JSON-RPC requests. The mock answers `workspace.current` with
-    /// `focusedWorkspaceId` so that, pre-fix, the command would visibly retarget there.
+    /// returns the recorded JSON-RPC requests plus the process result. The mock answers
+    /// `workspace.current` with `focusedWorkspaceId` so that, pre-fix, the command would
+    /// visibly retarget there. Pass `callerWorkspaceId: nil` to omit `CMUX_WORKSPACE_ID`.
     private func runMarkNotificationRead(
         workspaceArgument: String,
-        focusedWorkspaceId: String
-    ) throws -> [[String: Any]] {
+        focusedWorkspaceId: String,
+        callerWorkspaceId: String?
+    ) throws -> ([[String: Any]], ProcessRunResult) {
         let socketPath = Self.makeSocketPath("caller-ws")
         let listenerFD = try Self.bindUnixSocket(at: socketPath)
         defer {
@@ -84,27 +107,31 @@ struct CLICallerWorkspaceDefaultTests {
         let result = Self.runProcess(
             executablePath: try Self.bundledCLIPath(),
             arguments: ["mark-notification-read", "--workspace", workspaceArgument],
-            environment: cliEnvironment(socketPath: socketPath),
+            environment: cliEnvironment(socketPath: socketPath, callerWorkspaceId: callerWorkspaceId),
             timeout: 5
         )
 
         #expect(handled.wait(timeout: .now() + 5) == .success)
         #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
         #expect(!result.timedOut, Comment(rawValue: result.stderr))
-        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
 
-        return try state.requestObjects()
+        return (try state.requestObjects(), result)
     }
 
-    private func cliEnvironment(socketPath: String) -> [String: String] {
+    private func cliEnvironment(socketPath: String, callerWorkspaceId: String?) -> [String: String] {
         var environment = ProcessInfo.processInfo.environment
         environment["CMUX_SOCKET_PATH"] = socketPath
-        environment["CMUX_WORKSPACE_ID"] = Self.callerWorkspaceId
-        environment["CMUX_SURFACE_ID"] = Self.callerSurfaceId
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
-        // Clear any ambient window targeting inherited from the test host's own pane.
-        environment["CMUX_WINDOW_ID"] = nil
+        // Clear any ambient caller/window context inherited from the test host's own pane,
+        // then set only what this scenario needs.
+        environment.removeValue(forKey: "CMUX_SURFACE_ID")
+        environment.removeValue(forKey: "CMUX_WINDOW_ID")
+        if let callerWorkspaceId {
+            environment["CMUX_WORKSPACE_ID"] = callerWorkspaceId
+        } else {
+            environment.removeValue(forKey: "CMUX_WORKSPACE_ID")
+        }
         return environment
     }
 


### PR DESCRIPTION
## Problem

CLI commands run by an agent inside a terminal pane are supposed to scope to **that pane's workspace** (the caller). In practice, commands that lacked an explicit `--workspace`, or got a blank one, silently acted on whatever workspace the user had **focused** in the foreground.

Root cause: the two resolver sinks, `resolveWorkspaceId` and `normalizeWorkspaceHandle`, fall through to the socket method `workspace.current` (the focused/selected workspace) when no usable workspace handle is given. They never consulted the caller's `CMUX_WORKSPACE_ID`. This is a leftover from the single-window era, when focused and caller were effectively the same. The multi-window targeting work (#4211) and the explicit-surface routing fix (#6605) each peeled away a case where the caller's workspace was used, exposing this focused fallback more often.

The trigger is sneaky: the skill-recommended pattern `--workspace "${CMUX_WORKSPACE_ID:-}"` expands to an empty string whenever a background agent's environment is thin (nested shell, ssh, cloud VM, a re-exec that dropped env). An empty `--workspace ""` is not a UUID/ref/index, so it fell straight through to the focused workspace with no error.

## Fix

Prefer the caller's own workspace (the `CMUX_WORKSPACE_ID` the app injects into every terminal surface) before falling back to `workspace.current`:

- Gated on `windowHandle == nil`, so an explicit `--window` still routes to that window's selected workspace (preserves #4211).
- Placed **after** `normalizeWorkspaceHandle`'s `!allowCurrent` early return, so explicit-surface global routing is unaffected (preserves #6605).
- Only accepts a UUID from the env (the value the app actually injects), so a malformed value can't hijack resolution.

Behavior matrix:
- Explicit `--workspace <id>` → unchanged (wins).
- No/blank `--workspace`, caller env set → **caller's workspace** (was: focused).
- No/blank `--workspace`, no caller env → focused fallback (unchanged).
- Explicit `--window` → that window's selected workspace (unchanged).

## Verification

Built a tagged dev app and drove the real bundled CLI against it with caller=workspace:1 while workspace:3 was focused:

| scenario | baseline (main) | this PR |
|---|---|---|
| blank `--workspace`, caller env set | `OK workspace:3` (focused) ❌ | `OK workspace:1` (caller) ✅ |
| blank `--workspace`, no caller env | focused | `OK workspace:3` (focused) ✅ |
| explicit `--workspace workspace:3` | workspace:3 | `OK workspace:3` ✅ |

Regression test added as a separate first commit (red), fix second (green), per repo policy. The test runs the real CLI binary against a mock control socket and asserts a blank `--workspace` from a caller pane targets the caller and never calls `workspace.current`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784941259&installation_id=133855650&pr_number=6757&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6757&signature=36375fc7b4ff96230426052ab9986e0f02cc99ae67bd9d01102322237e953fa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default workspace targeting for many CLI commands and adds new error paths for blank/invalid --workspace; behavior is intentional but could break scripts that relied on focused-workspace fallback.
> 
> **Overview**
> Workspace-scoped CLI commands no longer fall through to **`workspace.current`** (the focused workspace) when `--workspace` is missing or blank. **`resolveWorkspaceId`** and **`normalizeWorkspaceHandle`** now prefer a valid UUID from **`CMUX_WORKSPACE_ID`** (when no explicit **`--window`** is set), so agents in background panes target the pane they were invoked from instead of the user’s foreground selection.
> 
> **Fail-closed** behavior was added: unrecognized non-blank **`--workspace`** values error instead of resolving elsewhere; an explicit blank **`--workspace`** with no caller env errors rather than using the focused workspace. Explicit **`--workspace`** UUIDs/refs and **`--window`** routing are unchanged.
> 
> Regression coverage is in **`CLICallerWorkspaceDefaultTests`** (bundled CLI + mock socket). Swift file-length budgets were bumped for **`CLI/cmux.swift`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c513702b39b4a372f1bdf75020c2052cbd57991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default workspace-scoped CLI commands to the caller’s workspace when `--workspace` is missing or blank, and fail closed on invalid selectors. Prevents background agents from acting on the focused workspace.

- **Bug Fixes**
  - Prefer caller workspace from `CMUX_WORKSPACE_ID` (UUID-only) before `workspace.current` when `windowHandle` is nil; applied in both `resolveWorkspaceId` and `normalizeWorkspaceHandle`.
  - Behavior: explicit `--workspace` wins; explicit `--window` uses that window’s selection; no/blank with caller env → caller; omitted with no caller env → focused; explicit blank with no caller env → error; explicit nonblank unrecognized → error (before caller fallback).
  - Added `CLICallerWorkspaceDefaultTests` covering caller default, fail-closed paths, and explicit `--workspace` precedence; ensures blank `--workspace` never calls `workspace.current`.

- **Refactors**
  - Refreshed Swift file-length budgets; comments only, no behavior change.

<sup>Written for commit 0c513702b39b4a372f1bdf75020c2052cbd57991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `mark-notification-read` workspace selection: when `--workspace` is omitted/blank, it now prefers the caller workspace from `CMUX_WORKSPACE_ID` (only if it’s a valid UUID).
  * Fail-closed behavior: whitespace/invalid `--workspace` now errors, and unresolved non-blank `--workspace` values fail with “Workspace not found”.
  * Explicit `--workspace <uuid>` continues to take precedence and avoids checking the focused workspace.
* **Tests**
  * Added regression tests covering caller defaulting, fail-closed cases, and explicit precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->