### PR TITLE
feat(vault): auto-resume Hermes sessions via state.db cwd lookup

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Vault/Providers/HermesAgent/HermesAgentIndex.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Vault/Providers/HermesAgent/HermesAgentIndex.swift
@@ -86,6 +86,57 @@ public enum HermesAgentIndex {
             .appendingPathComponent("state.db")
     }
 
+    /// Fast path for the resume scanner: the newest `cli`/`tui` session id whose
+    /// recorded `cwd` matches `cwdFilter`, or `nil` if there is none.
+    ///
+    /// Unlike `loadSessions`, this does NOT snapshot-copy `state.db`. It opens
+    /// the live database read-only and runs a single indexed `LIMIT 1` query
+    /// (the `idx_sessions_started` index makes it O(log n)). state.db is WAL, so
+    /// a read-only connection is safe under concurrent writes without copying —
+    /// which matters because this is reached from cmux's main-queue quit/save
+    /// path and the database can be multiple GB. A `nil`/empty `cwdFilter`
+    /// returns `nil` (the scanner must not bind a session it cannot attribute).
+    public static func latestSessionID(
+        cwdFilter: String?,
+        stateDBPath: String = Self.defaultStateDBPath()
+    ) -> String? {
+        guard let normalizedCwd = normalized(cwdFilter).map({ ($0 as NSString).standardizingPath }) else {
+            return nil
+        }
+        guard FileManager.default.fileExists(atPath: stateDBPath) else { return nil }
+
+        var db: OpaquePointer?
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX
+        guard sqlite3_open_v2(stateDBPath, &db, flags, nil) == SQLITE_OK, let db else {
+            sqlite3_close(db)
+            return nil
+        }
+        defer { sqlite3_close(db) }
+        _ = sqlite3_busy_timeout(db, 50)
+
+        let sql = """
+            SELECT s.id
+            FROM sessions s
+            WHERE s.source IN (\(knownSources.map { "'\($0)'" }.joined(separator: ", ")))
+              AND s.cwd = ?
+            ORDER BY s.started_at DESC
+            LIMIT 1
+            """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else {
+            sqlite3_finalize(stmt)
+            return nil
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        let transient = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
+        guard sqlite3_bind_text(stmt, 1, normalizedCwd, -1, transient) == SQLITE_OK else { return nil }
+
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+        let id = sqliteText(stmt, 0)
+        return (id?.isEmpty == false) ? id : nil
+    }
+
     /// Loads Hermes sessions from state.db, newest first.
     ///
     /// When `cwdFilter` is non-nil, only sessions whose recorded `cwd` matches the

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Vault/Providers/HermesAgent/HermesAgentIndex.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Vault/Providers/HermesAgent/HermesAgentIndex.swift
@@ -1,7 +1,11 @@
 import Foundation
 import SQLite3
 
-/// Indexed Hermes sessions do not carry cwd metadata and cannot be filtered by working directory.
+/// One indexed Hermes session row. Hermes records `cwd` on the session at
+/// creation time, so sessions can be filtered by working directory (see
+/// `loadSessions(cwdFilter:)`) to disambiguate concurrent sessions that share
+/// one state.db. Sessions created with a NULL/empty `cwd` are simply not
+/// matched by a cwd-scoped query.
 public struct HermesAgentIndexedSession: Equatable, Sendable {
     public let sessionId: String
     public let source: String
@@ -82,7 +86,15 @@ public enum HermesAgentIndex {
             .appendingPathComponent("state.db")
     }
 
-    /// Loads Hermes sessions from state.db. Hermes does not store cwd metadata, so any non-nil cwdFilter returns no sessions and no errors.
+    /// Loads Hermes sessions from state.db, newest first.
+    ///
+    /// When `cwdFilter` is non-nil, only sessions whose recorded `cwd` matches the
+    /// (standardized) filter are returned. Hermes records `cwd` on the `sessions`
+    /// row at creation time, so this is the disambiguator that lets cmux map a
+    /// scanned hermes process to *its* session rather than the newest session
+    /// globally — critical when several hermes panes/gateways write to the same
+    /// state.db concurrently. Rows with a NULL/empty `cwd` never match a non-nil
+    /// filter (so an un-attributable session is skipped rather than mis-bound).
     public static func loadSessions(
         needle: String,
         cwdFilter: String?,
@@ -95,9 +107,6 @@ public enum HermesAgentIndex {
         }
         let (_, overflow) = offset.addingReportingOverflow(limit)
         guard !overflow else {
-            return HermesAgentIndexResult(sessions: [], errors: [])
-        }
-        guard cwdFilter == nil else {
             return HermesAgentIndexResult(sessions: [], errors: [])
         }
 
@@ -117,7 +126,7 @@ public enum HermesAgentIndex {
 
         do {
             return try withDatabase(snapshot.databaseURL.path) { db in
-                try loadSessions(db: db, needle: needle, offset: offset, limit: limit)
+                try loadSessions(db: db, needle: needle, cwdFilter: cwdFilter, offset: offset, limit: limit)
             }
         } catch {
             return HermesAgentIndexResult(
@@ -146,11 +155,20 @@ public enum HermesAgentIndex {
     private static func loadSessions(
         db: OpaquePointer,
         needle: String,
+        cwdFilter: String?,
         offset: Int,
         limit: Int
     ) throws -> HermesAgentIndexResult {
         let trimmedNeedle = needle.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let hasNeedle = !trimmedNeedle.isEmpty
+        // Standardize the cwd filter the same way the caller's path is standardized
+        // (~ expansion, symlink-free) so equality holds regardless of how the path
+        // was spelled. A non-nil filter restricts to rows with a matching non-empty cwd.
+        let normalizedCwdFilter: String? = {
+            guard let cwdFilter = normalized(cwdFilter) else { return nil }
+            return (cwdFilter as NSString).standardizingPath
+        }()
+        let hasCwdFilter = normalizedCwdFilter != nil
         var sql = """
             SELECT
               s.id,
@@ -171,6 +189,9 @@ public enum HermesAgentIndex {
             LEFT JOIN messages m ON m.session_id = s.id
             WHERE s.source IN (\(knownSources.map { "'\($0)'" }.joined(separator: ", ")))
             """
+        if hasCwdFilter {
+            sql += "\n AND s.cwd = ?"
+        }
         if hasNeedle {
             sql += """
                  AND (
@@ -203,13 +224,25 @@ public enum HermesAgentIndex {
         }
         defer { sqlite3_finalize(stmt) }
 
+        // SQLITE_TRANSIENT — tell SQLite to copy the bound bytes (the Swift strings
+        // are deallocated as soon as this scope exits).
+        let destructor = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
+        // Bind in placeholder order: the cwd filter `?` (if present) comes before
+        // the five needle `?`s in the SQL above.
+        var bindIndex: Int32 = 1
+        if let normalizedCwdFilter {
+            guard sqlite3_bind_text(stmt, bindIndex, normalizedCwdFilter, -1, destructor) == SQLITE_OK else {
+                throw HermesAgentIndexError.sqlite(sqliteMessage(db) ?? "bind failed")
+            }
+            bindIndex += 1
+        }
         if hasNeedle {
             let likePattern = "%\(trimmedNeedle)%"
-            let destructor = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
-            for index in 1...5 {
-                guard sqlite3_bind_text(stmt, Int32(index), likePattern, -1, destructor) == SQLITE_OK else {
+            for _ in 0..<5 {
+                guard sqlite3_bind_text(stmt, bindIndex, likePattern, -1, destructor) == SQLITE_OK else {
                     throw HermesAgentIndexError.sqlite(sqliteMessage(db) ?? "bind failed")
                 }
+                bindIndex += 1
             }
         }
 

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Vault/Providers/HermesAgent/HermesAgentIndex.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Vault/Providers/HermesAgent/HermesAgentIndex.swift
@@ -100,9 +100,15 @@ public enum HermesAgentIndex {
         cwdFilter: String?,
         stateDBPath: String = Self.defaultStateDBPath()
     ) -> String? {
-        guard let normalizedCwd = normalized(cwdFilter).map({ ($0 as NSString).standardizingPath }) else {
-            return nil
-        }
+        guard let rawCwd = normalized(cwdFilter) else { return nil }
+        // Match the stored cwd against BOTH the standardized path (~ expanded,
+        // ./.. collapsed) and the symlink-resolved realpath. `standardizingPath`
+        // does NOT resolve symlinks, so a pane whose PWD is a symlink (e.g.
+        // /tmp/x) would otherwise never match a session hermes stored under the
+        // real path (/private/tmp/x), silently skipping the resume binding. We
+        // also resolve the symlink because hermes is observed to store realpaths.
+        let cwdCandidates = Self.cwdMatchCandidates(rawCwd)
+        guard !cwdCandidates.isEmpty else { return nil }
         guard FileManager.default.fileExists(atPath: stateDBPath) else { return nil }
 
         var db: OpaquePointer?
@@ -114,11 +120,12 @@ public enum HermesAgentIndex {
         defer { sqlite3_close(db) }
         _ = sqlite3_busy_timeout(db, 50)
 
+        let placeholders = cwdCandidates.map { _ in "?" }.joined(separator: ", ")
         let sql = """
             SELECT s.id
             FROM sessions s
             WHERE s.source IN (\(knownSources.map { "'\($0)'" }.joined(separator: ", ")))
-              AND s.cwd = ?
+              AND s.cwd IN (\(placeholders))
             ORDER BY s.started_at DESC
             LIMIT 1
             """
@@ -130,11 +137,30 @@ public enum HermesAgentIndex {
         defer { sqlite3_finalize(stmt) }
 
         let transient = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
-        guard sqlite3_bind_text(stmt, 1, normalizedCwd, -1, transient) == SQLITE_OK else { return nil }
+        for (offset, candidate) in cwdCandidates.enumerated() {
+            guard sqlite3_bind_text(stmt, Int32(offset + 1), candidate, -1, transient) == SQLITE_OK else {
+                return nil
+            }
+        }
 
         guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
         let id = sqliteText(stmt, 0)
         return (id?.isEmpty == false) ? id : nil
+    }
+
+    /// The set of cwd strings a stored `sessions.cwd` may equal for a given raw
+    /// working directory: the standardized path and its symlink-resolved
+    /// realpath (deduplicated, order-stable). Used to match a pane's cwd against
+    /// however hermes recorded it, regardless of symlink spelling.
+    static func cwdMatchCandidates(_ rawCwd: String) -> [String] {
+        let standardized = (rawCwd as NSString).standardizingPath
+        var candidates: [String] = []
+        var seen = Set<String>()
+        for path in [standardized, (standardized as NSString).resolvingSymlinksInPath] {
+            guard !path.isEmpty, seen.insert(path).inserted else { continue }
+            candidates.append(path)
+        }
+        return candidates
     }
 
     /// Loads Hermes sessions from state.db, newest first.

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Vault/Providers/HermesAgent/HermesAgentIndex.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Vault/Providers/HermesAgent/HermesAgentIndex.swift
@@ -166,7 +166,8 @@ public enum HermesAgentIndex {
     /// Loads Hermes sessions from state.db, newest first.
     ///
     /// When `cwdFilter` is non-nil, only sessions whose recorded `cwd` matches the
-    /// (standardized) filter are returned. Hermes records `cwd` on the `sessions`
+    /// filter — by standardized path or its symlink-resolved realpath — are
+    /// returned. Hermes records `cwd` on the `sessions`
     /// row at creation time, so this is the disambiguator that lets cmux map a
     /// scanned hermes process to *its* session rather than the newest session
     /// globally — critical when several hermes panes/gateways write to the same
@@ -238,14 +239,18 @@ public enum HermesAgentIndex {
     ) throws -> HermesAgentIndexResult {
         let trimmedNeedle = needle.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let hasNeedle = !trimmedNeedle.isEmpty
-        // Standardize the cwd filter the same way the caller's path is standardized
-        // (~ expansion, symlink-free) so equality holds regardless of how the path
-        // was spelled. A non-nil filter restricts to rows with a matching non-empty cwd.
-        let normalizedCwdFilter: String? = {
-            guard let cwdFilter = normalized(cwdFilter) else { return nil }
-            return (cwdFilter as NSString).standardizingPath
+        // Match the stored cwd against BOTH the standardized path and its
+        // symlink-resolved realpath, via the same `cwdMatchCandidates` helper the
+        // resume fast path (`latestSessionID`) uses. `standardizingPath` alone does
+        // NOT resolve symlinks, so a pane whose PWD is a symlink (e.g. /tmp/x) would
+        // otherwise never match a session hermes recorded under the real path
+        // (/private/tmp/x), silently returning no rows. A non-nil filter restricts
+        // to rows with a matching non-empty cwd.
+        let cwdFilterCandidates: [String] = {
+            guard let cwdFilter = normalized(cwdFilter) else { return [] }
+            return Self.cwdMatchCandidates(cwdFilter)
         }()
-        let hasCwdFilter = normalizedCwdFilter != nil
+        let hasCwdFilter = !cwdFilterCandidates.isEmpty
         var sql = """
             SELECT
               s.id,
@@ -267,7 +272,8 @@ public enum HermesAgentIndex {
             WHERE s.source IN (\(knownSources.map { "'\($0)'" }.joined(separator: ", ")))
             """
         if hasCwdFilter {
-            sql += "\n AND s.cwd = ?"
+            let placeholders = cwdFilterCandidates.map { _ in "?" }.joined(separator: ", ")
+            sql += "\n AND s.cwd IN (\(placeholders))"
         }
         if hasNeedle {
             sql += """
@@ -304,11 +310,11 @@ public enum HermesAgentIndex {
         // SQLITE_TRANSIENT — tell SQLite to copy the bound bytes (the Swift strings
         // are deallocated as soon as this scope exits).
         let destructor = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
-        // Bind in placeholder order: the cwd filter `?` (if present) comes before
+        // Bind in placeholder order: the cwd filter `?`s (if present) come before
         // the five needle `?`s in the SQL above.
         var bindIndex: Int32 = 1
-        if let normalizedCwdFilter {
-            guard sqlite3_bind_text(stmt, bindIndex, normalizedCwdFilter, -1, destructor) == SQLITE_OK else {
+        for candidate in cwdFilterCandidates {
+            guard sqlite3_bind_text(stmt, bindIndex, candidate, -1, destructor) == SQLITE_OK else {
                 throw HermesAgentIndexError.sqlite(sqliteMessage(db) ?? "bind failed")
             }
             bindIndex += 1

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Vault/Providers/HermesAgent/HermesAgentIndexTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Vault/Providers/HermesAgent/HermesAgentIndexTests.swift
@@ -41,8 +41,8 @@ struct HermesAgentIndexTests {
         #expect(result.sessions.first?.modified == Date(timeIntervalSince1970: 22))
     }
 
-    @Test("Searches messages and skips directory scoped requests")
-    func searchesMessagesAndSkipsDirectoryScopedRequests() throws {
+    @Test("Searches messages by needle")
+    func searchesMessagesByNeedle() throws {
         let root = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
         let dbURL = root.appendingPathComponent("state.db", isDirectory: false)
@@ -61,16 +61,90 @@ struct HermesAgentIndexTests {
             limit: 10,
             stateDBPath: dbURL.path
         )
-        let scoped = HermesAgentIndex.loadSessions(
-            needle: "",
-            cwdFilter: "/tmp/repo",
-            offset: 0,
-            limit: 10,
-            stateDBPath: dbURL.path
-        )
 
         #expect(found.sessions.map(\.sessionId) == ["session-a"])
-        #expect(scoped.sessions.isEmpty)
+    }
+
+    // Regression: cmux must be able to map a scanned hermes process to ITS
+    // session (not the newest one globally) when several hermes panes/gateways
+    // share one state.db. The disambiguator is the recorded `cwd`. Before this
+    // fix, any non-nil cwdFilter returned [] (the index ignored cwd entirely),
+    // so two concurrent panes would both bind to the global-newest session.
+    @Test("Filters sessions by working directory, newest-per-cwd")
+    func filtersSessionsByWorkingDirectory() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dbURL = root.appendingPathComponent("state.db", isDirectory: false)
+        try makeHermesStateDB(at: dbURL)
+        // Two panes (cwd A and cwd B) plus an older session in A. Globally newest
+        // is in B; pane A must still resolve A's newest, never B's.
+        try exec(dbURL, """
+        INSERT INTO sessions (id, source, model, started_at, title, cwd)
+        VALUES
+          ('a-old', 'cli', 'm', 10, NULL, '/repo/alpha'),
+          ('a-new', 'cli', 'm', 30, NULL, '/repo/alpha'),
+          ('b-new', 'cli', 'm', 40, NULL, '/repo/beta');
+        """)
+
+        let alpha = HermesAgentIndex.loadSessions(
+            needle: "", cwdFilter: "/repo/alpha", offset: 0, limit: 1, stateDBPath: dbURL.path
+        )
+        let beta = HermesAgentIndex.loadSessions(
+            needle: "", cwdFilter: "/repo/beta", offset: 0, limit: 1, stateDBPath: dbURL.path
+        )
+        let global = HermesAgentIndex.loadSessions(
+            needle: "", cwdFilter: nil, offset: 0, limit: 1, stateDBPath: dbURL.path
+        )
+
+        #expect(alpha.sessions.map(\.sessionId) == ["a-new"])   // not b-new (global newest)
+        #expect(beta.sessions.map(\.sessionId) == ["b-new"])
+        #expect(global.sessions.map(\.sessionId) == ["b-new"])  // unfiltered = global newest
+        #expect(alpha.errors.isEmpty && beta.errors.isEmpty)
+    }
+
+    @Test("A cwd filter with no matching session yields nothing (never mis-binds)")
+    func cwdFilterWithNoMatchYieldsNothing() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dbURL = root.appendingPathComponent("state.db", isDirectory: false)
+        try makeHermesStateDB(at: dbURL)
+        // A real session exists, but in a different cwd, and one with NULL cwd.
+        try exec(dbURL, """
+        INSERT INTO sessions (id, source, model, started_at, title, cwd)
+        VALUES
+          ('elsewhere', 'cli', 'm', 50, NULL, '/repo/elsewhere'),
+          ('nullcwd', 'cli', 'm', 60, NULL, NULL);
+        """)
+
+        let result = HermesAgentIndex.loadSessions(
+            needle: "", cwdFilter: "/repo/target", offset: 0, limit: 1, stateDBPath: dbURL.path
+        )
+        // Refuse to bind rather than fall back to the global-newest 'nullcwd' /
+        // 'elsewhere' session — a missed resume is recoverable; a wrong one is not.
+        #expect(result.sessions.isEmpty)
+        #expect(result.errors.isEmpty)
+    }
+
+    @Test("A NULL-cwd session never matches a non-nil cwd filter")
+    func nullCwdNeverMatchesFilter() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dbURL = root.appendingPathComponent("state.db", isDirectory: false)
+        try makeHermesStateDB(at: dbURL)
+        try exec(dbURL, """
+        INSERT INTO sessions (id, source, model, started_at, title, cwd)
+        VALUES ('nullcwd', 'cli', 'm', 60, NULL, NULL);
+        """)
+
+        let filtered = HermesAgentIndex.loadSessions(
+            needle: "", cwdFilter: "/repo/target", offset: 0, limit: 5, stateDBPath: dbURL.path
+        )
+        let unfiltered = HermesAgentIndex.loadSessions(
+            needle: "", cwdFilter: nil, offset: 0, limit: 5, stateDBPath: dbURL.path
+        )
+
+        #expect(filtered.sessions.isEmpty)
+        #expect(unfiltered.sessions.map(\.sessionId) == ["nullcwd"])  // still visible unscoped
     }
 
     @Test("Loads transcript and decodes Hermes JSON content")
@@ -138,7 +212,8 @@ struct HermesAgentIndexTests {
           cost_source TEXT,
           pricing_version TEXT,
           title TEXT,
-          api_call_count INTEGER DEFAULT 0
+          api_call_count INTEGER DEFAULT 0,
+          cwd TEXT
         );
         CREATE TABLE messages (
           id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Vault/Providers/HermesAgent/HermesAgentIndexTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Vault/Providers/HermesAgent/HermesAgentIndexTests.swift
@@ -176,6 +176,56 @@ struct HermesAgentIndexTests {
         #expect(turns[1].content.contains("pwd"))
     }
 
+    // latestSessionID is the copy-free, read-only fast path the resume scanner
+    // actually calls (loadSessions, with its state.db snapshot copy, is the
+    // session-browser path). These cover it directly.
+    @Test("latestSessionID resolves newest-per-cwd, excludes gateways and no-match")
+    func latestSessionIDNewestPerCwd() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dbURL = root.appendingPathComponent("state.db", isDirectory: false)
+        try makeHermesStateDB(at: dbURL)
+        try exec(dbURL, """
+        INSERT INTO sessions (id, source, model, started_at, title, cwd)
+        VALUES
+          ('a-old', 'cli', 'm', 10, NULL, '/repo/alpha'),
+          ('a-new', 'cli', 'm', 30, NULL, '/repo/alpha'),
+          ('b-new', 'cli', 'm', 40, NULL, '/repo/beta'),
+          ('gw',    'gateway', 'm', 99, NULL, '/repo/alpha');
+        """)
+
+        #expect(HermesAgentIndex.latestSessionID(cwdFilter: "/repo/alpha", stateDBPath: dbURL.path) == "a-new")  // not b-new (global newest), not gw (gateway)
+        #expect(HermesAgentIndex.latestSessionID(cwdFilter: "/repo/beta", stateDBPath: dbURL.path) == "b-new")
+        #expect(HermesAgentIndex.latestSessionID(cwdFilter: "/repo/none", stateDBPath: dbURL.path) == nil)      // no match → no binding
+        #expect(HermesAgentIndex.latestSessionID(cwdFilter: nil, stateDBPath: dbURL.path) == nil)               // nil cwd → no binding
+    }
+
+    // Regression: a pane whose PWD is a symlink (e.g. /tmp/x) must still match a
+    // session hermes recorded under the realpath (/private/tmp/x). Before the
+    // symlink-aware fix, standardizingPath left the symlink unresolved and the
+    // lookup silently skipped the binding.
+    @Test("latestSessionID matches a session stored under the cwd's realpath via a symlink path")
+    func latestSessionIDResolvesSymlinkedCwd() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dbURL = root.appendingPathComponent("state.db", isDirectory: false)
+        try makeHermesStateDB(at: dbURL)
+
+        let realDir = root.appendingPathComponent("realrepo", isDirectory: true)
+        try FileManager.default.createDirectory(at: realDir, withIntermediateDirectories: true)
+        let linkDir = root.appendingPathComponent("linkrepo", isDirectory: true).path
+        try FileManager.default.createSymbolicLink(atPath: linkDir, withDestinationPath: realDir.path)
+        let storedCwd = (realDir.path as NSString).resolvingSymlinksInPath  // what hermes stores
+
+        try exec(dbURL, """
+        INSERT INTO sessions (id, source, model, started_at, title, cwd)
+        VALUES ('sym-sess', 'cli', 'm', 50, NULL, '\(storedCwd)');
+        """)
+
+        // Look up via the SYMLINK path (a pane's PWD) — must resolve to the realpath-stored row.
+        #expect(HermesAgentIndex.latestSessionID(cwdFilter: linkDir, stateDBPath: dbURL.path) == "sym-sess")
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-hermes-index-\(UUID().uuidString)", isDirectory: true)

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Vault/Providers/HermesAgent/HermesAgentIndexTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Vault/Providers/HermesAgent/HermesAgentIndexTests.swift
@@ -125,6 +125,40 @@ struct HermesAgentIndexTests {
         #expect(result.errors.isEmpty)
     }
 
+    // Regression: `standardizingPath` does NOT resolve symlinks, so a filter
+    // spelled with a symlinked path (e.g. /tmp/x) must still match a session
+    // hermes recorded under the resolved realpath (/private/tmp/x), and vice
+    // versa. loadSessions matches against both spellings (cwdMatchCandidates),
+    // mirroring the resume fast path, so neither direction silently misses.
+    @Test("A symlink-spelled cwd filter matches a session stored under its realpath")
+    func cwdFilterMatchesAcrossSymlink() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dbURL = root.appendingPathComponent("state.db", isDirectory: false)
+        try makeHermesStateDB(at: dbURL)
+
+        // On macOS /tmp is a symlink to /private/tmp. Use a real dir under /tmp:
+        // its standardized spelling stays /tmp/... while resolvingSymlinksInPath
+        // yields /private/tmp/.... Pick the spelling that differs from the input
+        // so each assertion exercises the cross-symlink match (skip if, on some
+        // host, the two coincide and there is nothing to disambiguate).
+        let symlinkSpelling = "/tmp/cmux-hermes-symlink-test-\(UUID().uuidString)"
+        let realSpelling = (symlinkSpelling as NSString).resolvingSymlinksInPath
+        try #require(symlinkSpelling != realSpelling)
+
+        try exec(dbURL, """
+        INSERT INTO sessions (id, source, model, started_at, title, cwd)
+        VALUES ('under-realpath', 'cli', 'm', 30, NULL, '\(realSpelling)');
+        """)
+
+        // Query with the symlink spelling: must resolve to the realpath row.
+        let viaSymlink = HermesAgentIndex.loadSessions(
+            needle: "", cwdFilter: symlinkSpelling, offset: 0, limit: 1, stateDBPath: dbURL.path
+        )
+        #expect(viaSymlink.sessions.map(\.sessionId) == ["under-realpath"])
+        #expect(viaSymlink.errors.isEmpty)
+    }
+
     @Test("A NULL-cwd session never matches a non-nil cwd filter")
     func nullCwdNeverMatchesFilter() throws {
         let root = try temporaryDirectory()

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -498,6 +498,23 @@ enum AgentResumeCommandBuilder {
                     sessionId: sessionId
                 )
             }
+            if customRegistration.id == CmuxVaultAgentRegistration.builtInHermes.id {
+                // Resume by replaying the captured launch flags (so an interactive
+                // `hermes --tui` / `--model` / `--profile` session resumes in the
+                // SAME interface/model/profile) and appending `--resume <id>`. This
+                // routes through the existing hermes-agent argument policy (which
+                // passes --tui through and drops secrets), the one shared path the
+                // hermes-agent hook integration already uses — rather than a static
+                // template that would silently drop --tui and resume a TUI session
+                // into the classic REPL.
+                return resumeWithOption(
+                    kind: "hermes-agent",
+                    launchCommand: launchCommand,
+                    fallbackExecutable: customRegistration.defaultExecutable,
+                    option: "--resume",
+                    sessionId: sessionId
+                )
+            }
             let arguments = customResumeArguments(
                 registration: customRegistration,
                 sessionId: sessionId,

--- a/Sources/SessionIndexRegisteredAgents.swift
+++ b/Sources/SessionIndexRegisteredAgents.swift
@@ -681,7 +681,7 @@ extension SessionIndexStore {
         switch registration.sessionIdSource {
         case .argvOption:
             needsNativeSessionID = true
-        case .piSessionFile, .grokSessionDirectory:
+        case .piSessionFile, .grokSessionDirectory, .stateDB:
             needsNativeSessionID = false
         }
         forEachJSONLine(url: url, maxBytes: 512 * 1024) { object in

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -76,6 +76,19 @@ extension RestorableAgentSessionIndex {
         guard !registry.registrations.isEmpty else { return resolved }
         var registriesByWorkingDirectory: [String: CmuxVaultAgentRegistry] = [:]
 
+        // Per-scan memo for Hermes state.db lookups, keyed by (stateDBPath, cwd).
+        // Several hermes panes/gateways in the same cwd resolve to one query per
+        // scan instead of one per process. The value is the resolved session id
+        // (or nil for "looked up, none found" — cached either way).
+        var hermesSessionIDByKey: [String: String?] = [:]
+        func latestHermesSessionID(stateDBPath: String, cwd: String) -> String? {
+            let key = stateDBPath + "\u{1f}" + cwd
+            if let cached = hermesSessionIDByKey[key] { return cached }
+            let resolvedId = HermesAgentIndex.latestSessionID(cwdFilter: cwd, stateDBPath: stateDBPath)
+            hermesSessionIDByKey[key] = resolvedId
+            return resolvedId
+        }
+
         func registryForWorkingDirectory(_ workingDirectory: String?) -> CmuxVaultAgentRegistry {
             guard let workingDirectory else { return registry }
             let key = (workingDirectory as NSString).standardizingPath
@@ -109,7 +122,8 @@ extension RestorableAgentSessionIndex {
                       from: observed,
                       registration: registration,
                       workingDirectory: cwd,
-                      fileManager: fileManager
+                      fileManager: fileManager,
+                      latestHermesSessionID: latestHermesSessionID
                   ) else {
                 continue
             }
@@ -871,7 +885,8 @@ private extension CmuxVaultAgentSessionIDSource {
         from process: VaultObservedAgentProcess,
         registration: CmuxVaultAgentRegistration,
         workingDirectory: String?,
-        fileManager: FileManager
+        fileManager: FileManager,
+        latestHermesSessionID: (_ stateDBPath: String, _ cwd: String) -> String?
     ) -> VaultAgentSessionIDResolution? {
         switch self {
         case .argvOption(let option):
@@ -898,15 +913,14 @@ private extension CmuxVaultAgentSessionIDSource {
                 return nil
             }
             let stateDBPath = HermesAgentIndex.defaultStateDBPath(env: process.environment)
-            let result = HermesAgentIndex.loadSessions(
-                needle: "",
-                cwdFilter: workingDirectory,
-                offset: 0,
-                limit: 1,
-                stateDBPath: stateDBPath
-            )
-            guard let latest = result.sessions.first, !latest.sessionId.isEmpty else { return nil }
-            return VaultAgentSessionIDResolution(sessionId: latest.sessionId, source: .inferredLatestSessionFile)
+            // Lean, copy-free, per-scan-cached lookup: HermesAgentIndex.latestSessionID
+            // opens state.db read-only and runs one indexed LIMIT-1 query (no
+            // GB-scale snapshot copy — this runs on cmux's main-queue quit/save
+            // path), and the injected cache collapses repeated (db, cwd) lookups
+            // within a single scan to one query.
+            guard let sessionId = latestHermesSessionID(stateDBPath, workingDirectory),
+                  !sessionId.isEmpty else { return nil }
+            return VaultAgentSessionIDResolution(sessionId: sessionId, source: .inferredLatestSessionFile)
         case .piSessionFile:
             if let session = process.piCompatibleSessionID {
                 let sessionId = PiSessionLocator.resolvedSessionPath(

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -927,6 +927,17 @@ private extension CmuxVaultAgentSessionIDSource {
             // GB-scale snapshot copy — this runs on cmux's main-queue quit/save
             // path), and the injected cache collapses repeated (db, cwd) lookups
             // within a single scan to one query.
+            //
+            // KNOWN LIMITATION (same as `.piSessionFile`, which infers newest
+            // session per cwd the same way): two hermes panes launched in the
+            // IDENTICAL cwd both resolve to that cwd's newest session, so they
+            // can bind to the same conversation. cwd disambiguates panes in
+            // DIFFERENT directories (the common case, incl. the per-profile
+            // gateway dirs); state.db records no PID/TTY to separate two panes
+            // sharing one cwd. The result is marked `.inferredLatestSessionFile`
+            // so the resolved id yields to an exact hook-store identity when one
+            // exists. A precise fix needs a per-process key (e.g. hermes writing
+            // its PID into the session row) — tracked in manaflow-ai/cmux#7042.
             guard let sessionId = latestHermesSessionID(stateDBPath, workingDirectory),
                   !sessionId.isEmpty else { return nil }
             return VaultAgentSessionIDResolution(sessionId: sessionId, source: .inferredLatestSessionFile)

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -80,12 +80,21 @@ extension RestorableAgentSessionIndex {
         // Several hermes panes/gateways in the same cwd resolve to one query per
         // scan instead of one per process. The value is the resolved session id
         // (or nil for "looked up, none found" — cached either way).
+        //
+        // The stored value is `String?`, so a "no match" result is a *stored nil*
+        // that must still count as a cache hit (otherwise an unresolved cwd would
+        // re-query state.db every scan on the main-queue save path). Assigning a
+        // typed `String?` value via subscript already stores nil correctly and
+        // preserves the key; updateValue(_:forKey:) + an `if case .some` read are
+        // used to make that intent explicit and immune to a future refactor that
+        // assigns a bare `nil` literal (`dict[key] = nil` on [String: String?]
+        // *removes* the key — the footgun this guards against).
         var hermesSessionIDByKey: [String: String?] = [:]
         func latestHermesSessionID(stateDBPath: String, cwd: String) -> String? {
             let key = stateDBPath + "\u{1f}" + cwd
-            if let cached = hermesSessionIDByKey[key] { return cached }
+            if case .some(let cached) = hermesSessionIDByKey[key] { return cached }
             let resolvedId = HermesAgentIndex.latestSessionID(cwdFilter: cwd, stateDBPath: stateDBPath)
-            hermesSessionIDByKey[key] = resolvedId
+            hermesSessionIDByKey.updateValue(resolvedId, forKey: key)
             return resolvedId
         }
 

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -76,25 +76,29 @@ extension RestorableAgentSessionIndex {
         guard !registry.registrations.isEmpty else { return resolved }
         var registriesByWorkingDirectory: [String: CmuxVaultAgentRegistry] = [:]
 
-        // Per-scan memo for Hermes state.db lookups, keyed by (stateDBPath, cwd).
-        // Several hermes panes/gateways in the same cwd resolve to one query per
-        // scan instead of one per process. The value is the resolved session id
-        // (or nil for "looked up, none found" — cached either way).
+        // Per-scan memo for Hermes state.db lookups. Several hermes panes/gateways
+        // in the same cwd resolve to one query per scan instead of one per process.
         //
-        // The stored value is `String?`, so a "no match" result is a *stored nil*
-        // that must still count as a cache hit (otherwise an unresolved cwd would
-        // re-query state.db every scan on the main-queue save path). Assigning a
-        // typed `String?` value via subscript already stores nil correctly and
-        // preserves the key; updateValue(_:forKey:) + an `if case .some` read are
-        // used to make that intent explicit and immune to a future refactor that
-        // assigns a bare `nil` literal (`dict[key] = nil` on [String: String?]
-        // *removes* the key — the footgun this guards against).
-        var hermesSessionIDByKey: [String: String?] = [:]
+        // Nested [stateDBPath: [cwd: String?]] rather than a joined string key:
+        // session identity is correctness-critical (a wrong bind cross-attaches two
+        // panes), so the key is collision-proof by construction — no separator char
+        // that a path could theoretically contain.
+        //
+        // The inner value is `String?`, so a "no match" is a *stored nil* that must
+        // still count as a cache hit (else an unresolved cwd re-queries state.db
+        // every scan on the main-queue save path). updateValue(_:forKey:) + an
+        // `if case .some` read make that explicit and immune to a future bare-`nil`
+        // assignment (`dict[key] = nil` on [_: String?] removes the key).
+        var hermesSessionIDByStateDBPath: [String: [String: String?]] = [:]
         func latestHermesSessionID(stateDBPath: String, cwd: String) -> String? {
-            let key = stateDBPath + "\u{1f}" + cwd
-            if case .some(let cached) = hermesSessionIDByKey[key] { return cached }
+            if let cwdCache = hermesSessionIDByStateDBPath[stateDBPath],
+               case .some(let cached) = cwdCache[cwd] {
+                return cached
+            }
             let resolvedId = HermesAgentIndex.latestSessionID(cwdFilter: cwd, stateDBPath: stateDBPath)
-            hermesSessionIDByKey.updateValue(resolvedId, forKey: key)
+            var cwdCache = hermesSessionIDByStateDBPath[stateDBPath] ?? [:]
+            cwdCache.updateValue(resolvedId, forKey: cwd)
+            hermesSessionIDByStateDBPath[stateDBPath] = cwdCache
             return resolvedId
         }
 

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -108,6 +108,7 @@ extension RestorableAgentSessionIndex {
                   let sessionIDResolution = registration.sessionIdSource.sessionIDResolution(
                       from: observed,
                       registration: registration,
+                      workingDirectory: cwd,
                       fileManager: fileManager
                   ) else {
                 continue
@@ -869,12 +870,43 @@ private extension CmuxVaultAgentSessionIDSource {
     func sessionIDResolution(
         from process: VaultObservedAgentProcess,
         registration: CmuxVaultAgentRegistration,
+        workingDirectory: String?,
         fileManager: FileManager
     ) -> VaultAgentSessionIDResolution? {
         switch self {
         case .argvOption(let option):
             guard let sessionId = process.arguments.nonOptionValue(afterOption: option) else { return nil }
             return VaultAgentSessionIDResolution(sessionId: sessionId, source: .explicit)
+        case .stateDB:
+            // Hermes mints its own session id at startup and rejects a
+            // caller-supplied --resume id, so the id can only be read back from
+            // ~/.hermes/state.db. Scope to THIS process's working directory so
+            // concurrent hermes panes/gateways (all writing one state.db) never
+            // cross-bind.
+            //
+            // BY DESIGN, this records NO resume binding (returns nil) when:
+            //   - the process has no detectable working directory, or
+            //   - no state.db session row matches that cwd (incl. rows whose
+            //     own cwd is NULL/empty — see HermesAgentIndex).
+            // A missed resume is recoverable (the pane reopens as a plain hermes,
+            // and the session is still in state.db to resume by hand); a WRONG
+            // resume silently attaches two panes to one conversation. We prefer
+            // the recoverable failure. Do NOT "fix" this into a global-newest
+            // fallback — that reintroduces the cross-session mis-bind.
+            guard let workingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !workingDirectory.isEmpty else {
+                return nil
+            }
+            let stateDBPath = HermesAgentIndex.defaultStateDBPath(env: process.environment)
+            let result = HermesAgentIndex.loadSessions(
+                needle: "",
+                cwdFilter: workingDirectory,
+                offset: 0,
+                limit: 1,
+                stateDBPath: stateDBPath
+            )
+            guard let latest = result.sessions.first, !latest.sessionId.isEmpty else { return nil }
+            return VaultAgentSessionIDResolution(sessionId: latest.sessionId, source: .inferredLatestSessionFile)
         case .piSessionFile:
             if let session = process.piCompatibleSessionID {
                 let sessionId = PiSessionLocator.resolvedSessionPath(

--- a/Sources/VaultAgentRegistry.swift
+++ b/Sources/VaultAgentRegistry.swift
@@ -185,6 +185,30 @@ struct CmuxVaultAgentRegistration: Codable, Hashable, Sendable {
             sessionDirectory: "~/.grok/sessions"
         )
     }
+
+    static var builtInHermes: CmuxVaultAgentRegistration {
+        CmuxVaultAgentRegistration(
+            // Use the "hermes-agent" id so a single identity flows through every
+            // subsystem keyed on it: the SessionAgent.hermesAgent browser entry,
+            // the AgentLaunchSanitizer "hermes-agent" argv policy (preserves
+            // --tui/--model/--profile on resume), and the env policy that only
+            // passes HERMES_HOME through for kind == "hermes-agent". The detect
+            // rule still matches the `hermes` executable/process name.
+            id: "hermes-agent",
+            name: "Hermes",
+            detect: CmuxVaultAgentDetectRule(processName: "hermes", argvContains: ["hermes"]),
+            // Hermes assigns its own session id at startup and stores it in
+            // ~/.hermes/state.db (it rejects a caller-supplied --resume id that
+            // does not already exist), so the id can only be read back AFTER the
+            // process starts. `.stateDB` resolves it from state.db, scoped to the
+            // pane's working directory so concurrent hermes panes/gateways never
+            // cross-bind to each other's session.
+            sessionIdSource: .stateDB,
+            resumeCommand: "{{executable}} --resume {{sessionId}}",
+            cwd: .preserve,
+            sessionDirectory: "~/.hermes"
+        )
+    }
 }
 
 struct CmuxVaultAgentDetectRule: Codable, Hashable, Sendable {
@@ -246,6 +270,9 @@ enum CmuxVaultAgentSessionIDSource: Codable, Hashable, Sendable {
     case argvOption(String)
     case piSessionFile
     case grokSessionDirectory
+    /// Resolve the session id from the Hermes SQLite session store
+    /// (~/.hermes/state.db), scoped to the scanned process's working directory.
+    case stateDB
 
     private enum CodingKeys: String, CodingKey {
         case type, argvOption
@@ -260,6 +287,8 @@ enum CmuxVaultAgentSessionIDSource: Codable, Hashable, Sendable {
                 self = .piSessionFile
             case "grokSessionDirectory", "grok-session-directory":
                 self = .grokSessionDirectory
+            case "stateDB", "state-db":
+                self = .stateDB
             default:
                 guard !trimmed.isEmpty else {
                     throw DecodingError.dataCorrupted(
@@ -296,6 +325,17 @@ enum CmuxVaultAgentSessionIDSource: Codable, Hashable, Sendable {
                 )
             }
             self = .grokSessionDirectory
+        case "stateDB", "state-db":
+            if let option = try container.decodeIfPresent(String.self, forKey: .argvOption)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !option.isEmpty {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .argvOption,
+                    in: container,
+                    debugDescription: "stateDB must not include argvOption"
+                )
+            }
+            self = .stateDB
         case "argvOption", "argv-option":
             let option = try container.decodeIfPresent(String.self, forKey: .argvOption)?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -326,6 +366,8 @@ enum CmuxVaultAgentSessionIDSource: Codable, Hashable, Sendable {
             try container.encode("piSessionFile", forKey: .type)
         case .grokSessionDirectory:
             try container.encode("grokSessionDirectory", forKey: .type)
+        case .stateDB:
+            try container.encode("stateDB", forKey: .type)
         }
     }
 }
@@ -402,6 +444,7 @@ struct CmuxVaultAgentRegistry: Sendable {
             CmuxVaultAgentRegistration.builtInOmp,
             CmuxVaultAgentRegistration.builtInAntigravity,
             CmuxVaultAgentRegistration.builtInGrok,
+            CmuxVaultAgentRegistration.builtInHermes,
         ]
         for path in configPaths(homeDirectory: homeDirectory, workingDirectory: workingDirectory, environment: environment, fileManager: fileManager) {
             guard let config = decodeConfig(at: path, fileManager: fileManager) else { continue }

--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -1131,9 +1131,18 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         XCTAssertEqual(reg.sessionIdSource, .stateDB)
     }
 
-    func testBuiltInHermesIsRegisteredByDefault() {
+    func testBuiltInHermesIsRegisteredByDefault() throws {
+        // Use an isolated, empty home so the assertion reflects only the built-in
+        // registration set — never whatever vault config happens to exist on the
+        // machine running the suite (which would make this pass/fail for the
+        // wrong reason).
+        let isolatedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-hermes-registry-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: isolatedHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: isolatedHome) }
+
         let registry = CmuxVaultAgentRegistry.load(
-            homeDirectory: NSHomeDirectory(),
+            homeDirectory: isolatedHome.path,
             workingDirectory: nil,
             environment: [:],
             fileManager: .default

--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -1116,6 +1116,87 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         )
     }
 
+    // MARK: - Hermes built-in registration
+
+    func testBuiltInHermesRegistrationShape() {
+        let reg = CmuxVaultAgentRegistration.builtInHermes
+        // The id is "hermes-agent" so a single identity flows through the
+        // SessionAgent.hermesAgent browser entry, the AgentLaunchSanitizer
+        // "hermes-agent" argv policy, and the env policy that gates HERMES_HOME.
+        XCTAssertEqual(reg.id, "hermes-agent")
+        XCTAssertEqual(reg.detect.processName, "hermes")
+        // defaultExecutable comes from the process name (the binary), not the id.
+        XCTAssertEqual(reg.defaultExecutable, "hermes")
+        // state.db-backed: the only id source that can resolve a Hermes session.
+        XCTAssertEqual(reg.sessionIdSource, .stateDB)
+    }
+
+    func testBuiltInHermesIsRegisteredByDefault() {
+        let registry = CmuxVaultAgentRegistry.load(
+            homeDirectory: NSHomeDirectory(),
+            workingDirectory: nil,
+            environment: [:],
+            fileManager: .default
+        )
+        XCTAssertNotNil(registry.registration(id: "hermes-agent"),
+                        "hermes-agent must be a built-in vault registration so a running hermes process is detected and resumed")
+    }
+
+    // A resumed hermes session must replay the captured launch flags so an
+    // interactive `hermes --tui` session comes back in the TUI (not the classic
+    // REPL) and a `--model`/`--profile` choice is preserved — then append
+    // `--resume <id>`. A static template would silently drop these.
+    func testHermesResumeCommandPreservesTuiAndModelFlags() throws {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .custom("hermes-agent"),
+            sessionId: "20260629_120000_abc123",
+            workingDirectory: "/repo/work",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "hermes-agent",
+                executablePath: "/opt/homebrew/bin/hermes",
+                arguments: ["/opt/homebrew/bin/hermes", "--tui", "--model", "opus"],
+                workingDirectory: "/repo/work",
+                environment: nil,
+                capturedAt: 99,
+                source: "process"
+            ),
+            registration: .builtInHermes
+        )
+        let resume = try XCTUnwrap(snapshot.resumeCommand)
+        XCTAssertTrue(resume.contains("'--resume' '20260629_120000_abc123'"),
+                      "resume must target the session id; got: \(resume)")
+        XCTAssertTrue(resume.contains("'--tui'"),
+                      "resume must preserve --tui so a TUI session does not come back as the classic REPL; got: \(resume)")
+        XCTAssertTrue(resume.contains("'--model' 'opus'"),
+                      "resume must preserve the model selection; got: \(resume)")
+        XCTAssertTrue(resume.contains("hermes"),
+                      "resume must invoke the hermes executable; got: \(resume)")
+    }
+
+    // A plain `hermes` (classic REPL, the default) resumes without spurious flags.
+    func testHermesResumeCommandMinimalForReplLaunch() throws {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .custom("hermes-agent"),
+            sessionId: "20260629_130000_def456",
+            workingDirectory: "/repo/work",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "hermes-agent",
+                executablePath: "/opt/homebrew/bin/hermes",
+                arguments: ["/opt/homebrew/bin/hermes"],
+                workingDirectory: "/repo/work",
+                environment: nil,
+                capturedAt: 99,
+                source: "process"
+            ),
+            registration: .builtInHermes
+        )
+        let resume = try XCTUnwrap(snapshot.resumeCommand)
+        XCTAssertTrue(resume.contains("'--resume' '20260629_130000_def456'"),
+                      "resume must target the session id; got: \(resume)")
+        XCTAssertFalse(resume.contains("'--tui'"),
+                       "a REPL launch must not gain a --tui flag on resume; got: \(resume)")
+    }
+
     private func makeSnapshot() -> AppSessionSnapshot {
         let workspace = SessionWorkspaceSnapshot(
             processTitle: "Terminal",


### PR DESCRIPTION
Resolves #7042.

## What

Makes the `hermes` CLI agent auto-resume after a cmux quit/relaunch, the same way pi/omp/antigravity/grok already do. Hermes was absent from `VaultAgentProcessScanner`'s built-in registry, so a hermes pane recorded no resume binding and returned as a bare shell.

## Why hermes needed a new id source

Hermes mints its own session id at startup and stores it in `~/.hermes/state.db` (SQLite); `hermes --resume <id>` rejects an id that doesn't already exist. So the id can't come from a JSONL file (`.piSessionFile`) or from argv (`.argvOption`) — it can only be read from `state.db` after the process starts. cmux already had a `state.db` reader (`HermesAgentIndex`); this wires it to resume.

## Changes

- **`CmuxVaultAgentSessionIDSource.stateDB`** (+ Codable) — resolve the session id from the Hermes SQLite store via the existing `HermesAgentIndex` (no second reader).
- **`builtInHermes`** registration. Id is `hermes-agent` so a single identity flows through the `SessionAgent.hermesAgent` browser entry, the `AgentLaunchSanitizer` `hermes-agent` argv policy, and the env policy that passes `HERMES_HOME` only for `kind == "hermes-agent"`. `detect` still matches the `hermes` process/executable, and `defaultExecutable` resolves to `hermes`.
- **cwd-scoped resolution** — thread the scanned process working directory into `sessionIDResolution`; `.stateDB` resolves the *newest session for that cwd*. With no cwd, or no session row for that cwd (including NULL-cwd rows), it records **no binding** rather than guess the global-newest. Rationale: with concurrent hermes panes/gateways sharing one `state.db`, newest-globally would cross-bind two panes; a missed resume is recoverable (resume by hand), a wrong one corrupts two sessions. Gateway-source rows are already excluded (`source IN ('cli','tui')`).
- **flag replay on resume** — `resumeWithOption(kind: "hermes-agent", option: "--resume")` replays the captured launch flags through the existing `hermes-agent` argument policy (preserves `--tui`/`--model`/`--profile`, drops secrets) and re-selects `HERMES_HOME`, so a `hermes --tui` session resumes in the TUI rather than the classic REPL. A static template would have silently dropped `--tui`.
- **`HermesAgentIndex.loadSessions` cwd filter** — now honours a non-nil `cwdFilter` (`s.cwd = ?`); previously it short-circuited to `[]` on a stale "Hermes stores no cwd metadata" assumption (the column exists and is ~populated). Stale docstring corrected.

## Tests (red/green, two commits)

- Commit 1 (red): regression tests that fail on `main` — newest-per-cwd resolution, no-match yields nothing, NULL-cwd never matches a filter (package, swift-testing); `builtInHermes` shape/registry presence and `--tui`/`--model` flag-replay on resume (app target, XCTest). The package fixture gains the real `sessions.cwd` column.
- Commit 2 (green): the fix.

## Verification & limitation (honest)

I do not have Xcode on this machine (CommandLineTools only), so I could **not** build the full app target or run the XCTest suite locally — those rely on CI. What I did verify locally:
- The `CMUXAgentLaunch` SPM package builds.
- I exercised `HermesAgentIndex.loadSessions` against a fixture `state.db` via a standalone executable and confirmed: a cwd resolves *its* newest session (not the global newest in another cwd); `source NOT IN (cli,tui)` (gateway) rows never resolve; a no-match cwd returns empty; NULL-cwd rows are excluded under a filter but visible unfiltered.

Please run the app-target tests on CI.

## Open question (see #7042)

The cwd disambiguator is robust but heuristic. Happy to follow up with a small hermes-side change to write the PID into the `sessions` row for an exact PID→session join (cwd as fallback) if you'd prefer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785304476&installation_id=133855650&pr_number=7043&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7043&signature=a689e1d5bb6de3c568e1c77be69aacc06a89d137afdeb50fc585687874b228d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


## Local validation (built + ran natively)

Built this branch into a real cmux DEBUG app on Xcode 26.6 (the team-pinned 26.x major) and exercised the full path end to end — not just unit logic.

**Build:** `./scripts/reload.sh --tag hermes-vault-resume` → `** BUILD SUCCEEDED **`, 0 errors. The new code is confirmed compiled into the app binary (`stateDB`, `stateDB must not include argvOption`, and the `hermes-agent` registration all present in `cmux DEV.debug.dylib`).

**Runtime — the resume binding is recorded with auto-resume:** launched the built app, ran `hermes` in a workspace pane (cwd `~/Documents/workspace`), sent a prompt (creating session `20260629_211133_f563c6` in `state.db`). cmux then recorded — confirmed via both the live `surface.resume.set` socket state and the persisted session snapshot:

```json
{
  "kind": "hermes-agent",
  "source": "agent-hook",
  "autoResume": true,
  "approvalPolicy": "auto",
  "checkpointId": "20260629_211133_f563c6",
  "command": "{ cd -- '/Users/.../Documents/workspace' ... } && 'hermes' '--resume' '20260629_211133_f563c6'"
}
```

i.e. the `.stateDB` source resolved the real session id from `state.db` scoped to the pane's cwd, and the binding persisted with `autoResume: true` / `approvalPolicy: auto`, so `applyingStoredApproval` keeps it auto on restore — silent resume, matching the pi/claude path. Before this branch, a hermes pane recorded no such binding (came back as a bare shell).

**Package-level tests** (`CMUXAgentLaunch`) for the cwd-scoping, newest-per-cwd, no-match, NULL-cwd, and symlink-realpath cases were exercised against fixture and real `state.db` instances locally and pass. The app-target XCTest suite (`cmuxTests`) runs on CI.

Note: I'm an external contributor, so the Vercel checks show "Authorization required to deploy" (fork can't deploy) and the Swift CI workflow needs a maintainer to approve a first-time-contributor run — hence the local build/run evidence above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds auto-resume for `hermes` by reading the session id from `~/.hermes/state.db`, scoped to the pane’s cwd, and registers Hermes as a built-in vault agent. Prevents cross-binding across directories, preserves launch flags on resume, and now matches cwd across symlinks for both resume and search.

- **New Features**
  - Built-in `hermes-agent` registration: detects `hermes`, uses `.stateDB` for session ids, default exec `hermes`.
  - CWD-scoped `state.db` lookup: picks newest `cli`/`tui` for that cwd; excludes gateways; no binding if no cwd match.
  - Resume replays captured flags and appends `--resume <id>`; preserves `--tui`/`--model`/`--profile`.

- **Refactors**
  - Fast `latestSessionID(...)`: read-only WAL query with indexed LIMIT 1; no snapshot copy.
  - Collision-proof per-scan memo: nested `[stateDBPath: [cwd: String?]]` with explicit nil-caching to dedupe lookups.
  - `HermesAgentIndex.loadSessions` adds a cwd filter with symlink-aware matching; returns newest-first.

<sup>Written for commit 0efda6d457ff98f5ff5e990b4b085d1c306badb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in Hermes agent support using `state.db`-based session detection and Hermes-aware resume arguments.
  * Restoring a Hermes session now preserves relevant launch flags (for example, UI/model) when forming the resume command.
* **Bug Fixes**
  * Improved working-directory–scoped Hermes session matching, including symlink vs real-path handling.
  * When a working-directory filter is provided, non-matching sessions (including missing/empty directory info) are no longer selected, and gateway sessions are excluded from “latest” selection.
* **Tests**
  * Expanded regression coverage for cwd-scoped disambiguation, symlink-aware lookup, and Hermes resume command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
