### PR TITLE
Clamp large window stranded off-screen after display disconnect (#2824)

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -183,16 +183,34 @@ final class CmuxMainWindow: NSWindow {
 
     /// Whether `proposedFrame` is reachable enough across `visibleFrames` that
     /// AppKit's constraining pass should be skipped. The frame qualifies when it
-    /// overlaps some screen's visible area by at least `minimumVisibleExtent`
-    /// points in both dimensions (or its full extent, when smaller) — i.e. a
+    /// overlaps some screen's visible area by enough in *both* dimensions that a
     /// usable, grabbable slice of the window is on-screen.
+    ///
+    /// "Enough" is the larger of an absolute floor (`minimumVisibleExtent`) and a
+    /// fraction of the window (`minimumVisibleFraction`), capped at the window's
+    /// own extent. The fraction matters: a purely absolute floor treats a large
+    /// window with only a thin strip on-screen as "reachable" — e.g. after an
+    /// external display is unplugged a full-width window can be left hanging off
+    /// the right edge with hundreds of points still visible, far above any small
+    /// absolute floor, yet effectively off-screen and unusable (#2824). Requiring
+    /// a proportional slice means such a window is handed back to AppKit's default
+    /// constrain pass and pulled into view, while a window that is mostly (or
+    /// fully) on-screen — including one whose titlebar merely pokes into the menu
+    /// bar — is still preserved untouched, so it cannot creep on sleep/wake.
     nonisolated static func shouldPreserveFrameDuringConstrain(
         _ proposedFrame: NSRect,
         visibleFrames: [NSRect],
-        minimumVisibleExtent: CGFloat = 60
+        minimumVisibleExtent: CGFloat = 60,
+        minimumVisibleFraction: CGFloat = 0.6
     ) -> Bool {
-        let requiredWidth = min(proposedFrame.width, minimumVisibleExtent)
-        let requiredHeight = min(proposedFrame.height, minimumVisibleExtent)
+        let requiredWidth = min(
+            proposedFrame.width,
+            max(minimumVisibleExtent, proposedFrame.width * minimumVisibleFraction)
+        )
+        let requiredHeight = min(
+            proposedFrame.height,
+            max(minimumVisibleExtent, proposedFrame.height * minimumVisibleFraction)
+        )
         for visibleFrame in visibleFrames {
             let intersection = proposedFrame.intersection(visibleFrame)
             if intersection.width >= requiredWidth, intersection.height >= requiredHeight {

--- a/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
+++ b/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
@@ -91,6 +91,30 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
         )
     }
 
+    // #2824: unplugging an external display can leave a large window hanging off
+    // the right edge of the remaining screen. A few hundred points stay visible —
+    // far more than the absolute floor — but the window is effectively off-screen
+    // and unusable. A purely absolute extent check wrongly preserved it; only a
+    // proportional slice of the window being visible counts as reachable.
+    func testDoesNotPreserveLargeWindowStrandedOffRightEdge() {
+        let visible = NSRect(x: 0, y: 0, width: 1440, height: 900)
+        // 340pt of an 800pt-wide window peeks past the right edge (~42%).
+        let frame = NSRect(x: 1100, y: 100, width: 800, height: 600)
+        XCTAssertFalse(
+            CmuxMainWindow.shouldPreserveFrameDuringConstrain(frame, visibleFrames: [visible])
+        )
+    }
+
+    // A full-width window left off the right edge after disconnect: 556pt of a
+    // 1512pt window remain visible, yet it is unreachable in practice.
+    func testDoesNotPreserveFullWidthWindowStrandedAfterDisconnect() {
+        let visible = NSRect(x: 0, y: 0, width: 1512, height: 982)
+        let frame = NSRect(x: 956, y: 14, width: 1512, height: 968)
+        XCTAssertFalse(
+            CmuxMainWindow.shouldPreserveFrameDuringConstrain(frame, visibleFrames: [visible])
+        )
+    }
+
     func testDoesNotPreserveWhenNoScreensAvailable() {
         let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
         XCTAssertFalse(


### PR DESCRIPTION
Fixes #2824.

## Problem

When an external display is disconnected, the cmux window is left hanging off the right edge of the remaining screen — "effectively off screen" (per the issue), recoverable only by dragging it back or moving it to a new Space.

Reproduced on 0.64.17. Measuring the window via the Accessibility API right after a physical disconnect (built-in display, logical bounds `0,0 → 1512,982`):

```
window: x=956  y=-324  w=1512  h=968
```

So a 1512pt-wide window with only ~556pt visible on the right edge, its titlebar above the menu bar.

## Root cause

`CmuxMainWindow.constrainFrameRect` deliberately refuses AppKit's constrain pass for any frame judged "reachable", so an on-screen window is never repositioned and cannot creep on sleep/wake. `shouldPreserveFrameDuringConstrain` judged reachability as **≥60pt of overlap in each dimension**.

That absolute floor is too lenient for large windows: a full-width window stranded off the right edge keeps hundreds of points visible — far above 60pt — so it was treated as reachable and left stranded. The existing tests only covered a ~20pt sliver, so this large-but-mostly-off case slipped through.

## Fix

Require a **proportional** slice of the window to be visible: the larger of the 60pt floor and **60% of each dimension**, capped at the window's own extent.

- A window that is mostly or fully on-screen — including one whose titlebar merely pokes into the menu bar (the sleep/wake creep case) — is still preserved untouched.
- A window that is mostly off-screen is handed back to AppKit's default constrain pass and pulled into view.

## Tests

All existing `CmuxMainWindowConstrainFrameTests` cases keep their results. Two regression cases added:

- `testDoesNotPreserveLargeWindowStrandedOffRightEdge` — an 800pt window 42% past the right edge.
- `testDoesNotPreserveFullWidthWindowStrandedAfterDisconnect` — the measured 1512pt full-width window left ~556pt visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785384222&installation_id=133855650&pr_number=7084&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7084&signature=584f579cdcf7bd319001fcf9bd675493c184ff75cc72062405ee899a5af9255e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pulls windows back into view after a display disconnect by requiring a proportional visible area before skipping AppKit’s constrain pass. Fixes #2824.

- **Bug Fixes**
  - Require the larger of 60pt or 60% visible per dimension (capped by window size); AppKit re-constrains stranded windows while on-screen windows remain stable.
  - Add two regression tests for off-right-edge cases, including the measured full-width scenario.

<sup>Written for commit dffd54ece77c473a02e6e21f4d8ea7fe5f461d11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the app decides whether to keep a window’s position when screen layouts change.
  * Windows are now less likely to stay partially off-screen or become hard to reach after an external display is disconnected.
  * Added regression coverage for edge cases involving large windows on the edge of a missing display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->