### PR TITLE
Open the ssh-tmux auth ControlMaster in the foreground (drop -f) for a deterministic handoff

### DIFF
--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -220,14 +220,29 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
     /// TOFU prompt), and ssh's default `ask` already prompts to confirm a new
     /// fingerprint on this controlling tty.
     ///
-    /// `-f` makes ssh go to background **after authentication** (just before the
-    /// remote `true`): the password / host-key / MFA prompt and any auth error
-    /// ("Permission denied") still appear on the controlling tty first, and the
-    /// CLI's foreground ssh exits promptly — but the persistent ControlMaster that
-    /// `ControlPersist` leaves running then has its standard fds detached, so it no
-    /// longer holds the terminal's pty open. Without `-f` the backgrounded master
-    /// keeps the terminal's stdout/stderr, freezing window/app close until the
-    /// master gives up (~`ServerAliveInterval`×`ServerAliveCountMax` seconds).
+    /// Critically, this opens the master in the **foreground** (no `-f`): ssh
+    /// authenticates, opens the master, runs the remote `true`, and exits only once
+    /// the control socket has served that session. So by the time the CLI's
+    /// foreground ssh returns, the master is provably *serving* — the post-auth
+    /// retry rides it deterministically, with no `ssh -O check` readiness poll.
+    ///
+    /// `-f` (background-after-auth) is deliberately NOT used: it returns before the
+    /// backgrounded master binds its control socket, racing the immediate retry. The
+    /// historical worry that a foreground master would keep the terminal's
+    /// stdout/stderr and freeze window/app close does not apply: when `ControlPersist`
+    /// backgrounds the master, OpenSSH's `control_persist_detach()` redirects the
+    /// master's std fds to `/dev/null` (`stdfd_devnull(1, 1, …)` in `ssh.c`, identical
+    /// across OpenSSH 9.6/9.8/9.9/10.2 — the versions macOS 14/15/26 ship), and forces
+    /// that detach independent of `-f`. So the foreground ssh exits cleanly and the
+    /// detached master never pins the tty.
+    ///
+    /// `-n` is kept explicitly: `-f` *implied* `-n` (stdin from `/dev/null`), and
+    /// dropping `-f` would otherwise leave the controlling terminal as the remote
+    /// command's stdin. With the trivial `true` that's usually harmless, but a host
+    /// `ForceCommand` / forced wrapper, or noninteractive shell startup that reads
+    /// stdin, could consume the user's terminal input or block. `-n` preserves the
+    /// stdin-null behavior without backgrounding; auth prompts are unaffected (ssh
+    /// reads them from the controlling tty, not stdin).
     ///
     /// - Parameter sshExecutablePath: the local `ssh` binary the CLI will exec.
     /// - Parameter controlPersistSeconds: idle lifetime of the opened master.
@@ -240,7 +255,7 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
     ) -> [String] {
         [sshExecutablePath]
             + sshControlArguments(controlPersistSeconds: controlPersistSeconds, batchMode: false)
-            + ["-o", "BatchMode=no", "-f", "-T", "--", destination, "true"]
+            + ["-o", "BatchMode=no", "-n", "-T", "--", destination, "true"]
     }
 
     /// Single-quotes a value for safe interpolation into a `/bin/sh` command.

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -413,19 +413,9 @@ import Testing
         // Force interactive mode so the prompt works even under ssh_config BatchMode yes…
         #expect(consecutive(argv, "-o", "BatchMode=no"))
         #expect(!argv.contains("BatchMode=yes"))
-        // …and NO -f: the auth ssh opens the master in the FOREGROUND and exits only
-        // once it has authenticated and served the trivial remote command, so the
-        // master's control socket is provably serving by the time the process returns.
-        // That makes the post-auth retry deterministic — no need to poll `ssh -O check`
-        // to race a `-f`-backgrounded master that returned before its socket accepted
-        // connections. The persisted master still detaches: ControlPersist's
-        // control_persist_detach() redirects the backgrounded master's std fds to
-        // /dev/null regardless of -f (OpenSSH ssh.c, verified across 9.6–10.2), so
-        // dropping -f does not pin the terminal.
+        // No -f: foreground auth keeps the post-auth ControlMaster retry deterministic.
         #expect(!argv.contains("-f"))
-        // …but keep -n explicitly: -f used to IMPLY -n (stdin from /dev/null). Without
-        // it the controlling terminal would become the remote command's stdin, which a
-        // ForceCommand / stdin-reading remote startup could consume or block on.
+        // Keep -n explicitly; -f used to imply stdin from /dev/null.
         #expect(argv.contains("-n"))
         // The master must persist after the foreground client exits so discovery / the
         // -CC client can multiplex over it.

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -413,9 +413,23 @@ import Testing
         // Force interactive mode so the prompt works even under ssh_config BatchMode yes…
         #expect(consecutive(argv, "-o", "BatchMode=no"))
         #expect(!argv.contains("BatchMode=yes"))
