### PR TITLE
Fix zsh shell integration printing `file exists` under noclobber (#6714)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,6 +644,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_omx_fallback_path.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_omc_fallback_path.py
           python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py
+          python3 tests/test_issue_6714_zsh_shim_noclobber.py
           python3 tests/test_shell_git_branch_stale_cwd.py
           python3 tests/test_shell_git_config_remote_url_parsing.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_claude_hook_stop_last_assistant.py

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -292,7 +292,12 @@ _cmux_install_cli_command_shim() {
         else
             printf 'exec "%s" "$@"\n' "$escaped_wrapper"
         fi
-    } >"$shim_path" 2>/dev/null || return 0
+    # Use zsh's explicit clobber redirection (>|) so cmux always refreshes its
+    # own generated shim, even when the user's interactive zsh has `noclobber`
+    # set. A plain `>` is refused under noclobber and prints `file exists` on
+    # startup (the writer runs again from the _cmux_fix_path precmd hook after
+    # the shim already exists). See issue #6714.
+    } >|"$shim_path" 2>/dev/null || return 0
     /bin/chmod 0700 "$shim_path" >/dev/null 2>&1 || return 0
 
     if [[ "$command_name" == "claude" ]]; then

--- a/tests/test_issue_6714_zsh_shim_noclobber.py
+++ b/tests/test_issue_6714_zsh_shim_noclobber.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Regression coverage for https://github.com/manaflow-ai/cmux/issues/6714.
+
+When a user enables ``setopt noclobber`` in their interactive zsh, cmux's shell
+integration prints a spurious error on startup:
+
+    _cmux_install_cli_command_shim:13: file exists: \
+        /var/folders/.../T//cmux-cli-shims/<surface-id>/claude
+
+Root cause: ``Resources/shell-integration/cmux-zsh-integration.zsh`` writes a
+per-surface CLI shim with a plain ``>`` redirection::
+
+    } >"$shim_path" 2>/dev/null || return 0
+
+``_cmux_install_cli_command_shim`` runs more than once per shell (once at source
+time via the top-level ``_cmux_install_cli_wrapper claude`` call, and again on
+the first prompt via the ``_cmux_fix_path`` precmd hook). The second write
+targets a shim that already exists, so under ``noclobber`` zsh refuses to
+overwrite the file and emits ``file exists``. The ``2>/dev/null`` does not
+suppress the message because the no-clobber failure is reported by the shell's
+redirection machinery on the compound-command redirect itself, and the
+``|| return 0`` then *skips* the write entirely -- so the shim is also left
+stale (not refreshed to the latest wrapper path).
+
+The fix is zsh's explicit clobber redirection (``>|``) for this cmux-owned
+generated file, which overwrites regardless of the user's global ``noclobber``
+setting -- the same operator the rest of this integration already uses for its
+own generated marker/cache files.
+
+This test drives the *actual* integration file through real zsh with
+``noclobber`` enabled and asserts that a second shim write is silent **and**
+actually refreshes the shim contents. It is deterministic (no PTY, no sleeps,
+no network) and locale-pinned so the assertions do not depend on zsh's message
+wording.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION = REPO_ROOT / "Resources/shell-integration/cmux-zsh-integration.zsh"
+
+# Drive the real shim writer twice under noclobber. The first call creates the
+# shim; the second must overwrite the existing file (cmux owns it) without
+# tripping noclobber. We embed two *different* wrapper paths so we can prove the
+# second write actually refreshed the file rather than silently no-op'ing.
+#
+# Sourcing the integration with no CMUX_SHELL_INTEGRATION_DIR makes the
+# top-level `_cmux_install_cli_wrapper claude` early-return (no shim written at
+# source time), so the only writes are our two explicit calls. The precmd hooks
+# the integration registers never fire under `zsh -c` (non-interactive, no
+# prompt), keeping the scenario focused on the shim writer.
+DRIVER = r"""
+setopt noclobber
+source "$CMUX_ZSH_INTEGRATION" 2>/dev/null
+export TMPDIR="$CMUX_TEST_TMPDIR"
+export CMUX_SURFACE_ID="$CMUX_TEST_SURFACE_ID"
+_cmux_install_cli_command_shim claude "$CMUX_TEST_WRAPPER_A"
+_cmux_install_cli_command_shim claude "$CMUX_TEST_WRAPPER_B"
+"""
+
+
+def _run_driver(tmp: Path) -> subprocess.CompletedProcess[str]:
+    # Two distinct wrapper paths so the shim content differs between writes.
+    wrapper_a = tmp / "wrapper-a"
+    wrapper_b = tmp / "wrapper-b"
+    wrapper_a.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    wrapper_b.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    wrapper_a.chmod(0o755)
+    wrapper_b.chmod(0o755)
+
+    # Clean env: drop ambient CMUX_* so nothing the integration reads leaks in,
+    # and explicitly disable the socket/ghostty paths so sourcing stays quiet.
+    env = {key: value for key, value in os.environ.items() if not key.startswith("CMUX")}
+    env.update(
+        {
+            "LC_ALL": "C",
+            "LANG": "C",
+            "CMUX_ZSH_INTEGRATION": str(INTEGRATION),
+            "CMUX_TEST_TMPDIR": str(tmp),
+            "CMUX_TEST_SURFACE_ID": "issue-6714-shim",
+            "CMUX_TEST_WRAPPER_A": str(wrapper_a),
+            "CMUX_TEST_WRAPPER_B": str(wrapper_b),
+            # Keep sourcing side-effect-free: no socket sends, no nested ghostty
+            # integration.
+            "CMUX_SOCKET_PATH": "",
+            "CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION": "0",
+            "GHOSTTY_RESOURCES_DIR": "",
+        }
+    )
+
+    return subprocess.run(
+        ["zsh", "-f", "-c", DRIVER],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_zsh_shim_refresh_is_silent_and_refreshes_under_noclobber() -> None:
+    assert INTEGRATION.exists(), f"missing integration file: {INTEGRATION}"
+
+    with tempfile.TemporaryDirectory(prefix="cmux-6714-") as td:
+        tmp = Path(td)
+        proc = _run_driver(tmp)
+        debug = (
+            f"\nexit={proc.returncode}"
+            f"\n--- driver stdout ---\n{proc.stdout}"
+            f"\n--- driver stderr ---\n{proc.stderr}"
+        )
+
+        # The reported symptom: zsh prints `file exists` from the shim writer
+        # when it refuses to clobber the existing shim.
+        assert "file exists" not in proc.stderr.lower(), (
+            "cmux printed a noclobber 'file exists' error while refreshing its own "
+            "generated shim" + debug
+        )
+        # Locale-independent guard: no error should be attributed to the shim
+        # writer at all (the noclobber failure carries this function name).
+        assert "_cmux_install_cli_command_shim" not in proc.stderr, (
+            "the shim writer reported an error to stderr while refreshing the shim"
+            + debug
+        )
+
+        shim_path = tmp / "cmux-cli-shims" / "issue-6714-shim" / "claude"
+        assert shim_path.exists(), f"shim was not created at {shim_path}" + debug
+        assert os.access(shim_path, os.X_OK), (
+            f"shim is not executable: {shim_path}" + debug
+        )
+
+        # The second write must have actually overwritten the shim: under the
+        # bug, noclobber makes the redirect fail and `|| return 0` skips the
+        # write, so the shim still embeds wrapper A. With the fix it embeds B.
+        contents = shim_path.read_text(encoding="utf-8")
+        wrapper_b = str(tmp / "wrapper-b")
+        wrapper_a = str(tmp / "wrapper-a")
+        assert f'cmux_wrapper="{wrapper_b}"' in contents, (
+            "cmux did not refresh its generated shim on the second write under "
+            f"noclobber (expected wrapper {wrapper_b!r}).\n--- shim ---\n{contents}"
+            + debug
+        )
+        assert f'cmux_wrapper="{wrapper_a}"' not in contents, (
+            "stale wrapper path from the first write survived the refresh.\n"
+            f"--- shim ---\n{contents}" + debug
+        )
+
+
+if __name__ == "__main__":
+    test_zsh_shim_refresh_is_silent_and_refreshes_under_noclobber()
+    print("PASS: cmux refreshes its zsh CLI shim silently under noclobber")


### PR DESCRIPTION
Fixes #6714

## Problem

With `setopt noclobber` enabled in their interactive zsh, users see this error printed on every new zsh tab's startup:

```text
_cmux_install_cli_command_shim:13: file exists: /var/folders/.../T//cmux-cli-shims/<surface-id>/claude
```

## Root cause

`Resources/shell-integration/cmux-zsh-integration.zsh` writes a per-surface CLI shim with a plain `>` redirection:

```zsh
} >"$shim_path" 2>/dev/null || return 0
```

The shim writer (`_cmux_install_cli_command_shim`) runs more than once per shell:

1. At source time, via the top-level `_cmux_install_cli_wrapper claude` call.
2. On the first prompt, via the `_cmux_fix_path` precmd hook (which re-installs the cmux-owned wrappers after user startup files run).

The second write targets a shim that already exists. Under the user's global `noclobber`, zsh refuses to overwrite it and emits `file exists` (the `2>/dev/null` does not suppress it — the failure is reported by the shell's redirection machinery on the compound-command redirect itself). The `|| return 0` then *skips* the write, so the shim is also left stale.

