### PR TITLE
Keep iOS workspace toolbar visible before sessions

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChatPane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChatPane.swift
@@ -12,23 +12,12 @@ import UIKit
 /// The agent chat rendered inline in the workspace detail, in place of the
 /// terminal, when chat mode is toggled on. There is no cover and no Done
 /// button: the same toolbar toggle flips back to the terminal.
-struct WorkspaceChatPane<TitleMenuContent: View>: View {
+struct WorkspaceChatPane: View {
     let session: ChatSessionDescriptor
     let store: CMUXMobileShellStore
-    /// The owning workspace's name, shown as the header title (so the header
-    /// reads as the workspace, not the session's first prompt).
-    let workspaceName: String
-    /// The name of the tab/terminal this session lives on, shown as the
-    /// header subtitle.
-    let tabName: String?
     /// Composer draft, owned by the parent so it survives toggling back to
     /// the terminal and returning mid-thought.
     @Binding var draft: String
-    /// Compact-stack back button owned by the workspace toolbar, colocated with
-    /// the leading title so their order is deterministic.
-    let backButtonConfiguration: WorkspaceBackButtonConfiguration?
-    /// Workspace-scoped actions exposed from the title pill.
-    let titleMenuContent: () -> TitleMenuContent
     /// Flips chat mode off (the toggle's "back to terminal" path).
     let onExitChat: () -> Void
 
@@ -37,10 +26,6 @@ struct WorkspaceChatPane<TitleMenuContent: View>: View {
     @State private var conversation: ChatConversationStore?
     @State private var accessoryConfiguration = TerminalAccessoryConfiguration.shared
     @State private var isShowingShortcutSettings = false
-    /// Full content width, used to bound the leading toolbar header so a long
-    /// workspace name truncates before the trailing toolbar buttons.
-    @State private var contentWidth: CGFloat = 0
-
     var body: some View {
         Group {
             if let conversation {
@@ -52,47 +37,6 @@ struct WorkspaceChatPane<TitleMenuContent: View>: View {
                     providesOwnChrome: false,
                     onOpenTerminal: openTerminal
                 )
-                // The host (workspace detail) owns the nav bar, so the live
-                // session-state header is supplied here rather than by
-                // ChatScreen, which would be dropped under the workspace's own
-                // chrome.
-                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
-                .toolbar {
-                    if backButtonConfiguration != nil {
-                        ToolbarItem(placement: .topBarLeading) {
-                            workspaceBackToolbarButton
-                        }
-                        if #available(iOS 26.0, *) {
-                            ToolbarSpacer(.fixed, placement: .topBarLeading)
-                        }
-                    }
-                    ToolbarItem(placement: .topBarLeading) {
-                        Menu {
-                            titleMenuContent()
-                        } label: {
-                            ChatSessionHeaderView(
-                                descriptor: conversation.descriptor,
-                                agentState: conversation.agentState,
-                                isConnected: conversation.isConnected,
-                                titleOverride: workspaceName,
-                                subtitle: tabName,
-                                style: .toolbarCompact
-                            )
-                            .frame(
-                                minWidth: MobileNavTitleWidth.floor,
-                                maxWidth: MobileNavTitleWidth(
-                                    contentWidth: contentWidth,
-                                    hasBackButton: backButtonConfiguration != nil,
-                                    hasChatToggle: true
-                                ).leadingCap,
-                                alignment: .leading
-                            )
-                            .layoutPriority(1)
-                        }
-                        .mobileGlassCompactToolbarControl()
-                        .accessibilityIdentifier("MobileWorkspaceTitleMenu")
-                    }
-                }
             } else {
                 Color.clear
             }
@@ -109,17 +53,6 @@ struct WorkspaceChatPane<TitleMenuContent: View>: View {
         }
         .sheet(isPresented: $isShowingShortcutSettings) {
             TerminalShortcutsSettingsView(scope: .agentChat)
-        }
-    }
-
-    @ViewBuilder
-    private var workspaceBackToolbarButton: some View {
-        if let backButtonConfiguration {
-            WorkspaceBackButton(
-                unreadCount: backButtonConfiguration.unreadCount,
-                badgeContrast: backButtonConfiguration.badgeContrast,
-                action: backButtonConfiguration.action
-            )
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -117,6 +117,24 @@ struct WorkspaceDetailView: View {
         Group {
             detailSurfaceContent
         }
+        #if os(iOS)
+        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
+        .navigationTitle(systemNavigationTitle)
+        .mobileTerminalNavigationChrome()
+        .toolbar {
+            workspaceNavigationToolbar
+        }
+        .task(id: chatRefreshKey) { await refreshChatSessions() }
+        .closeWorkspaceConfirmation(
+            isPresented: $isConfirmingClose,
+            confirm: confirmCloseWorkspaceFromMenu
+        )
+        .workspaceRenameDialog(
+            isPresented: $isRenamePresented,
+            text: $renameText,
+            onSave: commitRenameFromDialog
+        )
+        #endif
         .mobileConnectionRecoveryOverlay(store: store, signOut: signOut)
     }
 
@@ -144,14 +162,10 @@ struct WorkspaceDetailView: View {
         WorkspaceChatPane(
             session: session,
             store: store,
-            workspaceName: workspace.name,
-            tabName: tabName(for: session),
             draft: Binding(
                 get: { chatDrafts[session.id] ?? "" },
                 set: { chatDrafts[session.id] = $0 }
             ),
-            backButtonConfiguration: backButtonConfiguration,
-            titleMenuContent: { titleMenuContent },
             onExitChat: {
                 withAnimation(.snappy(duration: 0.28)) {
                     isChatMode = false
@@ -162,23 +176,12 @@ struct WorkspaceDetailView: View {
         .id(session.id)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .mobileChatTopScrollEdgeLayout(legacyTopPadding: terminalTopPadding)
-        .mobileTerminalNavigationChrome()
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 chatToggleButton
                 terminalPickerToolbarButton
             }
         }
-        .task(id: chatRefreshKey) { await refreshChatSessions() }
-        .closeWorkspaceConfirmation(
-            isPresented: $isConfirmingClose,
-            confirm: confirmCloseWorkspaceFromMenu
-        )
-        .workspaceRenameDialog(
-            isPresented: $isRenamePresented,
-            text: $renameText,
-            onSave: commitRenameFromDialog
-        )
     }
 
     @ViewBuilder
@@ -295,47 +298,6 @@ struct WorkspaceDetailView: View {
         // Key on the surface id so switching/reopening rebuilds the WKWebView.
         .id(browser.id.rawValue)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
-        .navigationTitle("")
-        .mobileTerminalNavigationChrome()
-        .toolbar {
-            if backButtonConfiguration != nil {
-                ToolbarItem(placement: .topBarLeading) {
-                    workspaceBackToolbarButton
-                }
-                if #available(iOS 26.0, *) {
-                    ToolbarSpacer(.fixed, placement: .topBarLeading)
-                }
-            }
-            ToolbarItem(placement: .topBarLeading) {
-                WorkspaceTitleMenu(
-                    contentWidth: contentWidth,
-                    hasBackButton: backButtonConfiguration != nil,
-                    hasChatToggle: isChatMode || sessionForSelectedTerminal != nil,
-                    menuContent: { titleMenuContent }
-                ) {
-                    Text(browser.title ?? workspace.name)
-                        .font(.headline)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .foregroundStyle(TerminalPalette.foreground)
-                }
-            }
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                chatToggleButton
-                terminalPickerToolbarButton
-            }
-        }
-        .task(id: chatRefreshKey) { await refreshChatSessions() }
-        .closeWorkspaceConfirmation(
-            isPresented: $isConfirmingClose,
-            confirm: confirmCloseWorkspaceFromMenu
-        )
-        .workspaceRenameDialog(
-            isPresented: $isRenamePresented,
-            text: $renameText,
-            onSave: commitRenameFromDialog
-        )
     }
     #endif
 
@@ -400,9 +362,6 @@ struct WorkspaceDetailView: View {
             #endif
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        #if os(iOS)
-        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
-        #endif
         .overlay(alignment: .topLeading) {
             MobileMacConnectionStatusPill(host: host, status: connectionStatus)
                 .padding(.top, 10)
@@ -463,45 +422,14 @@ struct WorkspaceDetailView: View {
         #else
         .background(TerminalPalette.background)
         #endif
+        #if os(macOS)
         .navigationTitle(systemNavigationTitle)
-        .mobileTerminalNavigationChrome()
-        #if os(iOS)
-        .task(id: chatRefreshKey) { await refreshChatSessions() }
-        #endif
         .toolbar {
-            #if os(iOS)
-            if backButtonConfiguration != nil {
-                ToolbarItem(placement: .topBarLeading) {
-                    workspaceBackToolbarButton
-                }
-                if #available(iOS 26.0, *) {
-                    ToolbarSpacer(.fixed, placement: .topBarLeading)
-                }
-            }
-            ToolbarItem(placement: .topBarLeading) {
-                WorkspaceTitleMenu(
-                    contentWidth: contentWidth,
-                    hasBackButton: backButtonConfiguration != nil,
-                    hasChatToggle: isChatMode || sessionForSelectedTerminal != nil,
-                    menuContent: { titleMenuContent }
-                ) {
-                    WorkspaceToolbarTitleView(title: workspace.name, subtitle: selectedToolbarSubtitle)
-                }
-            }
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                chatToggleButton
-                terminalPickerToolbarButton
-            }
-            #else
             ToolbarItem {
                 terminalToolbarButtons
             }
-        #endif
         }
-        .closeWorkspaceConfirmation(
-            isPresented: $isConfirmingClose,
-            confirm: confirmCloseWorkspaceFromMenu
-        )
+        #endif
         #if canImport(UIKit)
         .sheet(isPresented: $isFeedbackComposerPresented) {
             feedbackComposer
@@ -509,11 +437,6 @@ struct WorkspaceDetailView: View {
         .sheet(isPresented: $isTextSheetPresented) {
             TerminalTextSheetView(surfaceID: textSheetSurfaceID)
         }
-        .workspaceRenameDialog(
-            isPresented: $isRenamePresented,
-            text: $renameText,
-            onSave: commitRenameFromDialog
-        )
         #endif
     }
 
@@ -524,6 +447,47 @@ struct WorkspaceDetailView: View {
     }
 
     #if os(iOS)
+    @ToolbarContentBuilder
+    private var workspaceNavigationToolbar: some ToolbarContent {
+        if backButtonConfiguration != nil {
+            ToolbarItem(placement: .topBarLeading) {
+                workspaceBackToolbarButton
+            }
+            if #available(iOS 26.0, *) {
+                ToolbarSpacer(.fixed, placement: .topBarLeading)
+            }
+        }
+        ToolbarItem(placement: .topBarLeading) {
+            WorkspaceTitleMenu(
+                contentWidth: contentWidth,
+                hasBackButton: backButtonConfiguration != nil,
+                hasChatToggle: isChatMode || sessionForSelectedTerminal != nil,
+                menuContent: { titleMenuContent }
+            ) {
+                workspaceTitleToolbarLabel
+            }
+        }
+        if !isChatMode {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                chatToggleButton
+                terminalPickerToolbarButton
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var workspaceTitleToolbarLabel: some View {
+        if let browser = activeBrowser {
+            Text(browser.title ?? workspace.name)
+                .font(.headline)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .foregroundStyle(TerminalPalette.foreground)
+        } else {
+            WorkspaceToolbarTitleView(title: workspace.name, subtitle: selectedToolbarSubtitle)
+        }
+    }
+
     /// Compact-stack back button colocated with the leading title so both
     /// terminal and chat modes share one toolbar order.
     @ViewBuilder

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -449,22 +449,17 @@ struct WorkspaceDetailView: View {
     #if os(iOS)
     @ToolbarContentBuilder
     private var workspaceNavigationToolbar: some ToolbarContent {
-        if backButtonConfiguration != nil {
-            ToolbarItem(placement: .topBarLeading) {
-                workspaceBackToolbarButton
-            }
-            if #available(iOS 26.0, *) {
-                ToolbarSpacer(.fixed, placement: .topBarLeading)
-            }
-        }
         ToolbarItem(placement: .topBarLeading) {
-            WorkspaceTitleMenu(
-                contentWidth: contentWidth,
-                hasBackButton: backButtonConfiguration != nil,
-                hasChatToggle: isChatMode || sessionForSelectedTerminal != nil,
-                menuContent: { titleMenuContent }
-            ) {
-                workspaceTitleToolbarLabel
+            HStack(spacing: 8) {
+                workspaceBackToolbarButton
+                WorkspaceTitleMenu(
+                    contentWidth: contentWidth,
+                    hasBackButton: backButtonConfiguration != nil,
+                    hasChatToggle: isChatMode || sessionForSelectedTerminal != nil,
+                    menuContent: { titleMenuContent }
+                ) {
+                    workspaceTitleToolbarLabel
+                }
             }
         }
         if !isChatMode {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -493,6 +493,7 @@ struct WorkspaceDetailView: View {
                 badgeContrast: backButtonConfiguration.badgeContrast,
                 action: backButtonConfiguration.action
             )
+            .mobileGlassCompactToolbarControl()
         }
     }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -285,6 +285,8 @@ final class cmuxUITests: XCTestCase {
 
         let app = try launchConnectedApp(port: port)
         try openSelectedWorkspaceIfNeeded(app)
+        XCTAssertTrue(app.buttons["MobileWorkspaceBackButton"].waitForExistence(timeout: 4))
+        XCTAssertTrue(app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 4))
 
         tap(app.buttons["MobileTerminalNewWorkspaceButton"], in: app)
         await assertHostSelection(


### PR DESCRIPTION
## Summary
- Move iOS workspace leading navigation chrome to the WorkspaceDetailView root for every mode
- Keep terminal/browser trailing toolbar content shared, and keep chat trailing controls mode-specific
- Remove WorkspaceChatPane leading toolbar ownership so conversation loading cannot drop the back/title chrome

## Verification
- `git diff --check`
- `xcodebuild test -workspace ios/cmux.xcworkspace -scheme cmux-ios -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /Users/abdulazizalbahar/Library/Developer/Xcode/DerivedData/cmux-ios-tbfix PRODUCT_BUNDLE_IDENTIFIER=dev.cmux.ios.tbfix 'PRODUCT_DISPLAY_NAME=cmux DEV tbfix' CMUX_GIT_SHA=$(git rev-parse --short=10 HEAD) CMUX_DEV_TAG=tbfix CODE_SIGNING_ALLOWED=NO -only-testing:cmuxUITests/cmuxUITests/testInlineWorkspaceTitleMenuShowsWorkspaceActions`

## Notes
- The remaining failure mode was chat mode: `isChatMode` could flip true, hiding the parent toolbar, before `WorkspaceChatPane` had built its conversation-backed toolbar. This PR now has one stable owner for leading workspace chrome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS workspace toolbar leading layout by consolidating the back button and workspace title menu into a single top-bar control, applying consistent behavior across browser and chat modes.
  * Refreshed compact “glass” styling for the workspace back button to improve visual consistency.
* **Tests**
  * Updated an iOS UI test to wait for the workspace back button and title menu to appear before creating a new terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->