### PR TITLE
iOS: remove Cancel button from sign-in screen

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
@@ -238,6 +238,14 @@ struct SignInView: View {
         }
     }
 
+    // While this is true the card dims (opacity 0.6) and inputs disable. There
+    // is intentionally no in-app "cancel sign-in" affordance: during the only
+    // long phase (the Apple/Google system sheet, generous on purpose for
+    // password + 2FA) the system sheet sits above this view and carries its own
+    // Cancel, and every coordinator phase is raced against a deadline
+    // (AuthTimeouts), so a wedged flow always ends in a localized, retryable
+    // AuthError and re-enables the card for retry. Do not reintroduce a manual
+    // cancel button here; it was occluded during the system sheet anyway.
     private var isInteractiveAuthInProgress: Bool {
         authManager.isLoading || isAppleSigningIn || isGoogleSigningIn
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
@@ -21,7 +21,6 @@ struct SignInView: View {
     @State private var isGoogleSigningIn = false
     @State private var shouldAutofocusCode = false
     @State private var shouldAutofocusEmail = false
-    @State private var signInTask: Task<Void, Never>?
     private let errorPresentation = SignInErrorPresentation()
     @FocusState private var isEmailFocused: Bool
     @FocusState private var isCodeFocused: Bool
@@ -77,7 +76,7 @@ struct SignInView: View {
                 SignInAuthRestoreStatusView()
 
                 Button {
-                    signInTask = Task {
+                    Task {
                         await signInWithApple()
                     }
                 } label: {
@@ -94,7 +93,7 @@ struct SignInView: View {
                 .accessibilityIdentifier("signin.apple")
 
                 Button {
-                    signInTask = Task {
+                    Task {
                         await signInWithGoogle()
                     }
                 } label: {
@@ -132,7 +131,7 @@ struct SignInView: View {
 
                     Button {
                         let autofocusCodeOnSuccess = isEmailFocused
-                        signInTask = Task {
+                        Task {
                             await sendCode(autofocusCodeOnSuccess: autofocusCodeOnSuccess)
                         }
                     } label: {
@@ -149,8 +148,6 @@ struct SignInView: View {
                 if let error {
                     errorText(error)
                 }
-
-                cancelSignInButton
             }
         }
         .opacity(isAuthInProgress ? 0.6 : 1.0)
@@ -189,7 +186,7 @@ struct SignInView: View {
                             case let .assign(normalizedCode):
                                 code = normalizedCode
                             case .verify:
-                                signInTask = Task {
+                                Task {
                                     await verifyCode()
                                 }
                             case .none:
@@ -210,10 +207,8 @@ struct SignInView: View {
                     errorText(error)
                 }
 
-                cancelSignInButton
-
                 Button {
-                    signInTask = Task {
+                    Task {
                         await verifyCode()
                     }
                 } label: {
@@ -249,24 +244,6 @@ struct SignInView: View {
 
     private var isAuthInProgress: Bool {
         isInteractiveAuthInProgress || authManager.isRestoringSession
-    }
-
-    /// Escape hatch while a sign-in flow is in flight: cancels the running
-    /// task, which tears down any presented system auth sheet and ends the
-    /// loading state silently (no error). Without this, a stuck flow left the
-    /// whole screen disabled with no way out.
-    @ViewBuilder
-    private var cancelSignInButton: some View {
-        if isInteractiveAuthInProgress {
-            Button {
-                signInTask?.cancel()
-            } label: {
-                Text(L10n.string("mobile.signIn.cancel", defaultValue: "Cancel"))
-                    .font(.subheadline)
-            }
-            .foregroundStyle(.secondary)
-            .accessibilityIdentifier("signin.cancel")
-        }
     }
 
     private func sendCode(autofocusCodeOnSuccess: Bool) async {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -4540,23 +4540,6 @@
         }
       }
     },
-    "mobile.signIn.cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンセル"
-          }
-        }
-      }
-    },
     "mobile.signIn.checkEmail": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Removes the Cancel button from the iOS sign-in screen. It previously appeared during an in-progress Apple/Google/email-code sign-in as an escape hatch (calling `signInTask.cancel()`).

Removed the button view, both call sites (email-entry and code-entry cards), the `signInTask` state that existed only to back cancellation (the sign-in `Task`s now run untracked), and the unused `mobile.signIn.cancel` localized string (en + ja).

Localization audit: removed one key with full en+ja coverage; no new user-facing strings introduced; no dangling references to `mobile.signIn.cancel` or `signin.cancel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785041460&installation_id=133855650&pr_number=6797&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6797&signature=380990db4b1b0ec31a5ab0818f6e3d52ef071322be4a430f2aa07b3e4180606e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auth UX loses an explicit escape hatch during non-OAuth loading; stuck states depend on coordinator timeouts and errors instead of task cancellation.
> 
> **Overview**
> **Removes the in-app Cancel affordance** from the iOS sign-in screen on both the email and code-entry cards, along with the `signInTask` state and `cancelSignInButton` that called `signInTask?.cancel()` to abort Apple/Google/email flows.
> 
> Sign-in actions now start **untracked** `Task { }` blocks instead of storing a handle for manual cancellation. The **`mobile.signIn.cancel`** localized strings (en/ja) and **`signin.cancel`** accessibility id go away with the button.
> 
> A **comment** on `isInteractiveAuthInProgress` documents the intended model: OAuth uses the system sheet’s Cancel; wedged flows should end via **`AuthTimeouts`** with a retryable error rather than an in-card cancel (which was often hidden behind the system sheet anyway).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 760589c116b8f017752dd99f647a4d5cef43db07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Cancel button from the iOS sign-in screen to simplify the flow and avoid mid-auth interruptions. Sign-in tasks now run untracked via `Task {}`, the `mobile.signIn.cancel` string is removed (en, ja), and a code comment explains why there’s no in-app cancel (system Apple/Google sheets include Cancel and phases are deadline-raced via `AuthTimeouts`).

<sup>Written for commit 760589c116b8f017752dd99f647a4d5cef43db07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sign-in flows so authentication now continues without an in-card cancel option.
  * Improved email and code verification behavior, including automatic verification when entry is complete and retry-friendly handling if a flow stalls.
  * Adjusted the sign-in screen layout to match the updated interaction flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->