### PR TITLE
Warn when a Claude/Codex session in a pane isn't being tracked

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1289,6 +1289,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // closedPanelHistoryEntry.
         if !isRunningUnderXCTest {
             SharedLiveAgentIndex.shared.scheduleRefreshIfStale()
+            // Periodically warn when an agent is running in a pane that cmux is
+            // not tracking (its hooks were bypassed), so it won't resume.
+            UntrackedAgentSessionMonitor.shared.start()
         }
 
         claimAuthCallbackURLSchemes()

--- a/Sources/UntrackedAgentSessionDetector.swift
+++ b/Sources/UntrackedAgentSessionDetector.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// The per-pane facts that decide whether cmux should warn the user that an
+/// agent session is running untracked (its hooks were bypassed, so it won't
+/// resume after a crash/update).
+///
+/// A plain value type with no app or filesystem coupling so the decision is
+/// exhaustively unit-testable. The MainActor monitor builds these facts from the
+/// live process-detection and hook-session indexes; the detector itself reads
+/// nothing.
+struct PaneTrackingFacts: Equatable, Sendable {
+    /// The agent kind detected running in the pane, if any.
+    var agentKind: RestorableAgentKind?
+    /// A live agent process was detected in this pane (e.g. `claude`).
+    var hasProcessDetectedAgent: Bool
+    /// cmux has a hook-proven session recorded for this pane (SessionStart
+    /// fired). When true the session IS tracked and resumable — no warning.
+    var hasHookProvenSession: Bool
+    /// How long the agent process has been continuously detected in this pane
+    /// *without* a hook-proven session. The grace window keys off this so a
+    /// session that simply hasn't fired SessionStart yet is not flagged.
+    var secondsDetectedWithoutHook: TimeInterval
+    /// This pane/session has already been warned about (dedupe).
+    var alreadyWarned: Bool
+    /// The user-facing warning is enabled (opt-out, default on).
+    var warningEnabled: Bool
+
+    init(
+        agentKind: RestorableAgentKind?,
+        hasProcessDetectedAgent: Bool,
+        hasHookProvenSession: Bool,
+        secondsDetectedWithoutHook: TimeInterval,
+        alreadyWarned: Bool,
+        warningEnabled: Bool
+    ) {
+        self.agentKind = agentKind
+        self.hasProcessDetectedAgent = hasProcessDetectedAgent
+        self.hasHookProvenSession = hasHookProvenSession
+        self.secondsDetectedWithoutHook = secondsDetectedWithoutHook
+        self.alreadyWarned = alreadyWarned
+        self.warningEnabled = warningEnabled
+    }
+}
+
+/// Why a pane is NOT warned. Stable raw form for logging and tests.
+enum UntrackedSessionSkipReason: Hashable, Sendable {
+    /// The opt-out setting is off.
+    case disabled
+    /// No agent process is detected in the pane.
+    case noAgent
+    /// A hook-proven session exists — the pane IS tracked.
+    case tracked
+    /// The agent kind is outside the set whose hooks cmux injects (Claude/Codex).
+    case unsupported(RestorableAgentKind)
+    /// The agent was detected too recently without a hook to distinguish a real
+    /// bypass from SessionStart latency.
+    case withinGrace
+    /// This pane/session was already warned once.
+    case alreadyWarned
+}
+
+/// The outcome of evaluating a pane.
+enum UntrackedSessionWarnDecision: Equatable, Sendable {
+    /// Warn the user once: this pane has a live agent that cmux is not tracking.
+    case warn
+    /// Do not warn; `reason` records why.
+    case skip(UntrackedSessionSkipReason)
+}
+
+/// Pure decision core for the "your agent session isn't being tracked" warning.
+///
+/// cmux records an agent session only when its `claude` wrapper shim injects the
+/// hook `--settings`. A custom launcher, alias, shell function, or PATH ordering
+/// that reaches the raw binary silently skips that injection — no SessionStart,
+/// no recorded session, no resume after a crash/update, and no feedback. This
+/// detector flags exactly that state: a live agent process in a pane with no
+/// hook-proven session, after a grace window, once.
+///
+/// Side-effect free by construction; the single `decide` entry mirrors the
+/// project's other pure policy types so the full warn/skip matrix is testable
+/// without the app host.
+struct UntrackedAgentSessionDetector {
+    /// How long an agent may be detected without a hook session before it counts
+    /// as a genuine bypass (vs. SessionStart not having fired yet).
+    var graceInterval: TimeInterval
+
+    init(graceInterval: TimeInterval = 10) {
+        self.graceInterval = graceInterval
+    }
+
+    /// Agent kinds whose sessions cmux tracks via injected hooks. Outside this
+    /// set there is nothing to be untracked *relative to*, so no warning.
+    static func isSupported(_ kind: RestorableAgentKind) -> Bool {
+        switch kind {
+        case .claude, .codex: return true
+        default: return false
+        }
+    }
+
+    func decide(_ facts: PaneTrackingFacts) -> UntrackedSessionWarnDecision {
+        // 1. Respect the opt-out before anything else.
+        guard facts.warningEnabled else { return .skip(.disabled) }
+
+        // 2. Nothing to warn about without a live agent process.
+        guard facts.hasProcessDetectedAgent, let kind = facts.agentKind else {
+            return .skip(.noAgent)
+        }
+
+        // 3. A hook-proven session means the pane IS tracked — the happy path.
+        guard !facts.hasHookProvenSession else { return .skip(.tracked) }
+
+        // 4. Only agents whose hooks cmux injects can be "untracked".
+        guard Self.isSupported(kind) else { return .skip(.unsupported(kind)) }
+
+        // 5. A freshly-detected agent may simply not have fired SessionStart yet;
+        //    wait out the grace window before calling it a bypass.
+        guard facts.secondsDetectedWithoutHook >= graceInterval else {
+            return .skip(.withinGrace)
+        }
+
+        // 6. Warn at most once per pane/session.
+        guard !facts.alreadyWarned else { return .skip(.alreadyWarned) }
+
+        return .warn
+    }
+
+    /// Convenience: whether these facts warrant a warning right now.
+    func shouldWarn(_ facts: PaneTrackingFacts) -> Bool {
+        decide(facts) == .warn
+    }
+}

--- a/Sources/UntrackedAgentSessionDiagnostics.swift
+++ b/Sources/UntrackedAgentSessionDiagnostics.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// The tracking status of a single agent pane, for diagnostics.
+enum PaneTrackingStatus: Equatable, Sendable {
+    /// A hook-proven session exists — the pane is tracked and resumable.
+    case tracked
+    /// A supported agent is running but cmux has no hook session for it — the
+    /// session is not being recorded and won't resume (the wrapper was bypassed).
+    case untracked
+    /// An agent is running whose hooks cmux does not inject; nothing to track.
+    case unsupportedAgent(RestorableAgentKind)
+}
+
+/// Pure, point-in-time classifier for "which panes are (un)tracked", backing a
+/// read-only diagnostic (a `doctor`-style listing). Unlike the live monitor it
+/// has no grace window or history — it reports the current state so a user can
+/// answer "will my windows resume?" on demand.
+struct UntrackedAgentSessionDiagnostics {
+    /// One pane's classification.
+    struct PaneReport: Equatable, Sendable {
+        var key: RestorableAgentSessionIndex.PanelKey
+        var agentKind: RestorableAgentKind
+        var status: PaneTrackingStatus
+    }
+
+    func classify(
+        detectedAgents: [RestorableAgentSessionIndex.PanelKey: RestorableAgentKind],
+        hasHookSession: (RestorableAgentSessionIndex.PanelKey) -> Bool
+    ) -> [PaneReport] {
+        detectedAgents
+            .map { key, kind -> PaneReport in
+                let status: PaneTrackingStatus
+                if hasHookSession(key) {
+                    status = .tracked
+                } else if UntrackedAgentSessionDetector.isSupported(kind) {
+                    status = .untracked
+                } else {
+                    status = .unsupportedAgent(kind)
+                }
+                return PaneReport(key: key, agentKind: kind, status: status)
+            }
+            // Stable order for deterministic output: untracked first (the thing a
+            // user is looking for), then tracked, then unsupported; tie-break by id.
+            .sorted { lhs, rhs in
+                func rank(_ s: PaneTrackingStatus) -> Int {
+                    switch s {
+                    case .untracked: return 0
+                    case .tracked: return 1
+                    case .unsupportedAgent: return 2
+                    }
+                }
+                if rank(lhs.status) != rank(rhs.status) { return rank(lhs.status) < rank(rhs.status) }
+                return lhs.key.panelId.uuidString < rhs.key.panelId.uuidString
+            }
+    }
+
+    /// Count of panes running a supported agent with no hook session — the
+    /// headline number for "you have N windows that won't resume".
+    func untrackedCount(_ reports: [PaneReport]) -> Int {
+        reports.filter { $0.status == .untracked }.count
+    }
+}

