### PR TITLE
Fix remote tmux mirror top-clip on in-tab split (#7053)

### DIFF
--- a/Sources/RemoteTmuxWindowMirror.swift
+++ b/Sources/RemoteTmuxWindowMirror.swift
@@ -121,24 +121,44 @@ final class RemoteTmuxWindowMirror {
         _ node: RemoteTmuxLayoutNode,
         gridForPane: (Int) -> (cols: Int, rows: Int)?
     ) -> (cols: Int, rows: Int)? {
-        nil
+        switch node.content {
+        case let .pane(id):
+            return gridForPane(id)
+        case let .horizontal(children):
+            let grids = children.compactMap { composeClientGrid($0, gridForPane: gridForPane) }
+            guard grids.count == children.count, !grids.isEmpty else { return nil }
+            // Sum cols along the split axis (+1 per tmux divider between children),
+            // take max rows on the cross axis.
+            return (grids.reduce(0) { $0 + $1.cols } + (grids.count - 1), grids.map(\.rows).max() ?? 0)
+        case let .vertical(children):
+            let grids = children.compactMap { composeClientGrid($0, gridForPane: gridForPane) }
+            guard grids.count == children.count, !grids.isEmpty else { return nil }
+            // Sum rows along the split axis (+1 per tmux divider), take max cols.
+            return (grids.map(\.cols).max() ?? 0, grids.reduce(0) { $0 + $1.rows } + (grids.count - 1))
+        }
     }
 
     /// Tells tmux to size this session's windows to the rendered cmux area, so
     /// captured/live pane content matches the on-screen grid. Derives cols/rows
-    /// from the content pixel area and a live pane's cell size; sends
-    /// `refresh-client -C` only when the grid actually changes (no feedback loop:
-    /// the cmux area doesn't change when tmux reflows).
-    /// Returns `true` once the pane surface is live and the size was applied (sent, or
-    /// already current via the `lastClientSize` dedup); `false` when no pane has
-    /// reported its cell size yet, so the caller should retry. Idempotent.
+    /// from each pane's actual rendered grid via ``composeClientGrid(_:gridForPane:)``
+    /// — this correctly excludes pane chrome (the 24+1pt ``RemoteTmuxPaneHeader``)
+    /// that the pixel-divide approach over-counted, which was the root cause of the
+    /// top-clip on in-tab splits (issue #7053).
+    ///
+    /// `contentSizePoints` is the container size that triggered the call (via
+    /// `onChange(of: geo.size)`) and is no longer used in the grid calculation;
+    /// the parameter is kept so the call site stays unchanged.
+    ///
+    /// Returns `true` once all pane surfaces are live and the size was applied (sent,
+    /// or already current via the `lastClientSize` dedup); `false` when any pane has
+    /// not yet reported its rendered grid, so the caller should retry. Idempotent.
     @discardableResult
     func updateClientSize(contentSizePoints: CGSize) -> Bool {
-        guard contentSizePoints.width > 1, contentSizePoints.height > 1,
-              let cell = panelsByPaneId.values.lazy.compactMap({ $0.surface.cellSizePoints() }).first,
-              cell.width > 1, cell.height > 1 else { return false }
-        let cols = max(20, Int(contentSizePoints.width / cell.width))
-        let rows = max(5, Int(contentSizePoints.height / cell.height))
+        guard let grid = Self.composeClientGrid(layout, gridForPane: { paneId in
+            panelsByPaneId[paneId]?.surface.renderedGridCells().map { ($0.columns, $0.rows) }
+        }) else { return false }
+        let cols = max(20, grid.cols)
+        let rows = max(5, grid.rows)
         guard lastClientSize?.cols != cols || lastClientSize?.rows != rows else { return true }
         lastClientSize = (cols, rows)
         connection?.setClientSize(columns: cols, rows: rows)

--- a/Sources/RemoteTmuxWindowMirror.swift
+++ b/Sources/RemoteTmuxWindowMirror.swift
@@ -104,6 +104,26 @@ final class RemoteTmuxWindowMirror {
 
     @ObservationIgnored private var lastClientSize: (cols: Int, rows: Int)?
 
+    /// Composes the tmux client grid from the per-pane rendered grids by walking
+    /// the layout tree and summing grid dimensions along each split axis (+1 per
+    /// tmux divider between children), taking the max on the cross axis.
+    ///
+    /// This is a pure function with no side effects, testable without a live
+    /// Ghostty surface or window.
+    ///
+    /// - Parameters:
+    ///   - node: The layout subtree to compose.
+    ///   - gridForPane: Returns the rendered `(cols, rows)` for a leaf pane id,
+    ///     or `nil` if the surface is not yet live.
+    /// - Returns: The composed client grid, or `nil` when any leaf surface is not
+    ///   yet live (caller should retry).
+    nonisolated static func composeClientGrid(
+        _ node: RemoteTmuxLayoutNode,
+        gridForPane: (Int) -> (cols: Int, rows: Int)?
+    ) -> (cols: Int, rows: Int)? {
+        nil
+    }
+
     /// Tells tmux to size this session's windows to the rendered cmux area, so
     /// captured/live pane content matches the on-screen grid. Derives cols/rows
     /// from the content pixel area and a live pane's cell size; sends

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -794,6 +794,7 @@
 		0A17C0DE0A17C0DE0A17CA02 /* RemoteTmuxVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A17C0DE0A17C0DE0A17CA01 /* RemoteTmuxVersionTests.swift */; };
 		A8C7BE33C1BD3C1AD4342CB1 /* RemoteTmuxWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB52610183419D424AE520B0 /* RemoteTmuxWindow.swift */; };
 		826F6597BF05F1242E17F0C3 /* RemoteTmuxWindowMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE03473FCBD453C7DA78A09 /* RemoteTmuxWindowMirror.swift */; };
