### PR TITLE
Fix titlebar SF Symbol raster sizing

### DIFF
--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -116,7 +116,7 @@ enum RenderableSystemSymbol {
         let configuredImage = baseImage.withSymbolConfiguration(configuration) ?? baseImage
         let image = (configuredImage.copy() as? NSImage) ?? configuredImage
         image.isTemplate = true
-        image.size = fittedSymbolSize(configuredImage.size, maximumDimension: rasterSize)
+        image.size = NSSize(width: rasterSize, height: rasterSize)
         appKitImageCache[cacheKey] = image
         appKitImageCacheInsertionOrder.append(cacheKey)
         while appKitImageCacheInsertionOrder.count > appKitImageCacheLimit {
@@ -136,18 +136,6 @@ enum RenderableSystemSymbol {
             let evictedSymbol = renderabilityCacheInsertionOrder.removeFirst()
             renderabilityCache.removeValue(forKey: evictedSymbol)
         }
-    }
-
-    static func fittedSymbolSize(_ naturalSize: NSSize, maximumDimension: CGFloat) -> NSSize {
-        let maximumDimension = clampedRasterPointSize(maximumDimension)
-        guard naturalSize.width.isFinite,
-              naturalSize.height.isFinite,
-              naturalSize.width > 0,
-              naturalSize.height > 0 else {
-            return NSSize(width: maximumDimension, height: maximumDimension)
-        }
-        let scale = maximumDimension / max(naturalSize.width, naturalSize.height)
-        return NSSize(width: naturalSize.width * scale, height: naturalSize.height * scale)
     }
 
     private static func nsFontWeight(for weight: Font.Weight?) -> NSFont.Weight {

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -116,7 +116,7 @@ enum RenderableSystemSymbol {
         let configuredImage = baseImage.withSymbolConfiguration(configuration) ?? baseImage
         let image = (configuredImage.copy() as? NSImage) ?? configuredImage
         image.isTemplate = true
-        image.size = NSSize(width: rasterSize, height: rasterSize)
+        image.size = symbolImageSize(configuredImage.size, fallbackDimension: rasterSize)
         appKitImageCache[cacheKey] = image
         appKitImageCacheInsertionOrder.append(cacheKey)
         while appKitImageCacheInsertionOrder.count > appKitImageCacheLimit {
@@ -136,6 +136,17 @@ enum RenderableSystemSymbol {
             let evictedSymbol = renderabilityCacheInsertionOrder.removeFirst()
             renderabilityCache.removeValue(forKey: evictedSymbol)
         }
+    }
+
+    static func symbolImageSize(_ naturalSize: NSSize, fallbackDimension: CGFloat) -> NSSize {
+        let fallbackDimension = clampedRasterPointSize(fallbackDimension)
+        guard naturalSize.width.isFinite,
+              naturalSize.height.isFinite,
+              naturalSize.width > 0,
+              naturalSize.height > 0 else {
+            return NSSize(width: fallbackDimension, height: fallbackDimension)
+        }
+        return naturalSize
     }
 
     private static func nsFontWeight(for weight: Font.Weight?) -> NSFont.Weight {

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -48,14 +48,28 @@ struct RenderableSystemSymbolTests {
         #expect(image.size == NSSize(width: 1, height: 1))
     }
 
-    @Test @MainActor func configuredAppKitImageKeepsRequestedRasterFrameForNonSquareSymbols() throws {
+    @Test @MainActor func configuredAppKitImagePreservesConfiguredSizeForNonSquareSymbols() throws {
         RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+        let baseImage = try #require(NSImage(systemSymbolName: "arrow.left.and.right", accessibilityDescription: nil))
+        let configuration = NSImage.SymbolConfiguration(pointSize: 16, weight: .regular)
+        let configuredImage = try #require(baseImage.withSymbolConfiguration(configuration))
         let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
-            systemName: "arrow.right",
+            systemName: "arrow.left.and.right",
             pointSize: 16,
             weight: .regular
         ))
-        #expect(image.size == NSSize(width: 16, height: 16))
+        #expect(image.size == configuredImage.size)
+    }
+
+    @Test func symbolImageSizePreservesValidConfiguredDimensions() {
+        #expect(RenderableSystemSymbol.symbolImageSize(
+            NSSize(width: 20, height: 10),
+            fallbackDimension: 16
+        ) == NSSize(width: 20, height: 10))
+        #expect(RenderableSystemSymbol.symbolImageSize(
+            NSSize(width: 0, height: 10),
+            fallbackDimension: 16
+        ) == NSSize(width: 16, height: 16))
     }
 
     @Test @MainActor func configuredAppKitImageReusesCachedImage() throws {

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -48,15 +48,14 @@ struct RenderableSystemSymbolTests {
         #expect(image.size == NSSize(width: 1, height: 1))
     }
 
-    @Test @MainActor func configuredAppKitImagePreservesNonSquareSymbolAspectRatio() throws {
+    @Test @MainActor func configuredAppKitImageKeepsRequestedRasterFrameForNonSquareSymbols() throws {
         RenderableSystemSymbol.resetRenderabilityCacheForTesting()
         let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
             systemName: "arrow.right",
             pointSize: 16,
             weight: .regular
         ))
-        #expect(abs(image.size.width - 16) < 0.001)
-        #expect(image.size.height < 16)
+        #expect(image.size == NSSize(width: 16, height: 16))
     }
 
     @Test func fittedSymbolSizeScalesLongerDimensionToRasterSize() {

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -58,17 +58,6 @@ struct RenderableSystemSymbolTests {
         #expect(image.size == NSSize(width: 16, height: 16))
     }
 
-    @Test func fittedSymbolSizeScalesLongerDimensionToRasterSize() {
-        #expect(RenderableSystemSymbol.fittedSymbolSize(
-            NSSize(width: 20, height: 10),
-            maximumDimension: 16
-        ) == NSSize(width: 16, height: 8))
-        #expect(RenderableSystemSymbol.fittedSymbolSize(
-            NSSize(width: 0, height: 10),
-            maximumDimension: 16
-        ) == NSSize(width: 16, height: 16))
-    }
-
     @Test @MainActor func configuredAppKitImageReusesCachedImage() throws {
         RenderableSystemSymbol.resetRenderabilityCacheForTesting()
         let first = try #require(RenderableSystemSymbol.configuredAppKitImage(


### PR DESCRIPTION
## Summary

Closes #7073.

Restores the requested square raster frame for AppKit-backed SF Symbols. The regression came from the `CmuxSystemSymbolImage` migration in `d4342fbaec` / #6728: titlebar callers still requested the same 12pt icon size, but `RenderableSystemSymbol.configuredAppKitImage` aspect-fit the configured AppKit image so non-square symbols rendered with a smaller intrinsic image inside the unchanged titlebar chrome.

## Reproduction / confirmation

Confirmed from code and history rather than launching local builds, per the no-build/no-local-test constraint:

- `v0.64.17` rendered top-left titlebar symbols with `Image(systemName: ...).symbolRenderingMode(.monochrome).cmuxSymbolRasterSize(config.iconSize, weight: ...)`.
- `cmuxSymbolRasterSize` applied a system font at the requested point size and a fixed square frame.
- Current `main` uses `CmuxSystemSymbolImage(systemName: ..., pointSize: config.iconSize, weight: ...)`.
- The AppKit path configured the symbol at the requested point size, then changed `NSImage.size` through `fittedSymbolSize(..., maximumDimension: rasterSize)`, shrinking the intrinsic image for non-square symbols while the titlebar button/frame metrics stayed unchanged.

Observed from the code path: requested titlebar metrics remained 20pt buttons / 12pt icons, but the rendered image size was reduced for non-square symbols. Expected: AppKit-backed symbol rendering should preserve the requested square raster frame so the visible chrome matches the pre-regression sizing behavior.

## Fix boundary

The fix belongs in `RenderableSystemSymbol`, not the titlebar callsite. The titlebar already passes the correct metric; the abstraction changed the meaning of `pointSize` when it aspect-fit the configured AppKit image. Keeping the AppKit image creation/cache preserves the macOS 27 crash fix, while removing the extra shrink restores the old `cmuxSymbolRasterSize` sizing contract for all callers that ask for a concrete symbol point size. Global font magnification remains opt-in through the existing `appliesGlobalFontMagnification` path.

## Tests

- Added a focused regression assertion in `RenderableSystemSymbolTests` that a non-square AppKit symbol keeps the requested square raster frame.
- First commit is test-only and should fail against the previous aspect-fit behavior; second commit applies the fix.
- Local tests/builds were not run, per instruction. CI is the validation path.

## Localization

No user-facing strings changed, so no localization catalog updates were needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix titlebar SF Symbol sizing by removing extra aspect-fit scaling for AppKit images so non-square symbols render at their configured size and aspect ratio, restoring the pre-migration look. Closes #7073.

- **Bug Fixes**
  - Stop downscaling AppKit symbols to a square raster; keep the configured dimensions and aspect ratio, with a square fallback only when the configured size is invalid.

<sup>Written for commit 2dac51a33d5cd3a13933e74673634c7025b11fea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

