### PR TITLE
Add Blacksmith iOS video recording workflow

### DIFF
--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -29,6 +29,8 @@ on:
         options:
           - macos
           - ios
+          - ios-video
+          - sync-video
       runner:
         description: >-
           macOS runner label to build on. Blacksmith (blacksmith-6vcpu-macos-26),
@@ -43,6 +45,19 @@ on:
         required: false
         default: ""
         type: string
+      test_filter:
+        description: XCUITest class or class/method used for ios-video/sync-video.
+        required: false
+        default: cmuxUITests/cmuxUITests/testStackAuthEntryUsesStableIdentifiers
+        type: string
+      device_family:
+        description: Simulator family used for ios-video/sync-video.
+        required: false
+        default: iphone
+        type: choice
+        options:
+          - iphone
+          - ipad
 
 # Surface tag/platform/nonce in the run title so the dispatcher can match its run
 # by the nonce it passed (gh workflow run does not return a run id).
@@ -115,7 +130,7 @@ jobs:
       # source refs that predate the crate are a no-op (scripts come from
       # inputs.ref, not this workflow's ref). install-rust-ci.sh is idempotent.
       - name: Provision cmux-iroh FFI (iOS)
-        if: ${{ inputs.platform == 'ios' }}
+        if: ${{ inputs.platform == 'ios' || inputs.platform == 'ios-video' || inputs.platform == 'sync-video' }}
         run: |
           set -euo pipefail
           if [ -f scripts/ensure-cmux-iroh.sh ]; then
@@ -170,6 +185,146 @@ jobs:
           [ -d "$archive" ] || { echo "archive not produced: $archive" >&2; exit 1; }
           mkdir -p artifact
           ( cd "$out" && ditto -c -k --keepParent "$(basename "$archive")" "$GITHUB_WORKSPACE/artifact/archive.zip" )
