### PR TITLE
Use full-height primary terminal output on iOS

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -14,7 +14,7 @@
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-6935	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7022	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift
@@ -28,7 +28,7 @@
 3934	Sources/Feed/FeedPanelView.swift
 3926	cmuxTests/TabManagerUnitTests.swift
 3896	cmuxTests/WindowAndDragTests.swift
-3688	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+3747	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 3668	cmuxTests/CLIGenericHookPersistenceTests.swift
 3397	Sources/CmuxConfig.swift
 3364	cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -165,6 +165,7 @@
 632	cmuxTests/AgentSessionAutoResumeSwiftTests.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
 627	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
+624	Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
 620	cmuxTests/FinderFileDropRegressionTests.swift
 620	cmuxTests/TerminalNotificationQueueTests.swift
 613	Sources/SettingsNavigation.swift

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
@@ -6,7 +6,11 @@ extension MobileShellComposite {
     /// Yield a raw PTY byte chunk to the surface stream, if one is attached.
     func deliverTerminalBytes(_ bytes: Data, surfaceID: String) {
         deliverTerminalOutput(
-            TerminalOutputDelivery(bytes: bytes, replaceable: false),
+            TerminalOutputDelivery(
+                bytes: bytes,
+                replaceable: false,
+                viewportPolicy: .natural
+            ),
             surfaceID: surfaceID
         )
     }
@@ -15,7 +19,8 @@ extension MobileShellComposite {
         deliverTerminalOutput(
             TerminalOutputDelivery(
                 renderGrid: frame,
-                replaceable: frame.isReplaceableViewportPatchForMobileDelivery
+                replaceable: frame.isReplaceableViewportPatchForMobileDelivery,
+                viewportPolicy: frame.mobileViewportPolicy
             ),
             surfaceID: surfaceID
         )
@@ -29,7 +34,11 @@ extension MobileShellComposite {
         terminalOutputQueuesBySurfaceID[surfaceID] = queue
         if let immediate {
             continuation.yield(
-                MobileTerminalOutputChunk(data: immediate.bytes, streamToken: streamToken)
+                MobileTerminalOutputChunk(
+                    data: immediate.bytes,
+                    streamToken: streamToken,
+                    viewportPolicy: immediate.viewportPolicy
+                )
             )
         }
     }
@@ -45,6 +54,10 @@ extension MobileShellComposite {
               terminalOutputStreamTokensBySurfaceID[surfaceID] == streamToken else {
             return
         }
-        continuation.yield(MobileTerminalOutputChunk(data: next.bytes, streamToken: streamToken))
+        continuation.yield(MobileTerminalOutputChunk(
+            data: next.bytes,
+            streamToken: streamToken,
+            viewportPolicy: next.viewportPolicy
+        ))
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
@@ -31,6 +31,7 @@ extension MobileShellComposite {
             TerminalOutputDelivery(
                 bytes: Data(),
                 replaceable: true,
+                replacementScope: .viewportPolicy,
                 viewportPolicy: policy
             ),
             surfaceID: surfaceID

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
@@ -26,6 +26,17 @@ extension MobileShellComposite {
         )
     }
 
+    func deliverTerminalViewportPolicy(_ policy: MobileTerminalOutputViewportPolicy, surfaceID: String) {
+        deliverTerminalOutput(
+            TerminalOutputDelivery(
+                bytes: Data(),
+                replaceable: true,
+                viewportPolicy: policy
+            ),
+            surfaceID: surfaceID
+        )
+    }
+
     private func deliverTerminalOutput(_ delivery: TerminalOutputDelivery, surfaceID: String) {
         guard let continuation = terminalByteContinuationsBySurfaceID[surfaceID],
               let streamToken = terminalOutputStreamTokensBySurfaceID[surfaceID] else { return }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6317,14 +6317,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         let previousScreen = terminalActiveScreenBySurfaceID[renderGrid.surfaceID]
-        terminalActiveScreenBySurfaceID[renderGrid.surfaceID] = renderGrid.activeScreen
         let deliveryDecision: RenderGridEventDeliveryDecision = source == "event"
             ? renderGridEventDeliveryDecision(renderGrid, previous: previousScreen)
             : .deliver
         switch deliveryDecision {
         case .deliver:
+            terminalActiveScreenBySurfaceID[renderGrid.surfaceID] = renderGrid.activeScreen
             break
         case .advisory(let requestReplay):
+            if !requestReplay {
+                terminalActiveScreenBySurfaceID[renderGrid.surfaceID] = renderGrid.activeScreen
+            }
             deliverTerminalViewportPolicy(renderGrid.mobileViewportPolicy, surfaceID: renderGrid.surfaceID)
             MobileDebugLog.anchormux(
                 "sync.render_grid_advisory source=\(source) surface=\(renderGrid.surfaceID) screen=\(renderGrid.activeScreen.rawValue) seq=\(renderGrid.stateSeq) requestReplay=\(requestReplay)"

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6281,15 +6281,23 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
-    private func shouldDeliverRenderGridEvent(
+    private enum RenderGridEventDeliveryDecision {
+        case deliver
+        case advisory(requestReplay: Bool)
+    }
+
+    private func renderGridEventDeliveryDecision(
         _ renderGrid: MobileTerminalRenderGridFrame,
         previous: MobileTerminalRenderGridFrame.Screen?
-    ) -> Bool {
+    ) -> RenderGridEventDeliveryDecision {
         guard terminalOutputTransport == .hybrid,
               renderGrid.activeScreen == .primary else {
-            return true
+            return .deliver
         }
-        return previous == .alternate
+        guard previous == .alternate else {
+            return .advisory(requestReplay: false)
+        }
+        return renderGrid.full ? .deliver : .advisory(requestReplay: true)
     }
 
     func deliverAuthoritativeTerminalRenderGrid(
@@ -6310,11 +6318,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         let previousScreen = terminalActiveScreenBySurfaceID[renderGrid.surfaceID]
         terminalActiveScreenBySurfaceID[renderGrid.surfaceID] = renderGrid.activeScreen
-        guard source != "event" || shouldDeliverRenderGridEvent(renderGrid, previous: previousScreen) else {
+        let deliveryDecision: RenderGridEventDeliveryDecision = source == "event"
+            ? renderGridEventDeliveryDecision(renderGrid, previous: previousScreen)
+            : .deliver
+        switch deliveryDecision {
+        case .deliver:
+            break
+        case .advisory(let requestReplay):
             deliverTerminalViewportPolicy(renderGrid.mobileViewportPolicy, surfaceID: renderGrid.surfaceID)
             MobileDebugLog.anchormux(
-                "sync.render_grid_advisory source=\(source) surface=\(renderGrid.surfaceID) screen=\(renderGrid.activeScreen.rawValue) seq=\(renderGrid.stateSeq)"
+                "sync.render_grid_advisory source=\(source) surface=\(renderGrid.surfaceID) screen=\(renderGrid.activeScreen.rawValue) seq=\(renderGrid.stateSeq) requestReplay=\(requestReplay)"
             )
+            if requestReplay {
+                requestTerminalReplay(surfaceID: renderGrid.surfaceID)
+            }
             return
         }
         markTerminalBytesDelivered(surfaceID: renderGrid.surfaceID, endSeq: renderGrid.stateSeq)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6241,8 +6241,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         let localSeq = deliveredTerminalByteEndSeqBySurfaceID[surfaceID] ?? 0
         guard remoteSeq > localSeq else { return }
-        if terminalOutputTransport.usesRenderGrid,
-           terminalEventListenerTask != nil {
+        let canRenderGridAdvancePendingSeq = terminalOutputTransport == .renderGrid
+            || (terminalOutputTransport == .hybrid && terminalActiveScreenBySurfaceID[surfaceID] == .alternate)
+        if canRenderGridAdvancePendingSeq, terminalEventListenerTask != nil {
             let pendingSeq = pendingTerminalByteEndSeqBySurfaceID[surfaceID]
             pendingTerminalByteEndSeqBySurfaceID[surfaceID] = max(remoteSeq, pendingSeq ?? 0)
             if let pendingSeq, localSeq < pendingSeq {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6308,8 +6308,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return .advisory(requestReplay: false, updateTrackedScreen: true, deliverViewportPolicy: true)
         }
         guard !renderGrid.full else { return .deliver }
-        let hasRowDelta = renderGrid.rowSpans.isEmpty == false || renderGrid.clearedRows.isEmpty == false
-        return .advisory(requestReplay: hasRowDelta, updateTrackedScreen: false, deliverViewportPolicy: false)
+        return .advisory(requestReplay: true, updateTrackedScreen: false, deliverViewportPolicy: false)
     }
 
     func deliverAuthoritativeTerminalRenderGrid(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6281,9 +6281,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
-    private func shouldDeliverRenderGridEvent(_ renderGrid: MobileTerminalRenderGridFrame) -> Bool {
-        let previous = terminalActiveScreenBySurfaceID[renderGrid.surfaceID]
-        terminalActiveScreenBySurfaceID[renderGrid.surfaceID] = renderGrid.activeScreen
+    private func shouldDeliverRenderGridEvent(
+        _ renderGrid: MobileTerminalRenderGridFrame,
+        previous: MobileTerminalRenderGridFrame.Screen?
+    ) -> Bool {
         guard terminalOutputTransport == .hybrid,
               renderGrid.activeScreen == .primary else {
             return true
@@ -6300,17 +6301,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
               hasTerminalOutputSink(surfaceID: renderGrid.surfaceID) else {
             return
         }
-        guard source != "event" || shouldDeliverRenderGridEvent(renderGrid) else {
-            deliverTerminalViewportPolicy(renderGrid.mobileViewportPolicy, surfaceID: renderGrid.surfaceID)
-            MobileDebugLog.anchormux(
-                "sync.render_grid_advisory source=\(source) surface=\(renderGrid.surfaceID) screen=\(renderGrid.activeScreen.rawValue) seq=\(renderGrid.stateSeq)"
-            )
-            return
-        }
         if let deliveredSeq = deliveredTerminalByteEndSeqBySurfaceID[renderGrid.surfaceID],
            deliveredSeq > renderGrid.stateSeq {
             MobileDebugLog.anchormux(
                 "sync.render_grid_stale source=\(source) surface=\(renderGrid.surfaceID) delivered=\(deliveredSeq) frame=\(renderGrid.stateSeq)"
+            )
+            return
+        }
+        let previousScreen = terminalActiveScreenBySurfaceID[renderGrid.surfaceID]
+        terminalActiveScreenBySurfaceID[renderGrid.surfaceID] = renderGrid.activeScreen
+        guard source != "event" || shouldDeliverRenderGridEvent(renderGrid, previous: previousScreen) else {
+            deliverTerminalViewportPolicy(renderGrid.mobileViewportPolicy, surfaceID: renderGrid.surfaceID)
+            MobileDebugLog.anchormux(
+                "sync.render_grid_advisory source=\(source) surface=\(renderGrid.surfaceID) screen=\(renderGrid.activeScreen.rawValue) seq=\(renderGrid.stateSeq)"
             )
             return
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6261,6 +6261,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         guard source != "event" || shouldDeliverRenderGridEvent(renderGrid) else {
+            deliverTerminalViewportPolicy(renderGrid.mobileViewportPolicy, surfaceID: renderGrid.surfaceID)
             MobileDebugLog.anchormux(
                 "sync.render_grid_advisory source=\(source) surface=\(renderGrid.surfaceID) screen=\(renderGrid.activeScreen.rawValue) seq=\(renderGrid.stateSeq)"
             )

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -34,15 +34,38 @@ public typealias CMUXMobileShellStore = MobileShellComposite
 @Observable
 public final class MobileShellComposite: MobileTerminalOutputSinking {
     private enum TerminalOutputTransport: Equatable {
+        case hybrid
         case renderGrid
         case rawBytes
 
         var eventTopics: [String] {
             switch self {
+            case .hybrid:
+                return ["workspace.updated", "terminal.bytes", "terminal.render_grid", "terminal.set_font", "notification.dismissed", "notification.badge"]
             case .renderGrid:
                 return ["workspace.updated", "terminal.render_grid", "terminal.set_font", "notification.dismissed", "notification.badge"]
             case .rawBytes:
                 return ["workspace.updated", "terminal.bytes", "terminal.set_font", "notification.dismissed", "notification.badge"]
+            }
+        }
+
+        var debugName: String {
+            switch self {
+            case .hybrid:
+                return "hybrid"
+            case .renderGrid:
+                return "render_grid"
+            case .rawBytes:
+                return "raw_bytes"
+            }
+        }
+
+        var usesRenderGrid: Bool {
+            switch self {
+            case .hybrid, .renderGrid:
+                return true
+            case .rawBytes:
+                return false
             }
         }
     }
@@ -683,6 +706,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var reportedViewportSizesByTerminalKey: [MobileTerminalViewportKey: MobileTerminalViewportSize]
     private var deliveredTerminalByteEndSeqBySurfaceID: [String: UInt64]
     private var pendingTerminalByteEndSeqBySurfaceID: [String: UInt64]
+    private var terminalActiveScreenBySurfaceID: [String: MobileTerminalRenderGridFrame.Screen]
     private var terminalReplaySurfaceIDsInFlight: Set<String>
     private var terminalOutputTransport: TerminalOutputTransport
     var terminalByteContinuationsBySurfaceID: [String: AsyncStream<MobileTerminalOutputChunk>.Continuation]
@@ -872,6 +896,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.reportedViewportSizesByTerminalKey = [:]
         self.deliveredTerminalByteEndSeqBySurfaceID = [:]
         self.pendingTerminalByteEndSeqBySurfaceID = [:]
+        self.terminalActiveScreenBySurfaceID = [:]
         self.terminalReplaySurfaceIDsInFlight = []
         self.terminalOutputTransport = .rawBytes
         self.terminalByteContinuationsBySurfaceID = [:]
@@ -4865,6 +4890,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func resetTerminalOutputTracking() {
         deliveredTerminalByteEndSeqBySurfaceID = [:]
         pendingTerminalByteEndSeqBySurfaceID = [:]
+        terminalActiveScreenBySurfaceID = [:]
         terminalReplaySurfaceIDsInFlight = []
         terminalOutputQueuesBySurfaceID = [:]
         terminalOutputStreamTokensBySurfaceID = terminalOutputStreamTokensBySurfaceID.mapValues { _ in UUID() }
@@ -5727,9 +5753,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // provider and no-ops once an identity is adopted).
             scheduleHostIdentityAdoptionIfNeeded(client: client)
             let transport: TerminalOutputTransport = payload.capabilities.contains(Self.terminalRenderGridCapability) ||
-                payload.terminalFidelity == "render_grid" ? .renderGrid : .rawBytes
+                payload.terminalFidelity == "render_grid" ? .hybrid : .rawBytes
             terminalOutputTransport = transport
-            MobileDebugLog.anchormux("sync.transport=\(transport == .renderGrid ? "render_grid" : "raw_bytes")")
+            MobileDebugLog.anchormux("sync.transport=\(transport.debugName)")
             return transport
         } catch {
             guard remoteClient === client else { return fallback }
@@ -6165,7 +6191,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         let localSeq = deliveredTerminalByteEndSeqBySurfaceID[surfaceID] ?? 0
         guard remoteSeq > localSeq else { return }
-        if terminalOutputTransport == .renderGrid,
+        if terminalOutputTransport.usesRenderGrid,
            terminalEventListenerTask != nil {
             let pendingSeq = pendingTerminalByteEndSeqBySurfaceID[surfaceID]
             pendingTerminalByteEndSeqBySurfaceID[surfaceID] = max(remoteSeq, pendingSeq ?? 0)
@@ -6215,6 +6241,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
+    private func shouldDeliverRenderGridEvent(_ renderGrid: MobileTerminalRenderGridFrame) -> Bool {
+        let previous = terminalActiveScreenBySurfaceID[renderGrid.surfaceID]
+        terminalActiveScreenBySurfaceID[renderGrid.surfaceID] = renderGrid.activeScreen
+        guard terminalOutputTransport == .hybrid,
+              renderGrid.activeScreen == .primary else {
+            return true
+        }
+        return previous == .alternate
+    }
+
     func deliverAuthoritativeTerminalRenderGrid(
         _ renderGrid: MobileTerminalRenderGridFrame,
         expectedSurfaceID: String? = nil,
@@ -6222,6 +6258,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ) {
         guard expectedSurfaceID == nil || renderGrid.surfaceID == expectedSurfaceID,
               hasTerminalOutputSink(surfaceID: renderGrid.surfaceID) else {
+            return
+        }
+        guard source != "event" || shouldDeliverRenderGridEvent(renderGrid) else {
+            MobileDebugLog.anchormux(
+                "sync.render_grid_advisory source=\(source) surface=\(renderGrid.surfaceID) screen=\(renderGrid.activeScreen.rawValue) seq=\(renderGrid.stateSeq)"
+            )
             return
         }
         if let deliveredSeq = deliveredTerminalByteEndSeqBySurfaceID[renderGrid.surfaceID],
@@ -6270,6 +6312,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalScrollbackPrefetchStatesBySurfaceID.removeValue(forKey: surfaceID)
         deliveredTerminalByteEndSeqBySurfaceID.removeValue(forKey: surfaceID)
         pendingTerminalByteEndSeqBySurfaceID.removeValue(forKey: surfaceID)
+        terminalActiveScreenBySurfaceID.removeValue(forKey: surfaceID)
         // Tell the Mac this device is no longer viewing the surface so it stops
         // pinning the shared grid to our viewport and clears the macOS border.
         clearTerminalViewport(surfaceID: surfaceID)
@@ -6456,6 +6499,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     self.markTerminalBytesDelivered(surfaceID: surfaceID, endSeq: replaySeq)
                 }
                 if let renderGrid {
+                    self.terminalActiveScreenBySurfaceID[surfaceID] = renderGrid.activeScreen
                     self.deliverTerminalRenderGrid(renderGrid, surfaceID: surfaceID)
                     return
                 }
@@ -6557,6 +6601,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let debugSeq = payload.sequence ?? 0
         mobileShellLog.info("CMUX_REPLAY live bytes surface=\(surfaceID, privacy: .public) byteCount=\(bytes.count, privacy: .public) seq=\(debugSeq, privacy: .public) hasSink=\(self.hasTerminalOutputSink(surfaceID: surfaceID), privacy: .public)")
         #endif
+        if terminalOutputTransport == .hybrid,
+           terminalActiveScreenBySurfaceID[surfaceID] == .alternate {
+            MobileDebugLog.anchormux("sync.bytes_suppressed_alt surface=\(surfaceID) bytes=\(bytes.count)")
+            return
+        }
         guard let seq = payload.sequence else {
             deliverTerminalBytes(bytes, surfaceID: surfaceID)
             return

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -82,6 +82,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private static let storedMacReconnectRestoringDeadlineSeconds: Double = 6
 
     private static let terminalRenderGridCapability = "terminal.render_grid.v1"
+    private static let terminalBytesCapability = "terminal.bytes.v1"
     private static let workspaceActionsCapability = "workspace.actions.v1"
     private static let workspaceReadStateCapability = "workspace.read_state.v1"
     private static let workspaceCloseCapability = "workspace.close.v1"
@@ -5792,8 +5793,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // applying, run the dedicated recovery (it re-asks the token
             // provider and no-ops once an identity is adopted).
             scheduleHostIdentityAdoptionIfNeeded(client: client)
-            let transport: TerminalOutputTransport = payload.capabilities.contains(Self.terminalRenderGridCapability) ||
-                payload.terminalFidelity == "render_grid" ? .hybrid : .rawBytes
+            let supportsRenderGrid = payload.capabilities.contains(Self.terminalRenderGridCapability) ||
+                payload.terminalFidelity == "render_grid"
+            let supportsTerminalBytes = payload.capabilities.contains(Self.terminalBytesCapability)
+            let transport: TerminalOutputTransport
+            if supportsRenderGrid, supportsTerminalBytes {
+                transport = .hybrid
+            } else if supportsRenderGrid {
+                transport = .renderGrid
+            } else {
+                transport = .rawBytes
+            }
             terminalOutputTransport = transport
             MobileDebugLog.anchormux("sync.transport=\(transport.debugName)")
             return transport
@@ -6283,7 +6293,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private enum RenderGridEventDeliveryDecision {
         case deliver
-        case advisory(requestReplay: Bool)
+        case advisory(requestReplay: Bool, updateTrackedScreen: Bool, deliverViewportPolicy: Bool)
     }
 
     private func renderGridEventDeliveryDecision(
@@ -6295,9 +6305,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return .deliver
         }
         guard previous == .alternate else {
-            return .advisory(requestReplay: false)
+            return .advisory(requestReplay: false, updateTrackedScreen: true, deliverViewportPolicy: true)
         }
-        return renderGrid.full ? .deliver : .advisory(requestReplay: true)
+        guard !renderGrid.full else { return .deliver }
+        let hasRowDelta = renderGrid.rowSpans.isEmpty == false || renderGrid.clearedRows.isEmpty == false
+        return .advisory(requestReplay: hasRowDelta, updateTrackedScreen: false, deliverViewportPolicy: false)
     }
 
     func deliverAuthoritativeTerminalRenderGrid(
@@ -6324,13 +6336,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         case .deliver:
             terminalActiveScreenBySurfaceID[renderGrid.surfaceID] = renderGrid.activeScreen
             break
-        case .advisory(let requestReplay):
-            if !requestReplay {
+        case .advisory(let requestReplay, let updateTrackedScreen, let deliverViewportPolicy):
+            if updateTrackedScreen {
                 terminalActiveScreenBySurfaceID[renderGrid.surfaceID] = renderGrid.activeScreen
             }
-            deliverTerminalViewportPolicy(renderGrid.mobileViewportPolicy, surfaceID: renderGrid.surfaceID)
+            if deliverViewportPolicy {
+                deliverTerminalViewportPolicy(renderGrid.mobileViewportPolicy, surfaceID: renderGrid.surfaceID)
+            }
             MobileDebugLog.anchormux(
-                "sync.render_grid_advisory source=\(source) surface=\(renderGrid.surfaceID) screen=\(renderGrid.activeScreen.rawValue) seq=\(renderGrid.stateSeq) requestReplay=\(requestReplay)"
+                "sync.render_grid_advisory source=\(source) surface=\(renderGrid.surfaceID) screen=\(renderGrid.activeScreen.rawValue) seq=\(renderGrid.stateSeq) requestReplay=\(requestReplay) updateTrackedScreen=\(updateTrackedScreen) deliverViewportPolicy=\(deliverViewportPolicy)"
             )
             if requestReplay {
                 requestTerminalReplay(surfaceID: renderGrid.surfaceID)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTerminalRenderGridFrame+TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileTerminalRenderGridFrame+TerminalOutputDelivery.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxMobileShellModel
 
 extension MobileTerminalRenderGridFrame {
     /// True when this delta fully replaces the visible viewport without needing
@@ -11,5 +12,14 @@ extension MobileTerminalRenderGridFrame {
             return false
         }
         return true
+    }
+
+    var mobileViewportPolicy: MobileTerminalOutputViewportPolicy {
+        switch activeScreen {
+        case .alternate:
+            return .remoteGrid(columns: columns, rows: rows)
+        case .primary:
+            return .natural
+        }
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxMobileShellModel
 import Foundation
 
 /// One terminal-output chunk waiting to be applied by a mounted mobile surface.
@@ -10,15 +11,26 @@ struct TerminalOutputDelivery: Equatable, Sendable {
 
     private var payload: Payload
     var replaceable: Bool
+    var viewportPolicy: MobileTerminalOutputViewportPolicy?
 
-    init(bytes: Data, replaceable: Bool) {
+    init(
+        bytes: Data,
+        replaceable: Bool,
+        viewportPolicy: MobileTerminalOutputViewportPolicy? = nil
+    ) {
         self.payload = .bytes(bytes)
         self.replaceable = replaceable
+        self.viewportPolicy = viewportPolicy
     }
 
-    init(renderGrid frame: MobileTerminalRenderGridFrame, replaceable: Bool) {
+    init(
+        renderGrid frame: MobileTerminalRenderGridFrame,
+        replaceable: Bool,
+        viewportPolicy: MobileTerminalOutputViewportPolicy? = nil
+    ) {
         self.payload = .renderGrid(frame)
         self.replaceable = replaceable
+        self.viewportPolicy = viewportPolicy
     }
 
     var bytes: Data {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
@@ -4,32 +4,44 @@ import Foundation
 
 /// One terminal-output chunk waiting to be applied by a mounted mobile surface.
 struct TerminalOutputDelivery: Equatable, Sendable {
+    enum ReplacementScope: Equatable, Sendable {
+        case byteViewport
+        case renderGridViewport
+        case viewportPolicy
+    }
+
     private enum Payload: Equatable, Sendable {
         case bytes(Data)
         case renderGrid(MobileTerminalRenderGridFrame)
     }
 
     private var payload: Payload
-    var replaceable: Bool
+    var replacementScope: ReplacementScope?
     var viewportPolicy: MobileTerminalOutputViewportPolicy?
+
+    var replaceable: Bool {
+        replacementScope != nil
+    }
 
     init(
         bytes: Data,
         replaceable: Bool,
+        replacementScope: ReplacementScope? = nil,
         viewportPolicy: MobileTerminalOutputViewportPolicy? = nil
     ) {
         self.payload = .bytes(bytes)
-        self.replaceable = replaceable
+        self.replacementScope = replaceable ? (replacementScope ?? .byteViewport) : nil
         self.viewportPolicy = viewportPolicy
     }
 
     init(
         renderGrid frame: MobileTerminalRenderGridFrame,
         replaceable: Bool,
+        replacementScope: ReplacementScope? = nil,
         viewportPolicy: MobileTerminalOutputViewportPolicy? = nil
     ) {
         self.payload = .renderGrid(frame)
-        self.replaceable = replaceable
+        self.replacementScope = replaceable ? (replacementScope ?? .renderGridViewport) : nil
         self.viewportPolicy = viewportPolicy
     }
 
@@ -95,10 +107,10 @@ struct TerminalOutputDeliveryQueue: Sendable {
     }
 
     private mutating func appendPending(_ delivery: TerminalOutputDelivery) {
-        if delivery.replaceable,
+        if let replacementScope = delivery.replacementScope,
            let lastIndex = pending.indices.last,
            lastIndex >= pendingHeadIndex,
-           pending[lastIndex].replaceable {
+           pending[lastIndex].replacementScope == replacementScope {
             pending[lastIndex] = delivery
         } else {
             pending.append(delivery)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -352,13 +352,15 @@ func renderGridEventFrame(
     surfaceID: String,
     seq: UInt64,
     text: String,
-    activeScreen: MobileTerminalRenderGridFrame.Screen = .primary
+    activeScreen: MobileTerminalRenderGridFrame.Screen = .primary,
+    full: Bool = true
 ) throws -> Data {
     let frame = try MobileTerminalRenderGridFrame(
         surfaceID: surfaceID,
         stateSeq: seq,
         columns: 16,
         rows: 4,
+        full: full,
         rowSpans: [
             MobileTerminalRenderGridFrame.RowSpan(
                 row: 0,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -1,5 +1,6 @@
 import CMUXMobileCore
 import CmuxMobileRPC
+import CmuxMobileShellModel
 import Foundation
 import Testing
 @testable import CmuxMobileShell
@@ -73,6 +74,13 @@ actor LivenessHostRouter {
 
     func count(of method: String) -> Int {
         recorded.filter { $0.method == method }.count
+    }
+
+    func topics(for method: String) -> [[String]] {
+        recorded.compactMap { request in
+            guard request.method == method else { return nil }
+            return request.topics
+        }
     }
 
     func setCapabilities(_ capabilities: [String]) {
@@ -290,12 +298,14 @@ actor LivenessTransport: CmxByteTransport {
 @MainActor
 final class OutputCollector {
     private(set) var lines: [String] = []
+    private(set) var viewportPolicies: [MobileTerminalOutputViewportPolicy?] = []
     private var task: Task<Void, Never>?
 
     func mount(store: MobileShellComposite, surfaceID: String) {
         task = Task { @MainActor [weak self] in
             for await chunk in store.terminalOutputStream(surfaceID: surfaceID) {
                 self?.lines.append(String(decoding: chunk.data, as: UTF8.self))
+                self?.viewportPolicies.append(chunk.viewportPolicy)
                 store.terminalOutputDidProcess(
                     surfaceID: surfaceID,
                     streamToken: chunk.streamToken
@@ -338,13 +348,26 @@ func attachURL(for ticket: CmxAttachTicket) throws -> String {
     return "cmux-ios://attach?v=\(ticket.version)&payload=\(payload)"
 }
 
-func renderGridEventFrame(surfaceID: String, seq: UInt64, text: String) throws -> Data {
-    let frame = try MobileTerminalRenderGridFrame.fromPlainRows(
+func renderGridEventFrame(
+    surfaceID: String,
+    seq: UInt64,
+    text: String,
+    activeScreen: MobileTerminalRenderGridFrame.Screen = .primary
+) throws -> Data {
+    let frame = try MobileTerminalRenderGridFrame(
         surfaceID: surfaceID,
         stateSeq: seq,
         columns: 16,
         rows: 4,
-        text: text
+        rowSpans: [
+            MobileTerminalRenderGridFrame.RowSpan(
+                row: 0,
+                column: 0,
+                styleID: 0,
+                text: text
+            ),
+        ],
+        activeScreen: activeScreen
     )
     let envelope: [String: Any] = [
         "kind": "event",

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -66,7 +66,7 @@ actor LivenessHostRouter {
     private var holdSubscribe = false
     private var hasActiveSubscription = false
     private var heldContinuations: [CheckedContinuation<Void, Never>] = []
-    private var capabilities = ["events.v1", "terminal.render_grid.v1", "terminal.replay.v1"]
+    private var capabilities = ["events.v1", "terminal.bytes.v1", "terminal.render_grid.v1", "terminal.replay.v1"]
 
     func record(method: String?, topics: [String]?) {
         recorded.append(RecordedRequest(method: method, topics: topics))
@@ -388,6 +388,29 @@ func terminalBytesEventFrame(surfaceID: String, seq: UInt64, text: String) throw
             "seq": seq,
             "data_b64": Data(text.utf8).base64EncodedString(),
         ],
+    ]
+    return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
+}
+
+func emptyRenderGridEventFrame(
+    surfaceID: String,
+    seq: UInt64,
+    activeScreen: MobileTerminalRenderGridFrame.Screen,
+    full: Bool = false
+) throws -> Data {
+    let frame = try MobileTerminalRenderGridFrame(
+        surfaceID: surfaceID,
+        stateSeq: seq,
+        columns: 16,
+        rows: 4,
+        full: full,
+        rowSpans: [],
+        activeScreen: activeScreen
+    )
+    let envelope: [String: Any] = [
+        "kind": "event",
+        "topic": "terminal.render_grid",
+        "payload": try frame.jsonObject(),
     ]
     return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -354,6 +354,19 @@ func renderGridEventFrame(surfaceID: String, seq: UInt64, text: String) throws -
     return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
 }
 
+func terminalBytesEventFrame(surfaceID: String, seq: UInt64, text: String) throws -> Data {
+    let envelope: [String: Any] = [
+        "kind": "event",
+        "topic": "terminal.bytes",
+        "payload": [
+            "surface_id": surfaceID,
+            "seq": seq,
+            "data_b64": Data(text.utf8).base64EncodedString(),
+        ],
+    ]
+    return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
+}
+
 /// Poll until `condition` is true, bounded at `attempts` x 10ms. Returns the
 /// final value so tests can assert both presence and (bounded) absence.
 @MainActor

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -171,6 +171,10 @@ actor LivenessHostRouter {
             ])
         case "mobile.events.unsubscribe", "mobile.terminal.replay", "mobile.terminal.viewport":
             return try? Self.resultFrame(id: id, result: [:])
+        case "terminal.input":
+            return try? Self.resultFrame(id: id, result: [
+                "terminal_seq": 100,
+            ])
         default:
             return try? Self.errorFrame(id: id, message: "Unexpected method \(method ?? "nil")")
         }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -144,6 +144,37 @@ import Testing
 }
 
 @MainActor
+@Test func hybridPrimaryInputBehindRequestsReplayInsteadOfWaitingOnAdvisoryRenderGrid() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+
+    let collector = OutputCollector()
+    collector.mount(store: store, surfaceID: "live-terminal")
+    let sawReplay = try await pollUntil { await router.count(of: "mobile.terminal.replay") >= 1 }
+    #expect(sawReplay, "mounting a sink must arm the cold-attach replay")
+    let replayCountAfterMount = await router.count(of: "mobile.terminal.replay")
+    let transport = try #require(box.get())
+
+    await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 0, text: "raw"))
+    let rawDelivered = try await pollUntil { collector.lines.contains { $0.contains("raw") } }
+    #expect(rawDelivered)
+
+    await store.submitTerminalRawInput(Data("x".utf8), surfaceID: "live-terminal")
+    let inputSent = try await pollUntil { await router.count(of: "terminal.input") >= 1 }
+    #expect(inputSent)
+    let replayRequested = try await pollUntil {
+        await router.count(of: "mobile.terminal.replay") > replayCountAfterMount
+    }
+    #expect(
+        replayRequested,
+        "hybrid primary output is advanced by terminal.bytes, so input recovery must request replay instead of waiting on advisory render-grid frames"
+    )
+    collector.unmount()
+}
+
+@MainActor
 @Test func alternateRenderGridPinsGridAndSuppressesRawBytes() async throws {
     let clock = TestClock()
     let router = LivenessHostRouter()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -88,6 +88,30 @@ import Testing
 }
 
 @MainActor
+@Test func renderGridOnlyHostKeepsPrimaryRenderGridDelivery() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    await router.setCapabilities(["events.v1", "terminal.render_grid.v1", "terminal.replay.v1"])
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+    #expect(store.connectionState == .connected)
+
+    let sawSubscribe = try await pollUntil { await router.count(of: "mobile.events.subscribe") >= 1 }
+    #expect(sawSubscribe, "listener must request the server-side subscription")
+    let topics = await router.topics(for: "mobile.events.subscribe").last ?? []
+    #expect(topics.contains("terminal.render_grid"))
+    #expect(topics.contains("terminal.bytes") == false)
+
+    let collector = OutputCollector()
+    collector.mount(store: store, surfaceID: "live-terminal")
+    let transport = try #require(box.get())
+    await transport.deliver(try renderGridEventFrame(surfaceID: "live-terminal", seq: 3, text: "grid-only"))
+    let gridDelivered = try await pollUntil { collector.lines.contains { $0.contains("grid-only") } }
+    #expect(gridDelivered, "render-grid-only hosts must keep painting primary render-grid frames")
+    collector.unmount()
+}
+
+@MainActor
 @Test func primaryRenderGridEventDoesNotPreemptRawBytes() async throws {
     let clock = TestClock()
     let router = LivenessHostRouter()
@@ -248,10 +272,13 @@ import Testing
         await router.count(of: "mobile.terminal.replay") > replayCountAfterMount
     }
     #expect(replayRequested, "a primary delta cannot switch the local surface out of alternate-screen mode; request a full replay instead")
-    #expect(collector.viewportPolicies.last == .natural)
     #expect(
         collector.lines.contains { $0.contains("primary-delta") } == false,
         "the alternate-to-primary transition must not be painted with a delta patch"
+    )
+    #expect(
+        collector.viewportPolicies.last == .remoteGrid(columns: 16, rows: 4),
+        "a primary delta must not clear the remote-grid pin before the full replay restores primary"
     )
 
     await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 7, text: "raw-after-delta"))
@@ -263,6 +290,55 @@ import Testing
     #expect(
         collector.lines.contains { $0.contains("raw-after-delta") } == false,
         "raw bytes must stay suppressed until a full primary restore switches the local surface out of alternate-screen mode"
+    )
+    #expect(collector.viewportPolicies.last == .natural)
+    collector.unmount()
+}
+
+@MainActor
+@Test func emptyPrimaryDeltaWhileAlternateDoesNotReplayOrChangeViewportPolicy() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+
+    let collector = OutputCollector()
+    collector.mount(store: store, surfaceID: "live-terminal")
+    let sawReplay = try await pollUntil { await router.count(of: "mobile.terminal.replay") >= 1 }
+    #expect(sawReplay, "mounting a sink must arm the cold-attach replay")
+    let replayCountAfterMount = await router.count(of: "mobile.terminal.replay")
+    let transport = try #require(box.get())
+
+    await transport.deliver(try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 3,
+        text: "alt",
+        activeScreen: .alternate
+    ))
+    let altDelivered = try await pollUntil { collector.viewportPolicies.last == .remoteGrid(columns: 16, rows: 4) }
+    #expect(altDelivered)
+
+    await transport.deliver(try emptyRenderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 6,
+        activeScreen: .primary
+    ))
+    await transport.deliver(try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 7,
+        text: "still-alt",
+        activeScreen: .alternate
+    ))
+    let laterAltDelivered = try await pollUntil { collector.lines.contains { $0.contains("still-alt") } }
+    #expect(laterAltDelivered)
+    let replayCountAfterEmptyDelta = await router.count(of: "mobile.terminal.replay")
+    #expect(
+        replayCountAfterEmptyDelta == replayCountAfterMount,
+        "empty or cursor-only primary deltas while alternate is active must not create replay storms"
+    )
+    #expect(
+        collector.viewportPolicies.last == .remoteGrid(columns: 16, rows: 4),
+        "empty primary deltas while alternate is active must not flicker the surface back to natural sizing"
     )
     collector.unmount()
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -52,7 +52,12 @@ import Testing
     // still pending (the server-side subscription from a previous generation
     // keeps pushing across re-subscribes; the ack is an enable handshake,
     // not a delivery precondition).
-    let event = try renderGridEventFrame(surfaceID: "live-terminal", seq: 5, text: "live")
+    let event = try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 5,
+        text: "live",
+        activeScreen: .alternate
+    )
     let transport = try #require(box.get())
     await transport.deliver(event)
 
@@ -65,6 +70,21 @@ import Testing
 
     await router.releaseAllHeld()
     collector.unmount()
+}
+
+@MainActor
+@Test func renderGridCapableHostUsesHybridTerminalOutputSubscription() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+    #expect(store.connectionState == .connected)
+
+    let sawSubscribe = try await pollUntil { await router.count(of: "mobile.events.subscribe") >= 1 }
+    #expect(sawSubscribe, "listener must request the server-side subscription")
+    let topics = await router.topics(for: "mobile.events.subscribe").last ?? []
+    #expect(topics.contains("terminal.bytes"))
+    #expect(topics.contains("terminal.render_grid"))
 }
 
 @MainActor
@@ -87,6 +107,66 @@ import Testing
     await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 0, text: "raw"))
     let rawDelivered = try await pollUntil { collector.lines.contains { $0.contains("raw") } }
     #expect(rawDelivered, "advisory primary render-grid must not advance delivered seq and starve overlapping raw bytes")
+    #expect(collector.viewportPolicies.last == .natural)
+    collector.unmount()
+}
+
+@MainActor
+@Test func alternateRenderGridPinsGridAndSuppressesRawBytes() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+
+    let collector = OutputCollector()
+    collector.mount(store: store, surfaceID: "live-terminal")
+    let sawReplay = try await pollUntil { await router.count(of: "mobile.terminal.replay") >= 1 }
+    #expect(sawReplay, "mounting a sink must arm the cold-attach replay")
+    let transport = try #require(box.get())
+
+    await transport.deliver(try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 3,
+        text: "alt",
+        activeScreen: .alternate
+    ))
+    let altDelivered = try await pollUntil { collector.lines.contains { $0.contains("alt") } }
+    #expect(altDelivered, "alternate-screen frames must still render through authoritative render-grid replay")
+    #expect(collector.viewportPolicies.last == .remoteGrid(columns: 16, rows: 4))
+
+    let deliveredCount = collector.lines.count
+    await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 3, text: "dup"))
+    let duplicateDelivered = try await pollUntil(attempts: 30) { collector.lines.count > deliveredCount }
+    #expect(duplicateDelivered == false, "raw bytes are suppressed while the authoritative screen is alternate")
+    collector.unmount()
+}
+
+@MainActor
+@Test func primaryRenderGridAfterAlternateClearsRemoteGrid() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+
+    let collector = OutputCollector()
+    collector.mount(store: store, surfaceID: "live-terminal")
+    let sawReplay = try await pollUntil { await router.count(of: "mobile.terminal.replay") >= 1 }
+    #expect(sawReplay, "mounting a sink must arm the cold-attach replay")
+    let transport = try #require(box.get())
+
+    await transport.deliver(try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 3,
+        text: "alt",
+        activeScreen: .alternate
+    ))
+    let altDelivered = try await pollUntil { collector.viewportPolicies.last == .remoteGrid(columns: 16, rows: 4) }
+    #expect(altDelivered)
+
+    await transport.deliver(try renderGridEventFrame(surfaceID: "live-terminal", seq: 6, text: "shell"))
+    let primaryDelivered = try await pollUntil { collector.lines.contains { $0.contains("shell") } }
+    #expect(primaryDelivered, "the first primary frame after alternate must restore the primary screen")
+    #expect(collector.viewportPolicies.last == .natural)
     collector.unmount()
 }
 
@@ -138,7 +218,12 @@ import Testing
 
     // The stream was never restarted: the original subscription still
     // delivers straight into the mounted sink.
-    let event = try renderGridEventFrame(surfaceID: "live-terminal", seq: 9, text: "still-alive")
+    let event = try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 9,
+        text: "still-alive",
+        activeScreen: .alternate
+    )
     let transport = try #require(box.get())
     await transport.deliver(event)
     let delivered = try await pollUntil { collector.lines.isEmpty == false }
@@ -191,7 +276,12 @@ import Testing
     #expect(workspaceRefetched, "the repaired subscription also carries workspace.updated, so the workspace list must be re-fetched")
 
     // The repaired stream delivers straight into the still-mounted sink.
-    let event = try renderGridEventFrame(surfaceID: "live-terminal", seq: 11, text: "repaired")
+    let event = try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 11,
+        text: "repaired",
+        activeScreen: .alternate
+    )
     let transport = try #require(box.get())
     await transport.deliver(event)
     let delivered = try await pollUntil { collector.lines.contains { $0.contains("repaired") } }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -296,7 +296,7 @@ import Testing
 }
 
 @MainActor
-@Test func emptyPrimaryDeltaWhileAlternateDoesNotReplayOrChangeViewportPolicy() async throws {
+@Test func emptyPrimaryDeltaWhileAlternateRequestsOneReplayAndKeepsRemoteGridUntilFullRestore() async throws {
     let clock = TestClock()
     let router = LivenessHostRouter()
     let box = TransportBox()
@@ -323,23 +323,45 @@ import Testing
         seq: 6,
         activeScreen: .primary
     ))
-    await transport.deliver(try renderGridEventFrame(
+    await transport.deliver(try emptyRenderGridEventFrame(
         surfaceID: "live-terminal",
         seq: 7,
+        activeScreen: .primary
+    ))
+    let replayRequested = try await pollUntil {
+        await router.count(of: "mobile.terminal.replay") > replayCountAfterMount
+    }
+    #expect(
+        replayRequested,
+        "an empty primary transition while alternate is active is ambiguous; request one full replay instead of dropping later primary bytes indefinitely"
+    )
+    let replayCountAfterRepeatedEmptyDelta = await router.count(of: "mobile.terminal.replay")
+    #expect(
+        replayCountAfterRepeatedEmptyDelta == replayCountAfterMount + 1,
+        "repeated empty primary deltas must be bounded by the replay in-flight guard"
+    )
+    await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 8, text: "raw-before-full"))
+    await transport.deliver(try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 9,
         text: "still-alt",
         activeScreen: .alternate
     ))
     let laterAltDelivered = try await pollUntil { collector.lines.contains { $0.contains("still-alt") } }
     #expect(laterAltDelivered)
-    let replayCountAfterEmptyDelta = await router.count(of: "mobile.terminal.replay")
-    #expect(
-        replayCountAfterEmptyDelta == replayCountAfterMount,
-        "empty or cursor-only primary deltas while alternate is active must not create replay storms"
-    )
     #expect(
         collector.viewportPolicies.last == .remoteGrid(columns: 16, rows: 4),
         "empty primary deltas while alternate is active must not flicker the surface back to natural sizing"
     )
+    #expect(
+        collector.lines.contains { $0.contains("raw-before-full") } == false,
+        "raw bytes stay suppressed until a full primary replay restores the local surface"
+    )
+
+    await transport.deliver(try renderGridEventFrame(surfaceID: "live-terminal", seq: 10, text: "primary-full"))
+    let fullPrimaryDelivered = try await pollUntil { collector.lines.contains { $0.contains("primary-full") } }
+    #expect(fullPrimaryDelivered)
+    #expect(collector.viewportPolicies.last == .natural)
     collector.unmount()
 }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -101,16 +101,20 @@ import Testing
     let transport = try #require(box.get())
 
     await transport.deliver(try renderGridEventFrame(surfaceID: "live-terminal", seq: 3, text: "grid"))
-    let gridDelivered = try await pollUntil(attempts: 30) { collector.lines.contains { $0.contains("grid") } }
-    #expect(gridDelivered == false, "primary render-grid events are advisory in hybrid mode; raw bytes own full-height primary rendering")
+    let policyDelivered = try await pollUntil { collector.viewportPolicies.last == .natural }
+    #expect(policyDelivered, "advisory primary render-grid events must still deliver their viewport policy")
     #expect(
-        collector.viewportPolicies.last == .natural,
-        "advisory primary render-grid events must still clear any stale remote-grid pin so primary output can use the phone's full height"
+        collector.lines.contains { $0.contains("grid") } == false,
+        "primary render-grid events are advisory in hybrid mode; raw bytes own full-height primary rendering"
     )
 
     await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 0, text: "raw"))
     let rawDelivered = try await pollUntil { collector.lines.contains { $0.contains("raw") } }
     #expect(rawDelivered, "advisory primary render-grid must not advance delivered seq and starve overlapping raw bytes")
+    #expect(
+        collector.lines.contains { $0.contains("grid") } == false,
+        "primary render-grid events are advisory in hybrid mode; raw bytes own full-height primary rendering"
+    )
     #expect(collector.viewportPolicies.last == .natural)
     collector.unmount()
 }
