### PR TITLE
Restore titlebar toolbar icon sizing

### DIFF
--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -222,10 +222,10 @@ struct CmuxSystemSymbolImage: View {
             pointSize: rasterSize,
             weight: weight
         ) {
-            let imageSize = RenderableSystemSymbol.configuredSymbolImageSize(image.size, fallbackDimension: rasterSize)
             Image(nsImage: image)
                 .renderingMode(.template)
-                .frame(width: imageSize.width, height: imageSize.height, alignment: alignment)
+                // Preserve the old font-based path's stable layout slot while the image draws at AppKit's natural size.
+                .frame(width: rasterSize, height: rasterSize, alignment: alignment)
         } else {
             Color.clear
                 .frame(width: rasterSize, height: rasterSize, alignment: alignment)

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -116,7 +116,7 @@ enum RenderableSystemSymbol {
         let configuredImage = baseImage.withSymbolConfiguration(configuration) ?? baseImage
         let image = (configuredImage.copy() as? NSImage) ?? configuredImage
         image.isTemplate = true
-        image.size = fittedSymbolSize(configuredImage.size, maximumDimension: rasterSize)
+        image.size = configuredSymbolImageSize(configuredImage.size, fallbackDimension: rasterSize)
         appKitImageCache[cacheKey] = image
         appKitImageCacheInsertionOrder.append(cacheKey)
         while appKitImageCacheInsertionOrder.count > appKitImageCacheLimit {
@@ -138,16 +138,15 @@ enum RenderableSystemSymbol {
         }
     }
 
-    static func fittedSymbolSize(_ naturalSize: NSSize, maximumDimension: CGFloat) -> NSSize {
-        let maximumDimension = clampedRasterPointSize(maximumDimension)
+    static func configuredSymbolImageSize(_ naturalSize: NSSize, fallbackDimension: CGFloat) -> NSSize {
+        let fallbackDimension = clampedRasterPointSize(fallbackDimension)
         guard naturalSize.width.isFinite,
               naturalSize.height.isFinite,
               naturalSize.width > 0,
               naturalSize.height > 0 else {
-            return NSSize(width: maximumDimension, height: maximumDimension)
+            return NSSize(width: fallbackDimension, height: fallbackDimension)
         }
-        let scale = maximumDimension / max(naturalSize.width, naturalSize.height)
-        return NSSize(width: naturalSize.width * scale, height: naturalSize.height * scale)
+        return naturalSize
     }
 
     private static func nsFontWeight(for weight: Font.Weight?) -> NSFont.Weight {

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -222,9 +222,10 @@ struct CmuxSystemSymbolImage: View {
             pointSize: rasterSize,
             weight: weight
         ) {
+            let imageSize = RenderableSystemSymbol.configuredSymbolImageSize(image.size, fallbackDimension: rasterSize)
             Image(nsImage: image)
                 .renderingMode(.template)
-                .frame(width: rasterSize, height: rasterSize, alignment: alignment)
+                .frame(width: imageSize.width, height: imageSize.height, alignment: alignment)
         } else {
             Color.clear
                 .frame(width: rasterSize, height: rasterSize, alignment: alignment)

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -59,6 +59,25 @@ struct RenderableSystemSymbolTests {
         #expect(image.size.height < 16)
     }
 
+    @Test @MainActor func configuredAppKitImageKeepsNaturalConfiguredSizeWhenItExceedsPointSize() throws {
+        RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+        let pointSize = CGFloat(16)
+        let symbolName = "bell"
+        let baseImage = try #require(NSImage(systemSymbolName: symbolName, accessibilityDescription: nil))
+        let configuredImage = baseImage.withSymbolConfiguration(NSImage.SymbolConfiguration(
+            pointSize: pointSize,
+            weight: .medium
+        )) ?? baseImage
+        #expect(max(configuredImage.size.width, configuredImage.size.height) > pointSize)
+
+        let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
+            systemName: symbolName,
+            pointSize: pointSize,
+            weight: .medium
+        ))
+        #expect(image.size == configuredImage.size)
+    }
+
     @Test func fittedSymbolSizeScalesLongerDimensionToRasterSize() {
         #expect(RenderableSystemSymbol.fittedSymbolSize(
             NSSize(width: 20, height: 10),

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -37,15 +37,24 @@ struct RenderableSystemSymbolTests {
         ) == 2)
     }
 
-    @Test @MainActor func configuredAppKitImageUsesTemplateImageWithClampedSize() throws {
+    @Test @MainActor func configuredAppKitImageUsesTemplateImageWithClampedRasterInput() throws {
         RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+        let pointSize = CGFloat(0)
+        let clampedPointSize = RenderableSystemSymbol.clampedRasterPointSize(pointSize)
+        let symbolName = "questionmark.circle"
+        let baseImage = try #require(NSImage(systemSymbolName: symbolName, accessibilityDescription: nil))
+        let configuredImage = baseImage.withSymbolConfiguration(NSImage.SymbolConfiguration(
+            pointSize: clampedPointSize,
+            weight: .medium
+        )) ?? baseImage
+
         let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
-            systemName: "questionmark.circle",
-            pointSize: 0,
+            systemName: symbolName,
+            pointSize: pointSize,
             weight: .medium
         ))
         #expect(image.isTemplate)
-        #expect(image.size == NSSize(width: 1, height: 1))
+        #expect(image.size == configuredImage.size)
     }
 
     @Test @MainActor func configuredAppKitImagePreservesNonSquareSymbolNaturalSize() throws {
@@ -93,6 +102,10 @@ struct RenderableSystemSymbolTests {
         ) == NSSize(width: 20, height: 10))
         #expect(RenderableSystemSymbol.configuredSymbolImageSize(
             NSSize(width: 0, height: 10),
+            fallbackDimension: 16
+        ) == NSSize(width: 16, height: 16))
+        #expect(RenderableSystemSymbol.configuredSymbolImageSize(
+            NSSize(width: .nan, height: 10),
             fallbackDimension: 16
         ) == NSSize(width: 16, height: 16))
     }

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -48,15 +48,23 @@ struct RenderableSystemSymbolTests {
         #expect(image.size == NSSize(width: 1, height: 1))
     }
 
