### PR TITLE
Fix browser webview divider resizing

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -24,7 +24,7 @@
 4487	Sources/Panels/FilePreviewPanel.swift
 4476	Sources/cmuxApp.swift
 4367	cmuxTests/BrowserPanelTests.swift
-4111	Sources/BrowserWindowPortal.swift
+4114	Sources/BrowserWindowPortal.swift
 3934	Sources/Feed/FeedPanelView.swift
 3926	cmuxTests/TabManagerUnitTests.swift
 3896	cmuxTests/WindowAndDragTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -24,7 +24,7 @@
 4487	Sources/Panels/FilePreviewPanel.swift
 4476	Sources/cmuxApp.swift
 4367	cmuxTests/BrowserPanelTests.swift
-4114	Sources/BrowserWindowPortal.swift
+4121	Sources/BrowserWindowPortal.swift
 3934	Sources/Feed/FeedPanelView.swift
 3926	cmuxTests/TabManagerUnitTests.swift
 3896	cmuxTests/WindowAndDragTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -10,7 +10,7 @@
 12233	Sources/GhosttyTerminalView.swift
 11592	Sources/Panels/BrowserPanel.swift
 9497	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
-8042	Sources/Panels/BrowserPanelView.swift
+8046	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -10,8 +10,8 @@
 12233	Sources/GhosttyTerminalView.swift
 11567	Sources/Panels/BrowserPanel.swift
 9497	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+8070	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
-7982	Sources/Panels/BrowserPanelView.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6895	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -10,7 +10,7 @@
 12233	Sources/GhosttyTerminalView.swift
 11567	Sources/Panels/BrowserPanel.swift
 9497	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
-8070	Sources/Panels/BrowserPanelView.swift
+8042	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -24,7 +24,7 @@
 4487	Sources/Panels/FilePreviewPanel.swift
 4476	Sources/cmuxApp.swift
 4367	cmuxTests/BrowserPanelTests.swift
-4133	Sources/BrowserWindowPortal.swift
+4111	Sources/BrowserWindowPortal.swift
 3934	Sources/Feed/FeedPanelView.swift
 3926	cmuxTests/TabManagerUnitTests.swift
 3896	cmuxTests/WindowAndDragTests.swift
@@ -42,7 +42,7 @@
 2395	Sources/Mobile/MobileHostService.swift
 2328	cmuxTests/CJKIMEInputTests.swift
 2242	Sources/TerminalNotificationStore.swift
