### PR TITLE
Browser: don't let unfocused omnibar submit on physical Enter (#6250)

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4776,6 +4776,19 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
                 )
             }
 #endif
+            // #6250: AppKit invokes `performKeyEquivalent` across the entire
+            // window view hierarchy, so this coordinator runs even while web
+            // content (the WKWebView) — not the omnibar — owns first responder.
+            // In that state the omnibar field has no field editor, so `editor`
+            // is nil. Treating Return/Escape/arrows (and Ctrl+N/P, Shift+Delete)
+            // as omnibar input there makes an *unfocused* omnibar submit and
+            // hard-navigate the pane on a physical Enter that belongs to the
+            // page — a spurious reload that aborts in-flight `fetch`/XHR in SPAs.
+            // Only act on these keys while the field is actually being edited.
+            // This mirrors the `currentEditor()`-gated `insertNewline:` path in
+            // `control(_:textView:doCommandBy:)`, which only runs for the live
+            // field editor.
+            guard editor != nil else { return false }
             guard editor?.hasMarkedText() != true else { return false }
             let keyCode = event.keyCode
             let modifiers = event.modifierFlags.intersection([.command, .control, .shift, .option, .function])

--- a/cmuxTests/OmnibarSubmitDecisionTests.swift
+++ b/cmuxTests/OmnibarSubmitDecisionTests.swift
@@ -296,3 +296,137 @@ import Testing
         #expect(decision == .navigate(text: "claude.c"))
     }
 }
+
+// Regression coverage for https://github.com/manaflow-ai/cmux/issues/6250:
+// a physical Return delivered to focused web content (the WKWebView) must not
+// reach the omnibar coordinator as a submit. AppKit dispatches
+// `performKeyEquivalent` across the whole window view hierarchy, so the omnibar
+// field's coordinator runs `handleKeyEvent` even while the omnibar is unfocused
+// and has no field editor. Without a focus guard the unguarded Return case calls
+// `onSubmit`, which hard-navigates the pane to the URL the omnibar shows — a
+// spurious reload that aborts in-flight `fetch`/XHR in SPAs and presents as data
+// loss. The coordinator must only treat Return/Escape/arrows as its own while
+// the field is actually being edited (`currentEditor() != nil`).
+@MainActor
+@Suite struct BrowserOmnibarUnfocusedKeyGuardTests {
+    private final class OmnibarActionRecorder {
+        var submitCount = 0
+        var escapeCount = 0
+        var moveSelectionCount = 0
+    }
+
+    private func makeCoordinator(
+        _ recorder: OmnibarActionRecorder
+    ) -> OmnibarTextFieldRepresentable.Coordinator {
+        let representable = OmnibarTextFieldRepresentable(
+            panelId: UUID(),
+            fontSize: 13,
+            text: .constant("https://example.com/app/projects/abc/prompts/19ccd6ff"),
+            isFocused: .constant(false),
+            selectAllRequestId: 0,
+            inlineCompletion: nil,
+            placeholder: "",
+            onTap: {},
+            onSubmit: { _ in recorder.submitCount += 1 },
+            onEscape: { recorder.escapeCount += 1 },
+            onFieldLostFocus: {},
+            onMoveSelection: { _ in recorder.moveSelectionCount += 1 },
+            onDeleteSelectedSuggestion: {},
+            onAcceptInlineCompletion: {},
+            onDeleteBackwardWithInlineSelection: {},
+            onClearTypedPrefixWithInlineSelection: {},
+            onDeleteWordBackwardWithInlineSelection: {},
+            onSelectionChanged: { _, _ in },
+            shouldSuppressWebViewFocus: { false }
+        )
+        return representable.makeCoordinator()
+    }
+
+    private func keyEvent(keyCode: UInt16, characters: String) throws -> NSEvent {
+        try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: 0,
+                context: nil,
+                characters: characters,
+                charactersIgnoringModifiers: characters,
+                isARepeat: false,
+                keyCode: keyCode
+            )
+        )
+    }
+
+    @Test func returnWithoutFieldEditorDoesNotSubmit() throws {
+        // editor == nil models web content (the WKWebView) owning first
+        // responder: the omnibar field has no field editor. A physical Return
+        // re-dispatched to the host must not be consumed or submitted here.
+        let recorder = OmnibarActionRecorder()
+        let coordinator = makeCoordinator(recorder)
+
+        let handled = coordinator.handleKeyEvent(
+            try keyEvent(keyCode: 36, characters: "\r"),
+            editor: nil
+        )
+
+        #expect(handled == false, "An unfocused omnibar must not consume a Return that belongs to web content.")
+        #expect(recorder.submitCount == 0, "An unfocused omnibar must never submit/navigate the pane (#6250).")
+    }
+
+    @Test func keypadEnterWithoutFieldEditorDoesNotSubmit() throws {
+        let recorder = OmnibarActionRecorder()
+        let coordinator = makeCoordinator(recorder)
+
+        let handled = coordinator.handleKeyEvent(
+            try keyEvent(keyCode: 76, characters: "\u{3}"),
+            editor: nil
+        )
+
+        #expect(handled == false)
+        #expect(recorder.submitCount == 0)
+    }
+
+    @Test func escapeAndArrowsWithoutFieldEditorAreIgnored() throws {
+        // The same unguarded switch also exposed Escape and Up/Down arrows to
+        // omnibar behavior while web content is focused. All must pass through.
+        let recorder = OmnibarActionRecorder()
+        let coordinator = makeCoordinator(recorder)
+
+        let escapeHandled = coordinator.handleKeyEvent(
+            try keyEvent(keyCode: 53, characters: "\u{1b}"),
+            editor: nil
+        )
+        let downHandled = coordinator.handleKeyEvent(
+            try keyEvent(keyCode: 125, characters: "\u{F701}"),
+            editor: nil
+        )
+        let upHandled = coordinator.handleKeyEvent(
+            try keyEvent(keyCode: 126, characters: "\u{F700}"),
+            editor: nil
+        )
+
+        #expect(escapeHandled == false)
+        #expect(downHandled == false)
+        #expect(upHandled == false)
+        #expect(recorder.escapeCount == 0)
+        #expect(recorder.moveSelectionCount == 0)
+    }
+
+    @Test func returnWhileFieldIsBeingEditedStillSubmits() throws {
+        // A non-nil field editor models a focused, actively-edited omnibar. The
+        // legitimate focused-submit path must be preserved.
+        let recorder = OmnibarActionRecorder()
+        let coordinator = makeCoordinator(recorder)
+        let fieldEditor = NSTextView()
+
+        let handled = coordinator.handleKeyEvent(
+            try keyEvent(keyCode: 36, characters: "\r"),
+            editor: fieldEditor
+        )
+
+        #expect(handled == true, "A focused, actively-edited omnibar must still submit on Return.")
+        #expect(recorder.submitCount == 1)
+    }
+}


