### PR TITLE
fix: repair Claude auto-naming (invalid --mcp-config) and false "Needs input" on idle

### DIFF
--- a/CLI/CMUXCLI+AutoNaming.swift
+++ b/CLI/CMUXCLI+AutoNaming.swift
@@ -15,6 +15,13 @@ struct AutoNamingConfig: Sendable {
     var minLineGrowth: Int = 6
     /// Minimum seconds between summarization calls for one session.
     var minInterval: TimeInterval = 180
+    /// Minimum seconds before retrying after a pass that attempted but never
+    /// produced a name (records `lastAttemptAt`, not `lastNamedAt`). Far
+    /// shorter than ``minInterval`` so a transient or fixable summarizer
+    /// failure does not lock a never-named workspace out of naming for a full
+    /// success-interval; the small floor still avoids hammering a persistently
+    /// failing summarizer across a burst of turns.
+    var failureRetryInterval: TimeInterval = 10
     /// Transcripts shorter than this are skipped entirely (subagent or
     /// trivial sessions).
     var minTranscriptLines: Int = 12
@@ -146,6 +153,28 @@ struct AutoNamingEnvironmentPolicy: Sendable {
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return override.isEmpty ? "haiku" : override
     }
+
+    /// JSON payload for `--mcp-config` that configures zero MCP servers.
+    /// Must be an object carrying an `mcpServers` record: current Claude Code
+    /// rejects a bare `{}` with `Invalid MCP configuration: mcpServers:
+    /// expected record, received undefined`, which made every Claude
+    /// auto-naming pass exit non-zero and silently produce no title.
+    static let emptyMCPConfigJSON = #"{"mcpServers":{}}"#
+
+    /// Argument vector for a tool-disabled, MCP-free, session-less
+    /// `claude -p` summarization pass. Pure so the MCP-config contract is
+    /// pinned by a unit test (a regression to `{}` fails CI instead of users).
+    static func claudeSummarizerArguments(model: String) -> [String] {
+        [
+            "-p",
+            "--model", model,
+            "--tools", "",
+            "--disable-slash-commands",
+            "--no-session-persistence",
+            "--strict-mcp-config",
+            "--mcp-config", emptyMCPConfigJSON
+        ]
+    }
 }
 
 /// Pure auto-naming logic: throttle decisions, transcript extraction,
