### PR TITLE
iOS: collapse composer band after send (fix stale-tall measurement)

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -230,9 +230,29 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// The proposed width is the surface width and the proposed height is unbounded
         /// so a multi-line field measures its full desired height (capped to 14 lines by
         /// the field's own `lineLimit`).
+        ///
+        /// `requestHeightRemeasure` fires the instant the field's content changes — a
+        /// `.onChange(of:)` action, or the post-send clear — which is BEFORE SwiftUI has
+        /// committed that change into the hosted controller's view graph. Measuring a
+        /// `UIHostingController` synchronously at that point captures the PRE-change
+        /// (tall) ideal height, so after a send the band stays reserved tall and the
+        /// empty field renders as a tall box that never collapses. It is worst for an
+        /// image-only send: clearing the text fires no `.onChange(of: terminalInputText)`
+        /// (it was already empty), so the stale measurement is never corrected by a
+        /// follow-up. Flush the host's pending SwiftUI update into a concrete layout pass
+        /// BEFORE calling `sizeThatFits` — mirroring the `setNeedsLayout()`/
+        /// `layoutIfNeeded()` the GUI chat composer relies on to keep its hosted-field
+        /// measurement current — so the measurement reflects the new (e.g. collapsed
+        /// one-line) content. `sizeThatFits` re-proposes the surface width itself, so the
+        /// flush only needs to apply the pending content change, not fix the width.
         @MainActor
         private func reportComposerHeight(animated: Bool) {
             guard let controller = composerController, let surfaceView else { return }
+            // The hosting controller is mounted before any remeasure, so its view is
+            // loaded; annotate to force-unwrap the `UIView!` rather than infer `UIView?`.
+            let hostView: UIView = controller.view
+            hostView.setNeedsLayout()
+            hostView.layoutIfNeeded()
             let width = max(1, surfaceView.bounds.width)
             let target = CGSize(width: width, height: .greatestFiniteMagnitude)
             let fitting = controller.sizeThatFits(in: target)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -163,6 +163,18 @@ struct TerminalComposerView: View {
         .onChange(of: store.terminalInputText) { _, _ in
             requestHeightRemeasure()
         }
+        // The chip row's presence is the OTHER driver of this view's height, and
+        // unlike the text it had no content-change remeasure trigger: an image-only
+        // send clears the staged attachments without touching `terminalInputText`,
+        // so the text trigger above never fires and the band was left reserved tall
+        // around the now-empty field. Remeasure whenever the chip row appears or
+        // disappears (its height is constant for any non-zero count, so the
+        // empty/non-empty edge is the only height-relevant transition); this action
+        // runs after SwiftUI commits the change, so the host measures the collapsed
+        // (chip-less) layout rather than the stale tall one.
+        .onChange(of: pendingAttachments.isEmpty) { _, _ in
+            requestHeightRemeasure()
+        }
         .onAppear {
             recordComposerEvent(.composerViewAppear)
             // Focus only when an explicit request preceded this mount (an


### PR DESCRIPTION
Fixes #6644

## Problem

On the **iOS app**, after sending a message the composer field **stays enlarged** — a tall, empty rounded box with the "Message" placeholder pinned to the top and dead space below — instead of collapsing back to its compact one-line height. Most reliably reproduced after sending a message that had a staged image attachment. It does not shrink until the next interaction.

## Root cause

A **measure-before-commit race** in the composer band sizing. The composer is a SwiftUI view hosted in a `UIHostingController` inside `GhosttySurfaceRepresentable`, pinned edge-to-edge in the surface's composer band; its height is reserved by the host via `controller.sizeThatFits(in:)` in `reportComposerHeight`.

`requestHeightRemeasure()` fires the instant the field's content changes (an `.onChange(of:)` action, or the post-send clear in `send()`), and the coordinator then measures `sizeThatFits` **synchronously**. But that runs *before* SwiftUI has committed the cleared text / removed chip row into the hosting controller's view graph, so it captures the **pre-clear (tall)** ideal height and reserves a stale band that never collapses.

It is worst for an **image-only send**: clearing the staged attachments touches no `terminalInputText`, so the existing `.onChange(of: store.terminalInputText)` trigger never fires and *nothing* corrects the stale measurement. (By contrast, the GUI chat composer in `ChatKeyboardTrackingViewController` measures inside its layout pass — `viewWillLayoutSubviews`/`viewDidLayoutSubviews` — and re-measures every pass, so it stays synced to SwiftUI's commit cycle and self-corrects.)

## Fix (two complementary parts)

1. **`reportComposerHeight` flushes before measuring.** It now calls `setNeedsLayout()` + `layoutIfNeeded()` on the host view to flush the pending SwiftUI update into a concrete layout pass *before* `sizeThatFits`, so every remeasure reflects the current (e.g. collapsed one-line) content rather than the pre-change graph. This mirrors the flush the chat composer and `TerminalInputTextView` already rely on. `sizeThatFits` re-proposes the surface width itself, so the flush only needs to apply the pending content change.

2. **Symmetric remeasure trigger for the chip row.** Added `.onChange(of: pendingAttachments.isEmpty)` → `requestHeightRemeasure()`, mirroring the existing text trigger. The chip row's presence is the *other* driver of composer height and previously had no content-change trigger; this makes the chip row appearing/disappearing always remeasure after SwiftUI commits, closing the image-only-send gap structurally (its height is constant for any non-zero count, so the empty/non-empty edge is the only height-relevant transition).

## Testing

This is a UI layout/timing bug. There is no pure-logic seam to extract — the bug lives entirely in the `UIHostingController.sizeThatFits` timing against SwiftUI's commit cycle, which a unit test cannot deterministically reproduce without a live rendering environment. Per the issue's own note ("likely not cleanly unit-testable; a simulator repro + before/after screenshots is the realistic verification") and the repo's testing policy, no fabricated test is added. Realistic verification is a simulator repro: stage an image (or grow the field), send, and confirm the band collapses back to one line.

## Localization

No user-facing strings added or changed (code + comments only); no `Localizable.xcstrings` update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785051664&installation_id=133855650&pr_number=6811&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6811&signature=c9a4fec630bb21a77941d2e367d20f870995583e14f79cc259294b65423fea26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse the iOS composer back to one line after send by measuring after SwiftUI commits and remeasuring on chip row changes. Fixes #6644.

- **Bug Fixes**
  - In `GhosttySurfaceRepresentable.reportComposerHeight`, flush host layout (`setNeedsLayout` + `layoutIfNeeded`) before `sizeThatFits` to avoid stale tall measurements.
  - In `TerminalComposerView`, trigger `requestHeightRemeasure()` on `.onChange(of: pendingAttachments.isEmpty)` so image-only sends collapse correctly.

<sup>Written for commit 7d5690759ee58a63020152caa6f004377ecc0164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed composer height updates so the input area now resizes correctly after sending or clearing content.
  * Improved height recalculation when attachments are removed, helping the composer collapse to the expected size.
  * Reduced cases where the composer could պահ a taller layout than needed during image-only send flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->