### PR TITLE
feat(skills): add SPA hydration wait and CSP pre-check to cmux-browser

### DIFF
--- a/skills/cmux-browser/SKILL.md
+++ b/skills/cmux-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cmux-browser
-description: End-user browser automation with cmux. Use when you need to open sites, interact with pages, wait for state changes, and extract data from cmux browser surfaces.
+description: End-user browser automation with cmux. Use when you need to open sites, interact with pages, wait for state changes, and extract data from cmux browser surfaces — including single-page apps (SPAs) that hydrate the DOM client-side.
 ---
 
 # Browser Automation with cmux
@@ -11,10 +11,11 @@ Use this skill for browser tasks inside cmux webviews.
 
 1. Open or target a browser surface.
 2. Verify navigation with `get url` before waiting or snapshotting.
-3. Snapshot (`--interactive`) to get fresh element refs.
-4. Act with refs (`click`, `fill`, `type`, `select`, `press`).
-5. Wait for state changes.
-6. Re-snapshot after DOM/navigation changes.
+3. **For SPAs: run the hydration wait before the first snapshot** (see below).
+4. Snapshot (`--interactive`) to get fresh element refs.
+5. Act with refs (`click`, `fill`, `type`, `select`, `press`).
+6. Wait for state changes.
+7. Re-snapshot after DOM/navigation changes.
 
 ```bash
 cmux --json browser open https://example.com
@@ -48,26 +49,76 @@ Notes:
 cmux supports wait patterns similar to agent-browser:
 
 ```bash
-cmux browser <surface> wait --selector "#ready" --timeout-ms 10000
-cmux browser <surface> wait --text "Success" --timeout-ms 10000
-cmux browser <surface> wait --url-contains "/dashboard" --timeout-ms 10000
-cmux browser <surface> wait --load-state complete --timeout-ms 15000
-cmux browser <surface> wait --function "document.readyState === 'complete'" --timeout-ms 10000
+cmux browser surface:7 wait --selector "#ready" --timeout-ms 10000
+cmux browser surface:7 wait --text "Success" --timeout-ms 10000
+cmux browser surface:7 wait --url-contains "/dashboard" --timeout-ms 10000
+cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+cmux browser surface:7 wait --function "document.readyState === 'complete'" --timeout-ms 10000
+```
+
+## SPA Hydration — Wait for Client-Side Render Before Snapshotting
+
+> **Iron law:** for single-page apps, run the hydration wait once before
+> `snapshot --interactive` or any DOM-dependent action (`click`/`fill`/`is`/`get`).
+> `wait --load-state complete` alone is NOT sufficient for SPAs.
+
+`wait --load-state complete` only guarantees network-level load (HTML, CSS, scripts).
+React/Vue/Next/Nuxt/SvelteKit/Angular render the actual DOM client-side *after* that
+point. A snapshot taken before hydration finishes returns only the empty shell/skeleton
+tree — the pre-hydration state — and every downstream selector then misses.
+
+Minimal, framework-agnostic hydration gate (works for both sparse login pages and dense
+dashboards):
+
+```bash
+cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+cmux browser surface:7 wait \
+  --function 'document.readyState==="complete" && !document.querySelector("[aria-busy=true],[data-loading=true]") && document.body.innerText.length>30' \
+  --timeout-ms 10000
+cmux browser surface:7 snapshot --interactive
+```
+
+Validate the snapshot actually hydrated — a 2-node skeleton means retry:
+
+```bash
+NODE_COUNT=$(cmux browser surface:7 eval 'document.querySelectorAll("a[href],h1,h2,h3,button,nav,article").length' | tr -d ' \n')
+# < 3  -> empty shell, re-run the hydration wait (longer timeout) then re-snapshot
+# >= 3 -> hydrated (sparse pages such as login/OTP are valid at 3-8 elements)
+```
+
+Full protocol — framework auto-detect, content-density tuning, and explicit-selector
+control — lives in [references/spa-hydration.md](references/spa-hydration.md).
+
+## CSP Pre-check (eval-dependent commands)
+
+`snapshot --interactive` and `eval` execute JavaScript in the page. A page whose
+Content-Security-Policy omits `unsafe-eval` can reject page-world eval. Note that
+`eval "1+1"` is NOT a reliable gate: when page-world eval is CSP-blocked, cmux retries
+in an isolated content world, so `1+1` still returns `2` while page globals stay
+unreachable. Probe a page-global instead; full procedure in
+[references/csp-precheck.md](references/csp-precheck.md).
+
+```bash
+# page-world discriminator — not "1+1"
+cmux browser surface:7 eval 'String(!!window.__NEXT_DATA__ || !!document.querySelector("[data-reactroot],[data-v-app],[ng-version]"))'
 ```
 
 ## Common Flows
 
-### Form Submit
+### Form Submit (with hydration wait)
 
 ```bash
 cmux --json browser open https://example.com/signup
 cmux browser surface:7 get url
 cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+cmux browser surface:7 wait --function 'document.body.innerText.length>30' --timeout-ms 10000
 cmux browser surface:7 snapshot --interactive
 cmux browser surface:7 fill e1 "Jane Doe"
 cmux browser surface:7 fill e2 "jane@example.com"
 cmux --json browser surface:7 click e3 --snapshot-after
 cmux browser surface:7 wait --url-contains "/welcome" --timeout-ms 15000
