### PR TITLE
Fix Computers remove confirmation row anchoring

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -27,8 +27,10 @@ struct DeviceTreeView: View {
     var showAddDevice: (() -> Void)?
     @Environment(\.dismiss) private var dismiss
 
-    /// The computer pending a remove confirmation.
-    @State private var pendingRemoval: MacComputerSnapshot?
+    /// The computer whose destructive remove action is awaiting confirmation.
+    /// Stored at list scope so reusable rows do not own transient presentation
+    /// state while `List` is recycling swipe-action rows.
+    @State private var computerPendingRemovalID: String?
 
     /// The user's computers as immutable snapshots, sourced from the paired-Mac
     /// backup (`pairedMacs`) — this feature's source of truth, the same set that
@@ -73,15 +75,12 @@ struct DeviceTreeView: View {
                 } else {
                     Section {
                         ForEach(computers) { computer in
-                            NavigationLink(value: computer.deviceId) {
-                                MacComputerRow(computer: computer)
-                            }
-                            .swipeActions(edge: .trailing) {
-                                removeButton(for: computer)
-                            }
-                            .contextMenu {
-                                removeButton(for: computer)
-                            }
+                            MacComputerRow(
+                                computer: computer,
+                                requestRemove: requestComputerRemoval,
+                                isConfirmingRemove: removalConfirmationBinding(for: computer.deviceId),
+                                confirmRemove: { _ in confirmComputerRemoval() }
+                            )
                         }
                     } footer: {
                         Text(L10n.string(
@@ -133,45 +132,8 @@ struct DeviceTreeView: View {
                     await store.refreshComputersScreen()
                 }
             }
-            .confirmationDialog(
-                removeTitle(pendingRemoval),
-                isPresented: removalDialogBinding,
-                titleVisibility: .visible
-            ) {
-                if let pending = pendingRemoval {
-                    Button(
-                        L10n.string("mobile.computers.remove", defaultValue: "Remove"),
-                        role: .destructive
-                    ) {
-                        let deviceId = pending.deviceId
-                        pendingRemoval = nil
-                        Task {
-                            await store.forgetMac(macDeviceID: deviceId)
-                            await reload()
-                        }
-                    }
-                }
-                Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {
-                    pendingRemoval = nil
-                }
-            } message: {
-                Text(removeMessage(pendingRemoval))
-            }
         }
         .accessibilityIdentifier("MobileDeviceTree")
-    }
-
-    @ViewBuilder
-    private func removeButton(for computer: MacComputerSnapshot) -> some View {
-        Button(role: .destructive) {
-            pendingRemoval = computer
-        } label: {
-            Label(
-                L10n.string("mobile.computers.remove", defaultValue: "Remove"),
-                systemImage: "trash"
-            )
-        }
-        .accessibilityIdentifier("MobileComputerRemove-\(computer.deviceId)")
     }
 
     @ViewBuilder
@@ -185,34 +147,32 @@ struct DeviceTreeView: View {
         }
     }
 
-    private var removalDialogBinding: Binding<Bool> {
+    private func requestComputerRemoval(_ deviceID: String) {
+        computerPendingRemovalID = deviceID
+    }
+
+    private func removalConfirmationBinding(for deviceID: String) -> Binding<Bool> {
         Binding(
-            get: { pendingRemoval != nil },
-            set: { presented in if !presented { pendingRemoval = nil } }
+            get: { computerPendingRemovalID == deviceID },
+            set: { isPresented in
+                if isPresented {
+                    computerPendingRemovalID = deviceID
+                } else if computerPendingRemovalID == deviceID {
+                    computerPendingRemovalID = nil
+                }
+            }
         )
     }
 
-    private func removeTitle(_ computer: MacComputerSnapshot?) -> String {
-        String(
-            format: L10n.string("mobile.computers.removeTitleFormat", defaultValue: "Remove %@?"),
-            computer?.title ?? ""
-        )
-    }
-
-    private func removeMessage(_ computer: MacComputerSnapshot?) -> String {
-        guard let computer, computer.aliasIDs.count > 1 else {
-            return L10n.string(
-                "mobile.computers.removeMessage",
-                defaultValue: "This computer and its workspaces stop appearing here. Pair it again to add it back."
-            )
+    private func confirmComputerRemoval() {
+        guard let deviceID = computerPendingRemovalID else {
+            return
         }
-        return String(
-            format: L10n.string(
-                "mobile.computers.removeMessageRepresentativeFormat",
-                defaultValue: "This removes paired record %@. Other matching records may still appear."
-            ),
-            computer.deviceId
-        )
+        computerPendingRemovalID = nil
+        Task {
+            await store.forgetMac(macDeviceID: deviceID)
+            await reload()
+        }
     }
 
     private func reload() async {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -25,9 +25,9 @@ struct MacComputerRow: View {
         NavigationLink(value: computer.deviceId) {
             rowLabel
         }
-        .contextMenu { removeButton }
+        .contextMenu { removeMenuButton }
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-            removeButton
+            removeSwipeButton
         }
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("MobileComputerRow-\(computer.deviceId)")
@@ -96,7 +96,23 @@ struct MacComputerRow: View {
     }
 
     @ViewBuilder
-    private var removeButton: some View {
+    private var removeSwipeButton: some View {
+        if let requestRemove {
+            Button {
+                requestRemove(computer.deviceId)
+            } label: {
+                Label(
+                    L10n.string("mobile.computers.remove", defaultValue: "Remove"),
+                    systemImage: "trash"
+                )
+            }
+            .tint(.red)
+            .accessibilityIdentifier("MobileComputerRemoveSwipeButton-\(computer.deviceId)")
+        }
+    }
+
+    @ViewBuilder
+    private var removeMenuButton: some View {
         if let requestRemove {
             Button(role: .destructive) {
                 requestRemove(computer.deviceId)
@@ -106,7 +122,7 @@ struct MacComputerRow: View {
                     systemImage: "trash"
                 )
             }
-            .accessibilityIdentifier("MobileComputerRemove-\(computer.deviceId)")
+            .accessibilityIdentifier("MobileComputerRemoveMenuButton-\(computer.deviceId)")
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -10,8 +10,50 @@ import SwiftUI
 /// the phone's connection (green = the phone is talking to this Mac now).
 struct MacComputerRow: View {
     let computer: MacComputerSnapshot
+    /// Request confirmation before removing this computer. When `nil`, the
+    /// destructive affordances are hidden.
+    var requestRemove: ((String) -> Void)? = nil
+    /// Whether this row's destructive remove action is awaiting confirmation.
+    /// The binding is owned by the list so recycled rows do not own presentation
+    /// state, but the presenter stays attached to the swiped row.
+    var isConfirmingRemove: Binding<Bool> = .constant(false)
+    /// Performs the confirmed removal. Separate from ``requestRemove`` so a
+    /// full-swipe can request confirmation without directly removing the row.
+    var confirmRemove: ((String) -> Void)? = nil
 
     var body: some View {
+        NavigationLink(value: computer.deviceId) {
+            rowLabel
+        }
+        .contextMenu { removeButton }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            removeButton
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("MobileComputerRow-\(computer.deviceId)")
+        .confirmationDialog(
+            removeTitle,
+            isPresented: isConfirmingRemove,
+            titleVisibility: .visible
+        ) {
+            if let confirmRemove {
+                Button(
+                    L10n.string("mobile.computers.remove", defaultValue: "Remove"),
+                    role: .destructive
+                ) {
+                    confirmRemove(computer.deviceId)
+                }
+                .accessibilityIdentifier("MobileComputerRemoveConfirm-\(computer.deviceId)")
+            }
+            Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {
+                isConfirmingRemove.wrappedValue = false
+            }
+        } message: {
+            Text(removeMessage)
+        }
+    }
+
+    private var rowLabel: some View {
         HStack(spacing: 12) {
             ZStack {
                 Circle()
@@ -51,8 +93,44 @@ struct MacComputerRow: View {
         }
         .padding(.vertical, 4)
         .contentShape(Rectangle())
-        .accessibilityElement(children: .combine)
-        .accessibilityIdentifier("MobileComputerRow-\(computer.deviceId)")
+    }
+
+    @ViewBuilder
+    private var removeButton: some View {
+        if let requestRemove {
+            Button(role: .destructive) {
+                requestRemove(computer.deviceId)
+            } label: {
+                Label(
+                    L10n.string("mobile.computers.remove", defaultValue: "Remove"),
+                    systemImage: "trash"
+                )
+            }
+            .accessibilityIdentifier("MobileComputerRemove-\(computer.deviceId)")
+        }
+    }
+
+    private var removeTitle: String {
+        String(
+            format: L10n.string("mobile.computers.removeTitleFormat", defaultValue: "Remove %@?"),
+            computer.title
+        )
+    }
+
+    private var removeMessage: String {
+        guard computer.aliasIDs.count > 1 else {
+            return L10n.string(
+                "mobile.computers.removeMessage",
+                defaultValue: "This computer and its workspaces stop appearing here. Pair it again to add it back."
+            )
+        }
+        return String(
+            format: L10n.string(
+                "mobile.computers.removeMessageRepresentativeFormat",
+                defaultValue: "This removes paired record %@. Other matching records may still appear."
+            ),
+            computer.deviceId
+        )
     }
 
     /// The connection dot: green only when the PHONE is actually connected to this


### PR DESCRIPTION
## Summary
- move the Computers remove swipe/context actions onto `MacComputerRow`, matching the workspace row presenter shape
- keep only the pending computer id at list scope, with a row-specific confirmation binding
- keep confirmed removal separate from the swipe action so swiping asks first and does not hide the row

## Verification
- `git diff --check`
- `./scripts/reload-cloud.sh --tag macdel` (cloud unavailable locally, fell back to local reload, succeeded)
- `./ios/scripts/reload.sh --tag macdel --simulator "iPhone 17"` (succeeded and launched `dev.cmux.ios.macdel`)

## Blocked local dogfood
- Web dev warm-up could not run: local Docker is not installed, and with DB startup disabled the dev server exits because `~/.secrets/cmuxterm-dev.env` is missing `STACK_SECRET_SERVER_KEY`, `NEXT_PUBLIC_STACK_PROJECT_ID`, and `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY`.
- Physical iPhone reload could not install: `ios/scripts/reload-cloud.sh --tag macdel --device-id 4A52829D-6427-599F-A166-4058881D2DF4` needs ASC API credentials, and the allowed local `ios/scripts/reload.sh --tag macdel --device-only --device-id 4A52829D-6427-599F-A166-4058881D2DF4` fallback failed because no local iOS development team is configured.
- The simulator app launched, but the fresh bundle landed on sign-in after onboarding; I could not reach the Computers rows locally without working auth setup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784997933&installation_id=133855650&pr_number=6770&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6770&signature=4b0a3909fd2d824665ed35972e578b8328f6ed372339da994ce98fbb1472cd27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remove confirmation so it anchors to the swiped computer row and keeps the row visible until the user confirms. Moves destructive actions into the row, matches workspace-row swipe behavior, and tracks confirmation by device ID to avoid List reuse issues.

- **Bug Fixes**
  - Moved remove swipe/context actions into `MacComputerRow` with a row-scoped confirmation dialog anchored to the swiped row.
  - Kept only the pending device ID in `DeviceTreeView` and passed a per-row Binding to control presentation.
  - Matched workspace rows: full-swipe and menu ask for confirmation; confirmed removal forgets the Mac and reloads.

<sup>Written for commit 378e08c4164279cc09cc33dce9a0e758fec6d056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now remove a computer directly from its row via swipe actions or the context menu.
  * The removal flow now shows a confirmation prompt with clearer, localized messaging (including details when multiple aliases exist).

* **Bug Fixes**
  * Improved the computer-removal experience to be more consistent.
  * The confirmation dialog now dismisses cleanly after canceling or confirming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->