### PR TITLE
Fix native fullscreen unreachable on the main window (#5933)

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -69,6 +69,58 @@ final class CmuxMainWindow: NSWindow {
         return frame
     }
 
+    /// cmux creates its main window programmatically (never from a nib), so it
+    /// cannot inherit fullscreen capability from Interface Builder and instead
+    /// relied on AppKit *implicitly* granting `.fullScreenPrimary` to a
+    /// resizable, titled window. That implicit grant is not reliable across
+    /// macOS versions / display arrangements: on macOS 26 (Tahoe) a
+    /// freshly-created window reports an empty collection behavior
+    /// (`rawValue == 0`) and AppKit does not treat it as fullscreen-capable, so
+    /// Toggle Full Screen / ⌃⌘F / the green traffic-light button all fail to
+    /// enter a native fullscreen Space — the green button only zooms (#5933).
+    ///
+    /// Declaring `.fullScreenPrimary` here makes native fullscreen reachable
+    /// regardless of the OS's implicit default. It is idempotent where AppKit
+    /// would have granted it anyway, and composes with the temporary
+    /// `.fullScreenDisallowsTiling` opt-out the window factory applies when
+    /// spawning a window out of an existing fullscreen Space.
+    override init(
+        contentRect: NSRect,
+        styleMask: NSWindow.StyleMask,
+        backing: NSWindow.BackingStoreType,
+        defer flag: Bool
+    ) {
+        super.init(
+            contentRect: contentRect,
+            styleMask: styleMask,
+            backing: backing,
+            defer: flag
+        )
+        collectionBehavior = Self.canonicalCollectionBehavior(collectionBehavior)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Returns `base` guaranteed to carry `.fullScreenPrimary` (and never
+    /// `.fullScreenNone`) so a cmux main window can always enter a native
+    /// fullscreen Space. Pure and `nonisolated` so it can be unit-tested
+    /// without constructing a window; see ``init(contentRect:styleMask:backing:defer:)``
+    /// for why declaring the capability explicitly is required.
+    nonisolated static func canonicalCollectionBehavior(
+        _ base: NSWindow.CollectionBehavior
+    ) -> NSWindow.CollectionBehavior {
+        var behavior = base
+        // `.fullScreenNone` and `.fullScreenPrimary` are mutually exclusive;
+        // drop any stale "none" before declaring primary so fullscreen is not
+        // suppressed.
+        behavior.remove(.fullScreenNone)
+        behavior.insert(.fullScreenPrimary)
+        return behavior
+    }
+
     private var isSoftHiddenForVisibilityController = false
 
     func setSoftHiddenForVisibilityController(_ isSoftHidden: Bool) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */; };
 		2F0C07000000000000000002 /* CmuxMainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C07000000000000000001 /* CmuxMainWindow.swift */; };
 		D36090010000000000000005 /* CmuxMainWindowConstrainFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */; };
+		D36090020000000000000005 /* CmuxMainWindowFullScreenCapabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */; };
 		799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */ = {isa = PBXBuildFile; productRef = EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */; };
 		EFB18E3C0000000000000001 /* CMUXMobileCore in Frameworks */ = {isa = PBXBuildFile; productRef = EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */; };
 		CA1F0A01CA1F0A01CA1F0A01 /* CmuxModalAlertPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1F0A02CA1F0A02CA1F0A02 /* CmuxModalAlertPresentation.swift */; };
@@ -1450,6 +1451,7 @@
 		E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxLifecycleEventPublishing.swift; sourceTree = "<group>"; };
 		2F0C07000000000000000001 /* CmuxMainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxMainWindow.swift; sourceTree = "<group>"; };
 		D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxMainWindowConstrainFrameTests.swift; sourceTree = "<group>"; };
+		D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxMainWindowFullScreenCapabilityTests.swift; sourceTree = "<group>"; };
 		CA1F0A02CA1F0A02CA1F0A02 /* CmuxModalAlertPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxModalAlertPresentation.swift; sourceTree = "<group>"; };
 		C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXOpenCommandTests.swift; sourceTree = "<group>"; };
 		C0DE31390000000000000112 /* CMUXOpenHTMLFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXOpenHTMLFocusTests.swift; sourceTree = "<group>"; };
@@ -3235,6 +3237,7 @@
 				A50019B3 /* SettingsSearchIndexTests.swift */,
 				D36090010000000000000004 /* SettingsWindowPresenterTests.swift */,
 				D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */,
