### PR TITLE
Fix sleep/wake window geometry restore

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -660,6 +660,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let display: SessionDisplaySnapshot?
     }
 
+    private struct PreSleepWindowGeometry {
+        let frame: SessionRectSnapshot
+        let display: SessionDisplaySnapshot?
+    }
+
     nonisolated static let persistedWindowGeometrySchemaVersion = 2
     private nonisolated static let persistedWindowGeometryDefaultsKey = "cmux.session.lastWindowGeometry.v2"
 #if DEBUG
@@ -805,6 +810,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     var shortcutLayoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
     private var workspaceObserver: NSObjectProtocol?
     private var lifecycleSnapshotObservers: [NSObjectProtocol] = []
+    private var preSleepWindowGeometries: [UUID: PreSleepWindowGeometry] = [:]
+    private var wakeWindowGeometryRestoreGeneration = 0
     private var windowKeyObservers: [NSObjectProtocol] = []
     private var shortcutMonitor: Any?
     private var shortcutDefaultsObserver: NSObjectProtocol?
@@ -3572,6 +3579,59 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    nonisolated static func shouldRestoreWindowFrameAfterWake(
+        currentFrame: CGRect,
+        targetFrame: CGRect,
+        sizeTolerance: CGFloat = 12,
+        originTolerance: CGFloat = 12,
+        shrinkRatioThreshold: CGFloat = 0.85,
+        dimensionShrinkRatioThreshold: CGFloat = 0.90
+    ) -> Bool {
+        guard isValidRestorableWindowFrame(currentFrame),
+              isValidRestorableWindowFrame(targetFrame) else {
+            return false
+        }
+
+        let current = currentFrame.standardized
+        let target = targetFrame.standardized
+        let widthDelta = abs(current.width - target.width)
+        let heightDelta = abs(current.height - target.height)
+        let originDelta = max(
+            abs(current.minX - target.minX),
+            abs(current.minY - target.minY)
+        )
+        if widthDelta <= sizeTolerance,
+           heightDelta <= sizeTolerance,
+           originDelta <= originTolerance {
+            return false
+        }
+
+        let currentArea = max(current.width * current.height, 1)
+        let targetArea = max(target.width * target.height, 1)
+        if currentArea < targetArea * shrinkRatioThreshold {
+            return true
+        }
+
+        let widthShrank = current.width < target.width * dimensionShrinkRatioThreshold
+        let heightShrank = current.height < target.height * dimensionShrinkRatioThreshold
+        if widthShrank || heightShrank {
+            return true
+        }
+
+        let sizeIsStable = widthDelta <= sizeTolerance * 2
+            && heightDelta <= sizeTolerance * 2
+        return sizeIsStable && originDelta > originTolerance * 2
+    }
+
+    nonisolated static func isValidRestorableWindowFrame(_ frame: CGRect) -> Bool {
+        frame.origin.x.isFinite
+            && frame.origin.y.isFinite
+            && frame.width.isFinite
+            && frame.height.isFinite
+            && frame.width >= CGFloat(SessionPersistencePolicy.minimumWindowWidth)
+            && frame.height >= CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+    }
+
     private nonisolated static func resolvedWindowFrame(
         frame: CGRect,
         displaySnapshot: SessionDisplaySnapshot?,
@@ -3873,11 +3933,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     _ = self.saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
                     ClosedItemHistoryStore.shared.flushPendingSaves()
                 } else {
+                    self.capturePreSleepWindowGeometries()
                     self.saveSessionSnapshotAfterLoadingProcessDetectedIndexes(includeScrollback: false)
                 }
             }
         }
         lifecycleSnapshotObservers.append(sessionResignObserver)
