### PR TITLE
fix: skip hook injection for Claude Code background sessions (CLAUDE_JOB_DIR)

### DIFF
--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -387,6 +387,18 @@ if [[ -n "$CMUX_SURFACE_ID" ]]; then
     IN_CMUX=1
 fi
 
+# Claude Code background jobs (fleet sessions) set CLAUDE_JOB_DIR. They
+# inherit CMUX_SURFACE_ID from the parent process, so IN_CMUX=1, but they
+# are headless — there is no terminal surface to route hook events to. The
+# cmux socket permits process-ancestry pings from bg subprocesses but rejects
+# the hook commands themselves, which produces "Failed to write to socket"
+# errors on every UserPromptSubmit, Stop, etc. Detect bg sessions early and
+# pass through without injecting hooks.
+IS_BG_SESSION=0
+if [[ -n "${CLAUDE_JOB_DIR:-}" ]]; then
+    IS_BG_SESSION=1
+fi
+
 exec_real_claude_passthrough() {
     if [[ "$IN_CMUX" == "1" ]]; then
         local cmux_key
@@ -411,7 +423,7 @@ if [[ "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]]; then
     exec "$REAL_CLAUDE" "$@"
 fi
 
-if [[ "$IN_CMUX" == "0" ]] || ! cmux_socket_available; then
+if [[ "$IN_CMUX" == "0" || "$IS_BG_SESSION" == "1" ]] || ! cmux_socket_available; then
     # In cmux-launched shells, preserve old behavior and always clear nested
     # Claude session markers, even when we must pass through due to stale socket.
     if [[ "$IN_CMUX" == "1" ]]; then

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -46,6 +46,7 @@ def run_wrapper(
     node_options: str | None = None,
     tmpdir: str | None = None,
     hooks_disabled: bool = False,
+    claude_job_dir: str | None = None,
 ) -> tuple[int, list[str], list[str], str, str, str, str, str, str, str]:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-test-") as td:
         tmp = Path(td)
@@ -183,6 +184,10 @@ exit 0
             env["CMUX_CLAUDE_HOOKS_DISABLED"] = "1"
         else:
             env.pop("CMUX_CLAUDE_HOOKS_DISABLED", None)
+        if claude_job_dir is not None:
+            env["CLAUDE_JOB_DIR"] = claude_job_dir
+        else:
+            env.pop("CLAUDE_JOB_DIR", None)
         env.pop("NODE_OPTIONS", None)
         if tmpdir is not None:
             env["TMPDIR"] = tmpdir
@@ -441,6 +446,7 @@ exit 0
                 "CLAUDE_CODE_USE_BEDROCK",
                 "CLAUDE_CODE_USE_VERTEX",
                 "CLAUDE_CONFIG_DIR",
+                "CLAUDE_JOB_DIR",
                 "CLOUD_ML_REGION",
             ):
                 env.pop(ambient_key, None)
@@ -1774,6 +1780,42 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     expect(hook_cmux_bin == "__UNSET__", f"stale socket: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
 
 
+def test_bg_session_skips_hook_injection(failures: list[str]) -> None:
+    # CLAUDE_JOB_DIR is set by Claude Code for all background (fleet) sessions.
+    # Bg sessions inherit CMUX_SURFACE_ID and can ping the socket, but they are
+    # headless — there is no terminal surface to route hook events to. The wrapper
+    # must skip hook injection when CLAUDE_JOB_DIR is set, regardless of socket
+    # availability, to prevent spurious "Failed to write to socket" errors on every
+    # hook event (UserPromptSubmit, Stop, etc.).
+    code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
+        socket_state="live",
+        argv=["hello"],
+        claude_job_dir="/tmp/claude-jobs/test-job-id",
+    )
+    expect(code == 0, f"bg session: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["hello"], f"bg session: expected passthrough args (no hook injection), got {real_argv}", failures)
+    expect("--settings" not in real_argv, f"bg session: expected no --settings injection, got {real_argv}", failures)
+    expect("--session-id" not in real_argv, f"bg session: expected no --session-id injection, got {real_argv}", failures)
+    expect(claudecode == "__UNSET__", f"bg session: expected CLAUDECODE unset, got {claudecode!r}", failures)
+    expect(node_options == "__UNSET__", f"bg session: expected no NODE_OPTIONS injection, got {node_options!r}", failures)
+    expect(hook_cmux_bin == "__UNSET__", f"bg session: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
+
+    # bg sessions with --resume should also skip hook injection.
+    code2, real_argv2, _, stderr2, *_ = run_wrapper(
+        socket_state="live",
+        argv=["--resume", "some-session-id", "--model", "opus"],
+        claude_job_dir="/tmp/claude-jobs/test-job-id",
+    )
+    expect(code2 == 0, f"bg session resume: wrapper exited {code2}: {stderr2}", failures)
+    expect("--settings" not in real_argv2, f"bg session resume: expected no --settings injection, got {real_argv2}", failures)
+    expect("--session-id" not in real_argv2, f"bg session resume: expected no --session-id injection, got {real_argv2}", failures)
+    expect(
+        real_argv2 == ["--resume", "some-session-id", "--model", "opus"],
+        f"bg session resume: expected clean passthrough argv, got {real_argv2}",
+        failures,
+    )
+
+
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
@@ -1816,6 +1858,7 @@ def main() -> int:
     test_missing_socket_skips_hook_injection(failures)
     test_disabled_integration_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
+    test_bg_session_skips_hook_injection(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")


### PR DESCRIPTION
## Problem

Claude Code background (fleet) sessions set `CLAUDE_JOB_DIR` and inherit `CMUX_SURFACE_ID` from the parent interactive process. This means the wrapper's `IN_CMUX=1` check passes, and `cmux_socket_available` returns true (the socket ping succeeds because bg subprocesses have valid cmux process ancestry).

However, bg sessions are **headless** — there is no terminal surface to route hook events to. The socket accepts the connection but rejects the hook command, closing the connection after sending an access-denied response. The CLI then gets EPIPE writing the remainder, which surfaces as:

```
UserPromptSubmit hook error - Failed with non-blocking status code:
Error: Failed to write to socket
```

This happens for every `UserPromptSubmit`, `Stop`, `SessionStart`, `Notification`, etc. hook event in a bg session.

## Root cause

`cmux_socket_available()` probes with `cmux ping`. The ping succeeds for bg sessions (ancestry check passes). The wrapper then injects `HOOKS_JSON` via `--settings`. But when those hooks actually fire and try to send events, the socket server rejects them with "only processes started inside cmux can connect" (meaning: no active surface for this session).

## Fix

Detect `CLAUDE_JOB_DIR` (always set by Claude Code for fleet/background sessions) before the socket check, and pass through without hook injection — exactly like the stale-socket and `CMUX_CLAUDE_HOOKS_DISABLED` paths.

```bash
# Claude Code background jobs (fleet sessions) set CLAUDE_JOB_DIR. They
# inherit CMUX_SURFACE_ID from the parent process, so IN_CMUX=1, but they
# are headless — there is no terminal surface to route hook events to.
IS_BG_SESSION=0
if [[ -n "${CLAUDE_JOB_DIR:-}" ]]; then
    IS_BG_SESSION=1
fi
```

Then:
```bash
if [[ "$IN_CMUX" == "0" || "$IS_BG_SESSION" == "1" ]] || ! cmux_socket_available; then
    ...passthrough without hook injection...
fi
```

## Test

Added `test_bg_session_skips_hook_injection` to `test_claude_wrapper_hooks.py`:
- With live socket + `CLAUDE_JOB_DIR` set: no `--settings` or `--session-id` injected, passthrough
- With `--resume` args in same scenario: clean passthrough
- `run_wrapper_auth_env` now clears ambient `CLAUDE_JOB_DIR` so the harness doesn't absorb it when tests run inside a bg session

All 37 existing tests continue to pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785012180&installation_id=133855650&pr_number=6780&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6780&signature=50d1421a8d886b6b8d4365058aa0fe24728cb2f8542a513d2c5d5bca9f85b963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip hook injection for Claude Code background (fleet) sessions by detecting CLAUDE_JOB_DIR, ensuring headless runs don’t try to send hooks to a non-existent surface. This prevents noisy “Failed to write to socket” errors and keeps bg sessions as clean passthrough.

- **Bug Fixes**
  - Detect background sessions via CLAUDE_JOB_DIR before the cmux socket check and bypass hook injection (same path as stale/disabled hooks).
  - Eliminates hook write errors for UserPromptSubmit, Stop, SessionStart, and Notification in headless sessions.
  - Added tests: test_bg_session_skips_hook_injection; test harness now clears CLAUDE_JOB_DIR to avoid ambient leakage.

<sup>Written for commit 2206abc087f024a779c2ffa40c29dd9d4ebf25b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Background Claude sessions now avoid interactive hook setup, preventing repeated failures in headless runs.
  * Resume actions in background mode now behave more reliably by using non-interactive pass-through handling.
  * Improved handling of session environment signals so background jobs are treated consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->