--- a/Sources/UntrackedAgentSessionMonitor.swift
+++ b/Sources/UntrackedAgentSessionMonitor.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// MainActor glue that periodically compares the live process-detection and
+/// hook-session indexes and warns (once per pane/session) when an agent is
+/// running untracked. The decision policy lives in `UntrackedAgentSessionDetector`;
+/// this type owns only the per-pane state (first-seen-without-hook timestamps,
+/// dedupe) and the index reads + delivery.
+///
+/// `evaluate(detectedAgents:hasHookSession:now:)` is the unit-testable core: it
+/// takes already-resolved inputs (the detected agents, a hook-present lookup, and
+/// the clock) so the warn-once / grace / reset behavior is provable without the
+/// live process capture. `refresh()` is the thin real tick that captures the
+/// process snapshot off-main and feeds `evaluate` on main.
+@MainActor
+final class UntrackedAgentSessionMonitor {
+    typealias PanelKey = RestorableAgentSessionIndex.PanelKey
+
+    /// A live agent process detected in a pane.
+    struct DetectedAgent: Equatable, Sendable {
+        var kind: RestorableAgentKind
+        var sessionId: String
+    }
+
+    private struct PaneWarnState {
+        var sessionId: String
+        var firstSeenWithoutHook: TimeInterval
+        var warned: Bool
+    }
+
+    private let detector: UntrackedAgentSessionDetector
+    private let warningEnabled: () -> Bool
+    private let deliver: (PanelKey, RestorableAgentKind) -> Void
+
+    /// Per-pane state for panes currently detected without a hook session. Pruned
+    /// when the pane gains a hook session or its agent process disappears, so a
+    /// later genuine bypass in the same pane warns again.
+    private var paneState: [PanelKey: PaneWarnState] = [:]
+
+    init(
+        detector: UntrackedAgentSessionDetector = UntrackedAgentSessionDetector(),
+        warningEnabled: @escaping () -> Bool = { UntrackedAgentSessionWarningSettings.isEnabled() },
+        deliver: @escaping (PanelKey, RestorableAgentKind) -> Void
+    ) {
+        self.detector = detector
+        self.warningEnabled = warningEnabled
+        self.deliver = deliver
+    }
+
+    /// Pure-over-inputs evaluation. For each detected agent pane: a hook-proven
+    /// session clears state; otherwise the pane is tracked as detected-without-hook
+    /// (resetting the clock when the session id changes — a new bypassed session),
+    /// the detector decides, and a warn is delivered at most once per pane/session.
+    func evaluate(
+        detectedAgents: [PanelKey: DetectedAgent],
+        hasHookSession: (PanelKey) -> Bool,
+        now: TimeInterval
+    ) {
+        // Drop state for panes whose agent process is gone.
+        paneState = paneState.filter { detectedAgents[$0.key] != nil }
+
+        let enabled = warningEnabled()
+
+        for (key, agent) in detectedAgents {
+            if hasHookSession(key) {
+                // Tracked — the happy path. Clear any pending bypass state.
+                paneState[key] = nil
+                continue
+            }
+
+            // Untracked: start (or continue) the without-hook clock for this
+            // session. A changed session id in the same pane is a new session, so
+            // the clock and dedupe reset.
+            var state = paneState[key]
+            if state == nil || state?.sessionId != agent.sessionId {
+                state = PaneWarnState(sessionId: agent.sessionId, firstSeenWithoutHook: now, warned: false)
+            }
+
+            let facts = PaneTrackingFacts(
+                agentKind: agent.kind,
+                hasProcessDetectedAgent: true,
+                hasHookProvenSession: false,
+                secondsDetectedWithoutHook: now - (state?.firstSeenWithoutHook ?? now),
+                alreadyWarned: state?.warned ?? false,
+                warningEnabled: enabled
+            )
+
+            if detector.decide(facts) == .warn {
+                deliver(key, agent.kind)
+                state?.warned = true
+            }
+            paneState[key] = state
+        }
+    }
+
+    /// Real tick: capture the process-detected agents off-main (the capture runs
+    /// sysctl/top and must not block the main thread), then evaluate on main using
+    /// the cached, non-blocking hook-session lookup.
+    func refresh(
+        homeDirectory: String = NSHomeDirectory(),
+        fileManager: FileManager = .default
+    ) {
+        Task.detached(priority: .utility) {
+            let registry = CmuxVaultAgentRegistry.load(homeDirectory: homeDirectory, fileManager: fileManager)
+            let detected = RestorableAgentSessionIndex.processDetectedSnapshots(
+                registry: registry,
+                fileManager: fileManager
+            )
+            let agents: [PanelKey: DetectedAgent] = detected.reduce(into: [:]) { acc, pair in
+                let snapshot = pair.value.snapshot
+                acc[pair.key] = DetectedAgent(kind: snapshot.kind, sessionId: snapshot.sessionId)
+            }
+            await MainActor.run {
+                self.evaluate(
+                    detectedAgents: agents,
+                    hasHookSession: { key in
+                        SharedLiveAgentIndex.shared.snapshot(workspaceId: key.workspaceId, panelId: key.panelId) != nil
+                    },
+                    now: Date().timeIntervalSince1970
+                )
+            }
+        }
+    }
+
+    /// Test seam: panes currently tracked as detected-without-hook.
+    var trackedPaneCountForTesting: Int { paneState.count }
+}

--- a/Sources/UntrackedAgentSessionMonitor.swift
+++ b/Sources/UntrackedAgentSessionMonitor.swift
@@ -36,6 +36,9 @@ final class UntrackedAgentSessionMonitor {
     /// later genuine bypass in the same pane warns again.
     private var paneState: [PanelKey: PaneWarnState] = [:]
 
+    /// Repeating background check timer (nil when not started).
+    private var pollTimer: Timer?
+
     init(
         detector: UntrackedAgentSessionDetector = UntrackedAgentSessionDetector(),
         warningEnabled: @escaping () -> Bool = { UntrackedAgentSessionWarningSettings.isEnabled() },
@@ -123,4 +126,49 @@ final class UntrackedAgentSessionMonitor {
 
     /// Test seam: panes currently tracked as detected-without-hook.
     var trackedPaneCountForTesting: Int { paneState.count }
+}
+
+extension UntrackedAgentSessionMonitor {
+    /// The app-wide monitor, wired to deliver the warning through the terminal
+    /// notification store. Started once at launch (see `AppDelegate`).
+    static let shared = UntrackedAgentSessionMonitor(deliver: deliverWarning)
+
+    private static func deliverWarning(_ key: PanelKey, _ kind: RestorableAgentKind) {
+        AppDelegate.shared?.notificationStore?.addNotification(
+            tabId: key.workspaceId,
+            surfaceId: key.panelId,
+            title: String(
+                localized: "agentTracking.untracked.title",
+                defaultValue: "Session not tracked"
+            ),
+            subtitle: "",
+            body: String(
+                localized: "agentTracking.untracked.body",
+                defaultValue: "This agent session isn't being recorded by cmux, so this window won't resume after a crash or update. The agent was launched outside cmux's wrapper — a custom launcher, alias, or PATH order can cause this."
+            ),
+            // Belt-and-suspenders dedupe in addition to the per-pane warn-once:
+            // never re-warn the same pane within an hour even across restarts.
+            cooldownKey: "untracked-agent-session.\(key.workspaceId.uuidString).\(key.panelId.uuidString)",
+            cooldownInterval: 3600
+        )
+    }
+
+    /// Begin the periodic check. Idempotent. The interval is coarse — this is a
+    /// background safety check, not a hot path.
+    func start(interval: TimeInterval = 7) {
+        guard pollTimer == nil else { return }
+        let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refresh()
+            }
+        }
+        pollTimer = timer
+        refresh()
+    }
+
+    /// Stop the periodic check.
+    func stop() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
 }

