### PR TITLE
Reconnect stale iOS shell clients after liveness failure

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -12,7 +12,7 @@
 9497	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
-7743	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7771	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7490	cmuxTests/WorkspaceUnitTests.swift
 7312	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1422,6 +1422,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         case manual
         case presencePush
         case livenessProbe
+
         var description: String {
             switch self {
             case .networkChange: return "networkChange"
@@ -1429,6 +1430,25 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             case .presencePush: return "presencePush"
             case .livenessProbe: return "livenessProbe"
             }
+        }
+    }
+
+    private enum RecoveryPlan {
+        case resyncConnectedClient
+        case reconnectStoredMac
+    }
+
+    private func recoveryPlan(for trigger: RecoveryTrigger) -> RecoveryPlan {
+        switch trigger {
+        case .livenessProbe, .presencePush:
+            return .reconnectStoredMac
+        case .manual:
+            return macConnectionStatus == .connected ? .resyncConnectedClient : .reconnectStoredMac
+        case .networkChange:
+            // macConnectionStatus is the health authority for a logical
+            // connection whose transport may already be wedged: unavailable
+            // means rebuild from the stored Mac instead of reusing the client.
+            return macConnectionStatus == .unavailable ? .reconnectStoredMac : .resyncConnectedClient
         }
     }
 
@@ -1453,10 +1473,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// User-initiated reconnect from the Retry control.
     public func retryMobileConnection() {
         connectionRecoveryFailed = false
-        recoverMobileConnection(
-            trigger: .manual,
-            forceReconnectConnectedClient: macConnectionStatus != .connected
-        )
+        recoverMobileConnection(trigger: .manual)
     }
 
     /// Single guarded recovery entry for every trigger (network change, manual
@@ -1465,19 +1482,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// resync re-subscribes and requests a render-grid replay to repaint.
     /// Otherwise the connection dropped, so reconnect once; on failure the UI
     /// shows Retry and the next network change re-attempts automatically.
