### PR TITLE
Show workspace group names in Cmd-P switcher

### DIFF
--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift
@@ -17,6 +17,8 @@ public struct CommandPaletteContextKeys: Hashable, Sendable {
     public static let hasWorkspace = CommandPaletteContextKeys(rawValue: "workspace.hasSelection")
     /// Selected workspace display name.
     public static let workspaceName = CommandPaletteContextKeys(rawValue: "workspace.name")
+    /// Whether the selected workspace is the anchor for a workspace group.
+    public static let workspaceIsGroupAnchor = CommandPaletteContextKeys(rawValue: "workspace.isGroupAnchor")
     /// Whether the workspace has a custom name.
     public static let workspaceHasCustomName = CommandPaletteContextKeys(rawValue: "workspace.hasCustomName")
     /// Whether the workspace has a custom description.

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Values/CommandPaletteRenameTarget.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Values/CommandPaletteRenameTarget.swift
@@ -87,4 +87,21 @@ public struct CommandPaletteRenameTarget: Equatable {
             return String(localized: "commandPalette.rename.tabConfirmHint", defaultValue: "Press Enter to apply this tab name, or Escape to cancel.", bundle: .main)
         }
     }
+
+    /// Whether submitting an empty name is a valid rename action.
+    public var allowsEmptyName: Bool {
+        switch kind {
+        case .workspace, .tab:
+            return true
+        case .workspaceGroup:
+            return false
+        }
+    }
+
+    /// Label shown if a confirmation state displays an empty proposed name.
+    public var emptyNameConfirmationLabel: String {
+        allowsEmptyName
+            ? String(localized: "commandPalette.rename.clearCustomName", defaultValue: "(clear custom name)", bundle: .main)
+            : currentName
+    }
 }

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Values/CommandPaletteRenameTarget.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Values/CommandPaletteRenameTarget.swift
@@ -1,12 +1,14 @@
 public import Foundation
 