+
+      # --- iOS video: drive an XCUITest on a Simulator while recording pixels ---
+      - name: Record iOS simulator video
+        if: ${{ inputs.platform == 'ios-video' || inputs.platform == 'sync-video' }}
+        env:
+          BUILD_TAG: ${{ inputs.tag }}
+          DEVICE_FAMILY: ${{ inputs.device_family }}
+          TEST_FILTER: ${{ inputs.test_filter }}
+          VIDEO_PLATFORM: ${{ inputs.platform }}
+        run: |
+          set -euo pipefail
+          case "$DEVICE_FAMILY" in iphone|ipad) ;; *) echo "invalid device_family: $DEVICE_FAMILY" >&2; exit 1 ;; esac
+          if [ -z "${TEST_FILTER:-}" ]; then
+            echo "test_filter is required for $VIDEO_PLATFORM" >&2
+            exit 1
+          fi
+
+          ios_ready() { xcrun simctl runtime list 2>/dev/null | grep -qiE "iOS [0-9].*\(Ready\)"; }
+          if ! ios_ready; then
+            echo "iOS platform not registered; installing via downloadPlatform iOS"
+            xcodebuild -downloadPlatform iOS 2>&1 | tr '\r' '\n' | grep -ivE 'Preparing to download|registering download' | tail -8 || true
+            ios_ready || { echo "iOS platform still not registered; simulator recording would fail" >&2; exit 1; }
+          fi
+
+          ./scripts/ensure-ghosttykit.sh
+
+          SIMULATOR_ENV="$RUNNER_TEMP/simulator-$DEVICE_FAMILY.env"
+          python3 - <<'PY' > "$SIMULATOR_ENV"
+          import json
+          import os
+          import subprocess
+
+          def simctl_json(*args):
+              return json.loads(subprocess.check_output(["xcrun", "simctl", "list", *args, "-j"]))
+
+          def version_key(runtime):
+              parts = []
+              for part in str(runtime.get("version") or "").split("."):
+                  try:
+                      parts.append(int(part))
+                  except ValueError:
+                      parts.append(0)
+              return tuple(parts)
+
+          family = os.environ["DEVICE_FAMILY"]
+          prefix = "iPad" if family == "ipad" else "iPhone"
+          preferred = ["iPad Pro 13-inch (M4)", "iPad Air 13-inch (M3)"] if family == "ipad" else ["iPhone 17", "iPhone 16"]
+          data = simctl_json("devices", "available")
+          devices = [
+              device
+              for runtimes in data.get("devices", {}).values()
+              for device in runtimes
+              if device.get("isAvailable", True)
+          ]
+          selected = next((d for name in preferred for d in devices if d.get("name") == name), None)
+          selected = selected or next((d for d in devices if d.get("name", "").startswith(prefix)), None)
+          if selected is None:
+              runtimes = [
+                  runtime
+                  for runtime in simctl_json("runtimes").get("runtimes", [])
+                  if runtime.get("isAvailable", True)
+                  and (
+                      runtime.get("platform") == "iOS"
+                      or "iOS" in runtime.get("name", "")
+                      or runtime.get("identifier", "").startswith("com.apple.CoreSimulator.SimRuntime.iOS")
+                  )
+              ]
+              device_types = [
+                  device_type
+                  for device_type in simctl_json("devicetypes").get("devicetypes", [])
+                  if device_type.get("name", "").startswith(prefix)
+              ]
+              runtime = max(runtimes, key=version_key, default=None)
+              device_type = next((d for name in preferred for d in device_types if d.get("name") == name), None)
+              device_type = device_type or (device_types[-1] if device_types else None)
+              if runtime is None or device_type is None:
+                  raise SystemExit(f"No available {family} simulator or creatable iOS runtime/device type found")
+              udid = subprocess.check_output([
+                  "xcrun",
+                  "simctl",
+                  "create",
+                  f"cmux video {device_type['name']}",
+                  device_type["identifier"],
+                  runtime["identifier"],
+              ], text=True).strip()
+              selected = {"udid": udid, "name": f"cmux video {device_type['name']}"}
+          print(f"SIMULATOR_ID={selected['udid']}")
+          print(f"SIMULATOR_NAME={selected['name']}")
+          PY
+          # shellcheck source=/dev/null
+          . "$SIMULATOR_ENV"
+          cat "$SIMULATOR_ENV"
+
+          IOS_DERIVED_DATA="$RUNNER_TEMP/cmux-ios-video-$DEVICE_FAMILY"
+          rm -rf "$IOS_DERIVED_DATA"
+          mkdir -p "$IOS_DERIVED_DATA/logs" artifact
+
+          xcrun simctl shutdown "$SIMULATOR_ID" >/dev/null 2>&1 || true
+          xcrun simctl erase "$SIMULATOR_ID"
+          xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
+          xcrun simctl bootstatus "$SIMULATOR_ID" -b
+
+          video_path="$GITHUB_WORKSPACE/artifact/cmux-$VIDEO_PLATFORM-$BUILD_TAG-$DEVICE_FAMILY.mp4"
+          record_log="$RUNNER_TEMP/sim-record.log"
+          xcrun simctl io "$SIMULATOR_ID" recordVideo --codec=h264 --force "$video_path" >"$record_log" 2>&1 &
+          record_pid=$!
+          cleanup_recording() {
+            if kill -0 "$record_pid" >/dev/null 2>&1; then
+              kill -INT "$record_pid" >/dev/null 2>&1 || true
+              wait "$record_pid" >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup_recording EXIT
+
+          for _ in $(seq 1 60); do
+            grep -q "Recording started" "$record_log" 2>/dev/null && break
+            sleep 1
+          done
+
+          test_log="$IOS_DERIVED_DATA/logs/video-test.log"
+          xcodebuild \
+            -workspace ios/cmux.xcworkspace \
+            -scheme cmux-ios \
+            -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
+            -derivedDataPath "$IOS_DERIVED_DATA" \
+            -only-testing:"$TEST_FILTER" \
+            test 2>&1 | tee "$test_log"
+
+          cleanup_recording
+          trap - EXIT
+          [ -s "$video_path" ] || { echo "recording missing or empty: $video_path" >&2; cat "$record_log" >&2 || true; exit 1; }
+          ffprobe -v error -show_entries format=duration,size -of json "$video_path" > "artifact/video-metadata.json" || true
+          {
+            echo "tag=$BUILD_TAG"
+            echo "platform=$VIDEO_PLATFORM"
+            echo "device_family=$DEVICE_FAMILY"
+            echo "simulator_id=$SIMULATOR_ID"
+            echo "simulator_name=$SIMULATOR_NAME"
+            echo "test_filter=$TEST_FILTER"
+          } > artifact/video.env
 
       - name: Write timings.json
         if: ${{ always() }}

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -50,6 +50,14 @@ on:
         required: false
         default: cmuxUITests/cmuxUITests/testStackAuthEntryUsesStableIdentifiers
         type: string
+      auth_mode:
+        description: Auth state to prove during ios-video/sync-video.
+        required: false
+        default: signed-out
+        type: choice
+        options:
+          - signed-out
+          - signed-in
       device_family:
         description: Simulator family used for ios-video/sync-video.
         required: false
@@ -193,12 +201,27 @@ jobs:
           BUILD_TAG: ${{ inputs.tag }}
           DEVICE_FAMILY: ${{ inputs.device_family }}
           TEST_FILTER: ${{ inputs.test_filter }}
+          AUTH_MODE: ${{ inputs.auth_mode }}
           VIDEO_PLATFORM: ${{ inputs.platform }}
+          CMUX_UITEST_STACK_EMAIL: ${{ secrets.CMUX_UITEST_STACK_EMAIL }}
+          CMUX_UITEST_STACK_PASSWORD: ${{ secrets.CMUX_UITEST_STACK_PASSWORD }}
         run: |
           set -euo pipefail
           case "$DEVICE_FAMILY" in iphone|ipad) ;; *) echo "invalid device_family: $DEVICE_FAMILY" >&2; exit 1 ;; esac
           if [ -z "${TEST_FILTER:-}" ]; then
             echo "test_filter is required for $VIDEO_PLATFORM" >&2