--- a/Sources/UntrackedAgentSessionMonitor.swift
+++ b/Sources/UntrackedAgentSessionMonitor.swift
@@ -18,11 +18,15 @@ final class UntrackedAgentSessionMonitor {
     /// A live agent process detected in a pane.
     struct DetectedAgent: Equatable, Sendable {
         var kind: RestorableAgentKind
-        var sessionId: String
+        /// A stable per-session identity used for warn-once dedupe and to detect
+        /// when a pane's agent has been replaced by a new session. For live
+        /// detection this is the agent process pid (a relaunch is a new pid, so a
+        /// later bypassed session re-warns); tests pass any stable token.
+        var identity: String
     }
 
     private struct PaneWarnState {
-        var sessionId: String
+        var identity: String
         var firstSeenWithoutHook: TimeInterval
         var warned: Bool
     }
@@ -71,11 +75,11 @@ final class UntrackedAgentSessionMonitor {
             }
 
             // Untracked: start (or continue) the without-hook clock for this
-            // session. A changed session id in the same pane is a new session, so
+            // session. A changed identity in the same pane is a new session, so
             // the clock and dedupe reset.
             var state = paneState[key]
-            if state == nil || state?.sessionId != agent.sessionId {
-                state = PaneWarnState(sessionId: agent.sessionId, firstSeenWithoutHook: now, warned: false)
+            if state == nil || state?.identity != agent.identity {
+                state = PaneWarnState(identity: agent.identity, firstSeenWithoutHook: now, warned: false)
             }
 
             let facts = PaneTrackingFacts(
@@ -95,22 +99,41 @@ final class UntrackedAgentSessionMonitor {
         }
     }
 
-    /// Real tick: capture the process-detected agents off-main (the capture runs
-    /// sysctl/top and must not block the main thread), then evaluate on main using
-    /// the cached, non-blocking hook-session lookup.
-    func refresh(
-        homeDirectory: String = NSHomeDirectory(),
-        fileManager: FileManager = .default
-    ) {
+    /// The agent kind for a process whose executable basename names a hook-tracked
+    /// agent (Claude/Codex), or nil. Claude/Codex are NOT in the vault
+    /// process-detection registry (that only emits custom/opencode kinds) and are
+    /// otherwise known to cmux only through their hook store — the tracked path. So
+    /// a *bypassed* claude/codex is invisible except as a raw process; detecting it
+    /// by executable name is the only signal for "running but untracked".
+    nonisolated static func supportedAgentKind(processName name: String, path: String?) -> RestorableAgentKind? {
+        let basename = ((path?.isEmpty == false ? path! : name) as NSString).lastPathComponent.lowercased()
+        switch basename {
+        case "claude": return .claude
+        case "codex": return .codex
+        default: return nil
+        }
+    }
+
+    /// Real tick: capture the process snapshot off-main (sysctl/top must not block
+    /// the main thread), find cmux-scoped Claude/Codex processes by executable
+    /// name, then evaluate on main using the cached, non-blocking hook lookup.
+    func refresh() {
         Task.detached(priority: .utility) {
-            let registry = CmuxVaultAgentRegistry.load(homeDirectory: homeDirectory, fileManager: fileManager)
-            let detected = RestorableAgentSessionIndex.processDetectedSnapshots(
-                registry: registry,
-                fileManager: fileManager
-            )
-            let agents: [PanelKey: DetectedAgent] = detected.reduce(into: [:]) { acc, pair in
-                let snapshot = pair.value.snapshot
-                acc[pair.key] = DetectedAgent(kind: snapshot.kind, sessionId: snapshot.sessionId)
+            let snapshot = CmuxTopProcessSnapshot.capture(includeProcessDetails: true)
+            // One agent process per pane (lowest pid is the stable identity).
+            var byPane: [PanelKey: (kind: RestorableAgentKind, pid: Int)] = [:]
+            for process in snapshot.cmuxScopedProcesses() {
+                guard let workspaceId = process.cmuxWorkspaceID,
+                      let surfaceId = process.cmuxSurfaceID,
+                      let kind = Self.supportedAgentKind(processName: process.name, path: process.path) else {
+                    continue
+                }
+                let key = PanelKey(workspaceId: workspaceId, panelId: surfaceId)
+                if let existing = byPane[key], existing.pid <= process.pid { continue }
+                byPane[key] = (kind, process.pid)
+            }
+            let agents: [PanelKey: DetectedAgent] = byPane.mapValues {
+                DetectedAgent(kind: $0.kind, identity: String($0.pid))
             }
             await MainActor.run {
                 self.evaluate(
@@ -144,7 +167,7 @@ extension UntrackedAgentSessionMonitor {
             subtitle: "",
             body: String(
                 localized: "agentTracking.untracked.body",
-                defaultValue: "This agent session isn't being recorded by cmux, so this window won't resume after a crash or update. The agent was launched outside cmux's wrapper — a custom launcher, alias, or PATH order can cause this."
+                defaultValue: "This agent session isn't being recorded by cmux, so this window won't resume after a crash or update. The agent was launched outside cmux's wrapper (a custom launcher, alias, or PATH order can cause this)."
             ),
             // Belt-and-suspenders dedupe in addition to the per-pane warn-once:
             // never re-warn the same pane within an hour even across restarts.

--- a/Sources/UntrackedAgentSessionWarningSettings.swift
+++ b/Sources/UntrackedAgentSessionWarningSettings.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// User setting (opt-out, default on) for the warning shown when an agent
+/// session is running in a pane that cmux is not tracking — i.e. its hooks were
+/// bypassed (custom launcher / alias / shell function / PATH), so it won't resume
+/// after a crash or update. Mirrors `AgentSessionAutoResumeSettings`.
+enum UntrackedAgentSessionWarningSettings {
+    static let warnUntrackedAgentSessionKey = "terminal.warnUntrackedAgentSession"
+    static let defaultWarnUntrackedAgentSession = true
+    static let didChangeNotification = Notification.Name("cmux.untrackedAgentSessionWarningSettingsDidChange")
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: warnUntrackedAgentSessionKey) != nil else {
+            return defaultWarnUntrackedAgentSession
+        }
+        return defaults.bool(forKey: warnUntrackedAgentSessionKey)
+    }
+
+    static func setEnabled(
+        _ enabled: Bool,
+        defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        let wasEnabled = isEnabled(defaults: defaults)
+        defaults.set(enabled, forKey: warnUntrackedAgentSessionKey)
+        if wasEnabled != enabled {
+            notifyDidChange(notificationCenter: notificationCenter)
+        }
+    }
+
+    @discardableResult
+    static func reset(
+        defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) -> Bool {
+        let wasEnabled = isEnabled(defaults: defaults)
+        defaults.removeObject(forKey: warnUntrackedAgentSessionKey)
+        let didChange = wasEnabled != isEnabled(defaults: defaults)
+        if didChange {
+            notifyDidChange(notificationCenter: notificationCenter)
+        }
+        return didChange
+    }
+
+    static func notifyDidChange(notificationCenter: NotificationCenter = .default) {
+        notificationCenter.post(name: didChangeNotification, object: nil)
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -979,6 +979,8 @@
 		C0DE64020000000000001004 /* TrackedQLPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE64020000000000001003 /* TrackedQLPreviewView.swift */; };
 		D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3284002A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift */; };
 		A5001501 /* UITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001511 /* UITestRecorder.swift */; };
+		B200000000000000000A0010 /* UntrackedAgentSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */; };
+		B200000000000000000A0020 /* UntrackedAgentSessionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */; };
 		A500120D /* UpdateLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001223 /* UpdateLogStore.swift */; };
 		F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */; };
 		C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
@@ -2050,6 +2052,8 @@
 		C0DE64020000000000001003 /* TrackedQLPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TrackedQLPreviewView.swift; sourceTree = "<group>"; };
 		D3284002A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraditionalChineseIMENumpadRegressionTests.swift; sourceTree = "<group>"; };
 		A5001511 /* UITestRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestRecorder.swift; sourceTree = "<group>"; };
+		B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionDetector.swift; sourceTree = "<group>"; };
+		B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionDetectorTests.swift; sourceTree = "<group>"; };
 		A5001223 /* UpdateLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateLogStore.swift; sourceTree = "<group>"; };
 		F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillReleaseVisibilityTests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
@@ -2943,6 +2947,7 @@
 				FE003001 /* SessionIndexStore.swift */,
 				B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */,
 				B35750000000000000000005 /* VaultAgentProcessScanner.swift */,
+				B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */,
 				FE003004 /* SessionIndexStore+CodexSQL.swift */,
 				FE003005 /* RovoDevIndex.swift */,
 				F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */,
@@ -3081,6 +3086,7 @@
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
 				B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
 				D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */,
+				B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */,
 				D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */,
 				A9E010000000000000000005 /* AgentExecutableResolverTests.swift */,
 				A9E010000000000000000010 /* AgentChatTranscriptResolverTests.swift */,
@@ -4319,6 +4325,7 @@
 				E30760000000000000000002 /* TmuxWorkspacePaneOverlayView.swift in Sources */,
 				C0DE64020000000000001004 /* TrackedQLPreviewView.swift in Sources */,
 				A5001501 /* UITestRecorder.swift in Sources */,
+				B200000000000000000A0010 /* UntrackedAgentSessionDetector.swift in Sources */,
 				A500120D /* UpdateLogStore.swift in Sources */,
 				A5001208 /* UpdateTitlebarAccessory.swift in Sources */,
 				B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */,
@@ -4748,6 +4755,7 @@
 				C0DE7B300000000000000001 /* TextBoxMentionCompletionTests.swift in Sources */,
 				F50030040000000000000001 /* TitlebarInteractiveControlTests.swift in Sources */,
 				D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */,
+				B200000000000000000A0020 /* UntrackedAgentSessionDetectorTests.swift in Sources */,
 				F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */,
 				C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,
 				063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -981,6 +981,8 @@
 		A5001501 /* UITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001511 /* UITestRecorder.swift */; };
 		B200000000000000000A0010 /* UntrackedAgentSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */; };
 		B200000000000000000A0020 /* UntrackedAgentSessionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */; };