-    private func recoverMobileConnection(
-        trigger: RecoveryTrigger,
-        forceReconnectConnectedClient: Bool = false
-    ) {
+    private func recoverMobileConnection(trigger: RecoveryTrigger) {
         guard remoteClient != nil || pairedMacStore != nil else { return }
+        guard !recoveryInFlight else { return }
+        let plan = recoveryPlan(for: trigger)
         if connectionState == .connected,
            remoteClient != nil,
-           (!forceReconnectConnectedClient || pairedMacStore == nil) {
+           (plan == .resyncConnectedClient || pairedMacStore == nil) {
             markMacConnectionReconnecting()
             resyncTerminalOutput(reason: "networkRecovery.\(trigger)", restartEventStream: true)
             return
         }
-        guard !recoveryInFlight else { return }
         recoveryInFlight = true
         isRecoveringConnection = true
         connectionRecoveryFailed = false
@@ -6653,10 +6668,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // after iOS suspension. Reusing that same client just repeats the
             // timeout loop; reconnect from the saved Mac record so the transport,
             // reader, writer, and subscription state are all rebuilt together.
-            self.recoverMobileConnection(
-                trigger: .livenessProbe,
-                forceReconnectConnectedClient: true
-            )
+            self.recoverMobileConnection(trigger: .livenessProbe)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1421,11 +1421,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         case networkChange
         case manual
         case presencePush
+        case livenessProbe
         var description: String {
             switch self {
             case .networkChange: return "networkChange"
             case .manual: return "manual"
             case .presencePush: return "presencePush"
+            case .livenessProbe: return "livenessProbe"
             }
         }
     }
@@ -1451,7 +1453,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// User-initiated reconnect from the Retry control.
     public func retryMobileConnection() {
         connectionRecoveryFailed = false
-        recoverMobileConnection(trigger: .manual)
+        recoverMobileConnection(
+            trigger: .manual,
+            forceReconnectConnectedClient: macConnectionStatus != .connected
+        )
     }
 
     /// Single guarded recovery entry for every trigger (network change, manual
@@ -1460,9 +1465,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// resync re-subscribes and requests a render-grid replay to repaint.
     /// Otherwise the connection dropped, so reconnect once; on failure the UI
     /// shows Retry and the next network change re-attempts automatically.
-    private func recoverMobileConnection(trigger: RecoveryTrigger) {
+    private func recoverMobileConnection(
+        trigger: RecoveryTrigger,
+        forceReconnectConnectedClient: Bool = false
+    ) {
         guard remoteClient != nil || pairedMacStore != nil else { return }
-        if connectionState == .connected, remoteClient != nil {
+        if connectionState == .connected,
+           remoteClient != nil,
+           (!forceReconnectConnectedClient || pairedMacStore == nil) {
             markMacConnectionReconnecting()
             resyncTerminalOutput(reason: "networkRecovery.\(trigger)", restartEventStream: true)
             return
@@ -1478,7 +1488,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 self?.recoveryInFlight = false
                 self?.isRecoveringConnection = false
             }
-            guard let self, self.connectionState != .connected else { return }
+            guard let self else { return }
+            if self.connectionState == .connected, self.remoteClient != nil {
+                self.disconnectLiveConnection(preservingOtherMacWorkspaceState: true)
+            }
+            guard self.connectionState != .connected else { return }
             let reconnected = await self.reconnectActiveMacIfAvailable(stackUserID: stackUserID)
             if !reconnected, !Task.isCancelled {
                 self.connectionRecoveryFailed = true
@@ -6635,12 +6649,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             MobileDebugLog.anchormux("sync.liveness re-subscribe silentMs=\(silentMs)")
             self.diagnosticLog?.record(DiagnosticEvent(.livenessResubscribe, ms: UInt32(clamping: silentMs)))
             mobileShellLog.info("render-grid stream silent for \(silentMs, privacy: .public)ms and subscription probe failed, re-subscribing")
-            // resyncTerminalOutput(restartEventStream: true) stops the wedged
-            // listener (which cancels this watchdog via stopTerminalRefreshPolling)
-            // and starts a fresh subscription + watchdog, then replays every
-            // surface so the phone catches up on the deltas it missed while the
-            // stream was dead.
-            self.resyncTerminalOutput(reason: "liveness", restartEventStream: true)
+            // A failed probe means the persistent RPC client itself may be wedged
+            // after iOS suspension. Reusing that same client just repeats the
+            // timeout loop; reconnect from the saved Mac record so the transport,
+            // reader, writer, and subscription state are all rebuilt together.
+            self.recoverMobileConnection(
+                trigger: .livenessProbe,
+                forceReconnectConnectedClient: true
+            )
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellReconnectRecoveryTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellReconnectRecoveryTestSupport.swift
@@ -1,0 +1,92 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileTransport
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+struct LivenessManualAttachTicketResultFrame {
+    var id: String?
+
+    func make() throws -> Data {
+        let route = try CmxAttachRoute(
+            id: "debug_loopback",
+            kind: .debugLoopback,
+            endpoint: .hostPort(host: "127.0.0.1", port: 56584)
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "live-workspace",
+            terminalID: "live-terminal",
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            macPairingCompatibilityVersion: CmxMobileDefaults.pairingCompatibilityVersion,
+            routes: [route],
+            expiresAt: Date().addingTimeInterval(3600),
+            authToken: "test-attach-token"
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let ticketObject = try JSONSerialization.jsonObject(with: encoder.encode(ticket))
+        let envelope: [String: Any] = [
+            "id": id ?? UUID().uuidString,
+            "ok": true,
+            "result": ["ticket": ticketObject],
+        ]
+        return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
+    }
+}
+
+// Test double protects its AsyncStream continuation behind a lock.
+final class ManualReachability: ReachabilityProviding, @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: AsyncStream<Void>.Continuation?
+
+    var isOnline: Bool { get async { true } }
+
+    var hasSubscriber: Bool {
+        lock.withLock { continuation != nil }
+    }
+
+    func pathChanges() -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            lock.withLock {
+                self.continuation = continuation
+            }
+        }
+    }
+
+    func emitPathChange() {
+        let continuation: AsyncStream<Void>.Continuation? = lock.withLock { self.continuation }
+        continuation?.yield(())
+    }
+}
+
+@MainActor
+func makeReconnectableConnectedStore(
+    router: LivenessHostRouter,
+    box: TransportBox,
+    clock: TestClock,
+    probeTimeoutNanoseconds: UInt64 = 200_000_000,
+    reachability: any ReachabilityProviding = AlwaysOnlineReachability()
+) async throws -> MobileShellComposite {
+    let runtime = LivenessTestRuntime(
+        transportFactory: LivenessTransportFactory(router: router, box: box),
+        now: { clock.now },
+        livenessProbeTimeoutNanoseconds: probeTimeoutNanoseconds
+    )
+    let databaseURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("cmux-liveness-\(UUID().uuidString).sqlite3")
+    let pairedMacStore = try MobilePairedMacStore(databaseURL: databaseURL)
+    let store = MobileShellComposite(
+        runtime: runtime,
+        pairedMacStore: pairedMacStore,
+        identityProvider: StaticIdentityProvider(userID: "user-1"),
+        reachability: reachability,
+        deliveredNotificationClearer: NoopDeliveredNotificationClearer()
+    )
+    store.signIn()
+    let ticket = try makeTicket(clock: clock)
+    let connected = await store.connectPairingURL(try attachURL(for: ticket))
+    #expect(connected, "scripted connect must succeed")
+    return store
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellReconnectRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellReconnectRecoveryTests.swift
@@ -1,0 +1,76 @@
+import CmuxMobileRPC
+import Testing
+@testable import CmuxMobileShell
+
+/// When a liveness probe times out on a reconnectable saved Mac, recovery must
+/// replace the persistent RPC client. Restarting only the event listener keeps
+/// sending through the same half-dead transport, which is why the iOS app felt
+/// permanently broken until process restart.
+@MainActor
+@Test func failedLivenessProbeReconnectsSavedMacWithFreshClient() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeReconnectableConnectedStore(router: router, box: box, clock: clock)
+    defer {
+        Task { await router.releaseAllHeld() }
+    }
+
+    let sawInitialSubscribe = try await pollUntil { await router.count(of: "mobile.events.subscribe") >= 1 }
+    #expect(sawInitialSubscribe, "listener must establish the initial push subscription")
+
+    await router.holdSubscribeRequest(number: 2)
+    clock.advance(by: 10)
+    store.debugRunRenderGridLivenessCheckForTesting()
+
+    let reconnected = try await pollUntil(attempts: 800) {
+        await router.count(of: "workspace.list") >= 2 && store.macConnectionStatus == .connected
+    }
+    #expect(
+        reconnected,
+        "a failed liveness probe must reconnect from the saved Mac record instead of reusing the stale RPC client"
+    )
+    #expect(store.connectionState == .connected)
+}
+
+/// Once an RPC failure has marked the logical connection unavailable, a later
+/// path-change recovery must trust that health status and rebuild the stored Mac
+/// connection. Re-subscribing on the old client can keep a wedged iOS transport
+/// alive forever.
+@MainActor
+@Test func networkChangeAfterUnavailableStatusReconnectsSavedMacWithFreshClient() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let reachability = ManualReachability()
+    let store = try await makeReconnectableConnectedStore(
+        router: router,
+        box: box,
+        clock: clock,
+        reachability: reachability
+    )
+    defer {
+        Task { await router.releaseAllHeld() }
+    }
+
+    let sawInitialSubscribe = try await pollUntil { await router.count(of: "mobile.events.subscribe") >= 1 }
+    #expect(sawInitialSubscribe, "listener must establish the initial push subscription")
+    store.startObservingNetworkPathChanges()
+    let observingNetwork = try await pollUntil { reachability.hasSubscriber }
+    #expect(observingNetwork, "connected stores must observe reachability changes")
+
+    store.markMacConnectionUnavailableIfNeeded(after: MobileShellConnectionError.requestTimedOut)
+    #expect(store.connectionState == .connected)
+    #expect(store.macConnectionStatus == .unavailable)
+
+    await router.holdSubscribeRequest(number: 2)
+    reachability.emitPathChange()
+
+    let reconnected = try await pollUntil(attempts: 800) {
+        await router.count(of: "workspace.list") >= 2 && store.macConnectionStatus == .connected
+    }
+    #expect(
+        reconnected,
+        "network recovery must reconnect from the saved Mac when macConnectionStatus has already declared the current client unavailable"
+    )
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -1,14 +1,11 @@
 import CMUXMobileCore
-import CmuxMobilePairedMac
 import CmuxMobileRPC
 import CmuxMobileShellModel
 import Foundation
 import Testing
 @testable import CmuxMobileShell
 
-// Shared fixtures for the render-grid liveness watchdog tests
-// (MobileShellRenderGridLivenessTests.swift): injected clock, scripted
-// host router, transport mocks, and the connected-store builder.
+// Shared render-grid liveness fixtures: clock, host router, transport mocks, and connected-store builder.
 
 // MARK: - Injected clock
 
@@ -302,7 +299,7 @@ actor LivenessHostRouter {
                 "capabilities": capabilities,
             ])
         case "mobile.attach_ticket.create":
-            return try? Self.manualAttachTicketResultFrame(id: id)
+            return try? LivenessManualAttachTicketResultFrame(id: id).make()
         case "mobile.events.subscribe":
             subscribeRequestCount += 1
             if holdSubscribe || heldSubscribeRequestNumbers.contains(subscribeRequestCount) {
@@ -398,28 +395,6 @@ actor LivenessHostRouter {
             "result": result,
         ]
         return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
-    }
-
-    private static func manualAttachTicketResultFrame(id: String?) throws -> Data {
-        let route = try CmxAttachRoute(
-            id: "debug_loopback",
-            kind: .debugLoopback,
-            endpoint: .hostPort(host: "127.0.0.1", port: 56584)
-        )
-        let ticket = try CmxAttachTicket(
-            workspaceID: "live-workspace",
-            terminalID: "live-terminal",
-            macDeviceID: "test-mac",
-            macDisplayName: "Test Mac",
-            macPairingCompatibilityVersion: CmxMobileDefaults.pairingCompatibilityVersion,
-            routes: [route],
-            expiresAt: Date().addingTimeInterval(3600),
-            authToken: "test-attach-token"
-        )
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        let ticketObject = try JSONSerialization.jsonObject(with: encoder.encode(ticket))
-        return try resultFrame(id: id, result: ["ticket": ticketObject])
     }
 
     private static func errorFrame(id: String?, message: String) throws -> Data {
@@ -659,33 +634,4 @@ func installFreshLivenessRemoteClient(
         ticket: ticket,
         allowsStackAuthFallback: true
     )
-}
-
-@MainActor
-func makeReconnectableConnectedStore(
-    router: LivenessHostRouter,
-    box: TransportBox,
-    clock: TestClock,
-    probeTimeoutNanoseconds: UInt64 = 200_000_000
-) async throws -> MobileShellComposite {
-    let runtime = LivenessTestRuntime(
-        transportFactory: LivenessTransportFactory(router: router, box: box),
-        now: { clock.now },
-        livenessProbeTimeoutNanoseconds: probeTimeoutNanoseconds
-    )
-    let databaseURL = FileManager.default.temporaryDirectory
-        .appendingPathComponent("cmux-liveness-\(UUID().uuidString).sqlite3")
-    let pairedMacStore = try MobilePairedMacStore(databaseURL: databaseURL)
-    let store = MobileShellComposite(
-        runtime: runtime,
-        pairedMacStore: pairedMacStore,
-        identityProvider: StaticIdentityProvider(userID: "user-1"),
-        reachability: AlwaysOnlineReachability(),
-        deliveredNotificationClearer: NoopDeliveredNotificationClearer()
-    )
-    store.signIn()
-    let ticket = try makeTicket(clock: clock)
-    let connected = await store.connectPairingURL(try attachURL(for: ticket))
-    #expect(connected, "scripted connect must succeed")
-    return store
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxMobilePairedMac
 import CmuxMobileRPC
 import CmuxMobileShellModel
 import Foundation
@@ -300,6 +301,8 @@ actor LivenessHostRouter {
                 "terminal_fidelity": "render_grid",
                 "capabilities": capabilities,
             ])
+        case "mobile.attach_ticket.create":
+            return try? Self.manualAttachTicketResultFrame(id: id)
         case "mobile.events.subscribe":
             subscribeRequestCount += 1
             if holdSubscribe || heldSubscribeRequestNumbers.contains(subscribeRequestCount) {
@@ -395,6 +398,28 @@ actor LivenessHostRouter {
             "result": result,
         ]
         return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
+    }
+
+    private static func manualAttachTicketResultFrame(id: String?) throws -> Data {
+        let route = try CmxAttachRoute(
+            id: "debug_loopback",
+            kind: .debugLoopback,
+            endpoint: .hostPort(host: "127.0.0.1", port: 56584)
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "live-workspace",
+            terminalID: "live-terminal",
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            macPairingCompatibilityVersion: CmxMobileDefaults.pairingCompatibilityVersion,
+            routes: [route],
+            expiresAt: Date().addingTimeInterval(3600),
+            authToken: "test-attach-token"
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let ticketObject = try JSONSerialization.jsonObject(with: encoder.encode(ticket))
+        return try resultFrame(id: id, result: ["ticket": ticketObject])
     }
 
     private static func errorFrame(id: String?, message: String) throws -> Data {
@@ -634,4 +659,33 @@ func installFreshLivenessRemoteClient(
         ticket: ticket,
         allowsStackAuthFallback: true
     )
+}
+
+@MainActor
+func makeReconnectableConnectedStore(
+    router: LivenessHostRouter,
+    box: TransportBox,
+    clock: TestClock,
+    probeTimeoutNanoseconds: UInt64 = 200_000_000
+) async throws -> MobileShellComposite {
+    let runtime = LivenessTestRuntime(
+        transportFactory: LivenessTransportFactory(router: router, box: box),
+        now: { clock.now },
+        livenessProbeTimeoutNanoseconds: probeTimeoutNanoseconds
+    )
+    let databaseURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("cmux-liveness-\(UUID().uuidString).sqlite3")
+    let pairedMacStore = try MobilePairedMacStore(databaseURL: databaseURL)
+    let store = MobileShellComposite(
+        runtime: runtime,
+        pairedMacStore: pairedMacStore,
+        identityProvider: StaticIdentityProvider(userID: "user-1"),
+        reachability: AlwaysOnlineReachability(),
+        deliveredNotificationClearer: NoopDeliveredNotificationClearer()
+    )
+    store.signIn()
+    let ticket = try makeTicket(clock: clock)
+    let connected = await store.connectPairingURL(try attachURL(for: ticket))
+    #expect(connected, "scripted connect must succeed")
+    return store
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -543,6 +543,37 @@ import Testing
     await router.releaseAllHeld()
 }
 
+/// When a liveness probe times out on a reconnectable saved Mac, recovery must
+/// replace the persistent RPC client. Restarting only the event listener keeps
+/// sending through the same half-dead transport, which is why the iOS app felt
+/// permanently broken until process restart.
+@MainActor
+@Test func failedLivenessProbeReconnectsSavedMacWithFreshClient() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeReconnectableConnectedStore(router: router, box: box, clock: clock)
+    defer {
+        Task { await router.releaseAllHeld() }
+    }
+
+    let sawInitialSubscribe = try await pollUntil { await router.count(of: "mobile.events.subscribe") >= 1 }
+    #expect(sawInitialSubscribe, "listener must establish the initial push subscription")
+
+    await router.holdSubscribeRequest(number: 2)
+    clock.advance(by: 10)
+    store.debugRunRenderGridLivenessCheckForTesting()
+
+    let reconnected = try await pollUntil(attempts: 800) {
+        await router.count(of: "workspace.list") >= 2 && store.macConnectionStatus == .connected
+    }
+    #expect(
+        reconnected,
+        "a failed liveness probe must reconnect from the saved Mac record instead of reusing the stale RPC client"
+    )
+    #expect(store.connectionState == .connected)
+}
+
 /// A transport that drops before the start handshake completes must converge
 /// to `.unavailable`, not livelock in `.reconnecting`: without the guard, the
 /// stream-end restart supersedes the listener generation, so the parked start

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -543,37 +543,6 @@ import Testing
     await router.releaseAllHeld()
 }
 