## Fix

Use zsh's explicit clobber redirection (`>|`) for this cmux-owned generated file:

```zsh
} >|"$shim_path" 2>/dev/null || return 0
```

This refreshes the shim regardless of the user's global `noclobber` setting, and is the **same operator this integration already uses everywhere else** for its own generated marker/cache files (e.g. the git active-pwd marker, PR-status cache, branch-watch signal files). The user's `noclobber` preference for their own files is untouched.

## Testing

Two-commit red/green structure:

1. **Commit 1** adds `tests/test_issue_6714_zsh_shim_noclobber.py` (failing test only) and wires it into the app-host focused-regression shard next to the other zsh-sourcing regression tests (`test_issue_2448`). The test drives the real integration file through zsh with `noclobber` enabled, writes the `claude` shim twice with distinct wrapper paths, and asserts the second write is **silent** *and* **actually refreshes** the shim contents. It is deterministic (no PTY/sleep/network) and locale-pinned.
2. **Commit 2** applies the one-line redirection fix, turning the test green.

Verified locally: test is red without the fix (reproducing the exact `file exists` symptom), green with it; the issue's double-source repro no longer prints anything. `zsh -n` parse check passes; `py_compile` and `check-test-determinism.py --strict` pass.

## Localization

No user-facing strings added or changed — this removes a spurious zsh-emitted error message and changes a shell redirection operator only. No `Localizable.xcstrings` / web message catalog changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785052500&installation_id=133855650&pr_number=6815&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6815&signature=7f9dda72a3fae793dbd1351c7537fc919d4b370e263d3711882a78d4333cbf54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the zsh “file exists” startup error under `setopt noclobber` by writing the cmux-owned CLI shim with `>|` so it always refreshes and stays silent. Adds a regression test and wires it into CI. Fixes #6714.

- **Bug Fixes**
  - Use `>|` when writing the per-surface CLI shim in `cmux-zsh-integration.zsh` to bypass user `noclobber` and refresh on reinstall.
  - Add `tests/test_issue_6714_zsh_shim_noclobber.py` and run it in CI to verify the second write is silent and updates the shim.

<sup>Written for commit d3621ef50e9bc44e095739bedcbbab84e703848c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI shim generation so it now overwrites existing files reliably, even when shell overwrite protection is enabled.
  * Fixed a shell integration issue where refreshed command shims could fail to update correctly.
  * Added a new regression test to cover this scenario on macOS and prevent future breakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->