### PR TITLE
Coalesce rapid sidebar workspace clicks to stop a main-thread layout-storm hang

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -17,7 +17,7 @@
 6895	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6317	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
-6197	Sources/TabManager.swift
+6201	Sources/TabManager.swift
 6077	Sources/TextBoxInput.swift
 5915	cmuxTests/TerminalAndGhosttyTests.swift
 5573	cmuxTests/BrowserConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -3,7 +3,7 @@
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 34643	CLI/cmux.swift
 17854	Sources/AppDelegate.swift
-16476	Sources/ContentView.swift
+16473	Sources/ContentView.swift
 13913	Sources/TerminalController.swift
 12886	Sources/Workspace.swift
 12348	cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -17,7 +17,7 @@
 6895	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6317	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
-6187	Sources/TabManager.swift
+6190	Sources/TabManager.swift
 6077	Sources/TextBoxInput.swift
 5915	cmuxTests/TerminalAndGhosttyTests.swift
 5573	cmuxTests/BrowserConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -17,7 +17,7 @@
 6895	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6317	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
-6190	Sources/TabManager.swift
+6197	Sources/TabManager.swift
 6077	Sources/TextBoxInput.swift
 5915	cmuxTests/TerminalAndGhosttyTests.swift
 5573	cmuxTests/BrowserConfigTests.swift

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14532,7 +14532,6 @@ struct TabItemView: View, Equatable {
         let modifiers = NSEvent.modifierFlags
         let isCommand = modifiers.contains(.command)
         let isShift = modifiers.contains(.shift)
-        let wasSelected = tabManager.selectedTabId == tab.id
         #if DEBUG
         var modStr = ""
         if modifiers.contains(.command) { modStr += "cmd " }
@@ -14596,12 +14595,10 @@ struct TabItemView: View, Equatable {
             resolvedShiftAnchorIndex: shiftAnchorIndex,
             clickedIndex: index
         )
-        tabManager.selectTab(tab)
-        if wasSelected, !isCommand, !isShift {
-            tabManager.dismissNotificationOnDirectInteraction(
-                tabId: tab.id,
-                surfaceId: tabManager.focusedSurfaceId(for: tab.id)
-            )
+        if isCommand || isShift {
+            tabManager.selectTab(tab)
+        } else {
+            tabManager.requestSidebarWorkspaceSelection(tab)
         }
         setSelectionToTabs()
     }

--- a/Sources/NotificationBurstCoalescer.swift
+++ b/Sources/NotificationBurstCoalescer.swift
@@ -57,6 +57,13 @@ final class NotificationBurstCoalescer {
         flush()
     }
 
+    /// Drops the pending action and any scheduled flush without running it.
+    func cancel() {
+        cancelScheduledFlush?()
+        cancelScheduledFlush = nil
+        pendingAction = nil
+    }
+
     private func scheduleFlushIfNeeded() {
         guard cancelScheduledFlush == nil else { return }
         let scheduledDelay = delay

--- a/Sources/NotificationBurstCoalescer.swift
+++ b/Sources/NotificationBurstCoalescer.swift
@@ -51,6 +51,19 @@ final class NotificationBurstCoalescer {
         scheduleFlushIfNeeded()
     }
 
+    /// Like `signal`, but resets the delay window on every call so the action
+    /// fires only after calls stop for `delay` (trailing debounce, not the
+    /// fire-from-first-signal throttle that `signal` provides).
+    func debounce(delay newDelay: TimeInterval? = nil, _ action: @escaping @MainActor () -> Void) {
+        if let newDelay {
+            delay = max(0, newDelay)
+        }
+        pendingAction = action
+        cancelScheduledFlush?()
+        cancelScheduledFlush = nil
+        scheduleFlushIfNeeded()
+    }
+
     func flushNow() {
         cancelScheduledFlush?()
         cancelScheduledFlush = nil

--- a/Sources/TabManager+SidebarWorkspaceSelection.swift
+++ b/Sources/TabManager+SidebarWorkspaceSelection.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension TabManager {
+    /// Selects the workspace for a normal sidebar workspace-row click. A click on
+    /// the already-selected workspace dismisses its notification directly instead.
+    func requestSidebarWorkspaceSelection(_ workspace: Workspace) {
+        if selectedTabId == workspace.id {
+            dismissNotificationOnDirectInteraction(
+                tabId: workspace.id,
+                surfaceId: focusedSurfaceId(for: workspace.id)
+            )
+            return
+        }
+
+        selectWorkspace(workspace)
+    }
+}

--- a/Sources/TabManager+SidebarWorkspaceSelection.swift
+++ b/Sources/TabManager+SidebarWorkspaceSelection.swift
@@ -1,43 +1,8 @@
 import Foundation
 
-/// Debounces rapid sidebar workspace-row clicks into one selection of the latest
-/// target, so a click burst collapses to the last-clicked workspace.
-@MainActor
-final class SidebarWorkspaceSelectionCoalescer {
-    private let delayNanoseconds: UInt64
-    private var pendingWorkspaceId: UUID?
-    private var pendingTask: Task<Void, Never>?
-
-    init(delayNanoseconds: UInt64) {
-        self.delayNanoseconds = delayNanoseconds
-    }
-
-    func schedule(workspaceId: UUID, _ select: @escaping @MainActor (UUID) -> Void) {
-        pendingWorkspaceId = workspaceId
-        pendingTask?.cancel()
-        let delayNanoseconds = delayNanoseconds
-        pendingTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: delayNanoseconds)
-            guard !Task.isCancelled,
-                  let self,
-                  let workspaceId = self.pendingWorkspaceId
-            else { return }
-
-            self.pendingWorkspaceId = nil
-            self.pendingTask = nil
-            select(workspaceId)
-        }
-    }
-
-    func cancel() {
-        pendingTask?.cancel()
-        pendingTask = nil
-        pendingWorkspaceId = nil
-    }
-}
-
 extension TabManager {
-    /// Debounces a normal sidebar workspace-row click. A click on the already-selected
+    /// Debounces a normal sidebar workspace-row click so a rapid burst collapses
+    /// into one switch to the last-clicked workspace. A click on the already-selected
     /// workspace instead cancels pending work and dismisses its notification directly.
     func requestSidebarWorkspaceSelection(_ workspace: Workspace) {
         if selectedTabId == workspace.id {
@@ -49,7 +14,8 @@ extension TabManager {
             return
         }
 
-        sidebarWorkspaceSelectionCoalescer.schedule(workspaceId: workspace.id) { [weak self] workspaceId in
+        let workspaceId = workspace.id
+        sidebarWorkspaceSelectionCoalescer.signal { [weak self] in
             guard let self,
                   let workspace = self.tabs.first(where: { $0.id == workspaceId })
             else { return }

--- a/Sources/TabManager+SidebarWorkspaceSelection.swift
+++ b/Sources/TabManager+SidebarWorkspaceSelection.swift
@@ -15,11 +15,8 @@ extension TabManager {
         }
 
         let workspaceId = workspace.id
-        sidebarWorkspaceSelectionCoalescer.signal { [weak self] in
-            guard let self,
-                  let workspace = self.tabs.first(where: { $0.id == workspaceId })
-            else { return }
-            self.selectWorkspace(workspace)
+        sidebarWorkspaceSelectionCoalescer.debounce { [weak self] in
+            self?.selectWorkspace(byId: workspaceId)
         }
     }
 

--- a/Sources/TabManager+SidebarWorkspaceSelection.swift
+++ b/Sources/TabManager+SidebarWorkspaceSelection.swift
@@ -1,10 +1,47 @@
 import Foundation
 
+/// Debounces rapid sidebar workspace-row clicks into one selection of the latest
+/// target, so a click burst collapses to the last-clicked workspace.
+@MainActor
+final class SidebarWorkspaceSelectionCoalescer {
+    private let delayNanoseconds: UInt64
+    private var pendingWorkspaceId: UUID?
+    private var pendingTask: Task<Void, Never>?
+
+    init(delayNanoseconds: UInt64) {
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func schedule(workspaceId: UUID, _ select: @escaping @MainActor (UUID) -> Void) {
+        pendingWorkspaceId = workspaceId
+        pendingTask?.cancel()
+        let delayNanoseconds = delayNanoseconds
+        pendingTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: delayNanoseconds)
+            guard !Task.isCancelled,
+                  let self,
+                  let workspaceId = self.pendingWorkspaceId
+            else { return }
+
+            self.pendingWorkspaceId = nil
+            self.pendingTask = nil
+            select(workspaceId)
+        }
+    }
+
+    func cancel() {
+        pendingTask?.cancel()
+        pendingTask = nil
+        pendingWorkspaceId = nil
+    }
+}
+
 extension TabManager {
-    /// Selects the workspace for a normal sidebar workspace-row click. A click on
-    /// the already-selected workspace dismisses its notification directly instead.
+    /// Debounces a normal sidebar workspace-row click. A click on the already-selected
+    /// workspace instead cancels pending work and dismisses its notification directly.
     func requestSidebarWorkspaceSelection(_ workspace: Workspace) {
         if selectedTabId == workspace.id {
+            cancelPendingSidebarWorkspaceSelection()
             dismissNotificationOnDirectInteraction(
                 tabId: workspace.id,
                 surfaceId: focusedSurfaceId(for: workspace.id)
@@ -12,6 +49,15 @@ extension TabManager {
             return
         }
 
-        selectWorkspace(workspace)
+        sidebarWorkspaceSelectionCoalescer.schedule(workspaceId: workspace.id) { [weak self] workspaceId in
+            guard let self,
+                  let workspace = self.tabs.first(where: { $0.id == workspaceId })
+            else { return }
+            self.selectWorkspace(workspace)
+        }
+    }
+
+    func cancelPendingSidebarWorkspaceSelection() {
+        sidebarWorkspaceSelectionCoalescer.cancel()
     }
 }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -229,6 +229,7 @@ class TabManager: ObservableObject {
     @Published private(set) var pendingBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var mountedBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var debugPinnedWorkspaceLoadIds: Set<UUID> = []
+    let sidebarWorkspaceSelectionCoalescer = SidebarWorkspaceSelectionCoalescer(delayNanoseconds: 60_000_000)
 
     /// Global monotonically increasing counter for CMUX_PORT ordinal assignment.
     /// Static so port ranges don't overlap across multiple windows (each window has its own TabManager).
@@ -2314,6 +2315,8 @@ class TabManager: ObservableObject {
     }
 
     func selectWorkspace(_ workspace: Workspace) {
+        // A direct selection supersedes any pending sidebar debounce.
+        cancelPendingSidebarWorkspaceSelection()
 #if DEBUG
         debugPrimeWorkspaceSwitchTrigger("select", to: workspace.id)
 #endif

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3259,6 +3259,10 @@ class TabManager: ObservableObject {
         notificationDismissalContext: NotificationDismissalContext?
     ) {
         guard selectedTabId != tabId else {
+            // Re-selecting the current workspace is still an authoritative choice and
+            // supersedes a pending sidebar switch (selectedWorkspaceIdDidChange, which
+            // owns the cancel for real changes, never runs on this no-op path).
+            cancelPendingSidebarWorkspaceSelection()
             notificationDismissal.setPendingSelectionContext(nil)
             if let notificationDismissalContext {
                 notificationDismissal.dismissFocusedPanelNotificationIfActive(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -229,7 +229,7 @@ class TabManager: ObservableObject {
     @Published private(set) var pendingBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var mountedBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var debugPinnedWorkspaceLoadIds: Set<UUID> = []
-    let sidebarWorkspaceSelectionCoalescer = SidebarWorkspaceSelectionCoalescer(delayNanoseconds: 60_000_000)
+    let sidebarWorkspaceSelectionCoalescer = NotificationBurstCoalescer(delay: 0.06)
 
     /// Global monotonically increasing counter for CMUX_PORT ordinal assignment.
     /// Static so port ranges don't overlap across multiple windows (each window has its own TabManager).
@@ -2315,8 +2315,6 @@ class TabManager: ObservableObject {
     }
 
     func selectWorkspace(_ workspace: Workspace) {
-        // A direct selection supersedes any pending sidebar debounce.
-        cancelPendingSidebarWorkspaceSelection()
 #if DEBUG
         debugPrimeWorkspaceSwitchTrigger("select", to: workspace.id)
 #endif
@@ -3251,6 +3249,8 @@ class TabManager: ObservableObject {
         _ tabId: UUID,
         notificationDismissalContext: NotificationDismissalContext?
     ) {
+        // A direct selection supersedes any pending sidebar debounce.
+        cancelPendingSidebarWorkspaceSelection()
         guard selectedTabId != tabId else {
             notificationDismissal.setPendingSelectionContext(nil)
             if let notificationDismissalContext {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -291,6 +291,9 @@ class TabManager: ObservableObject {
     /// chain, run synchronously after storage changed.
     func selectedWorkspaceIdDidChange(from oldValue: UUID?) {
             guard selectedTabId != oldValue else { return }
+            // Any authoritative selection (sidebar fire, keyboard, CLI, focus
+            // history) supersedes a still-pending sidebar debounce.
+            cancelPendingSidebarWorkspaceSelection()
             if !isRestoringSessionSnapshot {
                 workspaces.expandWorkspaceGroupForSelectionIfNeeded()
             }
@@ -2321,6 +2324,12 @@ class TabManager: ObservableObject {
         selectWorkspaceId(workspace.id, notificationDismissalContext: .explicitWorkspaceResume)
     }
 
+    /// O(1) selection by id; no-op if the workspace was closed meanwhile.
+    func selectWorkspace(byId id: UUID) {
+        guard let workspace = workspacesById[id] else { return }
+        selectWorkspace(workspace)
+    }
+
     // Keep selectTab as convenience alias
     func selectTab(_ tab: Workspace) { selectWorkspace(tab) }
 
@@ -3249,8 +3258,6 @@ class TabManager: ObservableObject {
         _ tabId: UUID,
         notificationDismissalContext: NotificationDismissalContext?
     ) {
-        // A direct selection supersedes any pending sidebar debounce.
-        cancelPendingSidebarWorkspaceSelection()
         guard selectedTabId != tabId else {
             notificationDismissal.setPendingSelectionContext(nil)
             if let notificationDismissalContext {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -934,10 +934,12 @@
 		E3B7A400000000000000000B /* TabManager+FocusHistoryHosting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B7A400000000000000000C /* TabManager+FocusHistoryHosting.swift */; };
 		E3B7A4000000000000000009 /* TabManager+NotificationDismissalHosting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B7A400000000000000000A /* TabManager+NotificationDismissalHosting.swift */; };
 		C5B6A10000000000000000B1 /* TabManager+SidebarGitHosting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5B6A10000000000000000B2 /* TabManager+SidebarGitHosting.swift */; };
+		C0DE67990000000000000003 /* TabManager+SidebarWorkspaceSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE67990000000000000004 /* TabManager+SidebarWorkspaceSelection.swift */; };
 		604500100000000000000007 /* TabManager+WindowTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604500100000000000000008 /* TabManager+WindowTitle.swift */; };
 		A5001003 /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001013 /* TabManager.swift */; };
 		C0DE64160000000000000001 /* TabManagerNotificationFocusRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */; };
 		2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
+		C0DE67990000000000000001 /* TabManagerSidebarSelectionCoalescingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE67990000000000000002 /* TabManagerSidebarSelectionCoalescingTests.swift */; };
 		C06552030000000000000001 /* TabManagerTitleUpdateStalenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */; };
 		C06552020000000000000001 /* TabManagerTitleUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */; };
 		B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */; };
@@ -2068,10 +2070,12 @@
 		E3B7A400000000000000000C /* TabManager+FocusHistoryHosting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabManager+FocusHistoryHosting.swift"; sourceTree = "<group>"; };
 		E3B7A400000000000000000A /* TabManager+NotificationDismissalHosting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabManager+NotificationDismissalHosting.swift"; sourceTree = "<group>"; };
 		C5B6A10000000000000000B2 /* TabManager+SidebarGitHosting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabManager+SidebarGitHosting.swift"; sourceTree = "<group>"; };
+		C0DE67990000000000000004 /* TabManager+SidebarWorkspaceSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabManager+SidebarWorkspaceSelection.swift"; sourceTree = "<group>"; };
 		604500100000000000000008 /* TabManager+WindowTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabManager+WindowTitle.swift"; sourceTree = "<group>"; };
 		A5001013 /* TabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManager.swift; sourceTree = "<group>"; };
 		C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerNotificationFocusRegressionTests.swift; sourceTree = "<group>"; };
 		10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
+		C0DE67990000000000000002 /* TabManagerSidebarSelectionCoalescingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSidebarSelectionCoalescingTests.swift; sourceTree = "<group>"; };
 		C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerTitleUpdateStalenessTests.swift; sourceTree = "<group>"; };
 		C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerTitleUpdateTests.swift; sourceTree = "<group>"; };
 		42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerUnitTests.swift; sourceTree = "<group>"; };
@@ -2689,6 +2693,7 @@
 					C06552010000000000000002 /* PanelTitleUpdateCoalescingSettings.swift */,
 					A5001013 /* TabManager.swift */,
 				C5B6A10000000000000000B2 /* TabManager+SidebarGitHosting.swift */,
+				C0DE67990000000000000004 /* TabManager+SidebarWorkspaceSelection.swift */,
 				F0C05170000000000000001 /* FocusHistory.swift */,
 				C0DEFB100000000000000002 /* FocusSurfaceBroadcaster.swift */,
 				C10D51700000000000000001 /* ClosedItemHistory.swift */,
@@ -3430,6 +3435,7 @@
 				D7AB00000000000000B020 /* NotificationDismissSyncTests.swift */,
 				4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */,
 				C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */,
+				C0DE67990000000000000002 /* TabManagerSidebarSelectionCoalescingTests.swift */,
 				C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */,
 				C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
@@ -4478,6 +4484,7 @@
 				E3B7A400000000000000000B /* TabManager+FocusHistoryHosting.swift in Sources */,
 				E3B7A4000000000000000009 /* TabManager+NotificationDismissalHosting.swift in Sources */,
 				C5B6A10000000000000000B1 /* TabManager+SidebarGitHosting.swift in Sources */,
+				C0DE67990000000000000003 /* TabManager+SidebarWorkspaceSelection.swift in Sources */,
 				604500100000000000000007 /* TabManager+WindowTitle.swift in Sources */,
 				A5001003 /* TabManager.swift in Sources */,
 				C7A503000000000000000002 /* TaskManagerSnapshot.swift in Sources */,
@@ -4974,6 +4981,7 @@
 				FBE660ABA1854983B84368C6 /* SystemWideHotkeyShortcutPolicyTests.swift in Sources */,
 				C0DE64160000000000000001 /* TabManagerNotificationFocusRegressionTests.swift in Sources */,
 				2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
+				C0DE67990000000000000001 /* TabManagerSidebarSelectionCoalescingTests.swift in Sources */,
 				C06552030000000000000001 /* TabManagerTitleUpdateStalenessTests.swift in Sources */,
 				C06552020000000000000001 /* TabManagerTitleUpdateTests.swift in Sources */,
 				B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,

--- a/cmuxTests/TabManagerSidebarSelectionCoalescingTests.swift
+++ b/cmuxTests/TabManagerSidebarSelectionCoalescingTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class TabManagerSidebarSelectionCoalescingTests: XCTestCase {
+    func testSidebarWorkspaceSelectionCoalescesToLatestTarget() async {
+        let manager = TabManager()
+        let first = manager.tabs[0]
+        let second = manager.addWorkspace(select: false)
+        let third = manager.addWorkspace(select: false)
+
+        manager.requestSidebarWorkspaceSelection(second)
+        manager.requestSidebarWorkspaceSelection(third)
+
+        XCTAssertEqual(
+            manager.selectedTabId,
+            first.id,
+            "Sidebar-origin selection should wait briefly so rapid clicks can collapse to the latest target."
+        )
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(manager.selectedTabId, third.id)
+    }
+
+    func testImmediateWorkspaceSelectionCancelsPendingSidebarSelection() async {
+        let manager = TabManager()
+        let first = manager.tabs[0]
+        let second = manager.addWorkspace(select: false)
+        let third = manager.addWorkspace(select: false)
+
+        manager.requestSidebarWorkspaceSelection(second)
+        manager.selectWorkspace(third)
+
+        XCTAssertEqual(manager.selectedTabId, third.id)
+
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(manager.selectedTabId, third.id)
+        XCTAssertNotEqual(manager.selectedTabId, second.id)
+        XCTAssertNotEqual(manager.selectedTabId, first.id)
+    }
+
+    func testRequestingCurrentlySelectedWorkspaceCancelsPendingSidebarSelection() async {
+        let manager = TabManager()
+        let first = manager.tabs[0]
+        let second = manager.addWorkspace(select: false)
+
+        manager.requestSidebarWorkspaceSelection(second)
+        manager.requestSidebarWorkspaceSelection(first)
+
+        XCTAssertEqual(manager.selectedTabId, first.id)
+
+        try? await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(manager.selectedTabId, first.id)
+        XCTAssertNotEqual(manager.selectedTabId, second.id)
+    }
+}

--- a/cmuxTests/TabManagerSidebarSelectionCoalescingTests.swift
+++ b/cmuxTests/TabManagerSidebarSelectionCoalescingTests.swift
@@ -56,6 +56,21 @@ final class TabManagerSidebarSelectionCoalescingTests: XCTestCase {
         XCTAssertNotEqual(manager.selectedTabId, second.id)
     }
 
+    func testReselectingCurrentWorkspaceViaDirectPathCancelsPendingSidebarSelection() async {
+        let manager = TabManager()
+        let first = manager.tabs[0]
+        let second = manager.addWorkspace(select: false)
+
+        manager.requestSidebarWorkspaceSelection(second)
+        // Re-select the already-selected workspace through the direct path (the
+        // numbered-shortcut / CLI no-op case); it must still drop the pending switch.
+        manager.selectWorkspace(first)
+
+        XCTAssertEqual(manager.selectedTabId, first.id)
+        await assertSelectionStays(manager, at: first.id)
+        XCTAssertNotEqual(manager.selectedTabId, second.id)
+    }
+
     /// Deadline-bounded poll: returns the instant the selection reaches `target`,
     /// only spinning up to the deadline so host load can slow a pass but never fail one.
     private func pollUntilSelection(_ manager: TabManager, equals target: UUID?) async {

--- a/cmuxTests/TabManagerSidebarSelectionCoalescingTests.swift
+++ b/cmuxTests/TabManagerSidebarSelectionCoalescingTests.swift
@@ -17,12 +17,14 @@ final class TabManagerSidebarSelectionCoalescingTests: XCTestCase {
         manager.requestSidebarWorkspaceSelection(second)
         manager.requestSidebarWorkspaceSelection(third)
 
+        // The debounce has not fired yet, so the selection is still unchanged.
         XCTAssertEqual(
             manager.selectedTabId,
             first.id,
             "Sidebar-origin selection should wait briefly so rapid clicks can collapse to the latest target."
         )
-        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        await pollUntilSelection(manager, equals: third.id)
         XCTAssertEqual(manager.selectedTabId, third.id)
     }
 
@@ -36,9 +38,7 @@ final class TabManagerSidebarSelectionCoalescingTests: XCTestCase {
         manager.selectWorkspace(third)
 
         XCTAssertEqual(manager.selectedTabId, third.id)
-
-        try? await Task.sleep(nanoseconds: 150_000_000)
-        XCTAssertEqual(manager.selectedTabId, third.id)
+        await assertSelectionStays(manager, at: third.id)
         XCTAssertNotEqual(manager.selectedTabId, second.id)
         XCTAssertNotEqual(manager.selectedTabId, first.id)
     }
@@ -52,9 +52,33 @@ final class TabManagerSidebarSelectionCoalescingTests: XCTestCase {
         manager.requestSidebarWorkspaceSelection(first)
 
         XCTAssertEqual(manager.selectedTabId, first.id)
-
-        try? await Task.sleep(nanoseconds: 150_000_000)
-        XCTAssertEqual(manager.selectedTabId, first.id)
+        await assertSelectionStays(manager, at: first.id)
         XCTAssertNotEqual(manager.selectedTabId, second.id)
+    }
+
+    /// Deadline-bounded poll: returns the instant the selection reaches `target`,
+    /// only spinning up to the deadline so host load can slow a pass but never fail one.
+    private func pollUntilSelection(_ manager: TabManager, equals target: UUID?) async {
+        for _ in 0..<60 {
+            if manager.selectedTabId == target { return }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+
+    /// Confirms a cancelled pending selection never fires: bails the instant the
+    /// selection wrongly changes, otherwise spins past the debounce window.
+    private func assertSelectionStays(
+        _ manager: TabManager,
+        at expected: UUID?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        for _ in 0..<24 {
+            if manager.selectedTabId != expected {
+                XCTFail("A cancelled sidebar selection should not fire.", file: file, line: line)
+                return
+            }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Rapidly clicking between workspace rows in the left sidebar freezes cmux — the UI
beachballs for tens of seconds, which users experience as a crash. It is a **main-thread
hang**, not a memory fault: each sidebar click changes `selectedTabId`, every change drives
a full SwiftUI transaction that re-lays-out the workspace `LazyVStack`, and a rapid burst
stacks those layout passes until the main thread is saturated.

This PR coalesces only normal (unmodified) sidebar row clicks, so a burst collapses into a
single selection (and a single layout pass) of the workspace the user lands on. Every other
selection path stays immediate.

## Evidence

Two hang reports captured on the affected machine (cmux `0.64.17 (97)`, macOS `26.0.1`,
`Mac16,7`) show the same signature: the main thread pinned at ~100% CPU inside SwiftUI's
lazy-layout engine, with no memory exception.

```
Event: hang        Duration: 13.89s   (report 1)
Event: hang        Duration: 58.53s   (report 2)
Thread "com.apple.main-thread"  cpu time 1.800s in a 1.90s sample

  main (cmux)
    NSHostingView.beginTransaction()
      ViewGraphRootValueUpdater.updateGraph
        LazySubviewPlacements.placeSubviews(...)
          _LazyLayoutViewCache.withMutableCacheState(...)
            LazyStack.place(subviews:context:cache:in:)
              ForEachList.applyNodes(...)
```

This is the same `LazyLayoutViewCache` main-thread spin class that previously hit the
Sessions panel and the workspace sidebar (https://github.com/manaflow-ai/cmux/issues/2586).

## Root cause

A sidebar row click calls `TabManager.selectWorkspace(_:)`, which assigns `selectedTabId`.
That change publishes through the view tree and triggers a SwiftUI transaction
(`NSHostingView.beginTransaction` → graph update → `LazyStack` placement →
`LazyLayoutViewCache`). A single click pays one such layout pass; a rapid burst of clicks
enqueues one per click with no rate limit, and the main thread cannot drain them faster than
they arrive, so it saturates and the app stops responding.

The async selection side-effects in `selectedTabId`'s change hook are already de-duplicated
to the latest target via `selectionSideEffectsGeneration`; the unbounded work is the
per-change SwiftUI layout pass on the list itself.

## Fix

Normal sidebar row clicks now go through `requestSidebarWorkspaceSelection(_:)`, backed by
the repo's existing `NotificationBurstCoalescer` — the same cancellation-aware coalescer
that already collapses panel-title and notification bursts, "where only the latest update
matters" — using a trailing 60ms debounce:

- A normal click is debounced for 60ms; the window resets on each click, so a rapid burst
  collapses to a single selection (one layout pass) of the workspace the user lands on.
- Cmd / Shift clicks stay immediate (`selectTab`), so multi-select and range-select are
  unchanged.
- Extension-sidebar selection and every direct `selectWorkspace` call (keyboard, CLI,
  programmatic) stay immediate.
- Every selection cancels a pending sidebar debounce — `selectedWorkspaceIdDidChange` owns
  the cancel for real changes (covering numbered-workspace shortcuts, the CLI index path,
  focus-history Back/Forward, and direct `selectWorkspace` calls), and the same-id no-op
  branch of `selectWorkspaceId` covers re-selecting the already-selected workspace — so the
  latest explicit intent always supersedes a pending switch.
- Clicking the already-selected workspace cancels pending work and keeps the existing
  direct notification-dismissal behavior.

This is event coalescing for a render storm, not a timing patch over a data race: the bad
state is "N redundant layout passes for N rapid selections," and the repo already collapses
exactly this kind of burst elsewhere with `NotificationBurstCoalescer`. `selectTab(_:)` is a
thin alias for `selectWorkspace(_:)`, so a coalesced click behaves exactly like the previous
immediate one; only its timing changes, by at most 60ms for a single click.

This PR adds two additive methods to `NotificationBurstCoalescer` (`cancel()` and a trailing
`debounce()`); its existing callers are untouched. The coalesced workspace is resolved
through the `workspacesById` index (O(1)). The sidebar glue lives in its own file,
`Sources/TabManager+SidebarWorkspaceSelection.swift`.

Trade-off: a single click now applies up to 60ms later, so for that window the view-local
highlight is ahead of `selectedTabId`. This is the intended cost of collapsing a burst; it
is below the interval at which a human can interleave a conflicting action, and any
authoritative selection in that window cancels the pending switch.

## Testing

Two-commit red/green per repo policy:

- Commit 1 adds `TabManagerSidebarSelectionCoalescingTests` and reroutes normal clicks
  through `requestSidebarWorkspaceSelection`, still selecting immediately (the pre-fix
  behavior). `testSidebarWorkspaceSelectionCoalescesToLatestTarget` fails because the
  selection is not deferred (CI red).
- Commit 2 adds the 60ms coalescer and switches the call site to it. All three tests pass
  (CI green).
- Follow-up commits address review feedback: swap the bespoke `Task.sleep` debounce for
  `NotificationBurstCoalescer` and rewrite the tests as deadline-bounded polls (so
  `check-test-determinism.py --strict` passes); make it a true trailing debounce; resolve
  the workspace via the `workspacesById` index (O(1)); move the pending-debounce cancel into
  `selectedWorkspaceIdDidChange`; and also cancel from the same-id no-op branch of
  `selectWorkspaceId` so re-selecting the current workspace supersedes a pending switch too
  (with a fourth regression test).

```bash
CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project cmux.xcodeproj -scheme cmux-unit \
  -configuration Debug -destination 'platform=macOS' \
  -only-testing:cmuxTests/TabManagerSidebarSelectionCoalescingTests test
```

4 tests pass. The test file is wired into `project.pbxproj` (`lint-pbxproj-test-wiring.sh`
passes). Also green: `git diff --check`, `./scripts/check-pbxproj.sh`, and the file-length
budget. `CMUX_SKIP_ZIG_BUILD=1` is needed locally because this machine doesn't have the
exact zig 0.15.2 the Ghostty CLI-helper build phase wants; it skips only that helper phase,
the Swift `cmux-unit` target still compiles in full and runs the tests, and CI builds zig
normally.

## Localization

No user-facing strings are added or changed (selection plumbing only), so the localization
audit is a no-op.

## Demo Video

The fix removes a freeze with no clean visual diff. I can record a before/after of rapid
sidebar clicking if that's useful.

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (no user-facing docs affected)
- [x] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved (CodeRabbit and Greptile withdrew their findings; Codex findings applied)
- [ ] All human review comments are resolved
