### PR TITLE
Avoid native hybrid prompt for platform passkeys

### DIFF
--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -4,7 +4,13 @@ import Bonsplit
 import CoreBluetooth
 import Foundation
 import ObjectiveC.runtime
+import os
 import WebKit
+
+nonisolated private let browserWebAuthnLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.cmuxterm.app",
+    category: "BrowserWebAuthn"
+)
 
 /// Native WebAuthn bridge for `WKWebView`.
 ///
@@ -1071,6 +1077,7 @@ final class BrowserWebAuthnCoordinator: NSObject, WKScriptMessageHandlerWithRepl
                 #if DEBUG
                 cmuxDebugLog("webauthn.dispatch kind=\(envelope.kind.rawValue) frame=\(message.frameInfo.isMainFrame ? "main" : "sub") url=\(message.frameInfo.securityOrigin.host)")
                 #endif
+                browserWebAuthnLogger.info("dispatch kind=\(envelope.kind.rawValue, privacy: .public) frame=\(message.frameInfo.isMainFrame ? "main" : "sub", privacy: .public) host=\(message.frameInfo.securityOrigin.host, privacy: .public)")
                 switch envelope.kind {
                 case .capabilities:
                     _ = try BrowserWebAuthnClientDataContext.resolvePermitted(for: message)
@@ -1163,10 +1170,11 @@ extension BrowserWebAuthnCoordinator: ASAuthorizationControllerDelegate, ASAutho
         controller: ASAuthorizationController,
         didCompleteWithError error: Error
     ) {
-        #if DEBUG
         let nsError = error as NSError
+        #if DEBUG
         cmuxDebugLog("webauthn.asAuth.didFail domain=\(nsError.domain) code=\(nsError.code)")
         #endif
+        browserWebAuthnLogger.error("asAuth.didFail domain=\(nsError.domain, privacy: .public) code=\(nsError.code) description=\(nsError.localizedDescription, privacy: .public)")
         finishAuthorization(with: .failure(bridgeError(from: error)))
     }
 
@@ -1447,12 +1455,12 @@ private extension BrowserWebAuthnCoordinator {
             if !excludedCredentials.isEmpty {
                 platformRequest.excludedCredentials = excludedCredentials
             }
-            platformRequest.shouldShowHybridTransport = attachment != "platform"
+            platformRequest.shouldShowHybridTransport = false
             platformRequests.append(platformRequest)
         }
 
         var securityKeyRequests: [ASAuthorizationRequest] = []