-/// Identifies what a palette rename flow edits (a workspace or a tab) and
-/// carries the name shown when the editor opens.
+/// Identifies what a palette rename flow edits and carries the name shown when
+/// the editor opens.
 public struct CommandPaletteRenameTarget: Equatable {
     /// The renameable entity.
     public enum Kind: Equatable {
         /// Rename the workspace with this id.
         case workspace(workspaceId: UUID)
+        /// Rename the workspace group with this id.
+        case workspaceGroup(groupId: UUID)
         /// Rename the tab `panelId` inside workspace `workspaceId`.
         case tab(workspaceId: UUID, panelId: UUID)
     }
@@ -31,6 +33,8 @@ public struct CommandPaletteRenameTarget: Equatable {
         switch kind {
         case .workspace:
             return String(localized: "commandPalette.rename.workspaceTitle", defaultValue: "Rename Workspace", bundle: .main)
+        case .workspaceGroup:
+            return String(localized: "workspaceGroup.rename.title", defaultValue: "Rename Group", bundle: .main)
         case .tab:
             return String(localized: "commandPalette.rename.tabTitle", defaultValue: "Rename Tab", bundle: .main)
         }
@@ -41,6 +45,8 @@ public struct CommandPaletteRenameTarget: Equatable {
         switch kind {
         case .workspace:
             return String(localized: "commandPalette.rename.workspaceDescription", defaultValue: "Choose a custom workspace name.", bundle: .main)
+        case .workspaceGroup:
+            return String(localized: "workspaceGroup.rename.message", defaultValue: "Enter a new name for this group.", bundle: .main)
         case .tab:
             return String(localized: "commandPalette.rename.tabDescription", defaultValue: "Choose a custom tab name.", bundle: .main)
         }
@@ -51,8 +57,34 @@ public struct CommandPaletteRenameTarget: Equatable {
         switch kind {
         case .workspace:
             return String(localized: "commandPalette.rename.workspacePlaceholder", defaultValue: "Workspace name", bundle: .main)
+        case .workspaceGroup:
+            return String(localized: "workspaceGroup.rename.placeholder", defaultValue: "Group name", bundle: .main)
         case .tab:
             return String(localized: "commandPalette.rename.tabPlaceholder", defaultValue: "Tab name", bundle: .main)
+        }
+    }
+
+    /// Localized input hint.
+    public var inputHint: String {
+        switch kind {
+        case .workspace:
+            return String(localized: "commandPalette.rename.workspaceInputHint", defaultValue: "Enter a workspace name. Press Enter to rename, Escape to cancel.", bundle: .main)
+        case .workspaceGroup:
+            return String(localized: "commandPalette.rename.workspaceGroupInputHint", defaultValue: "Enter a workspace group name. Press Enter to rename, Escape to cancel.", bundle: .main)
+        case .tab:
+            return String(localized: "commandPalette.rename.tabInputHint", defaultValue: "Enter a tab name. Press Enter to rename, Escape to cancel.", bundle: .main)
+        }
+    }
+
+    /// Localized confirmation hint.
+    public var confirmHint: String {
+        switch kind {
+        case .workspace:
+            return String(localized: "commandPalette.rename.workspaceConfirmHint", defaultValue: "Press Enter to apply this workspace name, or Escape to cancel.", bundle: .main)
+        case .workspaceGroup:
+            return String(localized: "commandPalette.rename.workspaceGroupConfirmHint", defaultValue: "Press Enter to apply this workspace group name, or Escape to cancel.", bundle: .main)
+        case .tab:
+            return String(localized: "commandPalette.rename.tabConfirmHint", defaultValue: "Press Enter to apply this tab name, or Escape to cancel.", bundle: .main)
         }
     }
 }

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteRenameTargetTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteRenameTargetTests.swift
@@ -15,5 +15,7 @@ import Testing
         #expect(target.placeholder == "Group name")
         #expect(target.inputHint == "Enter a workspace group name. Press Enter to rename, Escape to cancel.")
         #expect(target.confirmHint == "Press Enter to apply this workspace group name, or Escape to cancel.")
+        #expect(!target.allowsEmptyName)
+        #expect(target.emptyNameConfirmationLabel == "Backend")
     }
 }

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteRenameTargetTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteRenameTargetTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Testing
+
+@testable import CmuxCommandPalette
+
+@Suite struct CommandPaletteRenameTargetTests {
+    @Test func workspaceGroupTargetUsesGroupCopy() {
+        let target = CommandPaletteRenameTarget(
+            kind: .workspaceGroup(groupId: UUID()),
+            currentName: "Backend"
+        )
+
+        #expect(target.title == "Rename Group")
+        #expect(target.description == "Enter a new name for this group.")
+        #expect(target.placeholder == "Group name")
+        #expect(target.inputHint == "Enter a workspace group name. Press Enter to rename, Escape to cancel.")
+        #expect(target.confirmHint == "Press Enter to apply this workspace group name, or Escape to cancel.")
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3646,7 +3646,7 @@ struct ContentView: View {
         proposedName: String
     ) -> some View {
         let trimmedName = proposedName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let nextName = trimmedName.isEmpty ? String(localized: "commandPalette.rename.clearCustomName", defaultValue: "(clear custom name)") : trimmedName
+        let nextName = trimmedName.isEmpty ? target.emptyNameConfirmationLabel : trimmedName
 
         return VStack(spacing: 0) {
             Text(nextName)
@@ -6665,11 +6665,7 @@ struct ContentView: View {
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.renameWorkspace",
-                title: { context in
-                    context.bool(CommandPaletteContextKeys.workspaceIsGroupAnchor)
-                        ? String(localized: "workspaceGroup.contextMenu.rename", defaultValue: "Rename Group…")
-                        : String(localized: "command.renameWorkspace.title", defaultValue: "Rename Workspace…")
-                },
+                title: { $0.bool(CommandPaletteContextKeys.workspaceIsGroupAnchor) ? String(localized: "workspaceGroup.contextMenu.rename", defaultValue: "Rename Group…") : String(localized: "command.renameWorkspace.title", defaultValue: "Rename Workspace…") },
                 subtitle: workspaceSubtitle,
                 keywords: ["rename", "workspace", "group", "title"],
                 dismissOnRun: false,
@@ -9273,11 +9269,7 @@ struct ContentView: View {
             return
         }
         if let group = tabManager.workspaceGroups.first(where: { $0.anchorWorkspaceId == workspace.id }) {
-            let target = CommandPaletteRenameTarget(
-                kind: .workspaceGroup(groupId: group.id),
-                currentName: group.name
-            )
-            startRenameFlow(target)
+            startRenameFlow(CommandPaletteRenameTarget(kind: .workspaceGroup(groupId: group.id), currentName: group.name))
             return
         }
         let target = CommandPaletteRenameTarget(
@@ -9357,6 +9349,13 @@ struct ContentView: View {
     private func applyRenameFlow(target: CommandPaletteRenameTarget, proposedName: String) {
         let trimmedName = proposedName.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedName: String? = trimmedName.isEmpty ? nil : trimmedName
+        guard target.allowsEmptyName || !trimmedName.isEmpty else {
+            NSSound.beep()
+            commandPaletteMode = .renameInput(target)
+            resetCommandPaletteRenameFocus()
+            syncCommandPaletteDebugStateForObservedWindow()
+            return
+        }
 
         switch target.kind {
         case .workspace(let workspaceId):

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5175,7 +5175,16 @@ struct ContentView: View {
                 }
             )
         }
-        return CommandPaletteSwitcherFingerprintContext.fingerprint(windowContexts: fingerprintContexts)
+        var hasher = Hasher()
+        hasher.combine(CommandPaletteSwitcherFingerprintContext.fingerprint(windowContexts: fingerprintContexts))
+        for context in windowContexts {
+            hasher.combine(context.tabManager.workspaceGroups.count)
+            for group in context.tabManager.workspaceGroups {
+                hasher.combine(group.id)
+                hasher.combine(group.anchorWorkspaceId)
+            }
+        }
+        return hasher.finalize()
     }
 
     private static func commandPaletteHighlightedTitleText(_ title: String, matchedIndices: Set<Int>) -> Text {
@@ -5271,6 +5280,10 @@ struct ContentView: View {
             let windowKeywords = commandPaletteWindowKeywords(windowLabel: context.windowLabel)
             for workspace in workspaces {
                 let workspaceName = workspaceDisplayName(workspace)
+                let workspaceKindLabel = commandPaletteWorkspaceKindLabel(
+                    for: workspace,
+                    tabManager: windowTabManager
+                )
                 let workspaceCommandId = "switcher.workspace.\(workspace.id.uuidString.lowercased())"
                 let workspaceKeywords = CommandPaletteSwitcherSearchIndexer(
                     baseKeywords: [
@@ -5291,7 +5304,7 @@ struct ContentView: View {
                         title: workspaceName,
                         subtitle: Self.commandPaletteSwitcherSubtitle(base: String(localized: "commandPalette.switcher.workspaceLabel", defaultValue: "Workspace"), windowLabel: context.windowLabel),
                         shortcutHint: nil,
-                        kindLabel: String(localized: "commandPalette.kind.workspace", defaultValue: "Workspace"),
+                        kindLabel: workspaceKindLabel,
                         keywords: workspaceKeywords,
                         dismissOnRun: true,
                         action: {
@@ -5414,6 +5427,16 @@ struct ContentView: View {
     private func commandPaletteWindowKeywords(windowLabel: String?) -> [String] {
         guard let windowLabel else { return [] }
         return ["window", windowLabel.lowercased()]
+    }
+
+    private func commandPaletteWorkspaceKindLabel(
+        for workspace: Workspace,
+        tabManager: TabManager
+    ) -> String {
+        if tabManager.workspaceGroups.contains(where: { $0.anchorWorkspaceId == workspace.id }) {
+            return String(localized: "commandPalette.kind.workspaceGroup", defaultValue: "Workspace group")
+        }
+        return String(localized: "commandPalette.kind.workspace", defaultValue: "Workspace")
     }
 
     private func commandPaletteOrderedSwitcherWorkspaces(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5151,7 +5151,7 @@ struct ContentView: View {
                 workspaces: commandPaletteOrderedSwitcherWorkspaces(for: context).map { workspace in
                     CommandPaletteSwitcherFingerprintWorkspace(
                         id: workspace.id,
-                        displayName: workspaceDisplayName(workspace),
+                        displayName: workspaceDisplayName(workspace) + (context.tabManager.workspaceGroups.contains(where: { $0.anchorWorkspaceId == workspace.id }) ? "\u{0}group" : ""),
                         metadata: commandPaletteWorkspaceSearchMetadata(for: workspace),
                         surfaces: includeSurfaces
                             ? commandPaletteOrderedSwitcherPanels(for: workspace).compactMap { panelId in
@@ -5175,16 +5175,7 @@ struct ContentView: View {
                 }
             )
         }
-        var hasher = Hasher()
-        hasher.combine(CommandPaletteSwitcherFingerprintContext.fingerprint(windowContexts: fingerprintContexts))
-        for context in windowContexts {
-            hasher.combine(context.tabManager.workspaceGroups.count)
-            for group in context.tabManager.workspaceGroups {
-                hasher.combine(group.id)
-                hasher.combine(group.anchorWorkspaceId)
-            }
-        }
-        return hasher.finalize()
+        return CommandPaletteSwitcherFingerprintContext.fingerprint(windowContexts: fingerprintContexts)
     }
 
     private static func commandPaletteHighlightedTitleText(_ title: String, matchedIndices: Set<Int>) -> Text {
@@ -5280,10 +5271,7 @@ struct ContentView: View {
             let windowKeywords = commandPaletteWindowKeywords(windowLabel: context.windowLabel)
             for workspace in workspaces {
                 let workspaceName = workspaceDisplayName(workspace)
-                let workspaceKindLabel = commandPaletteWorkspaceKindLabel(
-                    for: workspace,
-                    tabManager: windowTabManager
-                )
+                let isWorkspaceGroupAnchor = windowTabManager.workspaceGroups.contains { $0.anchorWorkspaceId == workspace.id }
                 let workspaceCommandId = "switcher.workspace.\(workspace.id.uuidString.lowercased())"
                 let workspaceKeywords = CommandPaletteSwitcherSearchIndexer(
                     baseKeywords: [
@@ -5304,7 +5292,7 @@ struct ContentView: View {
                         title: workspaceName,
                         subtitle: Self.commandPaletteSwitcherSubtitle(base: String(localized: "commandPalette.switcher.workspaceLabel", defaultValue: "Workspace"), windowLabel: context.windowLabel),
                         shortcutHint: nil,
-                        kindLabel: workspaceKindLabel,
+                        kindLabel: isWorkspaceGroupAnchor ? String(localized: "commandPalette.kind.workspaceGroup", defaultValue: "Workspace group") : String(localized: "commandPalette.kind.workspace", defaultValue: "Workspace"),
                         keywords: workspaceKeywords,
                         dismissOnRun: true,
                         action: {
@@ -5427,16 +5415,6 @@ struct ContentView: View {
     private func commandPaletteWindowKeywords(windowLabel: String?) -> [String] {
         guard let windowLabel else { return [] }
         return ["window", windowLabel.lowercased()]
-    }
-
-    private func commandPaletteWorkspaceKindLabel(
-        for workspace: Workspace,
-        tabManager: TabManager
-    ) -> String {
-        if tabManager.workspaceGroups.contains(where: { $0.anchorWorkspaceId == workspace.id }) {
-            return String(localized: "commandPalette.kind.workspaceGroup", defaultValue: "Workspace group")
-        }
-        return String(localized: "commandPalette.kind.workspace", defaultValue: "Workspace")
     }
 
     private func commandPaletteOrderedSwitcherWorkspaces(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5144,14 +5144,17 @@ struct ContentView: View {
     private func commandPaletteSwitcherEntriesFingerprint(includeSurfaces: Bool) -> Int {
         let windowContexts = commandPaletteSwitcherWindowContexts()
         let fingerprintContexts = windowContexts.map { context in
-            CommandPaletteSwitcherFingerprintContext(
+            let groupNameByAnchorWorkspaceId = Dictionary(uniqueKeysWithValues: context.tabManager.workspaceGroups.map { ($0.anchorWorkspaceId, $0.name) })
+            return CommandPaletteSwitcherFingerprintContext(
                 windowId: context.windowId,
                 windowLabel: context.windowLabel,
                 selectedWorkspaceId: context.selectedWorkspaceId,
                 workspaces: commandPaletteOrderedSwitcherWorkspaces(for: context).map { workspace in
-                    CommandPaletteSwitcherFingerprintWorkspace(
+                    let groupName = groupNameByAnchorWorkspaceId[workspace.id]
+                    let displayName = Self.commandPaletteWorkspaceDisplayName(customTitle: workspace.customTitle, resolvedTitle: groupName ?? workspace.title, preferResolvedTitle: groupName != nil)
+                    return CommandPaletteSwitcherFingerprintWorkspace(
                         id: workspace.id,
-                        displayName: workspaceDisplayName(workspace) + (context.tabManager.workspaceGroups.contains(where: { $0.anchorWorkspaceId == workspace.id }) ? "\u{0}group" : ""),
+                        displayName: displayName + (groupName != nil ? "\u{0}group" : ""),
                         metadata: commandPaletteWorkspaceSearchMetadata(for: workspace),
                         surfaces: includeSurfaces
                             ? commandPaletteOrderedSwitcherPanels(for: workspace).compactMap { panelId in
@@ -5269,9 +5272,13 @@ struct ContentView: View {
             let windowId = context.windowId
             let windowTabManager = context.tabManager
             let windowKeywords = commandPaletteWindowKeywords(windowLabel: context.windowLabel)
+            let groupNameByAnchorWorkspaceId = Dictionary(uniqueKeysWithValues: windowTabManager.workspaceGroups.map { ($0.anchorWorkspaceId, $0.name) })
             for workspace in workspaces {
-                let workspaceName = workspaceDisplayName(workspace)
-                let isWorkspaceGroupAnchor = windowTabManager.workspaceGroups.contains { $0.anchorWorkspaceId == workspace.id }
+                let groupName = groupNameByAnchorWorkspaceId[workspace.id]
+                let isWorkspaceGroupAnchor = groupName != nil
+                let workspaceName = Self.commandPaletteWorkspaceDisplayName(customTitle: workspace.customTitle, resolvedTitle: groupName ?? workspace.title, preferResolvedTitle: isWorkspaceGroupAnchor)
+                let workspaceKindLabel = isWorkspaceGroupAnchor ? String(localized: "commandPalette.kind.workspaceGroup", defaultValue: "Workspace group") : String(localized: "commandPalette.kind.workspace", defaultValue: "Workspace")
+                let groupKeywords = isWorkspaceGroupAnchor ? ["workspace group", "group", workspaceKindLabel] : []
                 let workspaceCommandId = "switcher.workspace.\(workspace.id.uuidString.lowercased())"
                 let workspaceKeywords = CommandPaletteSwitcherSearchIndexer(
                     baseKeywords: [
@@ -5280,7 +5287,7 @@ struct ContentView: View {
                         "go",
                         "open",
                         workspaceName
-                    ] + windowKeywords,
+                    ] + groupKeywords + windowKeywords,
                     metadata: commandPaletteWorkspaceSearchMetadata(for: workspace),
                     detail: .workspace
                 ).keywords
@@ -5292,7 +5299,7 @@ struct ContentView: View {
                         title: workspaceName,
                         subtitle: Self.commandPaletteSwitcherSubtitle(base: String(localized: "commandPalette.switcher.workspaceLabel", defaultValue: "Workspace"), windowLabel: context.windowLabel),
                         shortcutHint: nil,
-                        kindLabel: isWorkspaceGroupAnchor ? String(localized: "commandPalette.kind.workspaceGroup", defaultValue: "Workspace group") : String(localized: "commandPalette.kind.workspace", defaultValue: "Workspace"),
+                        kindLabel: workspaceKindLabel,
                         keywords: workspaceKeywords,
                         dismissOnRun: true,
                         action: {
@@ -8169,22 +8176,26 @@ struct ContentView: View {
         return (workspace, panelId, panel)
     }
 
-    static func commandPaletteWorkspaceDisplayName(
-        customTitle: String?,
-        resolvedTitle: String
-    ) -> String {
-        let custom = customTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !custom.isEmpty {
-            return custom
-        }
+    static func commandPaletteWorkspaceDisplayName(customTitle: String?, resolvedTitle: String, preferResolvedTitle: Bool = false) -> String {
         let title = resolvedTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if preferResolvedTitle {
+            return title.isEmpty ? String(localized: "workspace.displayName.fallback", defaultValue: "Workspace") : title
+        }
+
+        let custom = customTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !custom.isEmpty { return custom }
         return title.isEmpty ? String(localized: "workspace.displayName.fallback", defaultValue: "Workspace") : title
     }
 
     private func workspaceDisplayName(_ workspace: Workspace) -> String {
-        Self.commandPaletteWorkspaceDisplayName(
+        workspaceDisplayName(workspace, tabManager: tabManager)
+    }
+
+    private func workspaceDisplayName(_ workspace: Workspace, tabManager: TabManager, preferResolvedTitle: Bool = false) -> String {
+        return Self.commandPaletteWorkspaceDisplayName(
             customTitle: workspace.customTitle,
-            resolvedTitle: tabManager.resolvedWorkspaceDisplayTitle(for: workspace)
+            resolvedTitle: tabManager.resolvedWorkspaceDisplayTitle(for: workspace),
+            preferResolvedTitle: preferResolvedTitle
         )
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8168,7 +8168,7 @@ struct ContentView: View {
         return (workspace, panelId, panel)
     }
 
-    private static func commandPaletteWorkspaceDisplayName(_ workspace: Workspace) -> String {
+    static func commandPaletteWorkspaceDisplayName(_ workspace: Workspace) -> String {
         let custom = workspace.customTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !custom.isEmpty {
             return custom

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8168,17 +8168,23 @@ struct ContentView: View {
         return (workspace, panelId, panel)
     }
 
-    static func commandPaletteWorkspaceDisplayName(_ workspace: Workspace) -> String {
-        let custom = workspace.customTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    static func commandPaletteWorkspaceDisplayName(
+        customTitle: String?,
+        resolvedTitle: String
+    ) -> String {
+        let custom = customTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !custom.isEmpty {
             return custom
         }
-        let title = workspace.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title = resolvedTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         return title.isEmpty ? String(localized: "workspace.displayName.fallback", defaultValue: "Workspace") : title
     }
 
     private func workspaceDisplayName(_ workspace: Workspace) -> String {
-        Self.commandPaletteWorkspaceDisplayName(workspace)
+        Self.commandPaletteWorkspaceDisplayName(
+            customTitle: workspace.customTitle,
+            resolvedTitle: tabManager.resolvedWorkspaceDisplayTitle(for: workspace)
+        )
     }
 
     private func panelDisplayName(workspace: Workspace, panelId: UUID, fallback: String) -> String {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3617,7 +3617,7 @@ struct ContentView: View {
 
             Divider()
 
-            Text(renameInputHintText(target: target))
+            Text(target.inputHint)
                 .cmuxFont(size: 11)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
@@ -3658,7 +3658,7 @@ struct ContentView: View {
 
             Divider()
 
-            Text(renameConfirmHintText(target: target))
+            Text(target.confirmHint)
                 .cmuxFont(size: 11)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
@@ -4552,24 +4552,6 @@ struct ContentView: View {
             nsView.textView.onHandleKeyEvent = nil
             nsView.textView.onDidBecomeFirstResponder = nil
             nsView.onMeasuredHeightChange = nil
-        }
-    }
-
-    private func renameInputHintText(target: CommandPaletteRenameTarget) -> String {
-        switch target.kind {
-        case .workspace:
-            return String(localized: "commandPalette.rename.workspaceInputHint", defaultValue: "Enter a workspace name. Press Enter to rename, Escape to cancel.")
-        case .tab:
-            return String(localized: "commandPalette.rename.tabInputHint", defaultValue: "Enter a tab name. Press Enter to rename, Escape to cancel.")
-        }
-    }
-
-    private func renameConfirmHintText(target: CommandPaletteRenameTarget) -> String {
-        switch target.kind {
-        case .workspace:
-            return String(localized: "commandPalette.rename.workspaceConfirmHint", defaultValue: "Press Enter to apply this workspace name, or Escape to cancel.")
-        case .tab:
-            return String(localized: "commandPalette.rename.tabConfirmHint", defaultValue: "Press Enter to apply this tab name, or Escape to cancel.")
         }
     }
 
@@ -6164,6 +6146,7 @@ struct ContentView: View {
             let pinState = WorkspaceActionDispatcher.pinState(in: tabManager, target: pinTarget)
             snapshot.setBool(CommandPaletteContextKeys.hasWorkspace, true)
             snapshot.setString(CommandPaletteContextKeys.workspaceName, workspaceDisplayName(workspace))
+            snapshot.setBool(CommandPaletteContextKeys.workspaceIsGroupAnchor, tabManager.workspaceGroups.contains { $0.anchorWorkspaceId == workspace.id })
             snapshot.setBool(CommandPaletteContextKeys.workspaceHasCustomName, workspace.customTitle != nil)
             snapshot.setBool(CommandPaletteContextKeys.workspaceHasCustomDescription, workspace.hasCustomDescription)
             snapshot.setBool(CommandPaletteContextKeys.workspaceShouldPin, pinState?.pinned ?? !workspace.isPinned)
@@ -6682,9 +6665,13 @@ struct ContentView: View {
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.renameWorkspace",
-                title: constant(String(localized: "command.renameWorkspace.title", defaultValue: "Rename Workspace…")),
+                title: { context in
+                    context.bool(CommandPaletteContextKeys.workspaceIsGroupAnchor)
+                        ? String(localized: "workspaceGroup.contextMenu.rename", defaultValue: "Rename Group…")
+                        : String(localized: "command.renameWorkspace.title", defaultValue: "Rename Workspace…")
+                },
                 subtitle: workspaceSubtitle,
-                keywords: ["rename", "workspace", "title"],
+                keywords: ["rename", "workspace", "group", "title"],
                 dismissOnRun: false,
                 when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) }
             )
@@ -9285,6 +9272,14 @@ struct ContentView: View {
             NSSound.beep()
             return
         }
+        if let group = tabManager.workspaceGroups.first(where: { $0.anchorWorkspaceId == workspace.id }) {
+            let target = CommandPaletteRenameTarget(
+                kind: .workspaceGroup(groupId: group.id),
+                currentName: group.name
+            )
+            startRenameFlow(target)
+            return
+        }
         let target = CommandPaletteRenameTarget(
             kind: .workspace(workspaceId: workspace.id),
             currentName: workspaceDisplayName(workspace)
@@ -9366,6 +9361,12 @@ struct ContentView: View {
         switch target.kind {
         case .workspace(let workspaceId):
             tabManager.setCustomTitle(tabId: workspaceId, title: normalizedName)
+        case .workspaceGroup(let groupId):
+            guard tabManager.workspaceGroups.contains(where: { $0.id == groupId }) else {
+                NSSound.beep()
+                return
+            }
+            tabManager.renameWorkspaceGroup(groupId: groupId, name: normalizedName ?? "")
         case .tab(let workspaceId, let panelId):
             guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else {
                 NSSound.beep()

--- a/cmuxTests/CommandPaletteEmojiTitleSearchTests.swift
+++ b/cmuxTests/CommandPaletteEmojiTitleSearchTests.swift
@@ -92,7 +92,40 @@ struct CommandPaletteEmojiTitleSearchTests {
 
         #expect(ContentView.commandPaletteWorkspaceDisplayName(
             customTitle: anchor.customTitle,
-            resolvedTitle: manager.resolvedWorkspaceDisplayTitle(for: anchor)
+            resolvedTitle: manager.resolvedWorkspaceDisplayTitle(for: anchor),
+            preferResolvedTitle: true
         ) == "AUSTIN GENERAL INTELLIGENCE")
+    }
+
+    @Test func commandPaletteWorkspaceNamePreservesCustomTitlesForRegularWorkspaces() {
+        #expect(ContentView.commandPaletteWorkspaceDisplayName(
+            customTitle: "Custom Workspace",
+            resolvedTitle: "Workspace",
+            preferResolvedTitle: false
+        ) == "Custom Workspace")
+    }
+
+    @Test func searchCanFindWorkspaceGroupsByKindKeywords() {
+        let entries = [
+            CommandPaletteSearchCorpusEntry(
+                payload: "workspace.group",
+                rank: 0,
+                title: "AUSTIN GENERAL INTELLIGENCE",
+                searchableTexts: ["AUSTIN GENERAL INTELLIGENCE", "Workspace group", "workspace group", "group"]
+            ),
+            CommandPaletteSearchCorpusEntry(
+                payload: "workspace.regular",
+                rank: 1,
+                title: "Regular Workspace",
+                searchableTexts: ["Regular Workspace", "Workspace", "workspace"]
+            ),
+        ]
+
+        let results = CommandPaletteSearchEngine(entries: entries).search(
+            query: "workspace group",
+            resultLimit: 5
+        ) { _, _ in 0 }
+
+        #expect(results.first?.payload == "workspace.group")
     }
 }

--- a/cmuxTests/CommandPaletteEmojiTitleSearchTests.swift
+++ b/cmuxTests/CommandPaletteEmojiTitleSearchTests.swift
@@ -1,6 +1,12 @@
 import CmuxCommandPalette
 import Testing
 
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
 struct CommandPaletteEmojiTitleSearchTests {
     @Test func searchPrefersEmojiPrefixedFullTitleWordsOverPartialTitlePrefix() {
         let entries = [
@@ -72,5 +78,21 @@ struct CommandPaletteEmojiTitleSearchTests {
         ) { _, _ in 0 }
 
         #expect(results.first?.payload == "workspace.fullTitleMatch")
+    }
+
+    @MainActor
+    @Test func commandPaletteWorkspaceNameUsesRenamedGroupAnchorTitle() throws {
+        let manager = TabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let groupId = try #require(manager.createWorkspaceGroup(name: "Group 1", childWorkspaceIds: [manager.tabs[0].id]))
+        let group = try #require(manager.workspaceGroups.first { $0.id == groupId })
+        let anchor = try #require(manager.tabs.first { $0.id == group.anchorWorkspaceId })
+
+        manager.renameWorkspaceGroup(groupId: groupId, name: "AUSTIN GENERAL INTELLIGENCE")
+
+        #expect(ContentView.commandPaletteWorkspaceDisplayName(
+            customTitle: anchor.customTitle,
+            resolvedTitle: manager.resolvedWorkspaceDisplayTitle(for: anchor)
+        ) == "AUSTIN GENERAL INTELLIGENCE")
     }
 }

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -910,7 +910,10 @@ struct WorkspaceGroupTests {
 
         manager.renameWorkspaceGroup(groupId: groupId, name: "AUSTIN GENERAL INTELLIGENCE")
 
-        let displayName = ContentView.commandPaletteWorkspaceDisplayName(anchor)
+        let displayName = ContentView.commandPaletteWorkspaceDisplayName(
+            customTitle: anchor.customTitle,
+            resolvedTitle: manager.resolvedWorkspaceDisplayTitle(for: anchor)
+        )
 
         #expect(displayName == "AUSTIN GENERAL INTELLIGENCE")
     }

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -900,24 +900,6 @@ struct WorkspaceGroupTests {
         #expect(manager.resolvedWorkspaceDisplayTitle(for: anchor) == "AUSTIN GENERAL INTELLIGENCE")
     }
 
-    @Test func commandPaletteWorkspaceNameUsesRenamedGroupAnchorTitle() throws {
-        let manager = makeTabManager()
-        let groupId = try #require(
-            manager.createWorkspaceGroup(name: "Group 1", childWorkspaceIds: [manager.tabs[0].id])
-        )
-        let group = try #require(manager.workspaceGroups.first { $0.id == groupId })
-        let anchor = try #require(manager.tabs.first { $0.id == group.anchorWorkspaceId })
-
-        manager.renameWorkspaceGroup(groupId: groupId, name: "AUSTIN GENERAL INTELLIGENCE")
-
-        let displayName = ContentView.commandPaletteWorkspaceDisplayName(
-            customTitle: anchor.customTitle,
-            resolvedTitle: manager.resolvedWorkspaceDisplayTitle(for: anchor)
-        )
-
-        #expect(displayName == "AUSTIN GENERAL INTELLIGENCE")
-    }
-
     // A non-anchor workspace keeps its own title; only the anchor mirrors the
     // group name. Guards against the derivation over-reaching to every member.
     @Test func renamingGroupLeavesNonAnchorMemberTitleAlone() throws {

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -900,6 +900,21 @@ struct WorkspaceGroupTests {
         #expect(manager.resolvedWorkspaceDisplayTitle(for: anchor) == "AUSTIN GENERAL INTELLIGENCE")
     }
 
+    @Test func commandPaletteWorkspaceNameUsesRenamedGroupAnchorTitle() throws {
+        let manager = makeTabManager()
+        let groupId = try #require(
+            manager.createWorkspaceGroup(name: "Group 1", childWorkspaceIds: [manager.tabs[0].id])
+        )
+        let group = try #require(manager.workspaceGroups.first { $0.id == groupId })
+        let anchor = try #require(manager.tabs.first { $0.id == group.anchorWorkspaceId })
+
+        manager.renameWorkspaceGroup(groupId: groupId, name: "AUSTIN GENERAL INTELLIGENCE")
+
+        let displayName = ContentView.commandPaletteWorkspaceDisplayName(anchor)
+
+        #expect(displayName == "AUSTIN GENERAL INTELLIGENCE")
+    }
+
     // A non-anchor workspace keeps its own title; only the anchor mirrors the
     // group name. Guards against the derivation over-reaching to every member.
     @Test func renamingGroupLeavesNonAnchorMemberTitleAlone() throws {

--- a/tests/test_claude_wrapper_user_binary_resolution.py
+++ b/tests/test_claude_wrapper_user_binary_resolution.py
@@ -191,7 +191,7 @@ def test_shell_integration_preserves_empty_path_components(failures: list[str]) 
         base_env["CMUX_SHELL_INTEGRATION_DIR"] = str(SHELL_INTEGRATION_DIR)
         base_env["CMUX_SURFACE_ID"] = surface_id
         base_env["TMPDIR"] = str(tmpdir)
-        base_env["PATH"] = f":{first}::{shim_root}:{last}:"
+        base_env["CMUX_TEST_PATH"] = f":{first}::{shim_root}:{last}:"
         base_env.pop("CMUX_SOCKET_PATH", None)
         base_env.pop("GHOSTTY_BIN_DIR", None)
 
@@ -201,13 +201,13 @@ def test_shell_integration_preserves_empty_path_components(failures: list[str]) 
                 "--noprofile",
                 "--norc",
                 "-c",
-                'source "$CMUX_SHELL_INTEGRATION_DIR/cmux-bash-integration.bash"; printf "%s\\n" "$PATH"',
+                'PATH="$CMUX_TEST_PATH"; export PATH; source "$CMUX_SHELL_INTEGRATION_DIR/cmux-bash-integration.bash"; printf "%s\\n" "$PATH"',
             ],
             [
                 "/bin/zsh",
                 "-f",
                 "-c",
-                'source "$CMUX_SHELL_INTEGRATION_DIR/cmux-zsh-integration.zsh"; printf "%s\\n" "$PATH"',
+                'PATH="$CMUX_TEST_PATH"; export PATH; source "$CMUX_SHELL_INTEGRATION_DIR/cmux-zsh-integration.zsh"; printf "%s\\n" "$PATH"',
             ],
         ]
         for argv in shell_commands:


### PR DESCRIPTION
Summary
- Route Cmd-P workspace switcher names through the group-aware workspace title resolver.
- Preserve custom workspace names and the fallback Workspace label.
- Add a regression test for renamed group anchors in the command palette display-name path.

Verification
- Built tagged macOS app with `./scripts/reload-cloud.sh --tag grpcp`: https://github.com/manaflow-ai/cmux/actions/runs/28218630720
- Launched tagged app on `/tmp/cmux-debug-grpcp.sock`, created workspace group `AUSTIN GENERAL INTELLIGENCE`, opened Cmd-P workspace switcher, and confirmed the group anchor row appears with that title.
- Captured tagged screenshot via `debug.window.screenshot`: `/var/folders/rr/vmfx6xh12dz2tlvgtmyvjmf80000gn/T/cmux-screenshots/2026-06-26T06-03-09Z_FD16FE7E.png`

Notes
- Local `xcodebuild test` is blocked by the repo guard because it launches a TEST_HOST app.
- Compile-only `cmux-unit` build reached dependency resolution after submodule init but this fresh worktree lacks a usable `GhosttyKit.xcframework`; cloud reload succeeded on the fleet builder.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785045906&installation_id=133855650&pr_number=6806&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6806&signature=c4546d6d29d07f19245e310ea974c56cbab8fef93fa53e8be0c32d8752631cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and naming for workspace groups in the command palette; no auth or data-model changes beyond existing group rename APIs.
> 
> **Overview**
> The Cmd-P workspace switcher now shows **workspace group** names on anchor rows (via `preferResolvedTitle` and `TabManager.resolvedWorkspaceDisplayTitle`), labels them **Workspace group**, and adds group-specific search keywords and fingerprinting so results stay in sync when group names change.
> 
> **Rename flow:** Selecting a group anchor routes **Rename Workspace…** to **Rename Group…** with a new `workspaceGroup` rename target, centralized hints/validation on `CommandPaletteRenameTarget` (groups cannot clear to an empty name), and `renameWorkspaceGroup` on apply. Context exposes `workspace.isGroupAnchor`.
> 
> Unrelated: shell integration path-preservation tests use `CMUX_TEST_PATH` instead of mutating `PATH` in the environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a79e55bc0121931b0bc399c97c944524436f158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show workspace group names in the Cmd‑P workspace switcher and make them searchable. Add group‑aware rename so group anchors show “Rename Group…” and rename the group, not the workspace.

- **New Features**
  - Route anchor names through the group‑aware resolver with `preferResolvedTitle`; add a “Workspace group” kind label, group keywords, and a “group” fingerprint so entries refresh on group name or membership changes. Regular workspaces still prefer custom names with a fallback to “Workspace”.
  - Add group rename flow: new `workspaceGroup` kind in `CommandPaletteRenameTarget` with localized title/description/placeholder/input and confirm hints; expose `workspace.isGroupAnchor` context; show “Rename Group…” when applicable; persist via `TabManager.renameWorkspaceGroup`.

- **Bug Fixes**
  - Reject empty group names in the palette rename flow; stabilize the shell wrapper PATH test by using `CMUX_TEST_PATH` before sourcing bash/zsh integrations.

<sup>Written for commit 1a79e55bc0121931b0bc399c97c944524436f158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the command palette to better distinguish workspace group anchors from regular workspaces.
  * Workspace group entries now show the correct, localized “Workspace group” label.
* **Bug Fixes**
  * Improved workspace/group title rendering for renamed group anchors, ensuring the expected resolved title is displayed.
  * Refined display-name handling to better preserve custom titles when appropriate.
* **Tests**
  * Added automated coverage for group-anchor naming behavior and custom title preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->