+# destination route also hydrates client-side — wait again before snapshotting
+cmux browser surface:7 wait --function 'document.body.innerText.length>30' --timeout-ms 10000
 cmux browser surface:7 snapshot --interactive
 ```
 
@@ -81,9 +132,10 @@ cmux browser surface:7 get value e11 --json
 ### Stable Agent Loop (Recommended)
 
 ```bash
-# navigate -> verify -> wait -> snapshot -> action -> snapshot
+# navigate -> verify -> wait(load) -> wait(hydrate) -> snapshot -> action -> snapshot
 cmux browser surface:7 get url
 cmux browser surface:7 wait --load-state complete --timeout-ms 15000
+cmux browser surface:7 wait --function 'document.readyState==="complete" && document.body.innerText.length>30' --timeout-ms 10000
 cmux browser surface:7 snapshot --interactive
 cmux --json browser surface:7 click e5 --snapshot-after
 cmux browser surface:7 snapshot --interactive
@@ -95,6 +147,8 @@ If `get url` is empty or `about:blank`, navigate first instead of waiting on loa
 
 | Reference | When to Use |
 |-----------|-------------|
+| [references/spa-hydration.md](references/spa-hydration.md) | SPA hydration protocol: framework auto-detect, content-density vs selector waits, snapshot validation |
+| [references/csp-precheck.md](references/csp-precheck.md) | Detect CSP that blocks `eval`/`snapshot --interactive`, and fallbacks |
 | [references/commands.md](references/commands.md) | Full browser command mapping and quick syntax |
 | [references/snapshot-refs.md](references/snapshot-refs.md) | Ref lifecycle and stale-ref troubleshooting |
 | [references/authentication.md](references/authentication.md) | Login/OAuth/2FA patterns and state save/load |
@@ -107,6 +161,8 @@ If `get url` is empty or `about:blank`, navigate first instead of waiting on loa
 
 | Template | Description |
 |----------|-------------|
+| [templates/spa-hydration-wait.sh](templates/spa-hydration-wait.sh) | Open + load-state + hydration wait + snapshot with validation/retry |
+| [templates/e2e-login-flow.sh](templates/e2e-login-flow.sh) | Login E2E: hydrate, fill, submit, wait for destination, re-hydrate, assert |
 | [templates/form-automation.sh](templates/form-automation.sh) | Snapshot/ref form fill loop |
 | [templates/authenticated-session.sh](templates/authenticated-session.sh) | Login once, save/load state |
 | [templates/capture-workflow.sh](templates/capture-workflow.sh) | Navigate + capture snapshots/screenshots |