+				D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */,
 				970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */,
 				BABA25000000000000000006 /* BrowserHTTPBasicAuthPromptCoordinatorTests.swift */,
 				BABA25000000000000000004 /* BrowserHTTPBasicAuthPromptTests.swift */,
@@ -4693,6 +4696,7 @@
 				C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,
 				E7E000000000000000000003 /* CmuxEventBusTests.swift in Sources */,
 				D36090010000000000000005 /* CmuxMainWindowConstrainFrameTests.swift in Sources */,
+				D36090020000000000000005 /* CmuxMainWindowFullScreenCapabilityTests.swift in Sources */,
 				C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */,
 				C0DE31390000000000000111 /* CMUXOpenHTMLFocusTests.swift in Sources */,
 				C3677001000000000000001 /* CmuxSSHURLRequestTests.swift in Sources */,

--- a/cmuxTests/CmuxMainWindowFullScreenCapabilityTests.swift
+++ b/cmuxTests/CmuxMainWindowFullScreenCapabilityTests.swift
@@ -44,5 +44,37 @@ final class CmuxMainWindowFullScreenCapabilityTests: XCTestCase {
             "Main window must never carry .fullScreenNone, which suppresses native fullscreen"
         )
     }
+
+    // The capability decision is a pure, screen-agnostic transform so it runs
+    // deterministically on CI regardless of the test host's display setup.
+
+    func testCanonicalBehaviorAddsFullScreenPrimaryToEmptyBehavior() {
+        let result = CmuxMainWindow.canonicalCollectionBehavior([])
+        XCTAssertTrue(result.contains(.fullScreenPrimary))
+        XCTAssertFalse(result.contains(.fullScreenNone))
+    }
+
+    func testCanonicalBehaviorDropsStaleFullScreenNone() {
+        let result = CmuxMainWindow.canonicalCollectionBehavior([.fullScreenNone])
+        XCTAssertTrue(result.contains(.fullScreenPrimary))
+        XCTAssertFalse(result.contains(.fullScreenNone))
+    }
+
+    func testCanonicalBehaviorPreservesUnrelatedBehaviorBits() {
+        // The window factory may layer `.fullScreenDisallowsTiling` on top when
+        // spawning out of an existing fullscreen Space; canonicalization must
+        // not clobber that (or any other unrelated bit).
+        let base: NSWindow.CollectionBehavior = [.fullScreenDisallowsTiling, .moveToActiveSpace]
+        let result = CmuxMainWindow.canonicalCollectionBehavior(base)
+        XCTAssertTrue(result.contains(.fullScreenPrimary))
+        XCTAssertTrue(result.contains(.fullScreenDisallowsTiling))
+        XCTAssertTrue(result.contains(.moveToActiveSpace))
+    }
+
+    func testCanonicalBehaviorIsIdempotent() {
+        let once = CmuxMainWindow.canonicalCollectionBehavior([])
+        let twice = CmuxMainWindow.canonicalCollectionBehavior(once)
+        XCTAssertEqual(once, twice)
+    }
 }
 #endif

--- a/cmuxTests/CmuxMainWindowFullScreenCapabilityTests.swift
+++ b/cmuxTests/CmuxMainWindowFullScreenCapabilityTests.swift
@@ -1,0 +1,48 @@
+import AppKit
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+#if DEBUG
+@MainActor
+final class CmuxMainWindowFullScreenCapabilityTests: XCTestCase {
+    // cmux creates its main window programmatically and never loaded fullscreen
+    // capability from a nib, so it historically relied on AppKit *implicitly*
+    // granting `.fullScreenPrimary` to a resizable, titled window. That implicit
+    // grant is not reliable across macOS versions / display arrangements: on
+    // macOS 26 (Tahoe) a freshly-created CmuxMainWindow reports an empty
+    // collection behavior (`rawValue == 0`) and AppKit does NOT treat it as
+    // fullscreen-capable — so `toggleFullScreen(_:)`, ⌃⌘F, and the green
+    // traffic-light button all fail to enter a native fullscreen Space (the
+    // green button only zooms). See issue #5933.
+    //
+    // A CmuxMainWindow must therefore *declare* `.fullScreenPrimary` itself so
+    // native fullscreen is reachable regardless of the OS's implicit default.
+    func testMainWindowDeclaresFullScreenPrimaryCapability() {
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        XCTAssertTrue(
+            window.collectionBehavior.contains(.fullScreenPrimary),
+            "Main window must declare .fullScreenPrimary so native fullscreen is reachable"
+        )
+        XCTAssertFalse(
+            window.collectionBehavior.contains(.fullScreenNone),
+            "Main window must never carry .fullScreenNone, which suppresses native fullscreen"
+        )
+    }
+}
+#endif

