### PR TITLE
Make cmuxOnly socket denials actionable

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1196,7 +1196,7 @@ class TerminalController {
             if let pid {
                 guard isDescendant(pid) else {
                     _ = writeSocketResponse(
-                        "ERROR: Access denied — only processes started inside cmux can connect",
+                        "ERROR: Access denied — only processes started inside cmux can connect. To let external automation clients (e.g. editor/agent hooks) control cmux, set Settings → Automation → Socket control mode to \"Automation mode\", or set automation.socketControlMode to \"automation\" in ~/.config/cmux/cmux.json.",
                         to: socket
                     )
                     return
@@ -1212,7 +1212,7 @@ class TerminalController {
             if pid == nil {
                 guard transport.peerHasSameUID(socket) else {
                     _ = writeSocketResponse(
-                        "ERROR: Unable to verify client process",
+                        "ERROR: Unable to verify client process. To let external automation clients (e.g. editor/agent hooks) control cmux, set Settings → Automation → Socket control mode to \"Automation mode\", or set automation.socketControlMode to \"automation\" in ~/.config/cmux/cmux.json.",
                         to: socket
                     )
                     return


### PR DESCRIPTION
## Problem

When the control socket is in the default `cmuxOnly` mode, an external local client (an editor/agent hook, or a companion app that wants to focus a surface via `surface.focus`) is rejected with a dead-end message:

- `ERROR: Access denied — only processes started inside cmux can connect`
- `ERROR: Unable to verify client process`

Neither tells the user that cmux already supports this via the `automation` socket mode, so the natural conclusion is "cmux can't be controlled from outside" — when in fact it's a one-setting opt-in.

## Change

Append an actionable hint to both denial paths in `TerminalController.handleClient`, pointing at the existing Automation mode (Settings and `cmux.json`). No behavior change — only the rejection text.

## Notes

- Matches the existing **bare-string** socket-response convention in this function (the surrounding `ERROR: …` responses are not localized literals); happy to route these through `Localizable.xcstrings` instead if you'd prefer socket errors localized.
- String-literal-only change; I have not run a local Xcode build, so I'm relying on CI for build verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785302256&installation_id=133855650&pr_number=7041&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7041&signature=e2e8c8138d3cc641ceec8b248c67746a8ff2bd8f75290ca5ad14a93a544b0c5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add actionable guidance to socket denial errors in `cmuxOnly` mode, telling users how to enable external control via Automation mode (Settings → Automation → Socket control mode or set `automation.socketControlMode: "automation"` in `~/.config/cmux/cmux.json`). No behavior change; only error strings in `TerminalController.handleClient` were updated.

<sup>Written for commit ce10876bf2220c467dcf8ea1947a35ac35dc5ac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved socket connection error messages when a connection is denied in cmux-only mode.
  * Added clearer guidance for switching to Automation mode when the client process can’t be validated or isn’t a descendant process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->