### PR TITLE
Browser pane: keep loopback bypass for *.localhost under "Exclude simple hostnames"

### DIFF
--- a/Sources/Panels/BrowserSystemProxyMirror.swift
+++ b/Sources/Panels/BrowserSystemProxyMirror.swift
@@ -27,14 +27,15 @@ struct BrowserSystemProxyMirror: Equatable {
     /// so the mirror only claims a system proxy that one configuration can
     /// represent for browser (HTTP/HTTPS) traffic:
     /// - `socksV5`: a SOCKSv5 proxy with no web proxy enabled.
-    /// - `httpCONNECT`: a matched HTTP+HTTPS system web proxy — both enabled
-    ///   and pointing at the same endpoint (the common Clash/Surge/mihomo
-    ///   mixed-port setup). It is mirrored as a CONNECT proxy so the loopback
-    ///   family can be excluded and `*.localhost` reaches local dev servers
-    ///   directly (#5703). The tradeoff: this forces CONNECT for plain-HTTP
-    ///   loads and does not carry system-managed proxy credentials, so an
-    ///   HTTP-only, HTTPS-only, or split web proxy — which a single CONNECT
-    ///   config cannot faithfully represent — is still declined (see `init?`).
+    /// - `httpCONNECT`: a matched HTTP+HTTPS system web proxy on a *loopback*
+    ///   endpoint — both enabled and pointing at the same local address (the
+    ///   common Clash/Surge/mihomo mixed-port setup on `127.0.0.1`). It is
+    ///   mirrored as a CONNECT proxy so the loopback family can be excluded and
+    ///   `*.localhost` reaches local dev servers directly (#5703). Because
+    ///   CONNECT forces tunneling for plain-HTTP loads and cannot carry
+    ///   system-managed credentials, this is scoped to loopback proxy tools the
+    ///   user runs locally; a remote/corporate web proxy, or an HTTP-only,
+    ///   HTTPS-only, or split web proxy, is still declined (see `init?`).
     enum Proxy: Equatable {
         case socksV5(host: String, port: UInt16)
         case httpCONNECT(host: String, port: UInt16)
@@ -130,11 +131,23 @@ struct BrowserSystemProxyMirror: Equatable {
     /// `ProxyConfiguration` can express it.
     ///
     /// A system web proxy takes precedence — it is what the system uses for
-    /// HTTP/HTTPS — but only a matched HTTP+HTTPS pair pointing at one endpoint
-    /// is representable as a single CONNECT proxy. An HTTP-only, HTTPS-only, or
-    /// split web proxy would change routing for the unmirrored scheme, so it
-    /// declines even when a SOCKS proxy is also configured. With no web proxy,
-    /// a SOCKS proxy is mirrored directly.
+    /// HTTP/HTTPS — but it is mirrored only when it is a matched HTTP+HTTPS pair
+    /// pointing at one **loopback** endpoint. That scopes the CONNECT mirror to
+    /// local proxy tools the user runs on this Mac (Clash/Surge/mihomo in "set
+    /// as system proxy" mode), which are reachable and — being general-purpose
+    /// tunnels with HTTPS already enabled — support CONNECT.
+    ///
+    /// The accepted residual (#5703): a *loopback* proxy that is forward-only or
+    /// requires client credentials would see ordinary `http://` loads tunneled
+    /// via CONNECT without auth. That is rare for a localhost proxy and is the
+    /// deliberate trade for reaching `*.localhost` dev servers at all; it cannot
+    /// be detected from the settings dictionary (no CONNECT-capability or
+    /// credential keys), so it is not gated further. A remote or corporate web
+    /// proxy — where forward-only routing and authentication are common — is
+    /// left on WebKit's native system-proxy path (#5959). An HTTP-only,
+    /// HTTPS-only, or split web proxy is likewise unrepresentable and declines,
+    /// even when a SOCKS proxy is also configured. With no web proxy, a SOCKS
+    /// proxy (which faithfully tunnels every scheme) is mirrored directly.
     private static func resolveProxy(in settings: [String: Any]) -> Proxy? {
         let httpEnabled = isEnabled(kCFNetworkProxiesHTTPEnable, in: settings)
         let httpsEnabled = isEnabled(kCFNetworkProxiesHTTPSEnable, in: settings)
@@ -153,7 +166,8 @@ struct BrowserSystemProxyMirror: Equatable {
                       portKey: kCFNetworkProxiesHTTPSPort
                   ),
                   http.host.caseInsensitiveCompare(https.host) == .orderedSame,
-                  http.port == https.port else {
+                  http.port == https.port,
+                  isLoopbackProxyHost(http.host) else {
                 return nil
             }
             return .httpCONNECT(host: http.host, port: http.port)
@@ -167,6 +181,24 @@ struct BrowserSystemProxyMirror: Equatable {
             return .socksV5(host: socks.host, port: socks.port)
         }
         return nil
+    }
+
+    /// Whether a proxy endpoint host is loopback (this Mac). Used to scope the
+    /// web-proxy CONNECT mirror to local proxy tools the user runs themselves;
+    /// see `resolveProxy(in:)`. Covers `localhost`, the IPv6 loopback `::1`
+    /// (with or without brackets), and the `127.0.0.0/8` IPv4 loopback block.
+    private static func isLoopbackProxyHost(_ host: String) -> Bool {
+        var value = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if value.hasPrefix("["), value.hasSuffix("]") {
+            value = String(value.dropFirst().dropLast())
+        }
+        if value == "localhost" || value == "::1" { return true }
+        // 127.0.0.0/8: require a real dotted-quad IPv4 literal whose first octet
+        // is 127, so a DNS name like "127.proxy.corp.example" is not loopback.
+        let octets = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4 else { return false }
+        let parsedOctets = octets.compactMap { UInt8($0) }
+        return parsedOctets.count == 4 && parsedOctets[0] == 127
     }
 
     /// How a single system bypass-list entry maps onto `excludedDomains`.

--- a/Sources/Panels/BrowserSystemProxyMirror.swift
+++ b/Sources/Panels/BrowserSystemProxyMirror.swift
@@ -10,22 +10,34 @@ import Network
 /// `WKWebsiteDataStore` has no explicit `proxyConfigurations`, every request —
 /// including `http://localhost:PORT` — follows the macOS system proxy and
 /// fails whenever that proxy is not running on this Mac (Clash/Surge global
-/// mode, LAN proxy box). Mirroring an active system proxy into explicit
-/// configurations keeps normal traffic on a faithfully representable proxy
-/// while loopback connects directly, matching Chromium's implicit proxy-bypass
-/// rules.
+/// mode, LAN proxy box). macOS bypasses the system proxy for the bare
+/// `localhost` hostname but not for `*.localhost` subdomains (its proxy
+/// exception matching is exact, not suffix-based), so subdomain-routed dev
+/// servers like `tenant.localhost:PORT` stay broken even when `localhost`
+/// works (#5703). Mirroring an active system proxy into explicit configurations
+/// keeps normal traffic on a faithfully representable proxy while the whole
+/// loopback family (including `*.localhost`) connects directly, matching
+/// Chromium's implicit proxy-bypass rules.
 /// https://github.com/manaflow-ai/cmux/issues/5888
+/// https://github.com/manaflow-ai/cmux/issues/5703
 struct BrowserSystemProxyMirror: Equatable {
     /// A system proxy expressible as a Network.framework `ProxyConfiguration`.
     ///
-    /// `ProxyConfiguration` routes every non-excluded connection the same way.
-    /// The mirror therefore only claims SOCKSv5 settings with no web proxy
-    /// enabled. HTTP and HTTPS system web proxies are ordinary forward-proxy
-    /// settings; Network.framework's HTTP CONNECT configuration is not a
-    /// faithful replacement for that policy, so those settings are never
-    /// mirrored and WebKit keeps its default system-proxy behavior.
+    /// `ProxyConfiguration` routes every non-excluded connection the same way,
+    /// so the mirror only claims a system proxy that one configuration can
+    /// represent for browser (HTTP/HTTPS) traffic:
+    /// - `socksV5`: a SOCKSv5 proxy with no web proxy enabled.
+    /// - `httpCONNECT`: a matched HTTP+HTTPS system web proxy — both enabled
+    ///   and pointing at the same endpoint (the common Clash/Surge/mihomo
+    ///   mixed-port setup). It is mirrored as a CONNECT proxy so the loopback
+    ///   family can be excluded and `*.localhost` reaches local dev servers
+    ///   directly (#5703). The tradeoff: this forces CONNECT for plain-HTTP
+    ///   loads and does not carry system-managed proxy credentials, so an
+    ///   HTTP-only, HTTPS-only, or split web proxy — which a single CONNECT
+    ///   config cannot faithfully represent — is still declined (see `init?`).
     enum Proxy: Equatable {
         case socksV5(host: String, port: UInt16)
+        case httpCONNECT(host: String, port: UInt16)
     }
 
     /// The proxy every non-excluded connection should use.
@@ -78,25 +90,13 @@ struct BrowserSystemProxyMirror: Equatable {
             return nil
         }
 
-        // System web proxies are forward-proxy settings. Mapping them to
-        // `ProxyConfiguration(httpCONNECTProxy:)` would force CONNECT
-        // semantics for ordinary HTTP loads and can lose system-managed proxy
-        // authentication, so leave WebKit on its native system-proxy path.
-        guard !Self.isEnabled(kCFNetworkProxiesHTTPEnable, in: settings),
-              !Self.isEnabled(kCFNetworkProxiesHTTPSEnable, in: settings) else {
+        // Resolve the single proxy that represents the system policy for
+        // browser traffic (a matched web proxy as CONNECT, otherwise SOCKS), or
+        // decline when no `ProxyConfiguration` can express it.
+        guard let resolvedProxy = Self.resolveProxy(in: settings) else {
             return nil
         }
-
-        if let socks = Self.endpoint(
-            in: settings,
-            enableKey: kCFNetworkProxiesSOCKSEnable,
-            hostKey: kCFNetworkProxiesSOCKSProxy,
-            portKey: kCFNetworkProxiesSOCKSPort
-        ) {
-            proxy = .socksV5(host: socks.host, port: socks.port)
-        } else {
-            return nil
-        }
+        proxy = resolvedProxy
 
         let bypassList = (settings[kCFNetworkProxiesExceptionsList as String] as? [Any] ?? [])
             .compactMap { $0 as? String }
@@ -123,6 +123,50 @@ struct BrowserSystemProxyMirror: Equatable {
         guard let port = (settings[portKey as String] as? NSNumber)?.intValue,
               port > 0, port <= 65535 else { return nil }
         return (host: host, port: UInt16(port))
+    }
+
+    /// Resolves the system proxy settings to the single proxy that represents
+    /// the policy for browser (HTTP/HTTPS) traffic, or `nil` when no
+    /// `ProxyConfiguration` can express it.
+    ///
+    /// A system web proxy takes precedence — it is what the system uses for
+    /// HTTP/HTTPS — but only a matched HTTP+HTTPS pair pointing at one endpoint
+    /// is representable as a single CONNECT proxy. An HTTP-only, HTTPS-only, or
+    /// split web proxy would change routing for the unmirrored scheme, so it
+    /// declines even when a SOCKS proxy is also configured. With no web proxy,
+    /// a SOCKS proxy is mirrored directly.
+    private static func resolveProxy(in settings: [String: Any]) -> Proxy? {
+        let httpEnabled = isEnabled(kCFNetworkProxiesHTTPEnable, in: settings)
+        let httpsEnabled = isEnabled(kCFNetworkProxiesHTTPSEnable, in: settings)
+        if httpEnabled || httpsEnabled {
+            guard httpEnabled, httpsEnabled,
+                  let http = endpoint(
+                      in: settings,
+                      enableKey: kCFNetworkProxiesHTTPEnable,
+                      hostKey: kCFNetworkProxiesHTTPProxy,
+                      portKey: kCFNetworkProxiesHTTPPort
+                  ),
+                  let https = endpoint(
+                      in: settings,
+                      enableKey: kCFNetworkProxiesHTTPSEnable,
+                      hostKey: kCFNetworkProxiesHTTPSProxy,
+                      portKey: kCFNetworkProxiesHTTPSPort
+                  ),
+                  http.host.caseInsensitiveCompare(https.host) == .orderedSame,
+                  http.port == https.port else {
+                return nil
+            }
+            return .httpCONNECT(host: http.host, port: http.port)
+        }
+        if let socks = endpoint(
+            in: settings,
+            enableKey: kCFNetworkProxiesSOCKSEnable,
+            hostKey: kCFNetworkProxiesSOCKSProxy,
+            portKey: kCFNetworkProxiesSOCKSPort
+        ) {
+            return .socksV5(host: socks.host, port: socks.port)
+        }
+        return nil
     }
 
     /// How a single system bypass-list entry maps onto `excludedDomains`.
@@ -215,15 +259,21 @@ extension BrowserSystemProxyMirror {
     func proxyConfigurations() -> [ProxyConfiguration] {
         let host: String
         let port: UInt16
+        let makeConfiguration: (NWEndpoint) -> ProxyConfiguration
         switch proxy {
         case .socksV5(let proxyHost, let proxyPort):
             host = proxyHost
             port = proxyPort
+            makeConfiguration = { ProxyConfiguration(socksv5Proxy: $0) }
+        case .httpCONNECT(let proxyHost, let proxyPort):
+            host = proxyHost
+            port = proxyPort
+            makeConfiguration = { ProxyConfiguration(httpCONNECTProxy: $0) }
         }
         guard let nwPort = NWEndpoint.Port(rawValue: port) else { return [] }
         let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(host), port: nwPort)
 
-        var configuration = ProxyConfiguration(socksv5Proxy: endpoint)
+        var configuration = makeConfiguration(endpoint)
         configuration.excludedDomains = excludedDomains
         return [configuration]
     }

--- a/cmuxTests/BrowserSystemProxyMirrorTests.swift
+++ b/cmuxTests/BrowserSystemProxyMirrorTests.swift
@@ -18,9 +18,9 @@ import Testing
 // fail closed (keep the system proxy) whenever the system policy cannot be
 // represented faithfully.
 @Suite struct BrowserSystemProxyMirrorTests {
-    /// A matched HTTP + HTTPS system web-proxy pair. This is deliberately not
-    /// mirrored because Network.framework's HTTP CONNECT proxy is not the same
-    /// policy as a system forward proxy.
+    /// A matched HTTP + HTTPS system web-proxy pair (both enabled, one
+    /// endpoint) — the common Clash/Surge/mihomo mixed-port setup. It is
+    /// mirrored as a single CONNECT proxy with loopback excluded (#5703).
     private func webProxySettings(
         host: String = "proxy.example.com",
         port: Any = 8888,
@@ -94,6 +94,7 @@ import Testing
         let mirror = try #require(
             BrowserSystemProxyMirror(systemProxySettings: webProxySettings())
         )
+        #expect(mirror.proxy == .httpCONNECT(host: "proxy.example.com", port: 8888))
         #expect(mirror.excludedDomains == BrowserSystemProxyMirror.implicitExclusions)
     }
 
@@ -110,6 +111,7 @@ import Testing
         var settings = webProxySettings()
         settings.merge(socksProxySettings()) { current, _ in current }
         let mirror = try #require(BrowserSystemProxyMirror(systemProxySettings: settings))
+        #expect(mirror.proxy == .httpCONNECT(host: "proxy.example.com", port: 8888))
         #expect(mirror.excludedDomains == BrowserSystemProxyMirror.implicitExclusions)
     }
 
@@ -371,6 +373,25 @@ import Testing
             BrowserSystemProxyMirror(
                 systemProxySettings: socksProxySettings(bypassList: ["intranet.corp.example"])
             )
+        )
+        let configurations = mirror.proxyConfigurations()
+        #expect(configurations.count == 1)
+        let configuration = try #require(configurations.first)
+        #expect(enumeratedExcludedDomains(configuration) == mirror.excludedDomains)
+        #expect(configuration.allowFailover == false)
+    }
+
+    @Test("A matched web-proxy mirror produces one CONNECT configuration carrying the exclusions")
+    func webProxyMirrorProducesConfigurationWithExclusions() throws {
+        let mirror = try #require(
+            BrowserSystemProxyMirror(
+                systemProxySettings: webProxySettings(bypassList: ["intranet.corp.example"])
+            )
+        )
+        #expect(mirror.proxy == .httpCONNECT(host: "proxy.example.com", port: 8888))
+        #expect(
+            mirror.excludedDomains ==
+                BrowserSystemProxyMirror.implicitExclusions + ["intranet.corp.example"]
         )
         let configurations = mirror.proxyConfigurations()
         #expect(configurations.count == 1)

--- a/cmuxTests/BrowserSystemProxyMirrorTests.swift
+++ b/cmuxTests/BrowserSystemProxyMirrorTests.swift
@@ -83,9 +83,18 @@ import Testing
 
     // MARK: - Mirrored proxy mapping
 
-    @Test("A matched HTTP+HTTPS web proxy is not mirrored as HTTP CONNECT")
-    func matchedWebProxyIsNotMirroredAsHTTPCONNECT() {
-        #expect(BrowserSystemProxyMirror(systemProxySettings: webProxySettings()) == nil)
+    // Regression coverage for https://github.com/manaflow-ai/cmux/issues/5703:
+    // macOS bypasses the system proxy for `localhost` but NOT for `*.localhost`
+    // subdomains, so a matched HTTP+HTTPS system web proxy (the common
+    // Clash/Surge/mihomo mixed-port setup) leaves `tenant.localhost:PORT` dev
+    // servers unreachable in the browser pane. A matched web proxy is now
+    // mirrored as a single CONNECT proxy with the loopback family excluded.
+    @Test("A matched HTTP+HTTPS web proxy mirrors as CONNECT with loopback excluded (#5703)")
+    func matchedWebProxyMirrorsAsHTTPCONNECT() throws {
+        let mirror = try #require(
+            BrowserSystemProxyMirror(systemProxySettings: webProxySettings())
+        )
+        #expect(mirror.excludedDomains == BrowserSystemProxyMirror.implicitExclusions)
     }
 
     @Test("A SOCKS proxy with no web proxy mirrors to a SOCKSv5 proxy")
@@ -96,11 +105,12 @@ import Testing
         #expect(mirror.proxy == .socksV5(host: "socks.example.com", port: 1080))
     }
 
-    @Test("SOCKS is not mirrored while a matched web proxy is active")
-    func matchedWebProxyDeclinesEvenWithSOCKS() {
+    @Test("A matched web proxy mirrors (as CONNECT) even while SOCKS is also active")
+    func matchedWebProxyMirrorsEvenWithSOCKS() throws {
         var settings = webProxySettings()
         settings.merge(socksProxySettings()) { current, _ in current }
-        #expect(BrowserSystemProxyMirror(systemProxySettings: settings) == nil)
+        let mirror = try #require(BrowserSystemProxyMirror(systemProxySettings: settings))
+        #expect(mirror.excludedDomains == BrowserSystemProxyMirror.implicitExclusions)
     }
 
     @Test("SOCKS host is trimmed and accepts the highest port")

--- a/cmuxTests/BrowserSystemProxyMirrorTests.swift
+++ b/cmuxTests/BrowserSystemProxyMirrorTests.swift
@@ -19,8 +19,9 @@ import Testing
 // represented faithfully.
 @Suite struct BrowserSystemProxyMirrorTests {
     /// A matched HTTP + HTTPS system web-proxy pair (both enabled, one
-    /// endpoint) — the common Clash/Surge/mihomo mixed-port setup. It is
-    /// mirrored as a single CONNECT proxy with loopback excluded (#5703).
+    /// endpoint). With a loopback `host` this is the common Clash/Surge/mihomo
+    /// mixed-port setup that is mirrored as a single CONNECT proxy with loopback
+    /// excluded (#5703); the default remote host stays fail-closed (#5959).
     private func webProxySettings(
         host: String = "proxy.example.com",
         port: Any = 8888,
@@ -85,17 +86,44 @@ import Testing
 
     // Regression coverage for https://github.com/manaflow-ai/cmux/issues/5703:
     // macOS bypasses the system proxy for `localhost` but NOT for `*.localhost`
-    // subdomains, so a matched HTTP+HTTPS system web proxy (the common
-    // Clash/Surge/mihomo mixed-port setup) leaves `tenant.localhost:PORT` dev
-    // servers unreachable in the browser pane. A matched web proxy is now
-    // mirrored as a single CONNECT proxy with the loopback family excluded.
-    @Test("A matched HTTP+HTTPS web proxy mirrors as CONNECT with loopback excluded (#5703)")
-    func matchedWebProxyMirrorsAsHTTPCONNECT() throws {
+    // subdomains, so a matched HTTP+HTTPS system web proxy on loopback (the
+    // common Clash/Surge/mihomo mixed-port setup on 127.0.0.1) leaves
+    // `tenant.localhost:PORT` dev servers unreachable in the browser pane. A
+    // matched loopback web proxy is now mirrored as a single CONNECT proxy with
+    // the loopback family excluded.
+    @Test("A matched loopback HTTP+HTTPS web proxy mirrors as CONNECT with loopback excluded (#5703)")
+    func matchedLoopbackWebProxyMirrorsAsHTTPCONNECT() throws {
         let mirror = try #require(
-            BrowserSystemProxyMirror(systemProxySettings: webProxySettings())
+            BrowserSystemProxyMirror(systemProxySettings: webProxySettings(host: "127.0.0.1"))
         )
-        #expect(mirror.proxy == .httpCONNECT(host: "proxy.example.com", port: 8888))
+        #expect(mirror.proxy == .httpCONNECT(host: "127.0.0.1", port: 8888))
         #expect(mirror.excludedDomains == BrowserSystemProxyMirror.implicitExclusions)
+    }
+
+    @Test("A remote (non-loopback) matched web proxy is not mirrored as CONNECT")
+    func remoteMatchedWebProxyDeclinesTheMirror() {
+        // A corporate/remote forward proxy may be forward-only or require auth a
+        // CONNECT ProxyConfiguration cannot carry, so it stays on WebKit's
+        // native system-proxy path (#5959). "127.proxy.corp.example" is a DNS
+        // name, not the 127.0.0.0/8 loopback block, so the loopback gate must
+        // not treat its "127." prefix as a local proxy.
+        for host in ["proxy.example.com", "10.0.0.5", "127.proxy.corp.example"] {
+            #expect(
+                BrowserSystemProxyMirror(systemProxySettings: webProxySettings(host: host)) == nil,
+                "host=\(host)"
+            )
+        }
+    }
+
+    @Test("Every loopback proxy-host form mirrors as CONNECT (#5703)")
+    func loopbackProxyHostVariantsMirror() throws {
+        for host in ["localhost", "::1", "127.0.0.5"] {
+            let mirror = try #require(
+                BrowserSystemProxyMirror(systemProxySettings: webProxySettings(host: host)),
+                "host=\(host)"
+            )
+            #expect(mirror.proxy == .httpCONNECT(host: host, port: 8888), "host=\(host)")
+        }
     }
 
     @Test("A SOCKS proxy with no web proxy mirrors to a SOCKSv5 proxy")
@@ -106,12 +134,12 @@ import Testing
         #expect(mirror.proxy == .socksV5(host: "socks.example.com", port: 1080))
     }
 
-    @Test("A matched web proxy mirrors (as CONNECT) even while SOCKS is also active")
-    func matchedWebProxyMirrorsEvenWithSOCKS() throws {
-        var settings = webProxySettings()
+    @Test("A matched loopback web proxy mirrors (as CONNECT) even while SOCKS is also active")
+    func matchedLoopbackWebProxyMirrorsEvenWithSOCKS() throws {
+        var settings = webProxySettings(host: "127.0.0.1")
         settings.merge(socksProxySettings()) { current, _ in current }
         let mirror = try #require(BrowserSystemProxyMirror(systemProxySettings: settings))
-        #expect(mirror.proxy == .httpCONNECT(host: "proxy.example.com", port: 8888))
+        #expect(mirror.proxy == .httpCONNECT(host: "127.0.0.1", port: 8888))
         #expect(mirror.excludedDomains == BrowserSystemProxyMirror.implicitExclusions)
     }
 
@@ -208,6 +236,22 @@ import Testing
         var settings = socksProxySettings()
         settings[kCFNetworkProxiesExcludeSimpleHostnames as String] = 1
         #expect(BrowserSystemProxyMirror(systemProxySettings: settings) == nil)
+    }
+
+    @Test("Exclude-simple-hostnames declines before any bypass-list processing")
+    func excludeSimpleHostnamesDeclinesRegardlessOfBypassList() {
+        // The decline takes precedence over the bypass-list merge, so neither a
+        // representable domain entry nor a deliberate CIDR changes the outcome:
+        // mirroring would route dot-less intranet hosts (which the OS bypasses
+        // under this flag) to the proxy, a privacy regression we avoid.
+        for bypassList in [["intranet.corp.example"], ["10.0.0.0/8"], ["intranet.corp.example", "10.0.0.0/8"]] {
+            var settings = socksProxySettings(bypassList: bypassList)
+            settings[kCFNetworkProxiesExcludeSimpleHostnames as String] = 1
+            #expect(
+                BrowserSystemProxyMirror(systemProxySettings: settings) == nil,
+                "bypassList=\(bypassList)"
+            )
+        }
     }
 
     @Test("Invalid endpoints are not mirrored")
