### PR TITLE
feat: add Fork as an "Open Current Directory in…" target

### DIFF
--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -70,6 +70,7 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
     case cursor
     case devin
     case finder
+    case fork
     case ghostty
     case intellij
     case iterm2
@@ -120,6 +121,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return String(localized: "menu.openInDevin", defaultValue: "Open Current Directory in Devin")
         case .finder:
             return String(localized: "menu.openInFinder", defaultValue: "Open Current Directory in Finder")
+        case .fork:
+            return String(localized: "menu.openInFork", defaultValue: "Open Current Directory in Fork")
         case .ghostty:
             return String(localized: "menu.openInGhostty", defaultValue: "Open Current Directory in Ghostty")
         case .intellij:
@@ -158,6 +161,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return common + ["devin", "cognition"]
         case .finder:
             return common + ["finder", "file", "manager", "reveal"]
+        case .fork:
+            return common + ["fork", "git", "client"]
         case .ghostty:
             return common + ["ghostty", "terminal", "shell"]
         case .intellij:
@@ -256,6 +261,8 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
             return ["/Applications/Devin.app"]
         case .finder:
             return ["/System/Library/CoreServices/Finder.app"]
+        case .fork:
+            return ["/Applications/Fork.app"]
         case .ghostty:
             return ["/Applications/Ghostty.app"]
         case .intellij:

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2816,6 +2816,11 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         XCTAssertTrue(TerminalDirectoryOpenTarget.tower.isAvailable(in: env))
     }
 
+    func testForkDetected() {
+        let env = environment(existingPaths: ["/Applications/Fork.app"])
+        XCTAssertTrue(TerminalDirectoryOpenTarget.fork.isAvailable(in: env))
+    }
+
     func testAvailableTargetsFallbackToApplicationLookupForVSCodeAliasOutsideApplications() {
         let vscodePath = "/Volumes/Tools/Code.app"
         let env = environment(
@@ -2843,6 +2848,18 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
         )
 
         XCTAssertTrue(TerminalDirectoryOpenTarget.tower.isAvailable(in: env))
+    }
+
+    func testForkDetectedViaApplicationLookupOutsideApplications() {
+        let forkPath = "/Volumes/Setapp/Fork.app"
+        let env = environment(
+            existingPaths: [forkPath],
+            applicationPathsByName: [
+                "Fork": forkPath,
+            ]
+        )
+
+        XCTAssertTrue(TerminalDirectoryOpenTarget.fork.isAvailable(in: env))
     }
 
     func testCommandPaletteShortcutsExcludeGenericIDEEntry() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2851,7 +2851,7 @@ final class TerminalDirectoryOpenTargetAvailabilityTests: XCTestCase {
     }
 
     func testForkDetectedViaApplicationLookupOutsideApplications() {
-        let forkPath = "/Volumes/Setapp/Fork.app"
+        let forkPath = "/Volumes/Tools/Fork.app"
         let env = environment(
             existingPaths: [forkPath],
             applicationPathsByName: [


### PR DESCRIPTION
## Summary

**What changed?** Adds **Fork** (the macOS Git GUI client) as an "Open Current Directory in…" target, alongside the existing editor / terminal / Tower targets.

**Why?** cmux already lets you open the focused terminal's working directory in a range of editors, terminals, and the **Tower** Git client. **Fork** is a popular Git client in the same category — this lets users jump straight from a cmux terminal into Fork on the current repo, with zero new UI surface to maintain.

Implementation notes:

- Adds a `.fork` case to `TerminalDirectoryOpenTarget` (`Sources/App/TerminalDirectoryOpenSupport.swift`). The command-palette contributions and the command handlers both iterate `allCases`, so the new target is registered across every entrypoint automatically — no per-surface duplication (consistent with the repo's shared-behavior policy).
- Detected at `/Applications/Fork.app`, `~/Applications/Fork.app`, and via LaunchServices (e.g. Setapp installs), reusing the existing detection path.
- Launches through the shared `NSWorkspace.open` `default` branch in `openFocusedDirectory(_:in:)` — equivalent to `open -a Fork <dir>`, which is exactly how Fork expects to receive a repository path. No special-casing needed.
- Localizes `menu.openInFork` ("Open Current Directory in Fork") across all 19 supported locales, matching the existing Tower string family. `Fork` is a proper noun and is preserved in each locale.

## Testing

- Added `testForkDetected` and `testForkDetectedViaApplicationLookupOutsideApplications` to `TerminalDirectoryOpenTargetAvailabilityTests`, mirroring the existing Tower coverage (standard `/Applications` path + LaunchServices fallback).
- `.fork` is handled in all three exhaustive `switch` statements over `TerminalDirectoryOpenTarget` (`commandPaletteTitle`, `commandPaletteKeywords`, `applicationBundlePathCandidates`); the only other use site (`openFocusedDirectory(_:in:)`) has a `default:` branch that `.fork` correctly falls into.
- ⚠️ **Full local app build / manual verification was not run in my environment** — the Zig toolchain and `GhosttyKit.xcframework` are not set up locally, so `reload.sh` / `xcodebuild` could not complete. The change is pure Swift. Please verify with `./scripts/reload.sh --tag open-in-fork` and confirm the **Open Current Directory in Fork** entry appears in the command palette when a terminal is focused (with `/Applications/Fork.app` installed) and opens the cwd in Fork.

## Demo Video

Not included — I could not produce a local build in this environment (see Testing). The behavior is a new command-palette / menu entry that mirrors the existing **Tower** target exactly.

## Notes

- No changelog edit: `CHANGELOG.md` has no `Unreleased` section and every entry carries a PR number, so it is compiled at release time (via the `/release` flow) from merged PRs rather than hand-edited per PR.

## Checklist

- [ ] I tested the change locally — *unit tests added; full app build not run locally (Zig/GhosttyKit toolchain unavailable in my environment — needs a maintainer/CI build)*
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed — *no docs enumerate the "Open in" targets; changelog is release-time generated (see Notes)*
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785032689&installation_id=133855650&pr_number=6789&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6789&signature=8c446a408970924f32b664e3e7b912c014767319c5411e5a8eaa58ed1159d589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Fork as an “Open Current Directory in…” target so users can jump from a cmux terminal into Fork on the current repo, mirroring the existing Tower integration.

- **New Features**
  - Added `.fork` to `TerminalDirectoryOpenTarget`, so it appears in the command palette and menus automatically.
  - Detects `Fork.app` in `/Applications`, `~/Applications`, and via LaunchServices for alternate install locations; launches via shared `NSWorkspace.open` (equivalent to `open -a Fork <dir>`). Tests cover the standard path and a LaunchServices fallback using a neutral external path (`/Volumes/Tools/Fork.app`).
  - Localized `menu.openInFork` across 19 locales.

<sup>Written for commit 410773a14c77b11168b9556b0a428ac086c2643f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening directories in Fork from the app’s menu and command palette.
  * Enhanced app detection to recognize Fork in common install locations and via fallback lookup.

* **Localization**
  * Added translated menu text for the “Open in Fork” option across multiple languages.

* **Tests**
  * Added coverage for Fork availability detection using both standard and alternate install paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->