+
+        let screensSleepObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.screensDidSleepNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.capturePreSleepWindowGeometries()
+            }
+        }
+        lifecycleSnapshotObservers.append(screensSleepObserver)
+
+        let screensWakeObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.screensDidWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleWakeWindowGeometryRestore()
+            }
+        }
+        lifecycleSnapshotObservers.append(screensWakeObserver)
 
         let didWakeObserver = workspaceCenter.addObserver(
             forName: NSWorkspace.didWakeNotification,
@@ -3885,10 +3968,115 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.restartSocketListenerIfEnabled(source: "workspace.didWake")
+                guard let self else { return }
+                self.restartSocketListenerIfEnabled(source: "workspace.didWake")
+                self.scheduleWakeWindowGeometryRestore()
             }
         }
         lifecycleSnapshotObservers.append(didWakeObserver)
+
+        let sessionActiveObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.sessionDidBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleWakeWindowGeometryRestore()
+            }
+        }
+        lifecycleSnapshotObservers.append(sessionActiveObserver)
+    }
+
+    private func capturePreSleepWindowGeometries() {
+        preSleepWindowGeometries = Dictionary(
+            uniqueKeysWithValues: mainWindowContexts.values.compactMap { context in
+                guard let window = resolvedWindow(for: context) ?? context.window,
+                      window.isVisible,
+                      !window.isMiniaturized,
+                      Self.isValidRestorableWindowFrame(window.frame) else {
+                    return nil
+                }
+                return (
+                    context.windowId,
+                    PreSleepWindowGeometry(
+                        frame: SessionRectSnapshot(window.frame),
+                        display: displaySnapshot(for: window)
+                    )
+                )
+            }
+        )
+    }
+
+    private func scheduleWakeWindowGeometryRestore() {
+        guard !preSleepWindowGeometries.isEmpty else { return }
+        wakeWindowGeometryRestoreGeneration += 1
+        let generation = wakeWindowGeometryRestoreGeneration
+        for delay in [0.25, 1.0, 2.5] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                Task { @MainActor [weak self] in
+                    guard let self, self.wakeWindowGeometryRestoreGeneration == generation else { return }
+                    self.restorePreSleepWindowGeometriesIfNeeded()
+                }
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.wakeWindowGeometryRestoreGeneration == generation else { return }
+                self.preSleepWindowGeometries.removeAll()
+            }
+        }
+    }
+
+    private func restorePreSleepWindowGeometriesIfNeeded() {
+        guard !preSleepWindowGeometries.isEmpty else { return }
+        let displays = currentDisplayGeometries()
+        for context in mainWindowContexts.values {
+            guard let captured = preSleepWindowGeometries[context.windowId],
+                  let window = resolvedWindow(for: context) ?? context.window,
+                  !window.isMiniaturized,
+                  let targetFrame = Self.resolvedWindowFrame(
+                      from: captured.frame,
+                      display: captured.display,
+                      availableDisplays: displays.available,
+                      fallbackDisplay: displays.fallback
+                  ),
+                  Self.shouldRestoreWindowFrameAfterWake(
+                      currentFrame: window.frame,
+                      targetFrame: targetFrame
+                  ) else {
+                continue
+            }
+            window.setFrame(targetFrame, display: true)
+        }
+    }
+
+    private func sessionWindowGeometry(
+        for context: MainWindowContext
+    ) -> (frame: SessionRectSnapshot?, display: SessionDisplaySnapshot?) {
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+        if let cached = preSleepWindowGeometries[context.windowId] {
+            guard let window else {
+                return (cached.frame, cached.display)
+            }
+            let displays = currentDisplayGeometries()
+            if let targetFrame = Self.resolvedWindowFrame(
+                from: cached.frame,
+                display: cached.display,
+                availableDisplays: displays.available,
+                fallbackDisplay: displays.fallback
+            ),
+            Self.shouldRestoreWindowFrameAfterWake(
+                currentFrame: window.frame,
+                targetFrame: targetFrame
+            ) {
+                return (cached.frame, cached.display)
+            }
+        }
+
+        return (
+            window.map { SessionRectSnapshot($0.frame) },
+            displaySnapshot(for: window)
+        )
     }
 
     private func socketListenerConfigurationIfEnabled() -> (mode: SocketControlMode, path: String)? {
@@ -4002,8 +4190,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 hasher.combine(1)
             }
 