@@ -140,8 +144,44 @@ import Testing
 
     let deliveredCount = collector.lines.count
     await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 3, text: "dup"))
-    let duplicateDelivered = try await pollUntil(attempts: 30) { collector.lines.count > deliveredCount }
-    #expect(duplicateDelivered == false, "raw bytes are suppressed while the authoritative screen is alternate")
+    await transport.deliver(try renderGridEventFrame(surfaceID: "live-terminal", seq: 6, text: "primary"))
+    let primaryDelivered = try await pollUntil { collector.lines.contains { $0.contains("primary") } }
+    #expect(primaryDelivered)
+    #expect(collector.lines.count == deliveredCount + 1)
+    #expect(
+        collector.lines.contains { $0.contains("dup") } == false,
+        "raw bytes are suppressed while the authoritative screen is alternate"
+    )
+    collector.unmount()
+}
+
+@MainActor
+@Test func staleAlternateRenderGridDoesNotSuppressPrimaryRawBytes() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+
+    let collector = OutputCollector()
+    collector.mount(store: store, surfaceID: "live-terminal")
+    let sawReplay = try await pollUntil { await router.count(of: "mobile.terminal.replay") >= 1 }
+    #expect(sawReplay, "mounting a sink must arm the cold-attach replay")
+    let transport = try #require(box.get())
+
+    await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 0, text: "raw-a"))
+    let firstRawDelivered = try await pollUntil { collector.lines.contains { $0.contains("raw-a") } }
+    #expect(firstRawDelivered)
+
+    await transport.deliver(try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 1,
+        text: "stale-alt",
+        activeScreen: .alternate
+    ))
+    await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 5, text: "raw-b"))
+    let secondRawDelivered = try await pollUntil { collector.lines.contains { $0.contains("raw-b") } }
+    #expect(secondRawDelivered, "a stale alternate render-grid frame must not flip active-screen state and suppress later primary bytes")
+    #expect(collector.lines.contains { $0.contains("stale-alt") } == false)
     collector.unmount()
 }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -214,6 +214,48 @@ import Testing
     collector.unmount()
 }
 
