### PR TITLE
Fix iOS workspace title toolbar island

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
@@ -70,13 +70,11 @@ struct AgentChatDemoScreen: View {
                             action: {}
                         )
                     }
-                    if #available(iOS 26.0, *) {
-                        ToolbarSpacer(.fixed, placement: .topBarLeading)
-                    }
-                    ToolbarItem(placement: .topBarLeading) {
+                    ToolbarItem(placement: .principal) {
                         WorkspaceToolbarTitleControl(
                             contentWidth: contentWidth,
                             hasBackButton: true,
+                            hasTrailingCluster: true,
                             hasChatToggle: true
                         ) {
                             header(for: stack)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileNavTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileNavTitleWidth.swift
@@ -1,15 +1,17 @@
 import CoreGraphics
 
-/// Width math for the leading glass nav-bar title pill, factored out so the
-/// "use the available row without underlapping toolbar controls" rule is pure.
+/// Width math for the centered glass nav-bar title pill, factored out so the
+/// "grow the middle as much as possible" rule is pure and testable.
 ///
-/// Workspace detail titles live in `.topBarLeading` beside the back button for
-/// consistent placement between terminal and GUI modes. The cap only limits the
-/// title's maximum width; the toolbar and glass button style keep their natural
-/// height.
+/// The title is a screen-centered `.principal` toolbar item, so it is bound by
+/// TWICE the wider of the two visible side clusters (the leading custom back
+/// button vs. the trailing terminal picker plus, when present, the chat toggle).
+/// Reserving only the visible side chrome lets a long title use as much of the
+/// center as it safely can before truncating.
 struct MobileNavTitleWidth {
     let contentWidth: CGFloat
     let hasBackButton: Bool
+    let hasTrailingCluster: Bool
     let hasChatToggle: Bool
 
     /// Reserved width of the leading cluster: the custom back button (chevron +
@@ -21,14 +23,17 @@ struct MobileNavTitleWidth {
     static let chatToggleReserve: CGFloat = 56
     /// Fallback before the pane width has been measured.
     static let unmeasuredFallback: CGFloat = 180
-    /// Never shrink the pill below this, so a tiny pane still shows some title.
+    /// Preferred minimum width when the safe centered slot can fit it.
     static let floor: CGFloat = 96
 
-    /// Max width for the leading title pill.
-    var leadingCap: CGFloat {
+    /// Max safe width for the centered title pill.
+    var cap: CGFloat {
         guard contentWidth > 0 else { return Self.unmeasuredFallback }
         let leading = hasBackButton ? Self.leadingReserve : 0
-        let trailing = Self.trailingReserveBase + (hasChatToggle ? Self.chatToggleReserve : 0)
-        return max(Self.floor, contentWidth - leading - trailing)
+        let trailing = hasTrailingCluster
+            ? Self.trailingReserveBase + (hasChatToggle ? Self.chatToggleReserve : 0)
+            : 0
+        let widerSide = max(leading, trailing)
+        return max(0, contentWidth - 2 * widerSide)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChatPane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChatPane.swift
@@ -25,8 +25,7 @@ struct WorkspaceChatPane: View {
     /// Composer draft, owned by the parent so it survives toggling back to
     /// the terminal and returning mid-thought.
     @Binding var draft: String
-    /// Compact-stack back button owned by the workspace toolbar, colocated with
-    /// the leading title so their order is deterministic.
+    /// Compact-stack back button owned by the workspace toolbar.
     let backButtonConfiguration: WorkspaceBackButtonConfiguration?
     /// Flips chat mode off (the toggle's "back to terminal" path).
     let onExitChat: () -> Void
@@ -35,7 +34,7 @@ struct WorkspaceChatPane: View {
 
     @State private var accessoryConfiguration = TerminalAccessoryConfiguration.shared
     @State private var isShowingShortcutSettings = false
-    /// Full content width, used to bound the leading toolbar header so a long
+    /// Full content width, used to bound the centered toolbar header so a long
     /// workspace name truncates before the trailing toolbar buttons.
     @State private var contentWidth: CGFloat = 0
 
@@ -55,23 +54,28 @@ struct WorkspaceChatPane: View {
             // which would be dropped under the workspace's own chrome.
             .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    HStack(spacing: 8) {
+                if backButtonConfiguration != nil {
+                    ToolbarItem(placement: .topBarLeading) {
                         workspaceBackToolbarButton
-                        WorkspaceToolbarTitleControl(
-                            contentWidth: contentWidth,
-                            hasBackButton: backButtonConfiguration != nil,
-                            hasChatToggle: true
-                        ) {
-                            ChatSessionHeaderView(
-                                descriptor: conversation.descriptor,
-                                agentState: conversation.agentState,
-                                isConnected: conversation.isConnected,
-                                titleOverride: workspaceName,
-                                subtitle: tabName,
-                                style: .toolbarCompact
-                            )
-                        }
+                    }
+                }
+                ToolbarItem(placement: .principal) {
+                    // WorkspaceDetailView mounts the terminal picker/chat
+                    // toggle in a sibling trailing toolbar item.
+                    WorkspaceToolbarTitleControl(
+                        contentWidth: contentWidth,
+                        hasBackButton: backButtonConfiguration != nil,
+                        hasTrailingCluster: true,
+                        hasChatToggle: true
+                    ) {
+                        ChatSessionHeaderView(
+                            descriptor: conversation.descriptor,
+                            agentState: conversation.agentState,
+                            isConnected: conversation.isConnected,
+                            titleOverride: workspaceName,
+                            subtitle: tabName,
+                            style: .toolbarCompact
+                        )
                     }
                 }
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+DerivedState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+DerivedState.swift
@@ -15,7 +15,7 @@ extension WorkspaceDetailView {
 
     var terminalTopPadding: CGFloat { 4 }
 
-    /// iOS renders the workspace title as a custom leading toolbar item. Keep
+    /// iOS renders the workspace title as a custom principal toolbar item. Keep
     /// the system title empty there so it does not draw a second centered title.
     var systemNavigationTitle: String {
         #if os(iOS)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -49,7 +49,7 @@ struct WorkspaceDetailView: View {
     /// editable text (seeded with the current name when presented).
     @State var isRenamePresented = false
     @State var renameText = ""
-    /// Live pane width, used to width-cap the leading glass title pill so a long
+    /// Live pane width, used to width-cap the centered glass title pill so a long
     /// workspace name truncates instead of underlapping the toolbar buttons.
     @State private var contentWidth: CGFloat = 0
     /// Captured at the moment the "View as Text" action is tapped so the
@@ -84,7 +84,6 @@ struct WorkspaceDetailView: View {
     /// that every push arrived.
     @Environment(\.scenePhase) var scenePhase
     #endif
-
     /// The active browser surface for this workspace, when a browser pane is open.
     private var activeBrowser: BrowserSurfaceState? {
         browserStore.activeBrowser(for: workspace.id.rawValue)
@@ -140,20 +139,21 @@ struct WorkspaceDetailView: View {
         .navigationTitle("")
         .mobileTerminalNavigationChrome()
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                HStack(spacing: 8) {
-                    workspaceBackToolbarButton
-                    WorkspaceToolbarTitleControl(
-                        contentWidth: contentWidth,
-                        hasBackButton: backButtonConfiguration != nil,
-                        hasChatToggle: shouldShowChatToggle
-                    ) {
-                        Text(browser.title ?? workspace.name)
-                            .font(.headline)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                            .foregroundStyle(TerminalPalette.foreground)
-                    }
+            if backButtonConfiguration != nil {
+                ToolbarItem(placement: .topBarLeading) { workspaceBackToolbarButton }
+            }
+            ToolbarItem(placement: .principal) {
+                WorkspaceToolbarTitleControl(
+                    contentWidth: contentWidth,
+                    hasBackButton: backButtonConfiguration != nil,
+                    hasTrailingCluster: true,
+                    hasChatToggle: shouldShowChatToggle
+                ) {
+                    Text(browser.title ?? workspace.name)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .foregroundStyle(TerminalPalette.foreground)
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
@@ -304,16 +304,17 @@ struct WorkspaceDetailView: View {
         #endif
         .toolbar {
             #if os(iOS)
-            ToolbarItem(placement: .topBarLeading) {
-                HStack(spacing: 8) {
-                    workspaceBackToolbarButton
-                    WorkspaceToolbarTitleControl(
-                        contentWidth: contentWidth,
-                        hasBackButton: backButtonConfiguration != nil,
-                        hasChatToggle: shouldShowChatToggle
-                    ) {
-                        WorkspaceToolbarTitleView(title: workspace.name, subtitle: selectedToolbarSubtitle)
-                    }
+            if backButtonConfiguration != nil {
+                ToolbarItem(placement: .topBarLeading) { workspaceBackToolbarButton }
+            }
+            ToolbarItem(placement: .principal) {
+                WorkspaceToolbarTitleControl(
+                    contentWidth: contentWidth,
+                    hasBackButton: backButtonConfiguration != nil,
+                    hasTrailingCluster: true,
+                    hasChatToggle: shouldShowChatToggle
+                ) {
+                    WorkspaceToolbarTitleView(title: workspace.name, subtitle: selectedToolbarSubtitle)
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
@@ -351,8 +352,7 @@ struct WorkspaceDetailView: View {
     }
 
     #if os(iOS)
-    /// Compact-stack back button colocated with the leading title so both
-    /// terminal and chat modes share one toolbar order.
+    /// Compact-stack back button rendered as its own leading toolbar island.
     @ViewBuilder
     private var workspaceBackToolbarButton: some View {
         if let backButtonConfiguration {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceToolbarTitleControl.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceToolbarTitleControl.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct WorkspaceToolbarTitleControl<Label: View>: View {
     let contentWidth: CGFloat
     let hasBackButton: Bool
+    let hasTrailingCluster: Bool
     let hasChatToggle: Bool
     @ViewBuilder let label: () -> Label
 
@@ -14,14 +15,17 @@ struct WorkspaceToolbarTitleControl<Label: View>: View {
     }
 
     private var fittedLabel: some View {
-        label()
+        let cap = MobileNavTitleWidth(
+            contentWidth: contentWidth,
+            hasBackButton: hasBackButton,
+            hasTrailingCluster: hasTrailingCluster,
+            hasChatToggle: hasChatToggle
+        ).cap
+
+        return label()
             .frame(
-                minWidth: MobileNavTitleWidth.floor,
-                maxWidth: MobileNavTitleWidth(
-                    contentWidth: contentWidth,
-                    hasBackButton: hasBackButton,
-                    hasChatToggle: hasChatToggle
-                ).leadingCap,
+                minWidth: min(MobileNavTitleWidth.floor, cap),
+                maxWidth: cap,
                 alignment: .leading
             )
             .layoutPriority(1)

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileNavTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileNavTitleWidthTests.swift
@@ -3,43 +3,73 @@ import Testing
 @testable import CmuxMobileShellUI
 
 @Suite struct MobileNavTitleWidthTests {
+    private func cap(
+        _ contentWidth: CGFloat,
+        hasBackButton: Bool = true,
+        hasTrailingCluster: Bool = true,
+        hasChatToggle: Bool = true
+    ) -> CGFloat {
+        MobileNavTitleWidth(
+            contentWidth: contentWidth,
+            hasBackButton: hasBackButton,
+            hasTrailingCluster: hasTrailingCluster,
+            hasChatToggle: hasChatToggle
+        ).cap
+    }
+
     @Test func unmeasuredReturnsFallback() {
-        #expect(
-            MobileNavTitleWidth(contentWidth: 0, hasBackButton: true, hasChatToggle: true).leadingCap
-                == MobileNavTitleWidth.unmeasuredFallback
-        )
+        #expect(cap(0) == MobileNavTitleWidth.unmeasuredFallback)
     }
 
     @Test func growsWithPaneWidth() {
-        let narrow = MobileNavTitleWidth(contentWidth: 320, hasBackButton: true, hasChatToggle: true).leadingCap
-        let wide = MobileNavTitleWidth(contentWidth: 1024, hasBackButton: true, hasChatToggle: true).leadingCap
+        let narrow = cap(320)
+        let wide = cap(1024)
         #expect(wide > narrow)
     }
 
     @Test func moreRoomWithoutChatToggle() {
-        let withToggle = MobileNavTitleWidth(contentWidth: 393, hasBackButton: true, hasChatToggle: true).leadingCap
-        let withoutToggle = MobileNavTitleWidth(contentWidth: 393, hasBackButton: true, hasChatToggle: false).leadingCap
+        let withToggle = cap(393)
+        let withoutToggle = cap(393, hasChatToggle: false)
         #expect(withoutToggle > withToggle)
     }
 
-    @Test func neverBelowFloor() {
-        #expect(
-            MobileNavTitleWidth(contentWidth: 120, hasBackButton: true, hasChatToggle: true).leadingCap
-                == MobileNavTitleWidth.floor
-        )
+    @Test func measuredCapNeverExceedsSafeCenteredSlot() {
+        let trailing = MobileNavTitleWidth.trailingReserveBase + MobileNavTitleWidth.chatToggleReserve
+        #expect(cap(320) == 320 - 2 * trailing)
     }
 
     @Test func moreRoomWithoutBackButton() {
-        let withBack = MobileNavTitleWidth(contentWidth: 393, hasBackButton: true, hasChatToggle: false).leadingCap
-        let withoutBack = MobileNavTitleWidth(contentWidth: 393, hasBackButton: false, hasChatToggle: false).leadingCap
+        let withBack = cap(393, hasChatToggle: false)
+        let withoutBack = cap(393, hasBackButton: false, hasChatToggle: false)
         #expect(withoutBack > withBack)
+    }
+
+    @Test func centeredCapReservesWiderSideSymmetrically() {
+        let measured = cap(393)
+        let expected = 393 - 2 * max(
+            MobileNavTitleWidth.leadingReserve,
+            MobileNavTitleWidth.trailingReserveBase + MobileNavTitleWidth.chatToggleReserve
+        )
+        #expect(measured == expected)
     }
 
     /// The whole point of the change: the old flat 300pt reserve left only ~93pt
     /// of title on a 393pt phone. The tight reserve must give a long title
     /// noticeably more room, even with the chat toggle present.
     @Test func growsMoreThanLegacyFlatReserve() {
-        let cap = MobileNavTitleWidth(contentWidth: 393, hasBackButton: true, hasChatToggle: true).leadingCap
-        #expect(cap > 393 - 300)
+        let measured = cap(393)
+        #expect(measured > 393 - 300)
+    }
+
+    @Test func noTrailingClusterDoesNotReserveChatToggle() {
+        let withTrailing = cap(393)
+        let withoutTrailing = cap(393, hasTrailingCluster: false)
+
+        #expect(withoutTrailing == 393 - 2 * MobileNavTitleWidth.leadingReserve)
+        #expect(withoutTrailing > withTrailing)
+    }
+
+    @Test func noSideClustersCanUseMeasuredWidth() {
+        #expect(cap(393, hasBackButton: false, hasTrailingCluster: false) == 393)
     }
 }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -560,10 +560,12 @@ final class cmuxUITests: XCTestCase {
         let app = launchAgentChatInlinePreviewApp()
         let titleControl = app.descendants(matching: .any)["MobileWorkspaceTitleMenu"]
         let backButton = app.buttons["MobileWorkspaceBackButton"]
+        let chatToggle = app.buttons["AgentChatInlinePreviewChatToggle"]
         let surfacePicker = app.buttons["AgentChatInlinePreviewTerminalPicker"]
         XCTAssertTrue(titleControl.waitForExistence(timeout: 8))
         XCTAssertFalse(app.buttons["MobileWorkspaceTitleMenu"].exists)
         XCTAssertTrue(backButton.waitForExistence(timeout: 4))
+        XCTAssertTrue(chatToggle.waitForExistence(timeout: 4))
         XCTAssertTrue(surfacePicker.waitForExistence(timeout: 4))
         XCTAssertTrue(
             waitForCompactToolbarHeightsToMatch(
@@ -571,6 +573,15 @@ final class cmuxUITests: XCTestCase {
                 backButton: backButton,
                 surfacePicker: surfacePicker,
                 tolerance: 2,
+                timeout: 4
+            )
+        )
+        XCTAssertTrue(
+            waitForWorkspaceTitleCenteredAndSeparated(
+                titleMenu: titleControl,
+                backButton: backButton,
+                trailingControl: chatToggle,
+                in: app,
                 timeout: 4
             )
         )
@@ -2043,6 +2054,45 @@ final class cmuxUITests: XCTestCase {
         let nearbyToolbarHeight = max(lastBackFrame.height, lastPickerFrame.height)
         XCTFail(
             "Tall glyphs must not make the compact title glass taller than nearby toolbar controls. title=\(lastTitleFrame), back=\(lastBackFrame), picker=\(lastPickerFrame), delta=\(abs(lastTitleFrame.height - nearbyToolbarHeight))",
+            file: file,
+            line: line
+        )
+        return false
+    }
+
+    @MainActor
+    private func waitForWorkspaceTitleCenteredAndSeparated(
+        titleMenu: XCUIElement,
+        backButton: XCUIElement,
+        trailingControl: XCUIElement,
+        in app: XCUIApplication,
+        timeout: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        let window = app.windows.firstMatch
+        let windowFrame = window.exists ? window.frame : app.frame
+        let centerTolerance = max(windowFrame.width * 0.10, 28)
+        var lastTitleFrame = titleMenu.frame
+        var lastBackFrame = backButton.frame
+        var lastTrailingFrame = trailingControl.frame
+
+        while Date() < deadline {
+            lastTitleFrame = titleMenu.frame
+            lastBackFrame = backButton.frame
+            lastTrailingFrame = trailingControl.frame
+            if lastTitleFrame.midY > 60,
+               abs(lastTitleFrame.midX - windowFrame.midX) <= centerTolerance,
+               lastTitleFrame.minX > lastBackFrame.maxX + 16,
+               lastTitleFrame.maxX < lastTrailingFrame.minX - 2 {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        XCTFail(
+            "Workspace title must be centered as its own toolbar island, separated from leading and trailing controls. title=\(lastTitleFrame), back=\(lastBackFrame), trailing=\(lastTrailingFrame), window=\(windowFrame)",
             file: file,
             line: line
         )


### PR DESCRIPTION
## Summary
- move the iOS workspace/browser/chat title control back to a centered `.principal` toolbar item so it renders as its own Liquid Glass island
- remove the fixed leading spacer / shared leading HStack path that fused the title to the back button
- restore centered title width math and update the existing width-math unit coverage

Fixes #7091

## Verification
- Not run locally: per issue instructions, no build/test/reload command should run before CI is green and the explicit launch go-ahead.
- No source-shape regression test added for the glass island layout; this is a visual SwiftUI toolbar regression. Existing pure width math coverage was updated to the restored centered cap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the iOS workspace/browser/chat title as a centered `.principal` toolbar item so it renders as its own glass island, independent of the back button. Updates width math to a symmetric centered cap that only reserves visible side chrome, giving the title more room and preventing overlap on small screens. Fixes #7091.

- **Bug Fixes**
  - Move the title to `.principal` across workspace, browser, chat, and the agent chat demo; keep the back button in `.topBarLeading`.
  - Keep the system nav title empty on iOS to avoid a duplicate centered title.
  - Add a UI test that asserts the title is centered and separated from the back button and trailing controls (chat toggle/terminal picker).

- **Refactors**
  - Replace `leadingCap` with `cap = contentWidth − 2 × max(leading, trailing)` and only reserve the trailing side when a trailing cluster is present (`hasTrailingCluster`).
  - Update `WorkspaceToolbarTitleControl` to use `.cap` and set min width to `min(floor, cap)`; expand unit tests for symmetric reserve, measured safe slot, and no-trailing/zero-side cases.

<sup>Written for commit b3ea2e33672edae855409571af9749d20104de76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785400872&installation_id=133855650&pr_number=7092&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7092&signature=9ec35f0b060d99f653a1ef9ba07595b5bbf26c17b95aae2943ea53811dda0733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated workspace and chat toolbars so the page title is centered in its own dedicated header area.
  * The back button is now shown as a separate leading control when available.
  * Title sizing now more reliably fits remaining space, factoring in the presence of the chat toggle.

* **Bug Fixes**
  * Improved toolbar layout consistency across workspace panes, reducing awkward spacing in narrow layouts.

* **Tests**
  * Updated and expanded title-width and toolbar layout tests to match the new centered header behavior and sizing rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->