@@ -381,14 +425,14 @@ import Testing
         #expect(configuration.allowFailover == false)
     }
 
-    @Test("A matched web-proxy mirror produces one CONNECT configuration carrying the exclusions")
+    @Test("A matched loopback web-proxy mirror produces one CONNECT configuration carrying the exclusions")
     func webProxyMirrorProducesConfigurationWithExclusions() throws {
         let mirror = try #require(
             BrowserSystemProxyMirror(
-                systemProxySettings: webProxySettings(bypassList: ["intranet.corp.example"])
+                systemProxySettings: webProxySettings(host: "127.0.0.1", bypassList: ["intranet.corp.example"])
             )
         )
-        #expect(mirror.proxy == .httpCONNECT(host: "proxy.example.com", port: 8888))
+        #expect(mirror.proxy == .httpCONNECT(host: "127.0.0.1", port: 8888))
         #expect(
             mirror.excludedDomains ==
                 BrowserSystemProxyMirror.implicitExclusions + ["intranet.corp.example"]


### PR DESCRIPTION
Fixes #5703.

## Symptom

A local dev server that uses subdomains (e.g. a Next.js app routing on `tenant.localhost:3000`) loads fine in Chrome but fails with "no internet connection" in the cmux browser pane — while plain `http://localhost:3000` works.