+@MainActor
+@Test func primaryDeltaAfterAlternateRequestsReplayInsteadOfPatchingAlternateScreen() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+
+    let collector = OutputCollector()
+    collector.mount(store: store, surfaceID: "live-terminal")
+    let sawReplay = try await pollUntil { await router.count(of: "mobile.terminal.replay") >= 1 }
+    #expect(sawReplay, "mounting a sink must arm the cold-attach replay")
+    let replayCountAfterMount = await router.count(of: "mobile.terminal.replay")
+    let transport = try #require(box.get())
+
+    await transport.deliver(try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 3,
+        text: "alt",
+        activeScreen: .alternate
+    ))
+    let altDelivered = try await pollUntil { collector.viewportPolicies.last == .remoteGrid(columns: 16, rows: 4) }
+    #expect(altDelivered)
+
+    await transport.deliver(try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 6,
+        text: "primary-delta",
+        activeScreen: .primary,
+        full: false
+    ))
+    let replayRequested = try await pollUntil {
+        await router.count(of: "mobile.terminal.replay") > replayCountAfterMount
+    }
+    #expect(replayRequested, "a primary delta cannot switch the local surface out of alternate-screen mode; request a full replay instead")
+    #expect(collector.viewportPolicies.last == .natural)
+    #expect(
+        collector.lines.contains { $0.contains("primary-delta") } == false,
+        "the alternate-to-primary transition must not be painted with a delta patch"
+    )
+    collector.unmount()
+}
+
 /// A healthy idle stream produces zero events (the Mac dedupes unchanged
 /// frames), so silence alone must not tear the subscription down. The
 /// watchdog may verify the silence with a bounded idempotent re-subscribe

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -253,6 +253,17 @@ import Testing
         collector.lines.contains { $0.contains("primary-delta") } == false,
         "the alternate-to-primary transition must not be painted with a delta patch"
     )
