### PR TITLE
Reclaim hidden terminal renderers on memory pressure

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -2,7 +2,7 @@
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 34658	CLI/cmux.swift
-17907	Sources/AppDelegate.swift
+17908	Sources/AppDelegate.swift
 16491	Sources/ContentView.swift
 14239	Sources/TerminalController.swift
 12921	Sources/Workspace.swift

--- a/Sources/App/RendererRealizationController.swift
+++ b/Sources/App/RendererRealizationController.swift
@@ -17,6 +17,7 @@ final class RendererRealizationController {
     static let shared = RendererRealizationController()
 
     private let timerQueue = DispatchQueue(label: "com.cmux.renderer-realization", qos: .utility)
+    private let systemMemoryPressureRetryPasses = 2
     private var timer: DispatchSourceTimer?
     private var settingsObserver: NSObjectProtocol?
 
@@ -83,7 +84,11 @@ final class RendererRealizationController {
     }
 
     func reclaimForSystemMemoryPressure(now: Date) {
-        evaluate(now: now, trigger: .systemMemoryPressure)
+        evaluate(
+            now: now,
+            trigger: .systemMemoryPressure,
+            remainingSystemMemoryPressureRetries: systemMemoryPressureRetryPasses
+        )
     }
 
     /// Run one reclamation pass. Internal so a unit/integration test can drive it
@@ -92,7 +97,11 @@ final class RendererRealizationController {
         evaluate(now: now, trigger: .scheduled)
     }
 
-    private func evaluate(now: Date, trigger: RendererRealizationReclaimTrigger) {
+    private func evaluate(
+        now: Date,
+        trigger: RendererRealizationReclaimTrigger,
+        remainingSystemMemoryPressureRetries: Int = 0
+    ) {
         let settings = RendererRealizationSettings.values()
         guard settings.enabled else { return }
 
@@ -132,8 +141,27 @@ final class RendererRealizationController {
             trigger: trigger
         )
         guard !selected.isEmpty else { return }
+        var needsSystemMemoryPressureRetry = false
         for surface in surfaces where selected.contains(surface.id) {
             surface.releaseRenderer()
+            // A dropped Ghostty mailbox enqueue leaves the renderer realized.
+            // Retry with the pressure policy; scheduled policy may keep recent
+            // hidden surfaces warm and skip the exact surface pressure selected.
+            if trigger == .systemMemoryPressure,
+               !surface.isRendererPortalVisible,
+               surface.isRendererRealized {
+                needsSystemMemoryPressureRetry = true
+            }
+        }
+
+        if needsSystemMemoryPressureRetry, remainingSystemMemoryPressureRetries > 0 {
+            Task { @MainActor in
+                RendererRealizationController.shared.evaluate(
+                    now: Date(),
+                    trigger: .systemMemoryPressure,
+                    remainingSystemMemoryPressureRetries: remainingSystemMemoryPressureRetries - 1
+                )
+            }
         }
     }
 }

--- a/Sources/App/RendererRealizationController.swift
+++ b/Sources/App/RendererRealizationController.swift
@@ -82,9 +82,17 @@ final class RendererRealizationController {
         }
     }
 