-2233	Sources/TerminalWindowPortal.swift
+2231	Sources/TerminalWindowPortal.swift
 2126	cmuxTests/CmuxConfigTests.swift
 2091	cmuxTests/ShortcutAndCommandPaletteTests.swift
 2078	Sources/SessionPersistence.swift

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1155,11 +1155,9 @@ final class WindowBrowserHostView: NSView {
     }
 
     private static func dividerHit(at windowPoint: NSPoint, in regions: [DividerRegion], checkLiveness: Bool = true) -> DividerHit? {
-        let expansion: CGFloat = 5
         for region in regions.reversed() {
             if checkLiveness, !region.isLive { continue }
-            let hitRect = region.rectInWindow.insetBy(dx: -expansion, dy: -expansion)
-                .intersection(region.boundsInWindow)
+            let hitRect = region.hitRectInWindow
             if !hitRect.isNull, hitRect.contains(windowPoint) {
                 return DividerHit(
                     kind: region.isVertical ? .vertical : .horizontal,
@@ -1974,30 +1972,10 @@ final class WindowBrowserPortal: NSObject {
         guard splitView.arrangedSubviews.count >= 2 else { return }
 
         let location = splitView.convert(event.locationInWindow, from: nil)
-        let first = splitView.arrangedSubviews[0].frame
-        let second = splitView.arrangedSubviews[1].frame
-        let thickness = splitView.dividerThickness
-        let dividerRect: NSRect
-
-        if splitView.isVertical {
-            guard first.width > 1, second.width > 1 else { return }
-            dividerRect = NSRect(
-                x: max(0, first.maxX),
-                y: 0,
-                width: thickness,
-                height: splitView.bounds.height
-            )
-        } else {
-            guard first.height > 1, second.height > 1 else { return }
-            dividerRect = NSRect(
-                x: 0,
-                y: max(0, first.maxY),
-                width: splitView.bounds.width,
-                height: thickness
-            )
-        }
-
-        let hitRect = dividerRect.insetBy(dx: -5, dy: -5)
+        guard let hitRect = PortalSplitDividerRegion.dividerHitRect(
+            in: splitView,
+            dividerIndex: 0
+        ) else { return }
         if dividerHitRectContains(location, rect: hitRect) {
             window.browserPortalHasInteractiveSplitDividerDrag = true
         }

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -818,7 +818,8 @@ final class WindowBrowserHostView: NSView {
         at point: NSPoint,
         visibleSlots: [WindowBrowserSlotView]
     ) -> Bool {
-        guard let rightMostEdge = visibleSlots.map(\.frame.maxX).max() else { return false }
+        let contentSlots = visibleSlots.filter { !$0.isRightSidebarDockSlot }
+        guard let rightMostEdge = contentSlots.map(\.frame.maxX).max() else { return false }
         let trailingGap = bounds.maxX - rightMostEdge
         guard trailingGap > Self.minimumVisibleLeadingContentWidth else { return false }
         return SidebarResizeInteraction.Edge.trailing.hitRange(dividerX: rightMostEdge).contains(point.x)
@@ -1311,6 +1312,7 @@ final class WindowBrowserSlotView: NSView {
     private var paneTopChromeHeight: CGFloat = 0
     var preferredHostedInspectorWidth: CGFloat?
     private var preferredHostedInspectorWidthFraction: CGFloat?
+    fileprivate var isRightSidebarDockSlot = false
     fileprivate var isHostedInspectorDividerDragActive = false
     var onHostedInspectorLayout: ((WindowBrowserSlotView) -> Void)?
     fileprivate var isApplyingHostedInspectorLayout = false
@@ -1398,6 +1400,7 @@ final class WindowBrowserSlotView: NSView {
 
     func setPaneDropContext(_ context: BrowserPaneDropContext?) {
         paneDropTargetView.dropContext = context
+        isRightSidebarDockSlot = context.map { AppDelegate.shared?.dockForPane($0.paneId) != nil } ?? false
     }
 
     var currentPaneDropContext: BrowserPaneDropContext? {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -818,11 +818,18 @@ final class WindowBrowserHostView: NSView {
         at point: NSPoint,
         visibleSlots: [WindowBrowserSlotView]
     ) -> Bool {
-        let contentSlots = visibleSlots.filter { !$0.isRightSidebarDockSlot }
-        guard let rightMostEdge = contentSlots.map(\.frame.maxX).max() else { return false }
-        let trailingGap = bounds.maxX - rightMostEdge
+        let dockDividerX = visibleSlots
+            .filter { $0.isRightSidebarDockSlot }
+            .map(\.frame.minX)
+            .min()
+        let contentRightEdge = visibleSlots
+            .filter { !$0.isRightSidebarDockSlot }
+            .map(\.frame.maxX)
+            .max()
+        guard let dividerX = dockDividerX ?? contentRightEdge else { return false }
+        let trailingGap = bounds.maxX - dividerX
         guard trailingGap > Self.minimumVisibleLeadingContentWidth else { return false }
-        return SidebarResizeInteraction.Edge.trailing.hitRange(dividerX: rightMostEdge).contains(point.x)
+        return SidebarResizeInteraction.Edge.trailing.hitRange(dividerX: dividerX).contains(point.x)
     }
 
     private func updateDividerCursor(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5525,8 +5525,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             var cursor: NSCursor { .resizeLeftRight }
         }
 
-        // Match bonsplit's effective divider grab expansion on pane edges.
-        private static let externalSplitDividerHitExpansion: CGFloat = 5
         private static let hostedInspectorDividerHitExpansion: CGFloat = 10
         private static let minimumHostedInspectorWidth: CGFloat = 120
         private static let minimumHostedInspectorPageWidthForSideDock: CGFloat = 240
@@ -6687,44 +6685,18 @@ struct WebViewRepresentable: NSViewRepresentable {
             dividerIndex: Int
         ) -> Bool {
             guard let window,
-                  dividerIndex >= 0,
-                  dividerIndex + 1 < splitView.arrangedSubviews.count,
-                  splitView.window === window else {
+                  splitView.window === window,
+                  let hitRect = PortalSplitDividerRegion.dividerHitRectInWindow(
+                      in: splitView,
+                      dividerIndex: dividerIndex
+                  ) else {
                 return false
             }
-
-            let first = splitView.arrangedSubviews[dividerIndex].frame
-            let second = splitView.arrangedSubviews[dividerIndex + 1].frame
-            let dividerRect: NSRect
-            if splitView.isVertical {
-                guard first.width > 1 || second.width > 1 else { return false }
-                dividerRect = NSRect(
-                    x: max(0, first.maxX),
-                    y: 0,
-                    width: splitView.dividerThickness,
-                    height: splitView.bounds.height
-                )
-            } else {
-                guard first.height > 1 || second.height > 1 else { return false }
-                dividerRect = NSRect(
-                    x: 0,
-                    y: max(0, first.maxY),
-                    width: splitView.bounds.width,
-                    height: splitView.dividerThickness
-                )
-            }
-
-            let hitRect = splitView.convert(dividerRect, to: nil)
-                .insetBy(
-                    dx: -Self.externalSplitDividerHitExpansion,
-                    dy: -Self.externalSplitDividerHitExpansion
-                )
-                .intersection(splitView.convert(splitView.bounds, to: nil))
-            return !hitRect.isNull && hitRect.contains(windowPoint)
+            return hitRect.contains(windowPoint)
         }
 
         private func isNearPaneEdge(_ point: NSPoint) -> Bool {
-            let expansion = Self.externalSplitDividerHitExpansion
+            let expansion = PortalSplitDividerRegion.dividerHitExpansion
             let nearVerticalEdge = point.x >= bounds.minX &&
                 point.x <= bounds.maxX &&
                 (point.x <= bounds.minX + expansion || point.x >= bounds.maxX - expansion)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5525,6 +5525,8 @@ struct WebViewRepresentable: NSViewRepresentable {
             var cursor: NSCursor { .resizeLeftRight }
         }
 
+        // Match bonsplit's effective divider grab expansion on pane edges.
+        private static let externalSplitDividerHitExpansion: CGFloat = 5
         private static let hostedInspectorDividerHitExpansion: CGFloat = 10
         private static let minimumHostedInspectorWidth: CGFloat = 120
         private static let minimumHostedInspectorPageWidthForSideDock: CGFloat = 240
@@ -6489,6 +6491,12 @@ struct WebViewRepresentable: NSViewRepresentable {
 #endif
                 return nil
             }
+            if shouldPassThroughToExternalSplitDivider(at: point, hostedInspectorHit: hostedInspectorHit) {
+#if DEBUG
+                debugLogHitTest(stage: "hitTest.splitPass", point: point, passThrough: true, hitView: nil)
+#endif
+                return nil
+            }
             if let hostedInspectorHit {
                 if let nativeHit = nativeHostedInspectorHit(at: point, hostedInspectorHit: hostedInspectorHit) {
 #if DEBUG
@@ -6644,6 +6652,86 @@ struct WebViewRepresentable: NSViewRepresentable {
                 return hostRectInContent.minX > 1
             }
             return contentView.bounds.maxX - hostRectInContent.maxX > 24
+        }
+
+        private func shouldPassThroughToExternalSplitDivider(
+            at point: NSPoint,
+            hostedInspectorHit: HostedInspectorDividerHit? = nil
+        ) -> Bool {
+            guard hostedInspectorHit == nil else { return false }
+            guard isNearPaneEdge(point) else { return false }
+            guard window != nil else { return false }
+
+            let windowPoint = convert(point, to: nil)
+            var ancestor = superview
+            while let currentAncestor = ancestor {
+                if let splitView = currentAncestor as? NSSplitView,
+                   let arrangedIndex = splitView.arrangedSubviews.firstIndex(where: { arrangedSubview in
+                       self === arrangedSubview || self.isDescendant(of: arrangedSubview)
+                   }) {
+                    if externalSplitDividerHit(at: windowPoint, in: splitView, dividerIndex: arrangedIndex - 1) {
+                        return true
+                    }
+                    if externalSplitDividerHit(at: windowPoint, in: splitView, dividerIndex: arrangedIndex) {
+                        return true
+                    }
+                }
+                ancestor = currentAncestor.superview
+            }
+            return false
+        }
+
+        private func externalSplitDividerHit(
+            at windowPoint: NSPoint,
+            in splitView: NSSplitView,
+            dividerIndex: Int
+        ) -> Bool {
+            guard let window,
+                  dividerIndex >= 0,
+                  dividerIndex + 1 < splitView.arrangedSubviews.count,
+                  splitView.window === window else {
+                return false
+            }
+
+            let first = splitView.arrangedSubviews[dividerIndex].frame
+            let second = splitView.arrangedSubviews[dividerIndex + 1].frame
+            let dividerRect: NSRect
+            if splitView.isVertical {
+                guard first.width > 1 || second.width > 1 else { return false }
+                dividerRect = NSRect(
+                    x: max(0, first.maxX),
+                    y: 0,
+                    width: splitView.dividerThickness,
+                    height: splitView.bounds.height
+                )
+            } else {
+                guard first.height > 1 || second.height > 1 else { return false }
+                dividerRect = NSRect(
+                    x: 0,
+                    y: max(0, first.maxY),
+                    width: splitView.bounds.width,
+                    height: splitView.dividerThickness
+                )
+            }
+
+            let hitRect = splitView.convert(dividerRect, to: nil)
+                .insetBy(
+                    dx: -Self.externalSplitDividerHitExpansion,
+                    dy: -Self.externalSplitDividerHitExpansion
+                )
+                .intersection(splitView.convert(splitView.bounds, to: nil))
+            return !hitRect.isNull && hitRect.contains(windowPoint)
+        }
+
+        private func isNearPaneEdge(_ point: NSPoint) -> Bool {
+            let expansion = Self.externalSplitDividerHitExpansion
+            let nearVerticalEdge = point.x >= bounds.minX &&
+                point.x <= bounds.maxX &&
+                (point.x <= bounds.minX + expansion || point.x >= bounds.maxX - expansion)
+            let nearHorizontalEdge = point.y >= bounds.minY &&
+                point.y <= bounds.maxY &&
+                (point.y <= bounds.minY + expansion || point.y >= bounds.maxY - expansion)
+            return nearVerticalEdge || nearHorizontalEdge
         }
 
         private func updateDividerCursor(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -6696,13 +6696,13 @@ struct WebViewRepresentable: NSViewRepresentable {
         }
 
         private func isNearPaneEdge(_ point: NSPoint) -> Bool {
+            // hitTest and cursor tracking call this with points in this view's bounds coordinates.
+            guard bounds.contains(point) else { return false }
             let expansion = PortalSplitDividerRegion.dividerHitExpansion
-            let nearVerticalEdge = point.x >= bounds.minX &&
-                point.x <= bounds.maxX &&
-                (point.x <= bounds.minX + expansion || point.x >= bounds.maxX - expansion)
-            let nearHorizontalEdge = point.y >= bounds.minY &&
-                point.y <= bounds.maxY &&
-                (point.y <= bounds.minY + expansion || point.y >= bounds.maxY - expansion)
+            let nearVerticalEdge = point.x <= bounds.minX + expansion ||
+                point.x >= bounds.maxX - expansion
+            let nearHorizontalEdge = point.y <= bounds.minY + expansion ||
+                point.y >= bounds.maxY - expansion
             return nearVerticalEdge || nearHorizontalEdge
         }
 
@@ -6712,6 +6712,10 @@ struct WebViewRepresentable: NSViewRepresentable {
         ) {
             let resolvedHostedInspectorHit = hostedInspectorHit ?? hostedInspectorDividerHit(at: point)
             if shouldPassThroughToSidebarResizer(at: point, hostedInspectorHit: resolvedHostedInspectorHit) {
+                clearActiveDividerCursor(restoreArrow: false)
+                return
+            }
+            if shouldPassThroughToExternalSplitDivider(at: point, hostedInspectorHit: resolvedHostedInspectorHit) {
                 clearActiveDividerCursor(restoreArrow: false)
                 return
             }

--- a/Sources/PortalSplitDividerRegion.swift
+++ b/Sources/PortalSplitDividerRegion.swift
@@ -10,6 +10,8 @@ final class PortalSplitDividerRegion {
     let isVertical: Bool
     let isInHostedContent: Bool
 
+    static let dividerHitExpansion: CGFloat = 5
+
     init(
         splitView: NSSplitView,
         dividerIndex: Int,
@@ -50,6 +52,44 @@ final class PortalSplitDividerRegion {
 
     static func allLive(_ regions: [PortalSplitDividerRegion]) -> Bool {
         regions.allSatisfy(\.isLive)
+    }
+
+    var hitRectInWindow: NSRect {
+        rectInWindow
+            .insetBy(dx: -Self.dividerHitExpansion, dy: -Self.dividerHitExpansion)
+            .intersection(boundsInWindow)
+    }
+
+    static func dividerRect(in splitView: NSSplitView, dividerIndex: Int) -> NSRect? {
+        guard dividerIndex >= 0,
+              dividerIndex + 1 < splitView.arrangedSubviews.count else {
+            return nil
+        }
+
+        let first = splitView.arrangedSubviews[dividerIndex].frame
+        let second = splitView.arrangedSubviews[dividerIndex + 1].frame
+        let thickness = splitView.dividerThickness
+        if splitView.isVertical {
+            guard first.width > 1 || second.width > 1 else { return nil }
+            return NSRect(x: max(0, first.maxX), y: 0, width: thickness, height: splitView.bounds.height)
+        }
+
+        guard first.height > 1 || second.height > 1 else { return nil }
+        return NSRect(x: 0, y: max(0, first.maxY), width: splitView.bounds.width, height: thickness)
+    }
+
+    static func dividerHitRect(in splitView: NSSplitView, dividerIndex: Int) -> NSRect? {
+        guard let dividerRect = dividerRect(in: splitView, dividerIndex: dividerIndex) else { return nil }
+        return dividerRect
+            .insetBy(dx: -Self.dividerHitExpansion, dy: -Self.dividerHitExpansion)
+            .intersection(splitView.bounds)
+    }
+
+    static func dividerHitRectInWindow(in splitView: NSSplitView, dividerIndex: Int) -> NSRect? {
+        guard let hitRect = dividerHitRect(in: splitView, dividerIndex: dividerIndex) else { return nil }
+        let hitRectInWindow = splitView.convert(hitRect, to: nil)
+        guard hitRectInWindow.width > 0, hitRectInWindow.height > 0 else { return nil }
+        return hitRectInWindow
     }
 
     static func collect(
@@ -142,19 +182,7 @@ final class PortalSplitDividerRegion {
         let splitBoundsInWindow = splitView.convert(splitView.bounds, to: nil)
         let dividerCount = max(0, splitView.arrangedSubviews.count - 1)
         for dividerIndex in 0..<dividerCount {
-            let first = splitView.arrangedSubviews[dividerIndex].frame
-            let second = splitView.arrangedSubviews[dividerIndex + 1].frame
-            let thickness = splitView.dividerThickness
-            let dividerRect: NSRect
-            if splitView.isVertical {
-                guard first.width > 1 || second.width > 1 else { continue }
-                let x = max(0, first.maxX)
-                dividerRect = NSRect(x: x, y: 0, width: thickness, height: splitView.bounds.height)
-            } else {
-                guard first.height > 1 || second.height > 1 else { continue }
-                let y = max(0, first.maxY)
-                dividerRect = NSRect(x: 0, y: y, width: splitView.bounds.width, height: thickness)
-            }
+            guard let dividerRect = dividerRect(in: splitView, dividerIndex: dividerIndex) else { continue }
             let dividerRectInWindow = splitView.convert(dividerRect, to: nil)
             guard dividerRectInWindow.width > 0, dividerRectInWindow.height > 0 else { continue }
             result.append(PortalSplitDividerRegion(

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -417,11 +417,9 @@ final class WindowTerminalHostView: NSView {
     }
 
     private static func dividerCursorKind(at windowPoint: NSPoint, in regions: [DividerRegion], checkLiveness: Bool = true) -> DividerCursorKind? {
-        let expansion: CGFloat = 5
         for region in regions.reversed() {
             if checkLiveness, !region.isLive { continue }
-            let hitRect = region.rectInWindow.insetBy(dx: -expansion, dy: -expansion)
-                .intersection(region.boundsInWindow)
+            let hitRect = region.hitRectInWindow
             if !hitRect.isNull, hitRect.contains(windowPoint) {
                 return region.isVertical ? .vertical : .horizontal
             }


### PR DESCRIPTION
## Summary

Fixes #7037

Browser panes now decline hits over real adjacent split-divider grab bands before descending into the hosted `WKWebView`. This prevents WebKit's internal scrollbar view from winning the mouse-down when the pointer is in the pane divider band, while preserving normal webview clicks, scrolling, selection, and DevTools inspector divider hits outside that band.

I used the `HostContainerView.hitTest` pass-through alternative instead of adding a child overlay in `pinHostedWebView()`: a child overlay would become the hit view and then has to rely on responder-chain forwarding to reach the split view, while returning `nil` from the host over a verified external divider band routes directly through the existing bonsplit/SwiftUI resize paths. The webview frame stays unchanged.

## Verification

- Confirmed the root cause in code: the webview is inserted above the slot and pinned to fill its container, while bonsplit expands the 1px divider by 5pt.
- `git diff --check`
- No local tests or local build run per task instruction.

## Test note

I did not add a regression test because the failure depends on `WKWebView`'s private internal scrollbar view winning AppKit hit-testing while layered over an `NSSplitView` divider. A unit test of the helper math would not prove the user-visible regression, and a meaningful test would need an end-to-end UI/AppKit/WebKit hit-test harness.

## Localization

No user-facing strings were added or changed. The only added string literal is a DEBUG hit-test log stage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785294431&installation_id=133855650&pr_number=7038&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7038&signature=742dc3a8e47cea9a37c28b99ec4a9bbbad2d66dd734e95535dabd9bb50a099e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes divider resizing and cursor/hover behavior in browser panes (including the docked right sidebar) by centralizing divider hit geometry and passing near-edge divider hits through `WKWebView` to the parent `NSSplitView`. Also updates Swift file length budgets.

- **Bug Fixes**
  - Share a 5pt divider hit band and window hit rects via `PortalSplitDividerRegion` (`dividerHitExpansion`, `hitRectInWindow`, `dividerHitRect{,InWindow}`) used across browser, terminal, and panel hit-testing.
  - Add a near-edge prefilter and only pass through when a real external split divider is hit; preserves normal web actions and ignores hosted inspector divider hits.
  - Use the Dock browser edge when present to detect trailing sidebar resize hits, falling back to the content edge otherwise.
  - Improve cursor feedback: when pass-through applies, clear the webview divider cursor and compute cursor kind via shared `hitRectInWindow` in both portals.

<sup>Written for commit c3ea0b4345f92f4a574d2586cb805eb70ac0571b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser split-pane edge pointer routing so resize/drag interactions correctly pass through to the external divider when appropriate, with matching cursor behavior.
  * Standardized divider hit-testing across browser and terminal views for more consistent hover and resizing detection.
  * Improved interactive divider drag detection accuracy using shared hit-rectangle calculations.
  * Corrected pass-through diagnostics in debug builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->