+
+    await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 7, text: "raw-after-delta"))
+    await transport.deliver(try renderGridEventFrame(surfaceID: "live-terminal", seq: 8, text: "primary-full"))
+    let fullPrimaryDelivered = try await pollUntil {
+        collector.lines.contains { $0.contains("primary-full") }
+    }
+    #expect(fullPrimaryDelivered)
+    #expect(
+        collector.lines.contains { $0.contains("raw-after-delta") } == false,
+        "raw bytes must stay suppressed until a full primary restore switches the local surface out of alternate-screen mode"
+    )
     collector.unmount()
 }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -103,6 +103,10 @@ import Testing
     await transport.deliver(try renderGridEventFrame(surfaceID: "live-terminal", seq: 3, text: "grid"))
     let gridDelivered = try await pollUntil(attempts: 30) { collector.lines.contains { $0.contains("grid") } }
     #expect(gridDelivered == false, "primary render-grid events are advisory in hybrid mode; raw bytes own full-height primary rendering")
+    #expect(
+        collector.viewportPolicies.last == .natural,
+        "advisory primary render-grid events must still clear any stale remote-grid pin so primary output can use the phone's full height"
+    )
 
     await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 0, text: "raw"))
     let rawDelivered = try await pollUntil { collector.lines.contains { $0.contains("raw") } }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -67,6 +67,29 @@ import Testing
     collector.unmount()
 }
 
