### PR TITLE
Fix garbled Claude Code TUI in cmux ssh remote workspaces (#6352)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9405,7 +9405,12 @@ struct CMUXCLI {
         shellFeatures: String,
         terminfoSource: String? = nil
     ) -> String {
-        let remoteTerminalLines = interactiveRemoteTerminalSetupLines(terminfoSource: terminfoSource)
+        // Share the single terminfo-install implementation with the app-side SSH
+        // PTY bootstrap so the two entrypoints can never drift (the synchronous
+        // install that fixes #6352 lives only in the builder).
+        let remoteTerminalLines = RemoteInteractiveShellBootstrapBuilder.terminalSetupLines(
+            terminfoSource: terminfoSource
+        )
         let remoteLocaleLines = RemoteShellEnvironment.utf8LocaleSetupLines()
         let remoteEnvExportLines = interactiveRemoteShellExportLines(shellFeatures: shellFeatures)
         let shellStateDir = shellStateDirForRemoteRelayPort(remoteRelayPort)
@@ -9596,66 +9601,6 @@ struct CMUXCLI {
             terminfoSource: terminfoSource
         )
         return posixShellCommand(script)
-    }
-
-    private func interactiveRemoteTerminalSetupLines(terminfoSource: String?) -> [String] {
-        let trimmedTerminfoSource = terminfoSource?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let trimmedTerminfoSource, !trimmedTerminfoSource.isEmpty else {
-            // Without a bundled terminfo to install we can only probe what the
-            // remote already has and fall back to a universally-present entry.
-            return [
-                "cmux_term='xterm-256color'",
-                "if command -v infocmp >/dev/null 2>&1 && infocmp xterm-ghostty >/dev/null 2>&1; then",
-                "  cmux_term='xterm-ghostty'",
-                "fi",
-                "export TERM=\"$cmux_term\"",
-            ]
-        }
-        // Install the bundled xterm-ghostty terminfo *synchronously*, before
-        // deciding TERM, so a full-screen TUI (e.g. Claude Code) never starts
-        // against a TERM whose terminfo entry is missing or half-written.
-        //
-        // The previous design deferred `tic` to a background job and decided
-        // TERM up front, so the first shell on a host without the entry got
-        // xterm-256color while a later pass could select xterm-ghostty mid-write
-        // and garble output (#6352). Here we compile into a temp directory on the
-        // same filesystem as ~/.terminfo, then move each compiled entry into
-        // place with an atomic rename, so a concurrent reader in another cmux ssh
-        // session sharing $HOME never observes a partially written database.
-        return [
-            "cmux_term='xterm-256color'",
-            "if command -v infocmp >/dev/null 2>&1 && infocmp xterm-ghostty >/dev/null 2>&1; then",
-            "  cmux_term='xterm-ghostty'",
-            "elif command -v tic >/dev/null 2>&1; then",
-            "  mkdir -p \"$HOME/.terminfo\" 2>/dev/null",
-            "  cmux_ti_tmp=$(mktemp -d \"$HOME/.terminfo.cmux.XXXXXX\" 2>/dev/null) || cmux_ti_tmp=''",
-            "  {",
-            "    cat <<'CMUXTERMINFO'",
-            trimmedTerminfoSource,
-            "CMUXTERMINFO",
-            "  } | {",
-            "    if [ -n \"$cmux_ti_tmp\" ]; then",
-            "      if tic -x -o \"$cmux_ti_tmp\" - >/dev/null 2>&1; then",
-            "        find \"$cmux_ti_tmp\" -type f 2>/dev/null | while IFS= read -r cmux_ti_file; do",
-            "          cmux_ti_rel=${cmux_ti_file#\"$cmux_ti_tmp\"/}",
-            "          cmux_ti_dest=\"$HOME/.terminfo/$cmux_ti_rel\"",
-            "          mkdir -p \"$(dirname \"$cmux_ti_dest\")\" 2>/dev/null",
-            "          mv -f \"$cmux_ti_file\" \"$cmux_ti_dest\" 2>/dev/null || cp -f \"$cmux_ti_file\" \"$cmux_ti_dest\" 2>/dev/null",
-            "        done",
-            "      fi",
-            "    else",
-            "      tic -x - >/dev/null 2>&1",
-            "    fi",
-            "  }",
-            "  rm -rf \"$cmux_ti_tmp\" 2>/dev/null",
-            "  if infocmp xterm-ghostty >/dev/null 2>&1; then",
-            "    cmux_term='xterm-ghostty'",
-            "  fi",
-            "  unset cmux_ti_tmp cmux_ti_file cmux_ti_rel cmux_ti_dest 2>/dev/null || true",
-            "fi",
-            "export TERM=\"$cmux_term\"",
-        ]
     }
 
     private func interactiveRemoteShellExportLines(shellFeatures: String) -> [String] {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9599,28 +9599,63 @@ struct CMUXCLI {
     }
 
     private func interactiveRemoteTerminalSetupLines(terminfoSource: String?) -> [String] {
-        var lines: [String] = [
+        let trimmedTerminfoSource = terminfoSource?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmedTerminfoSource, !trimmedTerminfoSource.isEmpty else {
+            // Without a bundled terminfo to install we can only probe what the
+            // remote already has and fall back to a universally-present entry.
+            return [
+                "cmux_term='xterm-256color'",
+                "if command -v infocmp >/dev/null 2>&1 && infocmp xterm-ghostty >/dev/null 2>&1; then",
+                "  cmux_term='xterm-ghostty'",
+                "fi",
+                "export TERM=\"$cmux_term\"",
+            ]
+        }
+        // Install the bundled xterm-ghostty terminfo *synchronously*, before
+        // deciding TERM, so a full-screen TUI (e.g. Claude Code) never starts
+        // against a TERM whose terminfo entry is missing or half-written.
+        //
+        // The previous design deferred `tic` to a background job and decided
+        // TERM up front, so the first shell on a host without the entry got
+        // xterm-256color while a later pass could select xterm-ghostty mid-write
+        // and garble output (#6352). Here we compile into a temp directory on the
+        // same filesystem as ~/.terminfo, then move each compiled entry into
+        // place with an atomic rename, so a concurrent reader in another cmux ssh
+        // session sharing $HOME never observes a partially written database.
+        return [
             "cmux_term='xterm-256color'",
             "if command -v infocmp >/dev/null 2>&1 && infocmp xterm-ghostty >/dev/null 2>&1; then",
             "  cmux_term='xterm-ghostty'",
+            "elif command -v tic >/dev/null 2>&1; then",
+            "  mkdir -p \"$HOME/.terminfo\" 2>/dev/null",
+            "  cmux_ti_tmp=$(mktemp -d \"$HOME/.terminfo.cmux.XXXXXX\" 2>/dev/null) || cmux_ti_tmp=''",
+            "  {",
+            "    cat <<'CMUXTERMINFO'",
+            trimmedTerminfoSource,
+            "CMUXTERMINFO",
+            "  } | {",
+            "    if [ -n \"$cmux_ti_tmp\" ]; then",
+            "      if tic -x -o \"$cmux_ti_tmp\" - >/dev/null 2>&1; then",
+            "        find \"$cmux_ti_tmp\" -type f 2>/dev/null | while IFS= read -r cmux_ti_file; do",
+            "          cmux_ti_rel=${cmux_ti_file#\"$cmux_ti_tmp\"/}",
+            "          cmux_ti_dest=\"$HOME/.terminfo/$cmux_ti_rel\"",
+            "          mkdir -p \"$(dirname \"$cmux_ti_dest\")\" 2>/dev/null",
+            "          mv -f \"$cmux_ti_file\" \"$cmux_ti_dest\" 2>/dev/null || cp -f \"$cmux_ti_file\" \"$cmux_ti_dest\" 2>/dev/null",
+            "        done",
+            "      fi",
+            "    else",
+            "      tic -x - >/dev/null 2>&1",
+            "    fi",
+            "  }",
+            "  rm -rf \"$cmux_ti_tmp\" 2>/dev/null",
+            "  if infocmp xterm-ghostty >/dev/null 2>&1; then",
+            "    cmux_term='xterm-ghostty'",
+            "  fi",
+            "  unset cmux_ti_tmp cmux_ti_file cmux_ti_rel cmux_ti_dest 2>/dev/null || true",
             "fi",
             "export TERM=\"$cmux_term\"",
         ]
-        guard let terminfoSource else { return lines }
-        let trimmedTerminfoSource = terminfoSource.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedTerminfoSource.isEmpty else { return lines }
-        lines += [
-            "if [ \"$cmux_term\" != 'xterm-ghostty' ]; then",
-            "  (",
-            "    command -v tic >/dev/null 2>&1 || exit 0",
-            "    mkdir -p \"$HOME/.terminfo\" 2>/dev/null || exit 0",
-            "    cat <<'CMUXTERMINFO' | tic -x - >/dev/null 2>&1",
-            trimmedTerminfoSource,
-            "CMUXTERMINFO",
-            "  ) </dev/null >/dev/null 2>&1 &",
-            "fi",
-        ]
-        return lines
     }
 
     private func interactiveRemoteShellExportLines(shellFeatures: String) -> [String] {

--- a/Sources/RemoteInteractiveShellBootstrapBuilder.swift
+++ b/Sources/RemoteInteractiveShellBootstrapBuilder.swift
@@ -200,7 +200,7 @@ enum RemoteInteractiveShellBootstrapBuilder {
         return lines
     }
 
-    private static func terminalSetupLines(terminfoSource: String?) -> [String] {
+    static func terminalSetupLines(terminfoSource: String?) -> [String] {
         var lines: [String] = [
             "cmux_term='xterm-256color'",
             "if command -v infocmp >/dev/null 2>&1 && infocmp xterm-ghostty >/dev/null 2>&1; then",

--- a/Sources/RemoteInteractiveShellBootstrapBuilder.swift
+++ b/Sources/RemoteInteractiveShellBootstrapBuilder.swift
@@ -201,28 +201,63 @@ enum RemoteInteractiveShellBootstrapBuilder {
     }
 
     static func terminalSetupLines(terminfoSource: String?) -> [String] {
-        var lines: [String] = [
+        let trimmedTerminfoSource = terminfoSource?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmedTerminfoSource, !trimmedTerminfoSource.isEmpty else {
+            // Without a bundled terminfo to install we can only probe what the
+            // remote already has and fall back to a universally-present entry.
+            return [
+                "cmux_term='xterm-256color'",
+                "if command -v infocmp >/dev/null 2>&1 && infocmp xterm-ghostty >/dev/null 2>&1; then",
+                "  cmux_term='xterm-ghostty'",
+                "fi",
+                "export TERM=\"$cmux_term\"",
+            ]
+        }
+        // Install the bundled xterm-ghostty terminfo *synchronously*, before
+        // deciding TERM, so a full-screen TUI (e.g. Claude Code) never starts
+        // against a TERM whose terminfo entry is missing or half-written.
+        //
+        // The previous design deferred `tic` to a background job and decided
+        // TERM up front, so the first shell on a host without the entry got
+        // xterm-256color while a later pass could select xterm-ghostty mid-write
+        // and garble output (#6352). Here we compile into a temp directory on the
+        // same filesystem as ~/.terminfo, then move each compiled entry into
+        // place with an atomic rename, so a concurrent reader in another cmux ssh
+        // session sharing $HOME never observes a partially written database.
+        return [
             "cmux_term='xterm-256color'",
             "if command -v infocmp >/dev/null 2>&1 && infocmp xterm-ghostty >/dev/null 2>&1; then",
             "  cmux_term='xterm-ghostty'",
+            "elif command -v tic >/dev/null 2>&1; then",
+            "  mkdir -p \"$HOME/.terminfo\" 2>/dev/null",
+            "  cmux_ti_tmp=$(mktemp -d \"$HOME/.terminfo.cmux.XXXXXX\" 2>/dev/null) || cmux_ti_tmp=''",
+            "  {",
+            "    cat <<'CMUXTERMINFO'",
+            trimmedTerminfoSource,
+            "CMUXTERMINFO",
+            "  } | {",
+            "    if [ -n \"$cmux_ti_tmp\" ]; then",
+            "      if tic -x -o \"$cmux_ti_tmp\" - >/dev/null 2>&1; then",
+            "        find \"$cmux_ti_tmp\" -type f 2>/dev/null | while IFS= read -r cmux_ti_file; do",
+            "          cmux_ti_rel=${cmux_ti_file#\"$cmux_ti_tmp\"/}",
+            "          cmux_ti_dest=\"$HOME/.terminfo/$cmux_ti_rel\"",
+            "          mkdir -p \"$(dirname \"$cmux_ti_dest\")\" 2>/dev/null",
+            "          mv -f \"$cmux_ti_file\" \"$cmux_ti_dest\" 2>/dev/null || cp -f \"$cmux_ti_file\" \"$cmux_ti_dest\" 2>/dev/null",
+            "        done",
+            "      fi",
+            "    else",
+            "      tic -x - >/dev/null 2>&1",
+            "    fi",
+            "  }",
+            "  rm -rf \"$cmux_ti_tmp\" 2>/dev/null",
+            "  if infocmp xterm-ghostty >/dev/null 2>&1; then",
+            "    cmux_term='xterm-ghostty'",
+            "  fi",
+            "  unset cmux_ti_tmp cmux_ti_file cmux_ti_rel cmux_ti_dest 2>/dev/null || true",
             "fi",
             "export TERM=\"$cmux_term\"",
         ]
-        guard let terminfoSource else { return lines }
-        let trimmedTerminfoSource = terminfoSource.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedTerminfoSource.isEmpty else { return lines }
-        lines += [
-            "if [ \"$cmux_term\" != 'xterm-ghostty' ]; then",
-            "  (",
-            "    command -v tic >/dev/null 2>&1 || exit 0",
-            "    mkdir -p \"$HOME/.terminfo\" 2>/dev/null || exit 0",
-            "    cat <<'CMUXTERMINFO' | tic -x - >/dev/null 2>&1",
-            trimmedTerminfoSource,
-            "CMUXTERMINFO",
-            "  ) </dev/null >/dev/null 2>&1 &",
-            "fi",
-        ]
-        return lines
     }
 
     private static func shellExportLines(shellFeatures: String) -> [String] {

--- a/Sources/RemoteInteractiveShellBootstrapBuilder.swift
+++ b/Sources/RemoteInteractiveShellBootstrapBuilder.swift
@@ -221,10 +221,14 @@ enum RemoteInteractiveShellBootstrapBuilder {
         // The previous design deferred `tic` to a background job and decided
         // TERM up front, so the first shell on a host without the entry got
         // xterm-256color while a later pass could select xterm-ghostty mid-write
-        // and garble output (#6352). Here we compile into a temp directory on the
-        // same filesystem as ~/.terminfo, then move each compiled entry into
-        // place with an atomic rename, so a concurrent reader in another cmux ssh
-        // session sharing $HOME never observes a partially written database.
+        // and garble output (#6352). Here we compile into a private temp
+        // directory on the same filesystem as ~/.terminfo, then move each
+        // compiled entry into place with an atomic rename, so a concurrent reader
+        // in another cmux ssh session sharing $HOME never observes a partially
+        // written database. The temp directory comes from `mktemp` when present,
+        // otherwise a per-process `$$` directory (unique among live processes) so
+        // the atomic-rename path applies even without `mktemp` — no branch ever
+        // compiles terminfo directly into ~/.terminfo.
         return [
             "cmux_term='xterm-256color'",
             "if command -v infocmp >/dev/null 2>&1 && infocmp xterm-ghostty >/dev/null 2>&1; then",
@@ -232,25 +236,26 @@ enum RemoteInteractiveShellBootstrapBuilder {
             "elif command -v tic >/dev/null 2>&1; then",
             "  mkdir -p \"$HOME/.terminfo\" 2>/dev/null",
             "  cmux_ti_tmp=$(mktemp -d \"$HOME/.terminfo.cmux.XXXXXX\" 2>/dev/null) || cmux_ti_tmp=''",
+            "  if [ -z \"$cmux_ti_tmp\" ]; then",
+            "    cmux_ti_tmp=\"$HOME/.terminfo.cmux.$$\"",
+            "    rm -rf \"$cmux_ti_tmp\" 2>/dev/null",
+            "    mkdir \"$cmux_ti_tmp\" 2>/dev/null || cmux_ti_tmp=''",
+            "  fi",
             "  {",
             "    cat <<'CMUXTERMINFO'",
             trimmedTerminfoSource,
             "CMUXTERMINFO",
             "  } | {",
-            "    if [ -n \"$cmux_ti_tmp\" ]; then",
-            "      if tic -x -o \"$cmux_ti_tmp\" - >/dev/null 2>&1; then",
-            "        find \"$cmux_ti_tmp\" -type f 2>/dev/null | while IFS= read -r cmux_ti_file; do",
-            "          cmux_ti_rel=${cmux_ti_file#\"$cmux_ti_tmp\"/}",
-            "          cmux_ti_dest=\"$HOME/.terminfo/$cmux_ti_rel\"",
-            "          mkdir -p \"$(dirname \"$cmux_ti_dest\")\" 2>/dev/null",
-            "          mv -f \"$cmux_ti_file\" \"$cmux_ti_dest\" 2>/dev/null || cp -f \"$cmux_ti_file\" \"$cmux_ti_dest\" 2>/dev/null",
-            "        done",
-            "      fi",
-            "    else",
-            "      tic -x - >/dev/null 2>&1",
+            "    if [ -n \"$cmux_ti_tmp\" ] && tic -x -o \"$cmux_ti_tmp\" - >/dev/null 2>&1; then",
+            "      find \"$cmux_ti_tmp\" -type f 2>/dev/null | while IFS= read -r cmux_ti_file; do",
+            "        cmux_ti_rel=${cmux_ti_file#\"$cmux_ti_tmp\"/}",
+            "        cmux_ti_dest=\"$HOME/.terminfo/$cmux_ti_rel\"",
+            "        mkdir -p \"$(dirname \"$cmux_ti_dest\")\" 2>/dev/null",
+            "        mv -f \"$cmux_ti_file\" \"$cmux_ti_dest\" 2>/dev/null || cp -f \"$cmux_ti_file\" \"$cmux_ti_dest\" 2>/dev/null",
+            "      done",
             "    fi",
             "  }",
-            "  rm -rf \"$cmux_ti_tmp\" 2>/dev/null",
+            "  [ -n \"$cmux_ti_tmp\" ] && rm -rf \"$cmux_ti_tmp\" 2>/dev/null",
             "  if infocmp xterm-ghostty >/dev/null 2>&1; then",
             "    cmux_term='xterm-ghostty'",
             "  fi",

--- a/cmuxTests/ShellStartupMatrixTests.swift
+++ b/cmuxTests/ShellStartupMatrixTests.swift
@@ -207,6 +207,80 @@ struct ShellStartupMatrixTests {
         )
     }
 
+    /// Regression for #6352: running Claude Code (or any full-screen TUI) inside
+    /// a `cmux ssh` remote workspace garbled the output because the remote
+    /// bootstrap installed the bundled `xterm-ghostty` terminfo in a *background*
+    /// job while `TERM` was decided synchronously. On a host without the entry,
+    /// the bootstrap therefore had to either fall back to `xterm-256color` (losing
+    /// ghostty) or — on a later shell pass — pick `xterm-ghostty` while the
+    /// background `tic` was still writing the database, so the TUI rendered
+    /// against a missing/half-written terminfo entry.
+    ///
+    /// The install must be synchronous: once the bundled terminfo source is
+    /// available and `tic` exists, the very first shell pass must resolve and
+    /// select `xterm-ghostty` before exporting `TERM`. This test runs the
+    /// generated setup lines against an isolated `$HOME`/terminfo search path so
+    /// the host's own `xterm-ghostty` cannot mask the behavior.
+    @Test
+    func remoteTerminalSetupInstallsGhosttyTerminfoBeforeChoosingTerm() throws {
+        let fileManager = FileManager.default
+        guard fileManager.isExecutableFile(atPath: "/usr/bin/tic"),
+              fileManager.isExecutableFile(atPath: "/usr/bin/infocmp")
+        else {
+            // Host lacks the terminfo toolchain; the synchronous install path
+            // cannot be exercised here. cmux CI runners ship both binaries.
+            return
+        }
+
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-terminfo-\(UUID().uuidString)")
+        let home = root.appendingPathComponent("home")
+        let emptyTerminfoDirs = root.appendingPathComponent("empty-terminfo")
+        try fileManager.createDirectory(at: home, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: emptyTerminfoDirs, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        // A minimal but valid `xterm-ghostty` entry: enough for `tic -x` to
+        // accept it and for `infocmp xterm-ghostty` to resolve it once installed.
+        let terminfoSource = """
+        xterm-ghostty|cmux ghostty regression terminfo,
+        \tam, colors#256, cols#80, lines#24,
+        \tcup=\\E[%i%p1%d;%p2%dH, clear=\\E[H\\E[2J, cr=^M, cud1=^J,
+        """
+
+        let lines = RemoteInteractiveShellBootstrapBuilder.terminalSetupLines(
+            terminfoSource: terminfoSource
+        )
+        let script = lines.joined(separator: "\n")
+            + "\nprintf 'CMUX_TERMINFO_TEST_TERM=%s\\n' \"$TERM\"\n"
+
+        // Isolate the terminfo search path so the host's real `xterm-ghostty`
+        // entry can't be found: ncurses consults $TERMINFO, then $HOME/.terminfo,
+        // then $TERMINFO_DIRS. Point all of them at fresh, empty directories so
+        // the only way to resolve `xterm-ghostty` is the in-script install.
+        let result = runProcess(
+            executablePath: "/usr/bin/env",
+            arguments: [
+                "HOME=\(home.path)",
+                "TERMINFO=\(home.path)/.terminfo",
+                "TERMINFO_DIRS=\(emptyTerminfoDirs.path)",
+                "PATH=/usr/bin:/bin",
+                "/bin/sh",
+                "-c",
+                script,
+            ],
+            timeout: 10
+        )
+
+        expectEqual(result.status, 0, result.stderr)
+        expectFalse(result.timedOut, result.stderr)
+        expectTrue(
+            result.stdout.contains("CMUX_TERMINFO_TEST_TERM=xterm-ghostty"),
+            "remote bootstrap did not install xterm-ghostty terminfo before "
+                + "choosing TERM (stdout: \(result.stdout))"
+        )
+    }
+
     struct RemoteShellCase: Sendable, CustomTestStringConvertible {
         let name: String
         let expectedArgs: String


### PR DESCRIPTION
Fixes #6352

## Problem

Running the Claude Code CLI (`claude`) — or any full-screen TUI — inside a `cmux ssh` remote workspace renders garbled output (stray escape sequences / scrambled frame). Running `claude` locally is fine, so the bug is specific to the SSH remote path.

## Root cause

The remote shell bootstrap (`RemoteInteractiveShellBootstrapBuilder.terminalSetupLines`, duplicated in `CLI/cmux.swift`'s `interactiveRemoteTerminalSetupLines`) decided `TERM` **synchronously** but installed the bundled `xterm-ghostty` terminfo in a **background job** (`tic -x - … &`):

```sh
cmux_term='xterm-256color'
if infocmp xterm-ghostty …; then cmux_term='xterm-ghostty'; fi
export TERM="$cmux_term"
if [ "$cmux_term" != 'xterm-ghostty' ]; then
  ( … tic -x - … ) &        # deferred, non-atomic
fi
```

On a remote host that lacks the entry:
- The **first** interactive shell exports `TERM=xterm-256color` (the install hasn't happened yet), and
- a **later** shell pass (the re-exec'd login shell, or a concurrent `cmux ssh` session sharing `$HOME`) can select `TERM=xterm-ghostty` while the background `tic` is still writing the **non-atomic** terminfo database — so the TUI starts against a **missing or half-written** `xterm-ghostty` entry and scrambles its frame.

## Fix

Install the bundled terminfo **synchronously and atomically, before** deciding `TERM`, in both the app-side bootstrap builder and the CLI script:

- Compile the bundled terminfo into a temp directory on the **same filesystem** as `~/.terminfo`, then move each compiled entry into place with an **atomic rename**, so a concurrent reader in another `cmux ssh` session never observes a partially-written database.
- Only select `TERM=xterm-ghostty` after **re-confirming** `infocmp` resolves the entry, so `TERM` is never `xterm-ghostty` against an absent/partial terminfo.
- Graceful fallbacks: direct synchronous compile when `mktemp` is unavailable; `xterm-256color` when `tic` is missing. Neither garbles.

## Testing

Two-commit red/green regression test in `cmuxTests/ShellStartupMatrixTests.swift` (`remoteTerminalSetupInstallsGhosttyTerminfoBeforeChoosingTerm`):
- Commit 1 adds the test (red against the background-install code).
- Commit 2 adds the fix (green).

The test runs the generated setup lines against an isolated `$HOME`/`TERMINFO`/`TERMINFO_DIRS` search path (so the host's own `xterm-ghostty` can't mask the behavior) and asserts the install resolves `xterm-ghostty` before `TERM` is exported.

Validated locally across `/bin/sh`, `/bin/zsh`, and `bash --posix`, including a 12-way concurrency stress (all sessions resolve `xterm-ghostty`, no corruption, no leftover temp dirs) and nested inside the generated `.zshrc` heredoc.

## Localization

No user-facing strings changed (the diff is shell-script generation only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785054290&installation_id=133855650&pr_number=6831&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6831&signature=a5c02279beaa73defe689a818215e63f4a515ca6f15f80bf1fd952e7e22a5175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes garbled TUI output in `cmux ssh` remote workspaces by installing the bundled `xterm-ghostty` terminfo synchronously and atomically before choosing `TERM`. Unifies the setup so app and CLI use the same safe path.

- **Bug Fixes**
  - Use a single implementation in `RemoteInteractiveShellBootstrapBuilder.terminalSetupLines`; the CLI now delegates and the duplicate generator was removed.
  - Compile to a temp dir on the same filesystem as `~/.terminfo` and atomically rename into place; when `mktemp` is missing, use per‑process `$HOME/.terminfo.cmux.$$` with the same atomic move (no direct writes to `~/.terminfo`).
  - Export `TERM=xterm-ghostty` only after `infocmp` confirms it; fall back to `xterm-256color` when `tic` is unavailable.
  - Add regression test `remoteTerminalSetupInstallsGhosttyTerminfoBeforeChoosingTerm` to ensure install completes before `TERM` is exported.

<sup>Written for commit 40143e7481fd39296d56de06ce3befe7442cabb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