-    @Test @MainActor func configuredAppKitImagePreservesNonSquareSymbolAspectRatio() throws {
+    @Test @MainActor func configuredAppKitImagePreservesNonSquareSymbolNaturalSize() throws {
         RenderableSystemSymbol.resetRenderabilityCacheForTesting()
+        let pointSize = CGFloat(16)
+        let symbolName = "arrow.right"
+        let baseImage = try #require(NSImage(systemSymbolName: symbolName, accessibilityDescription: nil))
+        let configuredImage = baseImage.withSymbolConfiguration(NSImage.SymbolConfiguration(
+            pointSize: pointSize,
+            weight: .regular
+        )) ?? baseImage
+
         let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
-            systemName: "arrow.right",
-            pointSize: 16,
+            systemName: symbolName,
+            pointSize: pointSize,
             weight: .regular
         ))
-        #expect(abs(image.size.width - 16) < 0.001)
-        #expect(image.size.height < 16)
+        #expect(image.size == configuredImage.size)
+        #expect(image.size.width > image.size.height)
     }
 
     @Test @MainActor func configuredAppKitImageKeepsNaturalConfiguredSizeWhenItExceedsPointSize() throws {
@@ -78,14 +86,14 @@ struct RenderableSystemSymbolTests {
         #expect(image.size == configuredImage.size)
     }
 
-    @Test func fittedSymbolSizeScalesLongerDimensionToRasterSize() {
-        #expect(RenderableSystemSymbol.fittedSymbolSize(
+    @Test func configuredSymbolImageSizeKeepsValidNaturalSize() {
+        #expect(RenderableSystemSymbol.configuredSymbolImageSize(
             NSSize(width: 20, height: 10),
-            maximumDimension: 16
-        ) == NSSize(width: 16, height: 8))
-        #expect(RenderableSystemSymbol.fittedSymbolSize(
+            fallbackDimension: 16
+        ) == NSSize(width: 20, height: 10))
+        #expect(RenderableSystemSymbol.configuredSymbolImageSize(
             NSSize(width: 0, height: 10),