-/// When a liveness probe times out on a reconnectable saved Mac, recovery must
-/// replace the persistent RPC client. Restarting only the event listener keeps
-/// sending through the same half-dead transport, which is why the iOS app felt
-/// permanently broken until process restart.
-@MainActor
-@Test func failedLivenessProbeReconnectsSavedMacWithFreshClient() async throws {
-    let clock = TestClock()
-    let router = LivenessHostRouter()
-    let box = TransportBox()
-    let store = try await makeReconnectableConnectedStore(router: router, box: box, clock: clock)
-    defer {
-        Task { await router.releaseAllHeld() }
-    }
-
-    let sawInitialSubscribe = try await pollUntil { await router.count(of: "mobile.events.subscribe") >= 1 }
-    #expect(sawInitialSubscribe, "listener must establish the initial push subscription")
-
-    await router.holdSubscribeRequest(number: 2)
-    clock.advance(by: 10)
-    store.debugRunRenderGridLivenessCheckForTesting()
-
-    let reconnected = try await pollUntil(attempts: 800) {
-        await router.count(of: "workspace.list") >= 2 && store.macConnectionStatus == .connected
-    }
-    #expect(
-        reconnected,
-        "a failed liveness probe must reconnect from the saved Mac record instead of reusing the stale RPC client"
-    )
-    #expect(store.connectionState == .connected)
-}
-
 /// A transport that drops before the start handshake completes must converge
 /// to `.unavailable`, not livelock in `.reconnecting`: without the guard, the
 /// stream-end restart supersedes the listener generation, so the parked start


