### PR TITLE
Fix _cmux_install_cli_command_shim failing with noclobber enabled

### DIFF
--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -292,7 +292,7 @@ _cmux_install_cli_command_shim() {
         else
             printf 'exec "%s" "$@"\n' "$escaped_wrapper"
         fi
-    } >"$shim_path" 2>/dev/null || return 0
+    } >| "$shim_path" 2>/dev/null || return 0
     /bin/chmod 0700 "$shim_path" >/dev/null 2>&1 || return 0
 
     if [[ "$command_name" == "claude" ]]; then


### PR DESCRIPTION
## Problem

When the shell has `noclobber` (`setopt noclobber` / `set -C`) enabled, launching cmux produces an error:

```
_cmux_install_cli_command_shim:13: file exists: /var/folders/k5/.../cmux-cli-shims/.../claude
```

`_cmux_install_cli_command_shim` writes the generated shim file with a plain `>` redirect. When the shim already exists (e.g. from a previous session or an earlier invocation in the same session), `noclobber` blocks `>` from overwriting it, so shim installation fails.

## Fix

Use `>|` to force-truncate the shim file, matching the noclobber-safe redirect pattern already used elsewhere in the same file (`_cmux_set_git_active_pwd`, `_cmux_report_pr_for_path`):

```diff
-    } >"$shim_path" 2>/dev/null || return 0
+    } >| "$shim_path" 2>/dev/null || return 0
```

## Notes

- `>|` overrides `noclobber` and is a no-op under the default (no-noclobber) shell, so this is safe regardless of the user's shell options.
- Verified the file still parses with `zsh -n Resources/shell-integration/cmux-zsh-integration.zsh`.

## Environment

- macOS
- zsh with `setopt noclobber`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784994509&installation_id=133855650&pr_number=6769&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6769&signature=e7abbcf52de9f843f712fc7a5fa4d7ba1925dbd57f788453a9727b4c4c57dd94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `_cmux_install_cli_command_shim` noclobber-safe by writing shim files with `>|`. This avoids “file exists” errors when a shim already exists and matches redirects used elsewhere.

<sup>Written for commit ce3e9f5f81c5b62d6a237c13c7a2ab5f98ec9355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell integration so the generated shim can be updated even when `noclobber` is enabled.
  * Existing shim files are now overwritten more reliably during installation, reducing setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->