### PR TITLE
Add native pages layout mode

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7389,8 +7389,8 @@ struct CMUXCLI {
             method = "canvas.info"
         case "mode":
             guard let mode = positionals.first?.lowercased(),
-                  ["canvas", "splits", "toggle"].contains(mode) else {
-                throw CLIError(message: "Usage: cmux canvas mode <canvas|splits|toggle>")
+                  ["canvas", "niri", "splits", "toggle"].contains(mode) else {
+                throw CLIError(message: "Usage: cmux canvas mode <canvas|niri|splits|toggle>")
             }
             params["mode"] = mode
             method = "canvas.set_mode"
@@ -13467,11 +13467,11 @@ struct CMUXCLI {
             return """
             Usage: cmux canvas <subcommand> [args] [--workspace <id|ref>]
 
-            Control a workspace's freeform canvas layout.
+            Control a workspace's canvas layout.
 
             Subcommands:
               info                          Print layout mode and pane frames (z-order)
-              mode <canvas|splits|toggle>   Switch layout mode
+              mode <canvas|niri|splits|toggle> Switch layout mode; toggle cycles modes
               set-frame <surface> --x <n> --y <n> --width <n> --height <n>
                                             Place one pane at an explicit frame
               align <command>               tidy, align-left, align-right, align-top,

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasCommandScrollHint.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasCommandScrollHint.swift
@@ -8,17 +8,12 @@ import SwiftUI
 struct CanvasCommandScrollHint: View {
     /// Pre-localized hint text, supplied by the host.
     let text: String
+    let style: CanvasScrollHintStyle
     @State private var shown = false
 
     var body: some View {
         HStack(spacing: 8) {
-            keycap("⌘")
-            Image(systemName: "plus")
-                .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(.secondary)
-            Image(systemName: "scroll")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(.secondary)
+            leadingGlyphs
             Text(text)
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.primary)
@@ -38,6 +33,27 @@ struct CanvasCommandScrollHint: View {
         }
         .allowsHitTesting(false)
         .accessibilityLabel(text)
+    }
+
+    @ViewBuilder
+    private var leadingGlyphs: some View {
+        switch style {
+        case .commandPan:
+            keycap("⌘")
+            Image(systemName: "plus")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(.secondary)
+            Image(systemName: "scroll")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+        case .horizontalPages:
+            Image(systemName: "arrow.left.and.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+            Image(systemName: "scroll")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+        }
     }
 
     private func keycap(_ text: String) -> some View {

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPageContentView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPageContentView.swift
@@ -1,0 +1,50 @@
+import AppKit
+import CmuxCanvas
+
+/// The concrete AppKit view used for one native Pages surface.
+@MainActor
+final class CanvasPageContentView: NSView {
+    private(set) var paneView: CanvasPaneView?
+
+    private static let horizontalInset: CGFloat = 14
+    private static let verticalInset: CGFloat = 12
+
+    override var isFlipped: Bool { true }
+
+    func configure(
+        paneID: CanvasPaneID,
+        paneBackground: NSColor,
+        delegate: (any CanvasPaneViewDelegate)?
+    ) -> CanvasPaneView {
+        let view: CanvasPaneView
+        if let existing = paneView, existing.paneID == paneID {
+            view = existing
+        } else {
+            paneView?.removeFromSuperview()
+            let created = CanvasPaneView(paneID: paneID)
+            created.autoresizingMask = [.width, .height]
+            addSubview(created)
+            paneView = created
+            view = created
+        }
+        view.delegate = delegate
+        view.allowsResize = false
+        view.allowsTitleBarDrag = false
+        view.paneBackground = paneBackground
+        needsLayout = true
+        return view
+    }
+
+    func clear() {
+        paneView?.removeFromSuperview()
+        paneView = nil
+    }
+
+    override func layout() {
+        super.layout()
+        guard let paneView else { return }
+        let insetX = min(Self.horizontalInset, bounds.width / 4)
+        let insetY = min(Self.verticalInset, bounds.height / 4)
+        paneView.frame = bounds.insetBy(dx: insetX, dy: insetY)
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPageObject.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPageObject.swift
@@ -1,0 +1,21 @@
+import AppKit
+import CmuxCanvas
+
+/// One arranged object in the native Pages strip.
+@MainActor
+final class CanvasPageObject: NSObject {
+    let pane: CanvasPane
+
+    init(pane: CanvasPane) {
+        self.pane = pane
+        super.init()
+    }
+
+    var paneID: CanvasPaneID {
+        pane.id
+    }
+
+    var selectedPanelId: UUID {
+        pane.selectedPanelId.rawValue
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPageViewController+CanvasPaneViewDelegate.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPageViewController+CanvasPaneViewDelegate.swift
@@ -1,0 +1,24 @@
+import AppKit
+import CmuxCanvas
+
+extension CanvasPageViewController: CanvasPaneViewDelegate {
+    func paneView(_ view: CanvasPaneView, mouseDownAt documentPoint: CGPoint, region: CanvasPaneHitRegion) {}
+
+    func paneView(_ view: CanvasPaneView, draggedTo documentPoint: CGPoint, modifiers: NSEvent.ModifierFlags) {}
+
+    func paneViewDidEndDrag(_ view: CanvasPaneView) {}
+
+    func paneView(_ view: CanvasPaneView, requestTearOutTab panelId: UUID, atDocumentPoint point: CGPoint) {}
+
+    func paneView(_ view: CanvasPaneView, didSelectTab panelId: UUID) {
+        owner?.selectTab(panelId)
+    }
+
+    func paneView(_ view: CanvasPaneView, didCloseTab panelId: UUID) {
+        owner?.closeTab(panelId)
+    }
+
+    func paneViewDidRequestFocus(_ view: CanvasPaneView) {
+        owner?.focusPage(for: view.paneID)
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPageViewController.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPageViewController.swift
@@ -1,0 +1,87 @@
+import AppKit
+import CmuxCanvas
+
+/// View controller reused by `NSPageController` for native Pages surfaces.
+@MainActor
+final class CanvasPageViewController: NSViewController {
+    private let contentView = CanvasPageContentView()
+    weak var owner: CanvasPagesRootView?
+    private var page: CanvasPageObject?
+    private var mountedPaneID: CanvasPaneID?
+    private var mountedPanelId: UUID?
+    private var mount: (any CanvasPaneContentMounting)?
+
+    var currentPageObject: CanvasPageObject? {
+        page
+    }
+
+    func isRendered(in viewport: NSView, requiresWindow: Bool = true) -> Bool {
+        guard isViewLoaded,
+              view.superview != nil,
+              !view.isHiddenOrHasHiddenAncestor,
+              view.bounds.width > 1,
+              view.bounds.height > 1,
+              viewport.bounds.width > 1,
+              viewport.bounds.height > 1 else {
+            return false
+        }
+        if requiresWindow {
+            guard let window = view.window,
+                  window === viewport.window else {
+                return false
+            }
+        }
+        return view.convert(view.bounds, to: viewport).intersects(viewport.bounds)
+    }
+
+    override func loadView() {
+        view = contentView
+    }
+
+    func prepare(page: CanvasPageObject?, owner: CanvasPagesRootView) {
+        self.owner = owner
+        guard let page else {
+            teardown()
+            return
+        }
+
+        self.page = page
+        let paneView = contentView.configure(
+            paneID: page.paneID,
+            paneBackground: owner.currentTheme.paneBackground,
+            delegate: self
+        )
+        paneView.updateChrome(owner.chrome(for: page.pane))
+        reconcileMount(for: page.pane, in: paneView, owner: owner)
+        mount?.setRendering(owner.isRendering(self))
+    }
+
+    func teardown() {
+        mount?.unmount()
+        mount = nil
+        mountedPaneID = nil
+        mountedPanelId = nil
+        page = nil
+        contentView.clear()
+    }
+
+    func setRendering(_ rendering: Bool) {
+        mount?.setRendering(rendering)
+    }
+
+    private func reconcileMount(
+        for pane: CanvasPane,
+        in paneView: CanvasPaneView,
+        owner: CanvasPagesRootView
+    ) {
+        let selected = pane.selectedPanelId.rawValue
+        guard mountedPaneID != pane.id || mountedPanelId != selected else { return }
+        mount?.unmount()
+        mount = nil
+
+        guard let descriptor = owner.descriptor(for: selected) else { return }
+        mount = descriptor.makeMount(paneView.contentContainer)
+        mountedPaneID = pane.id
+        mountedPanelId = selected
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPagesRootView+NSPageControllerDelegate.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPagesRootView+NSPageControllerDelegate.swift
@@ -1,0 +1,52 @@
+public import AppKit
+
+extension CanvasPagesRootView: NSPageControllerDelegate {
+    /// Returns the stable page-controller identifier for a page object.
+    public func pageController(
+        _ pageController: NSPageController,
+        identifierFor object: Any
+    ) -> NSPageController.ObjectIdentifier {
+        guard let page = object as? CanvasPageObject else {
+            return NSPageController.ObjectIdentifier("canvas.page")
+        }
+        return identifier(for: page)
+    }
+
+    /// Creates the reusable controller that hosts one native Pages surface.
+    public func pageController(
+        _ pageController: NSPageController,
+        viewControllerForIdentifier identifier: NSPageController.ObjectIdentifier
+    ) -> NSViewController {
+        CanvasPageViewController()
+    }
+
+    /// Updates a reused page controller with the pane content for the supplied page object.
+    public func pageController(
+        _ pageController: NSPageController,
+        prepare viewController: NSViewController,
+        with object: Any?
+    ) {
+        guard let controller = viewController as? CanvasPageViewController else { return }
+        let page = object as? CanvasPageObject
+        register(controller, for: page)
+        controller.prepare(page: page, owner: self)
+        scheduleRenderingUpdate()
+    }
+
+    /// Commits focus and viewport callbacks after a page transition selects a new object.
+    public func pageController(
+        _ pageController: NSPageController,
+        didTransitionTo object: Any
+    ) {
+        guard let page = object as? CanvasPageObject else { return }
+        finishSelection(of: page)
+    }
+
+    /// Finalizes AppKit's live transition and refreshes rendered page state.
+    public func pageControllerDidEndLiveTransition(_ pageController: NSPageController) {
+        pageController.completeTransition()
+        isApplyingSyncSelection = false
+        refreshPreparedControllers()
+        updateControllerRendering()
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPagesRootView+ScrollWheel.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPagesRootView+ScrollWheel.swift
@@ -1,0 +1,98 @@
+import AppKit
+
+extension CanvasPagesRootView {
+    func installPageScrollMonitor() {
+        guard pageScrollMonitor == nil else { return }
+        pageScrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+            guard let self,
+                  let window = self.window,
+                  let location = self.pageScrollLocation(for: event, in: window) else {
+                return event
+            }
+
+            guard self.canRoutePageScroll(at: location) else {
+                return event
+            }
+
+            guard self.handlePageScroll(event) else {
+                return event
+            }
+            return nil
+        }
+    }
+
+    func removePageScrollMonitor() {
+        if let pageScrollMonitor {
+            NSEvent.removeMonitor(pageScrollMonitor)
+        }
+        pageScrollMonitor = nil
+    }
+
+    private func pageScrollLocation(for event: NSEvent, in window: NSWindow) -> NSPoint? {
+        if event.window === window || event.windowNumber == window.windowNumber {
+            return convert(event.locationInWindow, from: nil)
+        }
+
+        if let eventWindow = event.window {
+            guard eventWindowBelongsToRoot(eventWindow, root: window) else { return nil }
+            return convert(window.mouseLocationOutsideOfEventStream, from: nil)
+        }
+
+        if event.windowNumber > 0,
+           let numberedWindow = NSApp.window(withWindowNumber: event.windowNumber),
+           numberedWindow !== window {
+            guard eventWindowBelongsToRoot(numberedWindow, root: window) else { return nil }
+            return convert(window.mouseLocationOutsideOfEventStream, from: nil)
+        }
+
+        // Portal-hosted content and synthesized scroll events can arrive
+        // without the main window on the event. The physical cursor location
+        // still tells us whether the gesture belongs to this Pages root.
+        return convert(window.mouseLocationOutsideOfEventStream, from: nil)
+    }
+
+    private func eventWindowBelongsToRoot(_ candidate: NSWindow, root: NSWindow) -> Bool {
+        var current: NSWindow? = candidate
+        while let window = current {
+            if window === root { return true }
+            current = window.parent
+        }
+        return false
+    }
+
+    func canRoutePageScroll(at location: NSPoint) -> Bool {
+        guard shouldRenderPreparedPages,
+              bounds.contains(location) else {
+            return false
+        }
+        return !paneTitleBarCanHandleScroll(at: location)
+    }
+
+    private func paneTitleBarCanHandleScroll(at location: NSPoint) -> Bool {
+        var current = hitTest(location)
+        while let view = current {
+            if let paneView = view as? CanvasPaneView {
+                return paneView.canHandleTitleBarScroll(at: location, in: self)
+            }
+            current = view.superview
+        }
+        return false
+    }
+
+    private func handlePageScroll(_ event: NSEvent) -> Bool {
+        guard pageObjects.count > 1 else { return false }
+
+        let deltaX = event.hasPreciseScrollingDeltas ? event.scrollingDeltaX : event.deltaX
+        let deltaY = event.hasPreciseScrollingDeltas ? event.scrollingDeltaY : event.deltaY
+        guard CanvasPagesScrollRouting().shouldRouteToNativePages(
+            deltaX: deltaX,
+            deltaY: deltaY,
+            isShiftPressed: event.modifierFlags.contains(.shift)
+        ) else {
+            return false
+        }
+
+        pageController.view.scrollWheel(with: event)
+        return true
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPagesRootView+Viewport.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPagesRootView+Viewport.swift
@@ -1,0 +1,77 @@
+public import AppKit
+import CmuxCanvas
+
+extension CanvasPagesRootView: CanvasViewportControlling {
+    /// Rebuilds arranged pages after a model mutation outside the native page controller.
+    public func modelDidChangeExternally(animated: Bool) {
+        let selectedPanel = latestFocusedPanelId ?? selectedPageObject()?.selectedPanelId
+        pageObjects = orderedPageObjects(from: model.layout)
+        pageController.arrangedObjects = pageObjects
+        if let index = indexForPanel(selectedPanel) ?? selectedPaneID.flatMap(indexForPane) {
+            selectPage(at: index, animated: animated, suppressFocus: true)
+        }
+        refreshPreparedControllers()
+        callbacks.onLayoutChanged()
+        callbacks.onViewportGeometryChanged(window)
+    }
+
+    /// Selects the native page containing the requested panel.
+    public func revealPane(_ panelId: UUID, animated: Bool) {
+        guard let paneID = model.paneID(containing: panelId),
+              indexForPane(paneID) != nil else { return }
+        model.selectPanel(panelId)
+        pageObjects = orderedPageObjects(from: model.layout)
+        pageController.arrangedObjects = pageObjects
+        guard let index = indexForPane(paneID) else { return }
+        selectPage(at: index, animated: false, suppressFocus: true)
+        refreshPreparedControllers()
+        callbacks.onViewportGeometryChanged(window)
+    }
+
+    /// Pages mode has no overview state to toggle.
+    public func toggleOverview() {}
+
+    /// Pages mode keeps native page scale fixed at 100%.
+    public func zoom(by factor: CGFloat) {}
+
+    /// Pages mode keeps native page scale fixed at 100%.
+    public func resetZoom() {}
+
+    /// Pages mode always reports 100% magnification.
+    public var currentMagnification: CGFloat {
+        1
+    }
+
+    /// Center point of the currently selected page in canvas coordinates.
+    public var currentCenterInCanvas: CGPoint {
+        guard let object = selectedPageObject(),
+              let frame = model.layout.frame(of: object.paneID)?.cgRect else {
+            return .zero
+        }
+        return CGPoint(x: frame.midX, y: frame.midY)
+    }
+
+    /// Panel ids whose page controllers are currently attached and rendering.
+    public var renderedPanelIds: Set<UUID> {
+        renderedPagePanelIds()
+    }
+
+    /// Selects the native page whose canvas frame is nearest to the requested center.
+    public func setViewport(center: CGPoint, magnification: CGFloat?) {
+        guard let nearest = pageObjects.enumerated().min(by: { lhs, rhs in
+            distanceSquared(from: lhs.element.pane.frame.cgRect, to: center) <
+                distanceSquared(from: rhs.element.pane.frame.cgRect, to: center)
+        }) else {
+            return
+        }
+        selectPage(at: nearest.offset, animated: false, suppressFocus: true)
+        refreshPreparedControllers()
+        callbacks.onViewportGeometryChanged(window)
+    }
+
+    private func distanceSquared(from rect: CGRect, to point: CGPoint) -> CGFloat {
+        let dx = rect.midX - point.x
+        let dy = rect.midY - point.y
+        return dx * dx + dy * dy
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPagesRootView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPagesRootView.swift
@@ -1,0 +1,341 @@
+public import AppKit
+import CmuxCanvas
+
+/// Native AppKit page-strip host for the Pages workspace layout.
+@MainActor
+public final class CanvasPagesRootView: NSView {
+    let model: CanvasModel
+    let callbacks: CanvasHostCallbacks
+    private let themeProvider: () -> CanvasTheme
+    let pageController = NSPageController()
+    private var descriptorsByPanelId: [UUID: CanvasPaneDescriptor] = [:]
+    var pageObjects: [CanvasPageObject] = []
+    private var viewControllers: [NSPageController.ObjectIdentifier: CanvasPageViewController] = [:]
+    var latestFocusedPanelId: UUID?
+    var selectedPaneID: CanvasPaneID?
+    private var isWorkspaceVisible = true
+    var isApplyingSyncSelection = false
+    var pageScrollMonitor: Any?
+    private var renderingUpdateTask: Task<Void, Never>?
+    private var publishedRenderedPanelIds: Set<UUID> = []
+
+    /// Creates a native Pages root view.
+    ///
+    /// - Parameters:
+    ///   - model: The durable canvas pane/tab model owned by the workspace.
+    ///   - callbacks: Host callbacks for focus, close, and layout events.
+    ///   - themeProvider: Supplies current page and pane colors.
+    public init(
+        model: CanvasModel,
+        callbacks: CanvasHostCallbacks,
+        themeProvider: @escaping () -> CanvasTheme
+    ) {
+        self.model = model
+        self.callbacks = callbacks
+        self.themeProvider = themeProvider
+        super.init(frame: .zero)
+
+        pageController.transitionStyle = .horizontalStrip
+        pageController.delegate = self
+        pageController.view.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(pageController.view)
+        NSLayoutConstraint.activate([
+            pageController.view.topAnchor.constraint(equalTo: topAnchor),
+            pageController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
+            pageController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            pageController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+
+        wantsLayer = true
+        applyTheme()
+        model.viewport = self
+    }
+
+    /// Interface Builder initialization is unavailable for this programmatic host view.
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        nil
+    }
+
+    var currentTheme: CanvasTheme {
+        themeProvider()
+    }
+
+    var shouldRenderPreparedPages: Bool {
+        isWorkspaceVisible
+    }
+
+    private func applyTheme() {
+        layer?.backgroundColor = currentTheme.canvasBackground.cgColor
+        for controller in viewControllers.values {
+            if let page = controller.currentPageObject {
+                controller.prepare(page: page, owner: self)
+            }
+        }
+    }
+
+    /// Reapplies page colors when AppKit reports an appearance change.
+    public override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyTheme()
+    }
+
+    /// Reconciles mounted page rendering after AppKit assigns page-controller child geometry.
+    public override func layout() {
+        super.layout()
+        reconcileRenderingAfterLayout()
+    }
+
+    func reconcileRenderingAfterLayout(requiresWindow: Bool = true) {
+        pageController.view.layoutSubtreeIfNeeded()
+        updateControllerRendering(requiresWindow: requiresWindow)
+    }
+
+    /// Installs or removes the local scroll monitor as the view enters or leaves a window.
+    public override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window == nil {
+            removePageScrollMonitor()
+            updateControllerRendering()
+        } else {
+            installPageScrollMonitor()
+            scheduleRenderingUpdate()
+        }
+    }
+
+    /// Reconciles the native page strip against the host's current panels.
+    public func sync(
+        descriptors: [CanvasPaneDescriptor],
+        focusedPanelId: UUID?,
+        isWorkspaceVisible: Bool
+    ) {
+        let previousFocusedPanelId = latestFocusedPanelId
+        self.isWorkspaceVisible = isWorkspaceVisible
+        latestFocusedPanelId = focusedPanelId
+        model.syncPanes(panelIds: descriptors.map(\.id), focusedPanelId: focusedPanelId)
+        if let focusedPanelId, model.paneID(containing: focusedPanelId) != nil {
+            model.selectPanel(focusedPanelId)
+        }
+        descriptorsByPanelId = Dictionary(uniqueKeysWithValues: descriptors.map { ($0.id, $0) })
+
+        let previousPaneID = selectedPaneID
+        pageObjects = orderedPageObjects(from: model.layout)
+        pageController.arrangedObjects = pageObjects
+
+        guard !pageObjects.isEmpty else {
+            selectedPaneID = nil
+            refreshPreparedControllers()
+            callbacks.onViewportGeometryChanged(window)
+            return
+        }
+
+        let focusedIndex = indexForPanel(focusedPanelId)
+        let shouldFollowFocus = previousPaneID == nil || focusedPanelId != previousFocusedPanelId
+        let targetIndex = (shouldFollowFocus ? focusedIndex : nil)
+            ?? previousPaneID.flatMap(indexForPane)
+            ?? focusedIndex
+            ?? min(max(pageController.selectedIndex, 0), pageObjects.count - 1)
+        selectPage(at: targetIndex, animated: false, suppressFocus: true)
+        refreshPreparedControllers()
+        callbacks.onViewportGeometryChanged(window)
+    }
+
+    /// Releases mounted panel content and disconnects from the model.
+    public func teardown() {
+        for controller in viewControllers.values {
+            controller.teardown()
+        }
+        renderingUpdateTask?.cancel()
+        renderingUpdateTask = nil
+        viewControllers.removeAll()
+        pageController.delegate = nil
+        descriptorsByPanelId.removeAll()
+        pageObjects.removeAll()
+        removePageScrollMonitor()
+        if model.viewport === self {
+            model.viewport = nil
+        }
+    }
+
+    func descriptor(for panelId: UUID) -> CanvasPaneDescriptor? {
+        descriptorsByPanelId[panelId]
+    }
+
+    func chrome(for pane: CanvasPane) -> CanvasPaneChrome {
+        let tabs = pane.panelIds.compactMap { descriptorsByPanelId[$0.rawValue]?.tab }
+        let isFocused = pane.panelIds.contains { descriptorsByPanelId[$0.rawValue]?.isFocused == true }
+        let closeLabel = descriptorsByPanelId[pane.selectedPanelId.rawValue]?.closeActionLabel
+            ?? descriptorsByPanelId.values.first?.closeActionLabel
+            ?? ""
+        return CanvasPaneChrome(
+            tabs: tabs,
+            selectedTabId: pane.selectedPanelId.rawValue,
+            isFocused: isFocused,
+            closeActionLabel: closeLabel
+        )
+    }
+
+    func identifier(for page: CanvasPageObject) -> NSPageController.ObjectIdentifier {
+        NSPageController.ObjectIdentifier("canvas.page.\(page.paneID.rawValue.uuidString)")
+    }
+
+    func register(_ controller: CanvasPageViewController, for page: CanvasPageObject?) {
+        let staleIdentifiers = viewControllers.compactMap { identifier, existing in
+            existing === controller ? identifier : nil
+        }
+        for identifier in staleIdentifiers {
+            viewControllers.removeValue(forKey: identifier)
+        }
+
+        guard let page else { return }
+        let identifier = identifier(for: page)
+        if let existing = viewControllers[identifier], existing !== controller {
+            existing.teardown()
+        }
+        viewControllers[identifier] = controller
+    }
+
+    func selectTab(_ panelId: UUID) {
+        model.selectPanel(panelId)
+        callbacks.onLayoutChanged()
+        callbacks.onFocusPanel(panelId)
+        modelDidChangeExternally(animated: false)
+    }
+
+    func closeTab(_ panelId: UUID) {
+        callbacks.onClosePanel(panelId)
+    }
+
+    func focusPage(for paneID: CanvasPaneID) {
+        guard let pane = model.layout.panes.first(where: { $0.id == paneID }) else { return }
+        callbacks.onFocusPanel(pane.selectedPanelId.rawValue)
+    }
+
+    func selectedPageObject() -> CanvasPageObject? {
+        guard pageController.selectedIndex >= 0,
+              pageController.selectedIndex < pageObjects.count else {
+            return nil
+        }
+        return pageObjects[pageController.selectedIndex]
+    }
+
+    func mountedPageObjects() -> [CanvasPageObject] {
+        viewControllers.values.compactMap(\.currentPageObject)
+    }
+
+    func renderedPageObjects(requiresWindow: Bool = true) -> [CanvasPageObject] {
+        viewControllers.values.compactMap { controller in
+            isRendering(controller, requiresWindow: requiresWindow) ? controller.currentPageObject : nil
+        }
+    }
+
+    func renderedPagePanelIds(requiresWindow: Bool = true) -> Set<UUID> {
+        Set(renderedPageObjects(requiresWindow: requiresWindow).map(\.selectedPanelId))
+    }
+
+    func indexForPanel(_ panelId: UUID?) -> Int? {
+        guard let panelId,
+              let paneID = model.paneID(containing: panelId) else {
+            return nil
+        }
+        return indexForPane(paneID)
+    }
+
+    func indexForPane(_ paneID: CanvasPaneID) -> Int? {
+        pageObjects.firstIndex(where: { $0.paneID == paneID })
+    }
+
+    func selectPage(at index: Int, animated: Bool, suppressFocus: Bool) {
+        guard index >= 0, index < pageObjects.count else { return }
+        selectedPaneID = pageObjects[index].paneID
+        guard pageController.selectedIndex != index else { return }
+        if animated && !suppressFocus {
+            pageController.animator().selectedIndex = index
+            return
+        }
+        // Suppressed model-sync selections must not depend on AppKit animation callbacks.
+        let wasApplyingSyncSelection = isApplyingSyncSelection
+        isApplyingSyncSelection = suppressFocus
+        pageController.selectedIndex = index
+        isApplyingSyncSelection = wasApplyingSyncSelection
+    }
+
+    func finishSelection(of object: CanvasPageObject) {
+        selectedPaneID = object.paneID
+        refreshPreparedControllers()
+        guard !isApplyingSyncSelection else { return }
+        callbacks.onFocusPanel(object.selectedPanelId)
+        callbacks.onViewportSettled(window)
+    }
+
+    func refreshPreparedControllers() {
+        let pagesByPaneID = Dictionary(uniqueKeysWithValues: pageObjects.map { ($0.paneID, $0) })
+        let retainedPaneIDs = preparedPaneIDs()
+        for (identifier, controller) in viewControllers {
+            guard let current = controller.currentPageObject,
+                  retainedPaneIDs.contains(current.paneID),
+                  let page = pagesByPaneID[current.paneID] else {
+                controller.teardown()
+                viewControllers.removeValue(forKey: identifier)
+                continue
+            }
+            controller.prepare(page: page, owner: self)
+        }
+        scheduleRenderingUpdate()
+    }
+
+    func preparedPaneIDs() -> Set<CanvasPaneID> {
+        guard !pageObjects.isEmpty else { return [] }
+        let selectedIndex = selectedPaneID.flatMap(indexForPane)
+            ?? min(max(pageController.selectedIndex, 0), pageObjects.count - 1)
+        let lowerBound = max(0, selectedIndex - 1)
+        let upperBound = min(pageObjects.count - 1, selectedIndex + 1)
+        var paneIDs = Set(pageObjects[lowerBound...upperBound].map(\.paneID))
+        for controller in viewControllers.values where controller.isRendered(in: pageController.view, requiresWindow: false) {
+            if let page = controller.currentPageObject {
+                paneIDs.insert(page.paneID)
+            }
+        }
+        return paneIDs
+    }
+
+    func scheduleRenderingUpdate() {
+        renderingUpdateTask?.cancel()
+        renderingUpdateTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard let self, !Task.isCancelled else { return }
+            updateControllerRendering()
+        }
+    }
+
+    func updateControllerRendering(requiresWindow: Bool = true) {
+        for controller in viewControllers.values {
+            controller.setRendering(isRendering(controller, requiresWindow: requiresWindow))
+        }
+        let renderedPanelIds = renderedPagePanelIds(requiresWindow: requiresWindow)
+        guard renderedPanelIds != publishedRenderedPanelIds else { return }
+        publishedRenderedPanelIds = renderedPanelIds
+        callbacks.onViewportGeometryChanged(window)
+    }
+
+    func isRendering(_ controller: CanvasPageViewController, requiresWindow: Bool = true) -> Bool {
+        shouldRenderPreparedPages && controller.isRendered(in: pageController.view, requiresWindow: requiresWindow)
+    }
+
+    /// Returns page objects ordered by their canvas position.
+    func orderedPageObjects(from layout: CanvasLayout) -> [CanvasPageObject] {
+        layout.panes.enumerated()
+            .sorted { lhs, rhs in
+                let left = lhs.element.frame
+                let right = rhs.element.frame
+                if left.midX != right.midX {
+                    return left.midX < right.midX
+                }
+                if left.midY != right.midY {
+                    return left.midY < right.midY
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map { CanvasPageObject(pane: $0.element) }
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPagesScrollRouting.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPagesScrollRouting.swift
@@ -1,0 +1,16 @@
+import CoreGraphics
+
+/// Decides which wheel events should be handed to the native Pages strip.
+struct CanvasPagesScrollRouting: Equatable {
+    func shouldRouteToNativePages(
+        deltaX: CGFloat,
+        deltaY: CGFloat,
+        isShiftPressed: Bool
+    ) -> Bool {
+        if isShiftPressed {
+            return deltaX != 0 || deltaY != 0
+        }
+
+        return abs(deltaX) > abs(deltaY) && deltaX != 0
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPaneView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPaneView.swift
@@ -49,6 +49,17 @@ final class CanvasPaneView: NSView {
     private var tabScrollOffset: CGFloat = 0
     private var tabContentWidth: CGFloat = 0
 
+    /// Whether the pane exposes freeform resize hit regions and cursors.
+    var allowsResize = true {
+        didSet {
+            guard allowsResize != oldValue else { return }
+            discardCursorRects()
+        }
+    }
+
+    /// Whether the title bar can drag panes/tabs around the canvas.
+    var allowsTitleBarDrag = true
+
     /// Pane fill behind the content, resolved by the host through
     /// ``CanvasTheme``.
     var paneBackground: NSColor = .windowBackgroundColor {
@@ -124,8 +135,7 @@ final class CanvasPaneView: NSView {
             },
             onContentWidthChanged: { [weak self] width in
                 guard let self, self.tabContentWidth != width else { return }
-                self.tabContentWidth = width
-                self.clampTabScrollOffset()
+                self.setMeasuredTabContentWidth(width)
             }
         )
         applyChromeColors()
@@ -136,6 +146,12 @@ final class CanvasPaneView: NSView {
         max(0, tabContentWidth - bounds.width)
     }
 
+    func setMeasuredTabContentWidth(_ width: CGFloat) {
+        guard tabContentWidth != width else { return }
+        tabContentWidth = width
+        clampTabScrollOffset()
+    }
+
     private func clampTabScrollOffset() {
         let clamped = min(max(0, tabScrollOffset), maxTabScrollOffset)
         if clamped != tabScrollOffset {
@@ -144,11 +160,17 @@ final class CanvasPaneView: NSView {
         }
     }
 
+    func canHandleTitleBarScroll(at point: NSPoint, in coordinateView: NSView?) -> Bool {
+        let local = convert(point, from: coordinateView)
+        return bounds.contains(local)
+            && local.y <= CanvasPaneTitleBarView.height
+            && maxTabScrollOffset > 0
+    }
+
     override func scrollWheel(with event: NSEvent) {
         // Only handle scrolls over the title bar with overflowing tabs;
         // everything else (content scroll, no overflow) passes through.
-        let local = convert(event.locationInWindow, from: nil)
-        guard local.y <= CanvasPaneTitleBarView.height, maxTabScrollOffset > 0 else {
+        guard canHandleTitleBarScroll(at: event.locationInWindow, in: nil) else {
             super.scrollWheel(with: event)
             return
         }
@@ -181,22 +203,24 @@ final class CanvasPaneView: NSView {
 
     private func hitRegion(at point: CGPoint) -> CanvasPaneHitRegion? {
         var edges: CanvasResizeEdges = []
-        if point.x <= Self.resizeBandWidth { edges.insert(.left) }
-        if point.x >= bounds.width - Self.resizeBandWidth { edges.insert(.right) }
-        if point.y <= Self.resizeBandWidth { edges.insert(.top) }
-        if point.y >= bounds.height - Self.resizeBandWidth { edges.insert(.bottom) }
+        if allowsResize {
+            if point.x <= Self.resizeBandWidth { edges.insert(.left) }
+            if point.x >= bounds.width - Self.resizeBandWidth { edges.insert(.right) }
+            if point.y <= Self.resizeBandWidth { edges.insert(.top) }
+            if point.y >= bounds.height - Self.resizeBandWidth { edges.insert(.bottom) }
 
-        // Widen corners so diagonal grabs are easy.
-        if edges == .left || edges == .right {
-            if point.y <= Self.cornerBandWidth { edges.insert(.top) }
-            if point.y >= bounds.height - Self.cornerBandWidth { edges.insert(.bottom) }
-        } else if edges == .top || edges == .bottom {
-            if point.x <= Self.cornerBandWidth { edges.insert(.left) }
-            if point.x >= bounds.width - Self.cornerBandWidth { edges.insert(.right) }
-        }
+            // Widen corners so diagonal grabs are easy.
+            if edges == .left || edges == .right {
+                if point.y <= Self.cornerBandWidth { edges.insert(.top) }
+                if point.y >= bounds.height - Self.cornerBandWidth { edges.insert(.bottom) }
+            } else if edges == .top || edges == .bottom {
+                if point.x <= Self.cornerBandWidth { edges.insert(.left) }
+                if point.x >= bounds.width - Self.cornerBandWidth { edges.insert(.right) }
+            }
 
-        if !edges.isEmpty {
-            return .resize(edges)
+            if !edges.isEmpty {
+                return .resize(edges)
+            }
         }
         if point.y <= CanvasPaneTitleBarView.height {
             return .titleBar
@@ -255,6 +279,11 @@ final class CanvasPaneView: NSView {
             let dx = abs(documentPoint.x - dragStartDocumentPoint.x)
             let dy = abs(documentPoint.y - dragStartDocumentPoint.y)
             guard dx >= Self.dragActivationDistance || dy >= Self.dragActivationDistance else { return }
+            guard allowsTitleBarDrag || region != .titleBar else {
+                activeDragRegion = nil
+                pendingTabClick = nil
+                return
+            }
             dragStartedMoving = true
             // A drag that began on a tab (not its close glyph) of a multi-tab
             // pane tears that tab out into its own pane and keeps dragging it,
@@ -306,6 +335,7 @@ final class CanvasPaneView: NSView {
 
     override func resetCursorRects() {
         super.resetCursorRects()
+        guard allowsResize else { return }
         let band = Self.resizeBandWidth
         let width = bounds.width
         let height = bounds.height

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+CommandScroll.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+CommandScroll.swift
@@ -51,8 +51,8 @@ extension CanvasRootView {
 
             // A plain scroll that lands on a pane is consumed by the pane's
             // content (the canvas doesn't pan), so this is the teachable
-            // moment for Command+scroll. Empty-canvas scrolls already pan and
-            // need no hint.
+            // moment for the command-scroll hint. Empty-canvas scrolls
+            // already pan and need no hint.
             if self.paneView(at: location) != nil {
                 self.noteInPaneScrollForHint()
             }
@@ -106,13 +106,13 @@ extension CanvasRootView {
         commandScrollMonitor = nil
     }
 
-    // MARK: Command+scroll discovery hint
+    // MARK: Scroll discovery hint
 
     /// Debounced trigger: after ~1.2s of scrolling inside a pane, show a
-    /// one-time hint that Command+scroll pans the canvas. Cancellable Task
+    /// one-time hint for the current canvas-hosted mode. Cancellable Task
     /// (no banned asyncAfter); re-entry restarts the debounce.
     func noteInPaneScrollForHint() {
-        guard !Self.didShowCommandScrollHintThisSession else { return }
+        guard !didShowCurrentScrollHint else { return }
         commandScrollHintTask?.cancel()
         commandScrollHintTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 1_200_000_000)
@@ -122,10 +122,13 @@ extension CanvasRootView {
     }
 
     func presentCommandScrollHint() {
-        guard !Self.didShowCommandScrollHintThisSession, commandScrollHintHost == nil else { return }
-        Self.didShowCommandScrollHintThisSession = true
+        guard !didShowCurrentScrollHint, commandScrollHintHost == nil else { return }
+        markCurrentScrollHintShown()
 
-        let host = NSHostingView(rootView: CanvasCommandScrollHint(text: commandScrollHintText))
+        let host = NSHostingView(rootView: CanvasCommandScrollHint(
+            text: currentScrollHintText,
+            style: currentScrollHintStyle
+        ))
         host.translatesAutoresizingMaskIntoConstraints = false
         host.wantsLayer = true
         addSubview(host, positioned: .above, relativeTo: nil)
@@ -149,8 +152,26 @@ extension CanvasRootView {
             context.duration = 0.25
             host.animator().alphaValue = 0
         }, completionHandler: { [weak host] in
-            host?.removeFromSuperview()
+            Task { @MainActor in
+                host?.removeFromSuperview()
+            }
         })
         commandScrollHintHost = nil
+    }
+
+    private var currentScrollHintStyle: CanvasScrollHintStyle {
+        .commandPan
+    }
+
+    private var currentScrollHintText: String {
+        commandScrollHintText
+    }
+
+    private var didShowCurrentScrollHint: Bool {
+        Self.didShowCommandScrollHintThisSession
+    }
+
+    private func markCurrentScrollHintShown() {
+        Self.didShowCommandScrollHintThisSession = true
     }
 }

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+SpacePan.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+SpacePan.swift
@@ -10,7 +10,7 @@ extension CanvasRootView {
     }
 
     func handleSpacePanEvent(_ event: NSEvent) -> NSEvent? {
-        guard canvasSpacePanShouldHandleEvents(isWorkspaceVisible: isWorkspaceVisible) else {
+        guard spacePanBehavior.shouldHandleEvents(isWorkspaceVisible: isWorkspaceVisible) else {
             cancelSpacePan()
             return event
         }
@@ -19,7 +19,7 @@ extension CanvasRootView {
             guard isSpacePanKeyEvent(event) else { return event }
             isSpacePanKeyDown = true
             if event.isARepeat {
-                return canvasSpacePanShouldConsumeSpaceKeyRepeat(
+                return spacePanBehavior.shouldConsumeSpaceKeyRepeat(
                     didConsumeSpaceKey: didConsumeSpacePanKeyDown,
                     isPanning: spacePanSession != nil
                 ) ? nil : event
@@ -40,7 +40,7 @@ extension CanvasRootView {
         case .leftMouseDown:
             refreshSpacePanKeyState()
             let pointerInsideCanvas = bounds.contains(convert(event.locationInWindow, from: nil))
-            guard canvasSpacePanCanBegin(
+            guard spacePanBehavior.canBeginPan(
                 didConsumeSpaceKey: didConsumeSpacePanKeyDown,
                 isPhysicalSpaceKeyPressed: Self.isPhysicalSpaceKeyPressed,
                 isPointerInsideCanvas: pointerInsideCanvas
@@ -90,7 +90,7 @@ extension CanvasRootView {
         // not owned by the canvas background. If the key was not swallowed, the
         // later mouse-down must not start a pan because a literal Space may
         // already have been delivered to that responder.
-        return canvasSpacePanShouldConsumeSpaceKey(
+        return spacePanBehavior.shouldConsumeSpaceKey(
             isPointerInsideCanvas: true,
             canInterceptKeyboardTarget: canInterceptSpacePanKeyboardTarget(in: window),
             isPanning: spacePanSession != nil
@@ -102,7 +102,7 @@ extension CanvasRootView {
         if responder === window {
             return true
         }
-        if canvasSpacePanIsTextInputOrControlResponder(responder) {
+        if isTextInputOrControlResponder(responder) {
             return false
         }
         guard let view = responder as? NSView else { return false }
@@ -135,7 +135,7 @@ extension CanvasRootView {
 
     private func updateSpacePan(with event: NSEvent) {
         guard let session = spacePanSession else { return }
-        let origin = canvasSpacePanClipOrigin(
+        let origin = spacePanBehavior.clipOrigin(
             startClipOrigin: session.startClipOrigin,
             startWindowPoint: session.startWindowPoint,
             currentWindowPoint: event.locationInWindow,
@@ -166,53 +166,11 @@ extension CanvasRootView {
         NSCursor.pop()
         didPushSpacePanCursor = false
     }
-}
 
-func canvasSpacePanClipOrigin(
-    startClipOrigin: CGPoint,
-    startWindowPoint: CGPoint,
-    currentWindowPoint: CGPoint,
-    magnification: CGFloat
-) -> CGPoint {
-    let scale = max(magnification, 0.0001)
-    let dx = (currentWindowPoint.x - startWindowPoint.x) / scale
-    let dy = (currentWindowPoint.y - startWindowPoint.y) / scale
-    return CGPoint(
-        x: startClipOrigin.x - dx,
-        y: startClipOrigin.y + dy
-    )
-}
-
-func canvasSpacePanShouldConsumeSpaceKey(
-    isPointerInsideCanvas: Bool,
-    canInterceptKeyboardTarget: Bool,
-    isPanning: Bool
-) -> Bool {
-    isPanning || (isPointerInsideCanvas && canInterceptKeyboardTarget)
-}
-
-func canvasSpacePanShouldConsumeSpaceKeyRepeat(
-    didConsumeSpaceKey: Bool,
-    isPanning: Bool
-) -> Bool {
-    didConsumeSpaceKey || isPanning
-}
-
-func canvasSpacePanCanBegin(
-    didConsumeSpaceKey: Bool,
-    isPhysicalSpaceKeyPressed: Bool,
-    isPointerInsideCanvas: Bool
-) -> Bool {
-    didConsumeSpaceKey && isPhysicalSpaceKeyPressed && isPointerInsideCanvas
-}
-
-func canvasSpacePanShouldHandleEvents(isWorkspaceVisible: Bool) -> Bool {
-    isWorkspaceVisible
-}
-
-private func canvasSpacePanIsTextInputOrControlResponder(_ responder: NSResponder) -> Bool {
-    if responder is NSText || responder is any NSTextInputClient {
-        return true
+    private func isTextInputOrControlResponder(_ responder: NSResponder) -> Bool {
+        if responder is NSText || responder is any NSTextInputClient {
+            return true
+        }
+        return responder is NSControl
     }
-    return responder is NSControl
 }

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Viewport.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Viewport.swift
@@ -18,8 +18,10 @@ extension CanvasRootView: CanvasViewportControlling {
                     }
                 }
             }, completionHandler: { [weak self] in
-                guard let self else { return }
-                self.callbacks.onViewportGeometryChanged(self.window)
+                Task { @MainActor in
+                    guard let self else { return }
+                    self.callbacks.onViewportGeometryChanged(self.window)
+                }
             })
         } else {
             applyAllPaneFrames()
@@ -68,6 +70,11 @@ extension CanvasRootView: CanvasViewportControlling {
         return CGPoint(x: canvas.midX, y: canvas.midY)
     }
 
+    /// Panel ids whose pane content is currently mounted for rendering.
+    public var renderedPanelIds: Set<UUID> {
+        Set(model.layout.panes.map(\.selectedPanelId.rawValue))
+    }
+
     public func setViewport(center: CGPoint, magnification: CGFloat?) {
         // An explicit viewport set invalidates the overview round-trip restore.
         overviewRestore = nil
@@ -100,6 +107,21 @@ extension CanvasRootView: CanvasViewportControlling {
         scrollView.reflectScrolledClipView(scrollView.contentView)
         callbacks.onViewportGeometryChanged(window)
         callbacks.onViewportSettled(window)
+    }
+
+    func setClipOrigin(_ origin: CGPoint, animated: Bool) {
+        if animated {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.28
+                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                context.allowsImplicitAnimation = true
+                scrollView.contentView.animator().setBoundsOrigin(origin)
+                scrollView.reflectScrolledClipView(scrollView.contentView)
+            }
+        } else {
+            scrollView.contentView.setBoundsOrigin(origin)
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+        }
     }
 
     /// Zooms by `factor` while keeping the document point under

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
@@ -30,6 +30,7 @@ public final class CanvasRootView: NSView {
     private var descriptorsByPanelId: [UUID: CanvasPaneDescriptor] = [:]
     private var renderingByPane: [CanvasPaneID: Bool] = [:]
     var isWorkspaceVisible = true
+    let spacePanBehavior = CanvasSpacePanBehavior()
     /// Canvas coordinates of the document view's (0,0).
     var documentOriginInCanvas: CGPoint = .zero
     var dragSession: DragSession?
@@ -43,6 +44,7 @@ public final class CanvasRootView: NSView {
     /// pinch, never fires `didEndLiveMagnify`), so portals re-anchor once the
     /// zoom gesture stops.
     var zoomSettleTask: Task<Void, Never>?
+    var latestFocusedPanelId: UUID?
     private var hasPlacedInitialViewport = false
     /// One-per-session throttle for the Command+scroll discovery hint.
     static var didShowCommandScrollHintThisSession = false
@@ -71,6 +73,13 @@ public final class CanvasRootView: NSView {
         var lastPoint: CGPoint = .zero
     }
 
+    /// Creates a canvas root view.
+    ///
+    /// - Parameters:
+    ///   - model: The durable canvas model owned by the host workspace.
+    ///   - commandScrollHintText: Localized text for the Command-scroll hint.
+    ///   - callbacks: Host callbacks for focus, layout, and viewport events.
+    ///   - themeProvider: Supplies current canvas and pane colors.
     public init(
         model: CanvasModel,
         commandScrollHintText: String,
@@ -203,6 +212,7 @@ public final class CanvasRootView: NSView {
         let becameVisible = isWorkspaceVisible && !self.isWorkspaceVisible
         self.isWorkspaceVisible = isWorkspaceVisible
         if !isWorkspaceVisible { cancelSpacePan() }
+        latestFocusedPanelId = focusedPanelId
         let added = model.syncPanes(
             panelIds: descriptors.map(\.id),
             focusedPanelId: focusedPanelId
@@ -276,6 +286,8 @@ public final class CanvasRootView: NSView {
                 documentView.addSubview(paneView)
                 paneViews[pane.id] = paneView
             }
+            paneView.allowsResize = true
+            paneView.allowsTitleBarDrag = true
             reconcileMount(for: pane, in: paneView)
             paneView.updateChrome(chrome(for: pane))
         }
@@ -482,18 +494,4 @@ public final class CanvasRootView: NSView {
         setClipOrigin(target, animated: animated)
     }
 
-    func setClipOrigin(_ origin: CGPoint, animated: Bool) {
-        if animated {
-            NSAnimationContext.runAnimationGroup { context in
-                context.duration = 0.28
-                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-                context.allowsImplicitAnimation = true
-                scrollView.contentView.animator().setBoundsOrigin(origin)
-                scrollView.reflectScrolledClipView(scrollView.contentView)
-            }
-        } else {
-            scrollView.contentView.setBoundsOrigin(origin)
-            scrollView.reflectScrolledClipView(scrollView.contentView)
-        }
-    }
 }

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasScrollHintStyle.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasScrollHintStyle.swift
@@ -1,0 +1,5 @@
+/// Presentation style for the canvas scroll discovery hint.
+enum CanvasScrollHintStyle {
+    case commandPan
+    case horizontalPages
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasSpacePanBehavior.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasSpacePanBehavior.swift
@@ -1,0 +1,46 @@
+import CoreGraphics
+
+/// Encapsulates Figma-style Space+drag pan decisions and drag math.
+struct CanvasSpacePanBehavior {
+    func clipOrigin(
+        startClipOrigin: CGPoint,
+        startWindowPoint: CGPoint,
+        currentWindowPoint: CGPoint,
+        magnification: CGFloat
+    ) -> CGPoint {
+        let scale = max(magnification, 0.0001)
+        let dx = (currentWindowPoint.x - startWindowPoint.x) / scale
+        let dy = (currentWindowPoint.y - startWindowPoint.y) / scale
+        return CGPoint(
+            x: startClipOrigin.x - dx,
+            y: startClipOrigin.y + dy
+        )
+    }
+
+    func shouldConsumeSpaceKey(
+        isPointerInsideCanvas: Bool,
+        canInterceptKeyboardTarget: Bool,
+        isPanning: Bool
+    ) -> Bool {
+        isPanning || (isPointerInsideCanvas && canInterceptKeyboardTarget)
+    }
+
+    func shouldConsumeSpaceKeyRepeat(
+        didConsumeSpaceKey: Bool,
+        isPanning: Bool
+    ) -> Bool {
+        didConsumeSpaceKey || isPanning
+    }
+
+    func canBeginPan(
+        didConsumeSpaceKey: Bool,
+        isPhysicalSpaceKeyPressed: Bool,
+        isPointerInsideCanvas: Bool
+    ) -> Bool {
+        didConsumeSpaceKey && isPhysicalSpaceKeyPressed && isPointerInsideCanvas
+    }
+
+    func shouldHandleEvents(isWorkspaceVisible: Bool) -> Bool {
+        isWorkspaceVisible
+    }
+}

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasViewportControlling.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasViewportControlling.swift
@@ -25,6 +25,8 @@ public protocol CanvasViewportControlling: AnyObject {
     var currentMagnification: CGFloat { get }
     /// Current viewport center, in canvas coordinates.
     var currentCenterInCanvas: CGPoint { get }
+    /// Panel ids whose content is currently mounted in the viewport.
+    var renderedPanelIds: Set<UUID> { get }
     /// Re-reads the model after an external mutation (palette command,
     /// automation verb) and animates pane views to their new frames.
     func modelDidChangeExternally(animated: Bool)

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasModelTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasModelTests.swift
@@ -183,4 +183,5 @@ struct CanvasModelTests {
         #expect(changed)
         #expect(model.frame(of: b)?.origin.y == 0)
     }
+
 }

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasPagesRootViewRenderingTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasPagesRootViewRenderingTests.swift
@@ -1,0 +1,70 @@
+import AppKit
+import Testing
+import CmuxCanvas
+@testable import CmuxCanvasUI
+
+@MainActor
+@Suite("CanvasPagesRootView rendering", .serialized)
+struct CanvasPagesRootViewRenderingTests {
+    @Test func layoutReconcilesRenderingAfterPageViewReceivesGeometry() throws {
+        let root = makeRoot()
+        root.frame = NSRect(x: 0, y: 0, width: 900, height: 600)
+        root.pageController.view.frame = root.bounds
+        defer { root.teardown() }
+
+        let paneID = CanvasPaneID(rawValue: UUID())
+        let probe = MountProbe()
+        root.sync(
+            descriptors: [makeDescriptor(id: paneID.rawValue, probe: probe)],
+            focusedPanelId: paneID.rawValue,
+            isWorkspaceVisible: true
+        )
+        let page = try #require(root.pageObjects.first)
+        let identifier = root.pageController(root.pageController, identifierFor: page)
+        let controller = try #require(
+            root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                as? CanvasPageViewController
+        )
+        root.pageController(root.pageController, prepare: controller, with: page)
+        root.pageController.view.addSubview(controller.view)
+        controller.view.frame = .zero
+        root.updateControllerRendering()
+        #expect(probe.renderStates.last == false)
+
+        controller.view.frame = root.pageController.view.bounds.insetBy(dx: 20, dy: 20)
+        root.reconcileRenderingAfterLayout(requiresWindow: false)
+
+        #expect(probe.renderStates.last == true)
+        #expect(root.renderedPagePanelIds(requiresWindow: false) == Set([page.selectedPanelId]))
+    }
+
+    private func makeRoot() -> CanvasPagesRootView {
+        CanvasPagesRootView(
+            model: CanvasModel(metricsProvider: {
+                CanvasMetrics(gap: 16, snapThreshold: 8, minPaneSize: CanvasSize(width: 120, height: 80))
+            }),
+            callbacks: CanvasHostCallbacks(
+                onFocusPanel: { _ in },
+                onClosePanel: { _ in },
+                onLayoutChanged: {},
+                onViewportGeometryChanged: { _ in }
+            ),
+            themeProvider: {
+                CanvasTheme(canvasBackground: .black, paneBackground: .black)
+            }
+        )
+    }
+
+    private func makeDescriptor(id: UUID, probe: MountProbe) -> CanvasPaneDescriptor {
+        CanvasPaneDescriptor(
+            id: id,
+            tab: CanvasTabChrome(id: id, title: "Terminal", iconSystemName: "terminal"),
+            isFocused: false,
+            closeActionLabel: "Close",
+            makeMount: { container in
+                probe.mountCount += 1
+                return FakeMount(container: container, probe: probe)
+            }
+        )
+    }
+}

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasPagesRootViewTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasPagesRootViewTests.swift
@@ -1,0 +1,492 @@
+import AppKit
+import Testing
+import CmuxCanvas
+@testable import CmuxCanvasUI
+
+@MainActor
+@Suite("CanvasPagesRootView", .serialized)
+struct CanvasPagesRootViewTests {
+    @Test func pageIdentifiersAreStablePerPane() {
+        let root = makeRoot()
+        let paneID = CanvasPaneID(rawValue: UUID())
+        let otherPaneID = CanvasPaneID(rawValue: UUID())
+
+        let first = CanvasPageObject(pane: makePane(id: paneID))
+        let recreated = CanvasPageObject(pane: makePane(id: paneID))
+        let other = CanvasPageObject(pane: makePane(id: otherPaneID))
+
+        let firstIdentifier = root.pageController(root.pageController, identifierFor: first)
+        #expect(root.pageController(root.pageController, identifierFor: recreated) == firstIdentifier)
+        #expect(root.pageController(root.pageController, identifierFor: other) != firstIdentifier)
+    }
+
+    @Test func controllersForRemovedPagesAreReleased() throws {
+        let root = makeRoot()
+        let page = CanvasPageObject(pane: makePane(id: CanvasPaneID(rawValue: UUID())))
+        let identifier = root.pageController(root.pageController, identifierFor: page)
+        weak var weakController: CanvasPageViewController?
+
+        do {
+            let controller = try #require(
+                root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                    as? CanvasPageViewController
+            )
+            weakController = controller
+            prepare(controller, with: page, in: root)
+
+            root.pageObjects = []
+            root.refreshPreparedControllers()
+        }
+
+        #expect(weakController == nil)
+    }
+
+    @Test func duplicateControllerForSamePageReplacesStaleMount() throws {
+        let root = makeRoot()
+        let paneID = CanvasPaneID(rawValue: UUID())
+        let probe = MountProbe()
+        root.sync(
+            descriptors: [makeDescriptor(id: paneID.rawValue, probe: probe)],
+            focusedPanelId: paneID.rawValue,
+            isWorkspaceVisible: true
+        )
+        let page = try #require(root.pageObjects.first)
+        let identifier = root.pageController(root.pageController, identifierFor: page)
+        let first = try #require(
+            root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                as? CanvasPageViewController
+        )
+        root.pageController(root.pageController, prepare: first, with: page)
+        #expect(probe.mountCount > 0)
+
+        let duplicate = try #require(
+            root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                as? CanvasPageViewController
+        )
+        #expect(first !== duplicate)
+        root.pageController(root.pageController, prepare: duplicate, with: page)
+
+        #expect(probe.unmountCount > 0)
+        #expect(root.mountedPageObjects().map(\.paneID) == [paneID])
+        #expect(root.renderedPanelIds.isEmpty)
+    }
+
+    @Test func reusedControllerMovesToNewPageWithoutStaleAlias() throws {
+        let root = makeRoot()
+        let first = CanvasPaneID(rawValue: UUID())
+        let second = CanvasPaneID(rawValue: UUID())
+        let firstProbe = MountProbe()
+        let secondProbe = MountProbe()
+        root.sync(
+            descriptors: [
+                makeDescriptor(id: first.rawValue, probe: firstProbe),
+                makeDescriptor(id: second.rawValue, probe: secondProbe),
+            ],
+            focusedPanelId: first.rawValue,
+            isWorkspaceVisible: true
+        )
+        let firstPage = try #require(root.pageObjects.first(where: { $0.paneID == first }))
+        let secondPage = try #require(root.pageObjects.first(where: { $0.paneID == second }))
+        let firstIdentifier = root.pageController(root.pageController, identifierFor: firstPage)
+        let controller = try #require(
+            root.pageController(root.pageController, viewControllerForIdentifier: firstIdentifier)
+                as? CanvasPageViewController
+        )
+        prepare(controller, with: firstPage, in: root)
+        #expect(root.mountedPageObjects().map(\.paneID) == [first])
+
+        root.pageController(root.pageController, prepare: controller, with: secondPage)
+
+        #expect(firstProbe.unmountCount > 0)
+        #expect(secondProbe.mountCount > 0)
+        #expect(root.mountedPageObjects().map(\.paneID) == [second])
+    }
+
+    @Test func nilPagePrepareUnregistersReusedController() throws {
+        let root = makeRoot()
+        let paneID = CanvasPaneID(rawValue: UUID())
+        let probe = MountProbe()
+        root.sync(
+            descriptors: [makeDescriptor(id: paneID.rawValue, probe: probe)],
+            focusedPanelId: paneID.rawValue,
+            isWorkspaceVisible: true
+        )
+        let page = try #require(root.pageObjects.first)
+        let identifier = root.pageController(root.pageController, identifierFor: page)
+        let controller = try #require(
+            root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                as? CanvasPageViewController
+        )
+        prepare(controller, with: page, in: root)
+        #expect(root.mountedPageObjects().map(\.paneID) == [paneID])
+
+        root.pageController(root.pageController, prepare: controller, with: nil)
+
+        #expect(probe.unmountCount > 0)
+        #expect(root.mountedPageObjects().isEmpty)
+    }
+
+    @Test func suppressedSelectionDoesNotFocusPageUntilTransitionEnds() {
+        var focusedPanelId: UUID?
+        let root = makeRoot(onFocusPanel: { focusedPanelId = $0 })
+        let second = CanvasPageObject(pane: makePane(id: CanvasPaneID(rawValue: UUID())))
+        root.isApplyingSyncSelection = true
+
+        root.finishSelection(of: second)
+
+        #expect(focusedPanelId == nil)
+        #expect(root.isApplyingSyncSelection)
+
+        root.pageControllerDidEndLiveTransition(root.pageController)
+        #expect(!root.isApplyingSyncSelection)
+    }
+
+    @Test func descriptorArrivingAfterMissMountsPage() throws {
+        let root = makeRoot()
+        let paneID = CanvasPaneID(rawValue: UUID())
+        let page = CanvasPageObject(pane: makePane(id: paneID))
+        let identifier = root.pageController(root.pageController, identifierFor: page)
+        let controller = try #require(
+            root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                as? CanvasPageViewController
+        )
+        prepare(controller, with: page, in: root)
+
+        let probe = MountProbe()
+        root.sync(
+            descriptors: [makeDescriptor(id: paneID.rawValue, probe: probe)],
+            focusedPanelId: nil,
+            isWorkspaceVisible: true
+        )
+
+        #expect(probe.mountCount > 0)
+    }
+
+    @Test func refreshEvictsVisitedControllersOutsideSelectedNeighborhood() throws {
+        let root = makeRoot()
+        let paneIDs = (0..<4).map { _ in CanvasPaneID(rawValue: UUID()) }
+        let probes = Dictionary(uniqueKeysWithValues: paneIDs.map { ($0, MountProbe()) })
+        root.sync(
+            descriptors: paneIDs.map { paneID in
+                makeDescriptor(id: paneID.rawValue, probe: probes[paneID]!)
+            },
+            focusedPanelId: paneIDs[1].rawValue,
+            isWorkspaceVisible: true
+        )
+        let orderedPaneIDs = root.pageObjects.map(\.paneID)
+        root.pageController.selectedIndex = 1
+
+        weak var evictedController: CanvasPageViewController?
+        var unmountCountsBeforeRefresh: [CanvasPaneID: Int] = [:]
+        do {
+            var strongEvictedController: CanvasPageViewController?
+            for page in root.pageObjects {
+                let paneID = page.paneID
+                let identifier = root.pageController(root.pageController, identifierFor: page)
+                let controller = try #require(
+                    root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                        as? CanvasPageViewController
+                )
+                prepare(controller, with: page, in: root)
+                if paneID == orderedPaneIDs[3] {
+                    evictedController = controller
+                    strongEvictedController = controller
+                }
+            }
+            unmountCountsBeforeRefresh = Dictionary(
+                uniqueKeysWithValues: orderedPaneIDs.map { paneID in
+                    (paneID, probes[paneID]?.unmountCount ?? 0)
+                }
+            )
+
+            root.refreshPreparedControllers()
+            withExtendedLifetime(strongEvictedController) {}
+            strongEvictedController = nil
+        }
+
+        #expect(probes[orderedPaneIDs[0]]?.unmountCount == unmountCountsBeforeRefresh[orderedPaneIDs[0]])
+        #expect(probes[orderedPaneIDs[1]]?.unmountCount == unmountCountsBeforeRefresh[orderedPaneIDs[1]])
+        #expect(probes[orderedPaneIDs[2]]?.unmountCount == unmountCountsBeforeRefresh[orderedPaneIDs[2]])
+        #expect((probes[orderedPaneIDs[3]]?.unmountCount ?? 0) > (unmountCountsBeforeRefresh[orderedPaneIDs[3]] ?? 0))
+        #expect(evictedController == nil)
+    }
+
+    @Test func renderedPanelIdsIncludeAttachedPagesOnly() throws {
+        let root = makeRoot()
+        let paneIDs = (0..<4).map { _ in CanvasPaneID(rawValue: UUID()) }
+        let probes = Dictionary(uniqueKeysWithValues: paneIDs.map { ($0, MountProbe()) })
+        root.sync(
+            descriptors: paneIDs.map { paneID in
+                makeDescriptor(id: paneID.rawValue, probe: probes[paneID]!)
+            },
+            focusedPanelId: paneIDs[1].rawValue,
+            isWorkspaceVisible: true
+        )
+        root.pageController.selectedIndex = 1
+        root.frame = NSRect(x: 0, y: 0, width: 900, height: 600)
+        root.pageController.view.frame = root.bounds
+        defer { root.teardown() }
+
+        let page = root.pageObjects[2]
+        let identifier = root.pageController(root.pageController, identifierFor: page)
+        let controller = try #require(
+            root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                as? CanvasPageViewController
+        )
+        prepare(controller, with: page, in: root)
+        #expect(probes[page.paneID]?.renderStates == [false])
+
+        controller.view.frame = NSRect(
+            x: root.pageController.view.bounds.maxX + 20,
+            y: 0,
+            width: 300,
+            height: 200
+        )
+        root.pageController.view.addSubview(controller.view)
+        root.updateControllerRendering()
+        #expect(probes[page.paneID]?.renderStates == [false, false])
+        #expect(!root.renderedPanelIds.contains(page.selectedPanelId))
+        #expect(!controller.isRendered(in: root.pageController.view, requiresWindow: false))
+
+        controller.view.frame = root.pageController.view.bounds.insetBy(dx: 20, dy: 20)
+        root.updateControllerRendering()
+        #expect(root.renderedPanelIds.isEmpty)
+        #expect(controller.isRendered(in: root.pageController.view, requiresWindow: false))
+
+        controller.view.removeFromSuperview()
+        root.updateControllerRendering()
+        #expect(!root.renderedPanelIds.contains(page.selectedPanelId))
+        #expect(Array(probes[page.paneID]?.renderStates.suffix(3) ?? []) == [false, false, false])
+    }
+
+    @Test func renderedPanelIdChangesPublishViewportGeometry() throws {
+        var geometryChangeCount = 0
+        let root = makeRoot(onViewportGeometryChanged: { _ in geometryChangeCount += 1 })
+        root.frame = NSRect(x: 0, y: 0, width: 900, height: 600)
+        root.pageController.view.frame = root.bounds
+        defer { root.teardown() }
+
+        let paneIDs = (0..<2).map { _ in CanvasPaneID(rawValue: UUID()) }
+        root.sync(
+            descriptors: paneIDs.map { makeDescriptor(id: $0.rawValue, probe: MountProbe()) },
+            focusedPanelId: paneIDs[0].rawValue,
+            isWorkspaceVisible: true
+        )
+        let page = root.pageObjects[1]
+        let identifier = root.pageController(root.pageController, identifierFor: page)
+        let controller = try #require(
+            root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                as? CanvasPageViewController
+        )
+        prepare(controller, with: page, in: root)
+        geometryChangeCount = 0
+
+        controller.view.frame = root.pageController.view.bounds.insetBy(dx: 20, dy: 20)
+        root.pageController.view.addSubview(controller.view)
+        root.updateControllerRendering(requiresWindow: false)
+
+        #expect(root.renderedPagePanelIds(requiresWindow: false).contains(page.selectedPanelId))
+        #expect(geometryChangeCount == 1)
+
+        controller.view.frame = NSRect(
+            x: root.pageController.view.bounds.maxX + 20,
+            y: 0,
+            width: 300,
+            height: 200
+        )
+        root.updateControllerRendering(requiresWindow: false)
+
+        #expect(!root.renderedPagePanelIds(requiresWindow: false).contains(page.selectedPanelId))
+        #expect(geometryChangeCount == 2)
+    }
+
+    @Test func revealSelectsPageWithoutPendingAnimatedTransition() {
+        let root = makeRoot()
+        let paneIDs = (0..<4).map { _ in CanvasPaneID(rawValue: UUID()) }
+        root.sync(
+            descriptors: paneIDs.map { makeDescriptor(id: $0.rawValue, probe: MountProbe()) },
+            focusedPanelId: paneIDs[0].rawValue,
+            isWorkspaceVisible: true
+        )
+        root.pageController.selectedIndex = 0
+
+        let target = root.pageObjects[3]
+        root.revealPane(target.selectedPanelId, animated: true)
+
+        #expect(root.pageController.selectedIndex == 3)
+        #expect(!root.isApplyingSyncSelection)
+    }
+
+    @Test func animatedExternalModelSyncDoesNotLeaveFocusSuppressed() {
+        var focusedPanelId: UUID?
+        let root = makeRoot(onFocusPanel: { focusedPanelId = $0 })
+        let paneIDs = (0..<4).map { _ in CanvasPaneID(rawValue: UUID()) }
+        root.sync(
+            descriptors: paneIDs.map { makeDescriptor(id: $0.rawValue, probe: MountProbe()) },
+            focusedPanelId: paneIDs[0].rawValue,
+            isWorkspaceVisible: true
+        )
+
+        let target = root.pageObjects[2]
+        root.latestFocusedPanelId = target.selectedPanelId
+        root.modelDidChangeExternally(animated: true)
+
+        #expect(root.pageController.selectedIndex == 2)
+        #expect(!root.isApplyingSyncSelection)
+        #expect(focusedPanelId == nil)
+    }
+
+    @Test func setViewportSelectsNearestPageAndPublishesGeometry() throws {
+        var geometryChangeCount = 0
+        let root = makeRoot(onViewportGeometryChanged: { _ in geometryChangeCount += 1 })
+        let first = CanvasPaneID(rawValue: UUID())
+        let second = CanvasPaneID(rawValue: UUID())
+        let secondProbe = MountProbe()
+        let descriptors = [
+            makeDescriptor(id: first.rawValue, probe: MountProbe()),
+            makeDescriptor(id: second.rawValue, probe: secondProbe),
+        ]
+        root.sync(
+            descriptors: descriptors,
+            focusedPanelId: first.rawValue,
+            isWorkspaceVisible: true
+        )
+        root.model.setFrame(CGRect(x: 0, y: 0, width: 300, height: 200), for: first.rawValue)
+        root.model.setFrame(CGRect(x: 1_000, y: 0, width: 300, height: 200), for: second.rawValue)
+        root.modelDidChangeExternally(animated: false)
+
+        let page = try #require(root.pageObjects.first(where: { $0.paneID == second }))
+        let identifier = root.pageController(root.pageController, identifierFor: page)
+        let controller = try #require(
+            root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                as? CanvasPageViewController
+        )
+        prepare(controller, with: page, in: root)
+        geometryChangeCount = 0
+
+        root.setViewport(center: CGPoint(x: 1_150, y: 100), magnification: nil)
+
+        #expect(root.pageController.selectedIndex == root.indexForPane(second))
+        #expect(geometryChangeCount == 1)
+        #expect(secondProbe.renderStates.allSatisfy { !$0 })
+
+        root.sync(
+            descriptors: descriptors,
+            focusedPanelId: first.rawValue,
+            isWorkspaceVisible: true
+        )
+        #expect(root.pageController.selectedIndex == root.indexForPane(second))
+    }
+
+    @Test func revealSelectsBackgroundTabBeforeRefreshingControllers() throws {
+        let root = makeRoot()
+        let first = UUID()
+        let second = UUID()
+        let firstProbe = MountProbe()
+        let secondProbe = MountProbe()
+        root.sync(
+            descriptors: [
+                makeDescriptor(id: first, probe: firstProbe),
+                makeDescriptor(id: second, probe: secondProbe),
+            ],
+            focusedPanelId: first,
+            isWorkspaceVisible: true
+        )
+        #expect(root.model.joinPanel(second, withPaneContaining: first))
+        root.model.selectPanel(first)
+        root.modelDidChangeExternally(animated: false)
+        let page = try #require(root.pageObjects.first)
+        let identifier = root.pageController(root.pageController, identifierFor: page)
+        let controller = try #require(
+            root.pageController(root.pageController, viewControllerForIdentifier: identifier)
+                as? CanvasPageViewController
+        )
+        prepare(controller, with: page, in: root)
+        #expect(firstProbe.mountCount > 0)
+        #expect(secondProbe.mountCount == 0)
+
+        root.revealPane(second, animated: true)
+
+        #expect(root.pageObjects.first?.selectedPanelId == second)
+        #expect(secondProbe.mountCount > 0)
+        #expect(firstProbe.unmountCount > 0)
+    }
+
+    @Test func paneTitleBarScrollRequiresOverflow() {
+        let pane = CanvasPaneView(paneID: CanvasPaneID(rawValue: UUID()))
+        pane.frame = CGRect(x: 0, y: 0, width: 100, height: 120)
+
+        pane.setMeasuredTabContentWidth(180)
+
+        #expect(pane.canHandleTitleBarScroll(at: NSPoint(x: 12, y: 12), in: pane))
+        #expect(!pane.canHandleTitleBarScroll(at: NSPoint(x: 12, y: CanvasPaneTitleBarView.height + 8), in: pane))
+
+        pane.setMeasuredTabContentWidth(80)
+        #expect(!pane.canHandleTitleBarScroll(at: NSPoint(x: 12, y: 12), in: pane))
+    }
+
+    @Test func inactivePagesRootDoesNotRoutePageScroll() {
+        let root = makeRoot()
+        defer { root.teardown() }
+        root.frame = NSRect(x: 0, y: 0, width: 900, height: 600)
+        let descriptors = [
+            makeDescriptor(id: UUID(), probe: MountProbe()),
+            makeDescriptor(id: UUID(), probe: MountProbe()),
+        ]
+        root.sync(descriptors: descriptors, focusedPanelId: nil, isWorkspaceVisible: false)
+
+        #expect(!root.canRoutePageScroll(at: NSPoint(x: 100, y: 100)))
+
+        root.sync(descriptors: descriptors, focusedPanelId: nil, isWorkspaceVisible: true)
+
+        #expect(root.canRoutePageScroll(at: NSPoint(x: 100, y: 100)))
+    }
+
+    private func makeRoot(
+        onFocusPanel: @escaping (UUID) -> Void = { _ in },
+        onViewportGeometryChanged: @escaping (NSWindow?) -> Void = { _ in }
+    ) -> CanvasPagesRootView {
+        CanvasPagesRootView(
+            model: CanvasModel(metricsProvider: {
+                CanvasMetrics(gap: 16, snapThreshold: 8, minPaneSize: CanvasSize(width: 120, height: 80))
+            }),
+            callbacks: CanvasHostCallbacks(
+                onFocusPanel: onFocusPanel,
+                onClosePanel: { _ in },
+                onLayoutChanged: {},
+                onViewportGeometryChanged: onViewportGeometryChanged
+            ),
+            themeProvider: {
+                CanvasTheme(canvasBackground: .black, paneBackground: .black)
+            }
+        )
+    }
+
+    private func prepare(
+        _ controller: CanvasPageViewController,
+        with page: CanvasPageObject,
+        in root: CanvasPagesRootView
+    ) {
+        root.pageController(root.pageController, prepare: controller, with: page)
+    }
+
+    private func makePane(id: CanvasPaneID) -> CanvasPane {
+        CanvasPane(
+            id: id,
+            frame: CanvasRect(x: 0, y: 0, width: 300, height: 200)
+        )
+    }
+
+    private func makeDescriptor(id: UUID, probe: MountProbe) -> CanvasPaneDescriptor {
+        CanvasPaneDescriptor(
+            id: id,
+            tab: CanvasTabChrome(id: id, title: "Terminal", iconSystemName: "terminal"),
+            isFocused: false,
+            closeActionLabel: "Close",
+            makeMount: { container in
+                probe.mountCount += 1
+                return FakeMount(container: container, probe: probe)
+            }
+        )
+    }
+}

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasPagesScrollRoutingTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasPagesScrollRoutingTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import CmuxCanvasUI
+
+@Suite("CanvasPagesScrollRouting")
+struct CanvasPagesScrollRoutingTests {
+    @Test func shiftWheelRoutesToNativePages() {
+        #expect(CanvasPagesScrollRouting().shouldRouteToNativePages(
+            deltaX: 0,
+            deltaY: -1,
+            isShiftPressed: true
+        ))
+    }
+
+    @Test func verticalWheelWithoutShiftStaysWithSurfaceContent() {
+        #expect(!CanvasPagesScrollRouting().shouldRouteToNativePages(
+            deltaX: 0,
+            deltaY: -10,
+            isShiftPressed: false
+        ))
+    }
+
+    @Test func dominantHorizontalWheelRoutesToNativePages() {
+        #expect(CanvasPagesScrollRouting().shouldRouteToNativePages(
+            deltaX: -12,
+            deltaY: 1,
+            isShiftPressed: false
+        ))
+    }
+
+    @Test func dominantVerticalTrackpadMovementStaysWithSurfaceContent() {
+        #expect(!CanvasPagesScrollRouting().shouldRouteToNativePages(
+            deltaX: -3,
+            deltaY: -18,
+            isShiftPressed: false
+        ))
+    }
+}

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasSpacePanTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasSpacePanTests.swift
@@ -5,8 +5,10 @@ import Testing
 @MainActor
 @Suite("Canvas space pan")
 struct CanvasSpacePanTests {
+    private let behavior = CanvasSpacePanBehavior()
+
     @Test func dragMovesViewportAsIfGrabbingCanvas() {
-        let origin = canvasSpacePanClipOrigin(
+        let origin = behavior.clipOrigin(
             startClipOrigin: CGPoint(x: 100, y: 200),
             startWindowPoint: CGPoint(x: 40, y: 50),
             currentWindowPoint: CGPoint(x: 70, y: 90),
@@ -18,7 +20,7 @@ struct CanvasSpacePanTests {
     }
 
     @Test func dragDeltaScalesWithMagnification() {
-        let origin = canvasSpacePanClipOrigin(
+        let origin = behavior.clipOrigin(
             startClipOrigin: CGPoint(x: 100, y: 200),
             startWindowPoint: CGPoint(x: 40, y: 50),
             currentWindowPoint: CGPoint(x: 70, y: 90),
@@ -30,7 +32,7 @@ struct CanvasSpacePanTests {
     }
 
     @Test func spaceKeyDoesNotArmPanWhilePaneOwnsKeyboardFocus() {
-        #expect(!canvasSpacePanShouldConsumeSpaceKey(
+        #expect(!behavior.shouldConsumeSpaceKey(
             isPointerInsideCanvas: true,
             canInterceptKeyboardTarget: false,
             isPanning: false
@@ -38,7 +40,7 @@ struct CanvasSpacePanTests {
     }
 
     @Test func spaceKeyCanArmPanWhenCanvasOwnsKeyboardFocus() {
-        #expect(canvasSpacePanShouldConsumeSpaceKey(
+        #expect(behavior.shouldConsumeSpaceKey(
             isPointerInsideCanvas: true,
             canInterceptKeyboardTarget: true,
             isPanning: false
@@ -46,7 +48,7 @@ struct CanvasSpacePanTests {
     }
 
     @Test func activePanConsumesSpaceKeyUntilGestureEnds() {
-        #expect(canvasSpacePanShouldConsumeSpaceKey(
+        #expect(behavior.shouldConsumeSpaceKey(
             isPointerInsideCanvas: false,
             canInterceptKeyboardTarget: false,
             isPanning: true
@@ -54,18 +56,18 @@ struct CanvasSpacePanTests {
     }
 
     @Test func spaceKeyRepeatPreservesInitialConsumptionDecision() {
-        #expect(canvasSpacePanShouldConsumeSpaceKeyRepeat(
+        #expect(behavior.shouldConsumeSpaceKeyRepeat(
             didConsumeSpaceKey: true,
             isPanning: false
         ))
-        #expect(!canvasSpacePanShouldConsumeSpaceKeyRepeat(
+        #expect(!behavior.shouldConsumeSpaceKeyRepeat(
             didConsumeSpaceKey: false,
             isPanning: false
         ))
     }
 
     @Test func spaceKeyDoesNotArmPanWhileTextOrControlOwnsKeyboardFocus() {
-        #expect(!canvasSpacePanShouldConsumeSpaceKey(
+        #expect(!behavior.shouldConsumeSpaceKey(
             isPointerInsideCanvas: true,
             canInterceptKeyboardTarget: false,
             isPanning: false
@@ -73,7 +75,7 @@ struct CanvasSpacePanTests {
     }
 
     @Test func spaceKeyDoesNotArmPanWhileForeignViewOwnsKeyboardFocus() {
-        #expect(!canvasSpacePanShouldConsumeSpaceKey(
+        #expect(!behavior.shouldConsumeSpaceKey(
             isPointerInsideCanvas: true,
             canInterceptKeyboardTarget: false,
             isPanning: false
@@ -81,12 +83,12 @@ struct CanvasSpacePanTests {
     }
 
     @Test func panBeginsOnlyWhenConsumedSpaceIsStillPhysicallyHeld() {
-        #expect(canvasSpacePanCanBegin(
+        #expect(behavior.canBeginPan(
             didConsumeSpaceKey: true,
             isPhysicalSpaceKeyPressed: true,
             isPointerInsideCanvas: true
         ))
-        #expect(!canvasSpacePanCanBegin(
+        #expect(!behavior.canBeginPan(
             didConsumeSpaceKey: true,
             isPhysicalSpaceKeyPressed: false,
             isPointerInsideCanvas: true
@@ -94,7 +96,7 @@ struct CanvasSpacePanTests {
     }
 
     @Test func panDoesNotBeginFromSpaceDeliveredToPane() {
-        #expect(!canvasSpacePanCanBegin(
+        #expect(!behavior.canBeginPan(
             didConsumeSpaceKey: false,
             isPhysicalSpaceKeyPressed: true,
             isPointerInsideCanvas: true
@@ -102,7 +104,7 @@ struct CanvasSpacePanTests {
     }
 
     @Test func hiddenCanvasDoesNotHandleSpacePanEvents() {
-        #expect(canvasSpacePanShouldHandleEvents(isWorkspaceVisible: true))
-        #expect(!canvasSpacePanShouldHandleEvents(isWorkspaceVisible: false))
+        #expect(behavior.shouldHandleEvents(isWorkspaceVisible: true))
+        #expect(!behavior.shouldHandleEvents(isWorkspaceVisible: false))
     }
 }

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/FakeMount.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/FakeMount.swift
@@ -1,0 +1,22 @@
+import AppKit
+@testable import CmuxCanvasUI
+
+@MainActor
+final class FakeMount: CanvasPaneContentMounting {
+    private let probe: MountProbe
+    private weak var container: NSView?
+
+    init(container: NSView, probe: MountProbe) {
+        self.container = container
+        self.probe = probe
+    }
+
+    func setRendering(_ rendering: Bool) {
+        probe.renderStates.append(rendering)
+    }
+
+    func unmount() {
+        probe.unmountCount += 1
+        container = nil
+    }
+}

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/MountProbe.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/MountProbe.swift
@@ -1,0 +1,6 @@
+@MainActor
+final class MountProbe {
+    var mountCount = 0
+    var unmountCount = 0
+    var renderStates: [Bool] = []
+}

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Canvas/ControlCanvasContext.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Canvas/ControlCanvasContext.swift
@@ -14,7 +14,7 @@ public protocol ControlCanvasContext: AnyObject {
     func controlCanvasInfo(routing: ControlRoutingSelectors) -> ControlCanvasInfoSnapshot?
 
     /// Sets the layout mode for `canvas.set_mode`. `mode` is `"canvas"`,
-    /// `"splits"`, or `"toggle"` (validated by the coordinator).
+    /// `"niri"`, `"splits"`, or `"toggle"` (validated by the coordinator).
     func controlCanvasSetMode(
         routing: ControlRoutingSelectors,
         mode: String

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Canvas/ControlCommandCoordinator+Canvas.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Canvas/ControlCommandCoordinator+Canvas.swift
@@ -82,14 +82,14 @@ extension ControlCommandCoordinator {
 
     // MARK: - set_mode
 
-    /// `canvas.set_mode` — switch the workspace between `canvas`, `splits`,
-    /// or `toggle`.
+    /// `canvas.set_mode` — switch the workspace between `canvas`, `niri`,
+    /// `splits`, or `toggle`.
     func canvasSetMode(_ params: [String: JSONValue]) -> ControlCallResult {
         guard let mode = string(params, "mode"),
-              ["canvas", "splits", "toggle"].contains(mode) else {
+              ["canvas", "niri", "splits", "toggle"].contains(mode) else {
             return .err(
                 code: "invalid_params",
-                message: "mode must be canvas, splits, or toggle",
+                message: "mode must be canvas, niri, splits, or toggle",
                 data: nil
             )
         }

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorCanvasTests.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorCanvasTests.swift
@@ -191,6 +191,14 @@ struct ControlCommandCoordinatorCanvasTests {
         #expect(result == .ok(.object(["mode": .string("canvas")])))
     }
 
+    @Test func setModeAcceptsNiriMode() {
+        let (coordinator, context) = makeCoordinator()
+        context.actionResolution = .ok(mode: "niri")
+        let result = coordinator.handle(request("canvas.set_mode", ["mode": .string("niri")]))
+        #expect(context.lastMode == "niri")
+        #expect(result == .ok(.object(["mode": .string("niri")])))
+    }
+
     @Test func setFrameRequiresSurfaceAndPositiveSize() {
         let (coordinator, context) = makeCoordinator()
         let surfaceID = UUID()

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -357,7 +357,7 @@ extension ShortcutAction {
         case .splitBrowserDown: return "Split Browser Down"
         case .toggleRightSidebar: return "Toggle Right Sidebar"
         case .toggleCanvasLayout:
-            return String(localized: "shortcut.toggleCanvasLayout.label", defaultValue: "Toggle Canvas Layout")
+            return String(localized: "shortcut.toggleCanvasLayout.label", defaultValue: "Cycle Layout Mode")
         case .canvasRevealFocusedPane:
             return String(localized: "shortcut.canvasRevealFocusedPane.label", defaultValue: "Canvas: Reveal Focused Pane")
         case .canvasOverview:

--- a/Sources/Canvas/CanvasAction.swift
+++ b/Sources/Canvas/CanvasAction.swift
@@ -8,7 +8,7 @@ import CmuxCanvasUI
 /// `canvas.*` debug-socket verbs all construct a `CanvasAction` and run it
 /// through ``CanvasActionExecutor`` — no surface carries its own logic.
 enum CanvasAction: Equatable {
-    /// Toggle the workspace between split and canvas layout.
+    /// Cycle the workspace through split, canvas, and horizontal pages layout.
     case toggleLayout
     /// Scroll the focused pane fully into view.
     case revealFocusedPane
@@ -85,7 +85,7 @@ struct CanvasActionExecutor {
             workspace.toggleCanvasLayout()
             return true
         case .revealFocusedPane:
-            guard workspace.layoutMode == .canvas,
+            guard workspace.layoutMode.usesCanvasHost,
                   let panelId = workspace.focusedPanelId else { return false }
             workspace.canvasModel.viewport?.revealPane(panelId, animated: true)
             return true

--- a/Sources/Canvas/CanvasPagesRootRepresentable.swift
+++ b/Sources/Canvas/CanvasPagesRootRepresentable.swift
@@ -1,0 +1,71 @@
+import AppKit
+import SwiftUI
+import CmuxCanvasUI
+
+/// Bridges descriptor snapshots into the package's native Pages host.
+struct CanvasPagesRootRepresentable: NSViewRepresentable {
+    let workspace: Workspace
+    let descriptors: [CanvasPaneDescriptor]
+    let focusedPanelId: UUID?
+    let isWorkspaceVisible: Bool
+
+    func makeNSView(context: Context) -> CanvasPagesRootView {
+        let workspace = workspace
+        return CanvasPagesRootView(
+            model: workspace.canvasModel,
+            callbacks: CanvasHostCallbacks(
+                onFocusPanel: { [weak workspace] panelId in
+                    guard let workspace else { return }
+                    AppDelegate.shared?.noteMainPanelKeyboardFocusIntent(
+                        workspaceId: workspace.id,
+                        panelId: panelId,
+                        in: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                    workspace.focusPanel(panelId)
+                },
+                onClosePanel: { [weak workspace] panelId in
+                    _ = workspace?.closePanel(panelId)
+                },
+                onLayoutChanged: { [weak workspace] in
+                    guard let workspace else { return }
+                    workspace.noteCanvasLayoutChanged()
+                    _ = workspace.reconcileBrowserPortalVisibilityForCurrentRenderedLayout(
+                        reason: "pages.layoutChanged"
+                    )
+                },
+                onViewportGeometryChanged: { [weak workspace] window in
+                    _ = workspace?.reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
+                    _ = workspace?.reconcileBrowserPortalVisibilityForCurrentRenderedLayout(
+                        reason: "pages.viewportGeometryChanged"
+                    )
+                    guard let window else { return }
+                    BrowserWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+                },
+                onViewportSettled: { [weak workspace] window in
+                    _ = workspace?.reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
+                    _ = workspace?.reconcileBrowserPortalVisibilityForCurrentRenderedLayout(
+                        reason: "pages.viewportSettled"
+                    )
+                    guard let window else { return }
+                    BrowserWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+                }
+            ),
+            themeProvider: {
+                let background = GhosttyBackgroundTheme.currentColor()
+                return CanvasTheme(canvasBackground: background, paneBackground: background)
+            }
+        )
+    }
+
+    func updateNSView(_ nsView: CanvasPagesRootView, context: Context) {
+        nsView.sync(
+            descriptors: descriptors,
+            focusedPanelId: focusedPanelId,
+            isWorkspaceVisible: isWorkspaceVisible
+        )
+    }
+
+    static func dismantleNSView(_ nsView: CanvasPagesRootView, coordinator: ()) {
+        nsView.teardown()
+    }
+}

--- a/Sources/Canvas/ContentView+CanvasCommandPalette.swift
+++ b/Sources/Canvas/ContentView+CanvasCommandPalette.swift
@@ -21,6 +21,21 @@ extension ContentView {
         ("palette.canvas.distributeHorizontally", .canvasDistributeHorizontally, ["canvas", "distribute", "horizontal", "gap", "pack"]),
         ("palette.canvas.distributeVertically", .canvasDistributeVertically, ["canvas", "distribute", "vertical", "gap", "pack"]),
     ]
+    private static let freeformOnlyCanvasPaletteActions: Set<KeyboardShortcutSettings.Action> = [
+        .canvasOverview,
+        .canvasZoomIn,
+        .canvasZoomOut,
+        .canvasZoomReset,
+        .canvasTidy,
+        .canvasAlignLeft,
+        .canvasAlignRight,
+        .canvasAlignTop,
+        .canvasAlignBottom,
+        .canvasEqualizeWidths,
+        .canvasEqualizeHeights,
+        .canvasDistributeHorizontally,
+        .canvasDistributeVertically,
+    ]
 
     static func commandPaletteCanvasCommandContributions() -> [CommandPaletteCommandContribution] {
         let subtitle = String(localized: "command.canvas.subtitle", defaultValue: "Canvas")
@@ -34,8 +49,13 @@ extension ContentView {
                     guard snapshot.bool(CommandPaletteContextKeys.hasWorkspace) else { return false }
                     // The mode toggle is always offered; everything else is
                     // canvas-only.
-                    return command.action == .toggleCanvasLayout
-                        || snapshot.bool(CommandPaletteContextKeys.workspaceCanvasLayout)
+                    if command.action == .toggleCanvasLayout {
+                        return true
+                    }
+                    if freeformOnlyCanvasPaletteActions.contains(command.action) {
+                        return snapshot.bool(CommandPaletteContextKeys.workspaceFreeformCanvasLayout)
+                    }
+                    return snapshot.bool(CommandPaletteContextKeys.workspaceCanvasLayout)
                 }
             )
         }

--- a/Sources/Canvas/Workspace+CanvasLayout.swift
+++ b/Sources/Canvas/Workspace+CanvasLayout.swift
@@ -22,7 +22,8 @@ extension Workspace {
     /// split tree itself is left untouched, so switching back restores it.
     func setLayoutMode(_ mode: WorkspaceLayoutMode) {
         guard mode != layoutMode else { return }
-        if mode == .canvas {
+        let wasCanvasHosted = layoutMode.usesCanvasHost
+        if mode.usesCanvasHost && !wasCanvasHosted {
             canvasModel.seedFromSplitFrames(splitPaneFramesByPanelId())
         }
         layoutMode = mode
@@ -39,9 +40,9 @@ extension Workspace {
         // each visible pane's selected terminal via its portal-detach path.
         // Leaving canvas: reconcile to the split-mode rendered set so the
         // re-attached terminals show at the correct split frames.
-        if mode == .canvas {
+        if mode.usesCanvasHost && !wasCanvasHosted {
             hideAllTerminalPortalViews()
-        } else {
+        } else if !mode.usesCanvasHost && wasCanvasHosted {
             reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
         }
         reconcileBrowserPortalVisibilityForCurrentRenderedLayout(
@@ -52,9 +53,9 @@ extension Workspace {
         NotificationCenter.default.post(name: .workspaceLayoutModeDidChange, object: self)
     }
 
-    /// Toggles between split and canvas layout.
+    /// Cycles between split, canvas, and horizontal pages layout.
     func toggleCanvasLayout() {
-        setLayoutMode(layoutMode == .canvas ? .splits : .canvas)
+        setLayoutMode(layoutMode.nextCycledMode)
     }
 
     /// Canvas-mode directional focus: nearest pane spatially, then reveal it.
@@ -131,8 +132,10 @@ extension Workspace {
             }
             canvasModel.restorePanes(restored)
         }
-        if snapshot.layoutMode == WorkspaceLayoutMode.canvas.rawValue {
-            layoutMode = .canvas
+        if let rawLayoutMode = snapshot.layoutMode,
+           let restoredLayoutMode = WorkspaceLayoutMode(rawValue: rawLayoutMode),
+           restoredLayoutMode.usesCanvasHost {
+            layoutMode = restoredLayoutMode
         }
     }
 
@@ -206,7 +209,7 @@ extension Workspace {
     /// disabled). Must be called in canvas mode.
     @discardableResult
     func openNewCanvasPane(type: CanvasNewPaneType, focus: Bool = true) -> UUID? {
-        guard layoutMode == .canvas else { return nil }
+        guard layoutMode.usesCanvasHost else { return nil }
         guard let focusedPaneId = bonsplitController.focusedPaneId else { return nil }
         let newPanelId: UUID
         switch type {
@@ -235,7 +238,7 @@ extension Workspace {
     /// the canvas model first, since panel creation can run before the next
     /// descriptor sync.
     func joinNewPanelIntoCanvasPane(_ panelId: UUID, anchor: UUID) {
-        guard layoutMode == .canvas else { return }
+        guard layoutMode.usesCanvasHost else { return }
         canvasModel.syncPanes(
             panelIds: orderedPanelIds,
             focusedPanelId: anchor
@@ -250,9 +253,11 @@ extension Workspace {
 extension Workspace {
     /// Mirrors canvas pane z-order onto portal-hosted browser webviews so a
     /// front pane's webview stacks above a back pane's.
-    func syncCanvasBrowserPortalZOrder() {
-        guard layoutMode == .canvas else { return }
+    @discardableResult
+    func syncCanvasBrowserPortalZOrder() -> Bool {
+        guard layoutMode == .canvas else { return false }
         let zOrder = canvasModel.layout.paneIDs
+        var didUpdate = false
         for panel in panels.values {
             guard let browserPanel = panel as? BrowserPanel,
                   !browserPanel.canvasInlineHostingActive,
@@ -263,6 +268,8 @@ extension Workspace {
                 visibleInUI: true,
                 zPriority: 2 + z
             )
+            didUpdate = true
         }
+        return didUpdate
     }
 }

--- a/Sources/Canvas/WorkspaceCanvasHostView.swift
+++ b/Sources/Canvas/WorkspaceCanvasHostView.swift
@@ -19,12 +19,23 @@ struct WorkspaceCanvasHostView: View {
     let appearance: PanelAppearance
 
     var body: some View {
-        CanvasRootRepresentable(
-            workspace: workspace,
-            descriptors: descriptors,
-            focusedPanelId: workspace.focusedPanelId,
-            isWorkspaceVisible: isWorkspaceVisible
-        )
+        Group {
+            if workspace.layoutMode == .niri {
+                CanvasPagesRootRepresentable(
+                    workspace: workspace,
+                    descriptors: descriptors,
+                    focusedPanelId: workspace.focusedPanelId,
+                    isWorkspaceVisible: isWorkspaceVisible
+                )
+            } else {
+                CanvasRootRepresentable(
+                    workspace: workspace,
+                    descriptors: descriptors,
+                    focusedPanelId: workspace.focusedPanelId,
+                    isWorkspaceVisible: isWorkspaceVisible
+                )
+            }
+        }
     }
 
     private var descriptors: [CanvasPaneDescriptor] {

--- a/Sources/Canvas/WorkspaceLayoutMode.swift
+++ b/Sources/Canvas/WorkspaceLayoutMode.swift
@@ -6,4 +6,28 @@ enum WorkspaceLayoutMode: String, Codable, Sendable {
     case splits
     /// The freeform 2D canvas layout.
     case canvas
+    /// A Niri-style horizontal page strip implemented by a native AppKit page host.
+    case niri
+
+    /// Whether this mode is rendered by the canvas host rather than bonsplit.
+    var usesCanvasHost: Bool {
+        switch self {
+        case .canvas, .niri:
+            return true
+        case .splits:
+            return false
+        }
+    }
+
+    /// Next mode used by the hidden layout-cycle action.
+    var nextCycledMode: WorkspaceLayoutMode {
+        switch self {
+        case .splits:
+            return .canvas
+        case .canvas:
+            return .niri
+        case .niri:
+            return .splits
+        }
+    }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1489,6 +1489,7 @@ struct ContentView: View {
         static let workspaceHasPullRequests = "workspace.hasPullRequests"
         static let workspaceHasSplits = "workspace.hasSplits"
         static let workspaceCanvasLayout = "workspace.canvasLayout"
+        static let workspaceFreeformCanvasLayout = "workspace.freeformCanvasLayout"
         static let workspaceHasPeers = "workspace.hasPeers"
         static let workspaceHasAbove = "workspace.hasAbove"
         static let workspaceHasBelow = "workspace.hasBelow"
@@ -6666,6 +6667,10 @@ struct ContentView: View {
             )
             snapshot.setBool(
                 CommandPaletteContextKeys.workspaceCanvasLayout,
+                workspace.layoutMode.usesCanvasHost
+            )
+            snapshot.setBool(
+                CommandPaletteContextKeys.workspaceFreeformCanvasLayout,
                 workspace.layoutMode == .canvas
             )
             let workspaceIndex = tabManager.tabs.firstIndex { $0.id == workspace.id }
@@ -19201,4 +19206,3 @@ enum SidebarPresetOption: String, CaseIterable, Identifiable {
         }
     }
 }
-

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -244,7 +244,7 @@ enum KeyboardShortcutSettings {
             case .equalizeSplits: return String(localized: "shortcut.equalizeSplits.label", defaultValue: "Equalize Splits")
             case .splitBrowserRight: return String(localized: "shortcut.splitBrowserRight.label", defaultValue: "Split Browser Right")
             case .splitBrowserDown: return String(localized: "shortcut.splitBrowserDown.label", defaultValue: "Split Browser Down")
-            case .toggleCanvasLayout: return String(localized: "shortcut.toggleCanvasLayout.label", defaultValue: "Toggle Canvas Layout")
+            case .toggleCanvasLayout: return String(localized: "shortcut.toggleCanvasLayout.label", defaultValue: "Cycle Layout Mode")
             case .canvasRevealFocusedPane: return String(localized: "shortcut.canvasRevealFocusedPane.label", defaultValue: "Canvas: Reveal Focused Pane")
             case .canvasOverview: return String(localized: "shortcut.canvasOverview.label", defaultValue: "Canvas: Toggle Overview")
             case .canvasZoomIn: return String(localized: "shortcut.canvasZoomIn.label", defaultValue: "Canvas: Zoom In")

--- a/Sources/TerminalController+ControlCanvasContext.swift
+++ b/Sources/TerminalController+ControlCanvasContext.swift
@@ -41,7 +41,7 @@ extension TerminalController: ControlCanvasContext {
         var magnification: Double?
         var centerX: Double?
         var centerY: Double?
-        if ws.layoutMode == .canvas, let viewport = ws.canvasModel.viewport {
+        if ws.layoutMode.usesCanvasHost, let viewport = ws.canvasModel.viewport {
             magnification = Double(viewport.currentMagnification)
             let center = viewport.currentCenterInCanvas
             centerX = Double(center.x)
@@ -67,6 +67,8 @@ extension TerminalController: ControlCanvasContext {
         switch mode {
         case "toggle":
             ws.toggleCanvasLayout()
+        case "niri":
+            ws.setLayoutMode(.niri)
         case "canvas":
             ws.setLayoutMode(.canvas)
         default:
@@ -114,7 +116,7 @@ extension TerminalController: ControlCanvasContext {
         guard let ws = resolveCanvasWorkspace(routing: routing) else {
             return .workspaceNotFound
         }
-        guard ws.layoutMode == .canvas else { return .notCanvasMode }
+        guard ws.layoutMode.usesCanvasHost else { return .notCanvasMode }
         guard let target = surfaceID ?? ws.focusedPanelId else {
             return .noFocusedPane
         }
@@ -131,8 +133,9 @@ extension TerminalController: ControlCanvasContext {
         guard let ws = resolveCanvasWorkspace(routing: routing) else {
             return .workspaceNotFound
         }
-        guard ws.layoutMode == .canvas else { return .notCanvasMode }
-        ws.canvasModel.viewport?.toggleOverview()
+        guard CanvasActionExecutor(workspace: ws).perform(.toggleOverview) else {
+            return .notCanvasMode
+        }
         return .ok(mode: ws.layoutMode.rawValue)
     }
 
@@ -143,15 +146,17 @@ extension TerminalController: ControlCanvasContext {
         guard let ws = resolveCanvasWorkspace(routing: routing) else {
             return .workspaceNotFound
         }
-        guard ws.layoutMode == .canvas else { return .notCanvasMode }
         let executor = CanvasActionExecutor(workspace: ws)
-        switch direction {
+        let didZoom = switch direction {
         case .zoomIn:
             executor.perform(.zoomIn)
         case .zoomOut:
             executor.perform(.zoomOut)
         case .reset:
             executor.perform(.zoomReset)
+        }
+        guard didZoom else {
+            return .notCanvasMode
         }
         return .ok(mode: ws.layoutMode.rawValue)
     }
@@ -164,7 +169,7 @@ extension TerminalController: ControlCanvasContext {
         guard let ws = resolveCanvasWorkspace(routing: routing) else {
             return .workspaceNotFound
         }
-        guard ws.layoutMode == .canvas else { return .notCanvasMode }
+        guard ws.layoutMode.usesCanvasHost else { return .notCanvasMode }
         guard ws.canvasModel.frame(of: surfaceID) != nil else { return .paneNotFound(surfaceID) }
         guard ws.canvasModel.frame(of: targetSurfaceID) != nil else { return .paneNotFound(targetSurfaceID) }
         if ws.canvasModel.joinPanel(surfaceID, withPaneContaining: targetSurfaceID) {
@@ -181,7 +186,7 @@ extension TerminalController: ControlCanvasContext {
         guard let ws = resolveCanvasWorkspace(routing: routing) else {
             return .workspaceNotFound
         }
-        guard ws.layoutMode == .canvas else { return .notCanvasMode }
+        guard ws.layoutMode.usesCanvasHost else { return .notCanvasMode }
         guard ws.canvasModel.frame(of: surfaceID) != nil else { return .paneNotFound(surfaceID) }
         if ws.canvasModel.breakOutPanel(surfaceID) {
             ws.canvasModel.viewport?.modelDidChangeExternally(animated: true)
@@ -198,7 +203,7 @@ extension TerminalController: ControlCanvasContext {
         guard let ws = resolveCanvasWorkspace(routing: routing) else {
             return .workspaceNotFound
         }
-        guard ws.layoutMode == .canvas else { return .notCanvasMode }
+        guard ws.layoutMode.usesCanvasHost else { return .notCanvasMode }
         guard ws.canvasModel.frame(of: surfaceID) != nil else { return .paneNotFound(surfaceID) }
         // focusPanel selects the tab in canvas mode and moves keyboard focus.
         ws.focusPanel(surfaceID)
@@ -215,7 +220,7 @@ extension TerminalController: ControlCanvasContext {
         guard let ws = resolveCanvasWorkspace(routing: routing) else {
             return .workspaceNotFound
         }
-        guard ws.layoutMode == .canvas else { return .notCanvasMode }
+        guard ws.layoutMode.usesCanvasHost else { return .notCanvasMode }
         ws.canvasModel.viewport?.setViewport(
             center: CGPoint(x: centerX, y: centerY),
             magnification: magnification.map { CGFloat($0) }
@@ -230,7 +235,7 @@ extension TerminalController: ControlCanvasContext {
         guard let ws = resolveCanvasWorkspace(routing: routing) else {
             return .workspaceNotFound
         }
-        guard ws.layoutMode == .canvas else { return .notCanvasMode }
+        guard ws.layoutMode.usesCanvasHost else { return .notCanvasMode }
         let paneType: CanvasNewPaneType = (type == "browser") ? .browser : .terminal
         guard let surfaceID = ws.openNewCanvasPane(type: paneType, focus: true) else {
             return .tabManagerUnavailable

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -208,7 +208,7 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
             let segmented = NSSegmentedControl()
             segmented.segmentStyle = .texturedRounded
             segmented.trackingMode = .selectOne
-            segmented.segmentCount = 2
+            segmented.segmentCount = 3
             segmented.controlSize = .small
             segmented.setImage(
                 NSImage(systemSymbolName: "rectangle.split.2x1", accessibilityDescription: nil),
@@ -218,6 +218,10 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
                 NSImage(systemSymbolName: "square.on.square.dashed", accessibilityDescription: nil),
                 forSegment: LayoutModeSegment.canvas.rawValue
             )
+            segmented.setLabel(
+                String(localized: "toolbar.layout.pages", defaultValue: "Pages"),
+                forSegment: LayoutModeSegment.niri.rawValue
+            )
             segmented.setToolTip(
                 String(localized: "toolbar.layout.splits", defaultValue: "Split panes"),
                 forSegment: LayoutModeSegment.splits.rawValue
@@ -226,11 +230,18 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
                 String(localized: "toolbar.layout.canvas", defaultValue: "Canvas"),
                 forSegment: LayoutModeSegment.canvas.rawValue
             )
+            segmented.setToolTip(
+                String(
+                    localized: "toolbar.layout.pages.tooltip",
+                    defaultValue: "Niri-style horizontal surface pages"
+                ),
+                forSegment: LayoutModeSegment.niri.rawValue
+            )
             segmented.target = self
             segmented.action = #selector(layoutModeSegmentChanged(_:))
             item.view = segmented
             item.label = String(localized: "toolbar.layout.label", defaultValue: "Layout")
-            item.toolTip = String(localized: "shortcut.toggleCanvasLayout.label", defaultValue: "Toggle Canvas Layout")
+            item.toolTip = String(localized: "shortcut.toggleCanvasLayout.label", defaultValue: "Cycle Layout Mode")
             layoutModeControls[ObjectIdentifier(toolbar)] = segmented
             updateLayoutModeSelection()
             return item
@@ -244,17 +255,34 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
     private enum LayoutModeSegment: Int {
         case splits = 0
         case canvas = 1
+        case niri = 2
     }
 
     @objc private func layoutModeSegmentChanged(_ sender: NSSegmentedControl) {
         guard let workspace = tabManager?.selectedWorkspace else { return }
-        let target: WorkspaceLayoutMode = sender.selectedSegment == LayoutModeSegment.canvas.rawValue ? .canvas : .splits
+        let target: WorkspaceLayoutMode
+        switch sender.selectedSegment {
+        case LayoutModeSegment.canvas.rawValue:
+            target = .canvas
+        case LayoutModeSegment.niri.rawValue:
+            target = .niri
+        default:
+            target = .splits
+        }
         workspace.setLayoutMode(target)
     }
 
     private func updateLayoutModeSelection() {
         let mode = tabManager?.selectedWorkspace?.layoutMode ?? .splits
-        let segment = mode == .canvas ? LayoutModeSegment.canvas.rawValue : LayoutModeSegment.splits.rawValue
+        let segment: Int
+        switch mode {
+        case .splits:
+            segment = LayoutModeSegment.splits.rawValue
+        case .canvas:
+            segment = LayoutModeSegment.canvas.rawValue
+        case .niri:
+            segment = LayoutModeSegment.niri.rawValue
+        }
         for control in layoutModeControls.values where control.selectedSegment != segment {
             control.selectedSegment = segment
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8734,7 +8734,7 @@ final class Workspace: Identifiable, ObservableObject {
         guard let tabId = surfaceIdFromPanelId(panelId) else { return }
         // In canvas mode, focusing a panel also brings it forward as its
         // pane's selected tab so focus and visibility never diverge.
-        if layoutMode == .canvas {
+        if layoutMode.usesCanvasHost {
             canvasModel.selectPanel(panelId)
         }
         let currentlyFocusedPanelId = focusedPanelId
@@ -8882,7 +8882,7 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func moveFocus(direction: NavigationDirection) {
-        if layoutMode == .canvas {
+        if layoutMode.usesCanvasHost {
             moveCanvasFocus(direction: direction)
             return
         }
@@ -8908,7 +8908,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     /// Select the next surface in the currently focused pane
     func selectNextSurface() {
-        if layoutMode == .canvas, selectAdjacentCanvasTab(offset: 1) { return }
+        if layoutMode.usesCanvasHost, selectAdjacentCanvasTab(offset: 1) { return }
         bonsplitController.selectNextTab()
 
         if let paneId = bonsplitController.focusedPaneId,
@@ -8919,7 +8919,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     /// Select the previous surface in the currently focused pane
     func selectPreviousSurface() {
-        if layoutMode == .canvas, selectAdjacentCanvasTab(offset: -1) { return }
+        if layoutMode.usesCanvasHost, selectAdjacentCanvasTab(offset: -1) { return }
         bonsplitController.selectPreviousTab()
 
         if let paneId = bonsplitController.focusedPaneId,
@@ -8959,7 +8959,7 @@ final class Workspace: Identifiable, ObservableObject {
         // In canvas mode, Cmd+T means "new tab in the focused canvas pane":
         // remember the anchor panel so the new one joins its pane instead of
         // floating as a separate canvas pane.
-        let canvasAnchorPanelId = layoutMode == .canvas ? focusedPanelId : nil
+        let canvasAnchorPanelId = layoutMode.usesCanvasHost ? focusedPanelId : nil
         let panel = newTerminalSurface(
             inPane: focusedPaneId,
             focus: focus,
@@ -9770,8 +9770,8 @@ final class Workspace: Identifiable, ObservableObject {
         // the terminal window portal float them at stale frames (chromeless
         // slivers). Offscreen clipping of the selected tabs is the canvas
         // viewport's job.
-        if layoutMode == .canvas {
-            return Set(canvasModel.layout.panes.map(\.selectedPanelId.rawValue))
+        if layoutMode.usesCanvasHost {
+            return canvasModel.viewport?.renderedPanelIds ?? []
         }
         let renderedPaneIds = bonsplitController.zoomedPaneId.map { [$0] } ?? bonsplitController.allPaneIds
         var visiblePanelIds: Set<UUID> = []
@@ -9800,6 +9800,12 @@ final class Workspace: Identifiable, ObservableObject {
         guard agentHibernationAutoResumePresentationVisible else { return [] }
         return renderedVisiblePanelIdsForCurrentLayout()
     }
+
+#if DEBUG
+    func renderedVisiblePanelIdsForTesting() -> Set<UUID> {
+        renderedVisiblePanelIdsForCurrentLayout()
+    }
+#endif
 
     @discardableResult
     func reconcileTerminalPortalVisibilityForCurrentRenderedLayout() -> Bool {

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -359,7 +359,7 @@ struct WorkspaceContentView: View {
         }
 
         Group {
-            if workspace.layoutMode == .canvas {
+            if workspace.layoutMode.usesCanvasHost {
                 WorkspaceCanvasHostView(
                     workspace: workspace,
                     isWorkspaceVisible: isWorkspaceVisible,

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1021,7 +1021,7 @@ struct cmuxApp: App {
             equalizeSplitsCommandButton()
             Divider()
 
-            splitCommandButton(title: String(localized: "menu.view.toggleCanvasLayout", defaultValue: "Toggle Canvas Layout"), shortcut: menuShortcut(for: .toggleCanvasLayout)) {
+            splitCommandButton(title: String(localized: "menu.view.toggleCanvasLayout", defaultValue: "Cycle Layout Mode"), shortcut: menuShortcut(for: .toggleCanvasLayout)) {
                 guard let workspace = activeTabManager.selectedWorkspace else { return }
                 CanvasActionExecutor(workspace: workspace).perform(.toggleLayout)
             }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -120,7 +120,9 @@
 		CA52B0010000000000000000 /* CanvasAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0010000000000000000 /* CanvasAction.swift */; };
 		CA52B0050000000000000000 /* CanvasHostedPanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0050000000000000000 /* CanvasHostedPanelContentView.swift */; };
 		CA52E0030000000000000000 /* CanvasInlineBrowserHostingEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52F0030000000000000000 /* CanvasInlineBrowserHostingEnvironment.swift */; };
+		CAFE0001CAFE0001CAFE0001 /* CanvasLayoutModeBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE0002CAFE0002CAFE0002 /* CanvasLayoutModeBehaviorTests.swift */; };
 		CA52B0060000000000000000 /* CanvasLayoutSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0060000000000000000 /* CanvasLayoutSettings.swift */; };
+		CA52B0190000000000000000 /* CanvasPagesRootRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0190000000000000000 /* CanvasPagesRootRepresentable.swift */; };
 		CA52B0070000000000000000 /* CanvasPaneContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0070000000000000000 /* CanvasPaneContent.swift */; };
 		F3000000A1B2C3D4E5F60718 /* CJKIMEInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */; };
 		D3571002A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */; };
@@ -747,6 +749,7 @@
 		5154BEAB50364B86A9E36E4B /* TerminalViewportUITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B04B98376C9BA8B9E44DCB /* TerminalViewportUITestRecorder.swift */; };
 		A5001532 /* TerminalWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001531 /* TerminalWindowPortal.swift */; };
 		D0B10006A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10007A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift */; };
+		CAFE0003CAFE0003CAFE0003 /* TestCanvasViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE0004CAFE0004CAFE0004 /* TestCanvasViewport.swift */; };
 		C0DE7B100000000000000001 /* TextBoxInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B100000000000000002 /* TextBoxInput.swift */; };
 		C0DE7B310000000000000001 /* TextBoxMentionCachedIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B310000000000000002 /* TextBoxMentionCachedIndex.swift */; };
 		C0DE7B250000000000000001 /* TextBoxMentionCandidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B250000000000000002 /* TextBoxMentionCandidate.swift */; };
@@ -1035,7 +1038,9 @@
 		CA52C0010000000000000000 /* CanvasAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CanvasAction.swift"; sourceTree = "<group>"; };
 		CA52C0050000000000000000 /* CanvasHostedPanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CanvasHostedPanelContentView.swift"; sourceTree = "<group>"; };
 		CA52F0030000000000000000 /* CanvasInlineBrowserHostingEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CanvasInlineBrowserHostingEnvironment.swift"; sourceTree = "<group>"; };
+		CAFE0002CAFE0002CAFE0002 /* CanvasLayoutModeBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasLayoutModeBehaviorTests.swift; sourceTree = "<group>"; };
 		CA52C0060000000000000000 /* CanvasLayoutSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CanvasLayoutSettings.swift"; sourceTree = "<group>"; };
+		CA52C0190000000000000000 /* CanvasPagesRootRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CanvasPagesRootRepresentable.swift"; sourceTree = "<group>"; };
 		CA52C0070000000000000000 /* CanvasPaneContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CanvasPaneContent.swift"; sourceTree = "<group>"; };
 		F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKIMEInputTests.swift; sourceTree = "<group>"; };
 		D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKIMEMarkedSelectionTests.swift; sourceTree = "<group>"; };
@@ -1587,6 +1592,7 @@
 		31B04B98376C9BA8B9E44DCB /* TerminalViewportUITestRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerminalViewportUITestRecorder.swift; sourceTree = "<group>"; };
 		A5001531 /* TerminalWindowPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindowPortal.swift; sourceTree = "<group>"; };
 		D0B10007A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindowPortalDebug.swift; sourceTree = "<group>"; };
+		CAFE0004CAFE0004CAFE0004 /* TestCanvasViewport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCanvasViewport.swift; sourceTree = "<group>"; };
 		C0DE7B100000000000000002 /* TextBoxInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxInput.swift; sourceTree = "<group>"; };
 		C0DE7B310000000000000002 /* TextBoxMentionCachedIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionCachedIndex.swift; sourceTree = "<group>"; };
 		C0DE7B250000000000000002 /* TextBoxMentionCandidate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionCandidate.swift; sourceTree = "<group>"; };
@@ -2402,6 +2408,7 @@
 				CA52C0050000000000000000 /* CanvasHostedPanelContentView.swift */,
 				CA52C0060000000000000000 /* CanvasLayoutSettings.swift */,
 				CA52C0070000000000000000 /* CanvasPaneContent.swift */,
+				CA52C0190000000000000000 /* CanvasPagesRootRepresentable.swift */,
 				CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */,
 				CA52C0160000000000000000 /* WorkspaceCanvasHostView.swift */,
 				CA52C0180000000000000000 /* WorkspaceLayoutMode.swift */,
@@ -2467,9 +2474,11 @@
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */,
 				604100010000000000000002 /* GhosttyDrawableSizeRetryTests.swift */,
 				BCBC0A0E0000000000000D02 /* BrowserChromeMetricsTests.swift */,
+				CAFE0002CAFE0002CAFE0002 /* CanvasLayoutModeBehaviorTests.swift */,
 				A11EB0000000000000000001 /* GhosttyConfigPathResolverTests.swift */,
 				C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */,
 				C13519000000000000000008 /* ClaudeConfigDirectoryPathTests.swift */,
+				CAFE0004CAFE0004CAFE0004 /* TestCanvasViewport.swift */,
 				DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */,
 				C135190000000000000000A2 /* PreferredEditorSettingsTests.swift */,
 				C135190000000000000000B2 /* SidebarWorkspaceGroupConfigOpenerTests.swift */,
@@ -3189,6 +3198,7 @@
 				CA52B0050000000000000000 /* CanvasHostedPanelContentView.swift in Sources */,
 				CA52E0030000000000000000 /* CanvasInlineBrowserHostingEnvironment.swift in Sources */,
 				CA52B0060000000000000000 /* CanvasLayoutSettings.swift in Sources */,
+				CA52B0190000000000000000 /* CanvasPagesRootRepresentable.swift in Sources */,
 				CA52B0070000000000000000 /* CanvasPaneContent.swift in Sources */,
 				A9F200000000000000000015 /* ClaudeStreamJSONAccumulator.swift in Sources */,
 				C46790000000000000000003 /* CLIForwardingLaunchRouter.swift in Sources */,
@@ -3719,6 +3729,7 @@
 				C7B800062D4202A13C962D2D /* BrowserSystemProxyMirrorTests.swift in Sources */,
 				C0DE49870000000000000001 /* BrowserWebContentProcessTests.swift in Sources */,
 				C0DE35530000000000000101 /* BundledCLILinkageTests.swift in Sources */,
+				CAFE0001CAFE0001CAFE0001 /* CanvasLayoutModeBehaviorTests.swift in Sources */,
 				F3000000A1B2C3D4E5F60718 /* CJKIMEInputTests.swift in Sources */,
 				D3571002A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift in Sources */,
 				C13519000000000000000007 /* ClaudeConfigDirectoryPathTests.swift in Sources */,
@@ -3867,6 +3878,7 @@
 				A5A5A503A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift in Sources */,
 				A5E380700000000000000001 /* TerminalNotificationSocketActionTests.swift in Sources */,
 				C0DE53360000000000000001 /* TerminalSearchOverlayMouseReleaseTests.swift in Sources */,
+				CAFE0003CAFE0003CAFE0003 /* TestCanvasViewport.swift in Sources */,
 				C0DE7B300000000000000001 /* TextBoxMentionCompletionTests.swift in Sources */,
 				F50030040000000000000001 /* TitlebarInteractiveControlTests.swift in Sources */,
 				D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */,

--- a/cmuxTests/CanvasLayoutModeBehaviorTests.swift
+++ b/cmuxTests/CanvasLayoutModeBehaviorTests.swift
@@ -1,0 +1,159 @@
+import AppKit
+import Bonsplit
+import CmuxCanvas
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Canvas layout mode behavior")
+struct CanvasLayoutModeBehaviorTests {
+    @Test func toggleCanvasLayoutCyclesThroughLayoutModes() {
+        let workspace = Workspace()
+
+        #expect(workspace.layoutMode == .splits)
+        workspace.toggleCanvasLayout()
+        #expect(workspace.layoutMode == .canvas)
+        workspace.toggleCanvasLayout()
+        #expect(workspace.layoutMode == .niri)
+        workspace.toggleCanvasLayout()
+        #expect(workspace.layoutMode == .splits)
+    }
+
+    @Test func switchingToNiriPreservesCanvasViewport() throws {
+        let workspace = Workspace()
+        workspace.setLayoutMode(.canvas)
+        workspace.canvasModel.savedViewport = (
+            canvasCenter: CGPoint(x: 123, y: 456),
+            magnification: 1.25
+        )
+
+        workspace.setLayoutMode(.niri)
+
+        let savedViewport = try #require(workspace.canvasModel.savedViewport)
+        #expect(abs(savedViewport.canvasCenter.x - 123) < 0.001)
+        #expect(abs(savedViewport.canvasCenter.y - 456) < 0.001)
+        #expect(abs(savedViewport.magnification - 1.25) < 0.001)
+    }
+
+    @Test func zoomAndOverviewActionsDoNotApplyInNiriMode() {
+        let workspace = Workspace()
+        workspace.setLayoutMode(.niri)
+        let executor = CanvasActionExecutor(workspace: workspace)
+
+        #expect(!executor.perform(.toggleOverview))
+        #expect(!executor.perform(.zoomIn))
+        #expect(!executor.perform(.zoomOut))
+        #expect(!executor.perform(.zoomReset))
+    }
+
+    @Test func freeformAlignmentDoesNotApplyInNiriMode() {
+        let workspace = Workspace()
+        workspace.setLayoutMode(.niri)
+        let executor = CanvasActionExecutor(workspace: workspace)
+
+        #expect(!executor.perform(.alignment(.tidy)))
+    }
+
+    @Test func freeformArrangePaletteCommandsAreHiddenInNiriMode() {
+        var pagesContext = ContentView.CommandPaletteContextSnapshot()
+        pagesContext.setBool(ContentView.CommandPaletteContextKeys.hasWorkspace, true)
+        pagesContext.setBool(ContentView.CommandPaletteContextKeys.workspaceCanvasLayout, true)
+        pagesContext.setBool(ContentView.CommandPaletteContextKeys.workspaceFreeformCanvasLayout, false)
+
+        var freeformContext = ContentView.CommandPaletteContextSnapshot()
+        freeformContext.setBool(ContentView.CommandPaletteContextKeys.hasWorkspace, true)
+        freeformContext.setBool(ContentView.CommandPaletteContextKeys.workspaceCanvasLayout, true)
+        freeformContext.setBool(ContentView.CommandPaletteContextKeys.workspaceFreeformCanvasLayout, true)
+
+        let contributions = ContentView.commandPaletteCanvasCommandContributions()
+        let pagesCommandIds = Set(contributions.filter { $0.when(pagesContext) }.map(\.commandId))
+        let freeformCommandIds = Set(contributions.filter { $0.when(freeformContext) }.map(\.commandId))
+        let freeformOnlyArrangeCommandIds: Set<String> = [
+            "palette.canvas.tidy",
+            "palette.canvas.alignLeft",
+            "palette.canvas.alignRight",
+            "palette.canvas.alignTop",
+            "palette.canvas.alignBottom",
+            "palette.canvas.equalizeWidths",
+            "palette.canvas.equalizeHeights",
+            "palette.canvas.distributeHorizontally",
+            "palette.canvas.distributeVertically",
+        ]
+
+        #expect(pagesCommandIds.contains("palette.canvas.toggleLayout"))
+        #expect(pagesCommandIds.contains("palette.canvas.revealFocusedPane"))
+        #expect(freeformOnlyArrangeCommandIds.isDisjoint(with: pagesCommandIds))
+        #expect(freeformOnlyArrangeCommandIds.isSubset(of: freeformCommandIds))
+    }
+
+    @Test func niriRenderedVisiblePanelsComeFromViewport() throws {
+        let workspace = Workspace()
+        let firstPanelId = try #require(workspace.orderedPanelIds.first)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let secondPanel = try #require(
+            workspace.splitPaneWithNewTerminal(
+                targetPane: paneId,
+                orientation: .horizontal,
+                insertFirst: false,
+                workingDirectory: nil,
+                initialInput: nil
+            )
+        )
+        workspace.setLayoutMode(.niri)
+        let viewport = TestCanvasViewport(renderedPanelIds: [secondPanel.id])
+        workspace.canvasModel.viewport = viewport
+
+        #expect(workspace.renderedVisiblePanelIdsForTesting() == [secondPanel.id])
+        #expect(workspace.renderedVisiblePanelIdsForTesting() != [firstPanelId, secondPanel.id])
+        withExtendedLifetime(viewport) {}
+    }
+
+    @Test func niriDoesNotRunFreeformBrowserPortalZOrder() throws {
+        let workspace = Workspace()
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        _ = try #require(workspace.newBrowserSurface(inPane: paneId, focus: false))
+        workspace.setLayoutMode(.niri)
+
+        #expect(!workspace.syncCanvasBrowserPortalZOrder())
+    }
+
+#if DEBUG
+    @Test func niriTerminalVisibilityReconcileTracksViewportRenderedPanels() throws {
+        let workspace = Workspace()
+        let firstPanelId = try #require(workspace.orderedPanelIds.first)
+        let firstPanel = try #require(workspace.terminalPanel(for: firstPanelId))
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let secondPanel = try #require(
+            workspace.splitPaneWithNewTerminal(
+                targetPane: paneId,
+                orientation: .horizontal,
+                insertFirst: false,
+                workingDirectory: nil,
+                initialInput: nil
+            )
+        )
+        workspace.setLayoutMode(.niri)
+        let viewport = TestCanvasViewport(renderedPanelIds: [secondPanel.id])
+        workspace.canvasModel.viewport = viewport
+        firstPanel.hostedView.setVisibleInUI(true)
+        secondPanel.hostedView.setVisibleInUI(true)
+
+        workspace.debugReconcileTerminalPortalVisibilityForTesting()
+
+        #expect(!firstPanel.hostedView.debugPortalVisibleInUI)
+        #expect(secondPanel.hostedView.debugPortalVisibleInUI)
+
+        viewport.renderedPanelIds = [firstPanel.id]
+        workspace.debugReconcileTerminalPortalVisibilityForTesting()
+
+        #expect(firstPanel.hostedView.debugPortalVisibleInUI)
+        #expect(!secondPanel.hostedView.debugPortalVisibleInUI)
+        withExtendedLifetime(viewport) {}
+    }
+#endif
+}

--- a/cmuxTests/TestCanvasViewport.swift
+++ b/cmuxTests/TestCanvasViewport.swift
@@ -1,0 +1,28 @@
+import AppKit
+import CmuxCanvasUI
+import Foundation
+
+@MainActor
+final class TestCanvasViewport: CanvasViewportControlling {
+    var renderedPanelIds: Set<UUID>
+
+    init(renderedPanelIds: Set<UUID>) {
+        self.renderedPanelIds = renderedPanelIds
+    }
+
+    func revealPane(_ panelId: UUID, animated: Bool) {}
+
+    func toggleOverview() {}
+
+    func zoom(by factor: CGFloat) {}
+
+    func resetZoom() {}
+
+    func setViewport(center: CGPoint, magnification: CGFloat?) {}
+
+    var currentMagnification: CGFloat { 1 }
+
+    var currentCenterInCanvas: CGPoint { .zero }
+
+    func modelDidChangeExternally(animated: Bool) {}
+}

--- a/docs/canvas-layout-design.md
+++ b/docs/canvas-layout-design.md
@@ -5,6 +5,11 @@ browser, markdown, file preview, agent session, ...) becomes a freely placed,
 individually resizable pane on an infinite scrollable canvas. Canvas layout
 coexists with the default bonsplit split layout; a workspace switches modes
 without losing panels, and switching back restores the previous split tree.
+The same pane/tab model also has a Niri-style Pages mode: each surface pane is
+available through a native AppKit page strip. Pages mode does not run inside
+the canvas `NSScrollView`: horizontal swipes are handled by `NSPageController`,
+vertical scroll remains with the surface, and canvas zoom/drag behaviors are
+inactive.
 
 ## Why
 
@@ -54,6 +59,9 @@ correct-but-not-perfect until they get direct hosting too.
 - splits → canvas: seed each pane's canvas frame from the bonsplit
   `LayoutSnapshot` pane frames, so the canvas initially looks identical to
   the split layout, then normalize to the canonical gap.
+- splits/canvas → niri: keep the same canvas pane/tab model, but render it in
+  `CanvasPagesRootView`, a native `NSPageController` host. The mode selects
+  one pane per page instead of scrolling a 2D canvas and snapping back.
 - canvas → splits: the workspace's previous bonsplit tree is kept while in
   canvas mode (panels are never removed from bonsplit bookkeeping); leaving
   canvas mode re-mounts the bonsplit view. Panels created while in canvas
@@ -103,10 +111,19 @@ shortcuts, command palette, View menu, and the `canvas.*` debug-socket verbs
 all call it. Spatial focus reuses the existing split-focus actions when the
 workspace is in canvas mode (same shortcut, mode-appropriate behavior).
 
-Actions: toggle canvas layout, focus left/right/up/down, focus previous,
+Actions: cycle layout mode, focus left/right/up/down, focus previous,
 reveal focused pane, overview (fit all), zoom to 100%, align
 lefts/rights/tops/bottoms, equalize widths/heights, distribute
 horizontally/vertically, tidy canvas.
+
+The hidden layout toggle path (`Cycle Layout Mode`, `canvas mode toggle`)
+cycles Splits → Canvas → Pages → Splits so existing keyboard, palette, menu,
+and socket entrypoints can reach Pages without requiring the toolbar selector.
+
+`canvas.set_mode` accepts `splits`, `canvas`, `niri`, and `toggle`. The Niri
+mode still reports through `canvas.info` and uses the same `canvas.*` control
+verbs because it shares the canvas pane/tab model, not because it is rendered
+by the canvas scroll view.
 
 All new shortcuts are registered in `KeyboardShortcutSettings`, editable in
 Settings, configurable in `~/.config/cmux/cmux.json`, and documented in the


### PR DESCRIPTION
## Summary
- Add a hidden native Pages/NIRI layout mode alongside the existing canvas layout modes.
- Route Pages rendering/focus through the shared canvas model and viewport plumbing.
- Keep lazy surface loading disabled for Pages for now so adjacent pages are ready while we tune the behavior later.

## Verification
- `git diff --check origin/feat-canvas-panes...HEAD`
- `jq empty Resources/Localizable.xcstrings`
- `scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `swift test` in `Packages/CmuxCanvasUI` (41 tests)
- `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-pages-toolbar-fix-test -only-testing:cmuxTests/CanvasLayoutModeBehaviorTests` (6 Swift Testing tests)
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-pages-toolbar-fix-build build`
- `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode branch --base origin/feat-canvas-panes` (clean, including cmux policy)

## Dogfood
- User confirmed the Pages behavior works and explicitly approved merge after dogfood.
- NIRI recording/frame assessment artifacts from the dogfood run:
  - `/tmp/cmux-pages-toolbar-fix-niri-window-dogfood-213300-final.mov`
  - `/tmp/cmux-pages-toolbar-fix-niri-window-frames-213300-final`
  - `/tmp/cmux-pages-toolbar-fix-niri-window-contact-213300-final.png`

## Localization
- User-facing keys are present in `Resources/Localizable.xcstrings`; the catalog parses with `jq empty`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785042278&installation_id=133855650&pr_number=6800&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6800&signature=e5c512ea05f986f21cc55727611307366a54a17d65d90ae0305c4accf1ddd281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native Pages layout mode (.niri) with a horizontal page strip powered by NSPageController, alongside canvas and splits. You can cycle splits → canvas → pages via the toolbar, shortcut (“Cycle Layout Mode”), CLI, control socket, and palette; viewport and focus carry over.

- **New Features**
  - New `.niri` Pages mode using a native page host (`CanvasPagesRootView` + `CanvasPageViewController`) wired to the shared canvas model for focus/select/close; canvas pan/zoom and pane resize/drag are disabled in Pages.
  - Scroll routing in Pages: dominant horizontal or Shift‑scroll switches pages; vertical scroll stays with surface content. The discovery hint adapts per mode via `CanvasScrollHintStyle`.
  - Unified canvas‑hosted behavior: `WorkspaceLayoutMode.usesCanvasHost` and `nextCycledMode`; toggle cycles splits → canvas → pages; viewport and selection are preserved; `revealFocusedPane` works in canvas and pages; viewport info is exposed via CLI/control socket in both.
  - UI updates: Toolbar gains a “Pages” segment; menu/shortcut label changed to “Cycle Layout Mode”; command palette shows freeform‑only actions only in freeform canvas.
  - Automation: CLI/control socket accept `niri`:
    - `cmux canvas mode <canvas|niri|splits|toggle>`
    - `canvas.set_mode` validates `"niri"`.

- **Migration**
  - No breaking changes. Try Pages via toolbar “Pages”, CLI `cmux canvas mode niri`, or control socket `canvas.set_mode` with `"niri"`. Pages lazy‑loading stays disabled.

<sup>Written for commit c87bb24f3217c3d70fbfef823d73cfc6c86ef620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

