### PR TITLE
fix: upload pasted images in preserved-ended remote PTY panels

### DIFF
--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -497,7 +497,7 @@ extension TerminalSurface {
     @MainActor
     func resolvedImageTransferTarget() -> TerminalImageTransferTarget {
         guard let workspace = owningWorkspace() else { return .local }
-        if workspace.isRemoteTerminalSurface(id) {
+        if workspace.isRemoteTerminalSurface(id) || workspace.isPreservedEndedRemoteTerminalSurface(id) {
             return .remote(.workspaceRemote)
         }
         // Remote tmux mirror surfaces have no local TTY/process, so the SSH

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5366,6 +5366,11 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     @MainActor
+    func isPreservedEndedRemoteTerminalSurface(_ panelId: UUID) -> Bool {
+        endedPersistentRemotePTYAttachSurfaceIds.contains(panelId)
+    }
+
+    @MainActor
     func markRemoteTerminalSessionClosingIfLast(surfaceId: UUID) {
         guard !isDetachingCloseTransaction,
               activeRemoteTerminalSurfaceIds.count == 1,


### PR DESCRIPTION
Fixes #1660.

## What

When a `cmux ssh` session ends and the panel is kept alive for reconnect (`preserveAfterTerminalExit`), pasting an image inserts a local macOS temp path (e.g. `/var/folders/.../T/clipboard-DATE-UUID.png`) instead of uploading the file to the remote host.

## Root cause

`resolvedImageTransferTarget()` checks `isRemoteTerminalSurface()`, which returns false once `markRemotePTYAttachEnded` removes the surface from `activeRemoteTerminalSurfaceIds`. The fallback path runs `TerminalSSHSessionDetector`, which looks for `ssh` or `et` as the foreground TTY process. In persistent SSH PTY sessions the foreground process is `cmux ssh-pty-attach`, which the detector does not recognize, so it returns nil and the code falls through to `.local`.

The regression was introduced in #4807, which added `preserveAfterTerminalExit` and `endedPersistentRemotePTYAttachSurfaceIds` but did not update `resolvedImageTransferTarget()` to handle the new state. Before #4807 the panel closed immediately on session end, so this code path was unreachable.

## Fix

Add `isPreservedEndedRemoteTerminalSurface()` on `Workspace` that checks `endedPersistentRemotePTYAttachSurfaceIds`, and extend the guard in `resolvedImageTransferTarget()` to return `.remote(.workspaceRemote)` for these surfaces.

The set already has correct lifecycle management — populated by `markRemotePTYAttachEnded` (only when `preserveAfterTerminalExit`) and cleared on disconnect, re-attach, discard, failure, and panel destruction — so no additional cleanup is needed.

## Changes

- `Sources/Workspace.swift`: add `isPreservedEndedRemoteTerminalSurface(_ panelId:)`
- `Sources/TerminalImageTransfer.swift`: extend `resolvedImageTransferTarget()` guard

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785325507&installation_id=133855650&pr_number=7046&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7046&signature=d53080dc9736a9dae68fc3149c838fa589f571348421f2c8bcc8605a5cb95aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image paste in preserved-ended remote PTY panels so images upload to the remote host instead of inserting a local temp path. Applies when a `cmux ssh` session ends with `preserveAfterTerminalExit` (fixes #1660).

- **Bug Fixes**
  - Extend `resolvedImageTransferTarget()` to treat preserved-ended remote terminal surfaces as `.remote(.workspaceRemote)`.
  - Add `Workspace.isPreservedEndedRemoteTerminalSurface(_:)` using `endedPersistentRemotePTYAttachSurfaceIds`; no lifecycle changes needed.

<sup>Written for commit e9e097a6be5948a7b6ec9a89efa4721871733e16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how remote terminal surfaces are recognized after a session ends, so preserved remote terminal panes are handled more consistently.
  * Fixed image transfer behavior for terminal surfaces in preserved remote workspace states, helping content display correctly in more cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->