### PR TITLE
browser: present a system-keychain client certificate for mutual-TLS challenges

### DIFF
--- a/Sources/Panels/BrowserClientCertificateResolver.swift
+++ b/Sources/Panels/BrowserClientCertificateResolver.swift
@@ -69,13 +69,18 @@ nonisolated struct BrowserClientCertificateResolver: Sendable {
         // 1. A host-specific keychain identity preference (the user's explicit
         //    choice for this host, what a system browser records on first use),
         //    constrained to the server's acceptable issuers so a stale preference
-        //    can't present a certificate the server never asked for. Try the bare
-        //    host and the URL forms a browser typically records.
-        let host = protectionSpace.host
-        let candidates = [host, "https://\(host)", "https://\(host):\(protectionSpace.port)"]
-        for name in candidates {
-            if let preferred = SecIdentityCopyPreferred(name as CFString, nil, issuerFilter) {
-                return preferred
+        //    can't present a certificate the server never asked for. Only consult
+        //    the preference when the server advertised acceptable issuers — with no
+        //    issuer constraint a stale preference would be presented unconditionally,
+        //    so we fail closed (defer to the system) instead. Try the bare host and
+        //    the URL forms a browser typically records.
+        if let issuerFilter {
+            let host = protectionSpace.host
+            let candidates = [host, "https://\(host)", "https://\(host):\(protectionSpace.port)"]
+            for name in candidates {
+                if let preferred = SecIdentityCopyPreferred(name as CFString, nil, issuerFilter) {
+                    return preferred
+                }
             }
         }
 

--- a/Sources/Panels/BrowserClientCertificateResolver.swift
+++ b/Sources/Panels/BrowserClientCertificateResolver.swift
@@ -12,10 +12,12 @@ import Security
 /// rejects the connection. This resolver finds a matching identity in the
 /// system keychain and the caller presents it with `.useCredential`.
 ///
-/// Note: a hardware-backed (Secure Enclave) identity is usable only by an
-/// application entitled to its keychain access group, so it can only be presented
-/// by a suitably code-signed build. An extractable identity in the system
-/// keychain works without that entitlement.
+/// Note: this works from an unsigned (ad-hoc) build with no special entitlement.
+/// A hardware-backed identity held in a CryptoTokenKit token (e.g. Secure
+/// Enclave) is presented through the token, which brokers the signing operation,
+/// so the browser does not need the token's keychain access group. An extractable
+/// software identity in the system keychain works the same way. (Verified
+/// empirically against a real mutual-TLS origin from an ad-hoc-signed build.)
 enum BrowserClientCertificateResolver {
     /// Answer a client-certificate (mutual-TLS) challenge by presenting a matching
     /// system-keychain identity, or deferring to the system when none matches.

--- a/Sources/Panels/BrowserClientCertificateResolver.swift
+++ b/Sources/Panels/BrowserClientCertificateResolver.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Security
+
+/// Resolves and presents a TLS client-certificate identity for a mutual-TLS
+/// (mTLS) challenge so the embedded browser can reach client-cert-gated origins
+/// (corporate zero-trust / device-attestation endpoints, MDM-enrolled client
+/// certs, Entra Conditional Access) the same way a system browser does, instead
+/// of failing the handshake.
+///
+/// `.performDefaultHandling` is not sufficient for a client-certificate
+/// challenge: the system presents no certificate, so a mutual-TLS endpoint
+/// rejects the connection. This resolver finds a matching identity in the
+/// system keychain and the caller presents it with `.useCredential`.
+///
+/// Note: a hardware-backed (Secure Enclave) identity is usable only by an
+/// application entitled to its keychain access group, so it can only be presented
+/// by a suitably code-signed build. An extractable identity in the system
+/// keychain works without that entitlement.
+enum BrowserClientCertificateResolver {
+    /// Answer a client-certificate (mutual-TLS) challenge by presenting a matching
+    /// system-keychain identity, or deferring to the system when none matches.
+    ///
+    /// Returns true when `challenge` was a client-certificate challenge (and the
+    /// completion handler has been invoked); returns false for every other
+    /// challenge kind so the caller applies its own default handling. Sharing this
+    /// across every browser navigation delegate keeps mTLS behavior identical for
+    /// the main browser and for popup/auth windows.
+    @discardableResult
+    static func handleIfClientCertificate(
+        _ challenge: URLAuthenticationChallenge,
+        completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) -> Bool {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate
+        else { return false }
+
+        if let credential = credential(for: challenge.protectionSpace) {
+            completionHandler(.useCredential, credential)
+        } else {
+            // No confident keychain match: defer to the system (it may present a
+            // picker or proceed without a certificate), preserving prior behavior.
+            completionHandler(.performDefaultHandling, nil)
+        }
+        return true
+    }
+
+    static func credential(for protectionSpace: URLProtectionSpace) -> URLCredential? {
+        guard let identity = identity(for: protectionSpace) else { return nil }
+        return URLCredential(identity: identity, certificates: nil, persistence: .forSession)
+    }
+
+    static func identity(for protectionSpace: URLProtectionSpace) -> SecIdentity? {
+        // The CAs the server advertised as acceptable in its TLS CertificateRequest
+        // (DER-encoded X.500 names). Used both to constrain a host preference and to
+        // match by issuer; may be empty if the server did not advertise a list.
+        let acceptableIssuers = protectionSpace.distinguishedNames ?? []
+        let issuerFilter = acceptableIssuers.isEmpty ? nil : acceptableIssuers as CFArray
+
+        // 1. A host-specific keychain identity preference (the user's explicit
+        //    choice for this host, what a system browser records on first use),
+        //    constrained to the server's acceptable issuers so a stale preference
+        //    can't present a certificate the server never asked for. Try the bare
+        //    host and the URL forms a browser typically records.
+        let host = protectionSpace.host
+        let candidates = [host, "https://\(host)", "https://\(host):\(protectionSpace.port)"]
+        for name in candidates {
+            if let preferred = SecIdentityCopyPreferred(name as CFString, nil, issuerFilter) {
+                return preferred
+            }
+        }
+
+        // 2. Otherwise, ask the keychain for any identity whose certificate was
+        //    issued by one of the acceptable CAs. Letting the keychain do the match
+        //    avoids issuer-DN normalization pitfalls.
+        guard !acceptableIssuers.isEmpty else { return nil }
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassIdentity,
+            kSecMatchIssuers: acceptableIssuers,
+            kSecReturnRef: true,
+        ]
+        var item: CFTypeRef?
+        if SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+           let item, CFGetTypeID(item) == SecIdentityGetTypeID() {
+            return (item as! SecIdentity)
+        }
+        return nil
+    }
+}

--- a/Sources/Panels/BrowserClientCertificateResolver.swift
+++ b/Sources/Panels/BrowserClientCertificateResolver.swift
@@ -18,39 +18,48 @@ import Security
 /// so the browser does not need the token's keychain access group. An extractable
 /// software identity in the system keychain works the same way. (Verified
 /// empirically against a real mutual-TLS origin from an ad-hoc-signed build.)
-enum BrowserClientCertificateResolver {
+nonisolated struct BrowserClientCertificateResolver: Sendable {
     /// Answer a client-certificate (mutual-TLS) challenge by presenting a matching
     /// system-keychain identity, or deferring to the system when none matches.
     ///
-    /// Returns true when `challenge` was a client-certificate challenge (and the
-    /// completion handler has been invoked); returns false for every other
-    /// challenge kind so the caller applies its own default handling. Sharing this
-    /// across every browser navigation delegate keeps mTLS behavior identical for
-    /// the main browser and for popup/auth windows.
+    /// Returns true when `challenge` was a client-certificate challenge (so the
+    /// caller must not also answer it — the completion handler is invoked
+    /// asynchronously); returns false for every other challenge kind so the
+    /// caller applies its own default handling. The cheap synchronous check is
+    /// only the authentication method; the keychain lookup itself runs off the
+    /// caller's (main) actor because `SecIdentityCopyPreferred` /
+    /// `SecItemCopyMatching` are synchronous and can block or trigger an auth
+    /// prompt — doing that inline during the handshake would freeze the browser
+    /// window. Sharing this across every browser navigation delegate keeps mTLS
+    /// behavior identical for the main browser and for popup/auth windows.
     @discardableResult
-    static func handleIfClientCertificate(
+    func handleIfClientCertificate(
         _ challenge: URLAuthenticationChallenge,
-        completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) -> Bool {
         guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate
         else { return false }
 
-        if let credential = credential(for: challenge.protectionSpace) {
-            completionHandler(.useCredential, credential)
-        } else {
-            // No confident keychain match: defer to the system (it may present a
-            // picker or proceed without a certificate), preserving prior behavior.
-            completionHandler(.performDefaultHandling, nil)
+        let protectionSpace = challenge.protectionSpace
+        DispatchQueue.global(qos: .userInitiated).async {
+            if let credential = self.credential(for: protectionSpace) {
+                completionHandler(.useCredential, credential)
+            } else {
+                // No confident keychain match: defer to the system (it may present
+                // a picker or proceed without a certificate), preserving prior
+                // behavior.
+                completionHandler(.performDefaultHandling, nil)
+            }
         }
         return true
     }
 
-    static func credential(for protectionSpace: URLProtectionSpace) -> URLCredential? {
+    private func credential(for protectionSpace: URLProtectionSpace) -> URLCredential? {
         guard let identity = identity(for: protectionSpace) else { return nil }
         return URLCredential(identity: identity, certificates: nil, persistence: .forSession)
     }
 
-    static func identity(for protectionSpace: URLProtectionSpace) -> SecIdentity? {
+    private func identity(for protectionSpace: URLProtectionSpace) -> SecIdentity? {
         // The CAs the server advertised as acceptable in its TLS CertificateRequest
         // (DER-encoded X.500 names). Used both to constrain a host preference and to
         // match by issuer; may be empty if the server did not advertise a list.
@@ -70,7 +79,7 @@ enum BrowserClientCertificateResolver {
             }
         }
 
-        // 2. Otherwise, ask the keychain for any identity whose certificate was
+        // 2. Otherwise, ask the keychain for every identity whose certificate was
         //    issued by one of the acceptable CAs. Letting the keychain do the match
         //    avoids issuer-DN normalization pitfalls.
         guard !acceptableIssuers.isEmpty else { return nil }
@@ -78,12 +87,16 @@ enum BrowserClientCertificateResolver {
             kSecClass: kSecClassIdentity,
             kSecMatchIssuers: acceptableIssuers,
             kSecReturnRef: true,
+            kSecMatchLimit: kSecMatchLimitAll,
         ]
-        var item: CFTypeRef?
-        if SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
-           let item, CFGetTypeID(item) == SecIdentityGetTypeID() {
-            return (item as! SecIdentity)
-        }
-        return nil
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let identities = result as? [SecIdentity] else { return nil }
+        // Fail closed: only auto-present when exactly one identity is eligible. If
+        // several match the server's acceptable issuers and the user expressed no
+        // host preference, defer to the system picker rather than silently choosing
+        // a certificate on their behalf.
+        guard identities.count == 1 else { return nil }
+        return identities.first
     }
 }

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -161,16 +161,21 @@ import WebKit
             return
         }
 
-        // WKWebView rejects all authentication challenges by default when this
-        // delegate method is not implemented (.rejectProtectionSpace). This
-        // breaks TLS client-certificate flows such as Microsoft Entra ID
-        // Conditional Access, which verifies device compliance via a client
-        // certificate stored in the system keychain by MDM enrollment.
-        //
-        // By returning .performDefaultHandling the system's standard URL-loading
-        // behaviour takes over: the keychain is searched for matching client
-        // identities, MDM-installed root CAs are trusted, and any configured SSO
-        // extensions (e.g. Microsoft Enterprise SSO) can intercept the challenge.
+        // A TLS client-certificate (mutual-TLS) challenge needs an explicit
+        // identity: .performDefaultHandling presents NO certificate, so a
+        // client-cert-gated origin (corporate zero-trust / device-attestation
+        // endpoints, MDM-enrolled client certs, Entra Conditional Access) rejects
+        // the handshake. Present a matching system-keychain identity, the same way
+        // a system browser does.
+        if BrowserClientCertificateResolver.handleIfClientCertificate(
+            challenge, completionHandler: completionHandler
+        ) {
+            return
+        }
+
+        // For all other challenges (server trust, etc.) defer to the system's
+        // standard handling, which trusts MDM-installed root CAs and lets
+        // configured SSO extensions intercept.
         completionHandler(.performDefaultHandling, nil)
     }
 

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -167,7 +167,7 @@ import WebKit
         // endpoints, MDM-enrolled client certs, Entra Conditional Access) rejects
         // the handshake. Present a matching system-keychain identity, the same way
         // a system browser does.
-        if BrowserClientCertificateResolver.handleIfClientCertificate(
+        if BrowserClientCertificateResolver().handleIfClientCertificate(
             challenge, completionHandler: completionHandler
         ) {
             return

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -916,7 +916,7 @@ private class PopupUIDelegate: NSObject, WKUIDelegate {
         // certificate for mutual-TLS challenges (auth/login popups can be
         // client-cert-gated too), then defer other challenges to the system
         // (keychain server-trust, MDM roots, SSO extensions e.g. Entra ID).
-        if BrowserClientCertificateResolver.handleIfClientCertificate(
+        if BrowserClientCertificateResolver().handleIfClientCertificate(
             challenge, completionHandler: completionHandler
         ) {
             return

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -912,8 +912,15 @@ private class PopupUIDelegate: NSObject, WKUIDelegate {
             return
         }
 
-        // Parity with main browser: performDefaultHandling enables system keychain
-        // lookups, MDM client certs, and SSO extensions (e.g. Microsoft Entra ID).
+        // Parity with the main browser: present a system-keychain client
+        // certificate for mutual-TLS challenges (auth/login popups can be
+        // client-cert-gated too), then defer other challenges to the system
+        // (keychain server-trust, MDM roots, SSO extensions e.g. Entra ID).
+        if BrowserClientCertificateResolver.handleIfClientCertificate(
+            challenge, completionHandler: completionHandler
+        ) {
+            return
+        }
         completionHandler(.performDefaultHandling, nil)
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		B3770BA00000000000000001 /* BrowserAutomation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3770BA00000000000000002 /* BrowserAutomation.swift */; };
 		BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBC0A0E0000000000000C02 /* BrowserChromeMetrics.swift */; };
 		BCBC0A0E0000000000000D01 /* BrowserChromeMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBC0A0E0000000000000D02 /* BrowserChromeMetricsTests.swift */; };
+		BACE25000000000000000001 /* BrowserClientCertificateResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE25000000000000000002 /* BrowserClientCertificateResolver.swift */; };
 		E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */; };
 		C59240010000000000000001 /* BrowserDownloadFilenameResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59240010000000000000002 /* BrowserDownloadFilenameResolver.swift */; };
 		C59240010000000000000003 /* BrowserDownloadFilenameResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59240010000000000000004 /* BrowserDownloadFilenameResolverTests.swift */; };
@@ -1365,6 +1366,7 @@
 		B3770BA00000000000000002 /* BrowserAutomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserAutomation.swift; sourceTree = "<group>"; };
 		BCBC0A0E0000000000000C02 /* BrowserChromeMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserChromeMetrics.swift; sourceTree = "<group>"; };
 		BCBC0A0E0000000000000D02 /* BrowserChromeMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserChromeMetricsTests.swift; sourceTree = "<group>"; };
+		BACE25000000000000000002 /* BrowserClientCertificateResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserClientCertificateResolver.swift; sourceTree = "<group>"; };
 		970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserConfigTests.swift; sourceTree = "<group>"; };
 		C59240010000000000000002 /* BrowserDownloadFilenameResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDownloadFilenameResolver.swift; sourceTree = "<group>"; };
 		C59240010000000000000004 /* BrowserDownloadFilenameResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDownloadFilenameResolverTests.swift; sourceTree = "<group>"; };
@@ -3045,6 +3047,7 @@
 				BABA2500000000000000000C /* BrowserHTTPBasicAuthProtectionSpaceKey.swift */,
 				BABA2500000000000000000E /* BrowserHTTPBasicAuthPromptRequest.swift */,
 				BABA2500000000000000000A /* BrowserNavigationDelegate.swift */,
+				BACE25000000000000000002 /* BrowserClientCertificateResolver.swift */,
 				A5001412 /* BrowserPanel.swift */,
 				C2035A010000000000000002 /* BrowserErrorPage.swift */,
 				C2035A020000000000000002 /* BrowserErrorPageContent.swift */,
@@ -4199,6 +4202,7 @@
 				D0B10002A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift in Sources */,
 				B3770BA00000000000000001 /* BrowserAutomation.swift in Sources */,
 				BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */,
+				BACE25000000000000000001 /* BrowserClientCertificateResolver.swift in Sources */,
 				C59240010000000000000001 /* BrowserDownloadFilenameResolver.swift in Sources */,
 				C2035A010000000000000001 /* BrowserErrorPage.swift in Sources */,
 				C2035A020000000000000001 /* BrowserErrorPageContent.swift in Sources */,


### PR DESCRIPTION
## Problem

The embedded browser answered every authentication challenge with `.performDefaultHandling`. That's fine for server-trust evaluation, but for a **TLS client-certificate (mutual-TLS)** challenge it presents *no* certificate, so a client-cert-gated origin (corporate zero-trust / device-attestation endpoints, MDM-enrolled client certs, Entra Conditional Access) rejects the handshake — the page fails to load even though a system browser, which presents the keychain identity, reaches it fine.

## Fix

Handle `NSURLAuthenticationMethodClientCertificate` explicitly via a shared `BrowserClientCertificateResolver`, used by **both** the main browser navigation delegate and the popup/auth-window delegate so mTLS behavior is identical at every entrypoint. It resolves an identity from the system keychain in the platform's order of preference:

1. a host-specific keychain **identity preference**, constrained to the CAs the server advertised as acceptable in its TLS `CertificateRequest` (`URLProtectionSpace.distinguishedNames`) — so an explicit per-host choice wins and a stale preference can't present a certificate the server never asked for;
2. otherwise, an identity whose certificate was **issued by one of those acceptable CAs**, matched by the keychain via `kSecMatchIssuers` — but **only when exactly one** identity is eligible. If several match and the user expressed no host preference, it falls back to `.performDefaultHandling` so the system shows its picker rather than silently choosing a certificate.

When no confident match exists it falls back to `.performDefaultHandling`, so **non-mTLS sites and the prior behavior are unchanged**. Other challenge kinds (server trust, etc.) continue to defer to the system.

## Notes

- The challenge is answered straight from the system keychain, and **no special code-signing or entitlement is required**. For a hardware-backed identity held in a CryptoTokenKit token (e.g. Secure Enclave), the OS/token brokers the signing operation, so the browser presents the identity without needing the token's keychain access group — verified from an unsigned (ad-hoc) build (see Verification).
- The keychain lookup runs **off the main actor** (`SecIdentityCopyPreferred`/`SecItemCopyMatching` are synchronous and can block or trigger an auth prompt); the handler answers the challenge asynchronously so the browser window never freezes during the handshake.

## Verification

Verified end-to-end against a real production origin that requires a client certificate for mutual TLS — including the harder case where the certificate's private key is **non-exportable and held in a hardware-backed CryptoTokenKit token (Secure Enclave)** rather than a plain software keychain item. The browser presents the keychain identity **from an unsigned (ad-hoc) local build** — the OS/token brokers the signing inside the secure hardware, the TLS handshake completes, and the previously-failing gated site loads and proceeds to its normal application login — matching the behavior of a system browser. Both software (extractable) and hardware-backed token identities were presented successfully with no special entitlement or signing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785221057&installation_id=133855650&pr_number=7025&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7025&signature=a1ca6aeb3ec76d835ef8a819725ae10d326a5659a4413325edacabcd82fba0f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Present a system‑keychain client certificate for mutual‑TLS (mTLS) challenges in the embedded browser so client‑cert‑gated sites load like they do in a system browser. Works with software and hardware‑backed identities via CryptoTokenKit without extra entitlements, and falls back to default handling when no clear match exists.

- **New Features**
  - Added a shared `BrowserClientCertificateResolver` used by both the main navigation delegate and popup/auth windows; keychain lookup runs off‑main.
  - Selection rules: use a host‑specific identity preference only when the server sends acceptable issuers; otherwise match by issuer. Fail closed on ambiguous matches or when no issuer list is provided.
  - Other challenge types still use `.performDefaultHandling`.

<sup>Written for commit 46b4d11a1ee6c8a9c651fd617e3a3e88fb13fc30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mutual TLS (client-certificate) support for embedded browser authentication challenges in both the main and popup web views.
  * The app attempts to select an eligible client certificate from the system keychain (including issuer/host-aware matching) and uses it for the current session.
  * If an unambiguous certificate match isn’t found, the app defers to the embedded browser’s default handling to preserve existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

