### PR TITLE
Run local terminals through persistent PTY daemon

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11301,6 +11301,12 @@ struct CMUXCLI {
                     of: "__CMUX_SURFACE_ID__",
                     with: ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] ?? ""
                 )
+            for key in Self.sshPTYAttachForwardedEnvironmentKeys {
+                let value = ProcessInfo.processInfo.environment[key] ?? ""
+                decoded = decoded
+                    .replacingOccurrences(of: "__CMUX_ENV_\(key)__", with: value)
+                    .replacingOccurrences(of: "__CMUX_ENV_SH_\(key)__", with: shellQuote(value))
+            }
             return decoded
         }
         var bridgeReachedReady = false
@@ -11444,6 +11450,24 @@ struct CMUXCLI {
             }
         }
     }
+
+    private static let sshPTYAttachForwardedEnvironmentKeys: [String] = [
+        "CMUX_BUNDLE_ID",
+        "CMUX_BUNDLED_CLI_PATH",
+        "CMUX_CLAUDE_HOOKS_DISABLED",
+        "CMUX_CLAUDE_WRAPPER_SHIM",
+        "CMUX_CLAUDE_WRAPPER_SHIM_ROOT",
+        "CMUX_CUSTOM_CLAUDE_PATH",
+        "CMUX_PORT",
+        "CMUX_PORT_END",
+        "CMUX_PORT_RANGE",
+        "CMUX_SHELL_INTEGRATION",
+        "CMUX_SHELL_INTEGRATION_DIR",
+        "CMUX_SOCKET_PATH",
+        "CMUX_SURFACE_ID",
+        "CMUX_WORKSPACE_ID",
+        "PATH",
+    ]
 
     private func cleanupFailedSSHPTYAttach(
         client: SocketClient,

--- a/Packages/macOS/CmuxCore/Sources/CmuxCore/Remote/WorkspaceRemoteConfiguration+SSHBatchCommands.swift
+++ b/Packages/macOS/CmuxCore/Sources/CmuxCore/Remote/WorkspaceRemoteConfiguration+SSHBatchCommands.swift
@@ -32,6 +32,16 @@ extension WorkspaceRemoteConfiguration {
             + ["-o", "RequestTTY=no", destination, command]
     }
 
+    /// Local `cmuxd-remote` argv for the stdio daemon transport.
+    public func localDaemonTransportArguments() -> [String] {
+        var serveArguments = ["serve", "--stdio"]
+        if let slot = persistentDaemonSlot?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !slot.isEmpty {
+            serveArguments += ["--persistent", "--slot", slot]
+        }
+        return serveArguments
+    }
+
     /// `ssh` argv that forwards `127.0.0.1:<localPort>` to the baked VM
     /// daemon's Unix socket (`-N`, no remote command). Argument text is
     /// wire/process behavior; do not alter.

--- a/Packages/macOS/CmuxCore/Sources/CmuxCore/Remote/WorkspaceRemoteTransport.swift
+++ b/Packages/macOS/CmuxCore/Sources/CmuxCore/Remote/WorkspaceRemoteTransport.swift
@@ -2,6 +2,8 @@
 ///
 /// Raw values are persisted in session snapshots; do not rename cases.
 public enum WorkspaceRemoteTransport: String, Codable, Equatable, Sendable {
+    /// Connect to a local persistent cmuxd-remote PTY daemon.
+    case local
     /// Connect over SSH (interactive shells, daemon bootstrap, port forwards).
     case ssh
     /// Connect through a brokered WebSocket daemon endpoint (Cloud VMs).

--- a/Packages/macOS/CmuxCore/Tests/CmuxCoreTests/SessionRemoteWorkspaceSnapshotTests.swift
+++ b/Packages/macOS/CmuxCore/Tests/CmuxCoreTests/SessionRemoteWorkspaceSnapshotTests.swift
@@ -47,6 +47,7 @@ struct SessionRemoteWorkspaceSnapshotTests {
 
     @Test("transport raw values are the persisted wire strings")
     func transportRawValues() {
+        #expect(WorkspaceRemoteTransport.local.rawValue == "local")
         #expect(WorkspaceRemoteTransport.ssh.rawValue == "ssh")
         #expect(WorkspaceRemoteTransport.websocket.rawValue == "websocket")
     }

--- a/Packages/macOS/CmuxCore/Tests/CmuxCoreTests/WorkspaceRemoteConfigurationTests.swift
+++ b/Packages/macOS/CmuxCore/Tests/CmuxCoreTests/WorkspaceRemoteConfigurationTests.swift
@@ -166,6 +166,7 @@ struct WorkspaceRemoteConfigurationValueTests {
 
     @Test("sessionSnapshot persists only SSH transports with a non-empty destination")
     func sessionSnapshotGating() {
+        #expect(makeConfiguration(transport: .local).sessionSnapshot() == nil)
         #expect(makeConfiguration(transport: .websocket).sessionSnapshot() == nil)
         #expect(makeConfiguration(destination: "   ").sessionSnapshot() == nil)
 

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+Transport.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+Transport.swift
@@ -7,6 +7,73 @@ internal import CmuxFoundation
 // forward, websocket). Faithful lift; argument composition lives on
 // WorkspaceRemoteConfiguration in CmuxCore.
 extension RemoteDaemonRPCClient {
+    func startViaLocalExec() throws {
+        let process = Process()
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+
+        stateQueue.sync {
+            self.stdinPipe = stdinPipe
+            self.stdoutPipe = stdoutPipe
+            self.stderrPipe = stderrPipe
+        }
+
+        process.executableURL = URL(fileURLWithPath: remotePath)
+        process.arguments = configuration.localDaemonTransportArguments()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            switch handle.readAvailableDataOrEndOfFile() {
+            case .data(let data):
+                self?.stateQueue.async { [weak self] in
+                    self?.consumeStdoutData(data)
+                }
+            case .wouldBlock:
+                return
+            case .endOfFile:
+                handle.readabilityHandler = nil
+                self?.stateQueue.async { [weak self] in
+                    self?.consumeStdoutData(Data())
+                }
+            }
+        }
+        stderrPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            switch handle.readAvailableDataOrEndOfFile() {
+            case .data(let data):
+                self?.stateQueue.async { [weak self] in
+                    self?.consumeStderrData(data)
+                }
+            case .wouldBlock:
+                return
+            case .endOfFile:
+                handle.readabilityHandler = nil
+            }
+        }
+        process.terminationHandler = { [weak self] terminated in
+            self?.stateQueue.async { [weak self] in
+                self?.handleProcessTermination(terminated)
+            }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            throw NSError(domain: "cmux.remote.daemon.rpc", code: 27, userInfo: [
+                NSLocalizedDescriptionKey: "Failed to launch local daemon transport: \(error.localizedDescription)",
+            ])
+        }
+
+        stateQueue.sync {
+            self.process = process
+            self.stdinHandle = stdinPipe.fileHandleForWriting
+            self.stdoutHandle = stdoutPipe.fileHandleForReading
+            self.stderrHandle = stderrPipe.fileHandleForReading
+        }
+    }
+
     func startViaSSHExec() throws {
         let process = Process()
         let stdinPipe = Pipe()

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient.swift
@@ -133,7 +133,10 @@ public final class RemoteDaemonRPCClient: @unchecked Sendable {
     public func start() throws {
         pendingCalls.reset()
 
-        if configuration.transport == .websocket {
+        if configuration.transport == .local {
+            try startViaLocalExec()
+            markTransportOpen()
+        } else if configuration.transport == .websocket {
             try startViaWebSocket()
         } else if Self.usesSocketForwardTransport(configuration: configuration) {
             try startViaBakedVMSocketForward()

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
@@ -83,6 +83,29 @@ extension RemoteSessionCoordinator {
         return hello
     }
 
+    func bootstrapLocalDaemonLocked(requiredCapabilities: [String]) throws -> DaemonHello {
+        debugLog("remote.bootstrap.local.begin \(debugConfigSummary())")
+        let version = remoteDaemonVersion()
+        let localBinary = try buildLocalDaemonBinary(
+            goOS: "darwin",
+            goArch: Self.localDaemonGoArch(),
+            version: version
+        )
+        let hello = try helloLocalDaemonLocked(localPath: localBinary.path)
+        let missingCapabilities = Self.missingRequiredCapabilities(requiredCapabilities, in: hello.capabilities)
+        guard missingCapabilities.isEmpty else {
+            throw NSError(domain: "cmux.remote.daemon", code: 44, userInfo: [
+                NSLocalizedDescriptionKey: daemonStrings.missingRequiredCapabilitiesMessage(missingCapabilities),
+                NSDebugDescriptionErrorKey: "local daemon missing required capability \(missingCapabilities.joined(separator: ","))",
+            ])
+        }
+        debugLog(
+            "remote.bootstrap.local.ready name=\(hello.name) version=\(hello.version) " +
+            "capabilities=\(hello.capabilities.joined(separator: ",")) path=\(hello.remotePath)"
+        )
+        return hello
+    }
+
     /// Builds the remote shell probe that reports platform and daemon availability markers.
     ///
     /// The OS/arch normalization uses literal `case` alternatives rather than
@@ -407,6 +430,66 @@ extension RemoteSessionCoordinator {
             capabilities: capabilities,
             remotePath: remotePath
         )
+    }
+
+    func helloLocalDaemonLocked(localPath: String) throws -> DaemonHello {
+        let request = #"{"id":1,"method":"hello","params":{}}"# + "\n"
+        let result = try runProcess(
+            executable: localPath,
+            arguments: ["serve", "--stdio"],
+            stdin: Data(request.utf8),
+            timeout: 12
+        )
+        guard result.status == 0 else {
+            let detail = Self.bestErrorLine(stderr: result.stderr, stdout: result.stdout) ?? "local daemon exited \(result.status)"
+            throw NSError(domain: "cmux.remote.daemon", code: 45, userInfo: [
+                NSLocalizedDescriptionKey: "failed to start local daemon: \(detail)",
+            ])
+        }
+        let responseLine = result.stdout
+            .split(separator: "\n")
+            .map(String.init)
+            .first(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) ?? ""
+        guard !responseLine.isEmpty,
+              let data = responseLine.data(using: .utf8),
+              let payload = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+            throw NSError(domain: "cmux.remote.daemon", code: 46, userInfo: [
+                NSLocalizedDescriptionKey: "local daemon hello returned invalid JSON",
+            ])
+        }
+        if let ok = payload["ok"] as? Bool, !ok {
+            let errorMessage: String = {
+                if let errorObject = payload["error"] as? [String: Any],
+                   let message = errorObject["message"] as? String,
+                   !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return message
+                }
+                return "hello call failed"
+            }()
+            throw NSError(domain: "cmux.remote.daemon", code: 47, userInfo: [
+                NSLocalizedDescriptionKey: "local daemon hello failed: \(errorMessage)",
+            ])
+        }
+        let resultObject = payload["result"] as? [String: Any] ?? [:]
+        let name = (resultObject["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let version = (resultObject["version"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let capabilities = (resultObject["capabilities"] as? [String]) ?? []
+        return DaemonHello(
+            name: (name?.isEmpty == false ? name! : "cmuxd-remote"),
+            version: (version?.isEmpty == false ? version! : "dev"),
+            capabilities: capabilities,
+            remotePath: localPath
+        )
+    }
+
+    static func localDaemonGoArch() -> String {
+    #if arch(arm64)
+        return "arm64"
+    #elseif arch(x86_64)
+        return "amd64"
+    #else
+        return "arm64"
+    #endif
     }
 
     static func mapUnameOS(_ raw: String) -> String? {

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -279,11 +279,13 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
     func beginConnectionAttemptLocked() {
         guard !isStopping else { return }
 
-        Self.killOrphanedRemoteSSHProcesses(
-            destination: configuration.destination,
-            relayPort: configuration.relayPort,
-            persistentDaemonSlot: configuration.persistentDaemonSlot
-        )
+        if configuration.transport != .local {
+            Self.killOrphanedRemoteSSHProcesses(
+                destination: configuration.destination,
+                relayPort: configuration.relayPort,
+                persistentDaemonSlot: configuration.persistentDaemonSlot
+            )
+        }
         connectionAttemptStartedAt = Date()
         debugLog("remote.session.connect.begin retry=\(reconnectRetryCount) \(debugConfigSummary())")
         // The armed retry (if any) is consumed by this attempt; a stale fire
@@ -314,7 +316,9 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
         do {
             let requiredCapabilities = requiredDaemonCapabilities
             let hello: DaemonHello
-            if configuration.skipDaemonBootstrap {
+            if configuration.transport == .local {
+                hello = try bootstrapLocalDaemonLocked(requiredCapabilities: requiredCapabilities)
+            } else if configuration.skipDaemonBootstrap {
                 // Cloud-VM path: cmuxd-remote is pre-baked in the image and exposed via
                 // systemd socket activation at /run/cmuxd-remote.sock. We skip the probe,
                 // upload, and stdio-hello steps entirely — they all depend on ssh-exec
@@ -349,7 +353,9 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
                 remotePath: hello.remotePath
             )
             recordHeartbeatActivityLocked()
-            if configuration.skipDaemonBootstrap {
+            if configuration.transport == .local {
+                startProxyLocked()
+            } else if configuration.skipDaemonBootstrap {
                 debugLog("remote.relay.skipped reason=vm-baked transport=\(configuration.transport.rawValue)")
                 if configuration.daemonWebSocketEndpoint != nil {
                     startProxyLocked()

--- a/Sources/Workspace+LocalPTYPersistence.swift
+++ b/Sources/Workspace+LocalPTYPersistence.swift
@@ -1,0 +1,129 @@
+import Foundation
+import CmuxCore
+
+extension Workspace {
+    var localPersistentPTYWorkspaceIdentity: UUID {
+        restoredLocalPersistentPTYWorkspaceId ?? id
+    }
+
+    func configureLocalPersistentPTYServerIfNeeded(autoConnect: Bool = true) {
+        if let remoteConfiguration, remoteConfiguration.transport != .local {
+            return
+        }
+        let configuration = WorkspaceRemoteConfiguration(
+            transport: .local,
+            destination: "local",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: nil,
+            relayID: nil,
+            relayToken: nil,
+            localSocketPath: nil,
+            terminalStartupCommand: nil,
+            foregroundAuthToken: nil,
+            agentSocketPath: nil,
+            daemonWebSocketEndpoint: nil,
+            preserveAfterTerminalExit: true,
+            persistentDaemonSlot: Self.localPersistentPTYSlot(workspaceId: localPersistentPTYWorkspaceIdentity),
+            skipDaemonBootstrap: false
+        )
+        if remoteConfiguration == configuration {
+            return
+        }
+        configureRemoteConnection(configuration, autoConnect: autoConnect)
+    }
+
+    func localPersistentPTYStartupCommand(
+        panelId: UUID,
+        workingDirectory: String?,
+        explicitCommand: String?,
+        startupEnvironment: [String: String]
+    ) -> String? {
+        guard remoteConfiguration?.transport == .local else { return nil }
+        let sessionID = Self.defaultSSHPTYSessionID(
+            workspaceId: localPersistentPTYWorkspaceIdentity,
+            panelId: panelId
+        )
+        let remoteCommand = Self.localPersistentPTYRemoteCommand(
+            workingDirectory: workingDirectory,
+            explicitCommand: explicitCommand,
+            startupEnvironment: startupEnvironment
+        )
+        return SSHPTYAttachStartupCommandBuilder.command(
+            sessionID: sessionID,
+            remoteCommand: remoteCommand,
+            requireExisting: false
+        )
+    }
+
+    private nonisolated static func localPersistentPTYSlot(workspaceId: UUID) -> String {
+        "local-\(workspaceId.uuidString.lowercased())"
+    }
+
+    private nonisolated static func localPersistentPTYRemoteCommand(
+        workingDirectory: String?,
+        explicitCommand: String?,
+        startupEnvironment: [String: String]
+    ) -> String {
+        var lines: [String] = [
+            "set +u",
+        ]
+        for key in localPersistentPTYForwardedEnvironmentKeys {
+            lines.append("cmux_forwarded_value=__CMUX_ENV_SH_\(key)__")
+            lines.append("if [ -n \"$cmux_forwarded_value\" ]; then export \(key)=\"$cmux_forwarded_value\"; fi")
+        }
+        for (key, value) in startupEnvironment.sorted(by: { $0.key < $1.key }) {
+            guard isSafeShellEnvironmentKey(key) else { continue }
+            lines.append("export \(key)=\(shellQuote(value))")
+        }
+        if let workingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !workingDirectory.isEmpty {
+            lines.append("cd \(shellQuote(workingDirectory)) || exit $?")
+        }
+        if let explicitCommand = explicitCommand?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !explicitCommand.isEmpty {
+            lines.append("exec /bin/sh -lc \(shellQuote(explicitCommand))")
+        } else {
+            lines.append("exec \"${SHELL:-/bin/zsh}\" -l")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private nonisolated static let localPersistentPTYForwardedEnvironmentKeys: [String] = [
+        "CMUX_BUNDLE_ID",
+        "CMUX_BUNDLED_CLI_PATH",
+        "CMUX_CLAUDE_HOOKS_DISABLED",
+        "CMUX_CLAUDE_WRAPPER_SHIM",
+        "CMUX_CLAUDE_WRAPPER_SHIM_ROOT",
+        "CMUX_CUSTOM_CLAUDE_PATH",
+        "CMUX_PORT",
+        "CMUX_PORT_END",
+        "CMUX_PORT_RANGE",
+        "CMUX_SHELL_INTEGRATION",
+        "CMUX_SHELL_INTEGRATION_DIR",
+        "CMUX_SOCKET_PATH",
+        "CMUX_SURFACE_ID",
+        "CMUX_WORKSPACE_ID",
+        "PATH",
+    ]
+
+    private nonisolated static func isSafeShellEnvironmentKey(_ key: String) -> Bool {
+        guard !key.isEmpty else { return false }
+        return key.utf8.allSatisfy { byte in
+            (byte >= 65 && byte <= 90) ||
+                (byte >= 97 && byte <= 122) ||
+                (byte >= 48 && byte <= 57) ||
+                byte == 95
+        }
+    }
+
+    private nonisolated static func shellQuote(_ value: String) -> String {
+        let safePattern = "^[A-Za-z0-9_@%+=:,./-]+$"
+        if value.range(of: safePattern, options: .regularExpression) != nil {
+            return value
+        }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -148,6 +148,7 @@ extension Workspace {
         let previousSuppressClosedPanelHistory = suppressClosedPanelHistory
         suppressClosedPanelHistory = true
         defer { suppressClosedPanelHistory = previousSuppressClosedPanelHistory }
+        restoredLocalPersistentPTYWorkspaceId = snapshot.workspaceId
 
         restoredTerminalScrollbackByPanelId.removeAll(keepingCapacity: false)
 #if DEBUG
@@ -174,6 +175,7 @@ extension Workspace {
             )
         } else {
             disconnectRemoteConnection(clearConfiguration: true)
+            configureLocalPersistentPTYServerIfNeeded(autoConnect: true)
         }
 
         let normalizedCurrentDirectory = snapshot.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2469,6 +2471,7 @@ final class Workspace: Identifiable, ObservableObject {
     private var activeRemoteTerminalSurfaceIds: Set<UUID> = []
     private var endedPersistentRemotePTYAttachSurfaceIds: Set<UUID> = []
     private var remotePTYSessionIDsByPanelId: [UUID: String] = [:]
+    var restoredLocalPersistentPTYWorkspaceId: UUID?
     private var remoteRelayWorkspaceIDAliases: [UUID: UUID] = [:]
     private var remoteRelaySurfaceIDAliases: [UUID: UUID] = [:]
     private var suppressRemoteTerminalStartupForSessionRestoreScaffold = false
@@ -3037,6 +3040,7 @@ final class Workspace: Identifiable, ObservableObject {
         paneTree.attach(host: self)
         surfaceList.attach(tree: self)
         bonsplitController.contextMenuShortcuts = Self.buildContextMenuShortcuts()
+        configureLocalPersistentPTYServerIfNeeded(autoConnect: true)
 
         // Remove the default "Welcome" tab that bonsplit creates
         let welcomeTabIds = bonsplitController.allTabIds
@@ -5283,7 +5287,8 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     var isRemoteWorkspace: Bool {
-        remoteConfiguration != nil
+        guard let remoteConfiguration else { return false }
+        return remoteConfiguration.transport != .local
     }
 
     /// Ephemeral remote tmux mirror; excluded from cmux session restore.
@@ -5309,6 +5314,7 @@ final class Workspace: Identifiable, ObservableObject {
     var isRestorableInSessionSnapshot: Bool {
         if isRemoteTmuxMirror { return false }
         guard let remoteConfiguration else { return true }
+        if remoteConfiguration.transport == .local { return true }
         return remoteConfiguration.sessionSnapshot() != nil
     }
 
@@ -5766,7 +5772,10 @@ final class Workspace: Identifiable, ObservableObject {
         transferredRemoteCleanupConfigurationsByPanelId.removeValue(forKey: panelId)
         if remoteConfiguration?.preserveAfterTerminalExit == true,
            normalizedRemotePTYSessionID(remotePTYSessionIDsByPanelId[panelId]) == nil {
-            remotePTYSessionIDsByPanelId[panelId] = Self.defaultSSHPTYSessionID(workspaceId: id, panelId: panelId)
+            remotePTYSessionIDsByPanelId[panelId] = Self.defaultSSHPTYSessionID(
+                workspaceId: remotePTYSessionWorkspaceId(),
+                panelId: panelId
+            )
         }
         guard activeRemoteTerminalSurfaceIds.insert(panelId).inserted else { return }
         activeRemoteTerminalSessionCount = activeRemoteTerminalSurfaceIds.count
@@ -6105,7 +6114,11 @@ final class Workspace: Identifiable, ObservableObject {
         guard activeRemoteTerminalSurfaceIds.contains(panelId) else {
             return nil
         }
-        return Self.defaultSSHPTYSessionID(workspaceId: id, panelId: panelId)
+        return Self.defaultSSHPTYSessionID(workspaceId: remotePTYSessionWorkspaceId(), panelId: panelId)
+    }
+
+    private func remotePTYSessionWorkspaceId() -> UUID {
+        remoteConfiguration?.transport == .local ? localPersistentPTYWorkspaceIdentity : id
     }
 
     nonisolated static func defaultSSHPTYSessionID(workspaceId: UUID, panelId: UUID) -> String {
@@ -6164,7 +6177,7 @@ final class Workspace: Identifiable, ObservableObject {
             return false
         }
         let expectedSessionID = normalizedRemotePTYSessionID(remotePTYSessionIDsByPanelId[panelId])
-            ?? Self.defaultSSHPTYSessionID(workspaceId: id, panelId: panelId)
+            ?? Self.defaultSSHPTYSessionID(workspaceId: remotePTYSessionWorkspaceId(), panelId: panelId)
         return normalizedSessionID == expectedSessionID
     }
 
@@ -6172,7 +6185,7 @@ final class Workspace: Identifiable, ObservableObject {
     func markRemotePTYAttachEnded(surfaceId: UUID, sessionID: String) -> (clearedRemotePTYSession: Bool, untrackedRemoteTerminal: Bool) {
         let normalizedSessionID = normalizedRemotePTYSessionID(sessionID)
         let expectedSessionID = normalizedRemotePTYSessionID(remotePTYSessionIDsByPanelId[surfaceId])
-            ?? Self.defaultSSHPTYSessionID(workspaceId: id, panelId: surfaceId)
+            ?? Self.defaultSSHPTYSessionID(workspaceId: remotePTYSessionWorkspaceId(), panelId: surfaceId)
         guard let normalizedSessionID, normalizedSessionID == expectedSessionID else {
             return (false, false)
         }
@@ -7034,8 +7047,19 @@ final class Workspace: Identifiable, ObservableObject {
         var inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId)
         let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
-        let remoteTerminalStartupCommand = remoteTerminalStartupCommand()
-        let startupCommand = explicitInitialCommand ?? remoteTerminalStartupCommand
+        let newPanelId = UUID()
+        let splitWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
+            requestedWorkingDirectory: workingDirectory,
+            sourcePanelId: panelId
+        )
+        let localPTYStartupCommand = localPersistentPTYStartupCommand(
+            panelId: newPanelId,
+            workingDirectory: splitWorkingDirectory,
+            explicitCommand: explicitInitialCommand,
+            startupEnvironment: startupEnvironmentMergingWorkspaceEnvironment(startupEnvironment)
+        )
+        let remoteTerminalStartupCommand = localPTYStartupCommand == nil ? remoteTerminalStartupCommand() : nil
+        let startupCommand = localPTYStartupCommand ?? explicitInitialCommand ?? remoteTerminalStartupCommand
         let remoteStartupCommandForEnvironment = explicitInitialCommand == nil ? remoteTerminalStartupCommand : nil
         let effectiveStartupEnvironment = terminalStartupEnvironment(
             base: startupEnvironmentMergingWorkspaceEnvironment(startupEnvironment),
@@ -7061,10 +7085,6 @@ final class Workspace: Identifiable, ObservableObject {
 
         // Resolve cwd as explicit request, source reported cwd, source requested
         // startup cwd, then workspace currentDirectory.
-        let splitWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
-            requestedWorkingDirectory: workingDirectory,
-            sourcePanelId: panelId
-        )
 #if DEBUG
         cmuxDebugLog(
             "split.cwd panelId=\(panelId.uuidString.prefix(5)) panelDir=\(panelDirectories[panelId] ?? "nil") requestedDir=\(terminalPanel(for: panelId)?.requestedWorkingDirectory ?? "nil") currentDir=\(currentDirectory) resolved=\(splitWorkingDirectory ?? "nil")"
@@ -7073,10 +7093,11 @@ final class Workspace: Identifiable, ObservableObject {
 
         // Create the new terminal panel.
         let newPanel = TerminalPanel(
+            id: newPanelId,
             workspaceId: id,
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: inheritedConfig,
-            workingDirectory: splitWorkingDirectory,
+            workingDirectory: localPTYStartupCommand == nil ? splitWorkingDirectory : nil,
             portOrdinal: portOrdinal,
             initialCommand: startupCommand,
             tmuxStartCommand: tmuxStartCommand,
@@ -7086,7 +7107,7 @@ final class Workspace: Identifiable, ObservableObject {
         panels[newPanel.id] = newPanel
         panelTitles[newPanel.id] = newPanel.displayTitle
         let normalizedRemotePTYSessionID = normalizedRemotePTYSessionID(remotePTYSessionID)
-        let tracksRemoteTerminalSurface = remoteTerminalStartupCommand != nil || normalizedRemotePTYSessionID != nil
+        let tracksRemoteTerminalSurface = localPTYStartupCommand != nil || remoteTerminalStartupCommand != nil || normalizedRemotePTYSessionID != nil
         if let normalizedRemotePTYSessionID {
             remotePTYSessionIDsByPanelId[newPanel.id] = normalizedRemotePTYSessionID
             registerRemoteRelayIDAliases(remotePTYSessionID: normalizedRemotePTYSessionID, restoredPanelId: newPanel.id)
@@ -7313,8 +7334,22 @@ final class Workspace: Identifiable, ObservableObject {
         var inheritedConfig = inheritedTerminalConfig(inPane: paneId)
         let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
-        let remoteTerminalStartupCommand = suppressWorkspaceRemoteStartupCommand ? nil : remoteTerminalStartupCommand()
-        let startupCommand = explicitInitialCommand ?? remoteTerminalStartupCommand
+        let newPanelId = restoredSurfaceId ?? UUID()
+        let requestedWorkingDirectoryCandidate = inheritWorkingDirectoryFallback && explicitInitialCommand == nil
+            ? resolvedTerminalStartupWorkingDirectory(
+                requestedWorkingDirectory: workingDirectory,
+                sourcePanelId: workingDirectoryFallbackSourcePanelId
+                    ?? bonsplitController.selectedTab(inPane: paneId).map(\.id).flatMap(panelIdFromSurfaceId)
+            )
+            : workingDirectory
+        let localPTYStartupCommand = suppressWorkspaceRemoteStartupCommand ? nil : localPersistentPTYStartupCommand(
+            panelId: newPanelId,
+            workingDirectory: requestedWorkingDirectoryCandidate,
+            explicitCommand: explicitInitialCommand,
+            startupEnvironment: startupEnvironmentMergingWorkspaceEnvironment(startupEnvironment)
+        )
+        let remoteTerminalStartupCommand = suppressWorkspaceRemoteStartupCommand || localPTYStartupCommand != nil ? nil : remoteTerminalStartupCommand()
+        let startupCommand = localPTYStartupCommand ?? explicitInitialCommand ?? remoteTerminalStartupCommand
         let remoteStartupCommandForEnvironment = explicitInitialCommand == nil ? remoteTerminalStartupCommand : nil
         let effectiveStartupEnvironment = terminalStartupEnvironment(
             base: startupEnvironmentMergingWorkspaceEnvironment(startupEnvironment),
@@ -7328,21 +7363,14 @@ final class Workspace: Identifiable, ObservableObject {
             template.waitAfterCommand = true
             inheritedConfig = template
         }
-        let fallbackSourcePanelId = workingDirectoryFallbackSourcePanelId
-            ?? bonsplitController.selectedTab(inPane: paneId).map(\.id).flatMap(panelIdFromSurfaceId)
-        let requestedWorkingDirectory = inheritWorkingDirectoryFallback && startupCommand == nil
-            ? resolvedTerminalStartupWorkingDirectory(
-                requestedWorkingDirectory: workingDirectory,
-                sourcePanelId: fallbackSourcePanelId
-            )
-            : workingDirectory
+        let requestedWorkingDirectory = localPTYStartupCommand == nil ? requestedWorkingDirectoryCandidate : nil
 
         // Create new terminal panel. A restored panel reuses its persisted
         // surface id (the panel/surface id IS the ghostty surface id, a
         // Swift-side UUID), so a session's terminal binding survives relaunch
         // and restore. The caller only passes an id it has verified is free.
         let newPanel = TerminalPanel(
-            id: restoredSurfaceId ?? UUID(),
+            id: newPanelId,
             workspaceId: id,
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: inheritedConfig,
@@ -7358,7 +7386,7 @@ final class Workspace: Identifiable, ObservableObject {
         panels[newPanel.id] = newPanel
         panelTitles[newPanel.id] = newPanel.displayTitle
         let normalizedRemotePTYSessionID = normalizedRemotePTYSessionID(remotePTYSessionID)
-        let tracksRemoteTerminalSurface = remoteTerminalStartupCommand != nil || normalizedRemotePTYSessionID != nil
+        let tracksRemoteTerminalSurface = localPTYStartupCommand != nil || remoteTerminalStartupCommand != nil || normalizedRemotePTYSessionID != nil
         if let normalizedRemotePTYSessionID {
             remotePTYSessionIDsByPanelId[newPanel.id] = normalizedRemotePTYSessionID
             registerRemoteRelayIDAliases(remotePTYSessionID: normalizedRemotePTYSessionID, restoredPanelId: newPanel.id)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1047,6 +1047,7 @@
 		9FC97DA1B422776BB1EEC821 /* Workspace+CustomSidebarPullRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C2726A34F27E7A43B77368 /* Workspace+CustomSidebarPullRequests.swift */; };
 		D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */; };
 		E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A06 /* Workspace+EqualizeSplitsSupport.swift */; };
+		E5A7C0010000000000000002 /* Workspace+LocalPTYPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A7C0010000000000000001 /* Workspace+LocalPTYPersistence.swift */; };
 		C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */; };
 		CA52B0170000000000000000 /* Workspace+SurfaceNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0170000000000000000 /* Workspace+SurfaceNavigation.swift */; };
 		E3B7A400000000000000020A /* Workspace+WorkspaceSurfaceTreeReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B7A400000000000000020B /* Workspace+WorkspaceSurfaceTreeReading.swift */; };
@@ -2152,6 +2153,7 @@
 		42C2726A34F27E7A43B77368 /* Workspace+CustomSidebarPullRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomSidebarPullRequests.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+DetachedSurfaceTransfer.swift"; sourceTree = "<group>"; };
 		E3309A06 /* Workspace+EqualizeSplitsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+EqualizeSplitsSupport.swift"; sourceTree = "<group>"; };
+		E5A7C0010000000000000001 /* Workspace+LocalPTYPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+LocalPTYPersistence.swift"; sourceTree = "<group>"; };
 		C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PanelLifecycle.swift"; sourceTree = "<group>"; };
 		CA52C0170000000000000000 /* Workspace+SurfaceNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+SurfaceNavigation.swift"; sourceTree = "<group>"; };
 		E3B7A400000000000000020B /* Workspace+WorkspaceSurfaceTreeReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+WorkspaceSurfaceTreeReading.swift"; sourceTree = "<group>"; };
@@ -2667,6 +2669,7 @@
 				D0C0D0C0D0C0D0C0D0C00004 /* RemoteLoopbackRuntimeBridge.swift */,
 				E3309A06 /* Workspace+EqualizeSplitsSupport.swift */,
 				D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */,
+				E5A7C0010000000000000001 /* Workspace+LocalPTYPersistence.swift */,
 				D7AB34400000000000000002 /* WorkspaceSurfaceConfig.swift */,
 				1A1B2C3D4E5F607180000002 /* WorkspacePromptSubmit.swift */,
 				D0B10005A1B2C3D4E5F60001 /* WorkspacePortalPaneDrop.swift */,
@@ -4473,6 +4476,7 @@
 				9FC97DA1B422776BB1EEC821 /* Workspace+CustomSidebarPullRequests.swift in Sources */,
 				D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */,
 				E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */,
+				E5A7C0010000000000000002 /* Workspace+LocalPTYPersistence.swift in Sources */,
 				C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */,
 				CA52B0170000000000000000 /* Workspace+SurfaceNavigation.swift in Sources */,
 				E3B7A400000000000000020A /* Workspace+WorkspaceSurfaceTreeReading.swift in Sources */,


### PR DESCRIPTION
## Summary
- add a local `cmuxd-remote` transport and bootstrap path
- start new local terminals through persistent PTY sessions instead of app-owned Ghostty PTYs
- restore local persistent PTY sessions by saved workspace/surface identity while keeping local workspaces session-restorable

## Verification
- `swift test --package-path Packages/macOS/CmuxCore`
- `bash scripts/check-pbxproj.sh`
- `git diff --check`
- `./scripts/reload-cloud.sh --tag ptyd`
- preflight: created a fresh terminal in tagged app, confirmed persisted session `ssh-F70A8E4B-B35B-4DEC-95F8-134DA9A51744-8BE13CE0-DCD0-4E8F-9D0F-F6E62A5AB751`, replaced the app process, and read restored output `PTYD_SNAPSHOTFIX_STILL_RUNNING_1782454868` from the restored terminal

## Dogfood
Use tagged build `ptyd`: http://127.0.0.1:17320/ptyd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785046947&installation_id=133855650&pr_number=6808&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6808&signature=6bf9280c6bd47b070c8abaf100ec34d06ea086ffd705c2271f40dcbf3c515b74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This changes the default local terminal spawn path and daemon lifecycle (bootstrap, proxy, PTY attach/restore), so regressions could affect every local shell, app relaunch behavior, and env forwarding into daemon sessions.
> 
> **Overview**
> **Local terminals now run through a persistent local `cmuxd-remote` daemon** instead of app-owned Ghostty PTYs. A new `WorkspaceRemoteTransport.local` wires bootstrap, RPC (`startViaLocalExec`), and proxy startup without SSH orphan cleanup or reverse relay.
> 
> **Workspaces auto-configure** a local remote connection with `preserveAfterTerminalExit` and a per-workspace persistent daemon slot. New and split panes get **ssh-pty-attach startup commands** (cwd, shell, env) rather than local PTY cwd; PTY session IDs use a **restored workspace id** after relaunch so sessions can reattach.
> 
> **CLI `ssh-pty-attach`** expands `__CMUX_ENV_*__` / `__CMUX_ENV_SH_*__` placeholders in base64 commands for the same forwarded env keys used in local shell scripts.
> 
> **Session restore**: non-SSH workspaces call `configureLocalPersistentPTYServerIfNeeded`; `isRemoteWorkspace` excludes `.local`; local workspaces stay restorable without persisting the local transport in remote snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 902099c86fdffeec8058e6196c4711e40d9f025a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run local terminals through a persistent local `cmuxd-remote` PTY daemon, enabling seamless terminal restore across app restarts. Adds a new `local` transport that boots the daemon over stdio and forwards key env vars.

- **New Features**
  - Added `local` transport in `WorkspaceRemoteTransport`; `RemoteDaemonRPCClient` can start the local daemon via `serve --stdio` with optional persistent slot.
  - `RemoteSessionCoordinator` bootstraps the local daemon, validates capabilities, and skips SSH cleanup for `.local`.
  - Local workspaces auto-configure a persistent PTY server; terminals attach to per-workspace slots and restore by workspace/surface IDs.
  - Forward selected env vars (e.g., `PATH`, `CMUX_*`) into PTY attach templates for consistent startup environments.
  - Session snapshots omit `.local` remote configs while keeping local workspaces/panels restorable; tests updated accordingly.

<sup>Written for commit 902099c86fdffeec8058e6196c4711e40d9f025a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