-            if let window = context.window ?? windowForMainWindowId(context.windowId) {
-                Self.hashFrame(window.frame, into: &hasher)
+            let geometry = sessionWindowGeometry(for: context)
+            if let frame = geometry.frame {
+                Self.hashFrame(frame.cgRect, into: &hasher)
+                if let display = geometry.display {
+                    Self.hashDisplaySnapshot(display, into: &hasher)
+                } else {
+                    hasher.combine(-1)
+                }
             } else {
                 hasher.combine(-1)
             }
@@ -4388,6 +4582,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         quantized.forEach { hasher.combine($0) }
     }
 
+    private nonisolated static func hashDisplaySnapshot(
+        _ display: SessionDisplaySnapshot,
+        into hasher: inout Hasher
+    ) {
+        hasher.combine(display.displayID.map(Int.init) ?? -1)
+        if let frame = display.frame?.cgRect {
+            hashFrame(frame, into: &hasher)
+        } else {
+            hasher.combine(-1)
+        }
+        if let visibleFrame = display.visibleFrame?.cgRect {
+            hashFrame(visibleFrame, into: &hasher)
+        } else {
+            hasher.combine(-1)
+        }
+    }
+
     private func persistSessionSnapshot(
         _ snapshot: AppSessionSnapshot?,
         removeWhenEmpty: Bool,
@@ -4516,11 +4727,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             surfaceResumeBindingIndex: surfaceResumeBindingIndex
         )
 
-        let window = context.window ?? windowForMainWindowId(context.windowId)
+        let geometry = sessionWindowGeometry(for: context)
         return SessionWindowSnapshot(
             windowId: context.windowId,
-            frame: window.map { SessionRectSnapshot($0.frame) },
-            display: displaySnapshot(for: window),
+            frame: geometry.frame,
+            display: geometry.display,
             tabManager: tabManagerSnapshot,
             sidebar: SessionSidebarSnapshot(
                 isVisible: context.sidebarState.isVisible,
@@ -15893,6 +16104,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let frame = window.frame
         lastCascadePoint = NSPoint(x: frame.minX, y: frame.maxY)
         let closingContext = contextForMainTerminalWindow(window, reindex: false)
+        if let closingContext {
+            preSleepWindowGeometries.removeValue(forKey: closingContext.windowId)
+        }
         let closingWindowIsCrashDiagnostic = closingContext.map { context in
             closeWindowSnapshotPruningCrashDiagnostics(
                 for: context,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -606,6 +606,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let display: SessionDisplaySnapshot?
     }
 
+    private struct PreSleepWindowGeometry {
+        let frame: SessionRectSnapshot
+        let display: SessionDisplaySnapshot?
+    }
+
     nonisolated static let persistedWindowGeometrySchemaVersion = 2
     private nonisolated static let persistedWindowGeometryDefaultsKey = "cmux.session.lastWindowGeometry.v2"
 #if DEBUG
@@ -749,6 +754,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     var shortcutLayoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
     private var workspaceObserver: NSObjectProtocol?
     private var lifecycleSnapshotObservers: [NSObjectProtocol] = []
+    private var preSleepWindowGeometries: [UUID: PreSleepWindowGeometry] = [:]
+    private var wakeWindowGeometryRestoreGeneration = 0
     private var windowKeyObservers: [NSObjectProtocol] = []
     private var shortcutMonitor: Any?
     private var shortcutDefaultsObserver: NSObjectProtocol?
@@ -3734,6 +3741,59 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         ) ?? resolvedFrame
     }
 
+    nonisolated static func shouldRestoreWindowFrameAfterWake(
+        currentFrame: CGRect,
+        targetFrame: CGRect,
+        sizeTolerance: CGFloat = 12,
+        originTolerance: CGFloat = 12,
+        shrinkRatioThreshold: CGFloat = 0.85,
+        dimensionShrinkRatioThreshold: CGFloat = 0.90
+    ) -> Bool {
+        guard isValidRestorableWindowFrame(currentFrame),
+              isValidRestorableWindowFrame(targetFrame) else {
+            return false
+        }
+
+        let current = currentFrame.standardized
+        let target = targetFrame.standardized
+        let widthDelta = abs(current.width - target.width)
+        let heightDelta = abs(current.height - target.height)
+        let originDelta = max(
+            abs(current.minX - target.minX),
+            abs(current.minY - target.minY)
+        )
+        if widthDelta <= sizeTolerance,
+           heightDelta <= sizeTolerance,
+           originDelta <= originTolerance {
+            return false
+        }
+
+        let currentArea = max(current.width * current.height, 1)
+        let targetArea = max(target.width * target.height, 1)
+        if currentArea < targetArea * shrinkRatioThreshold {
+            return true
+        }
+
+        let widthShrank = current.width < target.width * dimensionShrinkRatioThreshold
+        let heightShrank = current.height < target.height * dimensionShrinkRatioThreshold
+        if widthShrank || heightShrank {
+            return true
+        }
+
+        let sizeIsStable = widthDelta <= sizeTolerance * 2
+            && heightDelta <= sizeTolerance * 2
+        return sizeIsStable && originDelta > originTolerance * 2
+    }
+
+    nonisolated static func isValidRestorableWindowFrame(_ frame: CGRect) -> Bool {
+        frame.origin.x.isFinite
+            && frame.origin.y.isFinite
+            && frame.width.isFinite
+            && frame.height.isFinite
+            && frame.width >= CGFloat(SessionPersistencePolicy.minimumWindowWidth)
+            && frame.height >= CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+    }
+
     private nonisolated static func resolvedWindowFrame(
         frame: CGRect,
         displaySnapshot: SessionDisplaySnapshot?,
@@ -3933,6 +3993,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     _ = self.saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
                     ClosedItemHistoryStore.shared.flushPendingSaves()
                 } else {
+                    self.capturePreSleepWindowGeometries()
                     self.saveSessionSnapshotAfterLoadingProcessDetectedIndexes(includeScrollback: false)
                 }
             }
