### PR TITLE
Gracefully terminate live agents on quit/power-off (#2436)

### DIFF
--- a/Sources/App/AgentHibernationController.swift
+++ b/Sources/App/AgentHibernationController.swift
@@ -365,11 +365,17 @@ final class AgentHibernationController {
         )
     }
 
-    private func terminateScopedProcessesForHibernation(record: AgentHibernationRecord) {
-        guard !record.processIDs.isEmpty else { return }
+    /// SIGTERMs the cmux-scoped processes (and their process groups) backing one
+    /// restorable-agent panel, so the agent catches the signal and saves state
+    /// before exiting. Shared by idle hibernation and app-exit graceful shutdown.
+    /// Returns the individual PIDs signaled so callers can bound-wait for exit.
+    @discardableResult
+    func terminateScopedProcessesForHibernation(record: AgentHibernationRecord) -> Set<pid_t> {
+        guard !record.processIDs.isEmpty else { return [] }
         let currentProcessID = getpid()
         let currentProcessGroupID = getpgrp()
         var signaledProcessGroups: Set<pid_t> = []
+        var signaledPIDs: Set<pid_t> = []
         for rawPID in record.processIDs.sorted(by: >) {
             guard rawPID > 0, rawPID <= Int(Int32.max) else { continue }
             let pid = pid_t(rawPID)
@@ -385,7 +391,35 @@ final class AgentHibernationController {
                 _ = kill(-processGroupID, SIGTERM)
             }
             _ = kill(pid, SIGTERM)
+            signaledPIDs.insert(pid)
         }
+        return signaledPIDs
+    }
+
+    /// Gracefully SIGTERMs every live restorable-agent panel on app exit / power-off
+    /// so agents (Copilot CLI first) save state and leave the terminal's alternate
+    /// screen before cmux tears down. Returns the PIDs signaled. `kinds == nil`
+    /// signals all restorable agents; the default targets only Copilot CLI.
+    @discardableResult
+    func terminateLiveRestorableAgentsForAppExit(
+        kinds: Set<RestorableAgentKind>? = [.copilot]
+    ) -> Set<pid_t> {
+        guard let appDelegate = AppDelegate.shared else { return [] }
+        let resumeIndexes = ProcessDetectedResumeIndexes.loadSynchronously()
+        let records = appDelegate.agentHibernationRecords(
+            index: resumeIndexes.restorableAgentIndex,
+            activityByPanel: [:],
+            terminalInputByPanel: [:],
+            lifecycleChangeByPanel: [:]
+        )
+        var signaled: Set<pid_t> = []
+        for record in records {
+            if let kinds, !kinds.contains(record.agent.kind) { continue }
+            let isLive = record.terminalPanel.surface.hasLiveSurface || record.hasLiveProcess
+            guard isLive, !record.terminalPanel.isAgentHibernated else { continue }
+            signaled.formUnion(terminateScopedProcessesForHibernation(record: record))
+        }
+        return signaled
     }
 
     private func clearTrackingState() {
@@ -472,5 +506,55 @@ extension AppDelegate {
         }
 
         return records
+    }
+
+    /// Gracefully terminates live restorable-agent processes (Copilot CLI first) on
+    /// app quit / power-off, then bound-waits for them to exit so they leave the
+    /// terminal's alternate screen before the scrollback snapshot is taken. Bounded
+    /// and best-effort: the wait is self-limited and runs before the termination
+    /// watchdog, so a slow agent can never stall quit past `deadline`.
+    @MainActor
+    func gracefullyTerminateLiveAgentsForAppExit(
+        kinds: Set<RestorableAgentKind>? = [.copilot],
+        deadline: TimeInterval = 2.0
+    ) {
+        let pids = AgentHibernationController.shared.terminateLiveRestorableAgentsForAppExit(kinds: kinds)
+        AppExitAgentGracefulShutdown.waitForExit(
+            pids: pids,
+            deadline: deadline,
+            isAlive: AppExitAgentGracefulShutdown.processIsAlive,
+            now: { ProcessInfo.processInfo.systemUptime },
+            sleep: { Thread.sleep(forTimeInterval: $0) }
+        )
+    }
+}
+
+/// Bounded wait for signaled agent processes to exit during app teardown. Pure and
+/// injectable so the loop is unit-testable without real processes or sleeping.
+enum AppExitAgentGracefulShutdown {
+    static func waitForExit(
+        pids: Set<pid_t>,
+        deadline: TimeInterval,
+        pollInterval: TimeInterval = 0.05,
+        isAlive: (pid_t) -> Bool,
+        now: () -> TimeInterval,
+        sleep: (TimeInterval) -> Void
+    ) {
+        guard !pids.isEmpty, deadline > 0 else { return }
+        let start = now()
+        var remaining = pids
+        while true {
+            remaining = remaining.filter(isAlive)
+            if remaining.isEmpty { return }
+            if now() - start >= deadline { return }
+            sleep(pollInterval)
+        }
+    }
+
+    /// True while `pid` still exists. `kill(pid, 0)` fails with ESRCH once reaped;
+    /// EPERM means it exists but we lack permission (treated as alive).
+    static func processIsAlive(_ pid: pid_t) -> Bool {
+        if kill(pid, 0) == 0 { return true }
+        return errno == EPERM
     }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1999,6 +1999,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // method, so the primary arm above is what bounds #6758; this only
         // widens coverage to other entrypoints.
         isTerminatingApp = true
+        // Give live agents (Copilot CLI) a chance to save state and leave the
+        // terminal alternate screen before we snapshot scrollback (#2436).
+        gracefullyTerminateLiveAgentsForAppExit()
         _ = saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
         ClosedItemHistoryStore.shared.flushPendingSaves()
         terminationWatchdog.arm()
@@ -3871,6 +3874,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.isTerminatingApp = true
+                // Mirror quit: let agents (Copilot CLI) save state and leave the
+                // alternate screen before the scrollback snapshot (#2436).
+                self.gracefullyTerminateLiveAgentsForAppExit()
                 _ = self.saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
                 ClosedItemHistoryStore.shared.flushPendingSaves()
             }