+    func reclaimForSystemMemoryPressure(now: Date) {
+        evaluate(now: now, trigger: .systemMemoryPressure)
+    }
+
     /// Run one reclamation pass. Internal so a unit/integration test can drive it
     /// deterministically without the timer.
     func evaluate(now: Date) {
+        evaluate(now: now, trigger: .scheduled)
+    }
+
+    private func evaluate(now: Date, trigger: RendererRealizationPlanner.ReclaimTrigger) {
         let settings = RendererRealizationSettings.values()
         guard settings.enabled else { return }
 
@@ -120,7 +128,8 @@ final class RendererRealizationController {
         let selected = RendererRealizationPlanner.selectedSurfaceIds(
             inputs: inputs,
             settings: settings,
-            now: now.timeIntervalSince1970
+            now: now.timeIntervalSince1970,
+            trigger: trigger
         )
         guard !selected.isEmpty else { return }
         for surface in surfaces where selected.contains(surface.id) {

--- a/Sources/App/RendererRealizationController.swift
+++ b/Sources/App/RendererRealizationController.swift
@@ -92,7 +92,7 @@ final class RendererRealizationController {
         evaluate(now: now, trigger: .scheduled)
     }
 
-    private func evaluate(now: Date, trigger: RendererRealizationPlanner.ReclaimTrigger) {
+    private func evaluate(now: Date, trigger: RendererRealizationReclaimTrigger) {
         let settings = RendererRealizationSettings.values()
         guard settings.enabled else { return }
 

--- a/Sources/App/RendererRealizationPlanner.swift
+++ b/Sources/App/RendererRealizationPlanner.swift
@@ -14,10 +14,16 @@ struct RendererRealizationPlannerInput: Sendable {
 /// the rest only when they are offscreen and have been idle past `idleSeconds`.
 /// A currently-visible surface is never selected.
 enum RendererRealizationPlanner {
+    enum ReclaimTrigger: Sendable {
+        case scheduled
+        case systemMemoryPressure
+    }
+
     static func selectedSurfaceIds(
         inputs: [RendererRealizationPlannerInput],
         settings: RendererRealizationSettings.Values,
-        now: TimeInterval
+        now: TimeInterval,
+        trigger: ReclaimTrigger = .scheduled
     ) -> Set<UUID> {
         guard settings.enabled else { return [] }
 
@@ -32,6 +38,8 @@ enum RendererRealizationPlanner {
                 }
                 return lhs.lastVisibleAt > rhs.lastVisibleAt
             }
+
+        _ = trigger
 
         let warmCap = max(1, settings.maxWarmRenderers)
         var selected: Set<UUID> = []

--- a/Sources/App/RendererRealizationPlanner.swift
+++ b/Sources/App/RendererRealizationPlanner.swift
@@ -14,16 +14,11 @@ struct RendererRealizationPlannerInput: Sendable {
 /// the rest only when they are offscreen and have been idle past `idleSeconds`.
 /// A currently-visible surface is never selected.
 enum RendererRealizationPlanner {
-    enum ReclaimTrigger: Equatable, Sendable {
-        case scheduled
-        case systemMemoryPressure
-    }
-
     static func selectedSurfaceIds(
         inputs: [RendererRealizationPlannerInput],
         settings: RendererRealizationSettings.Values,
         now: TimeInterval,
-        trigger: ReclaimTrigger = .scheduled
+        trigger: RendererRealizationReclaimTrigger = .scheduled
     ) -> Set<UUID> {
         guard settings.enabled else { return [] }
 

--- a/Sources/App/RendererRealizationPlanner.swift
+++ b/Sources/App/RendererRealizationPlanner.swift
@@ -22,6 +22,14 @@ enum RendererRealizationPlanner {
     ) -> Set<UUID> {
         guard settings.enabled else { return [] }
 
+        if trigger == .systemMemoryPressure {
+            return Set(
+                inputs.lazy
+                    .filter { $0.isRealized && !$0.isVisible }
+                    .map(\.surfaceId)
+            )
+        }
+
         // Only realized surfaces hold releasable GPU resources. Rank by recency
         // (most-recent first); visible surfaces are stamped ~now so they sort to
         // the top and land inside the warm set.
@@ -33,10 +41,6 @@ enum RendererRealizationPlanner {
                 }
                 return lhs.lastVisibleAt > rhs.lastVisibleAt
             }
-
-        if trigger == .systemMemoryPressure {
-            return Set(ranked.lazy.filter { !$0.isVisible }.map(\.surfaceId))
-        }
 
         let warmCap = max(1, settings.maxWarmRenderers)
         var selected: Set<UUID> = []

--- a/Sources/App/RendererRealizationPlanner.swift
+++ b/Sources/App/RendererRealizationPlanner.swift
@@ -14,7 +14,7 @@ struct RendererRealizationPlannerInput: Sendable {
 /// the rest only when they are offscreen and have been idle past `idleSeconds`.
 /// A currently-visible surface is never selected.
 enum RendererRealizationPlanner {
-    enum ReclaimTrigger: Sendable {
+    enum ReclaimTrigger: Equatable, Sendable {
         case scheduled
         case systemMemoryPressure
     }
@@ -39,7 +39,9 @@ enum RendererRealizationPlanner {
                 return lhs.lastVisibleAt > rhs.lastVisibleAt
             }
 
-        _ = trigger
+        if trigger == .systemMemoryPressure {
+            return Set(ranked.lazy.filter { !$0.isVisible }.map(\.surfaceId))
+        }
 
         let warmCap = max(1, settings.maxWarmRenderers)
         var selected: Set<UUID> = []

--- a/Sources/App/RendererRealizationReclaimTrigger.swift
+++ b/Sources/App/RendererRealizationReclaimTrigger.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Reason a renderer realization pass is selecting surfaces to reclaim.
+enum RendererRealizationReclaimTrigger: Equatable, Sendable {
+    case scheduled
+    case systemMemoryPressure
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2108,6 +2108,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             self?.paneMemoryGuardrailDescriptors() ?? []
         }
         guardrail.onSystemMemoryPressure = { [weak self] in
+            RendererRealizationController.shared.reclaimForSystemMemoryPressure(now: Date())
             self?.discardHiddenBrowserWebViewsForSystemMemoryPressure()
         }
         guardrail.start()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -801,6 +801,7 @@
 		D36A00040000000000000001 /* RendererRealizationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00040000000000000002 /* RendererRealizationController.swift */; };
 		D36A00060000000000000001 /* RendererRealizationPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00060000000000000002 /* RendererRealizationPlanner.swift */; };
 		D36A00050000000000000001 /* RendererRealizationPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */; };
+		D36A00070000000000000001 /* RendererRealizationReclaimTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00070000000000000002 /* RendererRealizationReclaimTrigger.swift */; };
 		F5410004A1B2C3D4E5F60718 /* RestorableAgentHookProviderHermesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5410005A1B2C3D4E5F60718 /* RestorableAgentHookProviderHermesTests.swift */; };
 		F5410000A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5410001A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift */; };
 		F5410002A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5410003A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift */; };
@@ -1993,6 +1994,7 @@
 		D36A00040000000000000002 /* RendererRealizationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RendererRealizationController.swift; sourceTree = "<group>"; };
 		D36A00060000000000000002 /* RendererRealizationPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RendererRealizationPlanner.swift; sourceTree = "<group>"; };
 		D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RendererRealizationPlannerTests.swift; sourceTree = "<group>"; };
+		D36A00070000000000000002 /* RendererRealizationReclaimTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RendererRealizationReclaimTrigger.swift; sourceTree = "<group>"; };
 		F5410005A1B2C3D4E5F60718 /* RestorableAgentHookProviderHermesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableAgentHookProviderHermesTests.swift; sourceTree = "<group>"; };
 		F5410001A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableAgentHookProviderResumeTests.swift; sourceTree = "<group>"; };
 		F5410003A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableAgentNonInteractiveTests.swift; sourceTree = "<group>"; };
@@ -2692,6 +2694,7 @@
 				D36A00010000000000000002 /* AgentHibernationController.swift */,
 				D36A00040000000000000002 /* RendererRealizationController.swift */,
 				D36A00060000000000000002 /* RendererRealizationPlanner.swift */,
+				D36A00070000000000000002 /* RendererRealizationReclaimTrigger.swift */,
 				243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */,
 				D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */,
 				D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */,
@@ -4563,6 +4566,7 @@
 				D5037010000000000000003 /* RenderableSystemSymbol.swift in Sources */,
 				D36A00040000000000000001 /* RendererRealizationController.swift in Sources */,
 				D36A00060000000000000001 /* RendererRealizationPlanner.swift in Sources */,
+				D36A00070000000000000001 /* RendererRealizationReclaimTrigger.swift in Sources */,
 				A5001660 /* RestorableAgentSession.swift in Sources */,
 				C13519000000000000000005 /* RestorableAgentTypes.swift in Sources */,
 				B7F9A600B7F9A600B7F9A600 /* RightSidebarChromeGeometryReporting.swift in Sources */,

--- a/cmuxTests/RendererRealizationPlannerTests.swift
+++ b/cmuxTests/RendererRealizationPlannerTests.swift
@@ -137,4 +137,41 @@ struct RendererRealizationPlannerTests {
         #expect(selected.contains(b))
         #expect(!selected.contains(a))
     }
+
+    @Test func systemMemoryPressureReclaimsAllHiddenRealizedRenderers() {
+        let now: TimeInterval = 1000
+        let visible = UUID()
+        let recentHidden = UUID()
+        let oldHidden = UUID()
+        let alreadyReleased = UUID()
+        let selected = RendererRealizationPlanner.selectedSurfaceIds(
+            inputs: [
+                input(visible, visible: true, lastVisibleAt: now),
+                input(recentHidden, lastVisibleAt: now - 1),
+                input(oldHidden, lastVisibleAt: now - 100),
+                input(alreadyReleased, realized: false, lastVisibleAt: now - 100),
+            ],
+            settings: settings(idle: 600, warm: 12),
+            now: now,
+            trigger: .systemMemoryPressure
+        )
+
+        #expect(!selected.contains(visible))
+        #expect(selected.contains(recentHidden))
+        #expect(selected.contains(oldHidden))
+        #expect(!selected.contains(alreadyReleased))
+    }
+
+    @Test func systemMemoryPressureRespectsDisabledSetting() {
+        let now: TimeInterval = 1000
+        let hidden = UUID()
+        let selected = RendererRealizationPlanner.selectedSurfaceIds(
+            inputs: [input(hidden, lastVisibleAt: now - 1)],
+            settings: settings(enabled: false, idle: 600, warm: 12),
+            now: now,
+            trigger: .systemMemoryPressure
+        )
+
+        #expect(selected.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary

Closes #7039.
References the master resource-accumulation tracker #5731.

This PR makes the existing non-destructive terminal renderer reclamation path react to macOS memory-pressure warnings. The normal timer still uses the configured idle/LRU policy. On a warning/critical `DispatchSourceMemoryPressure` event, cmux now asks `RendererRealizationController` to release every hidden realized terminal renderer immediately, while preserving the hard safety rule that visible terminals are never selected. The existing hidden-browser discard runs in the same callback afterward.

This deliberately builds on the renderer realization machinery already on `main`; it does not duplicate the broader shell-restart hibernation work from #5739. It also does not conflict with #6979/#6984, which tune/apply the same renderer-reclaim direction for canvas/default behavior.

## Measurement Baseline

Captured on the running stable app without building locally:

- Stable app: `/Applications/cmux.app`, PID `26804`, version `0.64.17 (97)`.
- `footprint -summary -pid 26804`: `2060 MB` physical footprint, `2200 MB` peak.
- App-process graphics-heavy categories: `420 MB` IOSurface, `159 MB` IOAccelerator, `392 MB` owned graphics footprint, `22 MB` CoreAnimation.
- `heap -s 26804`: `118` `Workspace` Swift objects present, matching the many-open-workspace shape from #5731/#7039.
- `cmux memory --all --groups 12`: `2.04 GB` app footprint plus `4.55 GB` child RSS across `150` processes.

The change targets the app-process graphics resident set. It does not claim to reduce child-process RSS from agents; that remains the #5731/#6313 child-process guardrail/workspace lifecycle problem.

## Demo Video

Not attached. Per task instructions, the dev build must not be launched until after CI is green and the user explicitly approves the cloud build command.

## Review Trigger

Memory/performance fix. Please review the renderer realization pressure path, visible-surface safety invariant, bounded retry behavior for dropped Ghostty mailbox enqueues, and Xcode project wiring for the new source file.

## Validation

- `git diff --check`
- `python3 scripts/swift_file_length_budget.py --write-budget`
- `python3 scripts/swift_file_length_budget.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- Bundled autoreview: clean, no accepted/actionable findings; cmux policy clean.
- GitHub PR checks: all required checks green.

Per task instructions, I did not run local tests, `reload.sh`, `reload-cloud.sh`, or bare `xcodebuild`.

## Checklist

- [x] Links `Closes #7039` and references #5731.
- [x] Keeps visible terminals protected from renderer release.
- [x] Reuses the existing renderer realization/reclaim machinery.
- [x] Adds focused planner coverage for pressure-mode selection and disabled settings.
- [x] Wires the new Swift file into `cmux.xcodeproj`.
- [x] Updates the Swift file length budget with the repository script.
- [x] Avoids local build/test commands per task constraints.

## Localization Audit

No user-facing strings, settings rows, docs text, schema text, alerts, menus, or tooltips were added or changed. The changed Swift surfaces are internal planner/controller/callback code plus tests, so no localization catalog updates are required.
