### PR TITLE
Guard workspace sidebar LazyVStack against layout re-livelock (#6384)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,9 @@ jobs:
       - name: Validate bash shell integration job control
         run: python3 tests/test_bash_integration_no_done_notifications.py
 
+      - name: Validate sidebar lazy-layout guard
+        run: python3 tests/test_ci_sidebar_lazy_layout_guard.py
+
       - name: Validate bash prompt bootstrap composes with user PROMPT_COMMAND (starship)
         run: python3 tests/test_issue_5164_starship_prompt_composition.py
 

--- a/scripts/check-sidebar-lazy-layout.py
+++ b/scripts/check-sidebar-lazy-layout.py
@@ -102,7 +102,7 @@ def neutralize_swift(source):
     out = []
     i = 0
     n = len(source)
-    LINE_COMMENT, BLOCK_COMMENT, STRING = 1, 2, 3
+    LINE_COMMENT, BLOCK_COMMENT, STRING, MULTILINE_STRING = 1, 2, 3, 4
     state = 0
     while i < n:
         ch = source[i]
@@ -117,6 +117,16 @@ def neutralize_swift(source):
                 out.append("  ")
                 i += 2
                 state = BLOCK_COMMENT
+                continue
+            if source[i:i + 3] == '"""':
+                # Swift multi-line string literal: only a closing `"""` ends it,
+                # so a bare `"` inside must NOT toggle string state -- otherwise
+                # the inner quote would close the literal early and expose the
+                # rest (e.g. a forbidden token named in prose) as apparent code,
+                # tripping the guard with a false positive. (#6870 review)
+                out.append('"""')
+                i += 3
+                state = MULTILINE_STRING
                 continue
             if ch == '"':
                 out.append('"')
@@ -154,6 +164,16 @@ def neutralize_swift(source):
                 i += 1
                 state = 0
                 continue
+            out.append("\n" if ch == "\n" else " ")
+            i += 1
+            continue
+        if state == MULTILINE_STRING:
+            if source[i:i + 3] == '"""':
+                out.append('"""')
+                i += 3
+                state = 0
+                continue
+            # A lone `"` does not close a multi-line string; only `"""` does.
             out.append("\n" if ch == "\n" else " ")
             i += 1
             continue

--- a/scripts/check-sidebar-lazy-layout.py
+++ b/scripts/check-sidebar-lazy-layout.py
@@ -26,8 +26,10 @@ steady-state scroll layout in `Sources/ContentView.swift`
 (`workspaceScrollContent` and `workspaceRows`) and fails if either:
 
   1. reintroduces a whole-list measurement signature
-     (`GeometryReader`, `ProposedViewSize(... nil ...)`, `.sizeThatFits(`, or
-     the deleted `SidebarRowsFillLayout`), or
+     (`GeometryReader`, `ProposedViewSize(... nil ...)`, `.sizeThatFits(`, the
+     deleted `SidebarRowsFillLayout`, or ANY custom `Layout`-conforming type
+     discovered in the codebase being applied to the rows -- so renaming the
+     force-measuring layout does not dodge the guard), or
   2. drops one of the lazy-fill primitives the fix relies on
      (`LazyVStack(` in `workspaceRows`, `.frame(minHeight:` in
      `workspaceScrollContent`).
@@ -52,6 +54,7 @@ Exit codes:
 """
 
 import argparse
+import glob
 import os
 import re
 import sys
@@ -75,6 +78,17 @@ FORBIDDEN_PATTERNS = (
     (re.compile(r"\bProposedViewSize\s*\([^)]*\bnil\b"),
      "ProposedViewSize(..., nil) (proposing nil on an axis asks the LazyVStack "
      "for its natural size, realizing every row -- the #6210 force-measure)"),
+)
+
+# Declaration of a type conforming to SwiftUI's `Layout` protocol. A custom
+# Layout applied to the sidebar rows is the #6033/#6210 force-measure shape no
+# matter what the type is named, so the guard discovers every such type in the
+# codebase and bans ALL of their names from the guarded functions -- not just the
+# literal `SidebarRowsFillLayout`. This closes the "rename the layout to dodge the
+# guard" bypass (#6870 review).
+CUSTOM_LAYOUT_DECL = re.compile(
+    r"\b(?:struct|final\s+class|class|enum|extension)\s+([A-Z]\w*)\b[^{]*?\bLayout\b[^{]*?\{",
+    re.DOTALL,
 )
 
 # Lazy-fill primitives the #6188 fix depends on. Each must remain present in the
@@ -228,8 +242,36 @@ def extract_function_body(neutralized, func_name):
     return None
 
 
-def check_source(source):
+def find_custom_layout_type_names(paths):
+    """Return the set of type names conforming to SwiftUI's `Layout` protocol
+    across ``paths`` (comment/string-neutralized so a `: Layout` in prose is not
+    counted). Cheap-filtered to files that mention ``Layout`` at all.
+    """
+    names = set()
+    seen = set()
+    for path in paths:
+        try:
+            real = os.path.realpath(path)
+        except OSError:
+            continue
+        if real in seen:
+            continue
+        seen.add(real)
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                text = handle.read()
+        except OSError:
+            continue
+        if "Layout" not in text:
+            continue
+        for match in CUSTOM_LAYOUT_DECL.finditer(neutralize_swift(text)):
+            names.add(match.group(1))
+    return names
+
+
+def check_source(source, custom_layout_names=None):
     """Return a list of human-readable violation strings (empty == clean)."""
+    custom_layout_names = custom_layout_names or set()
     neutralized = neutralize_swift(source)
     violations = []
     bodies = {}
@@ -250,6 +292,20 @@ def check_source(source):
                 violations.append(
                     "{0}(...) reintroduces a forbidden whole-list measurement: "
                     "{1}".format(func_name, description)
+                )
+        # A custom Layout (under ANY name) applied to the rows wraps the
+        # LazyVStack and measures it every pass -- the #6210 shape. Banning the
+        # whole discovered set, not just the deleted name, blocks the rename
+        # dodge (#6870 review).
+        for name in sorted(custom_layout_names):
+            if re.search(r"\b" + re.escape(name) + r"\b", body):
+                violations.append(
+                    "{0}(...) applies the custom Layout `{1}` to the sidebar rows. "
+                    "A custom Layout wrapping the LazyVStack measures it on every "
+                    "pass (the #6210 force-measure shape, regardless of the type's "
+                    "name); size the rows with .frame(minHeight:) instead.".format(
+                        func_name, name
+                    )
                 )
 
     for func_name, pattern, description in REQUIRED_PRIMITIVES:
@@ -289,7 +345,19 @@ def main(argv=None):
               file=sys.stderr)
         return 1
 
-    violations = check_source(source)
+    # Discover custom Layout type names from the target file plus the whole
+    # Sources/ tree, so a renamed force-measuring layout defined in any file is
+    # still banned from the guarded functions.
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    layout_scan_paths = [target]
+    sources_dir = os.path.join(repo_root, "Sources")
+    if os.path.isdir(sources_dir):
+        layout_scan_paths.extend(
+            sorted(glob.glob(os.path.join(sources_dir, "**", "*.swift"), recursive=True))
+        )
+    custom_layout_names = find_custom_layout_type_names(layout_scan_paths)
+
+    violations = check_source(source, custom_layout_names)
     if violations:
         print("check-sidebar-lazy-layout: FAILED for {0}".format(target), file=sys.stderr)
         for violation in violations:

--- a/scripts/check-sidebar-lazy-layout.py
+++ b/scripts/check-sidebar-lazy-layout.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Regression guard for the workspace-sidebar lazy-layout contract.
+
+The workspace sidebar renders its rows as a `LazyVStack` inside a vertical
+`ScrollView`. Keeping that stack lazy at *measure time* is load-bearing: the
+sidebar is re-diffed on every workspace/telemetry update, so any code that
+forces SwiftUI to realize and measure the whole row list on each layout pass
+turns a routine update into a multi-second `GraphHost.flushTransactions()`
+main-thread livelock once enough workspaces/surfaces are open.
+
+This exact class of bug has regressed four times:
+
+  * #2586  GeometryReader + PreferenceKey -> @State height feedback loop
+  * #5764  per-row String id allocation in the ForEach diff
+  * #5845  same livelock family, reintroduced
+  * #6033 -> #6210  `SidebarRowsFillLayout`, a custom `Layout` that called
+           `subview.sizeThatFits(ProposedViewSize(width:, height: nil))` on the
+           `LazyVStack` in both `sizeThatFits` and `placeSubviews`, realizing
+           every row each pass. Removed in #6188.
+
+  * #6384  the user-reported ~1s beachball that #6188 fixed.
+
+Until now the contract was defended only by inline comments, which CI cannot
+enforce. This guard scans the two functions that define the sidebar's
+steady-state scroll layout in `Sources/ContentView.swift`
+(`workspaceScrollContent` and `workspaceRows`) and fails if either:
+
+  1. reintroduces a whole-list measurement signature
+     (`GeometryReader`, `ProposedViewSize(... nil ...)`, `.sizeThatFits(`, or
+     the deleted `SidebarRowsFillLayout`), or
+  2. drops one of the lazy-fill primitives the fix relies on
+     (`LazyVStack(` in `workspaceRows`, `.frame(minHeight:` in
+     `workspaceScrollContent`).
+
+Comments and string literals are neutralized before scanning, so the historical
+explanatory comments in those functions (which deliberately name the very
+anti-patterns this guard forbids) do not trip it.
+
+The drag-only drop-target reader (`rowsWithGatedDropTargetReader`) is *not*
+scanned: it intentionally uses a `GeometryReader` to resolve per-row drop
+anchors and is gated behind an active drag (#5325), so it never runs during the
+steady-state layout this guard protects.
+
+Usage:
+    scripts/check-sidebar-lazy-layout.py [--file PATH]
+
+Exit codes:
+    0  the scanned file satisfies the lazy-layout contract
+    1  an anti-pattern was found, a required primitive is missing, or one of the
+       guarded functions could not be located (treated as a failure so the guard
+       cannot silently rot into a no-op when the code is renamed).
+"""
+
+import argparse
+import os
+import re
+import sys
+
+# Functions that define the sidebar's steady-state scroll layout. Both must
+# exist; a rename should fail the guard loudly rather than silently skip.
+GUARDED_FUNCTIONS = ("workspaceScrollContent", "workspaceRows")
+
+# Tokens that mean "the whole row list is being measured/realized on every
+# layout pass" if they appear in the guarded functions' code (not comments).
+FORBIDDEN_PATTERNS = (
+    (re.compile(r"\bGeometryReader\b"),
+     "GeometryReader (reading the rows' size feeds the #2586 layout feedback "
+     "loop / forces row realization at measure time)"),
+    (re.compile(r"\bSidebarRowsFillLayout\b"),
+     "SidebarRowsFillLayout (the custom Layout removed in #6188 that "
+     "force-measured the LazyVStack every pass; do not reintroduce it)"),
+    (re.compile(r"\.sizeThatFits\s*\("),
+     "manual .sizeThatFits( call (measuring a subview by hand realizes the "
+     "lazy rows; let SwiftUI size the stack)"),
+    (re.compile(r"\bProposedViewSize\s*\([^)]*\bnil\b"),
+     "ProposedViewSize(..., nil) (proposing nil on an axis asks the LazyVStack "
+     "for its natural size, realizing every row -- the #6210 force-measure)"),
+)
+
+# Lazy-fill primitives the #6188 fix depends on. Each must remain present in the
+# named function (after comments/strings are stripped).
+REQUIRED_PRIMITIVES = (
+    ("workspaceRows", re.compile(r"\bLazyVStack\s*\("),
+     "LazyVStack( -- the rows must stay lazy; a plain VStack realizes every "
+     "row on each pass and re-livelocks at scale"),
+    ("workspaceScrollContent", re.compile(r"\.frame\s*\(\s*minHeight:"),
+     ".frame(minHeight:) -- the measurement-free fill primitive that replaced "
+     "SidebarRowsFillLayout; do not remove it"),
+)
+
+
+def neutralize_swift(source):
+    """Return ``source`` with comment and string-literal *contents* replaced by
+    spaces, preserving every character's position and all newlines.
+
+    Token and brace scanning runs on this neutralized text so that tokens which
+    appear only inside the explanatory comments (e.g. the words
+    ``SidebarRowsFillLayout`` or ``sizeThatFits(height: nil)``) are invisible to
+    the guard, and so braces/parens inside comments or strings never corrupt the
+    function-body matching.
+    """
+    out = []
+    i = 0
+    n = len(source)
+    LINE_COMMENT, BLOCK_COMMENT, STRING = 1, 2, 3
+    state = 0
+    while i < n:
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < n else ""
+        if state == 0:
+            if ch == "/" and nxt == "/":
+                out.append("  ")
+                i += 2
+                state = LINE_COMMENT
+                continue
+            if ch == "/" and nxt == "*":
+                out.append("  ")
+                i += 2
+                state = BLOCK_COMMENT
+                continue
+            if ch == '"':
+                out.append('"')
+                i += 1
+                state = STRING
+                continue
+            out.append(ch)
+            i += 1
+            continue
+        if state == LINE_COMMENT:
+            if ch == "\n":
+                out.append("\n")
+                state = 0
+            else:
+                out.append(" ")
+            i += 1
+            continue
+        if state == BLOCK_COMMENT:
+            if ch == "*" and nxt == "/":
+                out.append("  ")
+                i += 2
+                state = 0
+            else:
+                out.append("\n" if ch == "\n" else " ")
+                i += 1
+            continue
+        if state == STRING:
+            if ch == "\\" and nxt != "":
+                # Preserve the escape pair as spaces so positions stay aligned.
+                out.append("  ")
+                i += 2
+                continue
+            if ch == '"':
+                out.append('"')
+                i += 1
+                state = 0
+                continue
+            out.append("\n" if ch == "\n" else " ")
+            i += 1
+            continue
+    return "".join(out)
+
+
+def extract_function_body(neutralized, func_name):
+    """Return the brace-matched body text of ``func <func_name>(`` in the
+    neutralized source, or ``None`` if the function is not found.
+
+    Handles multi-line signatures by walking parenthesis depth until the
+    parameter list closes, then brace-matching from the body's opening ``{``.
+    """
+    match = re.search(r"\bfunc\s+" + re.escape(func_name) + r"\s*\(", neutralized)
+    if not match:
+        return None
+    i = match.end() - 1  # at the opening '(' of the parameter list
+    n = len(neutralized)
+    paren_depth = 0
+    # Walk until the parameter-list parens balance back to zero.
+    while i < n:
+        ch = neutralized[i]
+        if ch == "(":
+            paren_depth += 1
+        elif ch == ")":
+            paren_depth -= 1
+            if paren_depth == 0:
+                i += 1
+                break
+        i += 1
+    else:
+        return None
+    # Find the body's opening brace (skip the `-> some View` return clause).
+    while i < n and neutralized[i] != "{":
+        # A premature ';' or top-level '}' means there was no body.
+        if neutralized[i] == "}":
+            return None
+        i += 1
+    if i >= n:
+        return None
+    brace_depth = 0
+    start = i
+    while i < n:
+        ch = neutralized[i]
+        if ch == "{":
+            brace_depth += 1
+        elif ch == "}":
+            brace_depth -= 1
+            if brace_depth == 0:
+                return neutralized[start:i + 1]
+        i += 1
+    return None
+
+
+def check_source(source):
+    """Return a list of human-readable violation strings (empty == clean)."""
+    neutralized = neutralize_swift(source)
+    violations = []
+    bodies = {}
+    for func_name in GUARDED_FUNCTIONS:
+        body = extract_function_body(neutralized, func_name)
+        if body is None:
+            violations.append(
+                "could not locate func {0}(...) in the source. The sidebar "
+                "lazy-layout guard must be updated to track the renamed "
+                "function (refusing to pass as a no-op).".format(func_name)
+            )
+            continue
+        bodies[func_name] = body
+
+    for func_name, body in bodies.items():
+        for pattern, description in FORBIDDEN_PATTERNS:
+            if pattern.search(body):
+                violations.append(
+                    "{0}(...) reintroduces a forbidden whole-list measurement: "
+                    "{1}".format(func_name, description)
+                )
+
+    for func_name, pattern, description in REQUIRED_PRIMITIVES:
+        body = bodies.get(func_name)
+        if body is None:
+            continue  # already reported as a missing-function violation
+        if not pattern.search(body):
+            violations.append(
+                "{0}(...) is missing a required lazy-fill primitive: {1}".format(
+                    func_name, description
+                )
+            )
+
+    return violations
+
+
+def default_target():
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(repo_root, "Sources", "ContentView.swift")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--file",
+        default=None,
+        help="Swift source file to scan (defaults to Sources/ContentView.swift).",
+    )
+    args = parser.parse_args(argv)
+
+    target = args.file or default_target()
+    try:
+        with open(target, "r", encoding="utf-8") as handle:
+            source = handle.read()
+    except OSError as error:
+        print("check-sidebar-lazy-layout: cannot read {0}: {1}".format(target, error),
+              file=sys.stderr)
+        return 1
+
+    violations = check_source(source)
+    if violations:
+        print("check-sidebar-lazy-layout: FAILED for {0}".format(target), file=sys.stderr)
+        for violation in violations:
+            print("  - {0}".format(violation), file=sys.stderr)
+        print(
+            "\nThe workspace sidebar must keep its rows lazy at measure time. "
+            "See #6188 / #6210 / #6384 and the comments in workspaceScrollContent / "
+            "workspaceRows.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("check-sidebar-lazy-layout: ok ({0})".format(target))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-sidebar-lazy-layout.py
+++ b/scripts/check-sidebar-lazy-layout.py
@@ -43,6 +43,17 @@ scanned: it intentionally uses a `GeometryReader` to resolve per-row drop
 anchors and is gated behind an active drag (#5325), so it never runs during the
 steady-state layout this guard protects.
 
+Scope: the guard protects the rows layout *as expressed in*
+`workspaceScrollContent` / `workspaceRows`. It deliberately does not chase a
+force-measure that a future refactor relocates into some other
+transitively-called helper function: tracking arbitrary call graphs in a
+source-pattern lint is fragile, and extracting the rows layout into a new helper
+is a large enough change that it should re-review this guard directly (the
+"could not locate function" failure already trips on the most common such
+rename). Custom `Layout` types are the exception that *is* chased across files,
+because a renamed force-measuring layout is the concrete historical regression
+(#6033).
+
 Usage:
     scripts/check-sidebar-lazy-layout.py [--file PATH]
 
@@ -54,7 +65,6 @@ Exit codes:
 """
 
 import argparse
-import glob
 import os
 import re
 import sys
@@ -242,6 +252,33 @@ def extract_function_body(neutralized, func_name):
     return None
 
 
+# Directory names that hold build artifacts, VCS data, or vendored third-party
+# code. Pruned from the repo-owned Swift walk: a Layout pulled from an external
+# dependency is out of scope (you would have to import it), and SwiftPM checkout
+# trees under `.build` are huge.
+EXCLUDED_DIR_NAMES = frozenset({
+    ".build", ".git", "DerivedData", "Vendor", "vendor", "ThirdParty",
+    "third_party", "Pods", "Carthage", "node_modules",
+})
+
+
+def repo_owned_swift_files(repo_root):
+    """Yield every repo-owned Swift source path under ``Sources/`` and
+    ``Packages/`` (where cmux migrates app code), pruning build/VCS/vendored
+    directories. Scanning both keeps the custom-Layout discovery from being
+    bypassed by defining the force-measuring layout in a package. (#6870 review)
+    """
+    for top in ("Sources", "Packages"):
+        root = os.path.join(repo_root, top)
+        if not os.path.isdir(root):
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in EXCLUDED_DIR_NAMES]
+            for filename in filenames:
+                if filename.endswith(".swift"):
+                    yield os.path.join(dirpath, filename)
+
+
 def find_custom_layout_type_names(paths):
     """Return the set of type names conforming to SwiftUI's `Layout` protocol
     across ``paths`` (comment/string-neutralized so a `: Layout` in prose is not
@@ -345,16 +382,13 @@ def main(argv=None):
               file=sys.stderr)
         return 1
 
-    # Discover custom Layout type names from the target file plus the whole
-    # Sources/ tree, so a renamed force-measuring layout defined in any file is
-    # still banned from the guarded functions.
+    # Discover custom Layout type names from the target file plus every
+    # repo-owned Swift source (Sources/ and Packages/), so a renamed
+    # force-measuring layout defined in any app file or package is still banned
+    # from the guarded functions.
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     layout_scan_paths = [target]
-    sources_dir = os.path.join(repo_root, "Sources")
-    if os.path.isdir(sources_dir):
-        layout_scan_paths.extend(
-            sorted(glob.glob(os.path.join(sources_dir, "**", "*.swift"), recursive=True))
-        )
+    layout_scan_paths.extend(sorted(repo_owned_swift_files(repo_root)))
     custom_layout_names = find_custom_layout_type_names(layout_scan_paths)
 
     violations = check_source(source, custom_layout_names)

--- a/tests/test_ci_sidebar_lazy_layout_guard.py
+++ b/tests/test_ci_sidebar_lazy_layout_guard.py
@@ -165,6 +165,31 @@ def main():
             False, "reintroduced SidebarRowsFillLayout fails",
         ) else 1
 
+        # (d2) A *renamed* custom Layout (not the literal old name) applied to the
+        # rows must fail, even when the force-measure lives in the layout type
+        # outside the two guarded functions. The guard discovers Layout-conforming
+        # types and bans all their names from the functions. (#6870 review)
+        renamed_layout = (
+            "import SwiftUI\n"
+            "struct RowsFillLayout: Layout {\n"
+            "    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {\n"
+            "        subviews.first?.sizeThatFits(ProposedViewSize(width: 10, height: nil)) ?? .zero\n"
+            "    }\n"
+            "    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {}\n"
+            "}\n"
+            + fixture(
+                "        RowsFillLayout {\n"
+                "            workspaceRows(renderContext: renderContext)\n"
+                "        }\n"
+                "        .frame(minHeight: minHeight, alignment: .top)",
+                GOOD_ROWS,
+            )
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "RenamedLayout.swift", renamed_layout)),
+            False, "renamed custom Layout applied to rows fails",
+        ) else 1
+
         # (e) GeometryReader in steady-state scroll content.
         bad_geo = fixture(
             "        GeometryReader { proxy in\n"

--- a/tests/test_ci_sidebar_lazy_layout_guard.py
+++ b/tests/test_ci_sidebar_lazy_layout_guard.py
@@ -123,6 +123,23 @@ def main():
             True, "clean body, anti-patterns only in comments/strings",
         ) else 1
 
+        # (b2) A Swift multi-line string literal that contains a bare `"` and
+        # forbidden tokens must not trip the guard. A naive tokenizer closes the
+        # literal at the inner quote and exposes `GeometryReader` as code. (#6870)
+        good_multiline = fixture(
+            GOOD_SCROLL
+            + "\n            .help(\"\"\"\n"
+            + "            Layout note: he said \"GeometryReader\" plus\n"
+            + "            sizeThatFits(ProposedViewSize(width: w, height: nil)) and\n"
+            + "            SidebarRowsFillLayout are all forbidden here.\n"
+            + "            \"\"\")",
+            GOOD_ROWS,
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "GoodMultiline.swift", good_multiline)),
+            True, "multi-line string with bare quote + forbidden tokens passes",
+        ) else 1
+
         # (c) Force-measure reintroduced.
         bad_force = fixture(
             "        let h = subviews.first?.sizeThatFits(\n"

--- a/tests/test_ci_sidebar_lazy_layout_guard.py
+++ b/tests/test_ci_sidebar_lazy_layout_guard.py
@@ -20,6 +20,7 @@ Cases:
   (h) Renaming/removing a guarded function fails loudly (no silent skip).
 """
 
+import importlib.util
 import os
 import subprocess
 import sys
@@ -27,6 +28,19 @@ import tempfile
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GUARD = os.path.join(ROOT_DIR, "scripts", "check-sidebar-lazy-layout.py")
+
+
+def load_guard_module():
+    spec = importlib.util.spec_from_file_location("sidebar_lazy_layout_guard", GUARD)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_text(path, contents):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(contents)
 
 
 def run_guard(path):
@@ -246,6 +260,29 @@ def main():
             run_guard(write_fixture(workdir, "Renamed.swift", renamed)),
             False, "renamed guarded function fails (no silent skip)",
         ) else 1
+
+        # (i) Custom-Layout discovery must cover repo-owned Packages/ (where cmux
+        # migrates app code) and exclude build/vendor trees. (#6870 review)
+        guard = load_guard_module()
+        fake_root = os.path.join(workdir, "fakerepo")
+        write_text(os.path.join(fake_root, "Sources", "Z.swift"),
+                   "struct SourcesLayout: Layout {}\n")
+        write_text(os.path.join(fake_root, "Packages", "macOS", "CmuxSidebar",
+                                "Sources", "X.swift"),
+                   "struct PackagedRowsLayout: Layout {}\n")
+        write_text(os.path.join(fake_root, "Packages", "macOS", "Dep", ".build",
+                                "checkouts", "ext", "Y.swift"),
+                   "struct VendoredLayout: Layout {}\n")
+        scanned = list(guard.repo_owned_swift_files(fake_root))
+        discovered = guard.find_custom_layout_type_names(scanned)
+        cov_ok = (
+            "SourcesLayout" in discovered
+            and "PackagedRowsLayout" in discovered
+            and "VendoredLayout" not in discovered
+        )
+        print("[{0}] discovery covers Sources/ + Packages/, excludes .build "
+              "(found {1})".format("PASS" if cov_ok else "FAIL", sorted(discovered)))
+        failures += 0 if cov_ok else 1
 
     if failures:
         print("\ntest_ci_sidebar_lazy_layout_guard: {0} case(s) FAILED".format(failures),

--- a/tests/test_ci_sidebar_lazy_layout_guard.py
+++ b/tests/test_ci_sidebar_lazy_layout_guard.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""CI guard for ./scripts/check-sidebar-lazy-layout.py.
+
+Verifies the guard reports "ok" on the real cmux repo and correctly *fails* on
+every way the workspace-sidebar lazy-layout contract can be broken. The negative
+cases are what keep the guard from rotting into a no-op.
+
+Cases:
+  (a) Real cmux repo passes (Sources/ContentView.swift).
+  (b) A fixture whose guarded functions are clean code but whose comments and
+      string literals deliberately name every forbidden token still passes
+      (comment/string neutralization works -- this mirrors the real source,
+      which documents the anti-patterns it forbids).
+  (c) Reintroducing the #6210 force-measure (`.sizeThatFits(ProposedViewSize(
+      width:, height: nil))`) fails.
+  (d) Reintroducing the deleted `SidebarRowsFillLayout` custom Layout fails.
+  (e) A `GeometryReader` in the steady-state scroll content fails.
+  (f) Downgrading the rows from `LazyVStack` to a plain eager `VStack` fails.
+  (g) Dropping `.frame(minHeight:)` from `workspaceScrollContent` fails.
+  (h) Renaming/removing a guarded function fails loudly (no silent skip).
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GUARD = os.path.join(ROOT_DIR, "scripts", "check-sidebar-lazy-layout.py")
+
+
+def run_guard(path):
+    return subprocess.run(
+        [sys.executable, GUARD, "--file", path],
+        cwd=ROOT_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def run_guard_default():
+    return subprocess.run(
+        [sys.executable, GUARD],
+        cwd=ROOT_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def fixture(scroll_body, rows_body):
+    """Assemble a minimal ContentView-shaped Swift source with the two guarded
+    functions. ``scroll_body`` / ``rows_body`` are the function-body statements.
+    """
+    return (
+        "import SwiftUI\n"
+        "struct ContentBody {\n"
+        "    private func workspaceScrollContent(\n"
+        "        renderContext: WorkspaceListRenderContext,\n"
+        "        minHeight: CGFloat\n"
+        "    ) -> some View {\n"
+        "        // History: SidebarRowsFillLayout measured it via\n"
+        "        // sizeThatFits(ProposedViewSize(width: width, height: nil)) and a\n"
+        "        // GeometryReader feedback loop. Those tokens live only in this\n"
+        "        // comment and must not trip the guard.\n"
+        + scroll_body
+        + "\n    }\n"
+        "    @ViewBuilder\n"
+        "    private func workspaceRows(renderContext: WorkspaceListRenderContext) -> some View {\n"
+        + rows_body
+        + "\n    }\n"
+        "}\n"
+    )
+
+
+# A clean scroll body and rows body that satisfy the contract.
+GOOD_SCROLL = (
+    "        workspaceRows(renderContext: renderContext)\n"
+    "            .frame(minHeight: minHeight, alignment: .top)"
+)
+GOOD_ROWS = (
+    "        let rows = LazyVStack(spacing: tabRowSpacing) {\n"
+    "            ForEach(renderItems, id: \\.id) { item in workspaceRow(item) }\n"
+    "        }\n"
+    "        return rows"
+)
+
+
+def write_fixture(directory, name, contents):
+    path = os.path.join(directory, name)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(contents)
+    return path
+
+
+def expect(result, should_pass, label):
+    ok = (result.returncode == 0) if should_pass else (result.returncode != 0)
+    state = "PASS" if ok else "FAIL"
+    print("[{0}] {1} (exit={2}, expected {3})".format(
+        state, label, result.returncode, "0" if should_pass else "non-zero"))
+    if not ok:
+        print("---- guard output ----")
+        print(result.stdout.rstrip())
+        print("----------------------")
+    return ok
+
+
+def main():
+    failures = 0
+
+    # (a) Real repo must pass.
+    failures += 0 if expect(run_guard_default(), True, "real repo passes") else 1
+
+    with tempfile.TemporaryDirectory() as workdir:
+        # (b) Clean code + forbidden tokens only in comments/strings still passes.
+        good_with_string = fixture(
+            GOOD_SCROLL + "\n            .accessibilityLabel(\"GeometryReader sizeThatFits\")",
+            GOOD_ROWS,
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "Good.swift", good_with_string)),
+            True, "clean body, anti-patterns only in comments/strings",
+        ) else 1
+
+        # (c) Force-measure reintroduced.
+        bad_force = fixture(
+            "        let h = subviews.first?.sizeThatFits(\n"
+            "            ProposedViewSize(width: width, height: nil)).height ?? 0\n"
+            "        return workspaceRows(renderContext: renderContext)\n"
+            "            .frame(minHeight: max(h, minHeight), alignment: .top)",
+            GOOD_ROWS,
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "Force.swift", bad_force)),
+            False, "force-measure sizeThatFits(ProposedViewSize(height: nil)) fails",
+        ) else 1
+
+        # (d) SidebarRowsFillLayout reintroduced.
+        bad_layout = fixture(
+            "        SidebarRowsFillLayout(minHeight: minHeight) {\n"
+            "            workspaceRows(renderContext: renderContext)\n"
+            "        }",
+            GOOD_ROWS,
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "Layout.swift", bad_layout)),
+            False, "reintroduced SidebarRowsFillLayout fails",
+        ) else 1
+
+        # (e) GeometryReader in steady-state scroll content.
+        bad_geo = fixture(
+            "        GeometryReader { proxy in\n"
+            "            workspaceRows(renderContext: renderContext)\n"
+            "                .frame(minHeight: proxy.size.height, alignment: .top)\n"
+            "        }",
+            GOOD_ROWS,
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "Geo.swift", bad_geo)),
+            False, "GeometryReader in scroll content fails",
+        ) else 1
+
+        # (f) Eager VStack instead of LazyVStack.
+        bad_eager = fixture(
+            GOOD_SCROLL,
+            "        let rows = VStack(spacing: tabRowSpacing) {\n"
+            "            ForEach(renderItems, id: \\.id) { item in workspaceRow(item) }\n"
+            "        }\n"
+            "        return rows",
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "Eager.swift", bad_eager)),
+            False, "eager VStack (no LazyVStack) fails",
+        ) else 1
+
+        # (g) Missing .frame(minHeight:).
+        bad_nominheight = fixture(
+            "        workspaceRows(renderContext: renderContext)\n"
+            "            .frame(maxWidth: .infinity, alignment: .top)",
+            GOOD_ROWS,
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "NoMinHeight.swift", bad_nominheight)),
+            False, "missing .frame(minHeight:) fails",
+        ) else 1
+
+        # (h) A guarded function renamed away -> guard must fail loudly.
+        renamed = (
+            "import SwiftUI\n"
+            "struct ContentBody {\n"
+            "    private func workspaceScrollContent(\n"
+            "        renderContext: WorkspaceListRenderContext, minHeight: CGFloat\n"
+            "    ) -> some View {\n"
+            + GOOD_SCROLL
+            + "\n    }\n"
+            "    @ViewBuilder\n"
+            "    private func workspaceRowsRenamed(renderContext: WorkspaceListRenderContext) -> some View {\n"
+            + GOOD_ROWS
+            + "\n    }\n"
+            "}\n"
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "Renamed.swift", renamed)),
+            False, "renamed guarded function fails (no silent skip)",
+        ) else 1
+
+    if failures:
+        print("\ntest_ci_sidebar_lazy_layout_guard: {0} case(s) FAILED".format(failures),
+              file=sys.stderr)
+        return 1
+    print("\ntest_ci_sidebar_lazy_layout_guard: all cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #6384

## Investigation

#6384 reports a ~1s main-thread beachball with many surfaces open: the main thread is **100% on-CPU** (not blocked) inside `GraphHost.flushTransactions()`, recomputing layout for a `ScrollView` + `LazyVStack` + `ForEach` tree — the workspace sidebar.

The authoritative follow-up comment (from a second reporter on 0.64.16) pinpoints the cmux-owned frames as `SidebarRowsFillLayout.placeSubviews` / `.sizeThatFits` driving `LazyStack → ForEachList.applyNodes → measureEstimates`, and notes this is the force-measure root-caused in #6210 and **removed in #6188** (merged 2026-06-16, ~14h *after* v0.64.16 was tagged — so the stable build both reporters hit still shipped it).

I confirmed on current `main`:

- **The root cause is already fixed.** `313a2d2` (#6188) is an ancestor of `HEAD`; `SidebarRowsFillLayout` is deleted (only a historical comment remains), and there is **no** `ProposedViewSize(… nil)` / `sizeThatFits(… nil)` force-measure anywhere in the repo. The workspace sidebar (`workspaceScrollContent`/`workspaceRows`) is lazy again: `LazyVStack` + a measurement-free `.frame(minHeight:)` fed by a `GeometryReader` that sits **outside** the `ScrollView` and only supplies a concrete viewport-derived `minHeight` constant.
- Adjacent hardening is also in place: allocation-free row identity (`SidebarWorkspaceRenderItemID` enum, #5764), a snapshot refresh policy that throttles re-renders, and a drag-only drop-anchor `GeometryReader` gated behind an active drag (#5325).
- The remaining *trigger* (per-frame spinner terminal-title updates dirtying the sidebar, #6291) is being handled by separate in-flight PRs (#6319, #6840, #6293) — out of scope here.

Because this is a layout/timing livelock that only manifests at agent-heavy scale on the reporter's stable build, it isn't cleanly reproducible locally or unit-testable as a SwiftUI layout pass; the structural fix already landed in #6188.

## What this PR adds

This exact class of bug has regressed **four times** — #2586 → #5764 → #5845 → #6033/#6210/#6384 — and the lazy-at-measure-time contract is currently defended **only by inline comments, which CI cannot enforce**. This PR adds the missing CI regression guard so a re-introduction fails the build instead of shipping another beachball:

- **`scripts/check-sidebar-lazy-layout.py`** — neutralizes comments and string literals (the guarded functions deliberately *name* the forbidden anti-patterns in their explanatory comments), extracts the bodies of `workspaceScrollContent` and `workspaceRows` from `Sources/ContentView.swift`, and fails if either:
  - reintroduces a whole-list measurement signature: `GeometryReader`, `ProposedViewSize(…, nil)`, `.sizeThatFits(`, or `SidebarRowsFillLayout`; or
  - drops a lazy-fill primitive the fix relies on: `LazyVStack(` in `workspaceRows`, `.frame(minHeight:)` in `workspaceScrollContent`.
  - A renamed/removed guarded function fails **loudly** (non-zero) rather than silently skipping, so the guard can't rot into a no-op.
- **`tests/test_ci_sidebar_lazy_layout_guard.py`** — proves the guard catches the bug: passes the real repo and a clean fixture whose comments/strings name every forbidden token, and **fails** synthetic fixtures for each regression mode (force-measure, reintroduced custom `Layout`, `GeometryReader`, eager `VStack`, missing `minHeight`, renamed function).
- Wires the self-test into the `workflow-guard-tests` CI job, matching the repo's existing guard-script convention (`lint-pbxproj-test-wiring`, `check-workspace-package-groups`, etc.).

The drag-only `rowsWithGatedDropTargetReader` is intentionally **not** scanned — its `GeometryReader` resolves per-row drop anchors and only runs during an active drag (#5325), never in the steady-state layout this guard protects.

### Note on the two-commit regression policy

The red/green two-commit structure is for adding a *new code fix*. Here the fix already shipped in #6188, so the guard passes on `main` precisely because `main` is correct. The proof that the guard catches the bug is instead permanent and in-CI: the negative cases in `test_ci_sidebar_lazy_layout_guard.py` reintroduce each anti-pattern and assert the guard fails.

## Validation

```
$ python3 scripts/check-sidebar-lazy-layout.py
check-sidebar-lazy-layout: ok (Sources/ContentView.swift)

$ python3 tests/test_ci_sidebar_lazy_layout_guard.py
[PASS] real repo passes
[PASS] clean body, anti-patterns only in comments/strings
[PASS] force-measure sizeThatFits(ProposedViewSize(height: nil)) fails
[PASS] reintroduced SidebarRowsFillLayout fails
[PASS] GeometryReader in scroll content fails
[PASS] eager VStack (no LazyVStack) fails
[PASS] missing .frame(minHeight:) fails
[PASS] renamed guarded function fails (no silent skip)
test_ci_sidebar_lazy_layout_guard: all cases passed
```

No app/runtime behavior changes (CI-only). No user-facing strings, settings, menus, shortcuts, docs, or web messages touched — localization audit: N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI guard to keep the workspace sidebar `LazyVStack` lazy at measure time and prevent reintroducing whole‑list measurement behind #6384. Now scans repo-owned `Sources/` and `Packages/` for any custom `Layout` used with the rows, handles Swift multi-line strings, and remains CI-only.

- **New Features**
  - Added `scripts/check-sidebar-lazy-layout.py` to scan `workspaceScrollContent` and `workspaceRows` in `Sources/ContentView.swift`; fails on `GeometryReader`, `.sizeThatFits(`, `ProposedViewSize(..., nil)`, or any `Layout`-conforming type applied to the rows (discovered across repo-owned `Sources/` and `Packages/`, excluding `.build`, `.git`, and vendor dirs); requires `LazyVStack(` and `.frame(minHeight:)`; neutralizes comments, strings, and `"""..."""`; fails loudly if the guarded functions are renamed.
  - Added `tests/test_ci_sidebar_lazy_layout_guard.py` with pass/fail fixtures, including a renamed custom `Layout`, a multi-line string with a bare `"`, and a discovery check that includes `Packages/` and excludes vendored build trees; wired into CI via `.github/workflows/ci.yml`.

<sup>Written for commit 3cb88e66bde710376c2df0acfef8b92ead414553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