+		B200000000000000000A0050 /* UntrackedAgentSessionMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0051 /* UntrackedAgentSessionMonitor.swift */; };
+		B200000000000000000A0060 /* UntrackedAgentSessionMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0061 /* UntrackedAgentSessionMonitorTests.swift */; };
 		B200000000000000000A0030 /* UntrackedAgentSessionWarningSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0031 /* UntrackedAgentSessionWarningSettings.swift */; };
 		B200000000000000000A0040 /* UntrackedAgentSessionWarningSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0041 /* UntrackedAgentSessionWarningSettingsTests.swift */; };
 		A500120D /* UpdateLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001223 /* UpdateLogStore.swift */; };
@@ -2056,6 +2058,8 @@
 		A5001511 /* UITestRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestRecorder.swift; sourceTree = "<group>"; };
 		B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionDetector.swift; sourceTree = "<group>"; };
 		B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionDetectorTests.swift; sourceTree = "<group>"; };
+		B200000000000000000A0051 /* UntrackedAgentSessionMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionMonitor.swift; sourceTree = "<group>"; };
+		B200000000000000000A0061 /* UntrackedAgentSessionMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionMonitorTests.swift; sourceTree = "<group>"; };
 		B200000000000000000A0031 /* UntrackedAgentSessionWarningSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionWarningSettings.swift; sourceTree = "<group>"; };
 		B200000000000000000A0041 /* UntrackedAgentSessionWarningSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionWarningSettingsTests.swift; sourceTree = "<group>"; };
 		A5001223 /* UpdateLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateLogStore.swift; sourceTree = "<group>"; };
@@ -2953,6 +2957,7 @@
 				B35750000000000000000005 /* VaultAgentProcessScanner.swift */,
 				B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */,
 				B200000000000000000A0031 /* UntrackedAgentSessionWarningSettings.swift */,
+				B200000000000000000A0051 /* UntrackedAgentSessionMonitor.swift */,
 				FE003004 /* SessionIndexStore+CodexSQL.swift */,
 				FE003005 /* RovoDevIndex.swift */,
 				F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */,
@@ -3093,6 +3098,7 @@
 				D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */,
 				B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */,
 				B200000000000000000A0041 /* UntrackedAgentSessionWarningSettingsTests.swift */,
+				B200000000000000000A0061 /* UntrackedAgentSessionMonitorTests.swift */,
 				D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */,
 				A9E010000000000000000005 /* AgentExecutableResolverTests.swift */,
 				A9E010000000000000000010 /* AgentChatTranscriptResolverTests.swift */,
@@ -4332,6 +4338,7 @@
 				C0DE64020000000000001004 /* TrackedQLPreviewView.swift in Sources */,
 				A5001501 /* UITestRecorder.swift in Sources */,
 				B200000000000000000A0010 /* UntrackedAgentSessionDetector.swift in Sources */,
+				B200000000000000000A0050 /* UntrackedAgentSessionMonitor.swift in Sources */,
 				B200000000000000000A0030 /* UntrackedAgentSessionWarningSettings.swift in Sources */,
 				A500120D /* UpdateLogStore.swift in Sources */,
 				A5001208 /* UpdateTitlebarAccessory.swift in Sources */,
@@ -4763,6 +4770,7 @@
 				F50030040000000000000001 /* TitlebarInteractiveControlTests.swift in Sources */,
 				D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */,
 				B200000000000000000A0020 /* UntrackedAgentSessionDetectorTests.swift in Sources */,
+				B200000000000000000A0060 /* UntrackedAgentSessionMonitorTests.swift in Sources */,
 				B200000000000000000A0040 /* UntrackedAgentSessionWarningSettingsTests.swift in Sources */,
 				F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */,
 				C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -981,6 +981,8 @@
 		A5001501 /* UITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001511 /* UITestRecorder.swift */; };
 		B200000000000000000A0010 /* UntrackedAgentSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */; };
 		B200000000000000000A0020 /* UntrackedAgentSessionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */; };
