### PR TITLE
fix(macos): decode Meta/Option (ESC+key) sequences from mobile input

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
@@ -347,6 +347,15 @@ extension TerminalSurface {
         if next == 0x7F || next == 0x08 {
             return (UInt32(kVK_Delete), GHOSTTY_MODS_ALT, "alt-backspace", 2)
         }
+        // Meta+<key>: every other Option-modified keystroke arrives as ESC<byte>
+        // — Option+Enter (ESC CR/LF), Option+Left/Right word-jump (ESC b / ESC f),
+        // Option+digit, and so on. Re-issue as the base key with the Option
+        // modifier so libghostty encodes the meta byte sequence atomically for
+        // the surface, instead of the bare-ESC path emitting a stray Escape and
+        // leaking the trailing byte as literal text.
+        if let meta = metaKey(forFollowingByte: next) {
+            return (meta.keycode, GHOSTTY_MODS_ALT, meta.label, 2)
+        }
         // CSI (ESC[) / SS3 (ESCO) cursor + navigation sequences.
         guard next == 0x5B || next == 0x4F, start + 2 < scalars.count else { return nil }
         let final = scalars[start + 2].value
@@ -371,6 +380,30 @@ extension TerminalSurface {
             default:
                 break
             }
+        }
+        return nil
+    }
+
+    /// Maps the byte following ESC in an Option-modified ("meta") key sequence
+    /// to the macOS virtual key code that libghostty re-encodes with the Option
+    /// modifier (`ESC b` → Alt+B → the shell's backward-word motion, etc.).
+    ///
+    /// `O` (0x4F) and `P` (0x50) are intentionally excluded: they introduce the
+    /// SS3 cursor-key and DCS string-control sequences handled by the cursor-key
+    /// block in ``navigationEscapeKey(_:from:)`` and the caller's terminal-control
+    /// parser. Any byte that is not a simple Option-able key returns nil so it
+    /// keeps its existing handling.
+    private static func metaKey(forFollowingByte value: UInt32) -> (keycode: UInt32, label: String)? {
+        if value == 0x0D || value == 0x0A { // CR / LF — Option+Enter
+            return (UInt32(kVK_Return), "alt-return")
+        }
+        if value != 0x4F, value != 0x50,
+           let scalar = Unicode.Scalar(value),
+           let keycode = keycodeForLetter(Character(scalar)) {
+            return (keycode, "alt-\(String(Character(scalar)).lowercased())")
+        }
+        if let keycode = keycodeForDigit(value) {
+            return (keycode, "alt-\(value - 0x30)")
         }
         return nil
     }
@@ -560,7 +593,7 @@ extension TerminalSurface {
         return String(decoding: rawData, as: UTF8.self)
     }
 
