### PR TITLE
Bound waitlist email validation with fail-open timeouts

### DIFF
--- a/web/app/[locale]/components/waitlist-dialog.tsx
+++ b/web/app/[locale]/components/waitlist-dialog.tsx
@@ -22,6 +22,12 @@ const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // submit rather than an instant flash. The real wait is the capture POST below.
 const SUBMIT_DELAY_MS = 600;
 
+// Hard cap on the server-side deliverability check. If the route is slow, hung,
+// or rate-limiting, abort and let the signup through rather than stall the user
+// on "Joining…". Sits above the server's own ~2.5s DNS timeout so the server's
+// verdict usually wins; this is the backstop for a hung route.
+const VALIDATE_TIMEOUT_MS = 4000;
+
 /**
  * Records a waitlist signup by POSTing the event straight to PostHog's capture
  * endpoint and awaiting delivery, so the UI shows success only when the record
@@ -75,19 +81,24 @@ async function recordWaitlistSignup(
 /**
  * Asks the server whether the email's domain can receive mail (MX + disposable
  * check) before we record the signup. Returns `"invalid"` only on a definitive
- * rejection; network or server errors return `"ok"` so a transient failure never
- * blocks a real signup (the server itself also fails open on DNS hiccups).
+ * rejection; network errors, server errors, rate limits, and timeouts all return
+ * `"ok"` so a degraded backend never blocks a real signup (the server itself
+ * also fails open on DNS hiccups). Bounded by an abort timeout so a hung route
+ * can't stall the signup either.
  */
 async function verifyWaitlistEmail(
   email: string,
   platforms: WaitlistPlatform[],
   location: string,
 ): Promise<"ok" | "invalid"> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), VALIDATE_TIMEOUT_MS);
   try {
     const res = await fetch("/api/waitlist", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email, platforms, location, notify: false }),
+      signal: controller.signal,
     });
     if (!res.ok) return "ok";
     const data = (await res.json().catch(() => null)) as {
@@ -95,7 +106,10 @@ async function verifyWaitlistEmail(
     } | null;
     return data?.valid === false ? "invalid" : "ok";
   } catch {
+    // Network error or abort timeout: fail open.
     return "ok";
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/web/app/api/waitlist/email-check.ts
+++ b/web/app/api/waitlist/email-check.ts
@@ -134,6 +134,21 @@ async function withTimeout(
   }
 }
 