+		B200000000000000000A0030 /* UntrackedAgentSessionWarningSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0031 /* UntrackedAgentSessionWarningSettings.swift */; };
+		B200000000000000000A0040 /* UntrackedAgentSessionWarningSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0041 /* UntrackedAgentSessionWarningSettingsTests.swift */; };
 		A500120D /* UpdateLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001223 /* UpdateLogStore.swift */; };
 		F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */; };
 		C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
@@ -2054,6 +2056,8 @@
 		A5001511 /* UITestRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestRecorder.swift; sourceTree = "<group>"; };
 		B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionDetector.swift; sourceTree = "<group>"; };
 		B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionDetectorTests.swift; sourceTree = "<group>"; };
+		B200000000000000000A0031 /* UntrackedAgentSessionWarningSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionWarningSettings.swift; sourceTree = "<group>"; };
+		B200000000000000000A0041 /* UntrackedAgentSessionWarningSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionWarningSettingsTests.swift; sourceTree = "<group>"; };
 		A5001223 /* UpdateLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateLogStore.swift; sourceTree = "<group>"; };
 		F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillReleaseVisibilityTests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
@@ -2948,6 +2952,7 @@
 				B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */,
 				B35750000000000000000005 /* VaultAgentProcessScanner.swift */,
 				B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */,
+				B200000000000000000A0031 /* UntrackedAgentSessionWarningSettings.swift */,
 				FE003004 /* SessionIndexStore+CodexSQL.swift */,
 				FE003005 /* RovoDevIndex.swift */,
 				F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */,
@@ -3087,6 +3092,7 @@
 				B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
 				D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */,
 				B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */,
+				B200000000000000000A0041 /* UntrackedAgentSessionWarningSettingsTests.swift */,
 				D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */,
 				A9E010000000000000000005 /* AgentExecutableResolverTests.swift */,
 				A9E010000000000000000010 /* AgentChatTranscriptResolverTests.swift */,
@@ -4326,6 +4332,7 @@
 				C0DE64020000000000001004 /* TrackedQLPreviewView.swift in Sources */,
 				A5001501 /* UITestRecorder.swift in Sources */,
 				B200000000000000000A0010 /* UntrackedAgentSessionDetector.swift in Sources */,
+				B200000000000000000A0030 /* UntrackedAgentSessionWarningSettings.swift in Sources */,
 				A500120D /* UpdateLogStore.swift in Sources */,
 				A5001208 /* UpdateTitlebarAccessory.swift in Sources */,
 				B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */,
@@ -4756,6 +4763,7 @@
 				F50030040000000000000001 /* TitlebarInteractiveControlTests.swift in Sources */,
 				D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */,
 				B200000000000000000A0020 /* UntrackedAgentSessionDetectorTests.swift in Sources */,
+				B200000000000000000A0040 /* UntrackedAgentSessionWarningSettingsTests.swift in Sources */,
 				F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */,
 				C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,
 				063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -981,6 +981,8 @@
 		A5001501 /* UITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001511 /* UITestRecorder.swift */; };
 		B200000000000000000A0010 /* UntrackedAgentSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */; };
 		B200000000000000000A0020 /* UntrackedAgentSessionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */; };
+		B200000000000000000A0070 /* UntrackedAgentSessionDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0071 /* UntrackedAgentSessionDiagnostics.swift */; };
+		B200000000000000000A0080 /* UntrackedAgentSessionDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0081 /* UntrackedAgentSessionDiagnosticsTests.swift */; };
 		B200000000000000000A0050 /* UntrackedAgentSessionMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0051 /* UntrackedAgentSessionMonitor.swift */; };
 		B200000000000000000A0060 /* UntrackedAgentSessionMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0061 /* UntrackedAgentSessionMonitorTests.swift */; };
 		B200000000000000000A0030 /* UntrackedAgentSessionWarningSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B200000000000000000A0031 /* UntrackedAgentSessionWarningSettings.swift */; };
@@ -2058,6 +2060,8 @@
 		A5001511 /* UITestRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestRecorder.swift; sourceTree = "<group>"; };
 		B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionDetector.swift; sourceTree = "<group>"; };
 		B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionDetectorTests.swift; sourceTree = "<group>"; };
+		B200000000000000000A0071 /* UntrackedAgentSessionDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionDiagnostics.swift; sourceTree = "<group>"; };
+		B200000000000000000A0081 /* UntrackedAgentSessionDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionDiagnosticsTests.swift; sourceTree = "<group>"; };
 		B200000000000000000A0051 /* UntrackedAgentSessionMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionMonitor.swift; sourceTree = "<group>"; };
 		B200000000000000000A0061 /* UntrackedAgentSessionMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionMonitorTests.swift; sourceTree = "<group>"; };
 		B200000000000000000A0031 /* UntrackedAgentSessionWarningSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrackedAgentSessionWarningSettings.swift; sourceTree = "<group>"; };
@@ -2958,6 +2962,7 @@
 				B200000000000000000A0011 /* UntrackedAgentSessionDetector.swift */,
 				B200000000000000000A0031 /* UntrackedAgentSessionWarningSettings.swift */,
 				B200000000000000000A0051 /* UntrackedAgentSessionMonitor.swift */,
+				B200000000000000000A0071 /* UntrackedAgentSessionDiagnostics.swift */,
 				FE003004 /* SessionIndexStore+CodexSQL.swift */,
 				FE003005 /* RovoDevIndex.swift */,
 				F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */,
@@ -3099,6 +3104,7 @@
 				B200000000000000000A0021 /* UntrackedAgentSessionDetectorTests.swift */,
 				B200000000000000000A0041 /* UntrackedAgentSessionWarningSettingsTests.swift */,
 				B200000000000000000A0061 /* UntrackedAgentSessionMonitorTests.swift */,
+				B200000000000000000A0081 /* UntrackedAgentSessionDiagnosticsTests.swift */,
 				D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */,
 				A9E010000000000000000005 /* AgentExecutableResolverTests.swift */,
 				A9E010000000000000000010 /* AgentChatTranscriptResolverTests.swift */,
@@ -4338,6 +4344,7 @@
 				C0DE64020000000000001004 /* TrackedQLPreviewView.swift in Sources */,
 				A5001501 /* UITestRecorder.swift in Sources */,
 				B200000000000000000A0010 /* UntrackedAgentSessionDetector.swift in Sources */,
+				B200000000000000000A0070 /* UntrackedAgentSessionDiagnostics.swift in Sources */,
 				B200000000000000000A0050 /* UntrackedAgentSessionMonitor.swift in Sources */,
 				B200000000000000000A0030 /* UntrackedAgentSessionWarningSettings.swift in Sources */,
 				A500120D /* UpdateLogStore.swift in Sources */,
@@ -4770,6 +4777,7 @@
 				F50030040000000000000001 /* TitlebarInteractiveControlTests.swift in Sources */,
 				D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */,
 				B200000000000000000A0020 /* UntrackedAgentSessionDetectorTests.swift in Sources */,
+				B200000000000000000A0080 /* UntrackedAgentSessionDiagnosticsTests.swift in Sources */,
 				B200000000000000000A0060 /* UntrackedAgentSessionMonitorTests.swift in Sources */,
 				B200000000000000000A0040 /* UntrackedAgentSessionWarningSettingsTests.swift in Sources */,
 				F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */,