+            exit 1
+          fi
+          if [ "$AUTH_MODE" = "signed-in" ]; then
+            if [ "$TEST_FILTER" = "cmuxUITests/cmuxUITests/testStackAuthEntryUsesStableIdentifiers" ]; then
+              TEST_FILTER="cmuxUITests/cmuxUITests/testDogfoodAutoLoginReachesSignedInPairing"
+            fi
+            if [ -z "${CMUX_UITEST_STACK_EMAIL:-}" ] || [ -z "${CMUX_UITEST_STACK_PASSWORD:-}" ]; then
+              echo "auth_mode=signed-in requires CMUX_UITEST_STACK_EMAIL and CMUX_UITEST_STACK_PASSWORD repository secrets" >&2
+              exit 1
+            fi
+          elif [ "$AUTH_MODE" != "signed-out" ]; then
+            echo "invalid auth_mode: $AUTH_MODE" >&2
             exit 1
           fi
 
@@ -288,6 +311,51 @@ jobs:
           xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
           xcrun simctl bootstatus "$SIMULATOR_ID" -b
 
+          if [ "$VIDEO_PLATFORM" = "sync-video" ]; then
+            if [ -f scripts/create-virtual-display.m ]; then
+              clang -framework Foundation -framework CoreGraphics \
+                -o "$RUNNER_TEMP/create-virtual-display" scripts/create-virtual-display.m
+              VDISPLAY_READY="$RUNNER_TEMP/cmux-virtual-display.ready"
+              VDISPLAY_ID_PATH="$RUNNER_TEMP/cmux-virtual-display.id"
+              VDISPLAY_LOG="$RUNNER_TEMP/cmux-virtual-display.log"
+              rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
+              "$RUNNER_TEMP/create-virtual-display" \
+                --ready-path "$VDISPLAY_READY" \
+                --display-id-path "$VDISPLAY_ID_PATH" \
+                >"$VDISPLAY_LOG" 2>&1 &
+              VDISPLAY_PID=$!
+              for _ in $(seq 1 100); do
+                [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ] && break
+                kill -0 "$VDISPLAY_PID" >/dev/null 2>&1 || { cat "$VDISPLAY_LOG" >&2 || true; exit 1; }
+                sleep 0.1
+              done
+              [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ] || { cat "$VDISPLAY_LOG" >&2 || true; exit 1; }
+              echo "Virtual display ready: $(tr -d '\n' < "$VDISPLAY_ID_PATH")"
+            fi
+            if ! command -v ffmpeg >/dev/null 2>&1 || ! ffmpeg -version >/dev/null 2>&1; then
+              brew install --quiet ffmpeg
+            fi
+            FFMPEG_BIN="$(command -v ffmpeg)"
+            SYS_TCC="/Library/Application Support/com.apple.TCC/TCC.db"
+            if [ -f "$SYS_TCC" ] && command -v sudo >/dev/null 2>&1; then
+              sudo -n sqlite3 "$SYS_TCC" \
+                "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, csreq, policy_id, indirect_object_identifier_type, indirect_object_identifier, indirect_object_code_identity, flags, last_modified) VALUES ('kTCCServiceScreenCapture', '$FFMPEG_BIN', 1, 2, 4, 1, NULL, NULL, 0, 'UNUSED', NULL, 0, $(date +%s));" \
+                || true
+            fi
+            USER_TCC="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
+            if [ -f "$USER_TCC" ]; then
+              sqlite3 "$USER_TCC" \
+                "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, csreq, policy_id, indirect_object_identifier_type, indirect_object_identifier, indirect_object_code_identity, flags, last_modified) VALUES ('kTCCServiceScreenCapture', '$FFMPEG_BIN', 1, 2, 4, 1, NULL, NULL, 0, 'UNUSED', NULL, 0, $(date +%s));" \
+                || true
+            fi
+            APPROVALS_PLIST="$HOME/Library/Group Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist"
+            if [ -d "$(dirname "$APPROVALS_PLIST")" ]; then
+              defaults write "$APPROVALS_PLIST" "$FFMPEG_BIN" -date "3000-01-01T00:00:00Z" || true
+            fi
+
+            open -a Simulator --args -CurrentDeviceUDID "$SIMULATOR_ID" >/dev/null 2>&1 || true
+          fi
+
           build_log="$IOS_DERIVED_DATA/logs/video-build.log"
           xcodebuild \
             -workspace ios/cmux.xcworkspace \
