### PR TITLE
fix(claude-wrapper): don't strip ANTHROPIC_MODEL for custom-endpoint users (was: "Session model could not be restored")

### DIFF
--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -102,11 +102,21 @@ resolve_hook_cmux_bin() {
 
 CLAUDE_AUTH_SELECTION_ENV_KEYS=(
     ANTHROPIC_API_KEY
-    ANTHROPIC_MODEL
     ANTHROPIC_SMALL_FAST_MODEL
     CLAUDE_CODE_USE_BEDROCK
     CLAUDE_CODE_USE_VERTEX
 )
+# NOTE: ANTHROPIC_MODEL is intentionally NOT in this list. It is a user model
+# selection, not an auth-selection signal, and stripping it breaks any user who
+# runs Claude Code against a custom ANTHROPIC_BASE_URL with a non-Anthropic model
+# slug (BYOK gateways, OpenAI-compatible proxies, internal LLM endpoints) and
+# resumes sessions: Claude Code reports "Session model <slug> could not be
+# restored ... using the default model instead", falls back to a hardcoded
+# default model, sends it to the custom endpoint (which doesn't recognize it),
+# and the session exits to the shell. When ANTHROPIC_BASE_URL is set there is no
+# "default Anthropic API path" for a stale id to leak into; the Vertex/Bedrock
+# auto-preserve branch in should_preserve_claude_auth_selection_key already
+# covers the only dangerous case.
 
 PRESERVE_CLAUDE_AUTH_SELECTION_ENV=false
 case "${CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV:-}" in

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -940,9 +940,12 @@ def test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures
     expect(auth_env.get("CLAUDE_CONFIG_DIR") == "/tmp/claude-config", f"fresh auth env: expected CLAUDE_CONFIG_DIR preserved, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
     expect(auth_env.get("ANTHROPIC_AUTH_TOKEN") == "third-party-auth-token", f"fresh auth env: expected ANTHROPIC_AUTH_TOKEN preserved, got {auth_env.get('ANTHROPIC_AUTH_TOKEN')!r}", failures)
     expect(auth_env.get("ANTHROPIC_BASE_URL") == "https://api.example.test", f"fresh auth env: expected ANTHROPIC_BASE_URL preserved, got {auth_env.get('ANTHROPIC_BASE_URL')!r}", failures)
+    # ANTHROPIC_MODEL is a user model selection, not auth selection — it must be
+    # preserved so custom-endpoint users (ANTHROPIC_BASE_URL + non-Anthropic slug)
+    # can resume sessions without "Session model ... could not be restored".
+    expect(auth_env.get("ANTHROPIC_MODEL") == "stale-model", f"fresh auth env: expected ANTHROPIC_MODEL preserved, got {auth_env.get('ANTHROPIC_MODEL')!r}", failures)
     for key in [
         "ANTHROPIC_API_KEY",
-        "ANTHROPIC_MODEL",
         "ANTHROPIC_SMALL_FAST_MODEL",
         "CLAUDE_CODE_USE_BEDROCK",
         "CLAUDE_CODE_USE_VERTEX",
@@ -965,9 +968,10 @@ def test_hooks_disabled_clears_stale_auth_selection_before_passthrough(failures:
     )
     expect(code == 0, f"hooks-disabled auth env: wrapper exited {code}: {stderr}", failures)
     expect(auth_env.get("CLAUDE_CONFIG_DIR") == "/tmp/claude-config", f"hooks-disabled auth env: expected CLAUDE_CONFIG_DIR preserved, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
+    # ANTHROPIC_MODEL is preserved (not auth selection); only API_KEY/SMALL_FAST are stripped.
+    expect(auth_env.get("ANTHROPIC_MODEL") == "stale-model", f"hooks-disabled auth env: expected ANTHROPIC_MODEL preserved, got {auth_env.get('ANTHROPIC_MODEL')!r}", failures)
     for key in [
         "ANTHROPIC_API_KEY",
-        "ANTHROPIC_MODEL",
         "ANTHROPIC_SMALL_FAST_MODEL",
     ]:
         expect(auth_env.get(key) == "__UNSET__", f"hooks-disabled auth env: expected {key} unset, got {auth_env.get(key)!r}", failures)
@@ -1422,6 +1426,30 @@ def test_live_socket_preserves_only_listed_claude_auth_keys(failures: list[str])
     expect("--session-id" not in real_argv, f"listed auth env: expected no injected session id, got {real_argv}", failures)
 
 
+def test_live_socket_preserves_anthropic_model_for_custom_endpoint_resume(failures: list[str]) -> None:
+    # Regression: a user with a custom ANTHROPIC_BASE_URL + non-Anthropic model slug
+    # (BYOK gateway / OpenAI-compatible proxy / internal LLM endpoint) must keep
+    # ANTHROPIC_MODEL across the wrapper, otherwise `claude --resume` reports
+    # "Session model <slug> could not be restored ... using the default model
+    # instead" and the session exits when a later turn re-resolves the model.
+    inherited = {
+        "ANTHROPIC_BASE_URL": "https://my-gateway.example.test/anthropic",
+        "ANTHROPIC_AUTH_TOKEN": "third-party-token",
+        "ANTHROPIC_MODEL": "glm-5.2[1m]",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.2[1m]",
+    }
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["--resume", "claude-session-123"],
+        inherited_env=inherited,
+    )
+    expect(code == 0, f"custom-endpoint resume: wrapper exited {code}: {stderr}", failures)
+    expect(auth_env.get("ANTHROPIC_MODEL") == "glm-5.2[1m]", f"custom-endpoint resume: expected ANTHROPIC_MODEL preserved, got {auth_env.get('ANTHROPIC_MODEL')!r}", failures)
+    expect(auth_env.get("ANTHROPIC_BASE_URL") == "https://my-gateway.example.test/anthropic", f"custom-endpoint resume: expected ANTHROPIC_BASE_URL preserved, got {auth_env.get('ANTHROPIC_BASE_URL')!r}", failures)
+    expect(auth_env.get("ANTHROPIC_AUTH_TOKEN") == "third-party-token", f"custom-endpoint resume: expected ANTHROPIC_AUTH_TOKEN preserved, got {auth_env.get('ANTHROPIC_AUTH_TOKEN')!r}", failures)
+    # ANTHROPIC_API_KEY is genuine auth selection and must still be stripped.
+    expect(auth_env.get("ANTHROPIC_API_KEY") == "__UNSET__", f"custom-endpoint resume: expected ANTHROPIC_API_KEY unset, got {auth_env.get('ANTHROPIC_API_KEY')!r}", failures)
+
+
 def test_live_socket_auto_preserves_vertex_auth_when_truthy(failures: list[str]) -> None:
     # Regression for https://github.com/manaflow-ai/cmux/issues/3641.
     inherited = {
@@ -1561,8 +1589,9 @@ def test_live_socket_does_not_auto_preserve_when_all_backends_are_falsy(failures
         failures,
     )
     expect(
-        auth_env.get("ANTHROPIC_MODEL") == "__UNSET__",
-        f"falsy backends: expected ANTHROPIC_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_MODEL')!r}",
+        auth_env.get("ANTHROPIC_MODEL") == "stale-model",
+        "falsy backends: ANTHROPIC_MODEL is now always preserved (not auth selection); "
+        f"got {auth_env.get('ANTHROPIC_MODEL')!r}",
         failures,
     )
     expect(
@@ -1804,6 +1833,7 @@ def main() -> int:
     test_live_socket_resume_self_heal_ignores_prompt_text_after_double_dash(failures)
     test_live_socket_preserves_claude_auth_for_resume_launch(failures)
     test_live_socket_preserves_only_listed_claude_auth_keys(failures)
+    test_live_socket_preserves_anthropic_model_for_custom_endpoint_resume(failures)
     test_live_socket_auto_preserves_vertex_auth_when_truthy(failures)
     test_live_socket_auto_preserves_bedrock_auth_when_truthy(failures)
     test_live_socket_does_not_auto_preserve_when_all_backends_are_falsy(failures)


### PR DESCRIPTION
## Summary

- **What changed:** Removed `ANTHROPIC_MODEL` from `CLAUDE_AUTH_SELECTION_ENV_KEYS` in `Resources/bin/cmux-claude-wrapper`, so the wrapper no longer `unset`s a user's `ANTHROPIC_MODEL` inside cmux terminals.
- **Why:** Introduced in `a1af1153d` (#4429), `ANTHROPIC_MODEL` was grouped with auth-selection env (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_USE_BEDROCK|VERTEX`) and stripped when `IN_CMUX=1` unless `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1`. This breaks any user who runs Claude Code against a **custom `ANTHROPIC_BASE_URL` with a non-Anthropic model slug** (BYOK gateways, OpenAI-compatible proxies, internal LLM endpoints) and resumes sessions:

  ```
  claude --resume <id>
  -> "Session model <slug> could not be restored (not a model this version of Claude Code recognizes) — using the default model instead"
  -> falls back to a hardcoded default model
  -> sends it to the custom endpoint (which doesn't recognize it)
  -> session exits to the shell on the next compact/subagent/title-gen turn
  ```

  The fallback only survives while `ANTHROPIC_DEFAULT_SONNET_MODEL` etc. cover the path; turns that re-resolve from `ANTHROPIC_MODEL` (compact / subagent / title-generation) trigger the exit.

  The "stale ids leaking into the default Anthropic API path" concern that motivated stripping `ANTHROPIC_MODEL` (see the comment in `should_preserve_claude_auth_selection_key`) **does not apply when `ANTHROPIC_BASE_URL` is set** — there is no "default Anthropic API path" to leak into; the user's gateway receives whatever model they configured. The Vertex/Bedrock auto-preserve branch already correctly handles the only case where a stale model id is dangerous. `ANTHROPIC_MODEL` is a user model selection, not auth selection.

## Repro (without the fix)

```bash
# 1. In a plain Terminal (works):
ANTHROPIC_BASE_URL=https://my-gateway/anthropic \
ANTHROPIC_MODEL=my-model[1m] \
ANTHROPIC_DEFAULT_SONNET_MODEL=my-model[1m] \
claude --dangerously-skip-permissions
# → runs fine; resume is stable.

# 2. Inside a cmux tab (breaks): same env, but the wrapper unsets ANTHROPIC_MODEL.
# Start a session, let it idle, then `claude --resume <id>`:
# → "Session model my-model[1m] could not be restored ... using the default model instead"
# → after a compact/subagent/title-gen turn, the session exits to the shell.
# Workaround today: prefix the env with CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1.
```

## Fix

```diff
 CLAUDE_AUTH_SELECTION_ENV_KEYS=(
     ANTHROPIC_API_KEY
-    ANTHROPIC_MODEL
     ANTHROPIC_SMALL_FAST_MODEL
     CLAUDE_CODE_USE_BEDROCK
     CLAUDE_CODE_USE_VERTEX
 )
```

`ANTHROPIC_SMALL_FAST_MODEL` stays in the strip list (genuine auth-routing selection for the fast/cheap tier). The `should_preserve_claude_auth_selection_key` Vertex/Bedrock branch for `ANTHROPIC_MODEL` becomes unreachable but is left in place (harmless; documents intent should the key ever be re-added).

## Testing

- Updated `tests/test_claude_wrapper_hooks.py`:
  - `test_live_socket_preserves_third_party_claude_auth_for_fresh_launch`: `ANTHROPIC_MODEL` now expected **preserved** (was unset).
  - `test_hooks_disabled_clears_stale_auth_selection_before_passthrough`: `ANTHROPIC_MODEL` now expected **preserved**; `ANTHROPIC_API_KEY` / `ANTHROPIC_SMALL_FAST_MODEL` still stripped.
  - `test_live_socket_does_not_auto_preserve_when_all_backends_are_falsy`: `ANTHROPIC_MODEL` now expected **preserved** (it's no longer auth-selection-gated); `ANTHROPIC_SMALL_FAST_MODEL` still cleared when no Vertex/Bedrock backend.
  - New `test_live_socket_preserves_anthropic_model_for_custom_endpoint_resume`: regression for the exact user scenario (custom `ANTHROPIC_BASE_URL` + non-Anthropic `ANTHROPIC_MODEL` + `--resume`); asserts `ANTHROPIC_MODEL`/`BASE_URL`/`AUTH_TOKEN` preserved and `ANTHROPIC_API_KEY` still stripped.
- All 8 auth-related wrapper tests pass locally (`python3 tests/test_claude_wrapper_hooks.py`, auth subset). One unrelated pre-existing failure (`test_disabled_integration_skips_hook_injection`) also fails on `main` — it expects `CMUX_CLAUDE_HOOK_CMUX_BIN` unset in the test env; not introduced by this change.
- Manually verified: a `cld-glm`-style shell function (`ANTHROPIC_BASE_URL=<custom gateway>` + `ANTHROPIC_MODEL=glm-5.2[1m]`) resumed inside a cmux tab no longer reports "could not be restored" and survives compact/subagent turns. Plain-Terminal behavior unchanged.

## Demo Video

TODO (will attach a short screen capture: cmux tab before fix = exits on resume; after fix = stable) on request.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784977598&installation_id=133855650&pr_number=6767&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6767&signature=fe53ffe2a5d3306a5f46113269f641c8c0a34b4b855e93245f2897001a6358c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved Claude model settings in more login and resume scenarios, including custom Anthropic base URLs and proxy-based setups.
  * Improved session resume behavior so custom model and endpoint settings are kept when reconnecting.
  * Reduced cases where valid Claude auth-related settings were cleared unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop unsetting `ANTHROPIC_MODEL` in the `cmux-claude-wrapper` so custom endpoint users keep their chosen model across cmux sessions and resumes. This fixes session restore failures and avoids fallback to default models when using `ANTHROPIC_BASE_URL` with non-Anthropic slugs.

- **Bug Fixes**
  - Removed `ANTHROPIC_MODEL` from `CLAUDE_AUTH_SELECTION_ENV_KEYS`; still strip `ANTHROPIC_API_KEY`, `ANTHROPIC_SMALL_FAST_MODEL`, `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`.
  - Preserved `ANTHROPIC_MODEL` for `--resume` on custom gateways, eliminating "Session model ... could not be restored" and early exits.
  - Updated tests and added `test_live_socket_preserves_anthropic_model_for_custom_endpoint_resume` to cover the regression.

<sup>Written for commit caa6af9f54286c22ab34700151297687ed3feb87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