@@ -175,9 +204,12 @@ struct AutoNamingEngine: Sendable {
             // First naming for this session always qualifies; this also seeds
             // the baseline for resumed sessions arriving with a large
             // pre-existing transcript. A failed pass records only lastAttemptAt
-            // (not lastNamedAt), so honor the cooldown here too — otherwise a
-            // persistently failing summarizer respawns on every turn end.
-            if let lastAttemptAt = snapshot.lastAttemptAt, nowInterval - lastAttemptAt < config.minInterval {
+            // (not lastNamedAt), so honor a cooldown here too — otherwise a
+            // persistently failing summarizer respawns on every turn end. Use
+            // the short failure-retry interval (not the full success interval)
+            // so a never-named session recovers on its next turn once the
+            // failure clears, instead of staying "Claude Code" for minutes.
+            if let lastAttemptAt = snapshot.lastAttemptAt, nowInterval - lastAttemptAt < config.failureRetryInterval {
                 return .skipTooSoon
             }
             return .proceed(baseline: transcriptLineCount)

--- a/CLI/CMUXCLI+AutoNamingDispatch.swift
+++ b/CLI/CMUXCLI+AutoNamingDispatch.swift
@@ -68,7 +68,7 @@ extension CMUXCLI {
     ) -> String? {
         switch agent {
         case "claude":
-            return summarizeWithClaude(prompt: prompt, env: env, timeout: timeout)
+            return summarizeWithClaude(prompt: prompt, env: env, timeout: timeout, telemetry: telemetry)
         case "codex":
             return summarizeWithCodex(prompt: prompt, env: env, timeout: timeout)
         default:
@@ -104,7 +104,8 @@ extension CMUXCLI {
     private func summarizeWithClaude(
         prompt: String,
         env: [String: String],
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        telemetry: CLISocketSentryTelemetry
     ) -> String? {
         let policy = AutoNamingEnvironmentPolicy()
         let customPath = env["CMUX_CUSTOM_CLAUDE_PATH"]?
@@ -123,18 +124,19 @@ extension CMUXCLI {
         guard let executable else { return nil }
         return runAutoNamingSummarizer(
             executable: executable,
-            arguments: [
-                "-p",
-                "--model", policy.claudeModel(from: env),
-                "--tools", "",
-                "--disable-slash-commands",
-                "--no-session-persistence",
-                "--strict-mcp-config",
-                "--mcp-config", "{}"
-            ],
+            arguments: AutoNamingEnvironmentPolicy.claudeSummarizerArguments(
+                model: policy.claudeModel(from: env)
+            ),
             prompt: prompt,
             environment: policy.summarizerEnvironment(from: env),
-            timeout: timeout
+            timeout: timeout,
+            onFailure: { reason, exitStatus, stderrTail in
+                telemetry.breadcrumb("claude-hook.auto-name.summarizer-failed", data: [
+                    "reason": reason,
+                    "exit": exitStatus.map { String($0) } ?? "n/a",
+                    "stderr": stderrTail
+                ])
+            }
         )
     }
 

--- a/CLI/CMUXCLI+AutoNamingHooks.swift
+++ b/CLI/CMUXCLI+AutoNamingHooks.swift
@@ -90,7 +90,15 @@ extension CMUXCLI {
             return
         }
 
-        guard let sanitized = engine.sanitizeResponse(rawResponse, currentTitle: nil) else { return }
+        guard let sanitized = engine.sanitizeResponse(rawResponse, currentTitle: nil) else {
+            // The summarizer ran and returned output, but it sanitized to
+            // nothing usable (empty, whitespace, or only the current title).
+            // Distinct from `llm-failed` above so a "ran but produced no
+            // usable name" outcome is not silently indistinguishable from a
+            // healthy pass.
+            telemetry.breadcrumb("claude-hook.auto-name.unusable-response")
+            return
+        }
         confirmedTitle = applyAutoNamingTitle(
             sanitized,
             workspaceId: workspaceId,

--- a/CLI/CMUXCLI+AutoNamingSummarizers.swift
+++ b/CLI/CMUXCLI+AutoNamingSummarizers.swift
@@ -112,13 +112,19 @@ extension CMUXCLI {
 
     /// Runs the summarizer subprocess with the prompt on stdin and a hard
     /// deadline, returning captured stdout (nil on failure, timeout, or
-    /// non-zero exit).
+    /// non-zero exit). On any failure path `onFailure` receives a category, the
+    /// process exit status (when known), and a bounded tail of the subprocess
+    /// stderr. The summarizer runs detached with its fds pointed at /dev/null,
+    /// so this callback is the only way a failure reason (e.g. an invalid
+    /// `--mcp-config` payload) escapes — without it, a broken summarizer leaves
+    /// workspaces silently unnamed.
     func runAutoNamingSummarizer(
         executable: String,
         arguments: [String],
         prompt: String,
         environment: [String: String],
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        onFailure: ((_ reason: String, _ exitStatus: Int32?, _ stderrTail: String) -> Void)? = nil
     ) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
@@ -128,21 +134,36 @@ extension CMUXCLI {
         let stdinPipe = Pipe()
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-autoname-stdout-\(UUID().uuidString).txt")
+        let stderrURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-autoname-stderr-\(UUID().uuidString).txt")
         guard FileManager.default.createFile(atPath: outputURL.path, contents: nil),
-              let stdoutHandle = try? FileHandle(forWritingTo: outputURL) else {
+              let stdoutHandle = try? FileHandle(forWritingTo: outputURL),
+              FileManager.default.createFile(atPath: stderrURL.path, contents: nil),
+              let stderrHandle = try? FileHandle(forWritingTo: stderrURL) else {
+            onFailure?("spawn-setup", nil, "")
             return nil
         }
         defer {
             try? stdoutHandle.close()
+            try? stderrHandle.close()
             try? FileManager.default.removeItem(at: outputURL)
+            try? FileManager.default.removeItem(at: stderrURL)
         }
         process.standardInput = stdinPipe
         process.standardOutput = stdoutHandle
-        process.standardError = FileHandle.nullDevice
+        process.standardError = stderrHandle
+
+        func stderrTail() -> String {
+            try? stderrHandle.close()
+            guard let data = try? Data(contentsOf: stderrURL),
+                  let text = String(data: data, encoding: .utf8) else { return "" }
+            return String(text.trimmingCharacters(in: .whitespacesAndNewlines).suffix(200))
+        }
 
         do {
             try cliRunProcess(process)
         } catch {
+            onFailure?("spawn-failed", nil, "\(error)")
             return nil
         }
         if let promptData = prompt.data(using: .utf8) {
@@ -157,11 +178,16 @@ extension CMUXCLI {
                 kill(process.processIdentifier, SIGKILL)
                 _ = try? waitForProcessExit(process, timeout: 1)
             }
+            onFailure?("timeout", nil, stderrTail())
             return nil
         }
         try? stdoutHandle.close()
-        guard process.terminationStatus == 0,
-              let output = try? Data(contentsOf: outputURL) else {
+        guard process.terminationStatus == 0 else {
+            onFailure?("nonzero-exit", process.terminationStatus, stderrTail())
+            return nil
+        }
+        guard let output = try? Data(contentsOf: outputURL) else {
+            onFailure?("no-output", 0, stderrTail())
             return nil
         }
         return String(data: output, encoding: .utf8)

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -340,3 +340,106 @@ struct FeedEventClassifier {
         return false
     }
 }
+
+/// Semantic category of a Claude Code `Notification` hook event, derived from
+/// its signal + message. Separate from the display `(subtitle, body)` so the
+/// hook handler can decide whether to pull the user's attention without
+/// branching on localized strings.
+enum ClaudeNotificationKind: Equatable, Sendable {
+    case permission
+    case error
+    case completed
+    case waiting
+    case attention
+
+    /// Whether this notification warrants the "Needs input" sidebar badge +
+    /// bell on its own. Idle `waiting` and `completed` notifications are
+    /// informational: Claude Code emits the idle "Claude is waiting for your
+    /// input" Notification ~60s after a turn ends even when nothing is
+    /// blocked, so flagging it as needs-input is a false alarm (most visibly
+    /// under `--dangerously-skip-permissions`, where it is the only
+    /// Notification that ever fires). A genuinely pending block is recognized
+    /// separately by the handler via the session's current lifecycle, so a
+    /// real question/plan still raises the badge.
+    var raisesNeedsInput: Bool {
+        switch self {
+        case .permission, .error, .attention:
+            return true
+        case .completed, .waiting:
+            return false
+        }
+    }
+}
+
+extension FeedEventClassifier {
+    /// Pure classification of a Claude `Notification` into a
+    /// ``ClaudeNotificationKind``. Mirrors the keyword/cue order the display
+    /// classifier uses so the kind and the shown subtitle never disagree.
+    static func claudeNotificationKind(signal: String, message: String) -> ClaudeNotificationKind {
+        let lower = "\(signal) \(message)".lowercased()
+        if lower.contains("permission") || lower.contains("approve")
+            || lower.contains("approval") || lower.contains("permission_prompt") {
+            return .permission
+        }
+        if lower.contains("error") || lower.contains("failed") || lower.contains("exception") {
+            return .error
+        }
+        if containsCompletionCue(lower) {
+            return .completed
+        }
+        if containsWaitingCue(lower) {
+            return .waiting
+        }
+        return .attention
+    }
+
+    /// Tokenizes on any non-alphanumeric run; shared by the cue checks.
+    static func notificationCueTokens(_ lowercasedText: String) -> [Substring] {
+        lowercasedText.split { !$0.isLetter && !$0.isNumber }
+    }
+
+    static func containsCompletionCue(_ lowercasedText: String) -> Bool {
+        notificationCueTokens(lowercasedText).contains { token in
+            token == "done"
+                || token == "succeed"
+                || token == "succeeded"
+                || token.hasPrefix("complet")
+                || token.hasPrefix("finish")
+                || token.hasPrefix("success")
+        }
+    }
+
+    static func containsWaitingCue(_ lowercasedText: String) -> Bool {
+        let tokens = notificationCueTokens(lowercasedText)
+        for (index, token) in tokens.enumerated() {
+            let previous = index > 0 ? tokens[index - 1] : nil
+            let next = index + 1 < tokens.count ? tokens[index + 1] : nil
+            if token == "idle" {
+                return true
+            }
+            if token == "wait" || token == "waiting" || token == "awaiting" {
+                return true
+            }
+            if token == "prompt", previous == "idle" || previous == "input" || previous == "user" {
+                return true
+            }
+            if token == "input" {
+                if previous == "need" || previous == "needs" || previous == "needed"
+                    || previous == "require" || previous == "requires" || previous == "required"
+                    || previous == "request" || previous == "requests" || previous == "requested"
+                    || previous == "wait" || previous == "waiting" || previous == "awaiting"
+                    || previous == "user" || previous == "your"
+                    || next == "needed" || next == "required" || next == "requested" {
+                    return true
+                }
+            }
+            if token == "question", lowercasedText.contains("?") || tokens.contains(where: {
+                $0 == "answer" || $0 == "respond" || $0 == "response" || $0 == "reply"
+                    || $0 == "choose" || $0 == "confirm" || $0 == "continue"
+            }) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -23476,13 +23476,58 @@ struct CMUXCLI {
             if let mappedSession,
                let savedBody = mappedSession.lastBody, !savedBody.isEmpty,
                summary.body.contains("needs your attention") || summary.body.contains("needs your input") {
-                summary = (subtitle: mappedSession.lastSubtitle ?? summary.subtitle, body: savedBody)
+                summary = (
+                    subtitle: mappedSession.lastSubtitle ?? summary.subtitle,
+                    body: savedBody,
+                    raisesNeedsInput: summary.raisesNeedsInput
+                )
             }
+
+            // Whether to raise the "Needs input" badge + bell. Idle "waiting"
+            // and "completed" Notifications do not, on their own — Claude Code
+            // fires the idle "waiting for your input" Notification ~60s after a
+            // turn ends with nothing blocked, and treating that as needs-input
+            // is a false alarm (issue: a finished research turn shows a bell it
+            // shouldn't). A genuinely pending block is still honored: a
+            // preceding PreToolUse for AskUserQuestion/ExitPlanMode (and the
+            // permission flow) leaves the session lifecycle at `.needsInput`,
+            // so a real question/plan keeps the badge even if its notification
+            // text reads as "waiting".
+            let sessionPendingNeedsInput = (mappedSession?.agentLifecycle == .needsInput)
+            let raisesNeedsInput = summary.raisesNeedsInput || sessionPendingNeedsInput
 
             let title = String(
                 localized: "cli.claude-hook.notification.title",
                 defaultValue: "Claude Code"
             )
+
+            guard raisesNeedsInput else {
+                // Informational idle/completed ping: settle the workspace to
+                // idle rather than flagging it for input. Posting a banner here
+                // would re-raise the same false alarm, so skip it.
+                if let sessionId = parsedInput.sessionId {
+                    try? sessionStore.upsert(
+                        sessionId: sessionId,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        cwd: parsedInput.cwd,
+                        transcriptPath: parsedInput.transcriptPath,
+                        agentLifecycle: .idle,
+                        lastSubtitle: summary.subtitle,
+                        lastBody: summary.body
+                    )
+                }
+                setAgentLifecycle(
+                    client: client,
+                    key: Self.claudeCodeStatusKey,
+                    lifecycle: .idle,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId
+                )
+                print("OK")
+                return
+            }
+
             let payload = notificationPayload(title: title, subtitle: summary.subtitle, body: summary.body)
 
             if let sessionId = parsedInput.sessionId {
@@ -25822,12 +25867,19 @@ struct CMUXCLI {
         return nil
     }
 
-    private func summarizeClaudeHookNotification(parsedInput: ClaudeHookParsedInput) -> (subtitle: String, body: String) {
+    private func summarizeClaudeHookNotification(
+        parsedInput: ClaudeHookParsedInput
+    ) -> (subtitle: String, body: String, raisesNeedsInput: Bool) {
         guard let object = parsedInput.object else {
             if let fallback = parsedInput.rawFallback, !fallback.isEmpty {
-                return classifyClaudeNotification(signal: fallback, message: fallback)
+                let classified = classifyClaudeNotification(signal: fallback, message: fallback)
+                let kind = FeedEventClassifier.claudeNotificationKind(signal: fallback, message: fallback)
+                return (classified.subtitle, classified.body, kind.raisesNeedsInput)
             }
-            return ("Waiting", "Claude is waiting for your input")
+            // Bare idle ping with no payload: this is Claude Code's idle
+            // "waiting for your input" Notification — informational, not a
+            // block. Do not raise needs-input on its own.
+            return ("Waiting", "Claude is waiting for your input", false)
         }
 
         let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
@@ -25844,9 +25896,10 @@ struct CMUXCLI {
         let normalizedMessage = normalizedSingleLine(message)
         let signal = signalParts.compactMap { $0 }.joined(separator: " ")
         var classified = classifyClaudeNotification(signal: signal, message: normalizedMessage)
+        let kind = FeedEventClassifier.claudeNotificationKind(signal: signal, message: normalizedMessage)
 
         classified.body = truncate(classified.body, maxLength: 180)
-        return classified
+        return (classified.subtitle, classified.body, kind.raisesNeedsInput)
     }
 
     private func summarizeAgentHookNotification(
@@ -26174,7 +26227,7 @@ struct CMUXCLI {
                 isFallback: isFallback
             )
         }
-        if containsCompletionCue(lower) {
+        if FeedEventClassifier.containsCompletionCue(lower) {
             let body = message.isEmpty
                 ? String(localized: "agent.generic.notification.body.taskCompleted", defaultValue: "Task completed")
                 : message
@@ -26185,7 +26238,7 @@ struct CMUXCLI {
                 isFallback: isFallback
             )
         }
-        if containsWaitingCue(lower) {
+        if FeedEventClassifier.containsWaitingCue(lower) {
             let body = message.isEmpty
                 ? String(localized: "agent.generic.notification.body.waitingForInput", defaultValue: "Waiting for input")
                 : message
@@ -26216,78 +26269,26 @@ struct CMUXCLI {
         )
     }
 
+    /// Display `(subtitle, body)` for a Claude notification. The semantic
+    /// category comes from ``FeedEventClassifier/claudeNotificationKind`` so
+    /// the shown subtitle and the needs-input decision can never disagree.
     private func classifyClaudeNotification(signal: String, message: String) -> (subtitle: String, body: String) {
-        let lower = "\(signal) \(message)".lowercased()
-        if lower.contains("permission") || lower.contains("approve") || lower.contains("approval") || lower.contains("permission_prompt") {
-            let body = message.isEmpty ? "Approval needed" : message
-            return ("Permission", body)
-        }
-        if lower.contains("error") || lower.contains("failed") || lower.contains("exception") {
-            let body = message.isEmpty ? "Claude reported an error" : message
-            return ("Error", body)
-        }
-        if containsCompletionCue(lower) {
-            let body = message.isEmpty ? "Task completed" : message
-            return ("Completed", body)
-        }
-        if containsWaitingCue(lower) {
-            let body = message.isEmpty ? "Waiting for input" : message
-            return ("Waiting", body)
-        }
-        // Use the message directly if it's meaningful (not a generic placeholder).
-        if !message.isEmpty, message != "Claude needs your input" {
-            return ("Attention", message)
-        }
-        return ("Attention", "Claude needs your attention")
-    }
-
-    private func containsCompletionCue(_ lowercasedText: String) -> Bool {
-        notificationCueTokens(lowercasedText).contains { token in
-            token == "done"
-                || token == "succeed"
-                || token == "succeeded"
-                || token.hasPrefix("complet")
-                || token.hasPrefix("finish")
-                || token.hasPrefix("success")
-        }
-    }
-
-    private func containsWaitingCue(_ lowercasedText: String) -> Bool {
-        let tokens = notificationCueTokens(lowercasedText)
-        for (index, token) in tokens.enumerated() {
-            let previous = index > 0 ? tokens[index - 1] : nil
-            let next = index + 1 < tokens.count ? tokens[index + 1] : nil
-            if token == "idle" {
-                return true
+        switch FeedEventClassifier.claudeNotificationKind(signal: signal, message: message) {
+        case .permission:
+            return ("Permission", message.isEmpty ? "Approval needed" : message)
+        case .error:
+            return ("Error", message.isEmpty ? "Claude reported an error" : message)
+        case .completed:
+            return ("Completed", message.isEmpty ? "Task completed" : message)
+        case .waiting:
+            return ("Waiting", message.isEmpty ? "Waiting for input" : message)
+        case .attention:
+            // Use the message directly if it's meaningful (not a placeholder).
+            if !message.isEmpty, message != "Claude needs your input" {
+                return ("Attention", message)
             }
-            if token == "wait" || token == "waiting" || token == "awaiting" {
-                return true
-            }
-            if token == "prompt", previous == "idle" || previous == "input" || previous == "user" {
-                return true
-            }
-            if token == "input" {
-                if previous == "need" || previous == "needs" || previous == "needed"
-                    || previous == "require" || previous == "requires" || previous == "required"
-                    || previous == "request" || previous == "requests" || previous == "requested"
-                    || previous == "wait" || previous == "waiting" || previous == "awaiting"
-                    || previous == "user" || previous == "your"
-                    || next == "needed" || next == "required" || next == "requested" {
-                    return true
-                }
-            }
-            if token == "question", lowercasedText.contains("?") || tokens.contains(where: {
-                $0 == "answer" || $0 == "respond" || $0 == "response" || $0 == "reply"
-                    || $0 == "choose" || $0 == "confirm" || $0 == "continue"
-            }) {
-                return true
-            }
+            return ("Attention", "Claude needs your attention")
         }
-        return false
-    }
-
-    private func notificationCueTokens(_ lowercasedText: String) -> [Substring] {
-        lowercasedText.split { !$0.isLetter && !$0.isNumber }
     }
 
     private func sanitizeNotificationField(_ value: String) -> String {

--- a/cmuxTests/AutoNamingEngineTests.swift
+++ b/cmuxTests/AutoNamingEngineTests.swift
@@ -81,26 +81,39 @@ import Testing
         #expect(decision == .skipTooSoon)
     }
 
-    @Test func failedAttemptEnforcesCooldownBeforeRetry() {
+    @Test func failedAttemptRetriesAfterShortFailureInterval() {
         // A failed pass records lastAttemptAt but never lastNamedAt/lastLineCount.
-        // Within minInterval the throttle must back off (no per-turn respawn of a
-        // rate-limited summarizer); after it, retry is allowed.
+        // Within the short failure-retry interval the throttle backs off (no
+        // per-turn respawn of a rate-limited summarizer); after it — far sooner
+        // than the full success interval — a never-named session retries, so a
+        // transient or just-fixed summarizer failure recovers on the next turn
+        // instead of leaving the workspace stuck on "Claude Code" for minutes.
         let base = TimeInterval(1_000_000)
         let failed = snapshot(lastAttemptAt: base)
 
         let tooSoon = engine.throttleDecision(
             snapshot: failed,
             transcriptLineCount: 100,
-            now: Date(timeIntervalSince1970: base + config.minInterval - 1)
+            now: Date(timeIntervalSince1970: base + config.failureRetryInterval - 1)
         )
         #expect(tooSoon == .skipTooSoon)
 
-        let afterCooldown = engine.throttleDecision(
+        let afterFailureInterval = engine.throttleDecision(
             snapshot: failed,
             transcriptLineCount: 100,
-            now: Date(timeIntervalSince1970: base + config.minInterval + 1)
+            now: Date(timeIntervalSince1970: base + config.failureRetryInterval + 1)
         )
-        #expect(afterCooldown == .proceed(baseline: 100))
+        #expect(afterFailureInterval == .proceed(baseline: 100))
+
+        // The fix: a never-named failed pass retries well before the full
+        // success interval that previously gated it.
+        #expect(config.failureRetryInterval < config.minInterval)
+        let beforeSuccessInterval = engine.throttleDecision(
+            snapshot: failed,
+            transcriptLineCount: 100,
+            now: Date(timeIntervalSince1970: base + config.minInterval - 1)
+        )
+        #expect(beforeSuccessInterval == .proceed(baseline: 100))
     }
 
     @Test func failureAfterSuccessBacksOffOnLastAttemptNotLastNamed() {
@@ -320,5 +333,37 @@ import Testing
         #expect(policy.claudeModel(from: [:]) == "haiku")
         #expect(policy.claudeModel(from: ["ANTHROPIC_SMALL_FAST_MODEL": "  "]) == "haiku")
         #expect(policy.claudeModel(from: ["ANTHROPIC_SMALL_FAST_MODEL": "vertex-haiku-id"]) == "vertex-haiku-id")
+    }
+
+    // MARK: - Claude summarizer arguments
+
+    @Test func claudeSummarizerMCPConfigIsValidEmptyServerObject() throws {
+        // Regression: a bare `--mcp-config {}` is rejected by current Claude
+        // Code ("Invalid MCP configuration: mcpServers: expected record,
+        // received undefined"), making `claude -p` exit non-zero so every
+        // auto-naming pass failed silently. The payload must be an object that
+        // carries an `mcpServers` record.
+        let args = AutoNamingEnvironmentPolicy.claudeSummarizerArguments(model: "haiku")
+        let idx = try #require(args.firstIndex(of: "--mcp-config"))
+        try #require(idx + 1 < args.count)
+        let payload = args[idx + 1]
+
+        #expect(payload != "{}")
+        let data = try #require(payload.data(using: .utf8))
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let object = try #require(json)
+        #expect(object["mcpServers"] is [String: Any])
+    }
+
+    @Test func claudeSummarizerArgumentsAreToolAndSessionFree() throws {
+        let args = AutoNamingEnvironmentPolicy.claudeSummarizerArguments(model: "sonnet")
+        #expect(args.contains("-p"))
+        #expect(args.contains("--strict-mcp-config"))
+        #expect(args.contains("--no-session-persistence"))
+        #expect(args.contains("--disable-slash-commands"))
+        // Model is threaded through verbatim.
+        let modelIdx = try #require(args.firstIndex(of: "--model"))
+        try #require(modelIdx + 1 < args.count)
+        #expect(args[modelIdx + 1] == "sonnet")
     }
 }

--- a/cmuxTests/FeedEventClassificationTests.swift
+++ b/cmuxTests/FeedEventClassificationTests.swift
@@ -187,3 +187,57 @@ struct FeedEventClassificationTests {
         #expect(classify("gemini", "PreToolUse", tool: "execute_bash").actionable == false)
     }
 }
+
+/// Regression coverage for Claude `Notification` classification: the idle
+/// "waiting for your input" ping (and "completed") must NOT raise the
+/// "Needs input" badge on its own, while genuine permission/error/attention
+/// notifications must.
+@Suite struct ClaudeNotificationKindTests {
+    private func kind(_ signal: String, _ message: String) -> ClaudeNotificationKind {
+        FeedEventClassifier.claudeNotificationKind(signal: signal, message: message)
+    }
+
+    @Test func idleWaitingDoesNotRaiseNeedsInput() {
+        // The exact message Claude Code emits ~60s after a turn ends.
+        let k = kind("Notification", "Claude is waiting for your input")
+        #expect(k == .waiting)
+        #expect(k.raisesNeedsInput == false)
+    }
+
+    @Test func completedDoesNotRaiseNeedsInput() {
+        let k = kind("Notification", "Task completed successfully")
+        #expect(k == .completed)
+        #expect(k.raisesNeedsInput == false)
+    }
+
+    @Test func permissionRaisesNeedsInput() {
+        let k = kind("Notification", "Claude needs your permission to run a command")
+        #expect(k == .permission)
+        #expect(k.raisesNeedsInput == true)
+    }
+
+    @Test func errorRaisesNeedsInput() {
+        let k = kind("Notification", "The agent failed with an exception")
+        #expect(k == .error)
+        #expect(k.raisesNeedsInput == true)
+    }
+
+    @Test func genericAttentionRaisesNeedsInput() {
+        // No completion/waiting cue and no permission/error keyword: stay
+        // conservative and surface it (could be a real prompt).
+        let k = kind("Notification", "Claude needs your attention")
+        #expect(k == .attention)
+        #expect(k.raisesNeedsInput == true)
+    }
+
+    @Test func needsInputPhrasingClassifiesAsWaitingAtKindLevel() {
+        // "needs input" matches the same waiting cue as the idle ping, so at
+        // the pure-kind level it does not raise needs-input. A genuinely
+        // pending block is recognized by the handler via the session's
+        // `.needsInput` lifecycle (set by the preceding PreToolUse /
+        // permission flow), not by this string heuristic.
+        let k = kind("Notification", "Claude needs input to continue")
+        #expect(k == .waiting)
+        #expect(k.raisesNeedsInput == false)
+    }
+}


### PR DESCRIPTION
Two independent bugs in the agent-hook pipeline, fixed together.

## 1. Claude auto-naming was silently 100% broken

The auto-naming summarizer ran `claude -p ... --mcp-config "{}"`. Current Claude Code rejects a bare `{}`:

```
Error: Invalid MCP configuration:
mcpServers: Invalid input: expected record, received undefined
```

So `claude -p` exited non-zero, the summarizer returned `nil`, and the failure was swallowed (stderr → `/dev/null`, bare `return nil`). Result: no Claude-session workspace ever got an AI name, with no signal as to why. (Codex sessions were unaffected — they use a different, valid `-c mcp_servers={}` syntax.)

Reproduced against a real transcript and verified the fix:

```
# before
--mcp-config "{}"               → exit 1, Invalid MCP configuration
# after
--mcp-config '{"mcpServers":{}}' → "Kanye West last30days", exit 0 (~8s)
```

Changes:
- Pass a schema-valid `{"mcpServers":{}}` via a pure `claudeSummarizerArguments(model:)` helper, unit-tested so a regression back to `{}` fails CI.
- Capture summarizer stderr (was discarded) and breadcrumb the failure reason + exit code; add the missing breadcrumb on the sanitize-to-nothing branch — a future failure is diagnosable instead of invisible.
- Retry a failed never-named pass after a short interval instead of the full 180s success interval, so a transient/just-fixed failure recovers on the next turn.

## 2. Idle sessions flagged "Needs input"

Claude Code emits an idle "Claude is waiting for your input" Notification ~60s after a turn ends even when nothing is blocked. The `claude notification` handler set `.needsInput` + bell + "Needs input" unconditionally, ignoring the classification it already computes — so a finished, idle session (most visibly under `--dangerously-skip-permissions`, where the idle ping is the only Notification) showed an actionable alert it shouldn't.

Changes:
- Add a pure `ClaudeNotificationKind` classifier in `FeedEventClassifier` (now the single source of truth for the cue logic, shared with the agent notification path): permission/error/attention raise needs-input; idle waiting/completed do not.
- Gate the handler on `kind.raisesNeedsInput || session is already .needsInput`, so a genuinely pending AskUserQuestion/ExitPlanMode/permission block (which a preceding PreToolUse leaves at `.needsInput`) still raises the badge, while a bare idle ping settles the workspace to `.idle`.

## Test plan
- `cmux-cli` builds clean (compiles all changed CLI files incl. `cmux.swift`).
- `cmux-unit` green: `AutoNamingEngineTests`, `FeedEventClassificationTests`, `ClaudeNotificationKindTests` (44 tests, 0 failures), including new coverage pinning the `--mcp-config` contract, the failed-pass retry, and the idle-vs-blocking notification split.
- No `project.pbxproj` or `Localizable.xcstrings` changes (no new user-facing strings); tests live in already-wired files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784993493&installation_id=133855650&pr_number=6768&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6768&signature=1f48466086bfe719cc80d790da6106b40fea8cf9760fd3456deb6f529461e8d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two issues: Claude auto-naming now works again with a valid MCP config and visible failures, and idle notifications no longer trigger false “Needs input” alerts. Claude sessions get proper titles again and the sidebar only asks for input when something is actually blocked.

- Bug Fixes
  - Auto-naming: use a schema-valid `--mcp-config` payload (`{"mcpServers":{}}`) via a pure `claudeSummarizerArguments(model:)`; capture stderr and breadcrumb failures; retry never-named failures after a short `failureRetryInterval` instead of 180s.
  - Notifications: add `ClaudeNotificationKind` in `FeedEventClassifier` and gate needs-input on `kind.raisesNeedsInput` or an existing `.needsInput` lifecycle; idle/waiting/completed pings set `.idle` and don’t raise a banner.

<sup>Written for commit 67e9523be126fa92d9c24ddeb371e8758872b3c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Claude notification handling so idle, waiting, completed, permission, error, and attention updates are categorized more accurately.
  * Added faster retry timing for failed auto-naming attempts, helping recovery after temporary failures.

* **Bug Fixes**
  * Prevented non-actionable Claude pings from triggering the “needs input” state.
  * Added clearer failure tracking for summarization attempts, including reason details for troubleshooting.

* **Tests**
  * Expanded coverage for notification classification, retry timing, and summarizer argument generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->