--- a/cmuxTests/AgentHibernationTests.swift
+++ b/cmuxTests/AgentHibernationTests.swift
@@ -10,6 +10,54 @@ import CmuxTerminal
 #endif
 
 final class AgentHibernationTests: XCTestCase {
+    func testAppExitWaitReturnsOnceAllProcessesExit() {
+        var clock: TimeInterval = 0
+        var slept: [TimeInterval] = []
+        // Processes are "alive" until the clock passes 0.1s, then all exit.
+        AppExitAgentGracefulShutdown.waitForExit(
+            pids: [101, 102, 103],
+            deadline: 5,
+            pollInterval: 0.05,
+            isAlive: { _ in clock < 0.1 },
+            now: { clock },
+            sleep: { interval in
+                slept.append(interval)
+                clock += interval
+            }
+        )
+        XCTAssertEqual(slept.count, 2, "Two 0.05s polls reach 0.1s; the next poll sees all processes exited.")
+        XCTAssertEqual(clock, 0.1, accuracy: 1e-9)
+    }
+
+    func testAppExitWaitStopsAtDeadlineWhenProcessNeverExits() {
+        var clock: TimeInterval = 0
+        var sleeps = 0
+        AppExitAgentGracefulShutdown.waitForExit(
+            pids: [42],
+            deadline: 0.2,
+            pollInterval: 0.05,
+            isAlive: { _ in true },
+            now: { clock },
+            sleep: { interval in
+                sleeps += 1
+                clock += interval
+            }
+        )
+        XCTAssertEqual(sleeps, 4, "Bounded by deadline (0.2s / 0.05s), never loops forever on a stuck agent.")
+    }
+
+    func testAppExitWaitNoopsWithoutPids() {
+        var sleeps = 0
+        AppExitAgentGracefulShutdown.waitForExit(
+            pids: [],
+            deadline: 5,
+            isAlive: { _ in true },
+            now: { 0 },
+            sleep: { _ in sleeps += 1 }
+        )
+        XCTAssertEqual(sleeps, 0)
+    }
+
     func testLifecycleStateParsingAcceptsShellFriendlyAliases() throws {
         XCTAssertEqual(AgentHibernationLifecycleState.parseCLIValue("IDLE"), .idle)
         XCTAssertEqual(AgentHibernationLifecycleState.parseCLIValue("needsInput"), .needsInput)


### PR DESCRIPTION
Fixes #2436.

## Problem

On quit and on system power-off, cmux never signalled the TUI agent processes running in its tabs. They were killed abruptly when their PTY closed, so an agent like Copilot CLI had no chance to leave the terminal's alternate screen or persist its in-progress session. Because alt-screen TUIs never write to scrollback, the scrollback snapshot taken in `applicationWillTerminate` captured a blank alternate screen — and after a reboot the tab reopened empty.

## Fix

The idle-hibernation path already does exactly the graceful step we want: it SIGTERMs the cmux-scoped process groups behind a panel so the agent catches the signal, saves state, and exits cleanly. This change reuses that path and triggers it on app exit and power-off, *before* the scrollback snapshot, with a short bounded wait so the agent can leave the alternate screen first (so the snapshot captures the restored primary screen).

Scoped to Copilot CLI for this first cut (`kinds: [.copilot]`); broadening to all restorable agents is a one-line change.

## Changes

- `AgentHibernationController.terminateScopedProcessesForHibernation` now returns the signalled PIDs and is shared (no longer `private`).
- `terminateLiveRestorableAgentsForAppExit(kinds:)` enumerates live restorable-agent panels (via the existing synchronous `ProcessDetectedResumeIndexes` + `agentHibernationRecords`) and SIGTERMs each, returning the signalled PIDs.
- `AppExitAgentGracefulShutdown.waitForExit` — a pure, injectable bounded-wait loop (self-limited, runs before the termination watchdog so a slow agent can never stall quit).
- `AppDelegate.gracefullyTerminateLiveAgentsForAppExit(...)` wires the two together; called from `applicationWillTerminate` and the `willPowerOffNotification` handler before the scrollback snapshot.

## Tests

Unit tests for the bounded-wait loop (`AgentHibernationTests`): returns once all processes exit, stops at the deadline when a process never exits, and no-ops with no PIDs.

## Verification note

I don't have full Xcode on this machine (Command Line Tools only), so I couldn't run the macOS app build locally — relying on CI for the full build. Changed Swift files pass a syntax parse, and every reused symbol was verified against the existing hibernation code paths.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785352451&installation_id=133855650&pr_number=7052&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7052&signature=51f8380602c136f64c62575b5d0ea6cb794ec92c55233c63949c7933164f77b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully terminate live TUI agents on quit and power-off so they can save state and leave the alternate screen, preventing empty tabs and lost sessions. Reuses the existing hibernation SIGTERM path with a short bounded wait; scoped to Copilot CLI for now.

- **Bug Fixes**
  - On app exit/power-off, SIGTERM cmux-scoped process groups for live restorable agents before taking the scrollback snapshot.
  - Bound wait (2s default) for processes to exit; runs before the termination watchdog.
  - Expose `terminateScopedProcessesForHibernation(record)` to return signaled PIDs and add `terminateLiveRestorableAgentsForAppExit(kinds:)`; `AppDelegate` calls `gracefullyTerminateLiveAgentsForAppExit()` on quit and power-off.
  - Currently targets `.copilot`; expanding to all restorable agents is trivial.

- **Tests**
  - Unit tests for the bounded wait: exits when all processes end, stops at deadline if not, and no-ops with no PIDs.

<sup>Written for commit 267528a27f23255e5d3d7e8748863393b9c1d629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