-    private func keycodeForLetter(_ letter: Character) -> UInt32? {
+    private static func keycodeForLetter(_ letter: Character) -> UInt32? {
         switch String(letter).lowercased() {
         case "a": return UInt32(kVK_ANSI_A)
         case "b": return UInt32(kVK_ANSI_B)
@@ -588,6 +621,25 @@ extension TerminalSurface {
         case "x": return UInt32(kVK_ANSI_X)
         case "y": return UInt32(kVK_ANSI_Y)
         case "z": return UInt32(kVK_ANSI_Z)
+        default: return nil
+        }
+    }
+
+    /// macOS virtual key code for an ASCII digit scalar value (0x30–0x39). The
+    /// `kVK_ANSI_*` digit codes are not contiguous, so they need an explicit
+    /// lookup just like ``keycodeForLetter(_:)``.
+    private static func keycodeForDigit(_ value: UInt32) -> UInt32? {
+        switch value {
+        case 0x30: return UInt32(kVK_ANSI_0)
+        case 0x31: return UInt32(kVK_ANSI_1)
+        case 0x32: return UInt32(kVK_ANSI_2)
+        case 0x33: return UInt32(kVK_ANSI_3)
+        case 0x34: return UInt32(kVK_ANSI_4)
+        case 0x35: return UInt32(kVK_ANSI_5)
+        case 0x36: return UInt32(kVK_ANSI_6)
+        case 0x37: return UInt32(kVK_ANSI_7)
+        case 0x38: return UInt32(kVK_ANSI_8)
+        case 0x39: return UInt32(kVK_ANSI_9)
         default: return nil
         }
     }
@@ -665,7 +717,7 @@ extension TerminalSurface {
                 }
                 if baseKey.count == 1,
                    let char = baseKey.first,
-                   let keycode = keycodeForLetter(char) {
+                   let keycode = Self.keycodeForLetter(char) {
                     return PendingKeyEvent(keycode: keycode, mods: GHOSTTY_MODS_NONE, label: normalized)
                 }
                 return nil
@@ -692,7 +744,7 @@ extension TerminalSurface {
             }
             if baseKey.count == 1,
                let char = baseKey.first,
-               let keycode = keycodeForLetter(char) {
+               let keycode = Self.keycodeForLetter(char) {
                 return PendingKeyEvent(keycode: keycode, mods: mods, label: normalized)
             }
             return nil

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceSocketInputEscapeTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceSocketInputEscapeTests.swift
@@ -1,0 +1,95 @@
+import Carbon.HIToolbox
+import CmuxTerminalCore
+import GhosttyKit
+import Testing
+
+@testable import CmuxTerminal
+
+/// Covers the meta (Option-modified) escape sequences the iOS app sends over the
+/// socket-input grammar. The iPad encodes Option+<key> as `ESC<byte>`; the parser
+/// must collapse each into a single Alt+<key> press so libghostty re-encodes it
+/// atomically, instead of leaking a stray Escape press plus the trailing byte as
+/// literal text (the on-device word-jump / Option+Enter bug).
+@Suite("Socket input meta escape parsing")
+struct TerminalSurfaceSocketInputEscapeTests {
+    private static func keyEvent(_ input: ParsedSocketInput) -> PendingKeyEvent? {
+        guard case let .key(event) = input else { return nil }
+        return event
+    }
+
+    /// Parses `text` and returns its single key event, or nil when the parse did
+    /// not collapse to exactly one key press (e.g. the buggy Escape + literal).
+    private func soleKey(_ text: String) -> PendingKeyEvent? {
+        let events = TerminalSurface.parsedSocketInputEvents(for: text)
+        guard events.count == 1 else { return nil }
+        return events.first.flatMap(Self.keyEvent)
+    }
+
+    @Test("ESC b (Option+Left word-jump) becomes Alt+B, not Escape + literal b")
+    func metaBWordJumpBack() throws {
+        let event = try #require(soleKey("\u{1B}b"))
+        #expect(event.keycode == UInt32(kVK_ANSI_B))
+        #expect(event.mods.rawValue == GHOSTTY_MODS_ALT.rawValue)
+    }
+
+    @Test("ESC f (Option+Right word-jump) becomes Alt+F, not Escape + literal f")
+    func metaFWordJumpForward() throws {
+        let event = try #require(soleKey("\u{1B}f"))
+        #expect(event.keycode == UInt32(kVK_ANSI_F))
+        #expect(event.mods.rawValue == GHOSTTY_MODS_ALT.rawValue)
+    }
+
+    @Test("ESC CR (Option+Enter) becomes Alt+Return")
+    func metaReturnCarriageReturn() throws {
+        let event = try #require(soleKey("\u{1B}\r"))
+        #expect(event.keycode == UInt32(kVK_Return))
+        #expect(event.mods.rawValue == GHOSTTY_MODS_ALT.rawValue)
+    }
+
+    @Test("ESC LF (Option+Enter) also becomes Alt+Return")
+    func metaReturnLineFeed() throws {
+        let event = try #require(soleKey("\u{1B}\n"))
+        #expect(event.keycode == UInt32(kVK_Return))
+        #expect(event.mods.rawValue == GHOSTTY_MODS_ALT.rawValue)
+    }
+
+    @Test("ESC 5 (Option+5) becomes Alt+5")
+    func metaDigitFive() throws {
+        let event = try #require(soleKey("\u{1B}5"))
+        #expect(event.keycode == UInt32(kVK_ANSI_5))
+        #expect(event.mods.rawValue == GHOSTTY_MODS_ALT.rawValue)
+    }
+
+    // MARK: - Regression guards for the pre-existing escape handling
+
+    @Test("CSI left arrow (ESC [ D) stays a single unmodified arrow key")
+    func csiLeftArrowUnchanged() throws {
+        let event = try #require(soleKey("\u{1B}[D"))
+        #expect(event.keycode == UInt32(kVK_LeftArrow))
+        #expect(event.mods.rawValue == GHOSTTY_MODS_NONE.rawValue)
+    }
+
+    @Test("Meta+Backspace (ESC DEL) stays Backspace with the Option modifier")
+    func metaBackspaceUnchanged() throws {
+        let event = try #require(soleKey("\u{1B}\u{7F}"))
+        #expect(event.keycode == UInt32(kVK_Delete))
+        #expect(event.mods.rawValue == GHOSTTY_MODS_ALT.rawValue)
+    }
+
+    @Test("SS3 cursor key (ESC O A) stays an arrow, not swallowed as Alt+O")
+    func ss3CursorKeyPreserved() throws {
+        let event = try #require(soleKey("\u{1B}OA"))
+        #expect(event.keycode == UInt32(kVK_UpArrow))
+        #expect(event.mods.rawValue == GHOSTTY_MODS_NONE.rawValue)
+    }
+
+    @Test("DCS string control (ESC P … ST) stays a terminal-byte sequence, not Alt+P")
+    func dcsStringControlPreserved() {
+        let events = TerminalSurface.parsedSocketInputEvents(for: "\u{1B}Pq\u{1B}\\")
+        #expect(events.count == 1)
+        guard case .terminalBytes = events.first else {
+            Issue.record("expected a single .terminalBytes event, got \(events)")
+            return
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Typing from a mobile/companion client, **every Option/Meta keyboard shortcut is broken** — Option+Left/Right (word-jump), Option+Enter, Option+<letter>, etc. The bare key is inserted as literal text instead (e.g. Option+Left inserts `b`, since word-back is `ESC b`). Local Mac keyboard input is unaffected; this only hits input arriving from a mobile client.

## Root cause
Mobile keystrokes arrive as byte sequences decoded by `parsedSocketInputEvents` → `navigationEscapeKey` (`TerminalSurface+Input.swift`). That decoder handles CSI (`ESC [ …`), SS3 (`ESC O …`), and meta-Backspace (`ESC 0x7F`/`0x08`), but nothing else after `ESC`. So every `ESC`+<key> meta sequence falls through to the bare-ESC branch — emitting a stray Escape and buffering the trailing byte as literal text. Arrows work because they're CSI; meta shortcuts (how every Option/Alt combo is encoded) do not.

## Fix
A general meta branch in `navigationEscapeKey` mapping `ESC`+<key> → a single `Alt`+<key> key event, so libghostty re-encodes it atomically:
- letters a–z/A–Z via the existing `keycodeForLetter`
- CR/LF → `Alt+Return` (Option+Enter)
- digits 0–9 via a new `keycodeForDigit`
- excludes `O`/`P` so the SS3 cursor-key and DCS string-control paths are preserved

## Tests
New `TerminalSurfaceSocketInputEscapeTests` (9 cases): `ESC b`/`ESC f` → Alt+B/F, `ESC \r` → Alt+Return, `ESC 5` → Alt+5, plus regression guards proving CSI arrows, meta-Backspace, SS3, and DCS still parse. Full `CmuxTerminal` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785190587&installation_id=133855650&pr_number=7017&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7017&signature=1c46342a69aef3123efb3a0713ecad3c30614bb227a4ff46fd588e832d05317f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken Option/Meta shortcuts from mobile clients on macOS by decoding `ESC+<key>` into Alt-modified key events. Restores word-jump, Option+Enter, and Option+digit without affecting local keyboard input.

- **Bug Fixes**
  - Map `ESC+<key>` in `navigationEscapeKey` to Alt+<key> (letters a–z/A–Z, CR/LF → Return, digits 0–9) so `libghostty` re-encodes them atomically.
  - Exclude `O`/`P` to preserve SS3 and DCS paths.
  - Add `metaKey(forFollowingByte:)` and `keycodeForDigit` helpers.
  - Add `TerminalSurfaceSocketInputEscapeTests` covering meta sequences and regressions (CSI arrows, meta-Backspace, SS3, DCS).

<sup>Written for commit c853b82f0be8ede3583d44b714ae352f51734192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Option/Alt key escape sequences in terminal input, including better support for iOS-style `ESC`-based keystrokes.
  * Fixed cases where modified keys could produce an extra Escape or stray character.
  * Preserved existing behavior for arrow keys, Backspace, and other terminal control sequences.
* **Tests**
  * Added coverage for Option-modified keys such as arrows, Enter, digits, and Backspace.
  * Added regression tests to ensure non-key terminal escape sequences continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->