### PR TITLE
Fix iOS pairing stuck on "Checking…": honor manual fallback sign-in callback after popup ends

### DIFF
--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
@@ -206,18 +206,11 @@ public final class HostBrowserSignInFlow {
         let callbackState = manualCallbackState ?? makeCallbackState()
         activeAttemptID = attemptID
         activeCallbackState = callbackState
-        // A manually issued sign-in URL (`auth.sign_in_url` / the printed CLI
-        // fallback, or any out-of-band link the user already holds) shares this
-        // attempt's callback state, and the user may complete it in their own
-        // browser AFTER this popup attempt ends — e.g. the system popup
-        // auto-dismissed without completing the handoff. Retain that state as an
-        // accepted out-of-band fallback (the same durability the "Open in
-        // Browser" button gets via `activeAttemptSignInURL`), so the late
-        // callback still finishes sign-in instead of being rejected as
-        // "noActiveAttempt" and leaving auth stuck at signed_in=false (#6158).
-        // `finishAttempt` preserves this; sign-out and a replacing attempt clear
-        // it via `cancelActiveAttempt`, and a successful callback clears it in
-        // `completeCallback`.
+        // The manual fallback URL (`auth.sign_in_url` / the printed CLI link)
+        // shares this attempt's state; the user may complete it out-of-band
+        // after the popup ends (e.g. the system popup auto-dismissed). Retain it
+        // as an accepted fallback — like `activeAttemptSignInURL` — so the late
+        // callback completes sign-in instead of being rejected (#6158).
         if let manualCallbackState {
             pendingFallbackCallbackState = manualCallbackState
         }

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
@@ -201,10 +201,26 @@ public final class HostBrowserSignInFlow {
         lastFailure = nil
         nextAttemptID &+= 1
         let attemptID = nextAttemptID
-        let callbackState = pendingManualCallbackState ?? makeCallbackState()
+        let manualCallbackState = pendingManualCallbackState
         pendingManualCallbackState = nil
+        let callbackState = manualCallbackState ?? makeCallbackState()
         activeAttemptID = attemptID
         activeCallbackState = callbackState
+        // A manually issued sign-in URL (`auth.sign_in_url` / the printed CLI
+        // fallback, or any out-of-band link the user already holds) shares this
+        // attempt's callback state, and the user may complete it in their own
+        // browser AFTER this popup attempt ends — e.g. the system popup
+        // auto-dismissed without completing the handoff. Retain that state as an
+        // accepted out-of-band fallback (the same durability the "Open in
+        // Browser" button gets via `activeAttemptSignInURL`), so the late
+        // callback still finishes sign-in instead of being rejected as
+        // "noActiveAttempt" and leaving auth stuck at signed_in=false (#6158).
+        // `finishAttempt` preserves this; sign-out and a replacing attempt clear
+        // it via `cancelActiveAttempt`, and a successful callback clears it in
+        // `completeCallback`.
+        if let manualCallbackState {
+            pendingFallbackCallbackState = manualCallbackState
+        }
         isSigningIn = true
         log.log("auth.browser.attempt.start id=\(attemptID) generation=\(signOutGeneration) state=\(redactedAuthState(callbackState))")
         scheduleAttemptTimeout(attemptID)

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTests.swift
@@ -217,8 +217,7 @@ import Testing
         // (`auth.sign_in_url` -> `manualSignInURL`) BEFORE it starts the popup
         // attempt (`auth.begin_sign_in`), so the popup and the printed fallback
         // URL deliberately share one callback state. When the system popup
-        // auto-dismisses without completing the handoff (the reporter's "Safari
-        // flashes briefly and closes automatically"), the attempt ends — but a
+        // auto-dismisses without completing the handoff, the attempt ends — but a
         // callback later delivered from the manually opened fallback URL must
         // still complete sign-in instead of being rejected as "noActiveAttempt"
         // and leaving `auth.status` stuck at signed_in=false.

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTests.swift
@@ -211,6 +211,49 @@ import Testing
         #expect(await harness.tokenStore.getStoredAccessToken() == "access-1")
     }
 
+    @Test func manualFallbackURLCallbackSurvivesPopupCancellation() async throws {
+        // Regression for the iOS-pairing "stuck on Checking…" bug (#6158).
+        // The CLI `cmux auth login` flow requests the manual fallback URL
+        // (`auth.sign_in_url` -> `manualSignInURL`) BEFORE it starts the popup
+        // attempt (`auth.begin_sign_in`), so the popup and the printed fallback
+        // URL deliberately share one callback state. When the system popup
+        // auto-dismisses without completing the handoff (the reporter's "Safari
+        // flashes briefly and closes automatically"), the attempt ends — but a
+        // callback later delivered from the manually opened fallback URL must
+        // still complete sign-in instead of being rejected as "noActiveAttempt"
+        // and leaving `auth.status` stuck at signed_in=false.
+        let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
+        let harness = HostBrowserSignInFlowHarness(user: user)
+
+        // auth.sign_in_url: issue the manual fallback URL up front.
+        let manualURL = harness.flow.manualSignInURL
+        let manualState = try #require(URLComponents(url: manualURL, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == "cmux_auth_state" })?
+            .value)
+
+        // auth.begin_sign_in: start the popup attempt, which consumes that state
+        // so the popup and the printed fallback URL share one callback state.
+        let attempt = Task { await harness.flow.signIn(timeout: 60) }
+        await harness.waitForSession()
+        #expect(harness.callbackState(harness.factory.sessions[0]) == manualState)
+
+        // The system popup auto-dismisses without completing the handoff.
+        harness.factory.sessions[0].cancel()
+        #expect(await attempt.value == false)
+        await harness.waitForCondition { harness.flow.isSigningIn == false }
+
+        // The user finishes sign-in in their own browser and returns to the app
+        // via the manual fallback URL's callback.
+        let callbackResult = await harness.flow.handleCallbackURL(harness.callbackURL(state: manualState))
+
+        #expect(callbackResult)
+        #expect(harness.coordinator.isAuthenticated)
+        #expect(harness.coordinator.currentUser == user)
+        #expect(await harness.tokenStore.getStoredRefreshToken() == "refresh-1")
+        #expect(await harness.tokenStore.getStoredAccessToken() == "access-1")
+    }
+
     @Test func issuedFallbackCallbackStateSurvivesFailedRetryAndClearsFailureOnSuccess() async throws {
         let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
         let harness = HostBrowserSignInFlowHarness(user: user)


### PR DESCRIPTION
Fixes #6158

## Summary

The reporter could not pair their iPhone: after a successful browser login, `auth.status` stayed `signed_in=false`, `cmux auth status` reported `Not signed in`, and the **Pair iPhone** window was stuck on **"Checking…"** indefinitely.

(Note: the reporter observed `auth.login` returning `authenticated=true` — that RPC is the *socket password* handshake ack, unrelated to account sign-in. The real problem was that the desktop `AuthCoordinator` never became authenticated.)

## Root cause

The CLI `cmux auth login` flow makes two socket calls in order:

1. `auth.sign_in_url` → `HostBrowserSignInFlow.manualSignInURL` — issues the printed **fallback sign-in URL** and stores its callback state in `pendingManualCallbackState`.
2. `auth.begin_sign_in` → `startAttempt()` — **consumes** `pendingManualCallbackState` as the popup attempt's `activeCallbackState`, so the popup and the printed fallback URL deliberately share one state.

The state was recorded **only** in `pendingManualCallbackState` — never promoted to the durable `pendingFallbackCallbackState`. When the system sign-in popup auto-dismisses without completing the handoff (the reporter's *"Safari flashes briefly and closes automatically"*), the attempt ends and `finishAttempt` clears `activeCallbackState`. The user then finishes login in their own browser and clicks **Return to cmux**, but the resulting `cmux://auth-callback?…&cmux_auth_state=<S>` reaches `handleCallbackURL` with:

- no active attempt (`activeAttemptID == nil`),
- a non-nil state (so the stateless-fallback branch is skipped),
- and no matching `pendingFallbackCallbackState`,

so it is rejected as `noActiveAttempt`. The browser-side session is never seeded into the coordinator → `signed_in` stays false → pairing is stuck on "Checking…".

The existing "Open in Browser" slow-sign-in button (`activeAttemptSignInURL`) does **not** hit this because it sets `pendingFallbackCallbackState`. Only the manually issued URL path was missing that durability.

## Fix

When `startAttempt` consumes a manually issued callback state, promote it to `pendingFallbackCallbackState` — the same durability the "Open in Browser" button already gets. A late out-of-band callback now completes sign-in instead of being dropped.

The existing race guards are preserved:
- `finishAttempt` keeps the fallback state (so the late callback works).
- `cancelActiveAttempt` (sign-out, replacing attempt) clears it.
- `completeCallback` clears it on success.

## Tests

Two-commit red/green:
- **Commit 1** adds `manualFallbackURLCallbackSurvivesPopupCancellation`, which reproduces #6158 (issue the manual URL → start popup → popup cancels → deliver the manual callback → expect signed in). It **fails** without the fix.
- **Commit 2** applies the fix.

All 134 `CmuxAuthRuntime` tests pass locally (`swift test`), including the sign-out / stale-callback / mismatched-state rejection guards.

No user-facing strings changed (localization audit: clean).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785052713&installation_id=133855650&pr_number=6819&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6819&signature=d8a8739e87dbd7f4519d213b3a80424d2649d0a72c5faa377fd3cff5edbcf133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6158. iOS pairing no longer gets stuck on “Checking…” by honoring the manual fallback sign‑in callback even after the system popup closes.

- **Bug Fixes**
  - In `startAttempt`, promote a consumed manual callback state to `pendingFallbackCallbackState` so a late browser callback completes sign‑in instead of being rejected as `noActiveAttempt`.
  - Keeps existing race guards: `finishAttempt` preserves the fallback; `cancelActiveAttempt` clears it; `completeCallback` clears it on success.
  - Adds regression test `manualFallbackURLCallbackSurvivesPopupCancellation`.

- **Refactors**
  - Condensed new comments to keep `HostBrowserSignInFlow.swift` and its test under the file-length budget; no logic changes.

<sup>Written for commit 1deaba1c77cd49929b2a05e6b14c8bd5d3b630de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