--- a/cmuxTests/UntrackedAgentSessionDetectorTests.swift
+++ b/cmuxTests/UntrackedAgentSessionDetectorTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Behavior tests for the untracked-session detector: the full warn/skip matrix,
+/// the grace window that suppresses SessionStart-latency false positives, the
+/// once-per-pane dedupe, the opt-out, and ordered precedence of the guards.
+@Suite struct UntrackedAgentSessionDetectorTests {
+
+    private func facts(
+        kind: RestorableAgentKind? = .claude,
+        hasProcess: Bool = true,
+        hasHook: Bool = false,
+        secondsWithoutHook: TimeInterval = 30,
+        alreadyWarned: Bool = false,
+        enabled: Bool = true
+    ) -> PaneTrackingFacts {
+        PaneTrackingFacts(
+            agentKind: kind,
+            hasProcessDetectedAgent: hasProcess,
+            hasHookProvenSession: hasHook,
+            secondsDetectedWithoutHook: secondsWithoutHook,
+            alreadyWarned: alreadyWarned,
+            warningEnabled: enabled
+        )
+    }
+
+    private let detector = UntrackedAgentSessionDetector(graceInterval: 10)
+
+    @Test func liveAgentWithNoHookPastGraceWarns() {
+        // Covers R1: a detected agent with no hook session, past grace, warns.
+        #expect(detector.decide(facts()) == .warn)
+        #expect(detector.shouldWarn(facts()) == true)
+    }
+
+    @Test func codexAlsoWarns() {
+        #expect(detector.decide(facts(kind: .codex)) == .warn)
+    }
+
+    @Test func hookProvenSessionIsTracked() {
+        // A recorded hook session means the pane IS tracked — never warn.
+        #expect(detector.decide(facts(hasHook: true)) == .skip(.tracked))
+    }
+
+    @Test func withinGraceIsNotWarned() {
+        // Covers R2: SessionStart latency must not be flagged as a bypass.
+        #expect(detector.decide(facts(secondsWithoutHook: 5)) == .skip(.withinGrace))
+        // Boundary: exactly at grace warns.
+        #expect(detector.decide(facts(secondsWithoutHook: 10)) == .warn)
+        #expect(detector.decide(facts(secondsWithoutHook: 9.99)) == .skip(.withinGrace))
+    }
+
+    @Test func alreadyWarnedSkips() {
+        // Covers R4: warn at most once per pane/session.
+        #expect(detector.decide(facts(alreadyWarned: true)) == .skip(.alreadyWarned))
+    }
+
+    @Test func disabledSettingSkips() {
+        // Covers R5.
+        #expect(detector.decide(facts(enabled: false)) == .skip(.disabled))
+    }
+
+    @Test func noAgentProcessSkips() {
+        #expect(detector.decide(facts(hasProcess: false)) == .skip(.noAgent))
+        #expect(detector.decide(facts(kind: nil)) == .skip(.noAgent))
+    }
+
+    @Test func unsupportedAgentSkips() {
+        #expect(detector.decide(facts(kind: .gemini)) == .skip(.unsupported(.gemini)))
+        #expect(detector.decide(facts(kind: .custom("acme"))) == .skip(.unsupported(.custom("acme"))))
+    }
+
+    // MARK: - Ordered precedence
+
+    @Test func disabledBeatsEveryOtherReason() {
+        // Even a clear bypass is silent when the setting is off.
+        let f = facts(kind: .gemini, hasProcess: true, hasHook: false, secondsWithoutHook: 999, enabled: false)
+        #expect(detector.decide(f) == .skip(.disabled))
+    }
+
+    @Test func noAgentBeatsTracked() {
+        // No process at all reports noAgent, not tracked.
+        #expect(detector.decide(facts(hasProcess: false, hasHook: true)) == .skip(.noAgent))
+    }
+
+    @Test func trackedBeatsGraceAndUnsupported() {
+        // A tracked pane is the happy path regardless of grace/kind.
+        #expect(detector.decide(facts(hasHook: true, secondsWithoutHook: 0)) == .skip(.tracked))
+        #expect(detector.decide(facts(kind: .gemini, hasHook: true)) == .skip(.tracked))
+    }
+
+    @Test func unsupportedBeatsGrace() {
+        #expect(detector.decide(facts(kind: .gemini, secondsWithoutHook: 1)) == .skip(.unsupported(.gemini)))
+    }
+
+    @Test func graceBeatsAlreadyWarned() {
+        // Within grace we never reach the dedupe check.
+        #expect(detector.decide(facts(secondsWithoutHook: 1, alreadyWarned: true)) == .skip(.withinGrace))
+    }
+
+    @Test func customGraceIntervalRespected() {
+        let strict = UntrackedAgentSessionDetector(graceInterval: 30)
+        #expect(strict.decide(facts(secondsWithoutHook: 20)) == .skip(.withinGrace))
+        #expect(strict.decide(facts(secondsWithoutHook: 30)) == .warn)
+    }
+}

--- a/cmuxTests/UntrackedAgentSessionDiagnosticsTests.swift
+++ b/cmuxTests/UntrackedAgentSessionDiagnosticsTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Behavior tests for the point-in-time diagnostics classifier: tracked vs
+/// untracked vs unsupported per pane, the untracked headline count, and the
+/// stable untracked-first ordering.
+@Suite struct UntrackedAgentSessionDiagnosticsTests {
+    typealias PanelKey = RestorableAgentSessionIndex.PanelKey
+
+    private func key(_ n: Int) -> PanelKey {
+        PanelKey(
+            workspaceId: UUID(uuidString: "00000000-0000-0000-0000-0000000000\(String(format: "%02d", n))")!,
+            panelId: UUID(uuidString: "11111111-0000-0000-0000-0000000000\(String(format: "%02d", n))")!
+        )
+    }
+
+    private let diag = UntrackedAgentSessionDiagnostics()
+
+    @Test func classifiesTrackedUntrackedAndUnsupported() {
+        let tracked = key(1)
+        let untracked = key(2)
+        let unsupported = key(3)
+        let agents: [PanelKey: RestorableAgentKind] = [
+            tracked: .claude,
+            untracked: .claude,
+            unsupported: .gemini,
+        ]
+        let reports = diag.classify(detectedAgents: agents, hasHookSession: { $0 == tracked })
+        let byKey = Dictionary(uniqueKeysWithValues: reports.map { ($0.key, $0.status) })
+        #expect(byKey[tracked] == .tracked)
+        #expect(byKey[untracked] == .untracked)
+        #expect(byKey[unsupported] == .unsupportedAgent(.gemini))
+    }
+
+    @Test func untrackedCountIsTheHeadline() {
+        let agents: [PanelKey: RestorableAgentKind] = [
+            key(1): .claude, // untracked
+            key(2): .codex,  // untracked
+            key(3): .claude, // tracked
+            key(4): .gemini, // unsupported
+        ]
+        let reports = diag.classify(detectedAgents: agents, hasHookSession: { $0 == key(3) })
+        #expect(diag.untrackedCount(reports) == 2)
+    }
+
+    @Test func untrackedPanesSortFirst() {
+        let agents: [PanelKey: RestorableAgentKind] = [
+            key(1): .claude, // tracked
+            key(2): .claude, // untracked
+            key(3): .gemini, // unsupported
+        ]
+        let reports = diag.classify(detectedAgents: agents, hasHookSession: { $0 == key(1) })
+        #expect(reports.first?.status == .untracked)
+        #expect(reports.last.map { if case .unsupportedAgent = $0.status { return true } else { return false } } == true)
+    }
+
+    @Test func emptyInputYieldsEmptyReport() {
+        #expect(diag.classify(detectedAgents: [:], hasHookSession: { _ in false }).isEmpty)
+    }
+
+    @Test func codexIsSupportedSoUntrackedNotUnsupported() {
+        let k = key(1)
+        let reports = diag.classify(detectedAgents: [k: .codex], hasHookSession: { _ in false })
+        #expect(reports.first?.status == .untracked)
+    }
+}