-        // …and -f so ssh backgrounds AFTER auth: the persistent ControlMaster then
-        // detaches its fds and won't freeze the terminal on window/app close.
-        #expect(argv.contains("-f"))
+        // …and NO -f: the auth ssh opens the master in the FOREGROUND and exits only
+        // once it has authenticated and served the trivial remote command, so the
+        // master's control socket is provably serving by the time the process returns.
+        // That makes the post-auth retry deterministic — no need to poll `ssh -O check`
+        // to race a `-f`-backgrounded master that returned before its socket accepted
+        // connections. The persisted master still detaches: ControlPersist's
+        // control_persist_detach() redirects the backgrounded master's std fds to
+        // /dev/null regardless of -f (OpenSSH ssh.c, verified across 9.6–10.2), so
+        // dropping -f does not pin the terminal.
+        #expect(!argv.contains("-f"))
+        // …but keep -n explicitly: -f used to IMPLY -n (stdin from /dev/null). Without
+        // it the controlling terminal would become the remote command's stdin, which a
+        // ForceCommand / stdin-reading remote startup could consume or block on.
+        #expect(argv.contains("-n"))
+        // The master must persist after the foreground client exits so discovery / the
+        // -CC client can multiplex over it.
+        #expect(argv.contains(where: { $0.hasPrefix("ControlPersist=") }))
         // …but do NOT pin StrictHostKeyChecking — honor the user's host-key policy.
         #expect(!argv.contains(where: { $0.hasPrefix("StrictHostKeyChecking=") }))
         // Opens the SAME shared master that discovery / the -CC client multiplex over.


### PR DESCRIPTION
## Problem

`cmux ssh-tmux <host>` against a host that needs interactive auth could intermittently fail with **"authentication did not open the connection to \<host\>"**, even though the user authenticated successfully.

## Root cause — a ControlMaster readiness race

The interactive-auth `ssh` invocation used `-f`:

```
ssh … -o BatchMode=no -f -T -- <host> true
```

`-f` makes ssh **go to background right after authentication, before its ControlMaster control socket is accepting connections** (`man ssh`: *"go to background just before command execution … This implies `-n`"*). So the foreground process returned, the app immediately retried its BatchMode discovery probe over `ControlMaster=auto`, found no usable master yet, fell back to a fresh prompt-less connection, failed, and the one-shot `didAuthenticate` guard turned that into the hard error above.

## Fix — open the master in the foreground (deterministic handoff)

Drop `-f`. Now the foreground ssh authenticates, opens the master, runs the trivial remote `true`, and **exits only once the control socket has served that session** — so the master is provably accepting connections by the time control returns. The post-auth retry rides it deterministically; no readiness timing is involved.

`-n` is kept **explicitly**, because `-f` *implied* `-n` (stdin from `/dev/null`). Without it, the controlling terminal would become the remote command's stdin — usually harmless with `true`, but a host `ForceCommand` / forced wrapper or stdin-reading noninteractive startup could consume terminal input or block. `-n` preserves that without backgrounding; auth prompts are unaffected (ssh reads them from the controlling tty, not stdin).

## Why dropping `-f` is safe (the original reason it existed)

`-f` was added to avoid a persisted master keeping the terminal's stdout/stderr open and freezing window/app close. That does **not** happen: when `ControlPersist` backgrounds the master, OpenSSH's `control_persist_detach()` redirects the master's std fds to `/dev/null` (`stdfd_devnull(1, 1, …)` in `ssh.c`) and forces that detach **independent of `-f`**. This code is identical across **OpenSSH 9.6 / 9.8 / 9.9 / 10.2** — the versions macOS 14 / 15 / 26 ship — and was verified empirically on 10.2 under a real PTY (the persisted master's fd 0/1/2 all point at `/dev/null`). So the foreground ssh exits cleanly and the detached master never pins the tty. Persistence itself comes from `ControlPersist`, not `-f`, so it is unchanged.

## Scope

`interactiveAuthInvocation` feeds exactly one path — the `cmux ssh-tmux` interactive first-auth handoff (run by `runInteractiveAuthSSH`); it is not a general ssh wrapper. No caller depends on `-f` semantics. Master reuse (`ControlMaster=auto`), ProxyCommand/ProxyJump, and non-tty callers are unaffected.

## Tests

Two-commit red/green. Verified locally with `xcodebuild test` (scheme `cmux-unit`): `interactiveAuthInvocationShape` **fails** at the test-only commit (main's argv has `-f`, no `-n`) and **passes** after the fix. The test asserts the argv has no `-f`, keeps `-n`, and still sets `ControlPersist`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785361371&installation_id=133855650&pr_number=7063&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7063&signature=71b2fa77617dbf83bd538a1968f91b4a5a3ccc2e79cf14d7794d9b34c0dc0921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open the auth `ssh` ControlMaster in the foreground to remove the readiness race and make the post-auth retry deterministic. Fixes intermittent "authentication did not open the connection to <host>" on hosts that require interactive auth.

- **Bug Fixes**
  - Drop `-f` from the interactive auth `ssh` invocation; keep `-n`, `-T`, and `ControlPersist`.
  - Foreground `ssh` exits only after the master serves `true`, so the socket is accepting connections when control returns.
  - Safe for terminals: `ControlPersist` detaches stdio regardless of `-f`, so the persisted master does not pin the tty.
  - Tests updated to assert no `-f`, keep `-n`, ensure `ControlPersist` remains set, and stay within the test file budget.

<sup>Written for commit 5a506a56bfd76069699e1887b80300497bf09103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the remote interactive SSH sign-in flow by switching from backgrounding after authentication to a foreground session.
  * Makes authentication completion more deterministic, reducing failures during immediate reconnects or post-login retries.
  * Improves consistency of when remote terminal access becomes available after sign-in.
* **Tests**
  * Updated authentication flow tests to validate the new foreground SSH behavior and the expected SSH options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->