### PR TITLE
Fix iOS chat keyboard scroll edge bleed

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
@@ -419,8 +419,15 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
         scrollEdgeCoordinator.configure(
             tableView: tables.first,
             owner: self,
-            composerView: composerHostingController.view
+            composerView: composerHostingController.view,
+            suppressTopEdgeEffect: shouldSuppressTopScrollEdgeEffect
         )
+    }
+
+    private var shouldSuppressTopScrollEdgeEffect: Bool {
+        isKeyboardAnimationActive
+            || keyboardOverlap > 0.5
+            || keyboardAnimationTargetOverlap > 0.5
     }
 
     private func updateComposerVisibility() {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
@@ -419,15 +419,8 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
         scrollEdgeCoordinator.configure(
             tableView: tables.first,
             owner: self,
-            composerView: composerHostingController.view,
-            suppressTopEdgeEffect: shouldSuppressTopScrollEdgeEffect
+            composerView: composerHostingController.view
         )
-    }
-
-    private var shouldSuppressTopScrollEdgeEffect: Bool {
-        isKeyboardAnimationActive
-            || keyboardOverlap > 0.5
-            || keyboardAnimationTargetOverlap > 0.5
     }
 
     private func updateComposerVisibility() {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScrollEdgeCoordinator.swift
@@ -10,9 +10,10 @@ final class ChatScrollEdgeCoordinator {
     func configure(
         tableView: ChatTranscriptUITableView?,
         owner: UIViewController,
-        composerView: UIView
+        composerView: UIView,
+        suppressTopEdgeEffect: Bool
     ) {
-        configureEdgeEffect(for: tableView)
+        configureEdgeEffect(for: tableView, suppressTopEdgeEffect: suppressTopEdgeEffect)
         configureContentScrollView(tableView, owner: owner)
         configureBottomInteraction(tableView, composerView: composerView)
     }
@@ -22,10 +23,13 @@ final class ChatScrollEdgeCoordinator {
         clearTopContentScrollViewController()
     }
 
-    private func configureEdgeEffect(for tableView: ChatTranscriptUITableView?) {
+    private func configureEdgeEffect(
+        for tableView: ChatTranscriptUITableView?,
+        suppressTopEdgeEffect: Bool
+    ) {
         guard let tableView else { return }
         if #available(iOS 26.0, *) {
-            tableView.topEdgeEffect.style = .soft
+            tableView.topEdgeEffect.style = suppressTopEdgeEffect ? .automatic : .soft
             tableView.bottomEdgeEffect.style = .soft
         }
     }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScrollEdgeCoordinator.swift
@@ -28,10 +28,7 @@ final class ChatScrollEdgeCoordinator {
         suppressTopEdgeEffect: Bool
     ) {
         guard let tableView else { return }
-        if #available(iOS 26.0, *) {
-            tableView.topEdgeEffect.style = suppressTopEdgeEffect ? .automatic : .soft
-            tableView.bottomEdgeEffect.style = .soft
-        }
+        tableView.applyScrollEdgeEffects(topSoft: !suppressTopEdgeEffect, bottomSoft: true)
     }
 
     private func configureContentScrollView(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScrollEdgeCoordinator.swift
@@ -44,6 +44,9 @@ final class ChatScrollEdgeCoordinator {
                 topContentScrollViewController = topController
             }
             topController?.setContentScrollView(tableView, for: .top)
+            #if DEBUG
+            tableView?.recordTopContentScrollViewRegistration(topController != nil)
+            #endif
         }
     }
 

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScrollEdgeCoordinator.swift
@@ -6,6 +6,7 @@ final class ChatScrollEdgeCoordinator {
     private var bottomInteraction: UIInteraction?
     private weak var bottomInteractionTableView: ChatTranscriptUITableView?
     private weak var topContentScrollViewController: UIViewController?
+    private weak var topContentScrollViewTableView: ChatTranscriptUITableView?
 
     func configure(
         tableView: ChatTranscriptUITableView?,
@@ -14,7 +15,11 @@ final class ChatScrollEdgeCoordinator {
         suppressTopEdgeEffect: Bool
     ) {
         configureEdgeEffect(for: tableView, suppressTopEdgeEffect: suppressTopEdgeEffect)
-        configureContentScrollView(tableView, owner: owner)
+        configureContentScrollView(
+            tableView,
+            owner: owner,
+            suppressTopEdgeEffect: suppressTopEdgeEffect
+        )
         configureBottomInteraction(tableView, composerView: composerView)
     }
 
@@ -33,19 +38,31 @@ final class ChatScrollEdgeCoordinator {
 
     private func configureContentScrollView(
         _ tableView: ChatTranscriptUITableView?,
-        owner: UIViewController
+        owner: UIViewController,
+        suppressTopEdgeEffect: Bool
     ) {
         if #available(iOS 26.0, *) {
-            let topController = tableView == nil
-                ? nil
-                : nearestNavigationContentViewController(from: owner) ?? owner
+            guard let tableView, !suppressTopEdgeEffect else {
+                clearTopContentScrollViewController()
+                #if DEBUG
+                tableView?.recordTopContentScrollViewRegistration(false)
+                #endif
+                return
+            }
+            let topController = nearestNavigationContentViewController(from: owner) ?? owner
             if topContentScrollViewController !== topController {
                 clearTopContentScrollViewController()
                 topContentScrollViewController = topController
             }
-            topController?.setContentScrollView(tableView, for: .top)
+            if topContentScrollViewTableView !== tableView {
+                #if DEBUG
+                topContentScrollViewTableView?.recordTopContentScrollViewRegistration(false)
+                #endif
+                topContentScrollViewTableView = tableView
+            }
+            topController.setContentScrollView(tableView, for: .top)
             #if DEBUG
-            tableView?.recordTopContentScrollViewRegistration(topController != nil)
+            tableView.recordTopContentScrollViewRegistration(true)
             #endif
         }
     }
@@ -89,7 +106,11 @@ final class ChatScrollEdgeCoordinator {
         if #available(iOS 26.0, *) {
             topContentScrollViewController?.setContentScrollView(nil, for: .top)
         }
+        #if DEBUG
+        topContentScrollViewTableView?.recordTopContentScrollViewRegistration(false)
+        #endif
         topContentScrollViewController = nil
+        topContentScrollViewTableView = nil
     }
 
     private func nearestNavigationContentViewController(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScrollEdgeCoordinator.swift
@@ -11,15 +11,10 @@ final class ChatScrollEdgeCoordinator {
     func configure(
         tableView: ChatTranscriptUITableView?,
         owner: UIViewController,
-        composerView: UIView,
-        suppressTopEdgeEffect: Bool
+        composerView: UIView
     ) {
-        configureEdgeEffect(for: tableView, suppressTopEdgeEffect: suppressTopEdgeEffect)
-        configureContentScrollView(
-            tableView,
-            owner: owner,
-            suppressTopEdgeEffect: suppressTopEdgeEffect
-        )
+        configureEdgeEffect(for: tableView)
+        configureContentScrollView(tableView, owner: owner)
         configureBottomInteraction(tableView, composerView: composerView)
     }
 
@@ -28,25 +23,18 @@ final class ChatScrollEdgeCoordinator {
         clearTopContentScrollViewController()
     }
 
-    private func configureEdgeEffect(
-        for tableView: ChatTranscriptUITableView?,
-        suppressTopEdgeEffect: Bool
-    ) {
+    private func configureEdgeEffect(for tableView: ChatTranscriptUITableView?) {
         guard let tableView else { return }
-        tableView.applyScrollEdgeEffects(topSoft: !suppressTopEdgeEffect, bottomSoft: true)
+        tableView.applyScrollEdgeEffects(topSoft: true, bottomSoft: true)
     }
 
     private func configureContentScrollView(
         _ tableView: ChatTranscriptUITableView?,
-        owner: UIViewController,
-        suppressTopEdgeEffect: Bool
+        owner: UIViewController
     ) {
         if #available(iOS 26.0, *) {
-            guard let tableView, !suppressTopEdgeEffect else {
+            guard let tableView else {
                 clearTopContentScrollViewController()
-                #if DEBUG
-                tableView?.recordTopContentScrollViewRegistration(false)
-                #endif
                 return
             }
             let topController = nearestNavigationContentViewController(from: owner) ?? owner

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
@@ -45,7 +45,7 @@ struct ChatTranscriptTableView: UIViewRepresentable {
         tableView.allowsSelection = false
         tableView.accessibilityIdentifier = "ChatTranscriptTableView"
         if #available(iOS 26.0, *) {
-            tableView.topEdgeEffect.style = .soft
+            tableView.topEdgeEffect.style = .automatic
             tableView.bottomEdgeEffect.style = .soft
         }
         tableView.dataSource = context.coordinator

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
@@ -44,10 +44,7 @@ struct ChatTranscriptTableView: UIViewRepresentable {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.allowsSelection = false
         tableView.accessibilityIdentifier = "ChatTranscriptTableView"
-        if #available(iOS 26.0, *) {
-            tableView.topEdgeEffect.style = .automatic
-            tableView.bottomEdgeEffect.style = .soft
-        }
+        tableView.applyScrollEdgeEffects(topSoft: false, bottomSoft: true)
         tableView.dataSource = context.coordinator
         tableView.delegate = context.coordinator
         context.coordinator.attach(tableView)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
@@ -44,7 +44,7 @@ struct ChatTranscriptTableView: UIViewRepresentable {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.allowsSelection = false
         tableView.accessibilityIdentifier = "ChatTranscriptTableView"
-        tableView.applyScrollEdgeEffects(topSoft: false, bottomSoft: true)
+        tableView.applyScrollEdgeEffects(topSoft: true, bottomSoft: true)
         tableView.dataSource = context.coordinator
         tableView.delegate = context.coordinator
         context.coordinator.attach(tableView)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptUITableView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptUITableView.swift
@@ -37,6 +37,8 @@ final class ChatTranscriptUITableView: UITableView {
     private var recordedKeyboardAnimationID = 0
     private var keyboardDebugMaxAnimationPresentationGap: CGFloat = 0
     private var keyboardDebugAnimationSampleCount = 0
+    private var debugTopEdgeEffectSoft = false
+    private var debugBottomEdgeEffectSoft = false
     #endif
 
     #if DEBUG
@@ -63,6 +65,22 @@ final class ChatTranscriptUITableView: UITableView {
         updateDebugAccessibilityValue()
         #endif
         afterLayout?(oldBoundsSize, oldContentSize, oldViewport, oldAnchor)
+    }
+
+    func applyScrollEdgeEffects(topSoft: Bool, bottomSoft: Bool) {
+        #if DEBUG
+        debugTopEdgeEffectSoft = false
+        debugBottomEdgeEffectSoft = false
+        #endif
+        if #available(iOS 26.0, *) {
+            topEdgeEffect.style = topSoft ? .soft : .automatic
+            bottomEdgeEffect.style = bottomSoft ? .soft : .automatic
+            #if DEBUG
+            debugTopEdgeEffectSoft = topSoft
+            debugBottomEdgeEffectSoft = bottomSoft
+            updateDebugAccessibilityValue()
+            #endif
+        }
     }
 
     func keyboardViewportSnapshot() -> MobileScrollViewportSnapshot {
@@ -208,15 +226,6 @@ final class ChatTranscriptUITableView: UITableView {
         let visibleBottomY = contentOffset.y + bounds.height - adjustedContentInset.bottom
         let distanceFromBottom = max(0, contentSize.height - visibleBottomY)
         let presentationGap = composerPresentationMinY - presentationFrameMaxY
-        let topEdgeEffectSoft: Int
-        let bottomEdgeEffectSoft: Int
-        if #available(iOS 26.0, *) {
-            topEdgeEffectSoft = topEdgeEffect.style === UIScrollEdgeEffect.Style.soft ? 1 : 0
-            bottomEdgeEffectSoft = bottomEdgeEffect.style === UIScrollEdgeEffect.Style.soft ? 1 : 0
-        } else {
-            topEdgeEffectSoft = 0
-            bottomEdgeEffectSoft = 0
-        }
         recordKeyboardAnimationGap(presentationGap)
         return String(
             format: "frameMinY=%.2f;frameMaxY=%.2f;frameHeight=%.2f;presentationFrameMaxY=%.2f;boundsHeight=%.2f;offsetY=%.2f;adjustedTopInset=%.2f;adjustedBottomInset=%.2f;visibleTopY=%.2f;visibleBottomY=%.2f;contentHeight=%.2f;distanceFromBottom=%.2f;keyboardEvents=%d;keyboardOverlap=%.2f;keyboardTargetOverlap=%.2f;keyboardGuideOverlap=%.2f;keyboardBottomConstraint=%.2f;composerMinY=%.2f;composerPresentationMinY=%.2f;presentationGap=%.2f;topChromeOverlayInset=%.2f;composerOverlayBottomInset=%.2f;keyboardAnimationActive=%d;keyboardAnimationProgress=%.2f;keyboardTransitionDuration=%.3f;maxAnimationPresentationGap=%.2f;keyboardAnimationSamples=%d;topEdgeEffectSoft=%d;bottomEdgeEffectSoft=%d",
@@ -248,8 +257,8 @@ final class ChatTranscriptUITableView: UITableView {
             keyboardDebugTransitionDuration,
             keyboardDebugMaxAnimationPresentationGap,
             keyboardDebugAnimationSampleCount,
-            topEdgeEffectSoft,
-            bottomEdgeEffectSoft
+            debugTopEdgeEffectSoft ? 1 : 0,
+            debugBottomEdgeEffectSoft ? 1 : 0
         )
     }
 

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptUITableView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptUITableView.swift
@@ -208,9 +208,18 @@ final class ChatTranscriptUITableView: UITableView {
         let visibleBottomY = contentOffset.y + bounds.height - adjustedContentInset.bottom
         let distanceFromBottom = max(0, contentSize.height - visibleBottomY)
         let presentationGap = composerPresentationMinY - presentationFrameMaxY
+        let topEdgeEffectSoft: Int
+        let bottomEdgeEffectSoft: Int
+        if #available(iOS 26.0, *) {
+            topEdgeEffectSoft = topEdgeEffect.style === UIScrollEdgeEffect.Style.soft ? 1 : 0
+            bottomEdgeEffectSoft = bottomEdgeEffect.style === UIScrollEdgeEffect.Style.soft ? 1 : 0
+        } else {
+            topEdgeEffectSoft = 0
+            bottomEdgeEffectSoft = 0
+        }
         recordKeyboardAnimationGap(presentationGap)
         return String(
-            format: "frameMinY=%.2f;frameMaxY=%.2f;frameHeight=%.2f;presentationFrameMaxY=%.2f;boundsHeight=%.2f;offsetY=%.2f;adjustedTopInset=%.2f;adjustedBottomInset=%.2f;visibleTopY=%.2f;visibleBottomY=%.2f;contentHeight=%.2f;distanceFromBottom=%.2f;keyboardEvents=%d;keyboardOverlap=%.2f;keyboardTargetOverlap=%.2f;keyboardGuideOverlap=%.2f;keyboardBottomConstraint=%.2f;composerMinY=%.2f;composerPresentationMinY=%.2f;presentationGap=%.2f;topChromeOverlayInset=%.2f;composerOverlayBottomInset=%.2f;keyboardAnimationActive=%d;keyboardAnimationProgress=%.2f;keyboardTransitionDuration=%.3f;maxAnimationPresentationGap=%.2f;keyboardAnimationSamples=%d",
+            format: "frameMinY=%.2f;frameMaxY=%.2f;frameHeight=%.2f;presentationFrameMaxY=%.2f;boundsHeight=%.2f;offsetY=%.2f;adjustedTopInset=%.2f;adjustedBottomInset=%.2f;visibleTopY=%.2f;visibleBottomY=%.2f;contentHeight=%.2f;distanceFromBottom=%.2f;keyboardEvents=%d;keyboardOverlap=%.2f;keyboardTargetOverlap=%.2f;keyboardGuideOverlap=%.2f;keyboardBottomConstraint=%.2f;composerMinY=%.2f;composerPresentationMinY=%.2f;presentationGap=%.2f;topChromeOverlayInset=%.2f;composerOverlayBottomInset=%.2f;keyboardAnimationActive=%d;keyboardAnimationProgress=%.2f;keyboardTransitionDuration=%.3f;maxAnimationPresentationGap=%.2f;keyboardAnimationSamples=%d;topEdgeEffectSoft=%d;bottomEdgeEffectSoft=%d",
             locale: Locale(identifier: "en_US_POSIX"),
             frameInWindow.minY,
             frameInWindow.maxY,
@@ -238,7 +247,9 @@ final class ChatTranscriptUITableView: UITableView {
             keyboardDebugAnimationProgress,
             keyboardDebugTransitionDuration,
             keyboardDebugMaxAnimationPresentationGap,
-            keyboardDebugAnimationSampleCount
+            keyboardDebugAnimationSampleCount,
+            topEdgeEffectSoft,
+            bottomEdgeEffectSoft
         )
     }
 

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptUITableView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptUITableView.swift
@@ -39,6 +39,7 @@ final class ChatTranscriptUITableView: UITableView {
     private var keyboardDebugAnimationSampleCount = 0
     private var debugTopEdgeEffectSoft = false
     private var debugBottomEdgeEffectSoft = false
+    private var debugTopContentScrollViewRegistered = false
     #endif
 
     #if DEBUG
@@ -82,6 +83,13 @@ final class ChatTranscriptUITableView: UITableView {
             #endif
         }
     }
+
+    #if DEBUG
+    func recordTopContentScrollViewRegistration(_ isRegistered: Bool) {
+        debugTopContentScrollViewRegistered = isRegistered
+        updateDebugAccessibilityValue()
+    }
+    #endif
 
     func keyboardViewportSnapshot() -> MobileScrollViewportSnapshot {
         MobileScrollViewportSnapshot(
@@ -228,7 +236,7 @@ final class ChatTranscriptUITableView: UITableView {
         let presentationGap = composerPresentationMinY - presentationFrameMaxY
         recordKeyboardAnimationGap(presentationGap)
         return String(
-            format: "frameMinY=%.2f;frameMaxY=%.2f;frameHeight=%.2f;presentationFrameMaxY=%.2f;boundsHeight=%.2f;offsetY=%.2f;adjustedTopInset=%.2f;adjustedBottomInset=%.2f;visibleTopY=%.2f;visibleBottomY=%.2f;contentHeight=%.2f;distanceFromBottom=%.2f;keyboardEvents=%d;keyboardOverlap=%.2f;keyboardTargetOverlap=%.2f;keyboardGuideOverlap=%.2f;keyboardBottomConstraint=%.2f;composerMinY=%.2f;composerPresentationMinY=%.2f;presentationGap=%.2f;topChromeOverlayInset=%.2f;composerOverlayBottomInset=%.2f;keyboardAnimationActive=%d;keyboardAnimationProgress=%.2f;keyboardTransitionDuration=%.3f;maxAnimationPresentationGap=%.2f;keyboardAnimationSamples=%d;topEdgeEffectSoft=%d;bottomEdgeEffectSoft=%d",
+            format: "frameMinY=%.2f;frameMaxY=%.2f;frameHeight=%.2f;presentationFrameMaxY=%.2f;boundsHeight=%.2f;offsetY=%.2f;adjustedTopInset=%.2f;adjustedBottomInset=%.2f;visibleTopY=%.2f;visibleBottomY=%.2f;contentHeight=%.2f;distanceFromBottom=%.2f;keyboardEvents=%d;keyboardOverlap=%.2f;keyboardTargetOverlap=%.2f;keyboardGuideOverlap=%.2f;keyboardBottomConstraint=%.2f;composerMinY=%.2f;composerPresentationMinY=%.2f;presentationGap=%.2f;topChromeOverlayInset=%.2f;composerOverlayBottomInset=%.2f;keyboardAnimationActive=%d;keyboardAnimationProgress=%.2f;keyboardTransitionDuration=%.3f;maxAnimationPresentationGap=%.2f;keyboardAnimationSamples=%d;topEdgeEffectSoft=%d;bottomEdgeEffectSoft=%d;topContentScrollViewRegistered=%d",
             locale: Locale(identifier: "en_US_POSIX"),
             frameInWindow.minY,
             frameInWindow.maxY,
@@ -258,7 +266,8 @@ final class ChatTranscriptUITableView: UITableView {
             keyboardDebugMaxAnimationPresentationGap,
             keyboardDebugAnimationSampleCount,
             debugTopEdgeEffectSoft ? 1 : 0,
-            debugBottomEdgeEffectSoft ? 1 : 0
+            debugBottomEdgeEffectSoft ? 1 : 0,
+            debugTopContentScrollViewRegistered ? 1 : 0
         )
     }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1287,6 +1287,12 @@ final class cmuxUITests: XCTestCase {
             file: file,
             line: line
         )
+        XCTAssertFalse(
+            afterKeyboard.topContentScrollViewRegistered,
+            "Chat transcript must stop driving the navigation bar's top content scroll view while the keyboard clips the transcript from \(scrollPosition). Leaving it registered keeps the iOS 26 top scroll-edge treatment visible even though the transcript edge effect is suppressed. before=\(beforeKeyboard) after=\(afterKeyboard)",
+            file: file,
+            line: line
+        )
         let keyboardFrame = keyboardFrameAfterFocus(
             in: app,
             overlap: afterKeyboard.keyboardOverlap,
@@ -2061,9 +2067,10 @@ final class cmuxUITests: XCTestCase {
         let keyboardAnimationSamples: Int
         let topEdgeEffectSoft: Bool
         let bottomEdgeEffectSoft: Bool
+        let topContentScrollViewRegistered: Bool
 
         var description: String {
-            "frameMinY=\(frameMinY), frameMaxY=\(frameMaxY), frameHeight=\(frameHeight), presentationFrameMaxY=\(presentationFrameMaxY), boundsHeight=\(boundsHeight), offsetY=\(offsetY), adjustedTopInset=\(adjustedTopInset), adjustedBottomInset=\(adjustedBottomInset), visibleTopY=\(visibleTopY), visibleBottomY=\(visibleBottomY), contentHeight=\(contentHeight), distanceFromBottom=\(distanceFromBottom), keyboardEvents=\(keyboardEvents), keyboardOverlap=\(keyboardOverlap), keyboardTargetOverlap=\(keyboardTargetOverlap), composerMinY=\(composerMinY), composerPresentationMinY=\(composerPresentationMinY), presentationGap=\(presentationGap), topChromeOverlayInset=\(topChromeOverlayInset), composerOverlayBottomInset=\(composerOverlayBottomInset), keyboardAnimationActive=\(keyboardAnimationActive), keyboardAnimationProgress=\(keyboardAnimationProgress), keyboardTransitionDuration=\(keyboardTransitionDuration), maxAnimationPresentationGap=\(maxAnimationPresentationGap), keyboardAnimationSamples=\(keyboardAnimationSamples), topEdgeEffectSoft=\(topEdgeEffectSoft), bottomEdgeEffectSoft=\(bottomEdgeEffectSoft)"
+            "frameMinY=\(frameMinY), frameMaxY=\(frameMaxY), frameHeight=\(frameHeight), presentationFrameMaxY=\(presentationFrameMaxY), boundsHeight=\(boundsHeight), offsetY=\(offsetY), adjustedTopInset=\(adjustedTopInset), adjustedBottomInset=\(adjustedBottomInset), visibleTopY=\(visibleTopY), visibleBottomY=\(visibleBottomY), contentHeight=\(contentHeight), distanceFromBottom=\(distanceFromBottom), keyboardEvents=\(keyboardEvents), keyboardOverlap=\(keyboardOverlap), keyboardTargetOverlap=\(keyboardTargetOverlap), composerMinY=\(composerMinY), composerPresentationMinY=\(composerPresentationMinY), presentationGap=\(presentationGap), topChromeOverlayInset=\(topChromeOverlayInset), composerOverlayBottomInset=\(composerOverlayBottomInset), keyboardAnimationActive=\(keyboardAnimationActive), keyboardAnimationProgress=\(keyboardAnimationProgress), keyboardTransitionDuration=\(keyboardTransitionDuration), maxAnimationPresentationGap=\(maxAnimationPresentationGap), keyboardAnimationSamples=\(keyboardAnimationSamples), topEdgeEffectSoft=\(topEdgeEffectSoft), bottomEdgeEffectSoft=\(bottomEdgeEffectSoft), topContentScrollViewRegistered=\(topContentScrollViewRegistered)"
         }
 
         var effectiveFrameMaxY: CGFloat {
@@ -2117,6 +2124,7 @@ final class cmuxUITests: XCTestCase {
             self.keyboardAnimationSamples = Int(values["keyboardAnimationSamples"] ?? 0)
             self.topEdgeEffectSoft = (values["topEdgeEffectSoft"] ?? 0) >= 0.5
             self.bottomEdgeEffectSoft = (values["bottomEdgeEffectSoft"] ?? 0) >= 0.5
+            self.topContentScrollViewRegistered = (values["topContentScrollViewRegistered"] ?? 0) >= 0.5
         }
     }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1281,6 +1281,12 @@ final class cmuxUITests: XCTestCase {
         let afterKeyboard = try waitForTranscriptMetrics(table, timeout: 6) {
             $0.frameMaxY < beforeKeyboard.frameMaxY - 120
         }
+        XCTAssertFalse(
+            afterKeyboard.topEdgeEffectSoft,
+            "Chat transcript must not force the iOS 26 top scroll-edge effect while the keyboard clips the transcript from \(scrollPosition). before=\(beforeKeyboard) after=\(afterKeyboard)",
+            file: file,
+            line: line
+        )
         let keyboardFrame = keyboardFrameAfterFocus(
             in: app,
             overlap: afterKeyboard.keyboardOverlap,
@@ -2053,9 +2059,11 @@ final class cmuxUITests: XCTestCase {
         let keyboardTransitionDuration: TimeInterval
         let maxAnimationPresentationGap: CGFloat
         let keyboardAnimationSamples: Int
+        let topEdgeEffectSoft: Bool
+        let bottomEdgeEffectSoft: Bool
 
         var description: String {
-            "frameMinY=\(frameMinY), frameMaxY=\(frameMaxY), frameHeight=\(frameHeight), presentationFrameMaxY=\(presentationFrameMaxY), boundsHeight=\(boundsHeight), offsetY=\(offsetY), adjustedTopInset=\(adjustedTopInset), adjustedBottomInset=\(adjustedBottomInset), visibleTopY=\(visibleTopY), visibleBottomY=\(visibleBottomY), contentHeight=\(contentHeight), distanceFromBottom=\(distanceFromBottom), keyboardEvents=\(keyboardEvents), keyboardOverlap=\(keyboardOverlap), keyboardTargetOverlap=\(keyboardTargetOverlap), composerMinY=\(composerMinY), composerPresentationMinY=\(composerPresentationMinY), presentationGap=\(presentationGap), topChromeOverlayInset=\(topChromeOverlayInset), composerOverlayBottomInset=\(composerOverlayBottomInset), keyboardAnimationActive=\(keyboardAnimationActive), keyboardAnimationProgress=\(keyboardAnimationProgress), keyboardTransitionDuration=\(keyboardTransitionDuration), maxAnimationPresentationGap=\(maxAnimationPresentationGap), keyboardAnimationSamples=\(keyboardAnimationSamples)"
+            "frameMinY=\(frameMinY), frameMaxY=\(frameMaxY), frameHeight=\(frameHeight), presentationFrameMaxY=\(presentationFrameMaxY), boundsHeight=\(boundsHeight), offsetY=\(offsetY), adjustedTopInset=\(adjustedTopInset), adjustedBottomInset=\(adjustedBottomInset), visibleTopY=\(visibleTopY), visibleBottomY=\(visibleBottomY), contentHeight=\(contentHeight), distanceFromBottom=\(distanceFromBottom), keyboardEvents=\(keyboardEvents), keyboardOverlap=\(keyboardOverlap), keyboardTargetOverlap=\(keyboardTargetOverlap), composerMinY=\(composerMinY), composerPresentationMinY=\(composerPresentationMinY), presentationGap=\(presentationGap), topChromeOverlayInset=\(topChromeOverlayInset), composerOverlayBottomInset=\(composerOverlayBottomInset), keyboardAnimationActive=\(keyboardAnimationActive), keyboardAnimationProgress=\(keyboardAnimationProgress), keyboardTransitionDuration=\(keyboardTransitionDuration), maxAnimationPresentationGap=\(maxAnimationPresentationGap), keyboardAnimationSamples=\(keyboardAnimationSamples), topEdgeEffectSoft=\(topEdgeEffectSoft), bottomEdgeEffectSoft=\(bottomEdgeEffectSoft)"
         }
 
         var effectiveFrameMaxY: CGFloat {
@@ -2107,6 +2115,8 @@ final class cmuxUITests: XCTestCase {
             self.keyboardTransitionDuration = TimeInterval(values["keyboardTransitionDuration"] ?? 0)
             self.maxAnimationPresentationGap = values["maxAnimationPresentationGap"] ?? 0
             self.keyboardAnimationSamples = Int(values["keyboardAnimationSamples"] ?? 0)
+            self.topEdgeEffectSoft = (values["topEdgeEffectSoft"] ?? 0) >= 0.5
+            self.bottomEdgeEffectSoft = (values["bottomEdgeEffectSoft"] ?? 0) >= 0.5
         }
     }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1285,15 +1285,25 @@ final class cmuxUITests: XCTestCase {
         let afterKeyboard = try waitForTranscriptMetrics(table, timeout: 6) {
             $0.frameMaxY < beforeKeyboard.frameMaxY - 120
         }
-        XCTAssertFalse(
+        let metricsAttachment = XCTAttachment(
+            string: "scrollPosition=\(scrollPosition)\nbefore=\(beforeKeyboard)\nafter=\(afterKeyboard)"
+        )
+        metricsAttachment.name = "keyboard-top-edge-metrics-\(scrollPosition)"
+        metricsAttachment.lifetime = .keepAlways
+        add(metricsAttachment)
+        let screenshotAttachment = XCTAttachment(screenshot: app.screenshot())
+        screenshotAttachment.name = "keyboard-top-edge-screenshot-\(scrollPosition)"
+        screenshotAttachment.lifetime = .keepAlways
+        add(screenshotAttachment)
+        XCTAssertTrue(
             afterKeyboard.topEdgeEffectSoft,
-            "Chat transcript must not force the iOS 26 top scroll-edge effect while the keyboard clips the transcript from \(scrollPosition). before=\(beforeKeyboard) after=\(afterKeyboard)",
+            "Chat transcript must keep the iOS 26 top scroll-edge effect while the keyboard clips the transcript from \(scrollPosition). The keyboard may move the viewport, but it must not remove the top fade under the navigation chrome. before=\(beforeKeyboard) after=\(afterKeyboard)",
             file: file,
             line: line
         )
-        XCTAssertFalse(
+        XCTAssertTrue(
             afterKeyboard.topContentScrollViewRegistered,
-            "Chat transcript must stop driving the navigation bar's top content scroll view while the keyboard clips the transcript from \(scrollPosition). Leaving it registered keeps the iOS 26 top scroll-edge treatment visible even though the transcript edge effect is suppressed. before=\(beforeKeyboard) after=\(afterKeyboard)",
+            "Chat transcript must keep driving the navigation bar's top content scroll view while the keyboard clips the transcript from \(scrollPosition). Deregistering it removes the top scroll-edge treatment shown in the keyboard repro. before=\(beforeKeyboard) after=\(afterKeyboard)",
             file: file,
             line: line
         )

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1112,6 +1112,10 @@ final class cmuxUITests: XCTestCase {
                 && $0.adjustedTopInset > 20
                 && $0.contentHeight > $0.boundsHeight * 1.6
         }
+        XCTAssertTrue(
+            topMetrics.topContentScrollViewRegistered,
+            "When the keyboard is not active, the chat transcript should remain registered as the navigation bar's top content scroll view so the normal top underlap effect works. metrics=\(topMetrics)"
+        )
         XCTAssertEqual(
             topMetrics.offsetY,
             -topMetrics.adjustedTopInset,


### PR DESCRIPTION
## Summary
- stop forcing the iOS 26 soft top scroll-edge effect while the chat keyboard is active
- keep the bottom scroll-edge effect soft for composer/keyboard continuity
- expose scroll-edge style in debug metrics and assert the keyboard regression in the existing UI test

Supersedes https://github.com/manaflow-ai/cmux/pull/7070, which was based on an older branch that became dirty against current main.

## Tests
- swift test --package-path Packages/iOS/CmuxAgentChatUI
- xcodebuild test -workspace ios/cmux.xcworkspace -scheme cmux-ios -destination "platform=iOS Simulator,id=C9D82663-886D-4EBD-92A0-96CF38A42FF3" -derivedDataPath /tmp/cmux-ios-scroll-edge-main -only-testing:cmuxUITests/cmuxUITests/testAgentChatTranscriptFrameMovesUpWithKeyboardAcrossScrollPositions

## Dogfood
- macOS tagged reload: edg2
- iOS simulator reload: edg2 on iPhone 17
- iPhone reload: unavailable, ASC API key missing and device tunnel unavailable
- Next.js dev server: blocked because cmux helper terminal surfaces did not attach a terminal process in workspace:34

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785368538&installation_id=133855650&pr_number=7072&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7072&signature=549120adeb59b546f8a02629aef53bfee21e884ce419b510a9a767926fd3e6a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS 26 top scroll-edge bleed around the chat keyboard by keeping the top edge soft and keeping the transcript registered as the navigation bar’s top content scroll view during keyboard animation. The bottom edge remains soft, with stronger debug metrics and regression coverage.

- **Bug Fixes**
  - Always apply soft top and bottom edges via `applyScrollEdgeEffects`; expose `topEdgeEffectSoft`, `bottomEdgeEffectSoft`, and `topContentScrollViewRegistered` in debug metrics.
  - Keep the transcript registered as the top content scroll view while the keyboard overlaps; add UI tests and attachments to assert the edge effect and registration.

<sup>Written for commit e71e044059c0bdbe10a07a1441daa2c395180d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat transcript scrolling behavior on iOS 26, keeping the top-of-chat underlap consistent when the keyboard appears or disappears.
  * Refined edge effects at the top and bottom of the chat view for a smoother, softer scroll experience.
  * Preserved the transcript’s connection to the navigation bar’s top scroll behavior when returning to the top of the chat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->