+@MainActor
+@Test func primaryRenderGridEventDoesNotPreemptRawBytes() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+
+    let collector = OutputCollector()
+    collector.mount(store: store, surfaceID: "live-terminal")
+    let sawReplay = try await pollUntil { await router.count(of: "mobile.terminal.replay") >= 1 }
+    #expect(sawReplay, "mounting a sink must arm the cold-attach replay")
+    let transport = try #require(box.get())
+
+    await transport.deliver(try renderGridEventFrame(surfaceID: "live-terminal", seq: 3, text: "grid"))
+    let gridDelivered = try await pollUntil(attempts: 30) { collector.lines.contains { $0.contains("grid") } }
+    #expect(gridDelivered == false, "primary render-grid events are advisory in hybrid mode; raw bytes own full-height primary rendering")
+
+    await transport.deliver(try terminalBytesEventFrame(surfaceID: "live-terminal", seq: 0, text: "raw"))
+    let rawDelivered = try await pollUntil { collector.lines.contains { $0.contains("raw") } }
+    #expect(rawDelivered, "advisory primary render-grid must not advance delivered seq and starve overlapping raw bytes")
+    collector.unmount()
+}
+
 /// A healthy idle stream produces zero events (the Mac dedupes unchanged
 /// frames), so silence alone must not tear the subscription down. The
 /// watchdog may verify the silence with a bounded idempotent re-subscribe

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
@@ -90,6 +90,38 @@ import Testing
     #expect(!vt.contains("old"))
 }
 
