### PR TITLE
Eagerly publish this cmux instance's tmux identity before exec so ssh-tmux reuses the current window

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -433,8 +433,15 @@ _cmux_tmux_publish_cmux_environment() {
     local key value
     for key in "${_CMUX_TMUX_SYNC_KEYS[@]}"; do
         value="${!key}"
-        [[ -n "$value" ]] || continue
-        tmux set-environment -g "$key" "$value" >/dev/null 2>&1 || return 0
+        if [[ -n "$value" ]]; then
+            tmux set-environment -g "$key" "$value" >/dev/null 2>&1 || return 0
+        else
+            # Authoritative: clear a managed key THIS instance does not have, so a
+            # value seeded by a DIFFERENT instance (e.g. a stale CMUX_TAG from a
+            # tagged debug build) can't survive in the session and feed back via
+            # the in-tmux pull. Skipping it (the old behavior) left it stale.
+            tmux set-environment -gu "$key" >/dev/null 2>&1 || return 0
+        fi
     done
 
     for key in "${_CMUX_TMUX_SURFACE_SCOPED_KEYS[@]}"; do
@@ -493,6 +500,14 @@ _cmux_tmux_sync_cmux_environment() {
     else
         _cmux_tmux_publish_cmux_environment
     fi
+}
+
+# Twin of the zsh eager entrypoint; see cmux-zsh-integration.zsh for the rationale.
+# Invoked once by the app-generated bootstrap, in a one-shot subshell before the
+# login shell is exec'd, to refresh the tmux session's global env with this
+# instance's FULL identity. No-op inside tmux (the shared helper's guard).
+_cmux_tmux_publish_cmux_environment_eager() {
+    _cmux_tmux_publish_cmux_environment
 }
 
 _cmux_git_resolve_head_path() {

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -461,8 +461,15 @@ _cmux_tmux_publish_cmux_environment() {
     local key value
     for key in "${_CMUX_TMUX_SYNC_KEYS[@]}"; do
         value="${(P)key}"
-        [[ -n "$value" ]] || continue
-        tmux set-environment -g "$key" "$value" >/dev/null 2>&1 || return 0
+        if [[ -n "$value" ]]; then
+            tmux set-environment -g "$key" "$value" >/dev/null 2>&1 || return 0
+        else
+            # Authoritative: clear a managed key THIS instance does not have, so a
+            # value seeded by a DIFFERENT instance (e.g. a stale CMUX_TAG from a
+            # tagged debug build) can't survive in the session and feed back via
+            # the in-tmux pull. Skipping it (the old behavior) left it stale.
+            tmux set-environment -gu "$key" >/dev/null 2>&1 || return 0
+        fi
     done
 
     for key in "${_CMUX_TMUX_SURFACE_SCOPED_KEYS[@]}"; do
@@ -524,6 +531,22 @@ _cmux_tmux_sync_cmux_environment() {
     else
         _cmux_tmux_publish_cmux_environment
     fi
+}
+
+# Eager, authoritative publish: invoked once by the app-generated bootstrap, in a
+# one-shot subshell AFTER this instance's CMUX_* identity is exported but BEFORE
+# the login shell is exec'd (so before any rc / user dotfile that might auto-attach
+# tmux). Refreshes the tmux GLOBAL env with the current instance's FULL
+# workspace-scoped identity — authoritatively: managed keys this instance has are
+# published, managed keys it lacks are cleared, and surface-scoped keys are always
+# cleared — so a tmux session whose global env was seeded by a DIFFERENT cmux
+# instance (an older launch, or a separate production app) no longer feeds stale
+# identity to the in-tmux pull (_cmux_tmux_refresh_cmux_environment). No-op inside tmux — the
+# shared helper's `[[ -z "$TMUX" ]]` guard — so a nested surface never clobbers
+# the session. Reuses _cmux_tmux_publish_cmux_environment, so the published key
+# set stays single-sourced (no torn-identity subset).
+_cmux_tmux_publish_cmux_environment_eager() {
+    _cmux_tmux_publish_cmux_environment
 }
 
 _cmux_ensure_ghostty_preexec_strips_both_marks() {

--- a/Sources/RemoteInteractiveShellBootstrapBuilder.swift
+++ b/Sources/RemoteInteractiveShellBootstrapBuilder.swift
@@ -85,6 +85,14 @@ enum RemoteInteractiveShellBootstrapBuilder {
         outerLines += [
             "    export CMUX_REAL_ZDOTDIR=\"${ZDOTDIR:-$HOME}\"",
             "    export ZDOTDIR=\"$cmux_shell_dir\"",
+            // Authoritatively refresh the tmux session's full cmux identity with THIS
+            // instance's values BEFORE exec'ing the login shell (see
+            // eagerIdentityPublishLine). Without this, a tmux session seeded by a
+            // different cmux instance feeds stale identity to this surface.
+            eagerIdentityPublishLine(
+                integrationFileName: "cmux-zsh-integration.zsh",
+                hermeticInterpreter: #""$CMUX_LOGIN_SHELL" -f"#
+            ),
             "    exec \"$CMUX_LOGIN_SHELL\" -il",
             "    ;;",
             "  bash)",
@@ -106,6 +114,11 @@ enum RemoteInteractiveShellBootstrapBuilder {
         ]
         outerLines.append(contentsOf: relayWarmupLines.map { "    " + $0 })
         outerLines += [
+            // Same pre-exec identity refresh as the zsh branch (see above).
+            eagerIdentityPublishLine(
+                integrationFileName: "cmux-bash-integration.bash",
+                hermeticInterpreter: #"BASH_ENV= "$CMUX_LOGIN_SHELL" --noprofile --norc"#
+            ),
             "    exec \"$CMUX_LOGIN_SHELL\" --rcfile \"$cmux_shell_dir/.bashrc\" -i",
             "    ;;",
             "  fish)",
@@ -126,6 +139,32 @@ enum RemoteInteractiveShellBootstrapBuilder {
         ]
 
         return outerLines.joined(separator: "\n")
+    }
+
+    /// One-shot, pre-`exec` bootstrap line: sources the bundled shell integration
+    /// in a throwaway subshell and runs the eager tmux identity publish, so THIS
+    /// instance authoritatively refreshes the tmux session's global CMUX_* env
+    /// before the login shell is exec'd — i.e. before any rc / user dotfile that
+    /// might auto-attach tmux, and before the in-tmux pull.
+    ///
+    /// The subshell MUST be hermetic: a plain `"$CMUX_LOGIN_SHELL" -c` still runs
+    /// the user's startup files before the `-c` body — zsh reads `$ZDOTDIR/.zshenv`
+    /// (the generated one chains to the user's `~/.zshenv`), and bash reads
+    /// `$BASH_ENV`. A user startup file that auto-attaches tmux, hangs, or mutates
+    /// `CMUX_SHELL_INTEGRATION_DIR` would then run BEFORE the publish, defeating
+    /// its purpose. So callers pass a hermetic interpreter: zsh `-f` (NO_RCS, skips
+    /// `.zshenv`/`.zprofile`/`.zshrc`/`.zlogin`) and bash `BASH_ENV= … --noprofile
+    /// --norc`. The integration is then sourced explicitly inside the `-c` body and
+    /// inherits this instance's already-exported CMUX_* identity from the parent.
+    ///
+    /// The `-r` guard checks the just-written file under `$cmux_shell_dir`; the
+    /// source path uses the exported `$CMUX_SHELL_INTEGRATION_DIR` (same dir).
+    /// Single-sourced so the zsh and bash branches can't drift.
+    private static func eagerIdentityPublishLine(
+        integrationFileName: String,
+        hermeticInterpreter: String
+    ) -> String {
+        #"    if [ "${CMUX_SHELL_INTEGRATION:-1}" != "0" ] && [ -r "$cmux_shell_dir/\#(integrationFileName)" ]; then \#(hermeticInterpreter) -c '. "$CMUX_SHELL_INTEGRATION_DIR/\#(integrationFileName)" >/dev/null 2>&1; command -v _cmux_tmux_publish_cmux_environment_eager >/dev/null 2>&1 && _cmux_tmux_publish_cmux_environment_eager >/dev/null 2>&1' >/dev/null 2>&1 || true; fi"#
     }
 
     static func shellFeatures(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -4957,6 +4957,264 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
         XCTAssertTrue(log.contains("set-environment -gu CMUX_PANEL_ID"), log)
     }
 
+    // Eager bootstrap publish must refresh the tmux GLOBAL env with the FULL
+    // current-instance identity (not a torn subset) and clear surface-scoped keys,
+    // so a session seeded by another instance stops feeding stale identity to the
+    // in-tmux pull. $TMUX is unset here (app-spawned shell, pre-tmux).
+    func testBootstrapEagerPublishWritesFullWorkspaceIdentityAndClearsSurfaceScope() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-eager-publish-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let logPath = root.appendingPathComponent("tmux.log", isDirectory: false)
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("tmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            if [ "$1" = "show-environment" ] && [ "$2" = "-g" ]; then
+              exit 0
+            fi
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+
+        let output = try runInteractiveZsh(
+            cmuxLoadGhosttyIntegration: false,
+            cmuxLoadShellIntegration: true,
+            command: "_cmux_tmux_publish_cmux_environment_eager; print -r -- DONE",
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": "/tmp/cmux-current-instance.sock",
+                "CMUX_TAG": "current-instance",
+                "CMUX_BUNDLE_ID": "com.cmux.current",
+                "CMUX_BUNDLED_CLI_PATH": "/current/cmux",
+                // CMUX_SHELL_INTEGRATION_DIR is intentionally NOT overridden here: the
+                // harness .zshenv sources the integration from it, so a fake value would
+                // stop the integration (and the eager helper) from loading at all. It
+                // defaults to the real Resources/shell-integration dir and is asserted
+                // value-agnostically below.
+                "CMUXD_UNIX_PATH": "/tmp/cmuxd-current.sock",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_SURFACE_ID": "22222222-2222-2222-2222-222222222222",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        let log = (try? String(contentsOf: logPath, encoding: .utf8)) ?? ""
+        XCTAssertTrue(log.contains("set-environment -g CMUX_TAG current-instance"), log)
+        XCTAssertTrue(log.contains("set-environment -g CMUX_BUNDLE_ID com.cmux.current"), log)
+        XCTAssertTrue(log.contains("set-environment -g CMUX_SOCKET_PATH /tmp/cmux-current-instance.sock"), log)
+        XCTAssertTrue(log.contains("set-environment -g CMUX_BUNDLED_CLI_PATH /current/cmux"), log)
+        XCTAssertTrue(log.contains("set-environment -g CMUX_SHELL_INTEGRATION_DIR "), log)
+        XCTAssertTrue(log.contains("set-environment -g CMUXD_UNIX_PATH /tmp/cmuxd-current.sock"), log)
+        XCTAssertTrue(log.contains("set-environment -g CMUX_WORKSPACE_ID 11111111-1111-1111-1111-111111111111"), log)
+        XCTAssertTrue(log.contains("set-environment -g CMUX_TAB_ID 11111111-1111-1111-1111-111111111111"), log)
+        // Surface-scoped keys cleared in global; never published -g (attempt-#1 failure mode).
+        XCTAssertTrue(log.contains("set-environment -gu CMUX_SURFACE_ID"), log)
+        XCTAssertTrue(log.contains("set-environment -gu CMUX_PANEL_ID"), log)
+        XCTAssertFalse(log.contains("set-environment -g CMUX_SURFACE_ID "), log)
+        XCTAssertFalse(log.contains("set-environment -g CMUX_PANEL_ID "), log)
+        XCTAssertEqual(output, "DONE")
+    }
+
+    // With TMUX set the eager publish must be a no-op (the shared helper's guard),
+    // so a nested surface never clobbers the session and the in-tmux pull still owns.
+    func testBootstrapEagerPublishIsNoOpInsideTmux() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-eager-noop-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let logPath = root.appendingPathComponent("tmux.log", isDirectory: false)
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("tmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+
+        // Print HASFUNC only when the eager wrapper is actually defined, so this
+        // test fails (rather than trivially passing on an undefined function that
+        // emits nothing) if the wrapper is missing — making it a genuine red at
+        // the pre-fix commit and a real guard against deletion of the wrapper.
+        let output = try runInteractiveZsh(
+            cmuxLoadGhosttyIntegration: false,
+            cmuxLoadShellIntegration: true,
+            command: ": > \"\(logPath.path)\"; typeset -f _cmux_tmux_publish_cmux_environment_eager >/dev/null && print -r -- HASFUNC; _cmux_tmux_publish_cmux_environment_eager; print -r -- DONE",
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "TMUX": "/tmp/tmux-current,123,0",
+                "CMUX_SOCKET_PATH": "/tmp/cmux-current-instance.sock",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+            ]
+        )
+
+        let log = (try? String(contentsOf: logPath, encoding: .utf8)) ?? ""
+        XCTAssertFalse(log.contains("set-environment"), log)
+        XCTAssertEqual(output, "HASFUNC\nDONE")
+    }
+
+    // The remote bootstrap must run the eager publish BEFORE exec'ing the login
+    // shell, in BOTH the zsh and bash branches. Running before exec is the
+    // load-bearing property: an rc / user dotfile that auto-attaches tmux runs
+    // inside the exec'd shell, so a publish placed after exec (e.g. appended to
+    // the generated rc) could be pre-empted by that attach and feed stale
+    // identity to the surface. Asserting the one-shot precedes exec — not merely
+    // that it appears somewhere — pins that ordering against regression.
+    func testRemoteBootstrapPublishesTmuxIdentityBeforeExecingLoginShell() {
+        let script = RemoteInteractiveShellBootstrapBuilder.script(
+            remoteRelayPort: 5123,
+            shellFeatures: "ssh-env,ssh-terminfo",
+            bundledZshIntegration: "# zsh",
+            bundledBashIntegration: "# bash"
+        )
+        XCTAssertTrue(script.contains("_cmux_tmux_publish_cmux_environment_eager"), script)
+
+        let zshEager = script.range(
+            of: #"cmux-zsh-integration.zsh" >/dev/null 2>&1; command -v _cmux_tmux_publish_cmux_environment_eager"#
+        )
+        let zshExec = script.range(of: #"exec "$CMUX_LOGIN_SHELL" -il"#)
+        XCTAssertNotNil(zshEager, "zsh eager publish one-shot missing\n\(script)")
+        XCTAssertNotNil(zshExec, "zsh exec line missing\n\(script)")
+        if let zshEager, let zshExec {
+            XCTAssertTrue(zshEager.lowerBound < zshExec.lowerBound, "zsh eager publish must precede exec\n\(script)")
+        }
+
+        let bashEager = script.range(
+            of: #"cmux-bash-integration.bash" >/dev/null 2>&1; command -v _cmux_tmux_publish_cmux_environment_eager"#
+        )
+        let bashExec = script.range(of: #"exec "$CMUX_LOGIN_SHELL" --rcfile"#)
+        XCTAssertNotNil(bashEager, "bash eager publish one-shot missing\n\(script)")
+        XCTAssertNotNil(bashExec, "bash exec line missing\n\(script)")
+        if let bashEager, let bashExec {
+            XCTAssertTrue(bashEager.lowerBound < bashExec.lowerBound, "bash eager publish must precede exec\n\(script)")
+        }
+
+        // The one-shot must be HERMETIC — running the login shell with startup
+        // files disabled — so the user's own startup files cannot run before the
+        // publish. A plain `"$CMUX_LOGIN_SHELL" -c` would still source zsh's
+        // $ZDOTDIR/.zshenv (which chains to the user's ~/.zshenv) / bash's
+        // $BASH_ENV, defeating the "before any user dotfile" guarantee. zsh uses
+        // -f (NO_RCS); bash uses BASH_ENV= … --noprofile --norc.
+        XCTAssertTrue(
+            script.contains(#""$CMUX_LOGIN_SHELL" -f -c '. "$CMUX_SHELL_INTEGRATION_DIR/cmux-zsh-integration.zsh""#),
+            "zsh one-shot must run hermetically with -f\n\(script)"
+        )
+        XCTAssertTrue(
+            script.contains(#"BASH_ENV= "$CMUX_LOGIN_SHELL" --noprofile --norc -c '. "$CMUX_SHELL_INTEGRATION_DIR/cmux-bash-integration.bash""#),
+            "bash one-shot must run hermetically with BASH_ENV= --noprofile --norc\n\(script)"
+        )
+    }
+
+    // The eager publish must be AUTHORITATIVE: a managed workspace-scoped key that
+    // THIS instance does not have set must be CLEARED (-gu) from the tmux global
+    // env, not silently skipped — otherwise a value seeded by a DIFFERENT instance
+    // (e.g. a stale CMUX_TAG from a tagged debug build that an untagged/prod
+    // instance lacks) survives in the session and the in-tmux pull feeds it back.
+    // $TMUX is unset here (app-spawned shell, pre-tmux).
+    func testEagerPublishClearsManagedWorkspaceKeyUnsetByThisInstance() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-eager-clear-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let logPath = root.appendingPathComponent("tmux.log", isDirectory: false)
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("tmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            if [ "$1" = "show-environment" ] && [ "$2" = "-g" ]; then
+              exit 0
+            fi
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+
+        // CMUX_TAG intentionally NOT set: this instance is untagged, but a prior
+        // instance may have seeded CMUX_TAG into the session's global env.
+        let output = try runInteractiveZsh(
+            cmuxLoadGhosttyIntegration: false,
+            cmuxLoadShellIntegration: true,
+            command: "_cmux_tmux_publish_cmux_environment_eager; print -r -- DONE",
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": "/tmp/cmux-current-instance.sock",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "11111111-1111-1111-1111-111111111111",
+            ]
+        )
+
+        let log = (try? String(contentsOf: logPath, encoding: .utf8)) ?? ""
+        // A key this instance HAS is still published with its value...
+        XCTAssertTrue(log.contains("set-environment -g CMUX_SOCKET_PATH /tmp/cmux-current-instance.sock"), log)
+        // ...and a managed key this instance does NOT have is cleared, not skipped.
+        XCTAssertTrue(log.contains("set-environment -gu CMUX_TAG"), log)
+        XCTAssertFalse(log.contains("set-environment -g CMUX_TAG "), log)
+        XCTAssertEqual(output, "DONE")
+    }
+
+    // Bash executable twin of the eager publish: the zsh tests above exercise the
+    // zsh integration, but the bash integration carries an identical
+    // _cmux_tmux_publish_cmux_environment_eager + authoritative-clear that must be
+    // covered by a RUNNING test (not just the generated-script-text assertion in
+    // testRemoteBootstrapPublishesTmuxIdentityBeforeExecingLoginShell). Asserts the
+    // bash eager entrypoint exists, publishes a key this instance has (-g), and
+    // clears a managed key it lacks (-gu). The signature cache is reset so the
+    // publish runs regardless of any earlier hook firing in the interactive shell.
+    func testEagerPublishBashPublishesIdentityAndClearsUnsetKey() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-bash-eager-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let logPath = root.appendingPathComponent("tmux.log", isDirectory: false)
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("tmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            if [ "$1" = "show-environment" ] && [ "$2" = "-g" ]; then
+              exit 0
+            fi
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+
+        // CMUX_TAG intentionally unset; CMUX_SOCKET_PATH set to a known value.
+        let result = try runInteractiveBash(
+            cmuxLoadShellIntegration: true,
+            command: ": > \"\(logPath.path)\"; unset _CMUX_TMUX_PUSH_SIGNATURE; "
+                + "typeset -F _cmux_tmux_publish_cmux_environment_eager >/dev/null 2>&1 && printf 'HASFUNC\\n'; "
+                + "_cmux_tmux_publish_cmux_environment_eager; printf 'DONE\\n'",
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": "/tmp/cmux-bash-instance.sock",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+            ]
+        )
+
+        let log = (try? String(contentsOf: logPath, encoding: .utf8)) ?? ""
+        XCTAssertTrue(result.stdout.contains("HASFUNC"), "bash eager entrypoint missing\n\(result.stdout)\n\(result.stderr)")
+        XCTAssertTrue(log.contains("set-environment -g CMUX_SOCKET_PATH /tmp/cmux-bash-instance.sock"), log)
+        XCTAssertTrue(log.contains("set-environment -gu CMUX_TAG"), log)
+        XCTAssertFalse(log.contains("set-environment -g CMUX_TAG "), log)
+        XCTAssertTrue(result.stdout.contains("DONE"), result.stdout)
+    }
+
     func testShellIntegrationRefreshesWorkspaceScopedCmuxEnvironmentFromTmuxWithoutOverwritingSurfaceScope() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory


### PR DESCRIPTION
## Problem

When a cmux surface attaches a remote `tmux` session whose **global environment was seeded by a different cmux instance** (an older launch, or a separate app), `cmux ssh-tmux` opens a brand-new window instead of reusing the current one.

## Root cause

The shell integration syncs each instance's `CMUX_*` identity through the tmux session's **global** environment:

- An app-spawned shell *publishes* its workspace-scoped identity (`CMUX_SOCKET_PATH`, `CMUX_WORKSPACE_ID`, …) into the tmux global env (`set-environment -g`), and clears surface-scoped keys (`set-environment -gu`).
- A shell that starts **inside** tmux *pulls* that global env back (`_cmux_tmux_refresh_cmux_environment`).

If instance B attaches a session that instance A seeded, B's in-tmux pull reads **A's** stale identity — wrong `CMUX_SOCKET_PATH` / `CMUX_WORKSPACE_ID` — so `ssh-tmux` resolves the wrong instance and can't reuse the window.

## Fix

Eagerly, authoritatively publish **this** instance's identity into the tmux global env **before** the login shell is `exec`'d. Three parts:

1. **Eager entrypoint.** New `_cmux_tmux_publish_cmux_environment_eager()` (zsh + bash), a thin wrapper over the existing `_cmux_tmux_publish_cmux_environment` so the published key set stays single-sourced (no-op when `$TMUX` is already set).

2. **Authoritative.** The publish now **clears** (`set-environment -gu`) a managed workspace-scoped key this instance does *not* have set, instead of skipping it. Previously a value seeded by another instance (e.g. a stale `CMUX_TAG` from a tagged debug build) survived in the session and was fed back via the in-tmux pull. The publish is gated by a set-key signature, so the clear runs at most once per process.

3. **Hermetic & ordered.** The app-generated remote bootstrap invokes the eager publish from a one-shot subshell after exporting the instance's `CMUX_*` identity but before `exec`. A plain `"$CMUX_LOGIN_SHELL" -c` would still source the user's startup files first (zsh `$ZDOTDIR/.zshenv` chaining to `~/.zshenv`; bash `$BASH_ENV`), which could auto-attach tmux or mutate `CMUX_*` before the publish — so the subshell runs hermetically: **zsh `-f`** (NO_RCS) and **bash `BASH_ENV= … --noprofile --norc`**, sourcing the integration explicitly and inheriting the already-exported identity. The zsh/bash one-shot lines are single-sourced through `eagerIdentityPublishLine`.

This generalizes the existing publish path rather than special-casing window reuse; the shared helper and its `$TMUX` guard remain the single authority.

## Tests

Two-commit red/green (per the repo's regression-test policy). Verified locally with `xcodebuild test` (scheme `cmux-unit`): all 5 tests **fail** at the test-only commit and **pass** at the fix commit.

- `testBootstrapEagerPublishWritesFullWorkspaceIdentityAndClearsSurfaceScope` — eager publish writes the full workspace-scoped key set (`-g`) and clears surface-scoped keys (`-gu`).
- `testBootstrapEagerPublishIsNoOpInsideTmux` — no-op when `$TMUX` is set.
- `testRemoteBootstrapPublishesTmuxIdentityBeforeExecingLoginShell` — the bootstrap runs the eager publish before `exec` in both branches, and does so **hermetically** (`zsh -f`; `bash BASH_ENV= --noprofile --norc`).
- `testEagerPublishClearsManagedWorkspaceKeyUnsetByThisInstance` — a managed workspace key this instance lacks (e.g. `CMUX_TAG`) is **cleared** (`-gu`), not skipped.
- `testEagerPublishBashPublishesIdentityAndClearsUnsetKey` — bash executable twin: exercises the bash integration's eager publish + authoritative clear at runtime.