--- a/cmuxTests/CmuxMainWindowFullScreenCapabilityTests.swift
+++ b/cmuxTests/CmuxMainWindowFullScreenCapabilityTests.swift
@@ -1,5 +1,5 @@
 import AppKit
-import XCTest
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -7,9 +7,9 @@ import XCTest
 @testable import cmux
 #endif
 
-#if DEBUG
 @MainActor
-final class CmuxMainWindowFullScreenCapabilityTests: XCTestCase {
+@Suite("CmuxMainWindow native fullscreen capability")
+struct CmuxMainWindowFullScreenCapabilityTests {
     // cmux creates its main window programmatically and never loaded fullscreen
     // capability from a nib, so it historically relied on AppKit *implicitly*
     // granting `.fullScreenPrimary` to a resizable, titled window. That implicit
@@ -22,7 +22,7 @@ final class CmuxMainWindowFullScreenCapabilityTests: XCTestCase {
     //
     // A CmuxMainWindow must therefore *declare* `.fullScreenPrimary` itself so
     // native fullscreen is reachable regardless of the OS's implicit default.
-    func testMainWindowDeclaresFullScreenPrimaryCapability() {
+    @Test func mainWindowDeclaresFullScreenPrimaryCapability() {
         let window = CmuxMainWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
@@ -35,12 +35,12 @@ final class CmuxMainWindowFullScreenCapabilityTests: XCTestCase {
             window.close()
         }
 
-        XCTAssertTrue(
+        #expect(
             window.collectionBehavior.contains(.fullScreenPrimary),
             "Main window must declare .fullScreenPrimary so native fullscreen is reachable"
         )
-        XCTAssertFalse(
-            window.collectionBehavior.contains(.fullScreenNone),
+        #expect(
+            !window.collectionBehavior.contains(.fullScreenNone),
             "Main window must never carry .fullScreenNone, which suppresses native fullscreen"
         )
     }
@@ -48,33 +48,32 @@ final class CmuxMainWindowFullScreenCapabilityTests: XCTestCase {
     // The capability decision is a pure, screen-agnostic transform so it runs
     // deterministically on CI regardless of the test host's display setup.
 
-    func testCanonicalBehaviorAddsFullScreenPrimaryToEmptyBehavior() {
+    @Test func canonicalBehaviorAddsFullScreenPrimaryToEmptyBehavior() {
         let result = CmuxMainWindow.canonicalCollectionBehavior([])
-        XCTAssertTrue(result.contains(.fullScreenPrimary))
-        XCTAssertFalse(result.contains(.fullScreenNone))
+        #expect(result.contains(.fullScreenPrimary))
+        #expect(!result.contains(.fullScreenNone))
     }
 
-    func testCanonicalBehaviorDropsStaleFullScreenNone() {
+    @Test func canonicalBehaviorDropsStaleFullScreenNone() {
         let result = CmuxMainWindow.canonicalCollectionBehavior([.fullScreenNone])
-        XCTAssertTrue(result.contains(.fullScreenPrimary))
-        XCTAssertFalse(result.contains(.fullScreenNone))
+        #expect(result.contains(.fullScreenPrimary))
+        #expect(!result.contains(.fullScreenNone))
     }
 
-    func testCanonicalBehaviorPreservesUnrelatedBehaviorBits() {
+    @Test func canonicalBehaviorPreservesUnrelatedBehaviorBits() {
         // The window factory may layer `.fullScreenDisallowsTiling` on top when
         // spawning out of an existing fullscreen Space; canonicalization must
         // not clobber that (or any other unrelated bit).
         let base: NSWindow.CollectionBehavior = [.fullScreenDisallowsTiling, .moveToActiveSpace]
         let result = CmuxMainWindow.canonicalCollectionBehavior(base)
-        XCTAssertTrue(result.contains(.fullScreenPrimary))
-        XCTAssertTrue(result.contains(.fullScreenDisallowsTiling))
-        XCTAssertTrue(result.contains(.moveToActiveSpace))
+        #expect(result.contains(.fullScreenPrimary))
+        #expect(result.contains(.fullScreenDisallowsTiling))
+        #expect(result.contains(.moveToActiveSpace))
     }
 
-    func testCanonicalBehaviorIsIdempotent() {
+    @Test func canonicalBehaviorIsIdempotent() {
         let once = CmuxMainWindow.canonicalCollectionBehavior([])
         let twice = CmuxMainWindow.canonicalCollectionBehavior(once)
-        XCTAssertEqual(once, twice)
+        #expect(once == twice)
     }
 }
-#endif


### PR DESCRIPTION
Fixes #5933.

## Problem

On macOS 26 (Tahoe), cmux's main window cannot enter native fullscreen by any route:

- Command Palette **Toggle Full Screen** → no-op
- **⌃⌘F** → no-op
- Green traffic-light button → only zooms/maximizes; never moves to its own fullscreen Space

All three entrypoints resolve the right `CmuxMainWindow` and call `toggleFullScreen(_:)`, so window targeting is fine. The symptom set (toggle is a no-op *and* the green button zooms instead of fullscreening) is the textbook signature of a window that is **not fullscreen-capable**.

## Root cause

`CmuxMainWindow` is created programmatically (never from a nib), so it cannot inherit fullscreen capability from Interface Builder. It never declared `.fullScreenPrimary` and relied on AppKit *implicitly* granting fullscreen to a resizable, titled window.

That implicit grant is not reliable across macOS versions. Verified empirically on macOS 26.5 (Tahoe): a window created with cmux's exact style mask (`[.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]`) reports `collectionBehavior.rawValue == 0` — i.e. it carries **none** of `.fullScreenPrimary` / `.fullScreenAuxiliary` / `.fullScreenNone`, and AppKit does not treat it as fullscreen-capable. This matches CLAUDE.md's standing warning that AppKit semantics change silently between macOS majors, so implicit defaults must not be assumed stable.

## Fix

Declare `.fullScreenPrimary` explicitly in `CmuxMainWindow`'s initializer, via a pure, unit-testable `canonicalCollectionBehavior(_:)` helper. The helper:

- inserts `.fullScreenPrimary` so native fullscreen is always reachable,
- strips any stale `.fullScreenNone` (mutually exclusive with primary),
- preserves unrelated bits, so it composes with the temporary `.fullScreenDisallowsTiling` opt-out the window factory layers on when spawning a window out of an existing fullscreen Space.

It is idempotent and a no-op where AppKit would have granted fullscreen anyway, so it cannot regress setups that already worked.

## Tests

Two-commit red/green:
1. **Commit 1** adds `CmuxMainWindowFullScreenCapabilityTests` (wired into `project.pbxproj`). The window-instantiation test fails on current code because the default collection behavior lacks `.fullScreenPrimary`.
2. **Commit 2** adds the fix, turning the test green, plus pure-function tests for the `canonicalCollectionBehavior(_:)` contract (adds primary, drops stale none, preserves unrelated bits, idempotent).

## Scope note: sleep/wake size shrink

The issue also mentions the window shrinking after display sleep/wake. The reporter is on **v0.64.14**; the sleep/wake reposition fix (#6305, `CmuxMainWindow.constrainFrameRect`) landed in **v0.64.17 / nightly** and is already on `main`, which lines up with the reporter's note that the bug "does not reproduce on NIGHTLY." This PR targets the fullscreen-capability defect, which is the part still present on `main` and is not addressed anywhere else. The fullscreen change is orthogonal to and composes with the existing constrain-frame logic.

## Localization

No user-facing strings added or changed — the "Toggle Full Screen" command and its `command.toggleFullScreen.*` strings already exist in `Localizable.xcstrings`. Change is window-capability code + tests + pbxproj wiring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785054189&installation_id=133855650&pr_number=6830&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6830&signature=4aec1ee17db4562b3496f2cd97f40352599d8d7445b6bf005acf82edf6e9f0de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the main window explicitly fullscreen-capable so native fullscreen works again via Toggle Full Screen, ⌃⌘F, and the green button on macOS 26 and multi-monitor setups. Fixes #5933.

- **Bug Fixes**
  - Add `canonicalCollectionBehavior(_:)` and apply it in `CmuxMainWindow` init to insert `.fullScreenPrimary`, remove `.fullScreenNone`, and preserve other behavior bits.
  - Add tests for fullscreen capability and the helper’s contract (adds primary, drops none, preserves bits, idempotent), now using Swift Testing (`@Suite`, `@Test`).

<sup>Written for commit 4199e20add70325ca599971afc01dff3d53fc190. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

