### PR TITLE
Fix keyboard copy-mode selection not starting

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4622,10 +4622,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         _ = GhosttyRuntimeCInterop.clearSelection(surface)
         ghostty_surface_mouse_pos(surface, xRange.startX, Double(y), mods)
-        guard ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods) else {
-            _ = GhosttyRuntimeCInterop.clearSelection(surface)
-            return false
-        }
+        // ghostty_surface_mouse_button returns whether Ghostty *consumed* the event
+        // (e.g. via mouse reporting); for a normal selection-start on a surface without
+        // mouse reporting it returns false. Discard it like the real mouseDown handler
+        // does instead of treating it as failure, otherwise keyboard copy-mode selection
+        // never starts.
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods)
         ghostty_surface_mouse_pos(surface, xRange.endX, Double(y), mods)
         let selectedCursorCell = ghostty_surface_has_selection(surface)
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
@@ -4664,9 +4666,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         let mods = GHOSTTY_MODS_NONE
         ghostty_surface_mouse_pos(surface, Double(startX), Double(startY), mods)
-        guard ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods) else {
-            return false
-        }
+        // Discard the "consumed" return — false just means no mouse reporting, not failure.
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods)
         defer {
             _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods)
         }


### PR DESCRIPTION
## Summary

In keyboard copy mode, cursor movement (`hjkl`) works, but starting a selection (`v`/`V`) and yanking (`y`/`Y`) silently do nothing on a surface without mouse reporting, such as a plain shell prompt. No highlight appears and there is nothing to copy.

The two synthetic-selection helpers, `selectKeyboardCopyModeCursorCell` and `selectKeyboardCopyModeViewportLines`, guard on the return of `ghostty_surface_mouse_button(PRESS)`. That bool reports whether Ghostty *consumed* the event (forwarded it via mouse reporting, or matched a keybinding), not whether the press succeeded. A normal selection-start on a surface with no mouse reporting is not consumed, so it returns `false` and the guard bails before the drag and the `ghostty_surface_has_selection` check. The real `mouseDown` handler discards this return and proceeds, which is why click-drag selection works. This change makes both copy-mode helpers do the same and rely on `ghostty_surface_has_selection` as the source of truth.

## Testing

I built `main` and this branch as side-by-side Debug apps and compared them in a clean environment (no `cmux.json`, no `~/.config/ghostty`, shell launched with `zsh -f`). On `main`, pressing `v` then `l` in copy mode produces no highlight and `y` copies nothing; with the fix the selection highlights at the cursor cell and `y` copies, and `V`/`Y` work too. A runtime trace confirmed `ghostty_surface_has_selection` flips from false to true once the gate is removed.

## Demo Video

*Without the patch*
selection doesn't work

https://github.com/user-attachments/assets/70a9c7e7-d935-4c3c-a6ce-e1b87f19604d

*With the patch*
selection and copy work

https://github.com/user-attachments/assets/165f5a7d-4237-4a27-94e9-b7988f0a09ac


## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785245091&installation_id=133855650&pr_number=7027&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7027&signature=50a23177fa327f30d55967f0cdbc60a54f28c21eba9370d40accce58d5501dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard copy mode so `v`/`V` starts a selection and `y`/`Y` yanks, even when mouse reporting is off. We now ignore the `ghostty_surface_mouse_button(PRESS)` consumed return and rely on `ghostty_surface_has_selection`, matching real `mouseDown`.

- **Bug Fixes**
  - Removed guards on `ghostty_surface_mouse_button` in `selectKeyboardCopyModeCursorCell` and `selectKeyboardCopyModeViewportLines`.
  - Keep synthetic press/drag and use `ghostty_surface_has_selection` to confirm start; selection now highlights and copies.

<sup>Written for commit 645cc589165689ae5ff411189984964b3cf7f46b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard copy-mode selection so dragging a selection is no longer blocked when the initial mouse press isn’t reported as consumed.
  * Selection now continues to start normally and is validated later, making copy-mode selection more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->