+// Coalesce concurrent/sequential lookups for the same domain onto one in-flight
+// resolveDomain call. Without this, a slow domain that the timeout abandons
+// would be resolved again by the follow-up `notify` request (and by any other
+// caller), multiplying lingering c-ares work. Sharing one promise means a slow
+// domain has at most one outstanding lookup, which drains when c-ares settles.
+const inflight = new Map<string, Promise<EmailCheck>>();
+
+function resolveDomainShared(domain: string): Promise<EmailCheck> {
+  const existing = inflight.get(domain);
+  if (existing) return existing;
+  const pending = resolveDomain(domain).finally(() => inflight.delete(domain));
+  inflight.set(domain, pending);
+  return pending;
+}
+
 async function resolveDomain(domain: string): Promise<EmailCheck> {
   try {
     const mx = await dns.resolveMx(domain);
@@ -172,7 +187,7 @@ export async function checkEmailDeliverable(
   const cached = cacheGet(domain);
   if (cached) return cached;
 
-  const status = await withTimeout(resolveDomain(domain), timeoutMs);
+  const status = await withTimeout(resolveDomainShared(domain), timeoutMs);
   // Cache only stable answers; let `unknown` (transient failure or timeout)
   // retry on the next submit.
   if (status !== "unknown") cacheSet(domain, status);

--- a/web/app/api/waitlist/email-check.ts
+++ b/web/app/api/waitlist/email-check.ts
@@ -135,23 +135,27 @@ async function withTimeout(
 }
 
 // Coalesce concurrent/sequential lookups for the same domain onto one in-flight
-// resolveDomain call. Without this, a slow domain that the timeout abandons
-// would be resolved again by the follow-up `notify` request (and by any other
-// caller), multiplying lingering c-ares work. Sharing one promise means a slow
-// domain has at most one outstanding lookup, which drains when c-ares settles.
+// resolveDomain call, and cap the total number of concurrent lookups. Together
+// these bound outstanding DNS work on this public, user-controlled endpoint:
 //
-// Bounded so a flood of unique slow/hung domains on this public endpoint can't
-// retain entries without limit: once the map is full, extra lookups run
-// un-tracked (still bounded by the caller timeout and c-ares' own limits)
-// rather than growing the map. An entry is removed as soon as its lookup
-// settles, so under normal load the map stays near-empty.
-const INFLIGHT_MAX = 256;
+//   - Same domain already resolving -> share that promise (no new work). This
+//     also stops the follow-up `notify` request from re-resolving a domain the
+//     timeout abandoned.
+//   - A new domain while at capacity -> fail open immediately ("unknown", which
+//     the caller treats as deliverable) WITHOUT starting another resolver call.
+//
+// So the number of live c-ares operations can never exceed MAX_CONCURRENT_DNS,
+// regardless of how many unique slow/hung domains are thrown at the route. The
+// caller timeout can't cancel c-ares, so shedding load here (not starting the
+// work) is what actually bounds it. Entries clear as each lookup settles, so
+// under normal load the map stays near-empty and nothing is shed.
+const MAX_CONCURRENT_DNS = 256;
 const inflight = new Map<string, Promise<EmailCheck>>();
 
 function resolveDomainShared(domain: string): Promise<EmailCheck> {
   const existing = inflight.get(domain);
   if (existing) return existing;
-  if (inflight.size >= INFLIGHT_MAX) return resolveDomain(domain);
+  if (inflight.size >= MAX_CONCURRENT_DNS) return Promise.resolve("unknown");
   const pending = resolveDomain(domain).finally(() => inflight.delete(domain));
   inflight.set(domain, pending);
   return pending;

--- a/web/app/api/waitlist/email-check.ts
+++ b/web/app/api/waitlist/email-check.ts
@@ -139,11 +139,19 @@ async function withTimeout(
 // would be resolved again by the follow-up `notify` request (and by any other
 // caller), multiplying lingering c-ares work. Sharing one promise means a slow
 // domain has at most one outstanding lookup, which drains when c-ares settles.
+//
+// Bounded so a flood of unique slow/hung domains on this public endpoint can't
+// retain entries without limit: once the map is full, extra lookups run
+// un-tracked (still bounded by the caller timeout and c-ares' own limits)
+// rather than growing the map. An entry is removed as soon as its lookup
+// settles, so under normal load the map stays near-empty.
+const INFLIGHT_MAX = 256;
 const inflight = new Map<string, Promise<EmailCheck>>();
 
 function resolveDomainShared(domain: string): Promise<EmailCheck> {
   const existing = inflight.get(domain);
   if (existing) return existing;
+  if (inflight.size >= INFLIGHT_MAX) return resolveDomain(domain);
   const pending = resolveDomain(domain).finally(() => inflight.delete(domain));
   inflight.set(domain, pending);
   return pending;

--- a/web/app/api/waitlist/email-check.ts
+++ b/web/app/api/waitlist/email-check.ts
@@ -112,6 +112,28 @@ async function hasAddressRecord(domain: string): Promise<EmailCheck> {
   return "invalid";
 }
 
+// Upper bound on the DNS work per check. A slow or hung resolver should fail
+// open ("unknown" -> caller passes the email) within a couple of seconds rather
+// than stall the signup waiting on c-ares' multi-second retries.
+const DNS_TIMEOUT_MS = 2500;
+
+// resolveDomain never rejects (its callees swallow DNS errors), so the losing
+// race branch settles and is GC'd without an unhandled rejection.
+async function withTimeout(
+  work: Promise<EmailCheck>,
+  ms: number,
+): Promise<EmailCheck> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<EmailCheck>((resolve) => {
+    timer = setTimeout(() => resolve("unknown"), ms);
+  });
+  try {
+    return await Promise.race([work, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function resolveDomain(domain: string): Promise<EmailCheck> {
   try {
     const mx = await dns.resolveMx(domain);
@@ -133,7 +155,10 @@ async function resolveDomain(domain: string): Promise<EmailCheck> {
  * providers, without proving inbox ownership. Returns `unknown` on transient
  * DNS failures so callers can fail open.
  */
-export async function checkEmailDeliverable(email: string): Promise<EmailCheck> {
+export async function checkEmailDeliverable(
+  email: string,
+  timeoutMs: number = DNS_TIMEOUT_MS,
+): Promise<EmailCheck> {
   const at = email.lastIndexOf("@");
   if (at < 0) return "invalid";
   const domain = email
@@ -147,8 +172,9 @@ export async function checkEmailDeliverable(email: string): Promise<EmailCheck> 
   const cached = cacheGet(domain);
   if (cached) return cached;
 
-  const status = await resolveDomain(domain);
-  // Cache only stable answers; let `unknown` retry on the next submit.
+  const status = await withTimeout(resolveDomain(domain), timeoutMs);
+  // Cache only stable answers; let `unknown` (transient failure or timeout)
+  // retry on the next submit.
   if (status !== "unknown") cacheSet(domain, status);
   return status;
 }

--- a/web/bunfig.toml
+++ b/web/bunfig.toml
@@ -1,0 +1,4 @@
+[test]
+# Pin deterministic test env before any module (notably @/app/env) loads, so the
+# suite is not order-dependent on which test file imports env first.
+preload = ["./tests/test-preload.ts"]

--- a/web/tests/notifications-push-route.test.ts
+++ b/web/tests/notifications-push-route.test.ts
@@ -53,6 +53,14 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  // Re-assert the env each test rather than relying only on the module-top-level
+  // assignment. bun runs every test file in one process, and other suites
+  // (e.g. vm-route-auth) capture+restore process.env.VERCEL, so depending on
+  // file load order they can delete VERCEL before these tests run — which made
+  // the route skip rate-limiting and flaked this suite in CI.
+  process.env.SKIP_ENV_VALIDATION = "1";
+  process.env.VERCEL = "1";
+  process.env.CMUX_PUSH_RATE_LIMIT_ID = "cmux-push-test";
   getUser.mockClear();
   checkRateLimit.mockClear();
   checkRateLimit.mockResolvedValue({ rateLimited: true, error: null });

--- a/web/tests/test-preload.ts
+++ b/web/tests/test-preload.ts
@@ -1,0 +1,13 @@
+// Runs once before any test module loads (see bunfig.toml `[test].preload`).
+//
+// `@/app/env` builds its `env` object from `process.env` at module-load time
+// via t3-env's createEnv. bun runs every test file in one process, so whichever
+// test file first imports `@/app/env` (directly or through a route) freezes
+// those values for the whole run. That made env-dependent suites order-dependent
+// and flaky in CI — e.g. notifications-push-route asserts the push rate-limit
+// fires, but `env.CMUX_PUSH_RATE_LIMIT_ID` froze to `undefined` whenever another
+// suite imported env first. Pinning the deterministic test env here, before any
+// import, removes the ordering dependency. Individual suites may still override
+// these at their own top level.
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.CMUX_PUSH_RATE_LIMIT_ID ??= "cmux-push-test";

--- a/web/tests/waitlist-email-check.test.ts
+++ b/web/tests/waitlist-email-check.test.ts
@@ -98,4 +98,24 @@ describe("checkEmailDeliverable", () => {
     expect(await checkEmailDeliverable("a@hung.test", 20)).toBe("unknown");
     expect(Date.now() - start).toBeLessThan(500);
   });
+
+  test("coalesces concurrent lookups for one domain onto a single DNS call", async () => {
+    let mxCalls = 0;
+    let release!: (v: { exchange: string; priority: number }[]) => void;
+    resolveMx = () => {
+      mxCalls += 1;
+      return new Promise((res) => {
+        release = res;
+      });
+    };
+    resolve4 = noRecord;
+    resolve6 = noRecord;
+    const p1 = checkEmailDeliverable("a@coalesce.test");
+    const p2 = checkEmailDeliverable("b@coalesce.test");
+    await new Promise((r) => setTimeout(r, 5));
+    release([{ exchange: "mx.coalesce.test", priority: 10 }]);
+    expect(await p1).toBe("ok");
+    expect(await p2).toBe("ok");
+    expect(mxCalls).toBe(1);
+  });
 });

--- a/web/tests/waitlist-email-check.test.ts
+++ b/web/tests/waitlist-email-check.test.ts
@@ -90,23 +90,25 @@ describe("checkEmailDeliverable", () => {
   test("fails open (unknown) when DNS exceeds the timeout", async () => {
     // A hung resolver must never reject a real address; the bounded check
     // resolves to "unknown" so the caller passes the email through. Capture the
-    // rejecters so the abandoned lookup can be settled at the end rather than
-    // left dangling across other test files in the shared process.
+    // abandoned lookups so they can be settled deterministically at the end
+    // rather than left dangling across other test files in the shared process.
     const rejecters: Array<(reason: unknown) => void> = [];
-    const hang = () =>
-      new Promise<never>((_, reject) => {
+    const lookups: Array<Promise<never>> = [];
+    const hang = () => {
+      const p = new Promise<never>((_, reject) => {
         rejecters.push(reject);
       });
+      lookups.push(p);
+      return p;
+    };
     resolveMx = hang;
     resolve4 = hang;
     resolve6 = hang;
-    const start = Date.now();
-    expect(await checkEmailDeliverable("a@hung.test", 20)).toBe("unknown");
-    expect(Date.now() - start).toBeLessThan(500);
+    expect(await checkEmailDeliverable("a@hung.test", 1)).toBe("unknown");
     // Settle the abandoned lookup so its in-flight entry clears and nothing
     // lingers for later tests.
     rejecters.forEach((reject) => reject(new Error("test cleanup")));
-    await new Promise((r) => setTimeout(r, 0));
+    await Promise.allSettled(lookups);
   });
 
   test("coalesces concurrent lookups for one domain onto a single DNS call", async () => {
@@ -120,9 +122,13 @@ describe("checkEmailDeliverable", () => {
     };
     resolve4 = noRecord;
     resolve6 = noRecord;
+    // Each call runs synchronously up to its first await: the first invokes the
+    // single resolveMx and registers the in-flight entry (so `release` is set);
+    // the second coalesces onto it without calling resolveMx again. The dedupe
+    // has therefore already happened by the time these two statements return —
+    // no timer needed.
     const p1 = checkEmailDeliverable("a@coalesce.test");
     const p2 = checkEmailDeliverable("b@coalesce.test");
-    await new Promise((r) => setTimeout(r, 5));
     release([{ exchange: "mx.coalesce.test", priority: 10 }]);
     expect(await p1).toBe("ok");
     expect(await p2).toBe("ok");

--- a/web/tests/waitlist-email-check.test.ts
+++ b/web/tests/waitlist-email-check.test.ts
@@ -86,4 +86,16 @@ describe("checkEmailDeliverable", () => {
     resolve6 = noRecord;
     expect(await checkEmailDeliverable("not-an-email")).toBe("invalid");
   });
+
+  test("fails open (unknown) when DNS exceeds the timeout", async () => {
+    // A hung resolver must never reject a real address; the bounded check
+    // resolves to "unknown" so the caller passes the email through.
+    const hang = () => new Promise<never>(() => {});
+    resolveMx = hang;
+    resolve4 = hang;
+    resolve6 = hang;
+    const start = Date.now();
+    expect(await checkEmailDeliverable("a@hung.test", 20)).toBe("unknown");
+    expect(Date.now() - start).toBeLessThan(500);
+  });
 });

--- a/web/tests/waitlist-email-check.test.ts
+++ b/web/tests/waitlist-email-check.test.ts
@@ -89,14 +89,24 @@ describe("checkEmailDeliverable", () => {
 
   test("fails open (unknown) when DNS exceeds the timeout", async () => {
     // A hung resolver must never reject a real address; the bounded check
-    // resolves to "unknown" so the caller passes the email through.
-    const hang = () => new Promise<never>(() => {});
+    // resolves to "unknown" so the caller passes the email through. Capture the
+    // rejecters so the abandoned lookup can be settled at the end rather than
+    // left dangling across other test files in the shared process.
+    const rejecters: Array<(reason: unknown) => void> = [];
+    const hang = () =>
+      new Promise<never>((_, reject) => {
+        rejecters.push(reject);
+      });
     resolveMx = hang;
     resolve4 = hang;
     resolve6 = hang;
     const start = Date.now();
     expect(await checkEmailDeliverable("a@hung.test", 20)).toBe("unknown");
     expect(Date.now() - start).toBeLessThan(500);
+    // Settle the abandoned lookup so its in-flight entry clears and nothing
+    // lingers for later tests.
+    rejecters.forEach((reject) => reject(new Error("test cleanup")));
+    await new Promise((r) => setTimeout(r, 0));
   });
 
   test("coalesces concurrent lookups for one domain onto a single DNS call", async () => {


### PR DESCRIPTION
## What

Makes the waitlist email gate **fail open *fast*** when our own backend is degraded, so a slow/hung/rate-limited validation check never blocks or stalls a real signup.

## Why

The flow already fails open on hard errors (any non-2xx, network error → email passes). But neither side had a **timeout**, so the real-world failure mode — the resolver or function getting *slow* rather than cleanly erroring — would leave the user stuck on "Joining…" until they gave up. A signup lost to a hang is just as lost as one wrongly rejected.

## How

- **Server** (`email-check.ts`): `checkEmailDeliverable` caps DNS work at ~2.5s via a `Promise.race`; on timeout it returns `"unknown"`, which the route already treats as deliverable (`valid: true`). Takes an optional `timeoutMs` arg for deterministic tests.
- **Client** (`waitlist-dialog.tsx`): the validate `fetch` gets an `AbortController` with a 4s cap (above the server's 2.5s so the server's verdict usually wins); on abort/network error it returns `"ok"` and the signup proceeds to record.

Healthy backend: behaviorally unchanged. Degraded backend: email passes within a few seconds.

## Tests

Added a hung-resolver case: with all DNS lookups never resolving, `checkEmailDeliverable(email, 20)` returns `"unknown"` in <500ms. 12/12 pass; `tsc` clean. No new localized strings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784964087&installation_id=133855650&pr_number=6765&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6765&signature=a70d0354e98a91091625942ba3868eee7a273215d3c5ebbd373b844cf93f40e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a public waitlist endpoint’s DNS behavior and fail-open paths under load; healthy-path validation is unchanged but abuse or saturation now skips new lookups instead of queuing indefinitely.
> 
> **Overview**
> Waitlist signups no longer get stuck on **"Joining…"** when deliverability checks hang or crawl. The client aborts the validate `fetch` after **4s** and treats abort/network errors as pass-through; the server caps DNS work at **~2.5s** (`unknown` → still deliverable) and adds **per-domain coalescing** plus a **256** concurrent lookup cap that fails open without starting more resolver work when saturated.
> 
> Tests add hung-DNS and coalescing coverage, a **bun** test preload so `env` is pinned before modules load, and re-assert push rate-limit env in `notifications-push-route` `beforeEach` to fix CI order flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c2815b48d3c7ed1042445b12699944c0c41371. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add fail-open timeouts to waitlist email validation so slow or hung checks never stall signups. Coalesce per‑domain DNS lookups and cap total concurrent DNS at 256; when saturated, skip new lookups and let users through.

- **Bug Fixes**
  - Server: 2.5s DNS timeout → "unknown". Coalesce per‑domain lookups. Cap concurrent DNS at 256 and fail open immediately when full (no new resolver work). Optional timeout for tests; don't cache "unknown".
  - Client: Abort validate request after 4s and treat abort/network errors as "ok" to prevent "Joining…" hangs.
  - Tests: Added hung‑resolver and coalescing tests; made them deterministic (1ms timeout + Promise.allSettled); settled abandoned lookups. Pinned a deterministic test env via `bun` preload (`bunfig.toml` → `tests/test-preload.ts`) and re‑asserted env vars in `beforeEach` to fix an order‑dependent flake in `notifications-push-route`.

<sup>Written for commit 72c2815b48d3c7ed1042445b12699944c0c41371. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added bounded timeouts to waitlist email deliverability checks to prevent stalled verification from hanging.
  * Improved “fails open” handling: timeouts/lookup issues now result in a safe “unknown” outcome, while explicitly invalid emails remain “invalid.”
  * Implemented per-domain DNS coalescing with concurrency limits, and avoided caching uncertain “unknown” results to allow later retries.
* **Tests**
  * Added unit tests covering DNS timeouts (“unknown”) and per-domain in-flight coalescing.
  * Stabilized notification push route tests by re-setting key environment variables before each case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->