@@ -296,15 +364,49 @@ jobs:
             -derivedDataPath "$IOS_DERIVED_DATA" \
             build-for-testing 2>&1 | tee "$build_log"
 
-          video_path="$GITHUB_WORKSPACE/artifact/cmux-$VIDEO_PLATFORM-$BUILD_TAG-$DEVICE_FAMILY.mp4"
+          iphone_video_path="$GITHUB_WORKSPACE/artifact/cmux-$VIDEO_PLATFORM-$BUILD_TAG-$DEVICE_FAMILY-iphone.mp4"
+          mac_video_path="$GITHUB_WORKSPACE/artifact/cmux-$VIDEO_PLATFORM-$BUILD_TAG-mac.mp4"
+          stitched_video_path="$GITHUB_WORKSPACE/artifact/cmux-$VIDEO_PLATFORM-$BUILD_TAG-stitched.mp4"
           record_log="$RUNNER_TEMP/sim-record.log"
-          xcrun simctl io "$SIMULATOR_ID" recordVideo --codec=h264 --force "$video_path" >"$record_log" 2>&1 &
+          mac_record_log="$RUNNER_TEMP/mac-record.log"
+          mac_record_pid=""
+          stop_mac_recording() {
+            if [ -n "${mac_record_pid:-}" ] && kill -0 "$mac_record_pid" >/dev/null 2>&1; then
+              kill -INT "$mac_record_pid" >/dev/null 2>&1 || true
+              for _ in $(seq 1 15); do
+                kill -0 "$mac_record_pid" >/dev/null 2>&1 || break
+                sleep 1
+              done
+              kill -9 "$mac_record_pid" >/dev/null 2>&1 || true
+              wait "$mac_record_pid" >/dev/null 2>&1 || true
+            fi
+          }
+          if [ "$VIDEO_PLATFORM" = "sync-video" ]; then
+            DEVLIST="$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 || true)"
+            echo "$DEVLIST" > "$RUNNER_TEMP/ffmpeg-devices.log"
+            SCREEN_INDEX="$(echo "$DEVLIST" | grep "Capture screen" | head -1 | sed 's/.*\[\([0-9]*\)\].*/\1/' || true)"
+            SCREEN_INDEX="${SCREEN_INDEX:-0}"
+            ffmpeg -y -f avfoundation -framerate 10 -capture_cursor 1 \
+              -i "${SCREEN_INDEX}:none" \
+              -c:v libx264 -preset ultrafast -pix_fmt yuv420p \
+              "$mac_video_path" </dev/null >"$mac_record_log" 2>&1 &
+            mac_record_pid=$!
+            sleep 2
+            if ! kill -0 "$mac_record_pid" >/dev/null 2>&1; then
+              echo "mac screen recording failed to start" >&2
+              cat "$mac_record_log" >&2 || true
+              exit 1
+            fi
+          fi
+
+          xcrun simctl io "$SIMULATOR_ID" recordVideo --codec=h264 --force "$iphone_video_path" >"$record_log" 2>&1 &
           record_pid=$!
           cleanup_recording() {
             if kill -0 "$record_pid" >/dev/null 2>&1; then
               kill -INT "$record_pid" >/dev/null 2>&1 || true
               wait "$record_pid" >/dev/null 2>&1 || true
             fi
+            stop_mac_recording
           }
           trap cleanup_recording EXIT
 
@@ -324,17 +426,34 @@ jobs:
 
           cleanup_recording
           trap - EXIT
-          [ -s "$video_path" ] || { echo "recording missing or empty: $video_path" >&2; cat "$record_log" >&2 || true; exit 1; }
+          [ -s "$iphone_video_path" ] || { echo "recording missing or empty: $iphone_video_path" >&2; cat "$record_log" >&2 || true; exit 1; }
+          if [ "$VIDEO_PLATFORM" = "sync-video" ]; then
+            [ -s "$mac_video_path" ] || { echo "mac recording missing or empty: $mac_video_path" >&2; cat "$mac_record_log" >&2 || true; exit 1; }
+            ffmpeg -y \
+              -i "$mac_video_path" \
+              -i "$iphone_video_path" \
+              -filter_complex "[0:v]scale=-2:960,setpts=PTS-STARTPTS[mac];[1:v]scale=-2:960,setpts=PTS-STARTPTS[ios];[mac][ios]hstack=inputs=2[v]" \
+              -map "[v]" \
+              -shortest \
+              -c:v libx264 -preset veryfast -pix_fmt yuv420p \
+              "$stitched_video_path" > "$RUNNER_TEMP/stitch.log" 2>&1 \
+              || { echo "stitching failed" >&2; cat "$RUNNER_TEMP/stitch.log" >&2 || true; exit 1; }
+            [ -s "$stitched_video_path" ] || { echo "stitched video missing or empty: $stitched_video_path" >&2; exit 1; }
+          fi
           if command -v ffprobe >/dev/null 2>&1; then