@@ -3992,6 +4053,144 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
         lifecycleSnapshotObservers.append(screenParamsObserver)
+
+        let screensSleepObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.screensDidSleepNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.capturePreSleepWindowGeometries()
+            }
+        }
+        lifecycleSnapshotObservers.append(screensSleepObserver)
+
+        let screensWakeObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.screensDidWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleWakeWindowGeometryRestore()
+            }
+        }
+        lifecycleSnapshotObservers.append(screensWakeObserver)
+
+        let didWakeObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.restartSocketListenerIfEnabled(source: "workspace.didWake")
+                self.scheduleWakeWindowGeometryRestore()
+            }
+        }
+        lifecycleSnapshotObservers.append(didWakeObserver)
+
+        let sessionActiveObserver = workspaceCenter.addObserver(
+            forName: NSWorkspace.sessionDidBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleWakeWindowGeometryRestore()
+            }
+        }
+        lifecycleSnapshotObservers.append(sessionActiveObserver)
+    }
+
+    private func capturePreSleepWindowGeometries() {
+        preSleepWindowGeometries = Dictionary(
+            uniqueKeysWithValues: mainWindowContexts.values.compactMap { context in
+                guard let window = resolvedWindow(for: context) ?? context.window,
+                      window.isVisible,
+                      !window.isMiniaturized,
+                      Self.isValidRestorableWindowFrame(window.frame) else {
+                    return nil
+                }
+                return (
+                    context.windowId,
+                    PreSleepWindowGeometry(
+                        frame: SessionRectSnapshot(window.frame),
+                        display: displaySnapshot(for: window)
+                    )
+                )
+            }
+        )
+    }
+
+    private func scheduleWakeWindowGeometryRestore() {
+        guard !preSleepWindowGeometries.isEmpty else { return }
+        wakeWindowGeometryRestoreGeneration += 1
+        let generation = wakeWindowGeometryRestoreGeneration
+        for delay in [0.25, 1.0, 2.5] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                Task { @MainActor [weak self] in
+                    guard let self, self.wakeWindowGeometryRestoreGeneration == generation else { return }
+                    self.restorePreSleepWindowGeometriesIfNeeded()
+                }
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.wakeWindowGeometryRestoreGeneration == generation else { return }
+                self.preSleepWindowGeometries.removeAll()
+            }
+        }
+    }
+
+    private func restorePreSleepWindowGeometriesIfNeeded() {
+        guard !preSleepWindowGeometries.isEmpty else { return }
+        let displays = currentDisplayGeometries()
+        for context in mainWindowContexts.values {
+            guard let captured = preSleepWindowGeometries[context.windowId],
+                  let window = resolvedWindow(for: context) ?? context.window,
+                  !window.isMiniaturized,
+                  let targetFrame = Self.resolvedWindowFrame(
+                      from: captured.frame,
+                      display: captured.display,
+                      availableDisplays: displays.available,
+                      fallbackDisplay: displays.fallback
+                  ),
+                  Self.shouldRestoreWindowFrameAfterWake(
+                      currentFrame: window.frame,
+                      targetFrame: targetFrame
+                  ) else {
+                continue
+            }
+            window.setFrame(targetFrame, display: true)
+        }
+    }
+
+    private func sessionWindowGeometry(
+        for context: MainWindowContext
+    ) -> (frame: SessionRectSnapshot?, display: SessionDisplaySnapshot?) {
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+        if let cached = preSleepWindowGeometries[context.windowId] {
+            guard let window else {
+                return (cached.frame, cached.display)
+            }
+            let displays = currentDisplayGeometries()
+            if let targetFrame = Self.resolvedWindowFrame(
+                from: cached.frame,
+                display: cached.display,
+                availableDisplays: displays.available,
+                fallbackDisplay: displays.fallback
+            ),
+            Self.shouldRestoreWindowFrameAfterWake(
+                currentFrame: window.frame,
+                targetFrame: targetFrame
+            ) {
+                return (cached.frame, cached.display)
+            }
+        }
+
+        return (
+            window.map { SessionRectSnapshot($0.frame) },
+            displaySnapshot(for: window)
+        )
     }
 
     private func disableSuddenTerminationIfNeeded() {
@@ -4039,8 +4238,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 hasher.combine(1)
             }
 