+		B3F17053000D000D000D000D /* RemoteTmuxWindowMirrorClientSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F17053000C000C000C000C /* RemoteTmuxWindowMirrorClientSizeTests.swift */; };
 		063516351A6B6F642928B37D /* RemoteTmuxWindowMirrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E292DDF62C863C3553F4C9E7 /* RemoteTmuxWindowMirrorView.swift */; };
 		0F17C0DE0F17C0DE0F17C002 /* RemoteTmuxWindowRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F17C0DE0F17C0DE0F17C001 /* RemoteTmuxWindowRegistry.swift */; };
 		FA00C0DE0001BEEF0001CAFE /* RemoteTmuxWindowRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00C0DE0002BEEF0002CAFE /* RemoteTmuxWindowRegistryTests.swift */; };
@@ -1989,6 +1990,7 @@
 		0A17C0DE0A17C0DE0A17CA01 /* RemoteTmuxVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxVersionTests.swift; sourceTree = "<group>"; };
 		AB52610183419D424AE520B0 /* RemoteTmuxWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxWindow.swift; sourceTree = "<group>"; };
 		FCE03473FCBD453C7DA78A09 /* RemoteTmuxWindowMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxWindowMirror.swift; sourceTree = "<group>"; };
+		B3F17053000C000C000C000C /* RemoteTmuxWindowMirrorClientSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxWindowMirrorClientSizeTests.swift; sourceTree = "<group>"; };
 		E292DDF62C863C3553F4C9E7 /* RemoteTmuxWindowMirrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxWindowMirrorView.swift; sourceTree = "<group>"; };
 		0F17C0DE0F17C0DE0F17C001 /* RemoteTmuxWindowRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxWindowRegistry.swift; sourceTree = "<group>"; };
 		FA00C0DE0002BEEF0002CAFE /* RemoteTmuxWindowRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxWindowRegistryTests.swift; sourceTree = "<group>"; };
@@ -3594,6 +3596,7 @@
 				B0555304B0555304B0555304 /* DetachedFolderPathLookupCacheTests.swift */,
 				A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */,
 				F11ED7AB0002000200020002 /* RemoteTmuxMirrorNewTabPlacementTests.swift */,
+				B3F17053000C000C000C000C /* RemoteTmuxWindowMirrorClientSizeTests.swift */,
 				FA00C0DE0002BEEF0002CAFE /* RemoteTmuxWindowRegistryTests.swift */,
 				0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */,
 				0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */,
@@ -5126,6 +5129,7 @@
 				3AC9AB9046E742B93726A501 /* RemoteTmuxSessionRenameTitleTests.swift in Sources */,
 				9A5CF3AA2E6462E77144F9E6 /* RemoteTmuxSessionSnapshotTests.swift in Sources */,
 				0A17C0DE0A17C0DE0A17CA02 /* RemoteTmuxVersionTests.swift in Sources */,
+				B3F17053000D000D000D000D /* RemoteTmuxWindowMirrorClientSizeTests.swift in Sources */,
 				FA00C0DE0001BEEF0001CAFE /* RemoteTmuxWindowRegistryTests.swift in Sources */,
 				C58410010000000000000001 /* RenderableSystemSymbolTests.swift in Sources */,
 				D36A00050000000000000001 /* RendererRealizationPlannerTests.swift in Sources */,

