### PR TITLE
Fix bash + zsh shim rewrite failing under noclobber

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -285,7 +285,7 @@ _cmux_install_cli_command_shim() {
         else
             printf 'exec "%s" "$@"\n' "$escaped_wrapper"
         fi
-    } >"$shim_path" 2>/dev/null || return 0
+    } >|"$shim_path" 2>/dev/null || return 0
     /bin/chmod 0700 "$shim_path" >/dev/null 2>&1 || return 0
 
     if [[ "$command_name" == "claude" ]]; then

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -292,7 +292,7 @@ _cmux_install_cli_command_shim() {
         else
             printf 'exec "%s" "$@"\n' "$escaped_wrapper"
         fi
-    } >"$shim_path" 2>/dev/null || return 0
+    } >|"$shim_path" 2>/dev/null || return 0
     /bin/chmod 0700 "$shim_path" >/dev/null 2>&1 || return 0
 
     if [[ "$command_name" == "claude" ]]; then


### PR DESCRIPTION
Fixes #6714.

## Problem
With `noclobber` set in the interactive shell, every new tab prints an error as cmux rewrites its per-surface CLI shim on startup:

- **zsh** (`setopt noclobber`): `_cmux_install_cli_command_shim:13: file exists: …/cmux-cli-shims/<id>/claude`
- **bash** (`set -o noclobber`): `…/cmux-cli-shims/<id>/claude: cannot overwrite existing file`

## Root cause
`_cmux_install_cli_command_shim` writes the generated shim with a plain `>` redirect. When the shim already exists (re-source, or a `$TMPDIR` shim persisted across sessions), `noclobber` refuses the overwrite. The function's `2>/dev/null` can't suppress it — the redirection itself fails, so the shell reports it to the terminal.

## Fix
Use the explicit clobber operator `>|`, which this repo already uses for its own generated files (e.g. `cmux-zsh-integration.zsh` lines 689, 1205). One line in each integration:

- `Resources/shell-integration/cmux-zsh-integration.zsh`
- `Resources/shell-integration/cmux-bash-integration.bash`

The open zsh-only PRs (#6715, #6769, #6815) fix the zsh line; this PR also fixes the **identical bug in the bash integration**, which none of them touch — resolving #6714 for both shells in one change. (fish is unaffected: `>` there doesn't honor a noclobber option.)

## Verification
Under `setopt noclobber` / `set -o noclobber`, re-sourcing the integration with an existing shim prints the error before and is silent after; `>|` overwrites the cmux-owned shim cleanly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785255502&installation_id=133855650&pr_number=7030&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7030&signature=4539bcf44fc3e58f047c7faf560b782d3a8e3774aadbaba41b849eb31d6cf773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bash and zsh shim rewrite errors when `noclobber` is enabled by writing cmux CLI shims with the explicit clobber operator `>|`, resolving #6714. This prevents “file exists”/“cannot overwrite existing file” on new tabs and lets cmux reliably refresh its own shims.

<sup>Written for commit fd02b252a491bc478273e2c47ea46a5fbf58dfcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell integration so generated CLI shim files are reliably overwritten even when `noclobber` is enabled.
  * This helps installation and update flows complete successfully in Bash and Zsh environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->