### PR TITLE
Fix ssh-tmux remote path and attach seeding

### DIFF
--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -160,10 +160,11 @@ final class RemoteTmuxControlConnection {
     /// accepting unbounded user input that may never reach tmux.
     private static let maxPendingStdinBytes = 256 * 1024
     /// Cap pending stdout chunks between SSH's pipe callback and the main-actor
-    /// parser. A full buffer means parsing/rendering has fallen behind remote
-    /// output; reconnecting and re-seeding is safer than corrupting the stream by
-    /// dropping arbitrary control-mode bytes or growing memory without bound.
-    private static let maxPendingStdoutChunks = 16
+    /// parser. Initial attach can legitimately burst one `capture-pane -S 5000`
+    /// command block per mirrored session; the parser's byte budgets remain the
+    /// real corruption guard, while this outer queue just absorbs pipe delivery
+    /// jitter so a normal seed does not trigger a reconnect loop.
+    private static let maxPendingStdoutChunks = 4096
 
     /// Subscription-name prefix for per-pane `pane_current_path` (`refresh-client -B`).
     /// The tmux pane id is appended so an inbound `%subscription-changed` can be

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -248,6 +248,39 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
+    /// Builds a remote shell command that resolves `tmux` before executing it.
+    ///
+    /// OpenSSH runs remote commands under the account's shell, but not as an
+    /// interactive/login shell. On macOS that often means zsh starts with only
+    /// `/usr/bin:/bin:/usr/sbin:/sbin`, so Homebrew's `tmux` is invisible even
+    /// though it works in the user's normal terminal. Resolve the binary in a
+    /// tiny `/bin/sh` wrapper, then `exec` it with the original arguments so both
+    /// one-shot probes and `tmux -CC` use the same path behavior.
+    static func tmuxRemoteCommand(arguments: [String]) -> String {
+        (["/bin/sh", "-c", tmuxResolverShellScript, "cmux-remote-tmux"] + arguments)
+            .map(shellSingleQuoted)
+            .joined(separator: " ")
+    }
+
+    private static let tmuxResolverShellScript = """
+    cmux_tmux=""
+    if command -v tmux >/dev/null 2>&1; then
+      cmux_tmux="$(command -v tmux)"
+    else
+      for cmux_dir in "$HOME/.local/bin" "$HOME/bin" /opt/homebrew/bin /usr/local/bin /opt/local/bin /usr/pkg/bin /snap/bin /usr/bin /bin; do
+        if [ -x "$cmux_dir/tmux" ]; then cmux_tmux="$cmux_dir/tmux"; break; fi
+      done
+      if [ -z "$cmux_tmux" ] && [ -x /usr/libexec/path_helper ]; then
+        eval "$(/usr/libexec/path_helper -s 2>/dev/null)"
+        if command -v tmux >/dev/null 2>&1; then cmux_tmux="$(command -v tmux)"; fi
+      fi
+    fi
+    if [ -n "$cmux_tmux" ]; then
+      exec "$cmux_tmux" "$@"
+    fi
+    exec tmux "$@"
+    """
+
     /// Returns a non-empty tmux control-mode command argument, or `nil` when the
     /// value could break the line-oriented control stream. Shell quoting is not
     /// enough here: CR/LF/control bytes can terminate a `rename-*` command line
@@ -290,10 +323,9 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
             controlPersistSeconds: controlPersistSeconds,
             batchMode: true
         ))
-        let quotedName = Self.shellSingleQuoted(sessionName)
-        let remoteCommand = createIfMissing
-            ? "tmux -CC new-session -A -s \(quotedName)"
-            : "tmux -CC attach-session -t \(quotedName)"
+        let remoteCommand = Self.tmuxRemoteCommand(arguments: createIfMissing
+            ? ["-CC", "new-session", "-A", "-s", sessionName]
+            : ["-CC", "attach-session", "-t", sessionName])
         args.append(contentsOf: ["--", destination, remoteCommand])
         return args
     }