@@ -124,6 +180,11 @@ Use supported high-level commands (`click`, `fill`, `press`, `scroll`, `wait`, `
 
 ## Troubleshooting
 
+### Empty snapshot tree (2-5 nodes, no nav/content)
+
+SPA hydration did not complete. Re-run the hydration wait with a longer timeout or an
+explicit selector, then re-snapshot. See [references/spa-hydration.md](references/spa-hydration.md).
+
 ### `js_error` on `snapshot --interactive` or `eval`
 
 Some complex pages can reject or break the JavaScript used for rich snapshots and ad-hoc evaluation.
@@ -139,3 +200,4 @@ cmux browser surface:7 get html body
 - Use `get url` first so you know whether the page actually navigated.
 - Fall back to `get text body` or `get html body` when `snapshot --interactive` or `eval` returns `js_error`.
 - If the page is still failing, navigate to a simpler intermediate page, then retry the task from there.
+- Persistent `eval` rejection on a page that loads fine in a normal browser usually means CSP — see [references/csp-precheck.md](references/csp-precheck.md).

--- a/skills/cmux-browser/agents/openai.yaml
+++ b/skills/cmux-browser/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "cmux Browser"
-  short_description: "Automate cmux webview surfaces with snapshot/ref workflows."
-  default_prompt: "Use this skill for browser automation via cmux CLI: identify target surface, snapshot interactive refs, perform actions, wait for state changes, and re-snapshot to avoid stale refs."
+  short_description: "Automate cmux webview surfaces with snapshot/ref workflows, including SPA hydration waits."
+  default_prompt: "Use this skill for browser automation via cmux CLI: identify the target surface, wait for load state AND (for SPAs) client-side hydration before snapshotting, snapshot interactive refs, perform actions, wait for state changes, and re-snapshot to avoid stale refs. Validate snapshots are hydrated rather than empty shells."

--- a/skills/cmux-browser/references/csp-precheck.md
+++ b/skills/cmux-browser/references/csp-precheck.md
@@ -1,0 +1,77 @@
+# CSP Pre-check
+
+`snapshot --interactive` and `eval` run JavaScript inside the page. A
+Content-Security-Policy that omits `unsafe-eval` can reject them, so eval-dependent flows
+fail in a way that looks like a page bug. Probe for it before you rely on those commands.
+
+**Related**: [SKILL.md](../SKILL.md), [spa-hydration.md](spa-hydration.md)
+
+## Contents
+
+- [Why it matters](#why-it-matters)
+- [Three-step probe](#three-step-probe)
+- [Decision](#decision)
+- [Fallbacks when eval is blocked](#fallbacks-when-eval-is-blocked)
+
+## Why it matters
+
+The hydration protocol and rich snapshots both depend on in-page `eval`. If CSP blocks
+eval, the auto-detect and content-density waits cannot run, and `snapshot --interactive`
+may return `js_error`. Detecting this up front saves a confusing debugging loop.
+
+## Three-step probe
+
+```bash
+# 1. Response header CSP — -L follows redirects (http->https, bare domain->www)
+curl -sIL <target-url> | grep -i content-security-policy
+
+# 2. Meta-tag CSP — fetch the HTML with curl, NOT via cmux eval (which is itself blocked
+#    when the meta CSP omits unsafe-eval, creating a circular dependency)
+curl -sL <target-url> | grep -i 'content-security-policy'
+
+# 3. Live eval probe — open here and reuse $SURFACE downstream; do NOT re-open.
+SURFACE=$(cmux browser open <target-url> | grep -oE 'surface:[0-9]+')
+cmux browser "$SURFACE" wait --load-state complete --timeout-ms 10000
+
+# Do NOT probe with `eval "1+1"` — it is NOT a reliable CSP gate. When a page's CSP
+# blocks page-world eval, cmux retries the script in an isolated content world
+# (WKContentWorld.defaultClient), so a context-free expression like `1+1` still
+# returns 2 even though page-world eval is blocked. The isolated world cannot see
+# page globals (window.__NEXT_DATA__, framework markers), which is exactly what the
+# SPA auto-detect and content-density waits depend on.
+#
+# Probe a PAGE-WORLD-dependent expression instead — read a global the page itself sets:
+cmux browser "$SURFACE" eval 'typeof window.document.title'    # "string" in either world (sanity)
+cmux browser "$SURFACE" eval 'String(!!window.__NEXT_DATA__ || !!window.__NUXT__ || !!window.ng || !!document.querySelector("[data-reactroot],[data-v-app],[ng-version]"))'
+```
+
+## Decision
+
+- Steps 1-2 show `script-src` **without** `unsafe-eval` → page-world eval likely blocked.
+- Step 3, page-global probe returns a coherent value that matches what you can see on
+  the page (e.g. `true` on a known SPA) → page-world eval works, proceed with the full skill.
+- Step 3 errors, or returns `false`/`undefined` on a page you know is an SPA → page-world
+  eval is blocked (cmux fell back to the isolated world, which cannot read page globals).
+  The auto-detect and content-density waits will not work; use the selector/text-based
+  fallbacks below, or drive the page with a CDP-based tool for rich interaction.
+
+> Note: cmux's isolated-world retry is silent on the plain CLI — the output does not
+> label which world produced the result. That is why a page-global probe (not `1+1`)
+> is the reliable discriminator.
+
+## Fallbacks when eval is blocked
+
+`eval`-free commands still work — they do not inject page JavaScript:
+
+```bash
+cmux browser "$SURFACE" get url
+cmux browser "$SURFACE" get text body
+cmux browser "$SURFACE" get html body
+cmux browser "$SURFACE" wait --selector "#ready" --timeout-ms 10000
+cmux browser "$SURFACE" wait --text "Welcome" --timeout-ms 10000
+cmux browser "$SURFACE" click "button[type='submit']"
+```
+
+Replace the eval-based hydration gate with selector/text waits (see
+[spa-hydration.md](spa-hydration.md) → Explicit Selector Wait), and replace
+`snapshot --interactive` reads with `get text body` / `get html body`.

--- a/skills/cmux-browser/references/spa-hydration.md
+++ b/skills/cmux-browser/references/spa-hydration.md
@@ -114,6 +114,12 @@ if [ "${NODE_COUNT:-0}" -lt 3 ]; then
     --function 'document.readyState==="complete" && !document.querySelector("[aria-busy=true],[data-loading=true]") && document.body.innerText.length>30' \
     --timeout-ms 15000 || { echo "hydration retry timed out — supply an explicit selector and retry" >&2; exit 1; }
   cmux browser "$SURFACE" snapshot --interactive
+  # Re-validate after the retry — a still-shell page must NOT exit 0 as "hydrated".
+  NODE_COUNT=$(cmux browser "$SURFACE" eval 'document.querySelectorAll("a[href],h1,h2,h3,button,nav,article").length' | tr -d ' \n')
+  if [ "${NODE_COUNT:-0}" -lt 3 ]; then
+    echo "snapshot still a pre-hydration shell after retry ($NODE_COUNT elements) — supply an explicit selector and retry" >&2
+    exit 1
+  fi
 fi
 ```
 

--- a/skills/cmux-browser/references/spa-hydration.md
+++ b/skills/cmux-browser/references/spa-hydration.md
@@ -1,0 +1,142 @@
+# SPA Hydration
+
+Single-page apps render the DOM client-side *after* the network finishes loading.
+This reference is the full protocol for waiting until the page is actually hydrated
+before you snapshot or act on it.
+
+**Related**: [SKILL.md](../SKILL.md), [csp-precheck.md](csp-precheck.md), [snapshot-refs.md](snapshot-refs.md)
+
+## Contents
+
+- [Why load-state is not enough](#why-load-state-is-not-enough)
+- [The Protocol](#the-protocol)
+- [Framework Auto-detect](#framework-auto-detect)
+- [Content-Density Wait](#content-density-wait)
+- [Explicit Selector Wait](#explicit-selector-wait)
+- [Snapshot Validation](#snapshot-validation)
+- [Re-hydrate After Navigation](#re-hydrate-after-navigation)
+
+## Why load-state is not enough
+
+```text
+wait --load-state complete  =>  HTML + CSS + scripts downloaded and parsed
+                                (document.readyState === "complete")
+```
+
+That gate fires *before* the framework mounts. For React/Vue/Next/Nuxt/SvelteKit/Angular
+the visible DOM is built by JavaScript after `complete`. A snapshot taken at this moment
+captures the skeleton/shell — typically a 2-node tree — and every selector you derive
+from it misses.
+
+## The Protocol
+
+Run once per page (and again after every navigation):
+
+1. **Load-state gate** — necessary, not sufficient.
+2. **Detect** whether the page is an SPA.
+3. **Hydration wait** — content-density (default) or explicit selector (precision).
+4. **Snapshot.**
+5. **Validate** the snapshot really hydrated; retry if it is an empty shell.
+
+## Framework Auto-detect
+
+```bash
+cmux browser "$SURFACE" eval '!!(window.__NEXT_DATA__||window.__NUXT__||window.__remixContext||window.__SVELTEKIT_DATA__||window.___gatsby||window.__INITIAL_STATE__||window.ng||document.querySelector("[data-reactroot],[data-v-app],[data-server-rendered],[ng-version],[data-svelte-h],[q\\:container]"))'
+```
+
+- `true`  → SPA detected → run the content-density wait (or selector wait if you know the DOM).
+- `false`/`null`/error → run the content-density wait anyway with a short timeout as a
+  safety net (it passes instantly on truly static pages, so there is no penalty).
+
+| Framework | Detection signal |
+|-----------|------------------|
+| Next.js   | `window.__NEXT_DATA__` |
+| Nuxt.js   | `window.__NUXT__` |
+| Remix     | `window.__remixContext` |
+| React (CRA) | `[data-reactroot]` |
+| Vue 3     | `[data-v-app]` |
+| Gatsby    | `window.___gatsby` |
+| SvelteKit | `window.__SVELTEKIT_DATA__` |
+| Angular   | `[ng-version]` |
+| Qwik      | `[q:container]` |
+
+## Content-Density Wait
+
+Default, framework-agnostic. Waits past the loading state until real text exists:
+
+```bash
+cmux browser "$SURFACE" wait \
+  --function 'document.readyState==="complete" && !document.querySelector("[aria-busy=true],[data-loading=true]") && document.body.innerText.length>30' \
+  --timeout-ms 10000
+```
+
+- `innerText.length > 30` — minimal threshold; covers sparse login/OTP/confirmation pages.
+  A high threshold (e.g. `> 200`) would time out on fully-hydrated but sparse pages.
+- `[aria-busy=true]`, `[data-loading=true]` — loading state cleared. Unquoted attribute
+  selectors are valid per the CSS spec.
+
+For content-rich pages (docs, dashboards) you can tighten:
+
+```bash
+cmux browser "$SURFACE" wait \
+  --function 'document.readyState==="complete" && document.body.innerText.length>200 && document.querySelectorAll("a[href],button").length>5 && !document.querySelector("[aria-busy=true],[data-loading=true]")' \
+  --timeout-ms 10000
+```
+
+## Explicit Selector Wait
+
+When you know the target DOM, this is the most precise gate:
+
+```bash
+cmux browser "$SURFACE" wait --selector "nav, aside, [role='navigation']" --timeout-ms 10000
+cmux browser "$SURFACE" wait --selector "main article, .content > *:not(:empty)" --timeout-ms 10000
+cmux browser "$SURFACE" wait --text "API Reference" --timeout-ms 10000
+```
+
+Some sidebar-driven doc SPAs (e.g. ReadMe.io) need a class-prefix selector:
+
+```bash
+cmux browser "$SURFACE" wait --selector "[class*='Sidebar'],[class*='rm-Sidebar'],nav.sidebar" --timeout-ms 15000
+```
+
+## Snapshot Validation
+
+After snapshotting, confirm hydration completed. A near-empty tree means retry — do not
+proceed on the shell:
+
+```bash
+cmux browser "$SURFACE" snapshot --interactive
+
+NODE_COUNT=$(cmux browser "$SURFACE" eval 'document.querySelectorAll("a[href],h1,h2,h3,button,nav,article").length' | tr -d ' \n')
+if [ "${NODE_COUNT:-0}" -lt 3 ]; then
+  echo "snapshot validation: only $NODE_COUNT elements — likely pre-hydration shell, retrying" >&2
+  cmux browser "$SURFACE" wait \
+    --function 'document.readyState==="complete" && !document.querySelector("[aria-busy=true],[data-loading=true]") && document.body.innerText.length>30' \
+    --timeout-ms 15000 || { echo "hydration retry timed out — supply an explicit selector and retry" >&2; exit 1; }
+  cmux browser "$SURFACE" snapshot --interactive
+fi
+```
+
+- `< 3` → truly empty shell (2-node skeleton) → retry with the content-density wait.
+- `>= 3` → hydrated. Sparse pages (login/OTP/confirmation) are valid at 3-8 elements;
+  do not treat them as failures by setting the threshold too high.
+
+Use a **content-density** retry, not a bare structural selector — `main`/`nav` often exist
+in the pre-hydration shell, so waiting on them passes too early.
+
+## Re-hydrate After Navigation
+
+Every `goto`/`navigate`, and every client-side route change after a `click` that changes
+the URL, lands on a page that hydrates again. Re-run the load-state + hydration wait before
+the next snapshot:
+
+```bash
+cmux browser "$SURFACE" click e3 --snapshot-after
+cmux browser "$SURFACE" wait --url-contains "/dashboard" --timeout-ms 15000
+cmux browser "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser "$SURFACE" wait --function 'document.body.innerText.length>100 && document.querySelectorAll("a[href],button").length>3' --timeout-ms 10000
+cmux browser "$SURFACE" snapshot --interactive
+```
+
+**Never swallow a hydration timeout** (`|| true`): proceeding after a failed wait captures
+the pre-hydration DOM. Fall back to an explicit selector wait or stop with an error instead.

--- a/skills/cmux-browser/templates/e2e-login-flow.sh
+++ b/skills/cmux-browser/templates/e2e-login-flow.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Login E2E with hydration waits on both the form page and the post-login destination.
+# Usage: CMUX_E2E_PASSWORD=... e2e-login-flow.sh <login-url> <email> [workspace-id]
+# The password is read from the CMUX_E2E_PASSWORD env var, NOT argv — a positional
+# secret would leak into shell history and the process table (`ps`).
+set -euo pipefail
+
+LOGIN_URL="${1:?usage: CMUX_E2E_PASSWORD=... e2e-login-flow.sh <login-url> <email> [workspace-id]}"
+EMAIL="${2:?email required}"
+WORKSPACE="${3:-}"
+PASSWORD="${CMUX_E2E_PASSWORD:?set CMUX_E2E_PASSWORD env var (do not pass the password as an argument)}"
+
+if [ -n "$WORKSPACE" ]; then
+  SURFACE=$(cmux browser open "$LOGIN_URL" --workspace "$WORKSPACE" | grep -oE 'surface:[0-9]+')
+else
+  SURFACE=$(cmux browser open "$LOGIN_URL" | grep -oE 'surface:[0-9]+')
+fi
+echo "surface: $SURFACE"
+
+# Hydrate the login page before touching the form.
+cmux browser "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser "$SURFACE" wait \
+  --function 'document.body.innerText.length>50 && document.querySelectorAll("a[href],button,input").length>2' \
+  --timeout-ms 10000 \
+  || { echo "login page hydration timed out" >&2; exit 1; }
+
+# Fill and submit.
+cmux browser "$SURFACE" wait --selector "#email" --timeout-ms 10000
+cmux browser "$SURFACE" fill "#email" "$EMAIL"
+cmux browser "$SURFACE" fill "#password" "$PASSWORD"
+cmux browser "$SURFACE" click "button[type='submit']"
+
+# The destination route hydrates client-side too — wait again before asserting.
+cmux browser "$SURFACE" wait --url-contains "/dashboard" --timeout-ms 15000
+cmux browser "$SURFACE" wait --load-state complete --timeout-ms 15000
+cmux browser "$SURFACE" wait \
+  --function 'document.body.innerText.length>100 && document.querySelectorAll("a[href],button").length>3' \
+  --timeout-ms 10000 \
+  || { echo "dashboard hydration timed out" >&2; exit 1; }
+
+cmux browser "$SURFACE" snapshot --interactive
+
+# Assertions. Customize the success selector for your app. This MUST gate the result:
+# do not append `|| true` — that would let a failed login report success under `set -e`.
+cmux browser "$SURFACE" get url
+cmux browser "$SURFACE" errors list
+if ! cmux browser "$SURFACE" is visible --selector "#success-message"; then
+  echo "login flow FAILED — success indicator not visible" >&2
+  exit 1
+fi
+echo "login flow complete. surface=$SURFACE"

--- a/skills/cmux-browser/templates/spa-hydration-wait.sh
+++ b/skills/cmux-browser/templates/spa-hydration-wait.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Open a URL, wait for SPA hydration, snapshot, and validate the result.
+# Usage: spa-hydration-wait.sh <url> [workspace-id]
+set -euo pipefail
+
+URL="${1:?usage: spa-hydration-wait.sh <url> [workspace-id]}"
+WORKSPACE="${2:-}"
+
+# Open. Inside cmux, $CMUX_WORKSPACE_ID is used automatically; outside, pass a workspace id.
+if [ -n "$WORKSPACE" ]; then
+  SURFACE=$(cmux browser open "$URL" --workspace "$WORKSPACE" | grep -oE 'surface:[0-9]+')
+else
+  SURFACE=$(cmux browser open "$URL" | grep -oE 'surface:[0-9]+')
+fi
+echo "surface: $SURFACE"
+
+# 1. Network-level load gate.
+cmux browser "$SURFACE" wait --load-state complete --timeout-ms 15000
+
+# 2. Detect SPA (informational; the content-density wait runs either way).
+IS_SPA=$(cmux browser "$SURFACE" eval '!!(window.__NEXT_DATA__||window.__NUXT__||window.__remixContext||window.__SVELTEKIT_DATA__||window.___gatsby||window.__INITIAL_STATE__||window.ng||document.querySelector("[data-reactroot],[data-v-app],[data-server-rendered],[ng-version],[data-svelte-h],[q\\:container]"))' 2>/dev/null | tr -d '"' | tr -d ' \n')
+echo "spa-detected: ${IS_SPA:-unknown}"
+
+# 3. Content-density hydration wait. Never swallow the timeout.
+cmux browser "$SURFACE" wait \
+  --function 'document.readyState==="complete" && !document.querySelector("[aria-busy=true],[data-loading=true]") && document.body.innerText.length>30' \
+  --timeout-ms 10000 \
+  || { echo "hydration wait timed out — supply an explicit selector and retry" >&2; exit 1; }
+
+# 4. Snapshot.
+cmux browser "$SURFACE" snapshot --interactive
+
+# 5. Validate: < 3 interactive/heading nodes means a pre-hydration shell.
+NODE_COUNT=$(cmux browser "$SURFACE" eval 'document.querySelectorAll("a[href],h1,h2,h3,button,nav,article").length' | tr -d ' \n')
+if [ "${NODE_COUNT:-0}" -lt 3 ]; then
+  echo "snapshot validation: only ${NODE_COUNT:-0} elements — retrying with longer timeout" >&2
+  cmux browser "$SURFACE" wait \
+    --function 'document.readyState==="complete" && !document.querySelector("[aria-busy=true],[data-loading=true]") && document.body.innerText.length>30' \
+    --timeout-ms 15000 \
+    || { echo "hydration retry timed out — supply an explicit selector and retry" >&2; exit 1; }
+  cmux browser "$SURFACE" snapshot --interactive
+  # Re-validate after the retry — a still-shell page must NOT exit 0 as "hydrated".
+  NODE_COUNT=$(cmux browser "$SURFACE" eval 'document.querySelectorAll("a[href],h1,h2,h3,button,nav,article").length' | tr -d ' \n')
+  if [ "${NODE_COUNT:-0}" -lt 3 ]; then
+    echo "snapshot still a pre-hydration shell after retry (${NODE_COUNT:-0} elements) — supply an explicit selector and retry" >&2
+    exit 1
+  fi
+fi
+
+echo "hydrated. surface=$SURFACE node_count=${NODE_COUNT:-0}"


### PR DESCRIPTION
### What
Adds a single-page-app (SPA) hydration layer to the `cmux-browser` skill:
- `references/spa-hydration.md` — framework auto-detect, content-density wait, explicit-selector wait, and snapshot validation/retry.
- `references/csp-precheck.md` — detect a CSP that blocks page-world `eval` / `snapshot --interactive`, with eval-free fallbacks.
- `templates/spa-hydration-wait.sh`, `templates/e2e-login-flow.sh` — runnable templates using the protocol.
- `SKILL.md` and `agents/openai.yaml` gain short SPA-hydration / CSP sections and pointers to the new references.

### Why
`wait --load-state complete` only guarantees the network-level load (`document.readyState === "complete"`). React/Vue/Next/Nuxt/SvelteKit/Angular build the visible DOM client-side after that point, so a `snapshot --interactive` taken right after `load-state complete` captures the pre-hydration shell (often a 2-node tree) and every derived selector misses. The added protocol waits past hydration and validates the snapshot actually rendered before acting.

### Scope / compatibility
Purely additive. All existing references and templates are preserved unchanged; only `SKILL.md` and `agents/openai.yaml` are edited (new sections + reference-table rows). No change to CLI behavior or existing flows.

### Testing
- `bash -n` passes on both new templates.
- CLI usage verified against cmux 0.64.17 (`cmux browser --help`): positional `surface:N`, `--timeout-ms`, and `goto`.
- The CSP guidance reflects the isolated-world eval retry in `Sources/TerminalController.swift` (a page-world CSP block silently retries in `WKContentWorld.defaultClient`), so the probe checks a page global rather than `1+1`.
- Note: docs/skill-only change; the macOS app test suite in CONTRIBUTING.md does not cover skill content. Live browser E2E against a real SPA was not run.

Pre-commit verified: `bash -n` passed on both templates; CLI conventions checked against cmux 0.64.17 (`cmux browser --help`).
Caller chain verified: N/A — docs-only change (skill markdown + bash templates + yaml; no code symbols with callers).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785142743&installation_id=133855650&pr_number=7013&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7013&signature=b9c7ae2a68bbe8134cf476fbdc9e42a473b8de4af0f9bddd8fd182bf0629327a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a SPA hydration wait and a CSP pre-check to the `cmux-browser` skill so snapshots run after client-side render and flows degrade safely when page-world eval is blocked. Tightens the hydration reference with a post-retry validation so runs fail fast if the page is still a pre-hydration shell.

- **New Features**
  - New references: `references/spa-hydration.md` (auto-detect, content-density/selector waits, snapshot validation) and `references/csp-precheck.md` (detect blocked `eval`/`snapshot --interactive`, eval-free fallbacks).
  - New templates: `templates/spa-hydration-wait.sh` and `templates/e2e-login-flow.sh`.
  - Updated `SKILL.md` and `agents/openai.yaml` with SPA hydration and CSP guidance.

- **Bug Fixes**
  - `references/spa-hydration.md`: mirror the template’s guard to re-validate after a retry and exit non-zero if the snapshot is still a pre-hydration shell.

<sup>Written for commit 7b891da7fa9d56727fd47652eed5da72edb0c74f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SPA hydration-aware waiting and validation to browser workflows (before and after navigation) to avoid snapshotting pre-hydration shells.
  * Introduced ready-to-use templates for SPA hydration waiting and a login E2E flow that waits for post-login hydration.

* **Documentation**
  * Expanded cmux browser documentation with a dedicated SPA hydration protocol guide and updated workflow templates.
  * Added a CSP pre-check reference to diagnose cases where page security policies block hydration/snapshot interactive reads.
  * Enhanced troubleshooting for empty snapshots and hydration timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->