--- a/cmuxTests/UntrackedAgentSessionMonitorTests.swift
+++ b/cmuxTests/UntrackedAgentSessionMonitorTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Behavior tests for the monitor's evaluate core: warn exactly once per genuine
+/// bypass, never for tracked panes, reset on hook-gain / process-exit / new
+/// session, and the grace window across ticks. Driven with fake inputs so no
+/// process capture is needed.
+@MainActor
+@Suite struct UntrackedAgentSessionMonitorTests {
+    typealias PanelKey = RestorableAgentSessionIndex.PanelKey
+
+    private func key(_ n: Int) -> PanelKey {
+        PanelKey(
+            workspaceId: UUID(uuidString: "00000000-0000-0000-0000-0000000000\(String(format: "%02d", n))")!,
+            panelId: UUID(uuidString: "11111111-0000-0000-0000-0000000000\(String(format: "%02d", n))")!
+        )
+    }
+
+    private func agent(_ session: String, kind: RestorableAgentKind = .claude) -> UntrackedAgentSessionMonitor.DetectedAgent {
+        UntrackedAgentSessionMonitor.DetectedAgent(kind: kind, sessionId: session)
+    }
+
+    /// Builds a monitor with a 10s grace, recording delivered warnings.
+    private func makeMonitor(enabled: Bool = true) -> (UntrackedAgentSessionMonitor, () -> [PanelKey]) {
+        var delivered: [PanelKey] = []
+        let monitor = UntrackedAgentSessionMonitor(
+            detector: UntrackedAgentSessionDetector(graceInterval: 10),
+            warningEnabled: { enabled },
+            deliver: { key, _ in delivered.append(key) }
+        )
+        return (monitor, { delivered })
+    }
+
+    @Test func warnsOncePastGraceAndNotAgainNextTick() {
+        let (monitor, delivered) = makeMonitor()
+        let k = key(1)
+        let agents = [k: agent("sess-A")]
+        let noHook: (PanelKey) -> Bool = { _ in false }
+
+        // First sight at t=0: within grace, no warn.
+        monitor.evaluate(detectedAgents: agents, hasHookSession: noHook, now: 0)
+        #expect(delivered().isEmpty)
+        // t=12 (past grace): warn once.
+        monitor.evaluate(detectedAgents: agents, hasHookSession: noHook, now: 12)
+        #expect(delivered() == [k])
+        // t=20 still bypassed: no re-warn.
+        monitor.evaluate(detectedAgents: agents, hasHookSession: noHook, now: 20)
+        #expect(delivered() == [k]) // still just one
+    }
+
+    @Test func trackedPaneNeverWarns() {
+        let (monitor, delivered) = makeMonitor()
+        let k = key(1)
+        let agents = [k: agent("sess-A")]
+        // Hook present from the start.
+        monitor.evaluate(detectedAgents: agents, hasHookSession: { _ in true }, now: 0)
+        monitor.evaluate(detectedAgents: agents, hasHookSession: { _ in true }, now: 60)
+        #expect(delivered().isEmpty)
+        #expect(monitor.trackedPaneCountForTesting == 0)
+    }
+
+    @Test func gainingHookBeforeGraceNeverWarns() {
+        // Covers R2: a session that fires SessionStart within grace is never flagged.
+        let (monitor, delivered) = makeMonitor()
+        let k = key(1)
+        let agents = [k: agent("sess-A")]
+        monitor.evaluate(detectedAgents: agents, hasHookSession: { _ in false }, now: 0)   // detected, no hook
+        monitor.evaluate(detectedAgents: agents, hasHookSession: { _ in true }, now: 5)    // hook arrived within grace
+        monitor.evaluate(detectedAgents: agents, hasHookSession: { _ in true }, now: 30)
+        #expect(delivered().isEmpty)
+    }
+
+    @Test func processExitThenNewBypassedSessionWarnsAgain() {
+        let (monitor, delivered) = makeMonitor()
+        let k = key(1)
+        let noHook: (PanelKey) -> Bool = { _ in false }
+
+        // Session A: warns once past grace.
+        monitor.evaluate(detectedAgents: [k: agent("sess-A")], hasHookSession: noHook, now: 0)
+        monitor.evaluate(detectedAgents: [k: agent("sess-A")], hasHookSession: noHook, now: 12)
+        #expect(delivered() == [k])
+
+        // Process exits (pane no longer detected): state pruned.
+        monitor.evaluate(detectedAgents: [:], hasHookSession: noHook, now: 13)
+        #expect(monitor.trackedPaneCountForTesting == 0)
+
+        // New bypassed session B in the same pane: clock restarts, warns again past grace.
+        monitor.evaluate(detectedAgents: [k: agent("sess-B")], hasHookSession: noHook, now: 14)
+        #expect(delivered() == [k]) // within new grace, not yet
+        monitor.evaluate(detectedAgents: [k: agent("sess-B")], hasHookSession: noHook, now: 30)
+        #expect(delivered() == [k, k]) // second warn for session B
+    }
+
+    @Test func sessionIdChangeInSamePaneResetsGrace() {
+        let (monitor, delivered) = makeMonitor()
+        let k = key(1)
+        let noHook: (PanelKey) -> Bool = { _ in false }
+        // Session A detected at t=0.
+        monitor.evaluate(detectedAgents: [k: agent("sess-A")], hasHookSession: noHook, now: 0)
+        // At t=12, session id is now B (a new session) — clock resets, so within grace, no warn.
+        monitor.evaluate(detectedAgents: [k: agent("sess-B")], hasHookSession: noHook, now: 12)
+        #expect(delivered().isEmpty)
+        // t=24: B is now past its own grace -> warn.
+        monitor.evaluate(detectedAgents: [k: agent("sess-B")], hasHookSession: noHook, now: 24)
+        #expect(delivered() == [k])
+    }
+
+    @Test func twoPanesOneTrackedOneBypassedOnlyBypassedWarns() {
+        let (monitor, delivered) = makeMonitor()
+        let tracked = key(1)
+        let bypassed = key(2)
+        let agents = [tracked: agent("sess-T"), bypassed: agent("sess-B")]
+        let hook: (PanelKey) -> Bool = { $0 == tracked }
+        monitor.evaluate(detectedAgents: agents, hasHookSession: hook, now: 0)
+        monitor.evaluate(detectedAgents: agents, hasHookSession: hook, now: 15)
+        #expect(delivered() == [bypassed])
+    }
+
+    @Test func disabledSettingNeverWarns() {
+        let (monitor, delivered) = makeMonitor(enabled: false)
+        let k = key(1)
+        monitor.evaluate(detectedAgents: [k: agent("sess-A")], hasHookSession: { _ in false }, now: 0)
+        monitor.evaluate(detectedAgents: [k: agent("sess-A")], hasHookSession: { _ in false }, now: 999)
+        #expect(delivered().isEmpty)
+    }
+}

--- a/cmuxTests/UntrackedAgentSessionMonitorTests.swift
+++ b/cmuxTests/UntrackedAgentSessionMonitorTests.swift
@@ -22,8 +22,8 @@ import Testing
         )
     }
 