--- a/cmuxTests/RemoteTmuxWindowMirrorClientSizeTests.swift
+++ b/cmuxTests/RemoteTmuxWindowMirrorClientSizeTests.swift
@@ -1,0 +1,118 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for issue #7053: remote-tmux mirror in-tab splits clip
+/// the top of alt-screen TUIs (lazygit/htop) because the multi-pane path
+/// reported the full container pixel area to tmux instead of the actual
+/// rendered grid — which is smaller because each pane has a 24+1pt header
+/// consuming cell rows.
+///
+/// ``RemoteTmuxWindowMirror/composeClientGrid(_:gridForPane:)`` is the pure
+/// grid-composition function: it walks the ``RemoteTmuxLayoutNode`` tree, asks
+/// each leaf pane for its rendered grid, and assembles the client grid that
+/// tmux should see — summing along the split axis (+1 per tmux divider between
+/// children) and taking the max on the cross axis.
+@Suite struct RemoteTmuxWindowMirrorClientSizeTests {
+
+    // MARK: - leaf
+
+    @Test func leaf_returnsGridWhenPaneIsLive() {
+        let node = pane(1, cols: 80, rows: 24)
+        let result = RemoteTmuxWindowMirror.composeClientGrid(node) { id in
+            id == 1 ? (cols: 80, rows: 24) : nil
+        }
+        #expect(result?.cols == 80)
+        #expect(result?.rows == 24)
+    }
+
+    @Test func leaf_returnsNilWhenPaneIsNotLive() {
+        let node = pane(99, cols: 80, rows: 24)
+        let result = RemoteTmuxWindowMirror.composeClientGrid(node) { _ in nil }
+        #expect(result == nil)
+    }
+
+    // MARK: - vertical split (stacked top/bottom)
+
+    @Test func vertical_twoPane_rowsSummedPlusDivider() {
+        // Two panes stacked vertically, each 10 rows → composed rows = 10+10+1 = 21.
+        let node = RemoteTmuxLayoutNode(
+            width: 80, height: 21, x: 0, y: 0,
+            content: .vertical([pane(1, cols: 80, rows: 10), pane(2, cols: 80, rows: 10)])
+        )
+        let result = RemoteTmuxWindowMirror.composeClientGrid(node) { _ in (cols: 80, rows: 10) }
+        #expect(result?.rows == 21)
+        #expect(result?.cols == 80)
+    }
+
+    @Test func vertical_threePane_rowsSummedPlusTwoDividers() {
+        let node = RemoteTmuxLayoutNode(
+            width: 80, height: 32, x: 0, y: 0,
+            content: .vertical([
+                pane(1, cols: 80, rows: 10),
+                pane(2, cols: 80, rows: 10),
+                pane(3, cols: 80, rows: 10),
+            ])
+        )
+        let result = RemoteTmuxWindowMirror.composeClientGrid(node) { _ in (cols: 80, rows: 10) }
+        #expect(result?.rows == 32) // 10 + 10 + 10 + 2 dividers
+        #expect(result?.cols == 80)
+    }
+
+    // MARK: - horizontal split (side by side)
+
+    @Test func horizontal_twoPane_colsSummedPlusDivider() {
+        // Two panes side-by-side, each 40 cols → composed cols = 40+40+1 = 81.
+        let node = RemoteTmuxLayoutNode(
+            width: 81, height: 24, x: 0, y: 0,
+            content: .horizontal([pane(1, cols: 40, rows: 24), pane(2, cols: 40, rows: 24)])
+        )
+        let result = RemoteTmuxWindowMirror.composeClientGrid(node) { _ in (cols: 40, rows: 24) }
+        #expect(result?.cols == 81)
+        #expect(result?.rows == 24)
+    }
+
+    // MARK: - nested (vertical inside horizontal)
+
+    @Test func nested_verticalInsideHorizontal() {
+        // Left pane: 40×24. Right: vertical split of two 39×11 panes.
+        // Expected: cols = 40+39+1 = 80, rows = max(24, 11+11+1) = 24.
+        let rightSplit = RemoteTmuxLayoutNode(
+            width: 39, height: 23, x: 41, y: 0,
+            content: .vertical([pane(2, cols: 39, rows: 11), pane(3, cols: 39, rows: 11)])
+        )
+        let node = RemoteTmuxLayoutNode(
+            width: 80, height: 24, x: 0, y: 0,
+            content: .horizontal([pane(1, cols: 40, rows: 24), rightSplit])
+        )
+        let grids: [Int: (cols: Int, rows: Int)] = [1: (40, 24), 2: (39, 11), 3: (39, 11)]
+        let result = RemoteTmuxWindowMirror.composeClientGrid(node) { id in grids[id] }
+        #expect(result?.cols == 80)
+        #expect(result?.rows == 24)
+    }
+
+    // MARK: - nil propagation
+
+    @Test func nilWhenAnyLeafNotLive() {
+        // Pane 2 not yet live → entire composition must return nil so the caller
+        // retries rather than sending a partial/wrong grid to tmux.
+        let node = RemoteTmuxLayoutNode(
+            width: 81, height: 24, x: 0, y: 0,
+            content: .horizontal([pane(1, cols: 40, rows: 24), pane(2, cols: 40, rows: 24)])
+        )
+        let result = RemoteTmuxWindowMirror.composeClientGrid(node) { id in
+            id == 1 ? (cols: 40, rows: 24) : nil
+        }
+        #expect(result == nil)
+    }
+
+    // MARK: - helpers
+
+    private func pane(_ id: Int, cols: Int, rows: Int) -> RemoteTmuxLayoutNode {
+        RemoteTmuxLayoutNode(width: cols, height: rows, x: 0, y: 0, content: .pane(id))
+    }
+}


