### PR TITLE
ios landing: size hero phones like gallery images

### DIFF
--- a/web/app/[locale]/ios/page.tsx
+++ b/web/app/[locale]/ios/page.tsx
@@ -100,13 +100,13 @@ export default function IosLanding() {
         {/* Phone */}
         <div
           data-dev="ios-screenshot"
-          className="my-14 grid grid-cols-2 gap-5 sm:gap-10 max-w-lg mx-auto"
+          className="my-14 grid grid-cols-2 gap-4 sm:gap-6"
         >
           <RevealImage
             src={iosWorkspaces}
             alt={t("screenshotAlt")}
             priority
-            sizes="(max-width: 640px) 42vw, 240px"
+            sizes="(max-width: 640px) 42vw, 336px"
             className="w-full h-auto drop-shadow-[0_24px_56px_rgba(0,0,0,0.5)]"
           />
           <RevealImage
@@ -114,7 +114,7 @@ export default function IosLanding() {
             alt={t("screenshotAlt")}
             priority
             delay={90}
-            sizes="(max-width: 640px) 42vw, 240px"
+            sizes="(max-width: 640px) 42vw, 336px"
             className="w-full h-auto drop-shadow-[0_24px_56px_rgba(0,0,0,0.5)]"
           />
         </div>


### PR DESCRIPTION
The two hero phone screenshots at the top of `/ios` sat in a narrow `max-w-lg mx-auto` grid (~240px columns), so they rendered smaller than the gallery images below (~336px columns). This drops the width cap and matches the gallery's grid gap so every phone image renders at the same size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785011755&installation_id=133855650&pr_number=6779&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6779&signature=885c570d8604ea4b5e361a12eee272305408bc69f00c3dd716996efa58f35234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 45937f2babc7afd00c72e462bfefed50e635212d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the two hero phone screenshots on `/ios` the same size as the gallery images for a consistent look. Removes the max-width cap and adjusts grid gaps; updates the `sizes` attribute to 336px columns so both hero images render at the gallery width.

<sup>Written for commit 45937f2babc7afd00c72e462bfefed50e635212d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the iOS landing page screenshot section layout for better spacing across screen sizes.
  * Adjusted image sizing so the phone screenshots display more appropriately on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->