### PR TITLE
Gate DEV/staging builds off the public Sparkle update train

### DIFF
--- a/Packages/macOS/CmuxUpdater/Package.swift
+++ b/Packages/macOS/CmuxUpdater/Package.swift
@@ -30,7 +30,10 @@ let package = Package(
         ),
         .testTarget(
             name: "CmuxUpdaterTests",
-            dependencies: ["CmuxUpdater"],
+            dependencies: [
+                "CmuxUpdater",
+                .product(name: "Sparkle", package: "Sparkle"),
+            ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
                 .enableUpcomingFeature("ExistentialAny"),

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -70,28 +70,33 @@ public final class UpdateController {
     ///   - defaults: The `UserDefaults` the settings are applied to.
     ///   - fileManager: Filesystem access for the Sparkle installation-cache workaround;
     ///     injectable so tests can avoid touching the real filesystem.
+    ///   - isDevLikeBundle: Overrides whether this is a DEV/staging build. Defaults to `nil`,
+    ///     which derives it from `hostBundle.bundleIdentifier` via ``isDevLikeBundleIdentifier(_:)``.
+    ///     Injectable because a `Bundle` with an arbitrary identifier cannot be constructed in tests.
     public init(log: any UpdateLogging,
                 clock: any UpdateClock = SystemUpdateClock(),
                 settings: UpdateSettings = UpdateSettings(),
                 hostBundle: Bundle = .main,
                 defaults: UserDefaults = .standard,
-                fileManager: FileManager = .default) {
+                fileManager: FileManager = .default,
+                isDevLikeBundle: Bool? = nil) {
         self.log = log
         self.clock = clock
         self.defaults = defaults
         self.fileManager = fileManager
         self.hostBundle = hostBundle
         self.backgroundProbeInterval = settings.scheduledCheckInterval
-        let isDevLikeBundle = Self.isDevLikeBundleIdentifier(hostBundle.bundleIdentifier)
+        let isDevLikeBundle = isDevLikeBundle ?? Self.isDevLikeBundleIdentifier(hostBundle.bundleIdentifier)
         self.isDevLikeBundle = isDevLikeBundle
         settings.apply(to: defaults)
         if isDevLikeBundle {
             // DEV (`com.cmuxterm.app.debug[.<tag>]`) and staging (`com.cmuxterm.app.staging[.<tag>]`)
             // builds are produced from local source and are not on the public release train, so
             // they must never query the public appcast. Turning off Sparkle's automatic checks
-            // stops both vectors: Sparkle never schedules its own background checks, and cmux's
-            // launch/background probe is short-circuited by the `automaticallyChecksForUpdates`
-            // guard in `startLaunchUpdateProbeIfNeeded`. Manual "Check for Updates" still works.
+            // stops the passive vectors: Sparkle never schedules its own background checks, and
+            // cmux's launch/background probe is short-circuited by the `automaticallyChecksForUpdates`
+            // guard in `startLaunchUpdateProbeIfNeeded`. Manual "Check for Updates" is gated
+            // separately in `checkForUpdatesWhenReady`.
             defaults.set(false, forKey: UpdateSettings.automaticChecksKey)
         }
 
@@ -260,6 +265,17 @@ public final class UpdateController {
 
     /// Check for updates once the updater reports it can.
     private func checkForUpdatesWhenReady() {
+        if isDevLikeBundle {
+            // DEV/staging builds are not on the public release train. A manual check (menu,
+            // custom UI, or attempt-and-install) must not query the public appcast or offer the
+            // public release for install over a locally-built app. Surface "No Updates Available"
+            // without contacting the appcast or starting Sparkle. This is the shared entrypoint
+            // for every manual check path (#6292).
+            log.append("manual update check suppressed (dev/staging build)")
+            cancelReadinessRetry()
+            model.setState(.notFound(.init(acknowledgement: {})))
+            return
+        }
         cancelReadinessRetry()
         startUpdaterIfNeeded()
         ensureSparkleInstallationCache()

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -25,6 +25,9 @@ public final class UpdateController {
     private let fileManager: FileManager
     private let hostBundle: Bundle
     private let backgroundProbeInterval: TimeInterval
+    /// Whether the running build is a cmux DEV/staging build that must never be compared against
+    /// the public release appcast. See ``isDevLikeBundleIdentifier(_:)``.
+    private let isDevLikeBundle: Bool
 
     /// Host actions the updater delegates upward (retry, relaunch prep). Forwarded to the driver.
     public weak var actionDelegate: (any UpdateActionDelegate)? {
@@ -79,10 +82,21 @@ public final class UpdateController {
         self.fileManager = fileManager
         self.hostBundle = hostBundle
         self.backgroundProbeInterval = settings.scheduledCheckInterval
+        let isDevLikeBundle = Self.isDevLikeBundleIdentifier(hostBundle.bundleIdentifier)
+        self.isDevLikeBundle = isDevLikeBundle
         settings.apply(to: defaults)
+        if isDevLikeBundle {
+            // DEV (`com.cmuxterm.app.debug[.<tag>]`) and staging (`com.cmuxterm.app.staging[.<tag>]`)
+            // builds are produced from local source and are not on the public release train, so
+            // they must never query the public appcast. Turning off Sparkle's automatic checks
+            // stops both vectors: Sparkle never schedules its own background checks, and cmux's
+            // launch/background probe is short-circuited by the `automaticallyChecksForUpdates`
+            // guard in `startLaunchUpdateProbeIfNeeded`. Manual "Check for Updates" still works.
+            defaults.set(false, forKey: UpdateSettings.automaticChecksKey)
+        }
 
         let model = UpdateStateModel()
-        let driver = UpdateDriver(model: model, log: log, clock: clock)
+        let driver = UpdateDriver(model: model, log: log, clock: clock, isDevLikeBundle: isDevLikeBundle)
         self.driver = driver
         self.updater = SPUUpdater(
             hostBundle: hostBundle,
@@ -338,6 +352,15 @@ public final class UpdateController {
     }
 
     private func startLaunchUpdateProbeIfNeeded() {
+        if isDevLikeBundle {
+            // DEV/staging builds are not on the public release train; never probe the public
+            // appcast (init also disables Sparkle's own scheduled checks). Tear down any probe a
+            // prior path may have started. See `isDevLikeBundleIdentifier(_:)` (#6292).
+            log.append("launch update probe skipped (dev/staging build)")
+            backgroundProbeTask?.cancel()
+            backgroundProbeTask = nil
+            return
+        }
         guard updater.automaticallyChecksForUpdates else {
             log.append("launch update probe skipped (automatic checks disabled)")
             return
@@ -415,5 +438,25 @@ public final class UpdateController {
         } catch {
             log.append("Failed creating Sparkle installation cache: \(error)")
         }
+    }
+}
+
+extension UpdateController {
+    /// Whether `bundleIdentifier` is a cmux DEV (`com.cmuxterm.app.debug[.<tag>]`) or staging
+    /// (`com.cmuxterm.app.staging[.<tag>]`) build.
+    ///
+    /// Such builds are produced from local source and are not on the public release train, so
+    /// they must never be compared against the public Sparkle appcast (#6292).
+    ///
+    /// Mirrors `SocketControlSettings.isDebugLikeBundleIdentifier` +
+    /// `isStagingBundleIdentifier` (in the CmuxSettings package). The classification is
+    /// duplicated here deliberately to avoid introducing a `CmuxUpdater → CmuxSettings` package
+    /// dependency edge for a small string check.
+    static func isDevLikeBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return bundleIdentifier == "com.cmuxterm.app.debug"
+            || bundleIdentifier.hasPrefix("com.cmuxterm.app.debug.")
+            || bundleIdentifier == "com.cmuxterm.app.staging"
+            || bundleIdentifier.hasPrefix("com.cmuxterm.app.staging.")
     }
 }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -344,6 +344,13 @@ public final class UpdateController {
             log.append("reset sparkle permission defaults (ui test)")
         }
 #endif
+        if isDevLikeBundle {
+            // Re-assert the dev/staging auto-check override immediately before Sparkle starts.
+            // The init-time override can be cleared between construction and start — notably the
+            // DEBUG reset path above removes this key — and Sparkle reads it at `start()` to decide
+            // whether to schedule its own background checks against the public appcast (#6292).
+            defaults.set(false, forKey: UpdateSettings.automaticChecksKey)
+        }
         do {
             try updater.start()
             didStartUpdater = true

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
@@ -70,9 +70,9 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
     func handleDidFindValidUpdate(_ item: SUAppcastItem) {
         if isDevLikeBundle {
             // DEV/staging builds are not on the public release train. ``UpdateController`` already
-            // disables Sparkle's automatic checks and the launch probe for these builds, but a
-            // manual "Check for Updates" — or a probe that started before that gate landed — can
-            // still reach here. Clear any detected update rather than surfacing the pill (#6292).
+            // gates every known path (automatic checks, the launch/background probe, and manual
+            // checks), so this is the last-line defense: if any update is ever found for one of
+            // these builds, clear it rather than surfacing the pill (#6292).
             model.clearDetectedUpdate()
             log.append("ignoring update for dev/staging build: \(item.displayVersionString)")
             return

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
@@ -58,6 +58,15 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
     }
 
     func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        handleDidFindValidUpdate(item)
+    }
+
+    /// Records a background-detected available update.
+    ///
+    /// Extracted from the ``SPUUpdaterDelegate`` callback (which carries an `SPUUpdater` that is
+    /// awkward to construct) so the dev/staging gate is unit-testable directly from an
+    /// ``UpdateStateModel`` and an `SUAppcastItem`.
+    func handleDidFindValidUpdate(_ item: SUAppcastItem) {
         model.recordDetectedUpdate(item)
         let version = item.displayVersionString
         let fileURL = item.fileURL?.absoluteString ?? ""

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
@@ -61,12 +61,22 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
         handleDidFindValidUpdate(item)
     }
 
-    /// Records a background-detected available update.
+    /// Records a background-detected available update — unless this is a DEV/staging build, in
+    /// which case any detected update is cleared so the public appcast's pill never appears.
     ///
     /// Extracted from the ``SPUUpdaterDelegate`` callback (which carries an `SPUUpdater` that is
     /// awkward to construct) so the dev/staging gate is unit-testable directly from an
     /// ``UpdateStateModel`` and an `SUAppcastItem`.
     func handleDidFindValidUpdate(_ item: SUAppcastItem) {
+        if isDevLikeBundle {
+            // DEV/staging builds are not on the public release train. ``UpdateController`` already
+            // disables Sparkle's automatic checks and the launch probe for these builds, but a
+            // manual "Check for Updates" — or a probe that started before that gate landed — can
+            // still reach here. Clear any detected update rather than surfacing the pill (#6292).
+            model.clearDetectedUpdate()
+            log.append("ignoring update for dev/staging build: \(item.displayVersionString)")
+            return
+        }
         model.recordDetectedUpdate(item)
         let version = item.displayVersionString
         let fileURL = item.fileURL?.absoluteString ?? ""

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -14,6 +14,10 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     let model: UpdateStateModel
     let log: any UpdateLogging
     private let clock: any UpdateClock
+    /// Whether the running build is a cmux DEV/staging build that is not on the public release
+    /// train. When `true`, the driver must never surface the public appcast's update pill (see
+    /// ``UpdateController/isDevLikeBundleIdentifier(_:)``).
+    let isDevLikeBundle: Bool
     /// Host actions the driver delegates upward. Held weak; set by ``UpdateController``.
     weak var actionDelegate: (any UpdateActionDelegate)?
 
@@ -24,10 +28,11 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     private var checkTimeoutTask: Task<Void, Never>?
     private(set) var lastFeedURLString: String?
 
-    init(model: UpdateStateModel, log: any UpdateLogging, clock: any UpdateClock) {
+    init(model: UpdateStateModel, log: any UpdateLogging, clock: any UpdateClock, isDevLikeBundle: Bool = false) {
         self.model = model
         self.log = log
         self.clock = clock
+        self.isDevLikeBundle = isDevLikeBundle
         super.init()
     }
 

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
@@ -81,6 +81,40 @@ import Testing
             return
         }
     }
+
+    /// A DEV/staging build disables Sparkle's automatic checks so its scheduler never queries the
+    /// public appcast. (The override is also re-asserted before `start()`, so the DEBUG
+    /// permission-reset path cannot undo it.)
+    @Test func devLikeBundleDisablesAutomaticChecks() throws {
+        let suiteName = "com.cmuxterm.updatertests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        _ = UpdateController(
+            log: NoopUpdateLog(),
+            clock: ImmediateUpdateClock(),
+            hostBundle: .main,
+            defaults: defaults,
+            isDevLikeBundle: true
+        )
+        #expect(defaults.bool(forKey: UpdateSettings.automaticChecksKey) == false)
+    }
+
+    /// The public release train keeps automatic checks enabled.
+    @Test func publicBundleLeavesAutomaticChecksEnabled() throws {
+        let suiteName = "com.cmuxterm.updatertests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        _ = UpdateController(
+            log: NoopUpdateLog(),
+            clock: ImmediateUpdateClock(),
+            hostBundle: .main,
+            defaults: defaults,
+            isDevLikeBundle: false
+        )
+        #expect(defaults.bool(forKey: UpdateSettings.automaticChecksKey) == true)
+    }
 }
 
 private struct NoopUpdateLog: UpdateLogging {

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
@@ -15,7 +15,7 @@ import Testing
         let driver = UpdateDriver(
             model: model,
             log: NoopUpdateLog(),
-            clock: ImmediateUpdateClock(),
+            clock: SystemUpdateClock(),
             isDevLikeBundle: true
         )
 
@@ -32,7 +32,7 @@ import Testing
         let driver = UpdateDriver(
             model: model,
             log: NoopUpdateLog(),
-            clock: ImmediateUpdateClock(),
+            clock: SystemUpdateClock(),
             isDevLikeBundle: false
         )
 
@@ -68,7 +68,7 @@ import Testing
 
         let controller = UpdateController(
             log: NoopUpdateLog(),
-            clock: ImmediateUpdateClock(),
+            clock: SystemUpdateClock(),
             hostBundle: .main,
             defaults: defaults,
             isDevLikeBundle: true
@@ -92,7 +92,7 @@ import Testing
 
         _ = UpdateController(
             log: NoopUpdateLog(),
-            clock: ImmediateUpdateClock(),
+            clock: SystemUpdateClock(),
             hostBundle: .main,
             defaults: defaults,
             isDevLikeBundle: true
@@ -108,35 +108,27 @@ import Testing
 
         _ = UpdateController(
             log: NoopUpdateLog(),
-            clock: ImmediateUpdateClock(),
+            clock: SystemUpdateClock(),
             hostBundle: .main,
             defaults: defaults,
             isDevLikeBundle: false
         )
         #expect(defaults.bool(forKey: UpdateSettings.automaticChecksKey) == true)
     }
-}
 
-private struct NoopUpdateLog: UpdateLogging {
-    func append(_ message: String) {}
-    func logPath() -> String { "/dev/null" }
-}
-
-private struct ImmediateUpdateClock: UpdateClock {
-    func sleep(for duration: Duration) async throws {}
-}
-
-private func makeAppcastItem(version: String) -> SUAppcastItem? {
-    let enclosure: [String: Any] = [
-        "url": "https://example.com/cmux.zip",
-        "length": "1024",
-        "sparkle:version": version,
-        "sparkle:shortVersionString": version,
-    ]
-    let dictionary: [String: Any] = [
-        "title": "cmux \(version)",
-        "pubDate": "Wed, 25 Mar 2026 12:00:00 +0000",
-        "enclosure": enclosure,
-    ]
-    return SUAppcastItem(dictionary: dictionary)
+    /// Builds a minimal valid `SUAppcastItem` for a version string (nested helper, not API).
+    private func makeAppcastItem(version: String) -> SUAppcastItem? {
+        let enclosure: [String: Any] = [
+            "url": "https://example.com/cmux.zip",
+            "length": "1024",
+            "sparkle:version": version,
+            "sparkle:shortVersionString": version,
+        ]
+        let dictionary: [String: Any] = [
+            "title": "cmux \(version)",
+            "pubDate": "Wed, 25 Mar 2026 12:00:00 +0000",
+            "enclosure": enclosure,
+        ]
+        return SUAppcastItem(dictionary: dictionary)
+    }
 }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
@@ -42,6 +42,21 @@ import Testing
         #expect(model.detectedUpdateVersion == "0.64.99")
         #expect(model.showsPill)
     }
+
+    @Test func classifiesDebugAndStagingBundlesAsDevLike() {
+        #expect(UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.debug"))
+        #expect(UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.debug.my-tag"))
+        #expect(UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.staging"))
+        #expect(UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.staging.my-tag"))
+    }
+
+    @Test func doesNotClassifyPublicOrNightlyOrNilAsDevLike() {
+        #expect(!UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app"))
+        #expect(!UpdateController.isDevLikeBundleIdentifier(nil))
+        // A look-alike that is neither the exact base id nor a dotted suffix must not match.
+        #expect(!UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.debugger"))
+        #expect(!UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.stagingx"))
+    }
 }
 
 private struct NoopUpdateLog: UpdateLogging {

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Sparkle
+import Testing
+@testable import CmuxUpdater
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/6292: tagged DEV and
+/// staging builds are produced from local source and are not on the public release train, so
+/// they must never surface Sparkle's "Update Available" pill from the public appcast.
+@MainActor
+@Suite struct DevStagingUpdateGatingTests {
+    /// The bug: `didFindValidUpdate` recorded the update for every bundle id, surfacing the pill
+    /// on DEV/staging builds. A DEV/staging-gated driver must clear the detected update instead.
+    @Test func devLikeBundleClearsDetectedUpdateInsteadOfRecording() throws {
+        let model = UpdateStateModel()
+        let driver = UpdateDriver(
+            model: model,
+            log: NoopUpdateLog(),
+            clock: ImmediateUpdateClock(),
+            isDevLikeBundle: true
+        )
+
+        let item = try #require(makeAppcastItem(version: "0.64.99"))
+        driver.handleDidFindValidUpdate(item)
+
+        #expect(model.detectedUpdateVersion == nil)
+        #expect(!model.showsPill)
+    }
+
+    /// The public release train still records the detected update so the passive pill works.
+    @Test func publicBundleRecordsDetectedUpdate() throws {
+        let model = UpdateStateModel()
+        let driver = UpdateDriver(
+            model: model,
+            log: NoopUpdateLog(),
+            clock: ImmediateUpdateClock(),
+            isDevLikeBundle: false
+        )
+
+        let item = try #require(makeAppcastItem(version: "0.64.99"))
+        driver.handleDidFindValidUpdate(item)
+
+        #expect(model.detectedUpdateVersion == "0.64.99")
+        #expect(model.showsPill)
+    }
+}
+
+private struct NoopUpdateLog: UpdateLogging {
+    func append(_ message: String) {}
+    func logPath() -> String { "/dev/null" }
+}
+
+private struct ImmediateUpdateClock: UpdateClock {
+    func sleep(for duration: Duration) async throws {}
+}
+
+private func makeAppcastItem(version: String) -> SUAppcastItem? {
+    let enclosure: [String: Any] = [
+        "url": "https://example.com/cmux.zip",
+        "length": "1024",
+        "sparkle:version": version,
+        "sparkle:shortVersionString": version,
+    ]
+    let dictionary: [String: Any] = [
+        "title": "cmux \(version)",
+        "pubDate": "Wed, 25 Mar 2026 12:00:00 +0000",
+        "enclosure": enclosure,
+    ]
+    return SUAppcastItem(dictionary: dictionary)
+}

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
@@ -57,6 +57,30 @@ import Testing
         #expect(!UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.debugger"))
         #expect(!UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.stagingx"))
     }
+
+    /// A manual "Check for Updates" on a DEV/staging build must not query the public appcast or
+    /// offer the public release for install — it short-circuits to "No Updates Available" before
+    /// starting Sparkle. (Manual checks are the path that survived the passive-pill gating.)
+    @Test func devLikeBundleManualCheckIsSuppressed() throws {
+        let suiteName = "com.cmuxterm.updatertests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let controller = UpdateController(
+            log: NoopUpdateLog(),
+            clock: ImmediateUpdateClock(),
+            hostBundle: .main,
+            defaults: defaults,
+            isDevLikeBundle: true
+        )
+        controller.checkForUpdates()
+
+        // No query / no checking state — the manual check resolves to notFound synchronously.
+        guard case .notFound = controller.model.state else {
+            Issue.record("dev/staging manual check should surface .notFound, got \(controller.model.state)")
+            return
+        }
+    }
 }
 
 private struct NoopUpdateLog: UpdateLogging {

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/NoopUpdateLog.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/NoopUpdateLog.swift
@@ -1,0 +1,8 @@
+import Foundation
+@testable import CmuxUpdater
+
+/// A no-op ``UpdateLogging`` for tests that exercise the updater without asserting on log output.
+struct NoopUpdateLog: UpdateLogging {
+    func append(_ message: String) {}
+    func logPath() -> String { "/dev/null" }
+}


### PR DESCRIPTION
Fixes #6292

## Problem

Tagged DEV builds (`com.cmuxterm.app.debug[.<tag>]`) and staging builds (`com.cmuxterm.app.staging[.<tag>]`) share the public Sparkle appcast URL. After every release, every developer's locally-built tagged DEV build surfaces a passive "Update Available — behind 0.64.x" pill in the sidebar, even though the build came from local source and is not on the public release train. Worse, a manual "Check for Updates" could offer the public release for install over the locally-built app.

Vectors that reach the public appcast on these builds:

1. **cmux's launch + hourly background probe** (`startLaunchUpdateProbeIfNeeded` → `checkForUpdateInformation` → `updater(_:didFindValidUpdate:)` → `recordDetectedUpdate`).
2. **Sparkle's own scheduled checks** — `UpdateSettings` enables `SUEnableAutomaticChecks` (hourly), so `updater.start()` schedules background checks that call `showUpdateFound` → `.updateAvailable` independently of cmux's probe.
3. **Manual "Check for Updates"** (menu / custom UI / attempt-and-install) → `checkForUpdatesWhenReady` → `performCheckForUpdates` → the public appcast.

## Fix

Gate DEV/staging builds off the public update train. The classification mirrors `SocketControlSettings.isDebugLikeBundleIdentifier` + `isStagingBundleIdentifier`, duplicated locally as `UpdateController.isDevLikeBundleIdentifier` to avoid a new `CmuxUpdater → CmuxSettings` package edge (as suggested in the issue).

- **`UpdateController.init`**: for dev/staging bundles, disable Sparkle's automatic checks (`SUEnableAutomaticChecks = false`) after applying settings. This stops the passive vectors (1 and 2): Sparkle never schedules its own checks, and cmux's probe is short-circuited by the existing `automaticallyChecksForUpdates` guard.
- **`startLaunchUpdateProbeIfNeeded`**: explicit dev/staging short-circuit that also tears down the background probe task (defense-in-depth + clear logging).
- **`checkForUpdatesWhenReady`** (shared manual-check entrypoint): for dev/staging bundles, surface "No Updates Available" without starting Sparkle or contacting the appcast. This covers vector 3 — `checkForUpdates()`, `checkForUpdatesInCustomUI()`, and `attemptUpdate()` — so a manual check never offers the public release for install. `installUpdate()` is already a no-op when nothing is surfaced.
- **`updater(_:didFindValidUpdate:)`**: last-line defense — for dev/staging builds, clear any detected update instead of recording it.

Nightly and the public release (`com.cmuxterm.app`) are unaffected.

## Tests

`DevStagingUpdateGatingTests` (two-commit red/green for the core gate):

- `devLikeBundleClearsDetectedUpdateInsteadOfRecording` — a dev/staging-gated driver clears the detected update rather than surfacing the pill. Fails on commit 1 (no gate), passes on commit 2.
- `publicBundleRecordsDetectedUpdate` — the public train still records the detected update.
- `devLikeBundleManualCheckIsSuppressed` — a manual check on a dev/staging build resolves to `.notFound` without entering a checking/update-available state (no appcast query).
- `isDevLikeBundleIdentifier` classification across debug/staging/tagged/public/nil.

UI tests are unaffected: they drive `UpdateStateModel` directly via `UpdateTestSupport` and never go through the real Sparkle delegate or Sparkle's scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)