### PR TITLE
Gate iOS onboarding only on seen state

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -200,11 +200,9 @@ struct CMUXMobileRootView: View {
                 reconnectStoredMac: reconnectStoredMacIfNeeded
             )
         } else if shouldShowOnboarding {
-            // Placed after the reconnect-determining branch so `hasKnownPairedMac`
-            // has resolved: a genuine first run (never onboarded, never paired)
-            // sees the one-time explainer before the add-device flow; a returning
-            // paired-but-offline user (who can reach here after a failed
-            // reconnect) is excluded by the gate and falls through to pairing.
+            // Show the one-time explainer before the add-device flow. This is
+            // keyed only by onboarding completion so auto-pairing cannot defer
+            // onboarding until the user later removes every computer.
             onboardingFlow
         } else if store.connectionState != .connected && !store.hasKnownPairedMac {
             // ONLY when there are no saved Macs at all: the add-device flow (it
@@ -290,8 +288,7 @@ struct CMUXMobileRootView: View {
     private var shouldShowOnboarding: Bool {
         #if os(iOS)
         return MobileOnboardingGate.shouldShowOnboarding(
-            hasSeenOnboarding: hasSeenOnboarding,
-            hasKnownPairedMac: store.hasKnownPairedMac
+            hasSeenOnboarding: hasSeenOnboarding
         )
         #else
         return false

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileOnboardingGate.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileOnboardingGate.swift
@@ -2,36 +2,24 @@
 ///
 /// Onboarding is a one-time explainer (what cmux is, what it needs, how to pair)
 /// shown post-authentication and *in front of* the never-paired add-device state.
-/// The single decision — show it or fall through to pairing — combines the
-/// persisted "seen" flag with whether this install has a known paired Mac, so the
-/// gate is a pure function the root scene can branch on and tests can cover
-/// without a store. It mirrors ``MobileRootAuthGate``.
+/// The single decision — show it or fall through to pairing — uses only the
+/// persisted "seen" flag, so pairing state cannot defer onboarding until a later
+/// delete-all flow. It mirrors ``MobileRootAuthGate``.
 public struct MobileOnboardingGate {
     private init() {}
 
     /// Whether the first-run onboarding should be presented.
     ///
-    /// Onboarding shows only for a genuine first run: the user has not seen it
-    /// *and* this install has never paired a Mac. The paired check excludes a
-    /// returning, paired-but-offline user — who can reach this branch after a
-    /// failed stored-Mac reconnect — from being interrupted by onboarding even
-    /// when their seen flag is still `false` (an older install updating into the
-    /// build that introduced the flag).
-    ///
-    /// The caller places this branch *after* the stored-Mac reconnect-determining
-    /// branch, so ``hasKnownPairedMac`` has resolved (the determining spinner
-    /// absorbs the resolution window) and is authoritative here.
+    /// Onboarding shows when the user has not seen it yet, regardless of whether
+    /// the app has already auto-paired a Mac.
     ///
     /// - Parameters:
     ///   - hasSeenOnboarding: Whether onboarding has already been shown (or
     ///     bypassed for UI tests / dogfood) on this install.
-    ///   - hasKnownPairedMac: Whether this install has a known paired Mac.
-    /// - Returns: `true` only when onboarding has not been seen and no paired Mac
-    ///   is known.
+    /// - Returns: `true` only when onboarding has not been seen.
     public static func shouldShowOnboarding(
-        hasSeenOnboarding: Bool,
-        hasKnownPairedMac: Bool
+        hasSeenOnboarding: Bool
     ) -> Bool {
-        !hasSeenOnboarding && !hasKnownPairedMac
+        !hasSeenOnboarding
     }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileOnboardingGateTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileOnboardingGateTests.swift
@@ -6,8 +6,7 @@ import Testing
     /// The genuine first run: never onboarded and no paired Mac. Onboarding shows.
     @Test func showsOnboardingForNeverOnboardedNeverPaired() {
         #expect(MobileOnboardingGate.shouldShowOnboarding(
-            hasSeenOnboarding: false,
-            hasKnownPairedMac: false
+            hasSeenOnboarding: false
         ))
     }
 
@@ -16,8 +15,7 @@ import Testing
     /// sent to onboarding later.
     @Test func showsOnboardingForNeverOnboardedButPaired() {
         #expect(MobileOnboardingGate.shouldShowOnboarding(
-            hasSeenOnboarding: false,
-            hasKnownPairedMac: true
+            hasSeenOnboarding: false
         ))
     }
 
@@ -25,16 +23,14 @@ import Testing
     /// the add-device / pairing flow without showing it again.
     @Test func skipsOnboardingForOnboardedNeverPaired() {
         #expect(!MobileOnboardingGate.shouldShowOnboarding(
-            hasSeenOnboarding: true,
-            hasKnownPairedMac: false
+            hasSeenOnboarding: true
         ))
     }
 
     /// Onboarded and paired: never show onboarding.
     @Test func skipsOnboardingForOnboardedAndPaired() {
         #expect(!MobileOnboardingGate.shouldShowOnboarding(
-            hasSeenOnboarding: true,
-            hasKnownPairedMac: true
+            hasSeenOnboarding: true
         ))
     }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileOnboardingGateTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileOnboardingGateTests.swift
@@ -11,11 +11,11 @@ import Testing
         ))
     }
 
-    /// A returning, paired-but-offline user (reachable after a failed stored-Mac
-    /// reconnect) must not be interrupted by onboarding, even if the seen flag is
-    /// still `false` because they updated from a build that predates the flag.
-    @Test func skipsOnboardingForNeverOnboardedButPaired() {
-        #expect(!MobileOnboardingGate.shouldShowOnboarding(
+    /// Pairing state must not suppress the first-run explainer. Otherwise a user
+    /// who auto-paired before seeing onboarding can delete every computer and get
+    /// sent to onboarding later.
+    @Test func showsOnboardingForNeverOnboardedButPaired() {
+        #expect(MobileOnboardingGate.shouldShowOnboarding(
             hasSeenOnboarding: false,
             hasKnownPairedMac: true
         ))


### PR DESCRIPTION
## Summary
- gate first-run iOS onboarding only on the persisted seen flag
- remove paired-Mac state from the onboarding decision
- add regression coverage for auto-paired users who have not seen onboarding yet

## Tests
- `swift test --filter MobileOnboardingGateTests`

## Notes
- Test commit `245fb5e438` fails before the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785014450&installation_id=133855650&pr_number=6783&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6783&signature=37020acaff2fb228d179ae7b07b47b5aeb97f5377b7bee4bf29a03d0bb0c6d74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate iOS onboarding only on the persisted “seen” flag so users who auto-pair before seeing the explainer still see it once. Removes coupling to paired-Mac state to avoid onboarding being deferred until all Macs are removed.

- **Bug Fixes**
  - Simplified `MobileOnboardingGate.shouldShowOnboarding` to check only `hasSeenOnboarding`; removed the paired-Mac parameter and logic.
  - Updated `CMUXMobileRootView` to the new signature and clarified inline comments.
  - Updated tests to assert onboarding shows when unseen, even if a Mac is already paired.

<sup>Written for commit 3c32ca1199883669d330113d3e1ab10cbe6f56f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding now appears based on whether it has already been seen, even if a paired Mac is present.
  * Improved consistency in the app’s onboarding flow so users are no longer skipped unexpectedly.

* **Refactor**
  * Simplified the onboarding eligibility check to use a single saved onboarding flag.
  * Updated related tests to match the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->