## Root cause

Under a macOS system proxy, WebKit — unlike Chromium — has **no implicit loopback bypass**. `BrowserSystemProxyMirror` (#5888 / #5915 / #5959) mirrors an active system proxy into an explicit `ProxyConfiguration` with the loopback family excluded so loopback connects directly.

Two facts combine to break `*.localhost` specifically (both confirmed locally via `CFNetworkCopyProxiesForURL` and a `WKWebView` + `ProxyConfiguration` harness):

1. **macOS's proxy exception-list matching is exact, not suffix-based.** Even with the default bypass list, macOS sends bare `localhost` **direct** but routes `tenant.localhost` (and every `*.localhost`) **to the proxy**.
2. **The mirror only handled SOCKS proxies and declined every web proxy.** The common Clash/Surge/mihomo "set as system proxy" setup points HTTP **and** HTTPS at one mixed port, so the mirror declined and WebKit followed the system proxy → `*.localhost` unreachable.

(`ProxyConfiguration.excludedDomains`, what the mirror sets, *does* match by suffix — verified — so once a mirror is produced, `"localhost"` correctly covers `*.localhost`.)

## Fix

Mirror a **matched HTTP+HTTPS web proxy on a loopback endpoint** (both enabled, same `127.0.0.0/8`/`::1`/`localhost` address) as a single `ProxyConfiguration(httpCONNECTProxy:)` with the loopback family excluded. Verified end-to-end: a CONNECT `ProxyConfiguration` with `excludedDomains=["localhost"]` bypasses `sub.localhost`/`deep.nested.localhost` while routing other hosts to the proxy.

**Why loopback-only:** a loopback web proxy is by definition a local tool the user runs on this Mac (Clash/Surge/mihomo in "set as system proxy" mode) — reachable, and a general-purpose tunnel with HTTPS already enabled, so it supports CONNECT. This is also **privacy-safe**: it routes *strictly less* to the proxy than the system already does (it only *adds* loopback bypass).

### What still fails closed (unchanged)

- **Remote / corporate web proxies** — where forward-only routing and auth (which a CONNECT `ProxyConfiguration` can't carry) are common — stay on WebKit's native system-proxy path (#5959).
- HTTP-only / HTTPS-only / split HTTP≠HTTPS endpoints, PAC / WPAD.
- **"Exclude simple hostnames"** — mirroring there would route dot-less intranet hosts (`nas`, `printer`) to the proxy the OS bypasses, a privacy regression — still declines.
- Deliberate CIDR / non-leading-wildcard bypass entries.

### Reviewer note — accepted residual

This deliberately reverses #5959's blanket "don't mirror web proxies as CONNECT" for the **loopback** case only, per an explicit product decision to fix #5703 for the common local-proxy setup. The bundled autoreview flags the residual (a *loopback* proxy that is forward-only or auth-protected would have plain-`http://` loads CONNECT-tunneled without auth). That config can't be detected from the settings dict and is rare for a localhost proxy; it's the conscious trade for reaching `*.localhost` at all, and the loopback gate already keeps every remote/corporate proxy fail-closed.

## How verified

- `CFNetworkCopyProxiesForURL` with synthetic settings → proved macOS exact-matches the exception list (`localhost`→direct, `tenant.localhost`→proxy).
- `WKWebView` + SOCKS and CONNECT `ProxyConfiguration` harnesses → proved `excludedDomains=["localhost"]` bypasses `*.localhost` for both proxy types, and a non-excluded host is correctly routed to (and fails on) the proxy.
- Two-commit red/green plus loopback-scoping refinement; full unit coverage in `BrowserSystemProxyMirrorTests` (loopback variants mirror, remote/`127.`-prefixed-DNS decline, web-proxy + bypass-list merge, ExcludeSimpleHostnames precedence).

## Notes

- No user-facing strings changed (networking logic + tests only) — no localization updates required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)