+@Test func terminalOutputQueueDoesNotReplaceRenderGridSnapshotWithPolicyOnlyDelivery() throws {
+    var queue = TerminalOutputDeliveryQueue()
+    let inFlight = TerminalOutputDelivery(bytes: Data("in-flight".utf8), replaceable: false)
+    let frame = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: "terminal",
+        stateSeq: 1,
+        columns: 12,
+        rows: 2,
+        text: "snapshot\ncontents",
+        full: false,
+        changedRows: [0, 1]
+    )
+    let renderGrid = TerminalOutputDelivery(renderGrid: frame, replaceable: true)
+    let policyOnly = TerminalOutputDelivery(
+        bytes: Data(),
+        replaceable: true,
+        replacementScope: .viewportPolicy,
+        viewportPolicy: .natural
+    )
+
+    #expect(queue.enqueue(inFlight) == inFlight)
+    #expect(queue.enqueue(renderGrid) == nil)
+    #expect(queue.enqueue(policyOnly) == nil)
+
+    #expect(queue.pendingCount == 2)
+    let maybeDelivered = queue.completeInFlight()
+    let delivered = try #require(maybeDelivered)
+    let vt = try #require(String(data: delivered.bytes, encoding: .utf8))
+    #expect(vt.contains("snapshot"))
+    #expect(queue.completeInFlight() == policyOnly)
+}
+
 @Test func terminalOutputQueuePreservesNonreplaceableBarriers() {
     var queue = TerminalOutputDeliveryQueue()
     let inFlight = TerminalOutputDelivery(bytes: Data("in-flight".utf8), replaceable: false)

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalOutputSinking.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalOutputSinking.swift
@@ -12,14 +12,27 @@ public import Foundation
 ///
 /// This replaces the previous `(Data) -> Void` sink registry so output
 /// propagation is a structured, cancellable `AsyncSequence` instead of a stored
-/// callback.
+/// callback. Chunks may also carry a viewport policy so primary-screen output can
+/// use the phone's natural height while alternate-screen replay remains pinned
+/// to the remote grid.
+public enum MobileTerminalOutputViewportPolicy: Equatable, Sendable {
+    case natural
+    case remoteGrid(columns: Int, rows: Int)
+}
+
 public struct MobileTerminalOutputChunk: Sendable {
     public let data: Data
     public let streamToken: UUID
+    public let viewportPolicy: MobileTerminalOutputViewportPolicy?
 
-    public init(data: Data, streamToken: UUID) {
+    public init(
+        data: Data,
+        streamToken: UUID,
+        viewportPolicy: MobileTerminalOutputViewportPolicy? = nil
+    ) {
         self.data = data
         self.streamToken = streamToken
+        self.viewportPolicy = viewportPolicy
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -2,16 +2,15 @@
 import CMUXMobileCore
 import CmuxMobileDiagnostics
 import CmuxMobileShell
+import CmuxMobileShellModel
 import CmuxMobileTerminal
 import SwiftUI
 import UIKit
 
-/// SwiftUI wrapper that mounts a `GhosttySurfaceView` and routes the
-/// matching surface's PTY bytes (received via `terminal.bytes` events)
-/// into `ghostty_surface_process_output`. The result is that the iPhone
-/// runs the same libghostty terminal core + Metal renderer as the Mac,
-/// fed by the Mac's own read thread byte-for-byte. No Swift VT parser,
-/// no snapshot rehydration, no cell-by-cell SwiftUI tree.
+/// SwiftUI wrapper that mounts a `GhosttySurfaceView` and routes terminal output
+/// chunks into `ghostty_surface_process_output`. Primary-screen output can stay
+/// at the phone's natural height, while alternate-screen render-grid replay can
+/// pin the surface to the Mac's authoritative grid.
 ///
 /// The bottom dock (terminal grid / composer band / accessory toolbar / keyboard)
 /// is owned entirely by the `GhosttySurfaceView` in one coordinate system. The
@@ -138,6 +137,14 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 for await chunk in store.terminalOutputStream(surfaceID: surfaceID) {
                     guard !Task.isCancelled else { return }
                     guard let surfaceView else { return }
+                    switch chunk.viewportPolicy {
+                    case .natural:
+                        surfaceView.useNaturalViewSize()
+                    case .remoteGrid(let columns, let rows):
+                        surfaceView.applyViewSize(cols: columns, rows: rows)
+                    case nil:
+                        break
+                    }
                     await surfaceView.processOutputAndWait(chunk.data)
                     store.terminalOutputDidProcess(
                         surfaceID: surfaceID,
@@ -299,19 +306,17 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         }
 
         func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize) {
-            // Report our natural grid to the Mac and pin our render to the
-            // effective grid it returns (the smallest across every attached
-            // device, capped to the Mac pane). This is the tmux-style shared
-            // resize: the smallest viewport wins and each device letterboxes
-            // its render to match, drawing a border around the live area.
+            // Report our natural grid to the Mac. The output stream decides
+            // whether the phone should keep that natural grid (primary screen)
+            // or pin to the Mac grid (alternate-screen render-grid replay).
             guard size.columns > 0, size.rows > 0 else { return }
             Task { @MainActor [weak self, weak surfaceView] in
                 guard let self, let store = self.store else { return }
-                guard let effective = await store.updateTerminalViewport(
+                guard await store.updateTerminalViewport(
                     surfaceID: self.surfaceID,
                     columns: size.columns,
                     rows: size.rows
-                ) else {
+                ) != nil else {
                     // No effective grid came back (RPC timed out or returned
                     // nil). Left unhandled, the render stays pinned to the prior
                     // effective grid and looks like a frozen / letterboxed
@@ -323,7 +328,6 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     surfaceView?.retryViewportReport()
                     return
                 }
-                surfaceView?.applyViewSize(cols: effective.columns, rows: effective.rows)
             }
         }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -145,7 +145,9 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     case nil:
                         break
                     }
-                    await surfaceView.processOutputAndWait(chunk.data)
+                    if !chunk.data.isEmpty {
+                        await surfaceView.processOutputAndWait(chunk.data)
+                    }
                     store.terminalOutputDidProcess(
                         surfaceID: surfaceID,
                         streamToken: chunk.streamToken

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -112,6 +112,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// dismantle; mounted/unmounted by ``setComposerMounted(_:)``.
         private var composerController: UIHostingController<TerminalComposerView>?
         private var composerMounted = false
+        private var activeViewportPolicy: MobileTerminalOutputViewportPolicy = .natural
         /// Bumped on every mount/unmount transition so a deferred close completion
         /// can tell whether it is still the latest transition. Guards the
         /// close-then-quickly-reopen race: an interrupted close animation still runs
@@ -139,8 +140,10 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     guard let surfaceView else { return }
                     switch chunk.viewportPolicy {
                     case .natural:
+                        activeViewportPolicy = .natural
                         surfaceView.useNaturalViewSize()
                     case .remoteGrid(let columns, let rows):
+                        activeViewportPolicy = .remoteGrid(columns: columns, rows: rows)
                         surfaceView.applyViewSize(cols: columns, rows: rows)
                     case nil:
                         break
@@ -314,7 +317,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             guard size.columns > 0, size.rows > 0 else { return }
             Task { @MainActor [weak self, weak surfaceView] in
                 guard let self, let store = self.store else { return }
-                guard await store.updateTerminalViewport(
+                guard let effectiveGrid = await store.updateTerminalViewport(
                     surfaceID: self.surfaceID,
                     columns: size.columns,
                     rows: size.rows
@@ -329,6 +332,13 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     MobileDebugLog.anchormux("zoom.viewport.noEffective grid=\(size.columns)x\(size.rows)")
                     surfaceView?.retryViewportReport()
                     return
+                }
+                surfaceView?.markViewportReportConfirmed()
+                if case .remoteGrid = self.activeViewportPolicy {
+                    surfaceView?.applyConfirmedViewSize(
+                        cols: effectiveGrid.columns,
+                        rows: effectiveGrid.rows
+                    )
                 }
             }
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -142,10 +142,18 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     switch chunk.viewportPolicy {
                     case .natural:
                         self.activeViewportPolicy = .natural
-                        surfaceView.useNaturalViewSize()
+                        if chunk.data.isEmpty {
+                            surfaceView.useNaturalViewSize()
+                        } else {
+                            await surfaceView.useNaturalViewSizeAndWait()
+                        }
                     case .remoteGrid(let columns, let rows):
                         self.activeViewportPolicy = .remoteGrid(columns: columns, rows: rows)
-                        surfaceView.applyViewSize(cols: columns, rows: rows)
+                        if chunk.data.isEmpty {
+                            surfaceView.applyViewSize(cols: columns, rows: rows)
+                        } else {
+                            await surfaceView.applyViewSizeAndWait(cols: columns, rows: rows)
+                        }
                     case nil:
                         break
                     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -133,17 +133,18 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             // Drive every output chunk into the libghostty surface. Ending this
             // task terminates the stream, which unregisters the surface and
             // clears its viewport pin on the Mac (see `terminalOutputStream`).
-            outputTask = Task { @MainActor [weak surfaceView, weak store] in
+            outputTask = Task { @MainActor [weak self, weak surfaceView, weak store] in
                 guard let store else { return }
                 for await chunk in store.terminalOutputStream(surfaceID: surfaceID) {
                     guard !Task.isCancelled else { return }
+                    guard let self else { return }
                     guard let surfaceView else { return }
                     switch chunk.viewportPolicy {
                     case .natural:
-                        activeViewportPolicy = .natural
+                        self.activeViewportPolicy = .natural
                         surfaceView.useNaturalViewSize()
                     case .remoteGrid(let columns, let rows):
-                        activeViewportPolicy = .remoteGrid(columns: columns, rows: rows)
+                        self.activeViewportPolicy = .remoteGrid(columns: columns, rows: rows)
                         surfaceView.applyViewSize(cols: columns, rows: rows)
                     case nil:
                         break
@@ -321,7 +322,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     surfaceID: self.surfaceID,
                     columns: size.columns,
                     rows: size.rows
-                ) != nil else {
+                ) else {
                     // No effective grid came back (RPC timed out or returned
                     // nil). Left unhandled, the render stays pinned to the prior
                     // effective grid and looks like a frozen / letterboxed

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -93,12 +93,11 @@ protocol TerminalSurfaceHosting: AnyObject {
     var currentGridSize: TerminalGridSize { get }
     func processOutput(_ data: Data)
     func focusInput()
-    /// Apply the daemon's authoritative rendering grid. Unconditional —
-    /// implementations render at exactly cols × rows and letterbox any
-    /// remaining container area. The daemon broadcasts this on every
-    /// attach/resize/detach/open, plus inlined in RPC responses, so
-    /// every attached device converges on the same grid.
+    /// Apply the daemon's authoritative rendering grid for modes that cannot
+    /// reflow independently on the phone, such as alternate-screen TUIs.
     func applyViewSize(cols: Int, rows: Int)
+    /// Return to the phone's natural viewport capacity.
+    func useNaturalViewSize()
     #if DEBUG
     var onOutputProcessedForTesting: (() -> Void)? { get set }
     func accessibilityRenderedTextForTesting() -> String?
@@ -108,6 +107,7 @@ protocol TerminalSurfaceHosting: AnyObject {
 extension TerminalSurfaceHosting {
     func focusInput() {}
     func applyViewSize(cols _: Int, rows _: Int) {}
+    func useNaturalViewSize() {}
     #if DEBUG
     var onOutputProcessedForTesting: (() -> Void)? {
         get { nil }
@@ -816,10 +816,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// 120Hz / 0.13s at 60Hz.
     private static let viewportReportSettleThreshold = 8
     private var lastSnapshotFallbackHTML: String?
-    /// Daemon-authoritative effective grid (min across attached devices). When
-    /// set, the Ghostty surface is pinned to this cols×rows inside the
-    /// container so every attached device renders at the same grid. When
-    /// nil, the surface fills the container's natural capacity.
+    /// Daemon-authoritative grid used for modes that need exact remote-cell
+    /// replay. When nil, the surface fills the phone's natural capacity.
     private var effectiveGrid: (cols: Int, rows: Int)?
     /// Cached cell metrics derived from the most recent
     /// `ghostty_surface_size` measurement. Used to translate an effective
@@ -2989,6 +2987,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // storm of set_size calls + viewport RPCs. Geometry now settles once
         // per frame, and reassert=false avoids re-reporting the unchanged
         // natural grid back through the round trip.
+        setNeedsGeometrySync(reassertNaturalSize: false)
+    }
+
+    public func useNaturalViewSize() {
+        // A value came back from the Mac, so the round-trip recovered.
+        viewportReportRetries = 0
+        guard effectiveGrid != nil else { return }
+        MobileDebugLog.anchormux("zoom.useNaturalViewSize eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil")->nil")
+        effectiveGrid = nil
         setNeedsGeometrySync(reassertNaturalSize: false)
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2975,9 +2975,22 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     public func applyViewSize(cols: Int, rows: Int) {
-        guard cols > 0, rows > 0 else { return }
-        // A value came back from the Mac, so the round-trip recovered.
+        applyViewSize(cols: cols, rows: rows, confirmedViewportEcho: false)
+    }
+
+    public func applyConfirmedViewSize(cols: Int, rows: Int) {
+        applyViewSize(cols: cols, rows: rows, confirmedViewportEcho: true)
+    }
+
+    public func markViewportReportConfirmed() {
         viewportReportRetries = 0
+    }
+
+    private func applyViewSize(cols: Int, rows: Int, confirmedViewportEcho: Bool) {
+        guard cols > 0, rows > 0 else { return }
+        if confirmedViewportEcho {
+            markViewportReportConfirmed()
+        }
         if effectiveGrid?.cols == cols && effectiveGrid?.rows == rows { return }
         MobileDebugLog.anchormux("zoom.applyViewSize eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil")->\(cols)x\(rows)")
         effectiveGrid = (cols, rows)
@@ -2991,8 +3004,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     public func useNaturalViewSize() {
-        // A value came back from the Mac, so the round-trip recovered.
-        viewportReportRetries = 0
         guard effectiveGrid != nil else { return }
         MobileDebugLog.anchormux("zoom.useNaturalViewSize eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil")->nil")
         effectiveGrid = nil

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2978,6 +2978,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         applyViewSize(cols: cols, rows: rows, confirmedViewportEcho: false)
     }
 
+    public func applyViewSizeAndWait(cols: Int, rows: Int) async {
+        let changed = updateEffectiveGrid(cols: cols, rows: rows, confirmedViewportEcho: false)
+        if changed || needsGeometrySync {
+            await syncSurfaceGeometryAndWait(shouldReassertNaturalSize: false)
+        }
+    }
+
     public func applyConfirmedViewSize(cols: Int, rows: Int) {
         applyViewSize(cols: cols, rows: rows, confirmedViewportEcho: true)
     }
@@ -2987,13 +2994,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     private func applyViewSize(cols: Int, rows: Int, confirmedViewportEcho: Bool) {
-        guard cols > 0, rows > 0 else { return }
-        if confirmedViewportEcho {
-            markViewportReportConfirmed()
-        }
-        if effectiveGrid?.cols == cols && effectiveGrid?.rows == rows { return }
-        MobileDebugLog.anchormux("zoom.applyViewSize eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil")->\(cols)x\(rows)")
-        effectiveGrid = (cols, rows)
+        guard updateEffectiveGrid(cols: cols, rows: rows, confirmedViewportEcho: confirmedViewportEcho) else { return }
         // Mark dirty instead of recomputing synchronously. This breaks the
         // feedback loop (didResize → updateTerminalViewport RPC → applyViewSize
         // → syncSurfaceGeometry → didResize …) that, under fast zoom, drove a
@@ -3003,11 +3004,34 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         setNeedsGeometrySync(reassertNaturalSize: false)
     }
 
+    private func updateEffectiveGrid(cols: Int, rows: Int, confirmedViewportEcho: Bool) -> Bool {
+        guard cols > 0, rows > 0 else { return false }
+        if confirmedViewportEcho {
+            markViewportReportConfirmed()
+        }
+        if effectiveGrid?.cols == cols && effectiveGrid?.rows == rows { return false }
+        MobileDebugLog.anchormux("zoom.applyViewSize eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil")->\(cols)x\(rows)")
+        effectiveGrid = (cols, rows)
+        return true
+    }
+
     public func useNaturalViewSize() {
-        guard effectiveGrid != nil else { return }
+        guard clearEffectiveGrid() else { return }
+        setNeedsGeometrySync(reassertNaturalSize: false)
+    }
+
+    public func useNaturalViewSizeAndWait() async {
+        let changed = clearEffectiveGrid()
+        if changed || needsGeometrySync {
+            await syncSurfaceGeometryAndWait(shouldReassertNaturalSize: false)
+        }
+    }
+
+    private func clearEffectiveGrid() -> Bool {
+        guard effectiveGrid != nil else { return false }
         MobileDebugLog.anchormux("zoom.useNaturalViewSize eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil")->nil")
         effectiveGrid = nil
-        setNeedsGeometrySync(reassertNaturalSize: false)
+        return true
     }
 
     /// Pure libghostty resize refinement; `nonisolated` so it runs on the
@@ -3057,8 +3081,24 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let pinnedSize: CGSize?
     }
 
-    private func syncSurfaceGeometry(shouldReassertNaturalSize: Bool = true) {
-        guard let surface else { return }
+    private func syncSurfaceGeometryAndWait(shouldReassertNaturalSize: Bool = true) async {
+        needsGeometrySync = false
+        pendingGeometryReassert = false
+        await withCheckedContinuation { continuation in
+            syncSurfaceGeometry(shouldReassertNaturalSize: shouldReassertNaturalSize) {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func syncSurfaceGeometry(
+        shouldReassertNaturalSize: Bool = true,
+        completion: (@MainActor @Sendable () -> Void)? = nil
+    ) {
+        guard let surface else {
+            completion?()
+            return
+        }
 
         // Capture all main-actor inputs as values, then do every libghostty
         // WRITE (set_content_scale / set_size / fit) and its readback on the
@@ -3152,6 +3192,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                     containerH: containerH,
                     shouldReassertNaturalSize: shouldReassertNaturalSize
                 )
+                completion?()
             }
         }
     }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -2829,12 +2829,17 @@ private func terminalRenderGridStyledFrame(seq: UInt64, text: String) throws -> 
 
 private func rpcHostStatusFrame(
     renderGrid: Bool,
+    terminalBytes: Bool = true,
     macDeviceID: String? = nil,
     macDisplayName: String? = nil
 ) throws -> Data {
-    let capabilities = renderGrid
-        ? ["events.v1", "terminal.bytes.v1", "terminal.render_grid.v1", "terminal.replay.v1"]
-        : ["events.v1", "terminal.bytes.v1", "terminal.replay.v1"]
+    var capabilities = ["events.v1", "terminal.replay.v1"]
+    if terminalBytes {
+        capabilities.append("terminal.bytes.v1")
+    }
+    if renderGrid {
+        capabilities.append("terminal.render_grid.v1")
+    }
     var result: [String: Any] = [
         "terminal_fidelity": renderGrid ? "render_grid" : "ghostty_bytes",
         "capabilities": capabilities,
@@ -3390,7 +3395,7 @@ private actor TerminalRenderGridEventRouter: RequestAwareTransportRouter {
                 terminalID: "live-terminal"
             )
         case "mobile.host.status":
-            return try rpcHostStatusFrame(renderGrid: true)
+            return try rpcHostStatusFrame(renderGrid: true, terminalBytes: false)
         case "mobile.events.subscribe":
             return try rpcResultFrame(result: ["stream_id": "events"])
         case "mobile.terminal.replay":


### PR DESCRIPTION
## Summary
- keep render-grid output authoritative for alternate-screen terminal frames
- treat primary-screen render-grid frames as advisory and deliver raw byte output for natural iPhone height
- carry viewport policy through the iOS terminal output queue so primary clears remote-grid sizing

## Tests
- swift test --package-path Packages/iOS/CmuxMobileShell
- xcodebuild -workspace ios/cmux.xcworkspace -scheme cmux-ios -destination generic/platform=iOS Simulator -derivedDataPath /tmp/cmux-ios-fullht ARCHS=arm64 ONLY_ACTIVE_ARCH=YES build
- ./scripts/reload-cloud.sh --tag fullht, fell back to local tagged reload
- ./ios/scripts/reload.sh --tag fullht

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785368165&installation_id=133855650&pr_number=7071&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7071&signature=e3d03140f6b60a2af9d253918ccfe5b545f0b4082847f92e1c625eec3a143854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use hybrid terminal output on iOS so the primary screen renders at full iPhone height from raw PTY bytes, while alternate-screen TUIs stay authoritative on render-grid. Viewport policy is applied before output to avoid flicker, and hybrid recovery ensures primary bytes aren’t starved.

- New Features
  - Auto-selects hybrid when the host supports `terminal.bytes.v1` + `terminal.render_grid.v1`; render-grid-only hosts keep primary render-grid delivery; otherwise falls back to raw bytes.
  - Each output chunk carries a `viewportPolicy` (`.natural` or `.remoteGrid(cols,rows)`), including policy-only updates; the UI applies policy before data and skips empty chunks.

- Bug Fixes
  - Hybrid screen switching: track active screen; treat primary render-grid as advisory; suppress raw bytes while alternate is active; keep alt-screen until a full primary replay; request replay if the first primary frame is a delta or empty; ignore stale alternate frames; deliver primary policies without advancing seq.
  - Recovery liveness: only let render-grid advance pending byte seq in hybrid while the active screen is alternate, so advisory primary frames never block raw bytes; on input behind, request replay instead of waiting on advisory frames; hybrid subscriptions include both `terminal.bytes` and `terminal.render_grid`.
  - Output queue: scope replacements so policy-only updates don’t replace a pending render-grid snapshot.
  - Viewport reporting: confirm reports before pinning; apply confirmed grid only when pinned.

<sup>Written for commit ec54fc79c7ae7ca3f48ae2982d25459da0557981. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hybrid terminal output mode that subscribes to both byte streams and render-grid updates, improving smooth screen switching.
  * Propagated a per-output viewport sizing policy through rendering chunks so primary uses natural sizing while alternate can stay pinned to a remote grid.

* **Bug Fixes**
  * Improved viewport resize handling with clearer “confirmed” vs “retry” behavior to prevent conflicting size updates.
  * In hybrid mode, selectively suppresses overlapping byte rendering based on the last known alternate screen state.

* **Tests**
  * Expanded hybrid render-grid liveness tests and added viewport-policy assertions for primary/alternate transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->