-            if let window = context.window ?? windowForMainWindowId(context.windowId) {
-                Self.hashFrame(window.frame, into: &hasher)
+            let geometry = sessionWindowGeometry(for: context)
+            if let frame = geometry.frame {
+                Self.hashFrame(frame.cgRect, into: &hasher)
+                if let display = geometry.display {
+                    Self.hashDisplaySnapshot(display, into: &hasher)
+                } else {
+                    hasher.combine(-1)
+                }
             } else {
                 hasher.combine(-1)
             }
@@ -4444,6 +4649,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         quantized.forEach { hasher.combine($0) }
     }
 
+    private nonisolated static func hashDisplaySnapshot(
+        _ display: SessionDisplaySnapshot,
+        into hasher: inout Hasher
+    ) {
+        hasher.combine(display.displayID.map(Int.init) ?? -1)
+        if let frame = display.frame?.cgRect {
+            hashFrame(frame, into: &hasher)
+        } else {
+            hasher.combine(-1)
+        }
+        if let visibleFrame = display.visibleFrame?.cgRect {
+            hashFrame(visibleFrame, into: &hasher)
+        } else {
+            hasher.combine(-1)
+        }
+    }
+
     private func persistSessionSnapshot(
         _ snapshot: AppSessionSnapshot?,
         removeWhenEmpty: Bool,
@@ -4572,10 +4794,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if let window {
             captureWindowConfigFrame(window, reason: "sessionSnapshot")
         }
+        let geometry = sessionWindowGeometry(for: context)
         return SessionWindowSnapshot(
             windowId: context.windowId,
-            frame: window.map { SessionRectSnapshot($0.frame) },
-            display: displaySnapshot(for: window),
+            frame: geometry.frame,
+            display: geometry.display,
             tabManager: tabManagerSnapshot,
             sidebar: SessionSidebarSnapshot(
                 isVisible: context.sidebarState.isVisible,
@@ -16541,6 +16764,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let frame = window.frame
         lastCascadePoint = NSPoint(x: frame.minX, y: frame.maxY)
         let closingContext = contextForMainTerminalWindow(window, reindex: false)
+        if let closingContext {
+            preSleepWindowGeometries.removeValue(forKey: closingContext.windowId)
+        }
         let closingWindowIsCrashDiagnostic = closingContext.map { context in
             closeWindowSnapshotPruningCrashDiagnostics(
                 for: context,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1271,6 +1271,66 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertNotEqual(restored.minY, -90, "Changed display geometry should clamp/remap frame")
     }
 
+    func testWakeWindowFrameRestoreDetectsDisplaySleepShrinkByRatio() {
+        let target = CGRect(x: 0, y: 0, width: 1_600, height: 1_000)
+        let shrunkenByWake = CGRect(x: 350, y: 250, width: 800, height: 500)
+
+        XCTAssertTrue(
+            AppDelegate.shouldRestoreWindowFrameAfterWake(
+                currentFrame: shrunkenByWake,
+                targetFrame: target
+            )
+        )
+    }
+
+    func testWakeWindowFrameRestoreIgnoresAlreadyRestoredFrame() {
+        let target = CGRect(x: 0, y: 0, width: 1_600, height: 1_000)
+        let nearlyEqual = CGRect(x: 4, y: 3, width: 1_596, height: 998)
+
+        XCTAssertFalse(
+            AppDelegate.shouldRestoreWindowFrameAfterWake(
+                currentFrame: nearlyEqual,
+                targetFrame: target
+            )
+        )
+    }
+
+    func testWakeWindowFrameRestoreRejectsInvalidTinyFrame() {
+        let target = CGRect(x: 0, y: 0, width: 1_600, height: 1_000)
+        let invalid = CGRect(x: 10, y: 10, width: 120, height: 90)
+
+        XCTAssertFalse(
+            AppDelegate.shouldRestoreWindowFrameAfterWake(
+                currentFrame: invalid,
+                targetFrame: target
+            )
+        )
+    }
+
+    func testWakeWindowFrameRestoreDetectsStableSizeMovedBySystem() {
+        let target = CGRect(x: 100, y: 120, width: 1_000, height: 700)
+        let movedByWake = CGRect(x: 420, y: 320, width: 1_000, height: 700)
+
+        XCTAssertTrue(
+            AppDelegate.shouldRestoreWindowFrameAfterWake(
+                currentFrame: movedByWake,
+                targetFrame: target
+            )
+        )
+    }
+
+    func testWakeWindowFrameRestoreDoesNotFightLargerCurrentFrame() {
+        let target = CGRect(x: 100, y: 120, width: 1_000, height: 700)
+        let largerCurrent = CGRect(x: 100, y: 120, width: 1_120, height: 760)
+
+        XCTAssertFalse(
+            AppDelegate.shouldRestoreWindowFrameAfterWake(
+                currentFrame: largerCurrent,
+                targetFrame: target
+            )
+        )
+    }
+
     func testResolvedSnapshotTerminalScrollbackPrefersCaptured() {
         let resolved = Workspace.resolvedSnapshotTerminalScrollback(
             capturedScrollback: "captured-value",

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1270,6 +1270,66 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertNotEqual(restored.minY, -90, "Changed display geometry should clamp/remap frame")
     }
 
+    func testWakeWindowFrameRestoreDetectsDisplaySleepShrinkByRatio() {
+        let target = CGRect(x: 0, y: 0, width: 1_600, height: 1_000)
+        let shrunkenByWake = CGRect(x: 350, y: 250, width: 800, height: 500)
+
+        XCTAssertTrue(
+            AppDelegate.shouldRestoreWindowFrameAfterWake(
+                currentFrame: shrunkenByWake,
+                targetFrame: target
+            )
+        )
+    }
+
+    func testWakeWindowFrameRestoreIgnoresAlreadyRestoredFrame() {
+        let target = CGRect(x: 0, y: 0, width: 1_600, height: 1_000)
+        let nearlyEqual = CGRect(x: 4, y: 3, width: 1_596, height: 998)
+
+        XCTAssertFalse(
+            AppDelegate.shouldRestoreWindowFrameAfterWake(
+                currentFrame: nearlyEqual,
+                targetFrame: target
+            )
+        )
+    }
+
+    func testWakeWindowFrameRestoreRejectsInvalidTinyFrame() {
+        let target = CGRect(x: 0, y: 0, width: 1_600, height: 1_000)
+        let invalid = CGRect(x: 10, y: 10, width: 120, height: 90)
+
+        XCTAssertFalse(
+            AppDelegate.shouldRestoreWindowFrameAfterWake(
+                currentFrame: invalid,
+                targetFrame: target
+            )
+        )
+    }
+
+    func testWakeWindowFrameRestoreDetectsStableSizeMovedBySystem() {
+        let target = CGRect(x: 100, y: 120, width: 1_000, height: 700)
+        let movedByWake = CGRect(x: 420, y: 320, width: 1_000, height: 700)
+
+        XCTAssertTrue(
+            AppDelegate.shouldRestoreWindowFrameAfterWake(
+                currentFrame: movedByWake,
+                targetFrame: target
+            )
+        )
+    }
+
+    func testWakeWindowFrameRestoreDoesNotFightLargerCurrentFrame() {
+        let target = CGRect(x: 100, y: 120, width: 1_000, height: 700)
+        let largerCurrent = CGRect(x: 100, y: 120, width: 1_120, height: 760)
+
+        XCTAssertFalse(
+            AppDelegate.shouldRestoreWindowFrameAfterWake(
+                currentFrame: largerCurrent,
+                targetFrame: target
+            )
+        )
+    }
+
     func testResolvedSnapshotTerminalScrollbackPrefersCaptured() {
         let resolved = Workspace.resolvedSnapshotTerminalScrollback(
             capturedScrollback: "captured-value",


### PR DESCRIPTION
## Summary

This is a smaller, sleep/wake-focused version of the approach in #4825.

- Capture main-window geometry before screen/session sleep transitions.
- Restore that intended geometry after `screensDidWake`, `didWake`, or session reactivation if AppKit reports a shrunken or displaced frame.
- Use the cached pre-sleep geometry for session snapshots and autosave fingerprints while the wake restore window is active, so transient bad frames are not persisted.
- Include display metadata in the autosave fingerprint when geometry is hashed.

## Why

On macOS, display sleep/wake can cause AppKit to report a temporary constrained window frame. A window that previously filled the visible display can come back much smaller, and the autosave path may persist that transient frame before the user notices.

This patch keeps the scope narrower than #4825: it does not implement full display disconnect/reconnect home tracking. It only protects sleep/wake transitions and keeps the existing session geometry resolver in charge of clamping/remapping.

## Validation

- `git diff --check`
- Added geometry decision tests for ratio-based shrink, stable-size system move, already-restored frames, invalid tiny frames, and larger current frames.

Could not run `xcodebuild test` locally because this machine only has Command Line Tools selected, not a full Xcode installation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785030710&installation_id=133855650&pr_number=6787&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6787&signature=95c0d353a1d78798d3172ce959640aeb27e3a47c80a44945641075db1cd2abc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS sleep/wake window geometry by capturing main-window frames before sleep and restoring them after wake to avoid shrunken or shifted windows. Prevents transient frames from being persisted or used in autosave fingerprints.

- **Bug Fixes**
  - Capture per-window geometry on `screensDidSleep`; schedule restore after `screensDidWake`, `didWake`, and session activation with short delayed retries; clear cached data after a few seconds or on window close.
  - Restore only when `shouldRestoreWindowFrameAfterWake` flags shrink or system move; ignore invalid frames and larger current frames.
  - Use cached pre-sleep geometry for session snapshots and autosave fingerprinting during the wake restore window; include display metadata in the fingerprint.
  - Add tests for shrink-by-ratio, already-restored frames, invalid tiny frames, stable-size moved frames, and larger current frames.

<sup>Written for commit b3be6b7b67d4f2ecc86157683bdacce9afd2da30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