--- a/Sources/RemoteTmuxSSHTransport.swift
+++ b/Sources/RemoteTmuxSSHTransport.swift
@@ -158,9 +158,14 @@ actor RemoteTmuxSSHTransport {
     @discardableResult
     func run(_ remoteArgs: [String]) async throws -> RemoteTmuxCommandResult {
         try host.ensureControlSocketDirectory()
-        let remoteCommand = remoteArgs
-            .map { RemoteTmuxHost.shellSingleQuoted($0) }
-            .joined(separator: " ")
+        let remoteCommand: String
+        if remoteArgs.first == "tmux" {
+            remoteCommand = RemoteTmuxHost.tmuxRemoteCommand(arguments: Array(remoteArgs.dropFirst()))
+        } else {
+            remoteCommand = remoteArgs
+                .map { RemoteTmuxHost.shellSingleQuoted($0) }
+                .joined(separator: " ")
+        }
         // `--` ends ssh option parsing so a destination beginning with `-`
         // (e.g. `-oProxyCommand=…`) can never be consumed as an ssh option.
         let sshArgs =

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -124,6 +124,49 @@ import Testing
         #expect(!args.contains("BatchMode=no"))
     }
 
+    @Test func controlModeArgumentsFindUserLocalTmuxWithMinimalSSHPath() throws {
+        let root = try temporaryDirectory(prefix: "remote-tmux-path")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        let bin = home.appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let fakeTmux = bin.appendingPathComponent("tmux")
+        try writeExecutable(
+            at: fakeTmux,
+            contents: """
+            #!/bin/sh
+            printf 'fake-tmux'
+            for arg in "$@"; do printf ' <%s>' "$arg"; done
+            printf '\\n'
+            """
+        )
+
+        let host = RemoteTmuxHost(destination: "user@example.test")
+        let args = host.controlModeArguments(sessionName: "work session", createIfMissing: false)
+        let dashDash = try #require(args.firstIndex(of: "--"))
+        let command = args[dashDash + 2]
+        let result = try runShell(
+            command,
+            environment: [
+                "HOME": home.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            ]
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+        #expect(result.stdout == "fake-tmux <-CC> <attach-session> <-t> <work session>\n")
+    }
+
+    @Test func controlModeArgumentsUseRemoteTmuxResolverAfterDestinationGuard() throws {
+        let host = RemoteTmuxHost(destination: "-oProxyCommand=evil")
+        let args = host.controlModeArguments(sessionName: "work session", createIfMissing: false)
+        let dashDash = try #require(args.firstIndex(of: "--"))
+        #expect(args[dashDash + 1] == "-oProxyCommand=evil")
+        let remoteCommand = args[dashDash + 2]
+        #expect(remoteCommand.contains("/opt/homebrew/bin"))
+        #expect(remoteCommand.hasSuffix("'cmux-remote-tmux' '-CC' 'attach-session' '-t' 'work session'"))
+    }
+
     @Test func controlArgsAppendPortAndIdentity() {
         let host = RemoteTmuxHost(destination: "user@host", port: 2222, identityFile: "/keys/id")
         let args = host.sshControlArguments(controlPersistSeconds: 180, batchMode: true)
@@ -405,5 +448,40 @@ import Testing
             return true
         }
         return false
+    }
+
+    private func temporaryDirectory(prefix: String) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func writeExecutable(at url: URL, contents: String) throws {
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+
+    private func runShell(
+        _ command: String,
+        environment: [String: String]
+    ) throws -> (status: Int32, stdout: String, stderr: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.environment = environment
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+        return (
+            process.terminationStatus,
+            String(decoding: stdoutData, as: UTF8.self),
+            String(decoding: stderrData, as: UTF8.self)
+        )
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #6775.
- Resolves remote `tmux` through a small `/bin/sh` wrapper shared by `ssh-tmux` control-mode attach and one-shot tmux SSH probes. This covers non-login zsh sessions on macOS where Homebrew or user-local bin directories are missing from the default SSH command PATH.
- Raises the remote tmux pending stdout chunk queue so initial attach seeding can absorb the burst of `capture-pane -S 5000` output without entering a reconnect loop. The parser byte budgets still guard malformed or excessive control-mode output.

## Testing

- Test-only red check: commit `d78471073` failed `RemoteTmuxAuthTests` before the production fix because the old remote command could not find `tmux` under a minimal SSH PATH and did not include the resolver.
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-6775-red test -only-testing:cmuxTests/RemoteTmuxControlParserTests -only-testing:cmuxTests/RemoteTmuxControlStreamParserBudgetTests -only-testing:cmuxTests/RemoteTmuxAuthTests`
- `git diff --check upstream/main...HEAD`
- `./scripts/reload.sh --tag 6775-ssh-tmux --launch` built successfully. The local tagged app exited before its debug socket accepted a final CLI dogfood run, so I did not count that as a fresh manual `kramer-ts` attach verification.
- Localization audit: no user-facing UI, help, docs, menu, settings, alert, or tooltip strings changed. No localization catalog changes needed.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: Not attached. This is command/transport behavior and has focused regression coverage.

## Review Trigger (Copy/Paste as PR comment)

```text
@coderabbitai review
@greptile-apps review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785008576&installation_id=133855650&pr_number=6777&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6777&signature=1e556fc0387537dc13427f434b029025647270b3fe56ab8fded250c9d0a7092c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ssh-tmux` attaches on hosts with a minimal SSH PATH by resolving `tmux` via a small `/bin/sh` wrapper used for both control-mode attach and one-shot probes. Also prevents reconnect loops during initial attach by increasing the stdout chunk queue.

- **Bug Fixes**
  - Add `tmuxRemoteCommand` wrapper that finds `tmux` (`command -v` + common dirs like `/opt/homebrew/bin`, user-local bins) and `exec`s it; used in control-mode args and when `run()` sees `tmux`.
  - Keep the `ssh --` destination guard; the resolver runs after `--`.
  - Raise `maxPendingStdoutChunks` from 16 to 4096 to absorb `capture-pane -S 5000` bursts safely.
  - Add tests that simulate a minimal PATH and verify the resolver is used.

<sup>Written for commit 9792fc20cbcbce4b8fd786bbe00e53ec007a68bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote connections now more reliably find and launch the correct `tmux` executable, even in limited shell environments.
  * `tmux` control sessions are now built more safely, helping prevent malformed arguments from being misread.

* **Bug Fixes**
  * Improved handling of large initial output bursts during remote attach, reducing reconnect loops and connection instability.
  * Non-`tmux` remote commands continue to behave as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