### PR DESCRIPTION
Fixes #6250

## Problem

Pressing a physical Return/Enter while a cmux browser pane's **web content** (the `WKWebView`) has focus performs a full page navigation to the URL the omnibar currently shows. The page never asked to navigate — the **unfocused** omnibar submits itself.

- Ordinary pages: a spurious reload.
- SPAs: worse. The omnibar buffer tracks `history.pushState`/`replaceState`, so the hard navigation lands on the app's current virtual URL and **aborts any in-flight `fetch`/XHR**, rebooting the app. This presents as data loss ("creating an item just reloads the page and the item vanishes").

Only a **physical** keypress reproduces it (synthetic keys never enter the AppKit event pipeline), and only when the page does **not** `preventDefault()` the Enter (the common case).

## Root cause

1. `OmnibarNativeTextField.performKeyEquivalent` forwards every key event to the coordinator regardless of whether the field is focused. AppKit dispatches `performKeyEquivalent` across the whole window view hierarchy, so it runs even when the `WKWebView` is first responder.
2. `Coordinator.handleKeyEvent`'s Return case (`case 36, 76`) called `onSubmit` with **no focus guard** — unlike the legitimate `control(_:textView:doCommandBy:)` `insertNewline:` path, which only runs while the field editor is active.
3. `CmuxWebView.performKeyEquivalent` deliberately opts Return out so WebKit gets the normal keyDown path (the #426 fix). When the web process reports the Enter as unhandled, WebKit re-dispatches it to the host, where it re-enters the key-equivalent machinery, reaches the omnibar via (1), and submits via (2).

## Fix

Add a focus guard at the top of `Coordinator.handleKeyEvent` so the omnibar only treats Return/Escape/arrows (and Ctrl+N/P, Shift+Delete) as its own when the field is actually being edited (`editor != nil`, i.e. `currentEditor() != nil`). When web content owns first responder the omnibar field has no field editor, so the event falls through to `super.performKeyEquivalent` and stays in the page.

This mirrors the already focus-gated `doCommandBy` `insertNewline:` path and leaves the legitimate focused-submit path untouched. It also closes the same unguarded exposure of Escape and Up/Down arrows while web content is focused.

## Tests

Two-commit red/green structure:
- **Commit 1** (test only): `BrowserOmnibarUnfocusedKeyGuardTests` calls `Coordinator.handleKeyEvent` with a `nil` field editor (models web content focused) and asserts Return/keypad-Enter/Escape/arrows are not consumed and never call `onSubmit`/`onEscape`/`onMoveSelection`. Red without the fix.
- **Commit 2** (fix): adds the guard. Green. A companion test (`returnWhileFieldIsBeingEditedStillSubmits`) passes a non-nil field editor and asserts the focused omnibar still submits on Return, proving the legitimate path is preserved.

Added to the already-wired `cmuxTests/OmnibarSubmitDecisionTests.swift` (`lint-pbxproj-test-wiring.sh` passes).

## Localization

No user-facing strings, menus, or shortcut metadata changed — code-path-only fix plus tests. No localization updates required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785052682&installation_id=133855650&pr_number=6818&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6818&signature=a3ab9d2553cf581a2966f48b4da42beaea9becc2e68bcce4252b616091681152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent unfocused omnibar submits when pressing physical Enter in the browser pane. Fixes #6250 by stopping spurious reloads and SPA aborts.

- **Bug Fixes**
  - Added a focus check in `Coordinator.handleKeyEvent` so Return/Escape/arrows (and Ctrl+N/P, Shift+Delete) only act when the omnibar is being edited.
  - Physical Enter from web content (`WKWebView`) now stays in the page; no hard navigation via the omnibar.
  - Added regression tests to cover unfocused behavior and confirm focused Return still submits.

<sup>Written for commit 49cca394b2b698d64f81d7012b3d3b3db2fb4eaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed omnibar key handling so Return, Escape, and arrow keys are no longer intercepted when the omnibar is not active.
  * Prevented unintended omnibar submissions when another view has focus.
  * Improved behavior for physical Enter/Return and navigation keys by only handling them when the omnibar is ready for input.

* **Tests**
  * Added regression coverage for unfocused omnibar keyboard handling.
  * Verified both blocked and allowed key behavior with and without an active text editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->