-            maximumDimension: 16
+            fallbackDimension: 16
         ) == NSSize(width: 16, height: 16))
     }
 

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -79,20 +79,34 @@ struct RenderableSystemSymbolTests {
     @Test @MainActor func configuredAppKitImageKeepsNaturalConfiguredSizeWhenItExceedsPointSize() throws {
         RenderableSystemSymbol.resetRenderabilityCacheForTesting()
         let pointSize = CGFloat(16)
-        let symbolName = "bell"
-        let baseImage = try #require(NSImage(systemSymbolName: symbolName, accessibilityDescription: nil))
-        let configuredImage = baseImage.withSymbolConfiguration(NSImage.SymbolConfiguration(
-            pointSize: pointSize,
-            weight: .medium
-        )) ?? baseImage
-        #expect(max(configuredImage.size.width, configuredImage.size.height) > pointSize)
+        let oversizedCandidate = try #require([
+            "bell",
+            "plus",
+            "sidebar.left",
+            "arrow.right",
+            "questionmark.circle",
+            "chevron.left",
+            "chevron.right",
+        ].compactMap { symbolName -> (symbolName: String, configuredImage: NSImage)? in
+            guard let baseImage = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil) else {
+                return nil
+            }
+            let configuredImage = baseImage.withSymbolConfiguration(NSImage.SymbolConfiguration(
+                pointSize: pointSize,
+                weight: .medium
+            )) ?? baseImage
+            guard max(configuredImage.size.width, configuredImage.size.height) > pointSize else {
+                return nil
+            }
+            return (symbolName, configuredImage)
+        }.first)
 
         let image = try #require(RenderableSystemSymbol.configuredAppKitImage(
-            systemName: symbolName,
+            systemName: oversizedCandidate.symbolName,
             pointSize: pointSize,
             weight: .medium
         ))
-        #expect(image.size == configuredImage.size)
+        #expect(image.size == oversizedCandidate.configuredImage.size)
     }
 
     @Test func configuredSymbolImageSizeKeepsValidNaturalSize() {


### PR DESCRIPTION
## Summary
- Fix the titlebar/chrome SF Symbol size regression introduced by #6728 after v0.64.17.
- Keep the macOS 27 crash-avoidance path and renderability/image caches, but stop forcing AppKit-configured symbols into a pointSize-sized box.
- Preserve valid AppKit natural symbol sizes and use the clamped point size only as an invalid-size fallback.

## Regression
#6728 migrated toolbar symbols from the old font-based `Image(systemName:)` path to cached `NSImage` rendering. The new helper configured each symbol at a point size, then reset `image.size` so the longest dimension equaled that nominal point size. AppKit naturally produces SF Symbol bounds larger than the requested point size, so this clamp made the sidebar toggle, bell, plus, and browser chevrons visibly smaller than v0.64.17.

## Fix
`RenderableSystemSymbol.configuredAppKitImage` now leaves valid AppKit-configured symbol sizes at their natural size. The existing clamped point size remains the fallback only when AppKit returns an invalid/non-finite size, and the renderability cache plus bounded image cache from #6728 stay intact.

## Tests / proof
- Added a focused `RenderableSystemSymbolTests` guard proving a normal symbol whose AppKit natural size exceeds the requested point size is not shrunk to the point-size box.
- Updated the helper sizing test to preserve valid natural sizes while retaining the invalid-size fallback.
- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh`
- Attempted focused local `cmux-unit` test with tagged derived data; Xcode got stuck after package resolution and was terminated. CI is running the test target.

## Visual proof
Cloud-mac proof was attempted with run https://github.com/manaflow-ai/cmux-loader/actions/runs/28417875952. The VM reached the hold step, but local `macfleet` lookup is not authenticated (`No token stored for 'manaflow'`), so no SSH alias/video could be captured from this environment. The held run was cancelled.