### PR TITLE
ios landing: add centered TestFlight + GitHub CTA at bottom

### DIFF
--- a/web/app/[locale]/ios/page.tsx
+++ b/web/app/[locale]/ios/page.tsx
@@ -199,7 +199,7 @@ export default function IosLanding() {
             <AppleMark size={19} />
             {t("ctaBeta")}
           </a>
-          <GitHubButton />
+          <GitHubButton location="ios-bottom" />
         </div>
 
         {/* Bottom links */}

--- a/web/app/[locale]/ios/page.tsx
+++ b/web/app/[locale]/ios/page.tsx
@@ -186,8 +186,24 @@ export default function IosLanding() {
           </p>
         </section>
 
+        {/* Bottom CTA */}
+        <div
+          className="flex flex-wrap items-center justify-center gap-3 mt-12"
+          data-dev="ios-cta-bottom"
+        >
+          <a
+            href="https://github.com/manaflow-ai/cmux#founders-edition"
+            className={`${ctaButtonBase} ${ctaButtonDefaultSize}`}
+            style={ctaButtonStyle}
+          >
+            <AppleMark size={19} />
+            {t("ctaBeta")}
+          </a>
+          <GitHubButton />
+        </div>
+
         {/* Bottom links */}
-        <div className="flex justify-center gap-4 mt-12">
+        <div className="flex justify-center gap-4 mt-6">
           <Link href="/docs/ios" className={`text-sm text-muted hover:text-foreground transition-colors ${linkClass}`}>
             {t("ctaDocs")}
           </Link>


### PR DESCRIPTION
Adds a centered Download-on-TestFlight + View-on-GitHub button pair near the bottom of `/ios`, above the docs/back links, mirroring the top CTA. Reuses the existing `ctaButton*` styles, `AppleMark`, and `GitHubButton` so it stays consistent with the top CTA and the Mac landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785013226&installation_id=133855650&pr_number=6782&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6782&signature=38089be6c4a303de74ca3f883c2b154deae9dad10602bbaf6d954ec73cd30669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-page UI only; no auth, data, or backend changes.
> 
> **Overview**
> Adds a **centered bottom CTA** on `/ios` after “How it works,” duplicating the founders-edition/TestFlight link and `GitHubButton` so users can convert without scrolling back up. Reuses existing `ctaButton*` styles and `AppleMark`; the GitHub button passes `location="ios-bottom"` for distinct analytics.
> 
> Tightens layout by reducing spacing above the docs/back links from `mt-12` to `mt-6` and tagging the block with `data-dev="ios-cta-bottom"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b1efe4f5d643b94d3f92df72c6f3f48f0e680b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a centered "Download on TestFlight" + "View on GitHub" CTA at the bottom of `/ios`, mirroring the top CTA.

Reuses `ctaButton*`, `AppleMark`, `GitHubButton`, sets `location="ios-bottom"` for click attribution, adds `data-dev="ios-cta-bottom"`, and reduces bottom link spacing from `mt-12` to `mt-6`.

<sup>Written for commit 10b1efe4f5d643b94d3f92df72c6f3f48f0e680b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an extra call-to-action section on the iOS landing page below the “How it works” content.
  * Repeated the founders-edition and GitHub links to make them more prominent.

* **UI Improvements**
  * Adjusted spacing for the lower link area to create a tighter, cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->