-    private func agent(_ session: String, kind: RestorableAgentKind = .claude) -> UntrackedAgentSessionMonitor.DetectedAgent {
-        UntrackedAgentSessionMonitor.DetectedAgent(kind: kind, sessionId: session)
+    private func agent(_ identity: String, kind: RestorableAgentKind = .claude) -> UntrackedAgentSessionMonitor.DetectedAgent {
+        UntrackedAgentSessionMonitor.DetectedAgent(kind: kind, identity: identity)
     }
 
     /// Builds a monitor with a 10s grace, recording delivered warnings.
@@ -120,6 +120,25 @@ import Testing
         monitor.evaluate(detectedAgents: agents, hasHookSession: hook, now: 0)
         monitor.evaluate(detectedAgents: agents, hasHookSession: hook, now: 15)
         #expect(delivered() == [bypassed])
+    }
+
+    // MARK: - Live detection source: claude/codex are detected by process name
+
+    @Test func supportedAgentKindMatchesClaudeAndCodexByExecutableName() {
+        // Claude/Codex are NOT in the vault process-detection registry, so the
+        // live path must recognize them by executable basename.
+        #expect(UntrackedAgentSessionMonitor.supportedAgentKind(processName: "claude", path: nil) == .claude)
+        #expect(UntrackedAgentSessionMonitor.supportedAgentKind(processName: "codex", path: nil) == .codex)
+        // Full path wins over the (possibly truncated) name.
+        #expect(UntrackedAgentSessionMonitor.supportedAgentKind(processName: "claude", path: "/Users/me/.local/bin/claude") == .claude)
+        #expect(UntrackedAgentSessionMonitor.supportedAgentKind(processName: "CODEX", path: nil) == .codex) // case-insensitive
+    }
+
+    @Test func supportedAgentKindRejectsNonAgentProcesses() {
+        #expect(UntrackedAgentSessionMonitor.supportedAgentKind(processName: "node", path: nil) == nil)
+        #expect(UntrackedAgentSessionMonitor.supportedAgentKind(processName: "bun", path: nil) == nil)
+        #expect(UntrackedAgentSessionMonitor.supportedAgentKind(processName: "zsh", path: "/bin/zsh") == nil)
+        #expect(UntrackedAgentSessionMonitor.supportedAgentKind(processName: "", path: nil) == nil)
     }
 
     @Test func disabledSettingNeverWarns() {

--- a/cmuxTests/UntrackedAgentSessionWarningSettingsTests.swift
+++ b/cmuxTests/UntrackedAgentSessionWarningSettingsTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class UntrackedAgentSessionWarningSettingsTests: XCTestCase {
+    func testDefaultsKeyAndNotificationOnFlip() throws {
+        let suiteName = "cmux-untracked-agent-session-warning-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertEqual(
+            UntrackedAgentSessionWarningSettings.warnUntrackedAgentSessionKey,
+            "terminal.warnUntrackedAgentSession"
+        )
+        // Default is on (warn by default).
+        XCTAssertTrue(UntrackedAgentSessionWarningSettings.isEnabled(defaults: defaults))
+
+        let notificationCenter = NotificationCenter()
+        var notificationCount = 0
+        let observer = notificationCenter.addObserver(
+            forName: UntrackedAgentSessionWarningSettings.didChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            notificationCount += 1
+        }
+        defer { notificationCenter.removeObserver(observer) }
+
+        UntrackedAgentSessionWarningSettings.setEnabled(
+            false,
+            defaults: defaults,
+            notificationCenter: notificationCenter
+        )
+        XCTAssertFalse(UntrackedAgentSessionWarningSettings.isEnabled(defaults: defaults))
+        XCTAssertEqual(notificationCount, 1)
+
+        // Setting the same value again does not re-notify.
+        UntrackedAgentSessionWarningSettings.setEnabled(
+            false,
+            defaults: defaults,
+            notificationCenter: notificationCenter
+        )
+        XCTAssertEqual(notificationCount, 1)
+
+        // Reset restores the default (on) and notifies once.
+        UntrackedAgentSessionWarningSettings.reset(
+            defaults: defaults,
+            notificationCenter: notificationCenter
+        )
+        XCTAssertTrue(UntrackedAgentSessionWarningSettings.isEnabled(defaults: defaults))
+        XCTAssertEqual(notificationCount, 2)
+    }
+}


### PR DESCRIPTION
# Warn when a Claude/Codex session in a pane isn't being tracked

cmux records an agent session by injecting its hook `--settings` through the `claude` wrapper shim, which only happens when `claude` resolves to that shim. When a launch path reaches the raw binary instead - a custom launcher script, a shell `claude()` function, an alias, or a PATH that puts the real binary ahead of the shim - no hooks fire, `SessionStart` never records the session, the window is invisible to cmux, and it won't resume after a crash or update. Today this happens silently, with no feedback.

This adds a small background check that detects that state - a Claude/Codex process running in a pane with no hook-proven session - and shows a single, dismissible, per-pane warning explaining the session isn't tracked and won't resume, with the likely cause. It is detection-and-warning only: it does not modify any shell config, change hook injection, or touch the resume path.

It complements #6751: an untracked session is exactly the unverifiable-binding case the recovery layer there handles.

## How it detects

Claude/Codex are not in the vault process-detection registry (that only emits custom/opencode kinds); they're known to cmux only through their hook store, which is the tracked path. So a bypassed claude/codex is invisible except as a raw process. The monitor finds cmux-scoped `claude`/`codex` processes by executable name from `CmuxTopProcessSnapshot` and compares against `SharedLiveAgentIndex` (the hook-proven sessions). A process with no hook session, past a short grace window, is the bug.

- A grace window (~10s) avoids flagging a session that simply hasn't fired SessionStart yet.
- Warned at most once per pane/session (keyed by pid); a relaunch re-warns. Plus a 1h notification cooldown.
- Opt-out via `terminal.warnUntrackedAgentSession` (default on).
- The check runs off-main on a coarse poll; the hook lookup is the cached, non-blocking `SharedLiveAgentIndex`.

## What's in it

- `UntrackedAgentSessionDetector` - pure warn/skip decision (grace, dedupe, support, opt-out).
- `UntrackedAgentSessionWarningSettings` - opt-out setting, mirrors `AgentSessionAutoResumeSettings`.
- `UntrackedAgentSessionMonitor` - process-name detection vs hook gap, per-pane dedupe, delivery via `TerminalNotificationStore`; started at launch.
- `UntrackedAgentSessionDiagnostics` - point-in-time classifier (tracked / untracked / unsupported) for a doctor-style listing.
- Title + body localized EN + JA.

## Testing

- 28 unit tests across the detector matrix, the monitor evaluate core (warn-once / grace / reset / two-pane isolation), the process-name matcher, the settings round-trip, and the diagnostics classifier.
- Reproduced on a real machine: a custom `claude-launcher.sh` ran `caffeinate -- claude --dangerously-skip-permissions` (raw binary, no `--settings`); `ps -axww` confirmed fresh windows had no `--settings` while the one tracked session was the resume path's `claude --settings {...} --resume <id>`.

## Known limitation

If process capture transiently misses a PID for a poll, the grace clock restarts, delaying (never falsely emitting) the warning. Tunable via the poll interval / grace.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784943144&installation_id=133855650&pr_number=6759&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6759&signature=ce8aa7359152d2969b2429e57c5873fc1423f0a5f9c7f8f620e12fe2a0fdffe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when a Claude or Codex session in a pane isn’t tracked by cmux, so users know the window won’t auto‑resume. Adds a lightweight background check with a short grace period and a one‑time, dismissible notification.

- **New Features**
  - Background monitor compares process name detection to hook‑proven sessions, then warns once per pane after ~10s grace; runs off‑main with a 1h cooldown.
  - Opt‑out via `terminal.warnUntrackedAgentSession` (default on).
  - Point‑in‑time diagnostics classify panes as tracked, untracked, or unsupported.
  - Localized notification title/body (EN/JA).
  - Starts at app launch; does not change shell config or resume logic.

- **Bug Fixes**
  - Detects bypassed Claude/Codex by executable basename, ensuring untracked sessions are found even when not in the process registry.

<sup>Written for commit 9eb866b8757c9c3cf41dca7e065aadb1140c62f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alerts for untracked agent sessions, helping users know when a session may not resume after a crash or update.
  * Expanded support for detecting more agent types and showing clearer status information in diagnostics.
  * Added a setting to turn untracked-session warnings on or off.

* **Bug Fixes**
  * Improved startup monitoring so untracked sessions are detected reliably during normal launches.
  * Reduced repeated notifications by only warning once per session/pane within a cooldown window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->