### PR TITLE
web: add /pricing page (Free / Pro / Enterprise)

### DIFF
--- a/web/app/[locale]/components/nav-links.tsx
+++ b/web/app/[locale]/components/nav-links.tsx
@@ -32,6 +32,12 @@ export function NavLinks() {
       >
         {t("community")}
       </Link>
+      <Link
+        href="/pricing"
+        className="hover:text-foreground transition-colors"
+      >
+        {t("pricing")}
+      </Link>
       <a
         href="https://github.com/manaflow-ai/cmux"
         target="_blank"

--- a/web/app/[locale]/components/site-footer.tsx
+++ b/web/app/[locale]/components/site-footer.tsx
@@ -14,6 +14,7 @@ export async function SiteFooter() {
     {
       heading: t("product"),
       links: [
+        { label: t("pricing"), href: "/pricing" },
         { label: t("blog"), href: "/blog" },
         { label: t("community"), href: "/community" },
         { label: t("nightly"), href: "/nightly" },

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -137,6 +137,13 @@ export function SiteHeader({
           >
             {t("community")}
           </Link>
+          <Link
+            href="/pricing"
+            onClick={close}
+            className="hover:text-foreground transition-colors py-1"
+          >
+            {t("pricing")}
+          </Link>
           <GitHubStarsBadge location="mobile_drawer" />
           <div className="pt-2">
             <DownloadButton size="sm" location="mobile_drawer" />

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -8,6 +8,10 @@ import { buildAlternates } from "../../../i18n/seo";
 // Pro CTA points at the download today; swap this for the real checkout URL
 // when the billing flow is public.
 const PRO_CTA_URL = DOWNLOAD_URL;
+// Team is per-seat ($35/user/month). Install is still the entry point, so the
+// Team CTA points at the download today; swap for the team checkout URL once
+// the billing flow is public.
+const TEAM_CTA_URL = DOWNLOAD_URL;
 const SALES_EMAIL = "founders@manaflow.com";
 
 // Feature flag: cmux Vault (cloud session backup, cross-session search, and
@@ -41,6 +45,7 @@ export default function PricingPage() {
   const proFeatures = SHOW_VAULT
     ? [...proBaseFeatures.slice(0, 2), ...proVaultFeatures, ...proBaseFeatures.slice(2)]
     : proBaseFeatures;
+  const teamFeatures = t.raw("team.features") as string[];
   const enterpriseFeatures = t.raw("enterprise.features") as string[];
   const compareRows = (t.raw("compare.rows") as CompareRow[]).filter(
     (row) => SHOW_VAULT || !row.vault,
@@ -62,7 +67,7 @@ export default function PricingPage() {
         <h1 className="text-2xl font-medium tracking-tight">{t("title")}</h1>
 
         {/* Tier cards */}
-        <div className="mt-10 grid gap-5 md:grid-cols-3 items-stretch">
+        <div className="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-4 items-stretch">
           {/* Free */}
           <PlanCard
             name={t("free.name")}
@@ -85,6 +90,17 @@ export default function PricingPage() {
             <PrimaryLink href={PRO_CTA_URL}>{t("pro.cta")}</PrimaryLink>
             <p className="mt-5 text-sm font-medium">{t("pro.featuresLead")}</p>
             <FeatureList items={proFeatures} />
+          </PlanCard>
+
+          {/* Team */}
+          <PlanCard
+            name={t("team.name")}
+            price={t("team.price")}
+            period={t("perUserMonth")}
+          >
+            <PrimaryLink href={TEAM_CTA_URL}>{t("team.cta")}</PrimaryLink>
+            <p className="mt-5 text-sm font-medium">{t("team.featuresLead")}</p>
+            <FeatureList items={teamFeatures} />
           </PlanCard>
 
           {/* Enterprise */}
@@ -118,6 +134,10 @@ export default function PricingPage() {
                     price={`${t("pro.price")}${t("perMonth")}`}
                   />
                   <ColumnHead
+                    name={t("team.name")}
+                    price={`${t("team.price")}${t("perUserMonth")}`}
+                  />
+                  <ColumnHead
                     name={t("enterprise.name")}
                     price={t("enterprise.price")}
                   />
@@ -134,6 +154,7 @@ export default function PricingPage() {
                     </th>
                     <CompareCell value={row.free} />
                     <CompareCell value={row.pro} />
+                    <CompareCell value={row.team} />
                     <CompareCell value={row.enterprise} />
                   </tr>
                 ))}
@@ -334,6 +355,7 @@ type CompareRow = {
   label: string;
   free: string;
   pro: string;
+  team: string;
   enterprise: string;
   // Marks a row that only applies once cmux Vault ships (see SHOW_VAULT).
   vault?: boolean;

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -47,9 +47,6 @@ export default function PricingPage() {
     : proBaseFeatures;
   const teamFeatures = t.raw("team.features") as string[];
   const enterpriseFeatures = t.raw("enterprise.features") as string[];
-  const compareRows = (t.raw("compare.rows") as CompareRow[]).filter(
-    (row) => SHOW_VAULT || !row.vault,
-  );
   const sizeRows = t.raw("sizes.rows") as SizeRow[];
   const faqItems = (t.raw("faq.items") as FaqItem[]).filter(
     (item) => SHOW_VAULT || !item.vault,
@@ -66,8 +63,9 @@ export default function PricingPage() {
         {/* Title */}
         <h1 className="text-2xl font-medium tracking-tight">{t("title")}</h1>
 
-        {/* Tier cards */}
-        <div className="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-4 items-stretch">
+        {/* Tier cards. Sticky below the 48px (h-12) site header; lower z-index
+            than the header (z-30) so the header always wins when they overlap. */}
+        <div className="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-4 items-stretch sticky top-12 z-20 bg-background pb-5">
           {/* Free */}
           <PlanCard
             name={t("free.name")}
@@ -117,51 +115,6 @@ export default function PricingPage() {
             <FeatureList items={enterpriseFeatures} />
           </PlanCard>
         </div>
-
-        {/* Compare plans */}
-        <section className="mt-16 border-t border-border pt-10">
-          <h2 className="text-xs font-medium text-muted tracking-tight mb-3">
-            {t("compare.title")}
-          </h2>
-          <div className="mt-4 overflow-x-auto">
-            <table className="w-full border-collapse text-[15px]">
-              <thead>
-                <tr className="border-b border-border">
-                  <th className="py-3 pr-4 text-left align-bottom font-medium min-w-[12rem]" />
-                  <ColumnHead name={t("free.name")} price={t("free.price")} />
-                  <ColumnHead
-                    name={t("pro.name")}
-                    price={`${t("pro.price")}${t("perMonth")}`}
-                  />
-                  <ColumnHead
-                    name={t("team.name")}
-                    price={`${t("team.price")}${t("perUserMonth")}`}
-                  />
-                  <ColumnHead
-                    name={t("enterprise.name")}
-                    price={t("enterprise.price")}
-                  />
-                </tr>
-              </thead>
-              <tbody>
-                {compareRows.map((row, i) => (
-                  <tr key={i} className="border-b border-border">
-                    <th
-                      scope="row"
-                      className="py-3 pr-4 text-left font-normal align-top"
-                    >
-                      {row.label}
-                    </th>
-                    <CompareCell value={row.free} />
-                    <CompareCell value={row.pro} />
-                    <CompareCell value={row.team} />
-                    <CompareCell value={row.enterprise} />
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
 
         {/* Cloud VM sizes */}
         <section className="mt-16 border-t border-border pt-10">
@@ -351,16 +304,6 @@ function SecondaryLink({
   );
 }
 
-type CompareRow = {
-  label: string;
-  free: string;
-  pro: string;
-  team: string;
-  enterprise: string;
-  // Marks a row that only applies once cmux Vault ships (see SHOW_VAULT).
-  vault?: boolean;
-};
-
 type FaqItem = {
   q: string;
   a: string;
@@ -374,32 +317,3 @@ type SizeRow = {
   rate: string;
 };
 
-function ColumnHead({ name, price }: { name: string; price: string }) {
-  return (
-    <th className="px-4 py-3 text-left align-bottom font-medium">
-      {name}
-      <span className="block text-xs font-normal text-muted">{price}</span>
-    </th>
-  );
-}
-
-function CompareCell({ value }: { value: string }) {
-  const base = "px-4 py-3 text-left align-top";
-  if (value === "true") {
-    return (
-      <td className={base}>
-        <span className="inline-flex text-foreground">
-          <CheckIcon inline />
-        </span>
-      </td>
-    );
-  }
-  if (value === "false") {
-    return (
-      <td className={`${base} text-muted`} aria-label="Not included">
-        <span aria-hidden="true">–</span>
-      </td>
-    );
-  }
-  return <td className={`${base} text-[13px] text-muted`}>{value}</td>;
-}

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -47,6 +47,9 @@ export default function PricingPage() {
     : proBaseFeatures;
   const teamFeatures = t.raw("team.features") as string[];
   const enterpriseFeatures = t.raw("enterprise.features") as string[];
+  const compareRows = (t.raw("compare.rows") as CompareRow[]).filter(
+    (row) => SHOW_VAULT || !row.vault,
+  );
   const sizeRows = t.raw("sizes.rows") as SizeRow[];
   const faqItems = (t.raw("faq.items") as FaqItem[]).filter(
     (item) => SHOW_VAULT || !item.vault,
@@ -59,13 +62,12 @@ export default function PricingPage() {
     <div className="min-h-screen">
       <SiteHeader />
 
-      <main className="w-full max-w-5xl mx-auto px-6 py-16 sm:py-20">
+      <main className="w-full max-w-6xl mx-auto px-6 py-16 sm:py-20">
         {/* Title */}
         <h1 className="text-2xl font-medium tracking-tight">{t("title")}</h1>
 
-        {/* Tier cards. Sticky below the 48px (h-12) site header; lower z-index
-            than the header (z-30) so the header always wins when they overlap. */}
-        <div className="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-4 items-stretch sticky top-12 z-20 bg-background pb-5">
+        {/* Tier cards */}
+        <div className="mt-10 grid gap-5 md:grid-cols-2 lg:grid-cols-4 items-stretch">
           {/* Free */}
           <PlanCard
             name={t("free.name")}
@@ -115,6 +117,48 @@ export default function PricingPage() {
             <FeatureList items={enterpriseFeatures} />
           </PlanCard>
         </div>
+
+        {/* Compare plans (header row is sticky under the 48px h-12 site header) */}
+        <section className="mt-16">
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-[15px]">
+              <thead>
+                <tr>
+                  <th className="sticky top-12 z-20 bg-background border-b border-border py-3 pr-4 text-left align-bottom font-medium min-w-[12rem]" />
+                  <ColumnHead name={t("free.name")} price={t("free.price")} />
+                  <ColumnHead
+                    name={t("pro.name")}
+                    price={`${t("pro.price")}${t("perMonth")}`}
+                  />
+                  <ColumnHead
+                    name={t("team.name")}
+                    price={`${t("team.price")}${t("perUserMonth")}`}
+                  />
+                  <ColumnHead
+                    name={t("enterprise.name")}
+                    price={t("enterprise.price")}
+                  />
+                </tr>
+              </thead>
+              <tbody>
+                {compareRows.map((row, i) => (
+                  <tr key={i} className="border-b border-border">
+                    <th
+                      scope="row"
+                      className="py-3 pr-4 text-left font-normal align-top"
+                    >
+                      {row.label}
+                    </th>
+                    <CompareCell value={row.free} />
+                    <CompareCell value={row.pro} />
+                    <CompareCell value={row.team} />
+                    <CompareCell value={row.enterprise} />
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
 
         {/* Cloud VM sizes */}
         <section className="mt-16 border-t border-border pt-10">
@@ -311,9 +355,49 @@ type FaqItem = {
   vault?: boolean;
 };
 
+type CompareRow = {
+  label: string;
+  free: string;
+  pro: string;
+  team: string;
+  enterprise: string;
+  // Marks a row that only applies once cmux Vault ships (see SHOW_VAULT).
+  vault?: boolean;
+};
+
 type SizeRow = {
   size: string;
   use: string;
   rate: string;
 };
+
+function ColumnHead({ name, price }: { name: string; price: string }) {
+  return (
+    <th className="sticky top-12 z-20 bg-background border-b border-border px-4 py-3 text-left align-bottom font-medium">
+      {name}
+      <span className="block text-xs font-normal text-muted">{price}</span>
+    </th>
+  );
+}
+
+function CompareCell({ value }: { value: string }) {
+  const base = "px-4 py-3 text-left align-top";
+  if (value === "true") {
+    return (
+      <td className={base}>
+        <span className="inline-flex text-foreground">
+          <CheckIcon inline />
+        </span>
+      </td>
+    );
+  }
+  if (value === "false") {
+    return (
+      <td className={`${base} text-muted`} aria-label="Not included">
+        <span aria-hidden="true">–</span>
+      </td>
+    );
+  }
+  return <td className={`${base} text-[13px] text-muted`}>{value}</td>;
+}
 

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -118,46 +118,47 @@ export default function PricingPage() {
           </PlanCard>
         </div>
 
-        {/* Compare plans (header row is sticky under the 48px h-12 site header) */}
+        {/* Compare plans. Header row is sticky under the 48px h-12 site header.
+            No overflow-x wrapper: an overflow container becomes a scroll context
+            on both axes and would anchor the sticky header to itself instead of
+            the page. */}
         <section className="mt-16">
-          <div className="overflow-x-auto">
-            <table className="w-full border-collapse text-[15px]">
-              <thead>
-                <tr>
-                  <th className="sticky top-12 z-20 bg-background border-b border-border py-3 pr-4 text-left align-bottom font-medium min-w-[12rem]" />
-                  <ColumnHead name={t("free.name")} price={t("free.price")} />
-                  <ColumnHead
-                    name={t("pro.name")}
-                    price={`${t("pro.price")}${t("perMonth")}`}
-                  />
-                  <ColumnHead
-                    name={t("team.name")}
-                    price={`${t("team.price")}${t("perUserMonth")}`}
-                  />
-                  <ColumnHead
-                    name={t("enterprise.name")}
-                    price={t("enterprise.price")}
-                  />
+          <table className="w-full border-separate border-spacing-0 text-[15px]">
+            <thead>
+              <tr>
+                <th className="sticky top-12 z-20 bg-background border-b border-border py-3 pr-4 text-left align-bottom font-medium min-w-[12rem]" />
+                <ColumnHead name={t("free.name")} price={t("free.price")} />
+                <ColumnHead
+                  name={t("pro.name")}
+                  price={`${t("pro.price")}${t("perMonth")}`}
+                />
+                <ColumnHead
+                  name={t("team.name")}
+                  price={`${t("team.price")}${t("perUserMonth")}`}
+                />
+                <ColumnHead
+                  name={t("enterprise.name")}
+                  price={t("enterprise.price")}
+                />
+              </tr>
+            </thead>
+            <tbody>
+              {compareRows.map((row, i) => (
+                <tr key={i}>
+                  <th
+                    scope="row"
+                    className="border-b border-border py-3 pr-4 text-left font-normal align-top"
+                  >
+                    {row.label}
+                  </th>
+                  <CompareCell value={row.free} />
+                  <CompareCell value={row.pro} />
+                  <CompareCell value={row.team} />
+                  <CompareCell value={row.enterprise} />
                 </tr>
-              </thead>
-              <tbody>
-                {compareRows.map((row, i) => (
-                  <tr key={i} className="border-b border-border">
-                    <th
-                      scope="row"
-                      className="py-3 pr-4 text-left font-normal align-top"
-                    >
-                      {row.label}
-                    </th>
-                    <CompareCell value={row.free} />
-                    <CompareCell value={row.pro} />
-                    <CompareCell value={row.team} />
-                    <CompareCell value={row.enterprise} />
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+              ))}
+            </tbody>
+          </table>
         </section>
 
         {/* Cloud VM sizes */}
@@ -381,7 +382,7 @@ function ColumnHead({ name, price }: { name: string; price: string }) {
 }
 
 function CompareCell({ value }: { value: string }) {
-  const base = "px-4 py-3 text-left align-top";
+  const base = "border-b border-border px-4 py-3 text-left align-top";
   if (value === "true") {
     return (
       <td className={base}>

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -10,6 +10,13 @@ import { buildAlternates } from "../../../i18n/seo";
 const PRO_CTA_URL = DOWNLOAD_URL;
 const SALES_EMAIL = "founders@manaflow.com";
 
+// Feature flag: cmux Vault (cloud session backup, cross-session search, and
+// unlimited cross-machine history) isn't shipped yet. Keep its pricing copy out
+// of the page until it's live. Flip to `true` to surface every Vault entry
+// again: the Pro feature bullets, the compare rows, the FAQ, and the meta
+// description all key off this flag.
+const SHOW_VAULT = false;
+
 export async function generateMetadata({
   params,
 }: {
@@ -19,7 +26,7 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: "pricing" });
   return {
     title: t("metaTitle"),
-    description: t("metaDescription"),
+    description: SHOW_VAULT ? t("metaDescription") : t("metaDescriptionNoVault"),
     alternates: buildAlternates(locale, "/pricing"),
   };
 }
@@ -28,11 +35,20 @@ export default function PricingPage() {
   const t = useTranslations("pricing");
 
   const freeFeatures = t.raw("free.features") as string[];
-  const proFeatures = t.raw("pro.features") as string[];
+  const proBaseFeatures = t.raw("pro.features") as string[];
+  const proVaultFeatures = t.raw("pro.vaultFeatures") as string[];
+  // Vault bullets slot back in right after the Cloud VM compute-hours line.
+  const proFeatures = SHOW_VAULT
+    ? [...proBaseFeatures.slice(0, 2), ...proVaultFeatures, ...proBaseFeatures.slice(2)]
+    : proBaseFeatures;
   const enterpriseFeatures = t.raw("enterprise.features") as string[];
-  const compareRows = t.raw("compare.rows") as CompareRow[];
+  const compareRows = (t.raw("compare.rows") as CompareRow[]).filter(
+    (row) => SHOW_VAULT || !row.vault,
+  );
   const sizeRows = t.raw("sizes.rows") as SizeRow[];
-  const faqItems = t.raw("faq.items") as { q: string; a: string }[];
+  const faqItems = (t.raw("faq.items") as FaqItem[]).filter(
+    (item) => SHOW_VAULT || !item.vault,
+  );
 
   const linkClass =
     "underline underline-offset-2 decoration-border hover:decoration-foreground transition-colors";
@@ -319,6 +335,15 @@ type CompareRow = {
   free: string;
   pro: string;
   enterprise: string;
+  // Marks a row that only applies once cmux Vault ships (see SHOW_VAULT).
+  vault?: boolean;
+};
+
+type FaqItem = {
+  q: string;
+  a: string;
+  // Marks a Vault-specific question (see SHOW_VAULT).
+  vault?: boolean;
 };
 
 type SizeRow = {

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -1,0 +1,358 @@
+import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
+import { SiteHeader } from "../components/site-header";
+import { DOWNLOAD_URL } from "../../lib/download";
+import { buildAlternates } from "../../../i18n/seo";
+
+// Where the in-app Pro upgrade lives. Install is still the entry point, so the
+// Pro CTA points at the download today; swap this for the real checkout URL
+// when the billing flow is public.
+const PRO_CTA_URL = DOWNLOAD_URL;
+const SALES_EMAIL = "founders@manaflow.com";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "pricing" });
+  return {
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    alternates: buildAlternates(locale, "/pricing"),
+  };
+}
+
+export default function PricingPage() {
+  const t = useTranslations("pricing");
+
+  const freeFeatures = t.raw("free.features") as string[];
+  const proFeatures = t.raw("pro.features") as string[];
+  const enterpriseFeatures = t.raw("enterprise.features") as string[];
+  const compareRows = t.raw("compare.rows") as CompareRow[];
+  const sizeRows = t.raw("sizes.rows") as SizeRow[];
+  const faqItems = t.raw("faq.items") as { q: string; a: string }[];
+
+  const linkClass =
+    "underline underline-offset-2 decoration-border hover:decoration-foreground transition-colors";
+
+  return (
+    <div className="min-h-screen">
+      <SiteHeader />
+
+      <main className="w-full max-w-5xl mx-auto px-6 py-16 sm:py-20">
+        {/* Title */}
+        <h1 className="text-2xl font-medium tracking-tight">{t("title")}</h1>
+
+        {/* Tier cards */}
+        <div className="mt-10 grid gap-5 md:grid-cols-3 items-stretch">
+          {/* Free */}
+          <PlanCard
+            name={t("free.name")}
+            price={t("free.price")}
+            period={t("perMonth")}
+          >
+            <PrimaryLink href={DOWNLOAD_URL}>{t("free.cta")}</PrimaryLink>
+            <p className="mt-5 text-sm font-medium text-muted">
+              {t("free.featuresLead")}
+            </p>
+            <FeatureList items={freeFeatures} muted />
+          </PlanCard>
+
+          {/* Pro */}
+          <PlanCard
+            name={t("pro.name")}
+            price={t("pro.price")}
+            period={t("perMonth")}
+          >
+            <PrimaryLink href={PRO_CTA_URL}>{t("pro.cta")}</PrimaryLink>
+            <p className="mt-5 text-sm font-medium">{t("pro.featuresLead")}</p>
+            <FeatureList items={proFeatures} />
+          </PlanCard>
+
+          {/* Enterprise */}
+          <PlanCard
+            name={t("enterprise.name")}
+            price={t("enterprise.price")}
+          >
+            <SecondaryLink href={`mailto:${SALES_EMAIL}`}>
+              {t("enterprise.cta")}
+            </SecondaryLink>
+            <p className="mt-5 text-sm font-medium">
+              {t("enterprise.featuresLead")}
+            </p>
+            <FeatureList items={enterpriseFeatures} />
+          </PlanCard>
+        </div>
+
+        {/* Compare plans */}
+        <section className="mt-16 border-t border-border pt-10">
+          <h2 className="text-xs font-medium text-muted tracking-tight mb-3">
+            {t("compare.title")}
+          </h2>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full border-collapse text-[15px]">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="py-3 pr-4 text-left align-bottom font-medium min-w-[12rem]" />
+                  <ColumnHead name={t("free.name")} price={t("free.price")} />
+                  <ColumnHead
+                    name={t("pro.name")}
+                    price={`${t("pro.price")}${t("perMonth")}`}
+                  />
+                  <ColumnHead
+                    name={t("enterprise.name")}
+                    price={t("enterprise.price")}
+                  />
+                </tr>
+              </thead>
+              <tbody>
+                {compareRows.map((row, i) => (
+                  <tr key={i} className="border-b border-border">
+                    <th
+                      scope="row"
+                      className="py-3 pr-4 text-left font-normal align-top"
+                    >
+                      {row.label}
+                    </th>
+                    <CompareCell value={row.free} />
+                    <CompareCell value={row.pro} />
+                    <CompareCell value={row.enterprise} />
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Cloud VM sizes */}
+        <section className="mt-16 border-t border-border pt-10">
+          <h2 className="text-xs font-medium text-muted tracking-tight mb-3">
+            {t("sizes.title")}
+          </h2>
+          <p className="text-[15px] text-muted max-w-2xl">{t("sizes.body")}</p>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full border-collapse text-[15px]">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="py-3 pr-4 text-left align-bottom font-medium min-w-[10rem]">
+                    {t("sizes.colSize")}
+                  </th>
+                  <th className="px-4 py-3 text-left align-bottom font-medium">
+                    {t("sizes.colUse")}
+                  </th>
+                  <th className="px-4 py-3 text-left align-bottom font-medium whitespace-nowrap">
+                    {t("sizes.colRate")}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {sizeRows.map((row, i) => (
+                  <tr key={i} className="border-b border-border">
+                    <th
+                      scope="row"
+                      className="py-3 pr-4 text-left font-normal align-top whitespace-nowrap"
+                    >
+                      {row.size}
+                    </th>
+                    <td className="px-4 py-3 text-left align-top text-muted">
+                      {row.use}
+                    </td>
+                    <td className="px-4 py-3 text-left align-top whitespace-nowrap">
+                      {row.rate}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="mt-16 border-t border-border pt-10">
+          <h2 className="text-xs font-medium text-muted tracking-tight mb-3">
+            {t("faq.title")}
+          </h2>
+          <div
+            className="space-y-5 text-[15px] max-w-2xl"
+            style={{ lineHeight: 1.5 }}
+          >
+            {faqItems.map((item, i) => (
+              <div key={i}>
+                <p className="font-medium mb-1">{item.q}</p>
+                <p className="text-muted">{item.a}</p>
+              </div>
+            ))}
+          </div>
+          <p className="mt-8 text-[15px] text-muted">
+            {t.rich("help", {
+              discord: (chunks) => (
+                <a
+                  href="https://discord.gg/xsgFEVrWCZ"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={linkClass}
+                >
+                  {chunks}
+                </a>
+              ),
+              github: (chunks) => (
+                <a
+                  href="https://github.com/manaflow-ai/cmux"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={linkClass}
+                >
+                  {chunks}
+                </a>
+              ),
+              email: (chunks) => (
+                <a href="mailto:founders@manaflow.ai" className={linkClass}>
+                  {chunks}
+                </a>
+              ),
+            })}
+          </p>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function PlanCard({
+  name,
+  price,
+  period,
+  children,
+}: {
+  name: string;
+  price: string;
+  period?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex h-full flex-col border border-border p-6">
+      <h2 className="text-sm font-medium tracking-tight">{name}</h2>
+      <div className="mt-3 flex items-baseline gap-1.5">
+        <span className="text-3xl font-medium tracking-tight">{price}</span>
+        {period ? <span className="text-sm text-muted">{period}</span> : null}
+      </div>
+      <div className="mt-6">{children}</div>
+    </div>
+  );
+}
+
+function FeatureList({ items, muted }: { items: string[]; muted?: boolean }) {
+  return (
+    <ul
+      className={`mt-4 space-y-2.5 text-[15px] leading-relaxed ${
+        muted ? "text-muted" : ""
+      }`}
+    >
+      {items.map((item, i) => (
+        <li key={i} className="flex gap-2.5">
+          <CheckIcon />
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function CheckIcon({ inline }: { inline?: boolean }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={inline ? "shrink-0" : "mt-1 shrink-0 text-muted"}
+      aria-hidden="true"
+    >
+      <path d="M20 6L9 17l-5-5" />
+    </svg>
+  );
+}
+
+function PrimaryLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      className="inline-flex w-full items-center justify-center whitespace-nowrap bg-foreground px-5 py-2.5 text-[15px] font-medium hover:opacity-85 transition-opacity"
+      style={{ color: "var(--background)", textDecoration: "none" }}
+    >
+      {children}
+    </a>
+  );
+}
+
+function SecondaryLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      className="inline-flex w-full items-center justify-center whitespace-nowrap border border-border px-5 py-2.5 text-[15px] font-medium text-foreground hover:bg-code-bg transition-colors"
+    >
+      {children}
+    </a>
+  );
+}
+
+type CompareRow = {
+  label: string;
+  free: string;
+  pro: string;
+  enterprise: string;
+};
+
+type SizeRow = {
+  size: string;
+  use: string;
+  rate: string;
+};
+
+function ColumnHead({ name, price }: { name: string; price: string }) {
+  return (
+    <th className="px-4 py-3 text-left align-bottom font-medium">
+      {name}
+      <span className="block text-xs font-normal text-muted">{price}</span>
+    </th>
+  );
+}
+
+function CompareCell({ value }: { value: string }) {
+  const base = "px-4 py-3 text-left align-top";
+  if (value === "true") {
+    return (
+      <td className={base}>
+        <span className="inline-flex text-foreground">
+          <CheckIcon inline />
+        </span>
+      </td>
+    );
+  }
+  if (value === "false") {
+    return (
+      <td className={`${base} text-muted`} aria-label="Not included">
+        <span aria-hidden="true">–</span>
+      </td>
+    );
+  }
+  return <td className={`${base} text-[13px] text-muted`}>{value}</td>;
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -46,6 +46,7 @@
     "blog": "Blog",
     "changelog": "Changelog",
     "community": "Community",
+    "pricing": "Pricing",
     "github": "GitHub"
   },
   "footer": {
@@ -55,6 +56,7 @@
     "social": "Social",
     "blog": "Blog",
     "community": "Community",
+    "pricing": "Pricing",
     "docs": "Docs",
     "changelog": "Changelog",
     "privacy": "Privacy",
@@ -70,6 +72,231 @@
     "assets": "Assets",
     "openSource": "Open source",
     "guides": "Guides"
+  },
+  "pricing": {
+    "metaTitle": "Pricing — cmux",
+    "metaDescription": "cmux is a free, open source macOS terminal for AI coding agents. Upgrade to Pro for Cloud VMs, cmux Vault session backup, and a model gateway. Enterprise adds SSO and self-hosting.",
+    "title": "Pricing",
+    "perMonth": "/month",
+    "free": {
+      "name": "Free",
+      "price": "$0",
+      "cta": "Download for Mac",
+      "featuresLead": "Includes:",
+      "features": [
+        "Native macOS terminal built on Ghostty, fully open source",
+        "Run Claude Code, Codex, Gemini, and any CLI agent with your own keys",
+        "Vertical tabs, workspaces, split panes, and completion notifications",
+        "Browser panels, a scriptable socket API, and custom skills",
+        "Local session history and a one-time Cloud VM trial",
+        "Community support on Discord and GitHub"
+      ]
+    },
+    "pro": {
+      "name": "Pro",
+      "price": "$30",
+      "cta": "Get Pro",
+      "featuresLead": "Everything in Free, plus:",
+      "features": [
+        "Cloud agents on Cloud VMs in isolated remote sandboxes",
+        "20 active compute-hours per month on a 4 vCPU / 16 GB VM, then usage-based",
+        "cmux Vault: every session backed up to the cloud and searchable",
+        "Unlimited session history across all your machines",
+        "Model gateway: route across providers with usage and cost analytics",
+        "Hosted networking to reach your Mac from the iOS app, no Tailscale setup",
+        "The cmux iOS app and email support"
+      ]
+    },
+    "enterprise": {
+      "name": "Enterprise",
+      "price": "Custom",
+      "cta": "Contact sales",
+      "featuresLead": "Everything in Pro, plus:",
+      "features": [
+        "Self-hosted Cloud execution and networking, so nothing leaves your network",
+        "Self-hosted model gateway with org-wide usage and cost analytics",
+        "SSO and SAML sign-in",
+        "Centralized admin and shared team rules",
+        "Audit logs for terminal sessions, network requests, and browser activity",
+        "Committed cloud usage and volume pricing",
+        "SOC 2 and an SLA, with dedicated support"
+      ]
+    },
+    "compare": {
+      "title": "Compare plans",
+      "rows": [
+        {
+          "label": "Native macOS terminal, open source",
+          "free": "true",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "Local CLI agents with your own keys",
+          "free": "true",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "Vertical tabs, splits, notifications, socket API",
+          "free": "true",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "Session history",
+          "free": "Local",
+          "pro": "Unlimited",
+          "enterprise": "Unlimited"
+        },
+        {
+          "label": "cmux Vault: cloud session backup",
+          "free": "false",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "Search across all your sessions",
+          "free": "false",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "Cloud agents on Cloud VMs",
+          "free": "1 VM trial",
+          "pro": "20 hrs/mo, then usage-based",
+          "enterprise": "Committed usage"
+        },
+        {
+          "label": "Concurrent Cloud VMs",
+          "free": "1",
+          "pro": "Usage-based",
+          "enterprise": "Custom"
+        },
+        {
+          "label": "Model gateway: routing and usage analytics",
+          "free": "false",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "iOS app",
+          "free": "false",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "Networking to reach your Mac",
+          "free": "Bring your own",
+          "pro": "Hosted",
+          "enterprise": "Self-hosted"
+        },
+        {
+          "label": "SSO and SAML sign-in",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "Self-hosted and air-gapped execution",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "Centralized admin and shared team rules",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "Audit logs: sessions, network, browser",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "Committed usage and volume pricing",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "SOC 2 and an SLA",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "Support",
+          "free": "Community",
+          "pro": "Email",
+          "enterprise": "Dedicated"
+        }
+      ]
+    },
+    "sizes": {
+      "title": "Cloud VM sizes",
+      "body": "Pick a VM size per agent. You are billed per active compute-hour, and idle VMs suspend automatically. Pro includes 20 hours per month on the 4 vCPU / 16 GB size.",
+      "colSize": "Size",
+      "colUse": "Best for",
+      "colRate": "Per active hour",
+      "rows": [
+        {
+          "size": "2 vCPU / 8 GB",
+          "use": "Light agents and quick tasks",
+          "rate": "$0.20"
+        },
+        {
+          "size": "4 vCPU / 16 GB",
+          "use": "Standard development",
+          "rate": "$0.40"
+        },
+        {
+          "size": "8 vCPU / 32 GB",
+          "use": "Heavy builds and parallel agents",
+          "rate": "$0.80"
+        }
+      ]
+    },
+    "help": "Questions? Join our <discord>Discord</discord>, open a <github>GitHub issue</github>, or <email>email us</email>.",
+    "faq": {
+      "title": "FAQ",
+      "items": [
+        {
+          "q": "Is the terminal really free?",
+          "a": "Yes. The macOS app is open source and free forever. Local agents run with your own API keys at no cost to you. You only pay when you run agents on Cloud VMs."
+        },
+        {
+          "q": "What are Cloud VMs?",
+          "a": "Remote Linux sandboxes where agents clone repositories, run commands, and open pull requests in the cloud, without touching your machine. They cover parallel work, background jobs, and PR review. Idle VMs suspend automatically, so you are only billed for active compute-hours."
+        },
+        {
+          "q": "What is cmux Vault?",
+          "a": "Vault backs up every terminal session to the cloud and lets you search across all of them, with unlimited history across your machines. Free keeps history locally on each machine; Pro adds cloud backup and search."
+        },
+        {
+          "q": "What is the model gateway?",
+          "a": "A hosted gateway that routes each request to a strong model across providers and gives you usage and cost analytics in one place. Bring your own provider keys. Enterprise can self-host the gateway for org-wide control."
+        },
+        {
+          "q": "Do I still need Tailscale for the iOS app?",
+          "a": "You can bring your own networking, like Tailscale, on any plan. Pro adds hosted networking so the iOS app reaches your Mac with no setup, and Enterprise can self-host it."
+        },
+        {
+          "q": "How does billing work?",
+          "a": "Pro is $30 per month and includes 20 active compute-hours per month on the 4 vCPU / 16 GB Cloud VM. Beyond that, cloud usage is billed per active compute-hour by VM size (see Cloud VM sizes above). Idle VMs suspend automatically, and running agents in parallel just uses more hours. The terminal and local agents stay free."
+        },
+        {
+          "q": "Can I self-host the cloud?",
+          "a": "Yes, on Enterprise. Run agent execution on your own infrastructure or fully air-gapped, so source code never leaves your network."
+        },
+        {
+          "q": "Do you have a team plan?",
+          "a": "Not yet. Pro covers individuals today, and Enterprise covers organizations that need SSO, admin controls, and self-hosting. Reach out if you have team needs."
+        }
+      ]
+    }
   },
   "home": {
     "taglinePrefix": "The terminal built for ",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -79,6 +79,7 @@
     "metaDescriptionNoVault": "cmux is a free, open source macOS terminal for AI coding agents. Upgrade to Pro for Cloud VMs and a model gateway. Enterprise adds SSO and self-hosting.",
     "title": "Pricing",
     "perMonth": "/month",
+    "perUserMonth": "/user/month",
     "free": {
       "name": "Free",
       "price": "$0",
@@ -110,11 +111,25 @@
         "Unlimited session history across all your machines"
       ]
     },
+    "team": {
+      "name": "Team",
+      "price": "$35",
+      "cta": "Start a team",
+      "featuresLead": "Everything in Pro, plus:",
+      "features": [
+        "Unified billing: one invoice for the whole team",
+        "Centralized seat management: add and remove members anytime",
+        "Pooled Cloud VM compute hours shared across the team",
+        "Shared team rules, settings, and workspace templates",
+        "Team-wide model gateway with per-member usage and cost analytics",
+        "Centralized admin and priority email support"
+      ]
+    },
     "enterprise": {
       "name": "Enterprise",
       "price": "Custom",
       "cta": "Contact sales",
-      "featuresLead": "Everything in Pro, plus:",
+      "featuresLead": "Everything in Team, plus:",
       "features": [
         "Self-hosted Cloud execution and networking, so nothing leaves your network",
         "Self-hosted model gateway with org-wide usage and cost analytics",
@@ -132,24 +147,28 @@
           "label": "Native macOS terminal, open source",
           "free": "true",
           "pro": "true",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "Local CLI agents with your own keys",
           "free": "true",
           "pro": "true",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "Vertical tabs, splits, notifications, socket API",
           "free": "true",
           "pro": "true",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "Session history",
           "free": "Local",
           "pro": "Unlimited",
+          "team": "Unlimited",
           "enterprise": "Unlimited",
           "vault": true
         },
@@ -157,6 +176,7 @@
           "label": "cmux Vault: cloud session backup",
           "free": "false",
           "pro": "true",
+          "team": "true",
           "enterprise": "true",
           "vault": true
         },
@@ -164,6 +184,7 @@
           "label": "Search across all your sessions",
           "free": "false",
           "pro": "true",
+          "team": "true",
           "enterprise": "true",
           "vault": true
         },
@@ -171,72 +192,91 @@
           "label": "Cloud agents on Cloud VMs",
           "free": "1 VM trial",
           "pro": "20 hrs/mo, then usage-based",
+          "team": "Pooled, usage-based",
           "enterprise": "Committed usage"
         },
         {
           "label": "Concurrent Cloud VMs",
           "free": "1",
           "pro": "Usage-based",
+          "team": "Usage-based",
           "enterprise": "Custom"
         },
         {
           "label": "Model gateway: routing and usage analytics",
           "free": "false",
           "pro": "true",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "iOS app",
           "free": "false",
           "pro": "true",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "Networking to reach your Mac",
           "free": "Bring your own",
           "pro": "Hosted",
+          "team": "Hosted",
           "enterprise": "Self-hosted"
+        },
+        {
+          "label": "Unified billing and seat management",
+          "free": "false",
+          "pro": "false",
+          "team": "true",
+          "enterprise": "true"
         },
         {
           "label": "SSO and SAML sign-in",
           "free": "false",
           "pro": "false",
+          "team": "false",
           "enterprise": "true"
         },
         {
           "label": "Self-hosted and air-gapped execution",
           "free": "false",
           "pro": "false",
+          "team": "false",
           "enterprise": "true"
         },
         {
           "label": "Centralized admin and shared team rules",
           "free": "false",
           "pro": "false",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "Audit logs: sessions, network, browser",
           "free": "false",
           "pro": "false",
+          "team": "false",
           "enterprise": "true"
         },
         {
           "label": "Committed usage and volume pricing",
           "free": "false",
           "pro": "false",
+          "team": "false",
           "enterprise": "true"
         },
         {
           "label": "SOC 2 and an SLA",
           "free": "false",
           "pro": "false",
+          "team": "false",
           "enterprise": "true"
         },
         {
           "label": "Support",
           "free": "Community",
           "pro": "Email",
+          "team": "Priority",
           "enterprise": "Dedicated"
         }
       ]
@@ -300,7 +340,7 @@
         },
         {
           "q": "Do you have a team plan?",
-          "a": "Not yet. Pro covers individuals today, and Enterprise covers organizations that need SSO, admin controls, and self-hosting. Reach out if you have team needs."
+          "a": "Yes. Team is $35 per user per month: unified billing for the whole team, centralized seat management, pooled Cloud VM hours, and shared team rules. Enterprise adds SSO, self-hosting, and audit logs."
         }
       ]
     }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -76,6 +76,7 @@
   "pricing": {
     "metaTitle": "Pricing — cmux",
     "metaDescription": "cmux is a free, open source macOS terminal for AI coding agents. Upgrade to Pro for Cloud VMs, cmux Vault session backup, and a model gateway. Enterprise adds SSO and self-hosting.",
+    "metaDescriptionNoVault": "cmux is a free, open source macOS terminal for AI coding agents. Upgrade to Pro for Cloud VMs and a model gateway. Enterprise adds SSO and self-hosting.",
     "title": "Pricing",
     "perMonth": "/month",
     "free": {
@@ -100,11 +101,13 @@
       "features": [
         "Cloud agents on Cloud VMs in isolated remote sandboxes",
         "20 active compute-hours per month on a 4 vCPU / 16 GB VM, then usage-based",
-        "cmux Vault: every session backed up to the cloud and searchable",
-        "Unlimited session history across all your machines",
         "Model gateway: route across providers with usage and cost analytics",
         "Hosted networking to reach your Mac from the iOS app, no Tailscale setup",
         "The cmux iOS app and email support"
+      ],
+      "vaultFeatures": [
+        "cmux Vault: every session backed up to the cloud and searchable",
+        "Unlimited session history across all your machines"
       ]
     },
     "enterprise": {
@@ -147,19 +150,22 @@
           "label": "Session history",
           "free": "Local",
           "pro": "Unlimited",
-          "enterprise": "Unlimited"
+          "enterprise": "Unlimited",
+          "vault": true
         },
         {
           "label": "cmux Vault: cloud session backup",
           "free": "false",
           "pro": "true",
-          "enterprise": "true"
+          "enterprise": "true",
+          "vault": true
         },
         {
           "label": "Search across all your sessions",
           "free": "false",
           "pro": "true",
-          "enterprise": "true"
+          "enterprise": "true",
+          "vault": true
         },
         {
           "label": "Cloud agents on Cloud VMs",
@@ -273,7 +279,8 @@
         },
         {
           "q": "What is cmux Vault?",
-          "a": "Vault backs up every terminal session to the cloud and lets you search across all of them, with unlimited history across your machines. Free keeps history locally on each machine; Pro adds cloud backup and search."
+          "a": "Vault backs up every terminal session to the cloud and lets you search across all of them, with unlimited history across your machines. Free keeps history locally on each machine; Pro adds cloud backup and search.",
+          "vault": true
         },
         {
           "q": "What is the model gateway?",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -79,6 +79,7 @@
     "metaDescriptionNoVault": "cmux はAIコーディングエージェント向けの無料・オープンソースの macOS ターミナルです。Pro では Cloud VM とモデルゲートウェイが使えます。Enterprise は SSO とセルフホストに対応します。",
     "title": "料金",
     "perMonth": "/月",
+    "perUserMonth": "/ユーザー/月",
     "free": {
       "name": "Free",
       "price": "$0",
@@ -110,11 +111,25 @@
         "すべてのマシンをまたいだ無制限のセッション履歴"
       ]
     },
+    "team": {
+      "name": "Team",
+      "price": "$35",
+      "cta": "チームを始める",
+      "featuresLead": "Pro のすべてに加えて:",
+      "features": [
+        "一元請求: チーム全体をまとめて1つの請求書に",
+        "シート管理: メンバーをいつでも追加・削除",
+        "チームで共有する Cloud VM のプール計算時間",
+        "共有のチームルール、設定、ワークスペーステンプレート",
+        "メンバーごとの使用量・コスト分析付きのチーム全体モデルゲートウェイ",
+        "一元管理と優先メールサポート"
+      ]
+    },
     "enterprise": {
       "name": "Enterprise",
       "price": "カスタム",
       "cta": "営業に問い合わせ",
-      "featuresLead": "Pro のすべてに加えて:",
+      "featuresLead": "Team のすべてに加えて:",
       "features": [
         "セルフホストのクラウド実行とネットワーク、ネットワーク外に何も出ません",
         "組織全体の使用量・コスト分析を備えたセルフホストのモデルゲートウェイ",
@@ -132,24 +147,28 @@
           "label": "ネイティブ macOS ターミナル、オープンソース",
           "free": "true",
           "pro": "true",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "自分のキーで使うローカル CLI エージェント",
           "free": "true",
           "pro": "true",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "縦型タブ、分割、通知、ソケット API",
           "free": "true",
           "pro": "true",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "セッション履歴",
           "free": "ローカル",
           "pro": "無制限",
+          "team": "無制限",
           "enterprise": "無制限",
           "vault": true
         },
@@ -157,6 +176,7 @@
           "label": "cmux Vault: クラウドセッションバックアップ",
           "free": "false",
           "pro": "true",
+          "team": "true",
           "enterprise": "true",
           "vault": true
         },
@@ -164,6 +184,7 @@
           "label": "すべてのセッションを横断検索",
           "free": "false",
           "pro": "true",
+          "team": "true",
           "enterprise": "true",
           "vault": true
         },
@@ -171,72 +192,91 @@
           "label": "Cloud VM 上のクラウドエージェント",
           "free": "VM 1台トライアル",
           "pro": "月20時間、以降従量課金",
+          "team": "プール制・従量課金",
           "enterprise": "コミット利用"
         },
         {
           "label": "同時 Cloud VM 数",
           "free": "1",
           "pro": "従量制",
+          "team": "従量制",
           "enterprise": "カスタム"
         },
         {
           "label": "モデルゲートウェイ: ルーティングと使用量分析",
           "free": "false",
           "pro": "true",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "iOS アプリ",
           "free": "false",
           "pro": "true",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "Mac に接続するネットワーク",
           "free": "持ち込み",
           "pro": "ホスト型",
+          "team": "ホスト型",
           "enterprise": "セルフホスト"
+        },
+        {
+          "label": "一元請求とシート管理",
+          "free": "false",
+          "pro": "false",
+          "team": "true",
+          "enterprise": "true"
         },
         {
           "label": "SSO と SAML サインイン",
           "free": "false",
           "pro": "false",
+          "team": "false",
           "enterprise": "true"
         },
         {
           "label": "セルフホストとエアギャップ実行",
           "free": "false",
           "pro": "false",
+          "team": "false",
           "enterprise": "true"
         },
         {
           "label": "一元管理と共有チームルール",
           "free": "false",
           "pro": "false",
+          "team": "true",
           "enterprise": "true"
         },
         {
           "label": "監査ログ: セッション、ネットワーク、ブラウザ",
           "free": "false",
           "pro": "false",
+          "team": "false",
           "enterprise": "true"
         },
         {
           "label": "コミット利用とボリューム価格",
           "free": "false",
           "pro": "false",
+          "team": "false",
           "enterprise": "true"
         },
         {
           "label": "SOC 2 と SLA",
           "free": "false",
           "pro": "false",
+          "team": "false",
           "enterprise": "true"
         },
         {
           "label": "サポート",
           "free": "コミュニティ",
           "pro": "メール",
+          "team": "優先",
           "enterprise": "専任"
         }
       ]
@@ -300,7 +340,7 @@
         },
         {
           "q": "チームプランはありますか?",
-          "a": "現時点ではまだありません。Pro は個人向け、Enterprise は SSO、管理機能、セルフホストが必要な組織向けです。チームでのニーズがあればお問い合わせください。"
+          "a": "はい。Team は1ユーザーあたり月額 $35 です。チーム全体の一元請求、シート管理、Cloud VM 時間のプール、共有チームルールが含まれます。Enterprise では SSO、セルフホスト、監査ログが追加されます。"
         }
       ]
     }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -46,6 +46,7 @@
     "blog": "ブログ",
     "changelog": "変更履歴",
     "community": "コミュニティ",
+    "pricing": "料金",
     "github": "GitHub"
   },
   "footer": {
@@ -53,6 +54,7 @@
     "resources": "リソース",
     "legal": "法的事項",
     "social": "ソーシャル",
+    "pricing": "料金",
     "blog": "ブログ",
     "community": "コミュニティ",
     "docs": "ドキュメント",
@@ -70,6 +72,231 @@
     "assets": "アセット",
     "openSource": "オープンソース",
     "guides": "ガイド"
+  },
+  "pricing": {
+    "metaTitle": "料金 — cmux",
+    "metaDescription": "cmux はAIコーディングエージェント向けの無料・オープンソースの macOS ターミナルです。Pro では Cloud VM、cmux Vault によるセッションバックアップ、モデルゲートウェイが使えます。Enterprise は SSO とセルフホストに対応します。",
+    "title": "料金",
+    "perMonth": "/月",
+    "free": {
+      "name": "Free",
+      "price": "$0",
+      "cta": "Mac版をダウンロード",
+      "featuresLead": "含まれるもの:",
+      "features": [
+        "Ghostty 上に構築された、完全オープンソースのネイティブ macOS ターミナル",
+        "Claude Code、Codex、Gemini など任意の CLI エージェントを自分のキーで実行",
+        "縦型タブ、ワークスペース、分割ペイン、完了通知",
+        "ブラウザパネル、スクリプト可能なソケット API、カスタムスキル",
+        "ローカルのセッション履歴と Cloud VM の1回限りのトライアル",
+        "Discord と GitHub でのコミュニティサポート"
+      ]
+    },
+    "pro": {
+      "name": "Pro",
+      "price": "$30",
+      "cta": "Pro を入手",
+      "featuresLead": "Free のすべてに加えて:",
+      "features": [
+        "分離されたリモートサンドボックスの Cloud VM 上で動くクラウドエージェント",
+        "4 vCPU / 16 GB の VM で毎月20時間のアクティブ計算時間、超過分は従量課金",
+        "cmux Vault: すべてのセッションをクラウドにバックアップし検索可能に",
+        "すべてのマシンをまたいだ無制限のセッション履歴",
+        "モデルゲートウェイ: 複数プロバイダーへのルーティングと使用量・コスト分析",
+        "iOS アプリから Mac に接続するホスト型ネットワーク、Tailscale の設定不要",
+        "cmux iOS アプリとメールサポート"
+      ]
+    },
+    "enterprise": {
+      "name": "Enterprise",
+      "price": "カスタム",
+      "cta": "営業に問い合わせ",
+      "featuresLead": "Pro のすべてに加えて:",
+      "features": [
+        "セルフホストのクラウド実行とネットワーク、ネットワーク外に何も出ません",
+        "組織全体の使用量・コスト分析を備えたセルフホストのモデルゲートウェイ",
+        "SSO と SAML サインイン",
+        "一元管理と共有チームルール",
+        "ターミナルセッション、ネットワークリクエスト、ブラウザ操作の監査ログ",
+        "コミット型のクラウド利用とボリューム価格",
+        "SOC 2 と SLA、専任サポート付き"
+      ]
+    },
+    "compare": {
+      "title": "プラン比較",
+      "rows": [
+        {
+          "label": "ネイティブ macOS ターミナル、オープンソース",
+          "free": "true",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "自分のキーで使うローカル CLI エージェント",
+          "free": "true",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "縦型タブ、分割、通知、ソケット API",
+          "free": "true",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "セッション履歴",
+          "free": "ローカル",
+          "pro": "無制限",
+          "enterprise": "無制限"
+        },
+        {
+          "label": "cmux Vault: クラウドセッションバックアップ",
+          "free": "false",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "すべてのセッションを横断検索",
+          "free": "false",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "Cloud VM 上のクラウドエージェント",
+          "free": "VM 1台トライアル",
+          "pro": "月20時間、以降従量課金",
+          "enterprise": "コミット利用"
+        },
+        {
+          "label": "同時 Cloud VM 数",
+          "free": "1",
+          "pro": "従量制",
+          "enterprise": "カスタム"
+        },
+        {
+          "label": "モデルゲートウェイ: ルーティングと使用量分析",
+          "free": "false",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "iOS アプリ",
+          "free": "false",
+          "pro": "true",
+          "enterprise": "true"
+        },
+        {
+          "label": "Mac に接続するネットワーク",
+          "free": "持ち込み",
+          "pro": "ホスト型",
+          "enterprise": "セルフホスト"
+        },
+        {
+          "label": "SSO と SAML サインイン",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "セルフホストとエアギャップ実行",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "一元管理と共有チームルール",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "監査ログ: セッション、ネットワーク、ブラウザ",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "コミット利用とボリューム価格",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "SOC 2 と SLA",
+          "free": "false",
+          "pro": "false",
+          "enterprise": "true"
+        },
+        {
+          "label": "サポート",
+          "free": "コミュニティ",
+          "pro": "メール",
+          "enterprise": "専任"
+        }
+      ]
+    },
+    "sizes": {
+      "title": "Cloud VM サイズ",
+      "body": "エージェントごとに VM サイズを選べます。アクティブな計算時間に対して課金され、アイドルの VM は自動的に一時停止します。Pro には 4 vCPU / 16 GB サイズで毎月20時間が含まれます。",
+      "colSize": "サイズ",
+      "colUse": "おすすめ用途",
+      "colRate": "アクティブ1時間あたり",
+      "rows": [
+        {
+          "size": "2 vCPU / 8 GB",
+          "use": "軽いエージェントと短いタスク",
+          "rate": "$0.20"
+        },
+        {
+          "size": "4 vCPU / 16 GB",
+          "use": "標準的な開発",
+          "rate": "$0.40"
+        },
+        {
+          "size": "8 vCPU / 32 GB",
+          "use": "重いビルドと並列エージェント",
+          "rate": "$0.80"
+        }
+      ]
+    },
+    "help": "ご質問は <discord>Discord</discord> へ、<github>GitHub の Issue</github> を立てるか、<email>メール</email>でどうぞ。",
+    "faq": {
+      "title": "よくある質問",
+      "items": [
+        {
+          "q": "ターミナルは本当に無料ですか?",
+          "a": "はい。macOS アプリはオープンソースで永久に無料です。ローカルエージェントは自分の API キーで動き、追加費用はかかりません。料金が発生するのは Cloud VM でエージェントを実行したときだけです。"
+        },
+        {
+          "q": "Cloud VM とは何ですか?",
+          "a": "エージェントがリポジトリをクローンし、コマンドを実行し、プルリクエストをクラウド上で開くためのリモート Linux サンドボックスで、お使いのマシンには触れません。並列作業、バックグラウンドジョブ、PR レビューに対応します。アイドルの VM は自動的に一時停止するため、課金されるのはアクティブな計算時間だけです。"
+        },
+        {
+          "q": "cmux Vault とは何ですか?",
+          "a": "Vault はすべてのターミナルセッションをクラウドにバックアップし、それらを横断検索できるようにします。マシンをまたいだ無制限の履歴を保持します。Free では履歴は各マシンのローカルに残り、Pro でクラウドバックアップと検索が追加されます。"
+        },
+        {
+          "q": "モデルゲートウェイとは何ですか?",
+          "a": "各リクエストを複数プロバイダーの強力なモデルにルーティングし、使用量とコストの分析を1か所で提供するホスト型ゲートウェイです。自分のプロバイダーキーを持ち込めます。Enterprise では組織全体の管理のためにゲートウェイをセルフホストできます。"
+        },
+        {
+          "q": "iOS アプリにまだ Tailscale が必要ですか?",
+          "a": "どのプランでも Tailscale などの自前のネットワークを持ち込めます。Pro ではホスト型ネットワークが追加され、iOS アプリが設定なしで Mac に接続できます。Enterprise ではセルフホストも可能です。"
+        },
+        {
+          "q": "課金はどのように行われますか?",
+          "a": "Pro は月額 $30 で、4 vCPU / 16 GB の Cloud VM で毎月20時間のアクティブ計算時間が含まれます。それを超えると、VM サイズに応じてアクティブな計算時間あたりで課金されます(上記の Cloud VM サイズを参照)。アイドルの VM は自動的に一時停止し、エージェントを並列実行するとより多くの時間を使うだけです。ターミナルとローカルエージェントは無料のままです。"
+        },
+        {
+          "q": "クラウドをセルフホストできますか?",
+          "a": "はい、Enterprise で可能です。エージェントの実行を自社インフラ上で、または完全なエアギャップで動かせるため、ソースコードがネットワーク外に出ることはありません。"
+        },
+        {
+          "q": "チームプランはありますか?",
+          "a": "現時点ではまだありません。Pro は個人向け、Enterprise は SSO、管理機能、セルフホストが必要な組織向けです。チームでのニーズがあればお問い合わせください。"
+        }
+      ]
+    }
   },
   "home": {
     "taglinePrefix": "次のために作られたターミナル：",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -76,6 +76,7 @@
   "pricing": {
     "metaTitle": "料金 — cmux",
     "metaDescription": "cmux はAIコーディングエージェント向けの無料・オープンソースの macOS ターミナルです。Pro では Cloud VM、cmux Vault によるセッションバックアップ、モデルゲートウェイが使えます。Enterprise は SSO とセルフホストに対応します。",
+    "metaDescriptionNoVault": "cmux はAIコーディングエージェント向けの無料・オープンソースの macOS ターミナルです。Pro では Cloud VM とモデルゲートウェイが使えます。Enterprise は SSO とセルフホストに対応します。",
     "title": "料金",
     "perMonth": "/月",
     "free": {
@@ -100,11 +101,13 @@
       "features": [
         "分離されたリモートサンドボックスの Cloud VM 上で動くクラウドエージェント",
         "4 vCPU / 16 GB の VM で毎月20時間のアクティブ計算時間、超過分は従量課金",
-        "cmux Vault: すべてのセッションをクラウドにバックアップし検索可能に",
-        "すべてのマシンをまたいだ無制限のセッション履歴",
         "モデルゲートウェイ: 複数プロバイダーへのルーティングと使用量・コスト分析",
         "iOS アプリから Mac に接続するホスト型ネットワーク、Tailscale の設定不要",
         "cmux iOS アプリとメールサポート"
+      ],
+      "vaultFeatures": [
+        "cmux Vault: すべてのセッションをクラウドにバックアップし検索可能に",
+        "すべてのマシンをまたいだ無制限のセッション履歴"
       ]
     },
     "enterprise": {
@@ -147,19 +150,22 @@
           "label": "セッション履歴",
           "free": "ローカル",
           "pro": "無制限",
-          "enterprise": "無制限"
+          "enterprise": "無制限",
+          "vault": true
         },
         {
           "label": "cmux Vault: クラウドセッションバックアップ",
           "free": "false",
           "pro": "true",
-          "enterprise": "true"
+          "enterprise": "true",
+          "vault": true
         },
         {
           "label": "すべてのセッションを横断検索",
           "free": "false",
           "pro": "true",
-          "enterprise": "true"
+          "enterprise": "true",
+          "vault": true
         },
         {
           "label": "Cloud VM 上のクラウドエージェント",
@@ -273,7 +279,8 @@
         },
         {
           "q": "cmux Vault とは何ですか?",
-          "a": "Vault はすべてのターミナルセッションをクラウドにバックアップし、それらを横断検索できるようにします。マシンをまたいだ無制限の履歴を保持します。Free では履歴は各マシンのローカルに残り、Pro でクラウドバックアップと検索が追加されます。"
+          "a": "Vault はすべてのターミナルセッションをクラウドにバックアップし、それらを横断検索できるようにします。マシンをまたいだ無制限の履歴を保持します。Free では履歴は各マシンのローカルに残り、Pro でクラウドバックアップと検索が追加されます。",
+          "vault": true
         },
         {
           "q": "モデルゲートウェイとは何ですか?",


### PR DESCRIPTION
Adds a `/pricing` route to the marketing site.

**Tiers:** Free ($0) / Pro ($30/mo) / Enterprise (Custom), as three equal-height cards, plus a compare table, a Cloud VM sizes table, and an FAQ.

**Positioning:** leans on cmux-native cloud value rather than a generic enterprise checklist:
- Cloud VMs billed by active compute-hour (idle VMs auto-suspend); Pro includes 20 hrs/mo on a 4 vCPU / 16 GB VM, then usage-based ($0.20 / $0.40 / $0.80 per active hour by size).
- cmux Vault: session backup + search, unlimited session history.
- Model gateway with usage/cost analytics.
- Hosted (Pro) or self-hosted (Enterprise) networking to reach your Mac from the iOS app, no Tailscale setup required.
- Enterprise adds SSO/SAML, self-hosting, audit logs (sessions/network/browser), and SOC 2.

**Wiring:** Pricing added to nav, mobile drawer, and footer. Strings localized in `en.json` and `ja.json`.

**Known follow-up:** the Pro CTA currently points at the download (no public checkout URL yet). `PRO_CTA_URL` in `page.tsx` is the single swap point once billing is live. Prices and included-hours are drafts and easy to tune.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785034226&installation_id=133855650&pr_number=6791&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6791&signature=27a4bdb30a5b1fdf40570d62a027f998d7969c8b296bd5dcccf439b245c07b34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-site and i18n-only changes with no billing or auth logic; main caveat is published draft prices and Pro/Team CTAs routing to download instead of checkout.
> 
> **Overview**
> Adds a new **`/pricing`** marketing route with **Free**, **Pro** ($30/mo), **Team** ($35/user/mo), and **Enterprise** tier cards, a **sticky-header compare table**, **Cloud VM size** rates, and an **FAQ**, all driven by new **`pricing`** strings in **`en.json`** and **`ja.json`** (including SEO metadata via **`buildAlternates`**).
> 
> **Pricing** is linked from the main nav (**`nav-links`**), the mobile drawer (**`site-header`**), and the footer product column. Pro and Team CTAs temporarily use **`DOWNLOAD_URL`** via **`PRO_CTA_URL`** / **`TEAM_CTA_URL`** until checkout exists; Enterprise uses **`mailto:`** sales.
> 
> **cmux Vault** copy (Pro bullets, compare rows, FAQ, meta description) is hidden while **`SHOW_VAULT`** is **`false`**, so the public page matches what is not shipped yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a8e02f4aa2c4033322a6704949ca4644e4aa64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a localized `/pricing` page with Free, Pro ($30/mo), Team ($35/user/mo), and Enterprise tiers. The compare table is back with a sticky header that now pins correctly under the site header across browsers; page includes Cloud VM sizes and an FAQ, with Vault copy gated by `SHOW_VAULT`.

- **New Features**
  - New `/pricing` route with 4 tier cards.
  - Compare table with sticky header row.
  - Cloud VM sizes, FAQ, and localized SEO/copy (`en.json`, `ja.json`).
  - Pricing linked in header nav, mobile drawer, and footer.

- **Migration**
  - Pro and Team CTAs temporarily point to the download; update `PRO_CTA_URL` and `TEAM_CTA_URL` when checkout is live.

<sup>Written for commit a9a8e02f4aa2c4033322a6704949ca4644e4aa64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the localized **/pricing** page with tier cards (**Free/Pro/Team/Enterprise**), plan comparison, Cloud VM sizes, and a pricing FAQ (with Vault-related content shown when enabled).
  * Added **Pricing** links to the main navigation, mobile drawer menu, and site footer.
  * Added complete pricing page copy for **English and Japanese**, including translated SEO metadata and FAQ/help content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->