-            ffprobe -v error -show_entries format=duration,size -of json "$video_path" > artifact/video-metadata.json || true
+            ffprobe -v error -show_entries format=duration,size -of json "$iphone_video_path" > artifact/video-metadata.json || true
+            if [ "$VIDEO_PLATFORM" = "sync-video" ]; then
+              ffprobe -v error -show_entries format=duration,size -of json "$stitched_video_path" > artifact/stitched-video-metadata.json || true
+            fi
           else
-            size_bytes="$(stat -f %z "$video_path" 2>/dev/null || wc -c < "$video_path" | tr -d ' ')"
+            size_bytes="$(stat -f %z "$iphone_video_path" 2>/dev/null || wc -c < "$iphone_video_path" | tr -d ' ')"
             printf '{ "size": %s }\n' "$size_bytes" > artifact/video-metadata.json
           fi
           {
             echo "tag=$BUILD_TAG"
             echo "platform=$VIDEO_PLATFORM"
             echo "device_family=$DEVICE_FAMILY"
+            echo "auth_mode=$AUTH_MODE"
             echo "simulator_id=$SIMULATOR_ID"
             echo "simulator_name=$SIMULATOR_NAME"
             echo "test_filter=$TEST_FILTER"

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -371,13 +371,13 @@ jobs:
           mac_record_log="$RUNNER_TEMP/mac-record.log"
           mac_record_pid=""
           mac_record_control=""
-          mac_record_fd=""
+          mac_record_fd_open="0"
           stop_mac_recording() {
             if [ -n "${mac_record_pid:-}" ] && kill -0 "$mac_record_pid" >/dev/null 2>&1; then
-              if [ -n "${mac_record_fd:-}" ]; then
-                printf 'q' >&$mac_record_fd || true
-                exec {mac_record_fd}>&- || true
-                mac_record_fd=""
+              if [ "${mac_record_fd_open:-0}" = "1" ]; then
+                printf 'q' >&9 || true
+                exec 9>&- || true
+                mac_record_fd_open="0"
               else
                 kill -INT "$mac_record_pid" >/dev/null 2>&1 || true
               fi
@@ -404,7 +404,8 @@ jobs:
               -c:v libx264 -preset ultrafast -pix_fmt yuv420p \
               "$mac_video_path" <"$mac_record_control" >"$mac_record_log" 2>&1 &
             mac_record_pid=$!
-            exec {mac_record_fd}>"$mac_record_control"
+            exec 9>"$mac_record_control"
+            mac_record_fd_open="1"
             sleep 2
             if ! kill -0 "$mac_record_pid" >/dev/null 2>&1; then
               echo "mac screen recording failed to start" >&2

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -338,19 +338,24 @@ jobs:
             FFMPEG_BIN="$(command -v ffmpeg)"
             SYS_TCC="/Library/Application Support/com.apple.TCC/TCC.db"
             if [ -f "$SYS_TCC" ] && command -v sudo >/dev/null 2>&1; then
-              sudo -n sqlite3 "$SYS_TCC" \
-                "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, csreq, policy_id, indirect_object_identifier_type, indirect_object_identifier, indirect_object_code_identity, flags, last_modified) VALUES ('kTCCServiceScreenCapture', '$FFMPEG_BIN', 1, 2, 4, 1, NULL, NULL, 0, 'UNUSED', NULL, 0, $(date +%s));" \
-                || true
+              for client in "$FFMPEG_BIN" /usr/sbin/screencapture; do
+                sudo -n sqlite3 "$SYS_TCC" \
+                  "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, csreq, policy_id, indirect_object_identifier_type, indirect_object_identifier, indirect_object_code_identity, flags, last_modified) VALUES ('kTCCServiceScreenCapture', '$client', 1, 2, 4, 1, NULL, NULL, 0, 'UNUSED', NULL, 0, $(date +%s));" \
+                  || true
+              done
             fi
             USER_TCC="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
             if [ -f "$USER_TCC" ]; then
-              sqlite3 "$USER_TCC" \
-                "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, csreq, policy_id, indirect_object_identifier_type, indirect_object_identifier, indirect_object_code_identity, flags, last_modified) VALUES ('kTCCServiceScreenCapture', '$FFMPEG_BIN', 1, 2, 4, 1, NULL, NULL, 0, 'UNUSED', NULL, 0, $(date +%s));" \
-                || true
+              for client in "$FFMPEG_BIN" /usr/sbin/screencapture; do
+                sqlite3 "$USER_TCC" \
+                  "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, csreq, policy_id, indirect_object_identifier_type, indirect_object_identifier, indirect_object_code_identity, flags, last_modified) VALUES ('kTCCServiceScreenCapture', '$client', 1, 2, 4, 1, NULL, NULL, 0, 'UNUSED', NULL, 0, $(date +%s));" \
+                  || true
+              done
             fi
             APPROVALS_PLIST="$HOME/Library/Group Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist"
             if [ -d "$(dirname "$APPROVALS_PLIST")" ]; then
               defaults write "$APPROVALS_PLIST" "$FFMPEG_BIN" -date "3000-01-01T00:00:00Z" || true
+              defaults write "$APPROVALS_PLIST" /usr/sbin/screencapture -date "3000-01-01T00:00:00Z" || true
             fi
 
             open -a Simulator --args -CurrentDeviceUDID "$SIMULATOR_ID" >/dev/null 2>&1 || true
@@ -365,22 +370,14 @@ jobs:
             build-for-testing 2>&1 | tee "$build_log"
 
           iphone_video_path="$GITHUB_WORKSPACE/artifact/cmux-$VIDEO_PLATFORM-$BUILD_TAG-$DEVICE_FAMILY-iphone.mp4"
-          mac_video_path="$GITHUB_WORKSPACE/artifact/cmux-$VIDEO_PLATFORM-$BUILD_TAG-mac.mp4"
+          mac_video_path="$GITHUB_WORKSPACE/artifact/cmux-$VIDEO_PLATFORM-$BUILD_TAG-mac.mov"
           stitched_video_path="$GITHUB_WORKSPACE/artifact/cmux-$VIDEO_PLATFORM-$BUILD_TAG-stitched.mp4"
           record_log="$RUNNER_TEMP/sim-record.log"
           mac_record_log="$RUNNER_TEMP/mac-record.log"
           mac_record_pid=""
-          mac_record_control=""
-          mac_record_fd_open="0"
           stop_mac_recording() {
             if [ -n "${mac_record_pid:-}" ] && kill -0 "$mac_record_pid" >/dev/null 2>&1; then
-              if [ "${mac_record_fd_open:-0}" = "1" ]; then
-                printf 'q' >&9 || true
-                exec 9>&- || true
-                mac_record_fd_open="0"
-              else
-                kill -INT "$mac_record_pid" >/dev/null 2>&1 || true
-              fi
+              kill -INT "$mac_record_pid" >/dev/null 2>&1 || true
               for _ in $(seq 1 15); do
                 kill -0 "$mac_record_pid" >/dev/null 2>&1 || break
                 sleep 1
@@ -388,24 +385,10 @@ jobs:
               kill -9 "$mac_record_pid" >/dev/null 2>&1 || true
               wait "$mac_record_pid" >/dev/null 2>&1 || true
             fi
-            [ -z "${mac_record_control:-}" ] || rm -f "$mac_record_control"
           }
           if [ "$VIDEO_PLATFORM" = "sync-video" ]; then
-            DEVLIST="$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 || true)"
-            echo "$DEVLIST" > "$RUNNER_TEMP/ffmpeg-devices.log"
-            SCREEN_INDEX="$(echo "$DEVLIST" | grep "Capture screen" | head -1 | sed 's/.*\[\([0-9]*\)\].*/\1/' || true)"
-            SCREEN_INDEX="${SCREEN_INDEX:-0}"
-            mac_record_control="$RUNNER_TEMP/mac-record-control"
-            rm -f "$mac_record_control"
-            mkfifo "$mac_record_control"
-            ffmpeg -y -f avfoundation -framerate 10 -capture_cursor 1 \
-              -pixel_format uyvy422 \
-              -i "${SCREEN_INDEX}:none" \
-              -c:v libx264 -preset ultrafast -pix_fmt yuv420p \
-              "$mac_video_path" <"$mac_record_control" >"$mac_record_log" 2>&1 &
+            /usr/sbin/screencapture -v "$mac_video_path" >"$mac_record_log" 2>&1 &
             mac_record_pid=$!
-            exec 9>"$mac_record_control"
-            mac_record_fd_open="1"
             sleep 2
             if ! kill -0 "$mac_record_pid" >/dev/null 2>&1; then
               echo "mac screen recording failed to start" >&2

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -333,7 +333,7 @@ jobs:
               echo "Virtual display ready: $(tr -d '\n' < "$VDISPLAY_ID_PATH")"
             fi
             if ! command -v ffmpeg >/dev/null 2>&1 || ! ffmpeg -version >/dev/null 2>&1; then
-              brew install --quiet ffmpeg
+              HOMEBREW_NO_REQUIRE_TAP_TRUST=1 brew install --quiet ffmpeg
             fi
             FFMPEG_BIN="$(command -v ffmpeg)"
             SYS_TCC="/Library/Application Support/com.apple.TCC/TCC.db"

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -288,6 +288,14 @@ jobs:
           xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
           xcrun simctl bootstatus "$SIMULATOR_ID" -b
 
+          build_log="$IOS_DERIVED_DATA/logs/video-build.log"
+          xcodebuild \
+            -workspace ios/cmux.xcworkspace \
+            -scheme cmux-ios \
+            -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
+            -derivedDataPath "$IOS_DERIVED_DATA" \
+            build-for-testing 2>&1 | tee "$build_log"
+
           video_path="$GITHUB_WORKSPACE/artifact/cmux-$VIDEO_PLATFORM-$BUILD_TAG-$DEVICE_FAMILY.mp4"
           record_log="$RUNNER_TEMP/sim-record.log"
           xcrun simctl io "$SIMULATOR_ID" recordVideo --codec=h264 --force "$video_path" >"$record_log" 2>&1 &
@@ -312,7 +320,7 @@ jobs:
             -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
             -derivedDataPath "$IOS_DERIVED_DATA" \
             -only-testing:"$TEST_FILTER" \
-            test 2>&1 | tee "$test_log"
+            test-without-building 2>&1 | tee "$test_log"
 
           cleanup_recording
           trap - EXIT

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -325,7 +325,12 @@ jobs:
           cleanup_recording
           trap - EXIT
           [ -s "$video_path" ] || { echo "recording missing or empty: $video_path" >&2; cat "$record_log" >&2 || true; exit 1; }
-          ffprobe -v error -show_entries format=duration,size -of json "$video_path" > "artifact/video-metadata.json" || true
+          if command -v ffprobe >/dev/null 2>&1; then
+            ffprobe -v error -show_entries format=duration,size -of json "$video_path" > artifact/video-metadata.json || true
+          else
+            size_bytes="$(stat -f %z "$video_path" 2>/dev/null || wc -c < "$video_path" | tr -d ' ')"
+            printf '{ "size": %s }\n' "$size_bytes" > artifact/video-metadata.json
+          fi
           {
             echo "tag=$BUILD_TAG"
             echo "platform=$VIDEO_PLATFORM"

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -370,9 +370,17 @@ jobs:
           record_log="$RUNNER_TEMP/sim-record.log"
           mac_record_log="$RUNNER_TEMP/mac-record.log"
           mac_record_pid=""
+          mac_record_control=""
+          mac_record_fd=""
           stop_mac_recording() {
             if [ -n "${mac_record_pid:-}" ] && kill -0 "$mac_record_pid" >/dev/null 2>&1; then
-              kill -INT "$mac_record_pid" >/dev/null 2>&1 || true
+              if [ -n "${mac_record_fd:-}" ]; then
+                printf 'q' >&$mac_record_fd || true
+                exec {mac_record_fd}>&- || true
+                mac_record_fd=""
+              else
+                kill -INT "$mac_record_pid" >/dev/null 2>&1 || true
+              fi
               for _ in $(seq 1 15); do
                 kill -0 "$mac_record_pid" >/dev/null 2>&1 || break
                 sleep 1
@@ -380,17 +388,23 @@ jobs:
               kill -9 "$mac_record_pid" >/dev/null 2>&1 || true
               wait "$mac_record_pid" >/dev/null 2>&1 || true
             fi
+            [ -z "${mac_record_control:-}" ] || rm -f "$mac_record_control"
           }
           if [ "$VIDEO_PLATFORM" = "sync-video" ]; then
             DEVLIST="$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 || true)"
             echo "$DEVLIST" > "$RUNNER_TEMP/ffmpeg-devices.log"
             SCREEN_INDEX="$(echo "$DEVLIST" | grep "Capture screen" | head -1 | sed 's/.*\[\([0-9]*\)\].*/\1/' || true)"
             SCREEN_INDEX="${SCREEN_INDEX:-0}"
+            mac_record_control="$RUNNER_TEMP/mac-record-control"
+            rm -f "$mac_record_control"
+            mkfifo "$mac_record_control"
             ffmpeg -y -f avfoundation -framerate 10 -capture_cursor 1 \
+              -pixel_format uyvy422 \
               -i "${SCREEN_INDEX}:none" \
               -c:v libx264 -preset ultrafast -pix_fmt yuv420p \
-              "$mac_video_path" </dev/null >"$mac_record_log" 2>&1 &
+              "$mac_video_path" <"$mac_record_control" >"$mac_record_log" 2>&1 &
             mac_record_pid=$!
+            exec {mac_record_fd}>"$mac_record_control"
             sleep 2
             if ! kill -0 "$mac_record_pid" >/dev/null 2>&1; then
               echo "mac screen recording failed to start" >&2

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -215,6 +215,7 @@ jobs:
           python3 - <<'PY' > "$SIMULATOR_ENV"
           import json
           import os
+          import shlex
           import subprocess
 
           def simctl_json(*args):
@@ -271,8 +272,8 @@ jobs:
                   runtime["identifier"],
               ], text=True).strip()
               selected = {"udid": udid, "name": f"cmux video {device_type['name']}"}
-          print(f"SIMULATOR_ID={selected['udid']}")
-          print(f"SIMULATOR_NAME={selected['name']}")
+          print(f"SIMULATOR_ID={shlex.quote(selected['udid'])}")
+          print(f"SIMULATOR_NAME={shlex.quote(selected['name'])}")
           PY
           # shellcheck source=/dev/null
           . "$SIMULATOR_ENV"

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -27,6 +27,30 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
+    func testDogfoodAutoLoginReachesSignedInPairing() throws {
+        let processEnvironment = ProcessInfo.processInfo.environment
+        guard let email = processEnvironment["CMUX_UITEST_STACK_EMAIL"], !email.isEmpty,
+              let password = processEnvironment["CMUX_UITEST_STACK_PASSWORD"], !password.isEmpty else {
+            XCTFail("CMUX_UITEST_STACK_EMAIL and CMUX_UITEST_STACK_PASSWORD are required")
+            return
+        }
+
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_STACK_EMAIL": email,
+            "CMUX_UITEST_STACK_PASSWORD": password,
+        ])
+
+        if app.buttons["MobileOnboardingSkipButton"].waitForExistence(timeout: 20) {
+            tap(app.buttons["MobileOnboardingSkipButton"], in: app)
+        }
+
+        let signedInAccount = app.staticTexts["MobileAddDeviceSignedInAccount"]
+        XCTAssertTrue(signedInAccount.waitForExistence(timeout: 35))
+        XCTAssertTrue(signedInAccount.label.localizedCaseInsensitiveContains(email))
+        XCTAssertFalse(app.buttons["signin.apple"].exists)
+    }
+
+    @MainActor
     func testAddDeviceManualHostValidationUsesStableIdentifiers() throws {
         let invalidHostApp = launchAddDeviceApp(environment: [
             "CMUX_UITEST_ADD_DEVICE_HOST": "dev/path.local"


### PR DESCRIPTION
Summary:
- Add `ios-video` and `sync-video` modes to the dispatch-only `reload-build.yml` Blacksmith workflow.
- Record iOS Simulator pixels with `simctl io recordVideo` while a selected XCUITest drives the app.
- Build for testing before recording, then run `test-without-building` under the recorder so the mp4 captures the app launch and UI test instead of only build/install lead-in.
- Upload the mp4 plus small metadata in the existing reload artifact shape.

Notes:
- This is the cloud/Blacksmith half. A real iPhone cannot be physically attached to Blacksmith, so real-device capture has to happen on the local Mac after a Blacksmith-built archive is downloaded, signed, installed, and launched.
- The hq wrapper now has a local `--target device` path for that split, but this cmux PR only contains the workflow support.

Checks:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reload-build.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/reload-build.yml`
- `git diff --check`
- Live Blacksmith simulator recording: https://github.com/manaflow-ai/cmux/actions/runs/28216279692
- Downloaded mp4: `/Users/lawrence/fun/cmuxterm-hq/artifacts/ios-video-test/blacksmith-28216279692/cmux-ios-video-ivrec3-iphone.mp4` (23.9s H.264, 1206x2622, app sign-in UI visible in the 15s thumbnail)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new CI shell path touches simulator setup, optional TCC DB writes, and real auth secrets for signed-in video runs; scope is dev-build dispatch only, not production app code.
> 
> **Overview**
> Extends the dispatch-only **`reload-build`** workflow with **`ios-video`** and **`sync-video`** platforms plus inputs for **XCUITest filter**, **auth mode** (signed-out vs signed-in), and **simulator device family** (iPhone/iPad). **cmux-iroh FFI** provisioning now runs for those platforms as well as plain iOS.
> 
> A new **Record iOS simulator video** step boots or creates a simulator, **`build-for-testing`**, then runs **`test-without-building`** while **`simctl io recordVideo`** captures H.264. Artifacts include the simulator mp4, **`video-metadata.json`**, and **`video.env`**. **`sync-video`** additionally records the Mac host with **`screencapture`**, optionally sets up a virtual display and screen-capture TCC/ffmpeg, and **stitches** Mac + simulator into a side-by-side mp4. Signed-in runs can swap the default test to **`testDogfoodAutoLoginReachesSignedInPairing`** and require Stack auth repo secrets.
> 
> **`cmuxUITests`** gains **`testDogfoodAutoLoginReachesSignedInPairing`**, which auto-logs in via env credentials, skips onboarding when present, and asserts the signed-in pairing UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4646e3348ecccb374c57b10cdb5ec425ae09b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added video-based iOS test-run support in the build workflow.
  * Expanded workflow platform options to include iOS video modes, with new inputs to select a test filter and target device family (iPhone/iPad).
  * Automatically records simulator video for these runs, producing video artifacts and run metadata for review.
* **Tests**
  * Added a UI test that validates auto-login reaches the signed-in pairing screen using provided credentials, while skipping mobile onboarding when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->