### PR DESCRIPTION
## Summary
- Add a regression test for a saved iOS Mac connection whose render-grid liveness probe times out after the event subscription stops responding.
- Reconnect the saved Mac on failed liveness probes instead of reusing the same persistent RPC client.
- Make manual Retry force a reconnect when the UI already marked the Mac connection unavailable.

## Verification
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileShellRenderGridLivenessTests`
- `swift test --package-path Packages/iOS/CmuxMobileShell`
- `./scripts/reload-cloud.sh --tag ioscxn` (cloud unavailable locally, local fallback succeeded)
- `./ios/scripts/reload.sh --tag ioscxn` (simulator succeeded)

## Dogfood Notes
Test with the `ioscxn` tag. Previous bad behavior: after leaving the iOS app open for a while, sessions could stop reconnecting until the app was force-closed. Expected behavior: liveness failure or Retry rebuilds the saved-Mac client and sessions recover without restarting the iOS app.

Device reload note: `./ios/scripts/reload-cloud.sh --tag ioscxn --device-id 4A52829D-6427-599F-A166-4058881D2DF4 --wait 1200` could not run because local ASC credentials are missing. The allowed `ios/scripts/reload.sh --tag ioscxn --device-only --device-id 4A52829D-6427-599F-A166-4058881D2DF4` fallback reached signing and failed because no local development team is configured.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785361959&installation_id=133855650&pr_number=7065&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7065&signature=078bf2f03515794cbcea0099df2dd6d3bc20ae56a2c1fc814ff5c519b055ead2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconnect stale iOS shell clients when the render‑grid liveness probe fails and after network changes if the connection is marked unavailable. Recovery now rebuilds the transport and RPC client instead of reusing a wedged one, so sessions recover without restarting the app.

- **Bug Fixes**
  - Added recovery planning: livenessProbe and presencePush always reconnect; networkChange reconnects when `macConnectionStatus` is `unavailable`; manual reconnects only when already unavailable or disconnected.
  - On reconnect, disconnect any live client and rebuild transport, reader, writer, and subscriptions.
  - Liveness probe failures now trigger recovery (no longer just resubscribe).
  - Healthy clients still use fast resubscribe.

- **Tests**
  - Added `failedLivenessProbeReconnectsSavedMacWithFreshClient` and `networkChangeAfterUnavailableStatusReconnectsSavedMacWithFreshClient`.
  - Introduced helpers for manual reachability, attach‑ticket responses, and a reconnectable connected store.

<sup>Written for commit 13adb19d3daf6eec9cf0c76bde85ae9e37fbb0d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved mobile shell recovery after connection issues, including more reliable reconnect behavior when liveness checks fail.
  * Added support for recovering from saved Mac connections during network changes and probe timeouts.

* **Bug Fixes**
  * Fixed cases where recovery could stall while the app still reported an active connection.
  * Recovery now completes more consistently by refreshing the connection state before retrying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core iOS connection recovery and disconnect/reconnect paths; behavior change is intentional but could affect edge cases around network vs manual retry vs still-healthy transports.
> 
> **Overview**
> Fixes iOS sessions that stayed broken until force-quit when the render-grid stream died but the persistent RPC client was wedged (e.g. after suspension).
> 
> **Recovery planning** in `MobileShellComposite` adds a `livenessProbe` trigger and a `RecoveryPlan` that chooses **resync** vs **full reconnect from the saved Mac** using `macConnectionStatus` and trigger type. Failed liveness probes and presence-driven recovery now **rebuild transport** via `reconnectActiveMacIfAvailable` instead of only `resyncTerminalOutput`. On forced reconnect, a still-“connected” client is **disconnected first** (`disconnectLiveConnection`) while preserving other Mac workspace state. Manual Retry reconnects when the Mac is already marked unavailable; network changes after **unavailable** also take the reconnect path.
> 
> Adds regression tests and shared test helpers (attach ticket framing, manual reachability, reconnectable connected store) plus liveness router support for `mobile.attach_ticket.create`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13adb19d3daf6eec9cf0c76bde85ae9e37fbb0d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->