### PR DESCRIPTION
## Problem

Remote tmux mirror (`cmux ssh-tmux`, tmux `-CC`, beta from #5553) clips an
alt-screen TUI (lazygit/htop) at the **top** as soon as an in-tab split is
created. Fixes #7053.

## Root cause

The multi-pane render path sized the tmux client from raw pixels:
`RemoteTmuxWindowMirror.updateClientSize` divided the **full container** size by
the cell size, **without subtracting the per-pane chrome** — the fixed 24+1pt
`RemoteTmuxPaneHeader` that sits above each split pane
(`RemoteTmuxLayoutContainer`'s `VStack { header; TerminalPanelView }`). So tmux
was told each pane had more rows than were actually visible, the remote app drew
the full height, and the top rows fell outside the viewport.

The single-pane path was already correct: it reports the surface's *actual*
rendered grid via `surface.renderedGridCells()`.

### Evidence (live `-CC` session, window size unchanged across the split)

```
before split:  pane 147x85
after split:   pane %0: 74x85   pane %1: 73x85   ← height stays 85 despite the new header
```

`pane_height` should drop by the header's row count; it didn't. With the fix it
reports ~83 and the top rows stay visible.

## Fix

Report the **same source of truth as the single-pane path**: a pure
`nonisolated static func composeClientGrid` traverses the layout tree and
composes the tmux client grid from each leaf's `renderedGridCells()` — summing
along the split axis (+1 cell per tmux divider) and taking the max on the
perpendicular axis. This accounts for the header/dividers automatically and
matches tmux's own geometry model. The retry/dedup semantics of
`updateClientSize` are preserved (nil until every leaf surface is live).

## Verification

- Two-commit red/green regression (`RemoteTmuxWindowMirrorClientSizeTests`,
  7 tests): commit 1 (failing test only) is red, commit 2 (fix) is green.
- Manual: `cmux ssh-tmux` against a Linux VM, split a lazygit pane — no longer
  clipped at the top.
- Localization: not needed — no user-facing text changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785356151&installation_id=133855650&pr_number=7058&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7058&signature=c5682e577a341fe5977e85ad180eb3b1338e975434d658158e7e1289d79dd60b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes top clipping in remote tmux mirror when creating in-tab splits by deriving the client grid from rendered panes instead of dividing pixels. Alt-screen TUIs like lazygit and htop now render without losing top rows.

- **Bug Fixes**
  - Use `composeClientGrid` to build the tmux grid from each pane’s `renderedGridCells()`, summing along the split axis (+1 per divider) and taking the max on the cross axis.
  - Update `updateClientSize` to use the composed grid, preserve retry/dedup semantics, and avoid over-counting pane headers.
  - Add `RemoteTmuxWindowMirrorClientSizeTests` to cover vertical/horizontal/nested splits and nil propagation.

<sup>Written for commit fca5e523904b3ba75c730b4fc71f4dbf3e6c5a01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux client window sizing so it now reflects the full pane layout instead of relying on a single pane’s size.
  * Added safer handling when pane sizes are not yet available, preventing incomplete updates.
  * Better accounts for split dividers and nested layouts when calculating the overall client grid.

* **Tests**
  * Added regression coverage for client-size calculations across leaf panes, horizontal/vertical splits, nested layouts, and missing pane-size cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->