### PR TITLE
Fix macOS 27 launch crash in restore-path content views (#6745)

### DIFF
--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -298,6 +298,10 @@ private struct NotificationRow: View {
                     .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)
+            // CmuxSystemSymbolImage renders an AppKit NSImage with no accessibility
+            // description, so the icon-only button needs an explicit label (the prior
+            // SwiftUI system-symbol path used to supply one implicitly).
+            .accessibilityLabel(String(localized: "notifications.row.clear", defaultValue: "Clear notification"))
         }
         .padding(12)
         .background(

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -145,8 +145,7 @@ struct NotificationsPage: View {
 
     private var emptyState: some View {
         VStack(spacing: 8) {
-            Image(systemName: "bell.slash")
-                .cmuxFont(size: 32)
+            CmuxSystemSymbolImage(magnified: "bell.slash", pointSize: 32)
                 .foregroundColor(.secondary)
             Text(String(localized: "notifications.empty.title", defaultValue: "No notifications yet"))
                 .cmuxFont(.headline)
@@ -159,8 +158,7 @@ struct NotificationsPage: View {
 
     private var workspaceUnreadIndicatorState: some View {
         VStack(spacing: 8) {
-            Image(systemName: "bell.badge")
-                .cmuxFont(size: 32)
+            CmuxSystemSymbolImage(magnified: "bell.badge", pointSize: 32)
                 .foregroundColor(.secondary)
             Text(notificationStore.notificationMenuSnapshot.stateHintTitle)
                 .cmuxFont(.headline)
@@ -296,7 +294,7 @@ private struct NotificationRow: View {
             .modifier(DefaultActionModifier(isActive: focusedNotificationId.wrappedValue == notification.id))
 
             Button(action: onClear) {
-                Image(systemName: "xmark.circle.fill")
+                CmuxSystemSymbolImage(systemName: "xmark.circle.fill", pointSize: 14)
                     .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -147,8 +147,7 @@ private struct AgentHibernationPlaceholderView: View {
 
     var body: some View {
         VStack(spacing: 14) {
-            Image(systemName: "pause.circle")
-                .cmuxFont(size: 34, weight: .regular)
+            CmuxSystemSymbolImage(magnified: "pause.circle", pointSize: 34, weight: .regular)
                 .foregroundStyle(.secondary)
             VStack(spacing: 4) {
                 Text(String(localized: "terminal.agentHibernation.title", defaultValue: "Agent hibernated"))

--- a/Sources/RemoteTmuxPaneHeader.swift
+++ b/Sources/RemoteTmuxPaneHeader.swift
@@ -46,8 +46,7 @@ struct RemoteTmuxPaneHeader: View {
 
     private func button(system: String, label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            Image(systemName: system)
-                .cmuxFont(size: 11, weight: .medium)
+            CmuxSystemSymbolImage(magnified: system, pointSize: 11, weight: .medium)
                 .frame(width: 18, height: 18)
                 .contentShape(Rectangle())
         }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -737,7 +737,10 @@ struct EmptyPanelView: View {
         if let key = shortcut.keyEquivalent {
             Button(action: action) {
                 HStack(spacing: 10) {
-                    Label(title, systemImage: systemImage)
+                    HStack(spacing: 6) {
+                        CmuxSystemSymbolImage(systemName: systemImage, pointSize: 13)
+                        Text(title)
+                    }
                     ShortcutHint(text: shortcut.displayString)
                 }
             }
@@ -746,7 +749,10 @@ struct EmptyPanelView: View {
         } else {
             Button(action: action) {
                 HStack(spacing: 10) {
-                    Label(title, systemImage: systemImage)
+                    HStack(spacing: 6) {
+                        CmuxSystemSymbolImage(systemName: systemImage, pointSize: 13)
+                        Text(title)
+                    }
                     ShortcutHint(text: shortcut.displayString)
                 }
             }
@@ -756,8 +762,7 @@ struct EmptyPanelView: View {
 
     var body: some View {
         VStack(spacing: 16) {
-            Image(systemName: "terminal.fill")
-                .cmuxFont(size: 48)
+            CmuxSystemSymbolImage(magnified: "terminal.fill", pointSize: 48)
                 .foregroundStyle(.tertiary)
 
             Text(String(localized: "emptyPanel.title", defaultValue: "Empty Panel"))

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -734,29 +734,21 @@ struct EmptyPanelView: View {
         shortcut: StoredShortcut,
         action: @escaping () -> Void
     ) -> some View {
+        let button = Button(action: action) {
+            HStack(spacing: 10) {
+                HStack(spacing: 6) {
+                    CmuxSystemSymbolImage(systemName: systemImage, pointSize: 13)
+                    Text(title)
+                }
+                ShortcutHint(text: shortcut.displayString)
+            }
+        }
+        .buttonStyle(.borderedProminent)
+
         if let key = shortcut.keyEquivalent {
-            Button(action: action) {
-                HStack(spacing: 10) {
-                    HStack(spacing: 6) {
-                        CmuxSystemSymbolImage(systemName: systemImage, pointSize: 13)
-                        Text(title)
-                    }
-                    ShortcutHint(text: shortcut.displayString)
-                }
-            }
-            .buttonStyle(.borderedProminent)
-            .keyboardShortcut(key, modifiers: shortcut.eventModifiers)
+            button.keyboardShortcut(key, modifiers: shortcut.eventModifiers)
         } else {
-            Button(action: action) {
-                HStack(spacing: 10) {
-                    HStack(spacing: 6) {
-                        CmuxSystemSymbolImage(systemName: systemImage, pointSize: 13)
-                        Text(title)
-                    }
-                    ShortcutHint(text: shortcut.displayString)
-                }
-            }
-            .buttonStyle(.borderedProminent)
+            button
         }
     }
 

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -94,41 +94,4 @@ struct RenderableSystemSymbolTests {
         ) == nil)
         #expect(RenderableSystemSymbol.isRenderable("not.an.sf.symbol") == false)
     }
-
-    /// Every SF Symbol rendered by a view that is laid out during launch or session
-    /// restore must resolve through the AppKit `NSImage` path (`CmuxSystemSymbolImage`
-    /// / `configuredAppKitImage`). On macOS 27 these symbols crash when rendered via
-    /// SwiftUI `Image(systemName:)` / `Label(systemImage:)`: CoreUI throws inside
-    /// `-[CUINamedVectorGlyph _rasterizeImageUsingScaleFactor:...]` while the glyph is
-    /// measured during the first `NSWindow.makeKeyAndOrderFront:` layout, killing the
-    /// app before any window appears (issues #6703 / #6745). `NotificationsPage` is the
-    /// decisive one: it is mounted unconditionally in the main content `ZStack` and only
-    /// toggled with `.opacity`, so its body is laid out on every launch.
-    ///
-    /// The crash only reproduces on macOS 27, so it cannot be reproduced on CI's older
-    /// macOS — macOS 27 launch coverage has to be validated on a macOS 27 runner/device.
-    /// This test instead pins the launch/restore symbol set and proves each one renders
-    /// through the non-crashing AppKit path that the fix routes them onto.
-    @Test @MainActor func launchPathSymbolsRenderThroughAppKitPath() throws {
-        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
-        // NotificationsPage, EmptyPanelView, AgentHibernationPlaceholderView, and
-        // RemoteTmuxPaneHeader — the content-area views laid out on launch / restore.
-        let launchPathSymbols = [
-            "bell.slash", "bell.badge", "xmark.circle.fill",
-            "terminal.fill", "globe", "pause.circle",
-            "square.split.2x1", "square.split.1x2", "xmark",
-        ]
-        for symbol in launchPathSymbols {
-            let image = try #require(
-                RenderableSystemSymbol.configuredAppKitImage(
-                    systemName: symbol,
-                    pointSize: 16,
-                    weight: .regular
-                ),
-                "Launch/restore-path symbol \(symbol) must resolve through the AppKit path"
-            )
-            #expect(image.isTemplate)
-            #expect(image.size.width > 0 && image.size.height > 0)
-        }
-    }
 }

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -95,3 +95,65 @@ struct RenderableSystemSymbolTests {
         #expect(RenderableSystemSymbol.isRenderable("not.an.sf.symbol") == false)
     }
 }
+
+/// Guards the views that are laid out during the first frame of a launched or
+/// session-restored main window against the macOS 27 SF Symbol launch crash.
+///
+/// On macOS 27, SwiftUI `Image(systemName:)` / `Label(systemImage:)` rasterize
+/// through CoreUI `-[CUINamedVectorGlyph _rasterizeImageUsingScaleFactor:...]`,
+/// which throws an uncaught exception while `_layoutSubtreeIfNeeded` measures the
+/// glyph during `NSWindow.makeKeyAndOrderFront:` — the app dies before any window
+/// appears (issues #6703 / #6745). The fix is to render SF Symbols through
+/// `CmuxSystemSymbolImage`, which resolves them as AppKit `NSImage`s and never
+/// enters the crashing `RB::Symbol::Presentation::template_image()` path.
+///
+/// This crash only reproduces on the macOS 27 beta, so CI (older macOS) cannot
+/// catch a regression behaviorally. Instead, assert at the source level that the
+/// launch/restore-reachable content views never reintroduce the crash-prone
+/// SwiftUI symbol APIs. `NotificationsPage` in particular is mounted unconditionally
+/// in the main content `ZStack` (toggled only via `.opacity`), so its body is laid
+/// out on every launch even when the sidebar shows the tab list.
+@Suite("Launch-path SF Symbol rendering guard")
+struct LaunchPathSymbolRenderingGuardTests {
+    /// Content views that render without any user interaction when a main window is
+    /// created or its session is restored. #6728 moved launch *chrome* (sidebar,
+    /// titlebar, toolbars) off `Image(systemName:)`; these are the content-area views
+    /// it left behind.
+    static let launchPathSources = [
+        "Sources/NotificationsPage.swift",
+        "Sources/WorkspaceContentView.swift",
+        "Sources/Panels/TerminalPanelView.swift",
+        "Sources/RemoteTmuxPaneHeader.swift",
+    ]
+
+    @Test func launchPathViewsAvoidCrashingSwiftUISymbolRasterizer() throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // cmuxTests
+            .deletingLastPathComponent() // repo root
+        var offenders: [String] = []
+        for relativePath in Self.launchPathSources {
+            let fileURL = repoRoot.appendingPathComponent(relativePath)
+            let contents = try String(contentsOf: fileURL, encoding: .utf8)
+            for (lineNumber, line) in contents.components(separatedBy: .newlines).enumerated() {
+                // Match SwiftUI `Image(systemName:` but not `CmuxSystemSymbolImage(systemName:`.
+                let usesRawImageSymbol = line.range(
+                    of: "(?<![A-Za-z])Image\\(systemName:",
+                    options: .regularExpression
+                ) != nil
+                let usesRawLabelSymbol = line.contains("Label(") && line.contains("systemImage:")
+                if usesRawImageSymbol || usesRawLabelSymbol {
+                    offenders.append("\(relativePath):\(lineNumber + 1): \(line.trimmingCharacters(in: .whitespaces))")
+                }
+            }
+        }
+        #expect(
+            offenders.isEmpty,
+            """
+            Launch/restore-path views must render SF Symbols through CmuxSystemSymbolImage, \
+            not SwiftUI Image(systemName:)/Label(systemImage:), to avoid the macOS 27 CoreUI \
+            rasterization launch crash (#6745). Offenders:
+            \(offenders.joined(separator: "\n"))
+            """
+        )
+    }
+}

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -94,66 +94,41 @@ struct RenderableSystemSymbolTests {
         ) == nil)
         #expect(RenderableSystemSymbol.isRenderable("not.an.sf.symbol") == false)
     }
-}
 
-/// Guards the views that are laid out during the first frame of a launched or
-/// session-restored main window against the macOS 27 SF Symbol launch crash.
-///
-/// On macOS 27, SwiftUI `Image(systemName:)` / `Label(systemImage:)` rasterize
-/// through CoreUI `-[CUINamedVectorGlyph _rasterizeImageUsingScaleFactor:...]`,
-/// which throws an uncaught exception while `_layoutSubtreeIfNeeded` measures the
-/// glyph during `NSWindow.makeKeyAndOrderFront:` — the app dies before any window
-/// appears (issues #6703 / #6745). The fix is to render SF Symbols through
-/// `CmuxSystemSymbolImage`, which resolves them as AppKit `NSImage`s and never
-/// enters the crashing `RB::Symbol::Presentation::template_image()` path.
-///
-/// This crash only reproduces on the macOS 27 beta, so CI (older macOS) cannot
-/// catch a regression behaviorally. Instead, assert at the source level that the
-/// launch/restore-reachable content views never reintroduce the crash-prone
-/// SwiftUI symbol APIs. `NotificationsPage` in particular is mounted unconditionally
-/// in the main content `ZStack` (toggled only via `.opacity`), so its body is laid
-/// out on every launch even when the sidebar shows the tab list.
-@Suite("Launch-path SF Symbol rendering guard")
-struct LaunchPathSymbolRenderingGuardTests {
-    /// Content views that render without any user interaction when a main window is
-    /// created or its session is restored. #6728 moved launch *chrome* (sidebar,
-    /// titlebar, toolbars) off `Image(systemName:)`; these are the content-area views
-    /// it left behind.
-    static let launchPathSources = [
-        "Sources/NotificationsPage.swift",
-        "Sources/WorkspaceContentView.swift",
-        "Sources/Panels/TerminalPanelView.swift",
-        "Sources/RemoteTmuxPaneHeader.swift",
-    ]
-
-    @Test func launchPathViewsAvoidCrashingSwiftUISymbolRasterizer() throws {
-        let repoRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent() // cmuxTests
-            .deletingLastPathComponent() // repo root
-        var offenders: [String] = []
-        for relativePath in Self.launchPathSources {
-            let fileURL = repoRoot.appendingPathComponent(relativePath)
-            let contents = try String(contentsOf: fileURL, encoding: .utf8)
-            for (lineNumber, line) in contents.components(separatedBy: .newlines).enumerated() {
-                // Match SwiftUI `Image(systemName:` but not `CmuxSystemSymbolImage(systemName:`.
-                let usesRawImageSymbol = line.range(
-                    of: "(?<![A-Za-z])Image\\(systemName:",
-                    options: .regularExpression
-                ) != nil
-                let usesRawLabelSymbol = line.contains("Label(") && line.contains("systemImage:")
-                if usesRawImageSymbol || usesRawLabelSymbol {
-                    offenders.append("\(relativePath):\(lineNumber + 1): \(line.trimmingCharacters(in: .whitespaces))")
-                }
-            }
+    /// Every SF Symbol rendered by a view that is laid out during launch or session
+    /// restore must resolve through the AppKit `NSImage` path (`CmuxSystemSymbolImage`
+    /// / `configuredAppKitImage`). On macOS 27 these symbols crash when rendered via
+    /// SwiftUI `Image(systemName:)` / `Label(systemImage:)`: CoreUI throws inside
+    /// `-[CUINamedVectorGlyph _rasterizeImageUsingScaleFactor:...]` while the glyph is
+    /// measured during the first `NSWindow.makeKeyAndOrderFront:` layout, killing the
+    /// app before any window appears (issues #6703 / #6745). `NotificationsPage` is the
+    /// decisive one: it is mounted unconditionally in the main content `ZStack` and only
+    /// toggled with `.opacity`, so its body is laid out on every launch.
+    ///
+    /// The crash only reproduces on macOS 27, so it cannot be reproduced on CI's older
+    /// macOS — macOS 27 launch coverage has to be validated on a macOS 27 runner/device.
+    /// This test instead pins the launch/restore symbol set and proves each one renders
+    /// through the non-crashing AppKit path that the fix routes them onto.
+    @Test @MainActor func launchPathSymbolsRenderThroughAppKitPath() throws {
+        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+        // NotificationsPage, EmptyPanelView, AgentHibernationPlaceholderView, and
+        // RemoteTmuxPaneHeader — the content-area views laid out on launch / restore.
+        let launchPathSymbols = [
+            "bell.slash", "bell.badge", "xmark.circle.fill",
+            "terminal.fill", "globe", "pause.circle",
+            "square.split.2x1", "square.split.1x2", "xmark",
+        ]
+        for symbol in launchPathSymbols {
+            let image = try #require(
+                RenderableSystemSymbol.configuredAppKitImage(
+                    systemName: symbol,
+                    pointSize: 16,
+                    weight: .regular
+                ),
+                "Launch/restore-path symbol \(symbol) must resolve through the AppKit path"
+            )
+            #expect(image.isTemplate)
+            #expect(image.size.width > 0 && image.size.height > 0)
         }
-        #expect(
-            offenders.isEmpty,
-            """
-            Launch/restore-path views must render SF Symbols through CmuxSystemSymbolImage, \
-            not SwiftUI Image(systemName:)/Label(systemImage:), to avoid the macOS 27 CoreUI \
-            rasterization launch crash (#6745). Offenders:
-            \(offenders.joined(separator: "\n"))
-            """
-        )
     }
 }


### PR DESCRIPTION
Fixes #6745

## Root cause

#6745 (dup of #6703) is the macOS 27 beta 2 launch crash: SwiftUI `Image(systemName:)` rasterizes through CoreUI `-[CUINamedVectorGlyph _rasterizeImageUsingScaleFactor:forTargetSize:...]`, which throws while `_layoutSubtreeIfNeeded` measures the glyph during `NSWindow.makeKeyAndOrderFront:` — the app dies before any window appears.

#6728 (merged earlier today, closed #6703) moved launch **chrome** — sidebar, titlebar, toolbars, text box, right sidebar — off `Image(systemName:)` and onto the AppKit-backed `CmuxSystemSymbolImage`. But it left the **content-area** views that are also laid out on the first frame.

The decisive one is **`NotificationsPage`**. It is mounted *unconditionally* in the main content `ZStack` (`ContentView.terminalContent`, line ~1827) and only toggled with `.opacity(selection == .notifications ? 1 : 0)`. `.opacity(0)` does **not** remove a view from layout, so its `body` is evaluated and its glyphs are measured on **every** launch — including a default, config-cleared launch where the sidebar shows the tab list. With no notifications, it renders `emptyState`, whose `Image(systemName: "bell.slash")` is exactly the kind of raw SwiftUI symbol that crashes on macOS 27 beta 2. That is the variant still reproducing on top of #6728.

## Fix

Route these launch/restore-reachable content views' SF Symbols through `CmuxSystemSymbolImage` (resolves via `NSImage(systemSymbolName:)`, never enters `RB::Symbol::Presentation::template_image()`), using the same mapping #6728 established (`magnified:` for former `cmuxFont(size:)` sites, fixed `pointSize` for ambient-font sites):

- **`NotificationsPage`** — `bell.slash`, `bell.badge`, `xmark.circle.fill` *(always-mounted overlay → the actual #6745 launch fix)*
- **`WorkspaceContentView` (`EmptyPanelView`)** — `terminal.fill` + the Terminal/Browser action-button labels (`Label(systemImage:)` rasterizes the same way)
- **`TerminalPanelView` (`AgentHibernationPlaceholderView`)** — `pause.circle`
- **`RemoteTmuxPaneHeader`** — pane control glyphs

The last three render the instant a saved layout containing an empty panel, a hibernated agent, or a remote tmux pane is restored — no user interaction — so they are part of the same launch-crash surface.

`NotificationRow`'s icon-only clear button gets an explicit `.accessibilityLabel` (reusing the existing `notifications.row.clear` string), because `CmuxSystemSymbolImage` renders an AppKit `NSImage` without the implicit VoiceOver name the SwiftUI system-symbol path supplied.

## Testing / macOS 27 validation

This CoreUI crash only reproduces on the macOS 27 beta. On CI's older macOS, the raw `Image(systemName:)` route and the `CmuxSystemSymbolImage` route both render without crashing, so **no CI-runnable unit test can distinguish them** — a behavioral test would pass with the bug present, and a source-grep guard was (correctly) flagged in review as brittle. Per the repo's testing policy ("if the bug isn't cleanly testable, say so rather than faking a test"), there is no synthetic regression test here.

- The existing `RenderableSystemSymbolTests` already cover the AppKit rendering path (`configuredAppKitImage`) the fix routes onto.
- The fix itself is a faithful, mechanical substitution matching the already-shipped #6728 pattern.
- **The actual launch-crash fix must be validated on a macOS 27 runner/device** (build the tagged DEV app on macOS 27 beta 2 and confirm it launches). I am on macOS 26 and cannot reproduce the macOS 27 crash locally.

## Localization

No new user-facing strings: `Text(title)` in `EmptyPanelView` renders the pre-existing `title` param verbatim exactly as the prior `Label(title, systemImage:)` did, and the accessibility label reuses the existing `notifications.row.clear` key (en + ja already present).