-        if attachment != "platform",
+        if attachment == "cross-platform",
            #available(macOS 14.4, *) {
             let provider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(
                 relyingPartyIdentifier: relyingPartyIdentifier
@@ -1497,12 +1505,13 @@ private extension BrowserWebAuthnCoordinator {
         #if DEBUG
         cmuxDebugLog("webauthn.buildCreationPlan rp=\(relyingPartyIdentifier) platform=\(platformRequests.count) securityKey=\(securityKeyRequests.count) attachment=\(attachment ?? "(nil)")")
         #endif
+        browserWebAuthnLogger.info("buildCreationPlan rp=\(relyingPartyIdentifier, privacy: .public) platform=\(platformRequests.count) securityKey=\(securityKeyRequests.count) attachment=\(attachment ?? "(nil)", privacy: .public)")
         return .init(
             platformRequests: platformRequests,
             securityKeyRequests: securityKeyRequests,
             order: attachment == "cross-platform" ? .securityKeyFirst : .platformFirst,
-            needsBluetoothForPlatformRequests: attachment != "platform",
-            needsBluetoothForSecurityKeyRequests: false,
+            needsBluetoothForPlatformRequests: false,
+            needsBluetoothForSecurityKeyRequests: attachment == "cross-platform",
             prefersImmediatelyAvailableCredentials: false
         )
     }
@@ -1528,7 +1537,7 @@ private extension BrowserWebAuthnCoordinator {
         let includePlatformRequests =
             allowCredentials.isEmpty || transportSummary.allowsPlatformCredentials
         let includeSecurityKeyRequests =
-            allowCredentials.isEmpty || transportSummary.allowsSecurityKeyCredentials
+            !allowCredentials.isEmpty && transportSummary.allowsSecurityKeyCredentials
 
         var platformRequests: [ASAuthorizationRequest] = []
         if includePlatformRequests,
@@ -1553,8 +1562,7 @@ private extension BrowserWebAuthnCoordinator {
             if !allowedCredentials.isEmpty {
                 platformRequest.allowedCredentials = allowedCredentials
             }
-            platformRequest.shouldShowHybridTransport =
-                allowCredentials.isEmpty ? true : transportSummary.shouldShowHybridTransport
+            platformRequest.shouldShowHybridTransport = false
             platformRequests.append(platformRequest)
         }
 
@@ -1587,12 +1595,12 @@ private extension BrowserWebAuthnCoordinator {
 
         let order: BrowserWebAuthnRequestOrder =
             transportSummary.prefersSecurityKeysFirst ? .securityKeyFirst : .platformFirst
-        let needsBluetoothForPlatformRequests =
-            allowCredentials.isEmpty ? true : transportSummary.shouldShowHybridTransport
+        let needsBluetoothForPlatformRequests = false
 
         #if DEBUG
         cmuxDebugLog("webauthn.buildAssertionPlan rp=\(relyingPartyIdentifier) platform=\(platformRequests.count) securityKey=\(securityKeyRequests.count) allowCredentials=\(allowCredentials.count) mediation=\(request.mediation ?? "(nil)") hybridTransport=\(transportSummary.shouldShowHybridTransport)")
         #endif
+        browserWebAuthnLogger.info("buildAssertionPlan rp=\(relyingPartyIdentifier, privacy: .public) platform=\(platformRequests.count) securityKey=\(securityKeyRequests.count) allowCredentials=\(allowCredentials.count) mediation=\(request.mediation ?? "(nil)", privacy: .public) hybrid=\(transportSummary.shouldShowHybridTransport)")
         return .init(
             platformRequests: platformRequests,
             securityKeyRequests: securityKeyRequests,

--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -12,6 +12,21 @@ nonisolated private let browserWebAuthnLogger = Logger(
     category: "BrowserWebAuthn"
 )
 
+private func browserWebAuthnTrace(_ message: @autoclosure () -> String) {
+    let text = message()
+    browserWebAuthnLogger.notice("\(text, privacy: .public)")
+
+    let path = "/tmp/cmux-webauthn-nightly.log"
+    let line = "\(ISO8601DateFormatter().string(from: Date())) \(text)\n"
+    if !FileManager.default.fileExists(atPath: path) {
+        _ = FileManager.default.createFile(atPath: path, contents: nil)
+    }
+    guard let handle = FileHandle(forWritingAtPath: path) else { return }
+    defer { try? handle.close() }
+    try? handle.seekToEnd()
+    try? handle.write(contentsOf: Data(line.utf8))
+}
+
 /// Native WebAuthn bridge for `WKWebView`.
 ///
 /// The page world overrides `navigator.credentials.create/get`, serializes the
@@ -1077,7 +1092,7 @@ final class BrowserWebAuthnCoordinator: NSObject, WKScriptMessageHandlerWithRepl
                 #if DEBUG
                 cmuxDebugLog("webauthn.dispatch kind=\(envelope.kind.rawValue) frame=\(message.frameInfo.isMainFrame ? "main" : "sub") url=\(message.frameInfo.securityOrigin.host)")
                 #endif
-                browserWebAuthnLogger.info("dispatch kind=\(envelope.kind.rawValue, privacy: .public) frame=\(message.frameInfo.isMainFrame ? "main" : "sub", privacy: .public) host=\(message.frameInfo.securityOrigin.host, privacy: .public)")
+                browserWebAuthnTrace("dispatch kind=\(envelope.kind.rawValue) frame=\(message.frameInfo.isMainFrame ? "main" : "sub") host=\(message.frameInfo.securityOrigin.host)")
                 switch envelope.kind {
                 case .capabilities:
                     _ = try BrowserWebAuthnClientDataContext.resolvePermitted(for: message)
@@ -1090,6 +1105,7 @@ final class BrowserWebAuthnCoordinator: NSObject, WKScriptMessageHandlerWithRepl
                     #if DEBUG
                     cmuxDebugLog("webauthn.capabilities reply=\(capReply)")
                     #endif
+                    browserWebAuthnTrace("capabilities callerMayPrompt=\(callerMayPrompt) state=\(BrowserPasskeyAuthorizationGate.shared.currentAuthorizationState().rawValue) reply=\(capReply)")
                     replyHandler(capReply, nil)
                 case .createCredential:
                     let request = try BrowserWebAuthnRequestParser.decodePayload(
@@ -1105,10 +1121,16 @@ final class BrowserWebAuthnCoordinator: NSObject, WKScriptMessageHandlerWithRepl
                         "algorithmCount=\(request.publicKey.requestedAlgorithms.count)"
                     )
                     #endif
+                    browserWebAuthnTrace(
+                        "createCredential rp=\(request.publicKey.rp?.id ?? "(nil)") " +
+                            "attachment=\(request.publicKey.authenticatorSelection?.attachment ?? "(nil)") " +
+                            "algorithms=\(request.publicKey.requestedAlgorithms) exclude=\(request.publicKey.excludeCredentials?.count ?? 0)"
+                    )
                     let reply = try await handleCreateCredential(request, message: message)
                     #if DEBUG
                     cmuxDebugLog("webauthn.createCredential reply.ok=\(reply["ok"] ?? "nil") hasCredential=\(reply["credential"] != nil) fallback=\(reply["useWebKitFallback"] ?? "nil")")
                     #endif
+                    browserWebAuthnTrace("createCredential reply ok=\(reply["ok"] ?? "nil") hasCredential=\(reply["credential"] != nil) fallback=\(reply["useWebKitFallback"] ?? "nil")")
                     replyHandler(reply, nil)
                 case .getCredential:
                     let request = try BrowserWebAuthnRequestParser.decodePayload(
@@ -1122,22 +1144,35 @@ final class BrowserWebAuthnCoordinator: NSObject, WKScriptMessageHandlerWithRepl
                         "mediation=\(request.mediation ?? "(nil)")"
                     )
                     #endif
+                    let transportSummary = BrowserWebAuthnTransportSummary(
+                        descriptors: (request.publicKey.allowCredentials ?? []).filter(\.isPublicKeyCredential)
+                    )
+                    browserWebAuthnTrace(
+                        "getCredential rp=\(request.publicKey.rpId ?? "(nil)") " +
+                            "allowCredentials=\(request.publicKey.allowCredentials?.count ?? 0) " +
+                            "mediation=\(request.mediation ?? "(nil)") transports=[\(transportSummary.debugSummary)]"
+                    )
                     let reply = try await handleGetCredential(request, message: message)
                     #if DEBUG
                     cmuxDebugLog("webauthn.getCredential reply.ok=\(reply["ok"] ?? "nil") hasCredential=\(reply["credential"] != nil) fallback=\(reply["useWebKitFallback"] ?? "nil")")
                     #endif
+                    browserWebAuthnTrace("getCredential reply ok=\(reply["ok"] ?? "nil") hasCredential=\(reply["credential"] != nil) fallback=\(reply["useWebKitFallback"] ?? "nil")")
                     replyHandler(reply, nil)
                 }
             } catch let error as BrowserWebAuthnBridgeError {
                 #if DEBUG
                 cmuxDebugLog("webauthn.error bridge: \(error.replyObject())")
                 #endif
-                replyHandler(error.replyObject(), nil)
+                let reply = error.replyObject()
+                browserWebAuthnTrace("bridgeError reply=\(reply)")
+                replyHandler(reply, nil)
             } catch {
                 #if DEBUG
                 cmuxDebugLog("webauthn.error unknown: \(error.localizedDescription)")
                 #endif
-                replyHandler(BrowserWebAuthnBridgeError.unknown(error.localizedDescription).replyObject(), nil)
+                let reply = BrowserWebAuthnBridgeError.unknown(error.localizedDescription).replyObject()
+                browserWebAuthnTrace("unknownError description=\(error.localizedDescription) reply=\(reply)")
+                replyHandler(reply, nil)
             }
         }
     }
@@ -1152,6 +1187,7 @@ extension BrowserWebAuthnCoordinator: ASAuthorizationControllerDelegate, ASAutho
         #if DEBUG
         cmuxDebugLog("webauthn.asAuth.didComplete credentialType=\(type(of: authorization.credential))")
         #endif
+        browserWebAuthnTrace("asAuth.didComplete credentialType=\(type(of: authorization.credential))")
         do {
             finishAuthorization(
                 with: .success(
@@ -1174,7 +1210,7 @@ extension BrowserWebAuthnCoordinator: ASAuthorizationControllerDelegate, ASAutho
         #if DEBUG
         cmuxDebugLog("webauthn.asAuth.didFail domain=\(nsError.domain) code=\(nsError.code)")
         #endif
-        browserWebAuthnLogger.error("asAuth.didFail domain=\(nsError.domain, privacy: .public) code=\(nsError.code) description=\(nsError.localizedDescription, privacy: .public)")
+        browserWebAuthnTrace("asAuth.didFail domain=\(nsError.domain) code=\(nsError.code) description=\(nsError.localizedDescription)")
         finishAuthorization(with: .failure(bridgeError(from: error)))
     }
 
@@ -1299,12 +1335,14 @@ private extension BrowserWebAuthnCoordinator {
         #if DEBUG
         cmuxDebugLog("webauthn.authRequests hasPlatform=\(plan.hasPlatformRequests) hasSecurityKey=\(plan.securityKeyRequests.count > 0) order=\(plan.order)")
         #endif
+        browserWebAuthnTrace("authRequests start hasPlatform=\(plan.hasPlatformRequests) hasSecurityKey=\(plan.hasSecurityKeyRequests) order=\(plan.order)")
 
         if includePlatformRequests {
             let currentState = BrowserPasskeyAuthorizationGate.shared.currentAuthorizationState()
             #if DEBUG
             cmuxDebugLog("webauthn.authRequests passkeyAuthState=\(currentState.rawValue) callerMayPrompt=\(callerMayPromptForPlatformAuthorization(message))")
             #endif
+            browserWebAuthnTrace("authRequests platformAuthState=\(currentState.rawValue) callerMayPrompt=\(callerMayPromptForPlatformAuthorization(message))")
             if currentState == .notDetermined && !callerMayPromptForPlatformAuthorization(message) {
                 #if DEBUG
                 cmuxDebugLog("webauthn.authRequests skipping platform: cross-origin subframe can't prompt")
@@ -1315,6 +1353,7 @@ private extension BrowserWebAuthnCoordinator {
                 #if DEBUG
                 cmuxDebugLog("webauthn.authRequests authorizeIfNeeded result=\(authorizationState.rawValue)")
                 #endif
+                browserWebAuthnTrace("authRequests authorizeIfNeeded result=\(authorizationState.rawValue)")
                 if authorizationState != .authorized {
                     includePlatformRequests = false
                 }
@@ -1325,6 +1364,7 @@ private extension BrowserWebAuthnCoordinator {
         #if DEBUG
         cmuxDebugLog("webauthn.authRequests finalCount=\(requests.count) includePlatform=\(includePlatformRequests)")
         #endif
+        browserWebAuthnTrace("authRequests finalCount=\(requests.count) includePlatform=\(includePlatformRequests) requestTypes=\(requests.map { String(describing: type(of: $0)) })")
         guard !requests.isEmpty else {
             #if DEBUG
             cmuxDebugLog("webauthn.authRequests FAIL: no requests available, throwing notAllowed")
@@ -1340,6 +1380,7 @@ private extension BrowserWebAuthnCoordinator {
             #if DEBUG
             cmuxDebugLog("webauthn.authRequests bluetooth result=\(btState)")
             #endif
+            browserWebAuthnTrace("authRequests bluetooth result=\(btState)")
         }
 
         return requests
@@ -1361,6 +1402,10 @@ private extension BrowserWebAuthnCoordinator {
             cmuxDebugLog("webauthn.performAuth request[\(i)]=\(type(of: req))")
         }
         #endif
+        browserWebAuthnTrace(
+            "performAuth requestCount=\(requests.count) hasWindow=\(window == nil ? 0 : 1) " +
+                "prefersImmediate=\(prefersImmediatelyAvailableCredentials) requestTypes=\(requests.map { String(describing: type(of: $0)) })"
+        )
         guard !requests.isEmpty else {
             throw BrowserWebAuthnBridgeError.notSupported("Native passkey support is unavailable.")
         }
@@ -1505,7 +1550,11 @@ private extension BrowserWebAuthnCoordinator {
         #if DEBUG
         cmuxDebugLog("webauthn.buildCreationPlan rp=\(relyingPartyIdentifier) platform=\(platformRequests.count) securityKey=\(securityKeyRequests.count) attachment=\(attachment ?? "(nil)")")
         #endif
-        browserWebAuthnLogger.info("buildCreationPlan rp=\(relyingPartyIdentifier, privacy: .public) platform=\(platformRequests.count) securityKey=\(securityKeyRequests.count) attachment=\(attachment ?? "(nil)", privacy: .public)")
+        browserWebAuthnTrace(
+            "buildCreationPlan rp=\(relyingPartyIdentifier) platform=\(platformRequests.count) " +
+                "securityKey=\(securityKeyRequests.count) attachment=\(attachment ?? "(nil)") " +
+                "algorithms=\(requestedAlgorithms)"
+        )
         return .init(
             platformRequests: platformRequests,
             securityKeyRequests: securityKeyRequests,
@@ -1600,7 +1649,11 @@ private extension BrowserWebAuthnCoordinator {
         #if DEBUG
         cmuxDebugLog("webauthn.buildAssertionPlan rp=\(relyingPartyIdentifier) platform=\(platformRequests.count) securityKey=\(securityKeyRequests.count) allowCredentials=\(allowCredentials.count) mediation=\(request.mediation ?? "(nil)") hybridTransport=\(transportSummary.shouldShowHybridTransport)")
         #endif
-        browserWebAuthnLogger.info("buildAssertionPlan rp=\(relyingPartyIdentifier, privacy: .public) platform=\(platformRequests.count) securityKey=\(securityKeyRequests.count) allowCredentials=\(allowCredentials.count) mediation=\(request.mediation ?? "(nil)", privacy: .public) hybrid=\(transportSummary.shouldShowHybridTransport)")
+        browserWebAuthnTrace(
+            "buildAssertionPlan rp=\(relyingPartyIdentifier) platform=\(platformRequests.count) " +
+                "securityKey=\(securityKeyRequests.count) allowCredentials=\(allowCredentials.count) " +
+                "mediation=\(request.mediation ?? "(nil)") transports=[\(transportSummary.debugSummary)]"
+        )
         return .init(
             platformRequests: platformRequests,
             securityKeyRequests: securityKeyRequests,

--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -997,6 +997,7 @@ private final class BrowserPasskeyAuthorizationGate {
 
     private let manager = ASAuthorizationWebBrowserPublicKeyCredentialManager()
     private var inFlightRequest: Task<ASAuthorizationWebBrowserPublicKeyCredentialManager.AuthorizationState, Never>?
+    private var lastAuthorizationRequestCompletedAt: Date?
 
     func currentAuthorizationState() -> ASAuthorizationWebBrowserPublicKeyCredentialManager.AuthorizationState {
         manager.authorizationStateForPlatformCredentials
@@ -1021,7 +1022,20 @@ private final class BrowserPasskeyAuthorizationGate {
         inFlightRequest = request
         let result = await request.value
         inFlightRequest = nil
+        lastAuthorizationRequestCompletedAt = Date()
         return result
+    }
+
+    func waitForCredentialRequestReadinessIfNeeded() async {
+        guard let completedAt = lastAuthorizationRequestCompletedAt else { return }
+
+        let settleInterval: TimeInterval = 0.5
+        let elapsed = Date().timeIntervalSince(completedAt)
+        guard elapsed < settleInterval else { return }
+
+        let remaining = settleInterval - elapsed
+        browserWebAuthnTrace("authRequests settlingAfterAuthorization delayMs=\(Int(remaining * 1000))")
+        try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
     }
 }
 
@@ -1211,7 +1225,7 @@ extension BrowserWebAuthnCoordinator: ASAuthorizationControllerDelegate, ASAutho
         cmuxDebugLog("webauthn.asAuth.didFail domain=\(nsError.domain) code=\(nsError.code)")
         #endif
         browserWebAuthnTrace("asAuth.didFail domain=\(nsError.domain) code=\(nsError.code) description=\(nsError.localizedDescription)")
-        finishAuthorization(with: .failure(bridgeError(from: error)))
+        finishAuthorization(with: .failure(error))
     }
 
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
@@ -1356,6 +1370,8 @@ private extension BrowserWebAuthnCoordinator {
                 browserWebAuthnTrace("authRequests authorizeIfNeeded result=\(authorizationState.rawValue)")
                 if authorizationState != .authorized {
                     includePlatformRequests = false
+                } else {
+                    await BrowserPasskeyAuthorizationGate.shared.waitForCredentialRequestReadinessIfNeeded()
                 }
             }
         }
@@ -1387,6 +1403,38 @@ private extension BrowserWebAuthnCoordinator {
     }
 
     func performAuthorization(
+        requests: [ASAuthorizationRequest],
+        window: NSWindow?,
+        prefersImmediatelyAvailableCredentials: Bool
+    ) async throws -> [String: Any] {
+        do {
+            return try await performAuthorizationAttempt(
+                requests: requests,
+                window: window,
+                prefersImmediatelyAvailableCredentials: prefersImmediatelyAvailableCredentials
+            )
+        } catch {
+            guard isRequestAlreadyInProgress(error) else {
+                throw bridgeError(from: error)
+            }
+
+            browserWebAuthnTrace("performAuth alreadyInProgress retryingAfterDelay")
+            cancelActiveAuthorization()
+            try? await Task.sleep(nanoseconds: 500_000_000)
+
+            do {
+                return try await performAuthorizationAttempt(
+                    requests: requests,
+                    window: window,
+                    prefersImmediatelyAvailableCredentials: prefersImmediatelyAvailableCredentials
+                )
+            } catch {
+                throw bridgeError(from: error)
+            }
+        }
+    }
+
+    func performAuthorizationAttempt(
         requests: [ASAuthorizationRequest],
         window: NSWindow?,
         prefersImmediatelyAvailableCredentials: Bool
@@ -1441,10 +1489,13 @@ private extension BrowserWebAuthnCoordinator {
     }
 
     func finishAuthorization(with result: Result<[String: Any], Error>) {
+        let controller = activeAuthorizationController
         let continuation = activeAuthorizationContinuation
         activeAuthorizationController = nil
         activeAuthorizationContinuation = nil
         activePresentationWindow = nil
+        controller?.delegate = nil
+        controller?.presentationContextProvider = nil
 
         switch result {
         case .success(let reply):
@@ -1828,6 +1879,16 @@ private extension BrowserWebAuthnCoordinator {
         default:
             return .unknown("The passkey request failed.")
         }
+    }
+
+    func isRequestAlreadyInProgress(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == ASAuthorizationErrorDomain,
+              nsError.code == BrowserWebAuthnAuthorizationErrorCode.failed else {
+            return false
+        }
+
+        return nsError.localizedDescription.localizedCaseInsensitiveContains("request already in progress")
     }
 
     func capabilityReply(

--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -815,6 +815,7 @@ private extension BrowserWebAuthnCredentialDescriptor {
 
         let descriptorTransports: [ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor.Transport]
         if transports.isEmpty {
+            guard normalizedTransports.isEmpty else { return nil }
             descriptorTransports = [
                 .init(rawValue: "usb"),
                 .init(rawValue: "nfc"),
@@ -1544,7 +1545,7 @@ private extension BrowserWebAuthnCoordinator {
                 }
 
                 let transports = Set(descriptor.normalizedTransports)
-                guard transports.contains(.internal) || transports.contains(.hybrid) else {
+                guard transports.contains(.internal) else {
                     return nil
                 }
                 return descriptor.platformDescriptor()

--- a/Sources/Panels/BrowserWebAuthnTransportSummary.swift
+++ b/Sources/Panels/BrowserWebAuthnTransportSummary.swift
@@ -41,6 +41,11 @@ struct BrowserWebAuthnTransportSummary {
         self.containsUnspecifiedTransport = containsUnspecifiedTransport
     }
 
+    var debugSummary: String {
+        "bt=\(containsBluetooth) hybrid=\(containsHybrid) internal=\(containsInternal) " +
+            "securityKey=\(containsSecurityKeyTransport) unspecified=\(containsUnspecifiedTransport)"
+    }
+
     var allowsPlatformCredentials: Bool {
         containsInternal || containsUnspecifiedTransport
     }

--- a/Sources/Panels/BrowserWebAuthnTransportSummary.swift
+++ b/Sources/Panels/BrowserWebAuthnTransportSummary.swift
@@ -42,19 +42,19 @@ struct BrowserWebAuthnTransportSummary {
     }
 
     var allowsPlatformCredentials: Bool {
-        containsInternal || containsHybrid || containsUnspecifiedTransport
+        containsInternal || containsUnspecifiedTransport
     }
 
     var allowsSecurityKeyCredentials: Bool {
-        containsSecurityKeyTransport || containsHybrid || containsUnspecifiedTransport
+        containsSecurityKeyTransport || containsUnspecifiedTransport
     }
 
     var needsBluetoothPreparation: Bool {
-        containsBluetooth || containsHybrid
+        containsBluetooth
     }
 
     var shouldShowHybridTransport: Bool {
-        containsHybrid || containsUnspecifiedTransport
+        containsUnspecifiedTransport
     }
 
     var prefersSecurityKeysFirst: Bool {

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -231,6 +231,29 @@ struct BrowserWebContentProcessTests {
     }
 
     @Test
+    func webAuthnHybridTransportDoesNotForceNativeHybridPrompt() throws {
+        let hybridOnly = BrowserWebAuthnTransportSummary(
+            descriptors: [
+                try webAuthnCredentialDescriptor(transports: ["hybrid"]),
+            ]
+        )
+        #expect(!hybridOnly.allowsPlatformCredentials)
+        #expect(!hybridOnly.allowsSecurityKeyCredentials)
+        #expect(!hybridOnly.needsBluetoothPreparation)
+        #expect(!hybridOnly.shouldShowHybridTransport)
+
+        let platformGoogleStyle = BrowserWebAuthnTransportSummary(
+            descriptors: [
+                try webAuthnCredentialDescriptor(transports: ["internal", "hybrid"]),
+            ]
+        )
+        #expect(platformGoogleStyle.allowsPlatformCredentials)
+        #expect(!platformGoogleStyle.allowsSecurityKeyCredentials)
+        #expect(!platformGoogleStyle.needsBluetoothPreparation)
+        #expect(!platformGoogleStyle.shouldShowHybridTransport)
+    }
+
+    @Test
     func webViewReplacementAfterProcessTerminationUpdatesInstanceIdentity() {
         let panel = BrowserPanel(
             workspaceId: UUID(),
@@ -390,6 +413,15 @@ struct BrowserWebContentProcessTests {
         #expect(popupWebView.window == nil)
         #expect(!popupWindow.isVisible)
     }
+}
+
+private func webAuthnCredentialDescriptor(transports: [String]) throws -> BrowserWebAuthnCredentialDescriptor {
+    let data = try JSONSerialization.data(withJSONObject: [
+        "type": "public-key",
+        "id": "AQID",
+        "transports": transports,
+    ])
+    return try JSONDecoder().decode(BrowserWebAuthnCredentialDescriptor.self, from: data)
 }
 
 private final class BrowserWebContentProcessLoadDelegate: NSObject, WKNavigationDelegate {


### PR DESCRIPTION
## Summary
- stop treating WebAuthn `hybrid` transport as a local platform credential signal
- avoid defaulting hybrid/internal-only descriptors into USB/NFC/BLE security-key requests
- add regression coverage for Google-style `internal` + `hybrid` descriptors

## Verification
- Signed Nightly workflow passed: https://github.com/manaflow-ai/cmux/actions/runs/28153923268
- Installed and verified `com.cmuxterm.app.nightly` commit `2918140` with passkey entitlement and notarization

## Dogfood
- Waiting on passkey retry in signed Nightly before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native passkey routing and AuthenticationServices request planning for real sign-in flows; mistakes could block logins or mis-route security keys, though behavior is covered by new transport tests.
> 
> **Overview**
> Stops **`hybrid`** WebAuthn transport from steering native ceremonies toward hybrid/phone prompts or security-key paths when sites list platform-style descriptors (e.g. **`internal` + `hybrid`**).
> 
> **Transport routing** no longer treats `hybrid` as platform- or security-key-eligible; Bluetooth prep runs only for BLE transports, and platform **`ASAuthorization`** requests always set **`shouldShowHybridTransport = false`**. Security-key registration is limited to **`cross-platform`** attachment; assertion security-key requests require an allow-list with real security-key transports. **`securityKeyDescriptor()`** skips the USB/NFC/BLE default when normalized transports are present but only hybrid/internal.
> 
> **Reliability/diagnostics:** Nightly tracing via `Logger` and `/tmp/cmux-webauthn-nightly.log`, a short post-authorization settle delay, retry on “request already in progress,” and clearer teardown of active authorization controllers. Adds regression tests for hybrid-only vs internal+hybrid transport flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b024ba5d6b990386e7217c42759d7175dc0d5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784965477&installation_id=133855650&pr_number=6766&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6766&signature=a7761647ae40b4da02d6c743088840e7d5134ae759f8eb39905c4b6ae69427ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids the native hybrid prompt for passkeys and prefers local platform credentials by default. Adds Nightly tracing and serializes passkey authorization requests to prevent “request already in progress” errors.

- **Bug Fixes**
  - Treat only `internal` as platform; ignore `hybrid` for platform and security-key routing.
  - Build security-key requests only for `cross-platform` attachment or when allow-list transports include security keys; remove USB/NFC/BLE fallback and disable hybrid UI for platform prompts; Bluetooth prep only for security keys.
  - Serialize passkey authorization: detect in-progress requests, cancel and retry with a 500ms backoff; wait ~500ms after authorization before starting credential requests; clear controller delegates/providers on finish; improved error mapping.
  - Add regression test for `hybrid`-only and `internal` + `hybrid` descriptors.

- **Diagnostics**
  - Add hard Nightly logging via system logger and `/tmp/cmux-webauthn-nightly.log`, tracing dispatch, capability checks, plan building, authorization callbacks, errors, and replies.

<sup>Written for commit 93b024ba5d6b990386e7217c42759d7175dc0d5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WebAuthn transport handling so hybrid-only credentials no longer trigger platform/hybrid prompt flows; Bluetooth preparation is avoided for platform requests.
  * Improved request planning and capability gating using transport flags, including removing the security-key descriptor fallback when transports are missing.
  * Refined authorization flow timing and retries, with clearer handling of “already in progress” cases.
* **Tests**
  * Added a WebAuthn transport behavior test covering hybrid-only vs internal+hybrid capability outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->