### PR TITLE
Fix iOS workspace filter machine snapshots

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceFilterMachine.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceFilterMachine.swift
@@ -1,5 +1,26 @@
+import Foundation
+
 /// A machine the workspace list can be filtered to.
 struct WorkspaceFilterMachine: Identifiable, Hashable {
     let id: String
     let name: String
+}
+
+extension WorkspaceFilterMachine {
+    init(id: String, namesByID: [String: String], fallbackName: String) {
+        self.id = id
+        self.name = namesByID[id] ?? fallbackName
+    }
+}
+
+extension Array where Element == WorkspaceFilterMachine {
+    func sortedForMenuDisplay() -> [WorkspaceFilterMachine] {
+        sorted { lhs, rhs in
+            let nameOrder = lhs.name.localizedStandardCompare(rhs.name)
+            if nameOrder != .orderedSame {
+                return nameOrder == .orderedAscending
+            }
+            return lhs.id < rhs.id
+        }
+    }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
@@ -79,12 +79,13 @@ extension MobileWorkspaceListFilter {
     /// must be cleared before it becomes hidden state.
     @discardableResult
     mutating func pruneMachinesForFilterMenu(presentMachineIDs: [String]) -> Bool {
-        guard presentMachineIDs.count > 1 else {
+        let presentMachineIDSet = Set(presentMachineIDs)
+        guard presentMachineIDSet.count > 1 else {
             guard !machines.isEmpty else { return false }
             machines.removeAll()
             return true
         }
-        return pruneMachines(notIn: presentMachineIDs)
+        return pruneMachines(notIn: Array(presentMachineIDSet))
     }
 
     /// The localized copy for "this filter hid every workspace". `nil` for the

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
@@ -88,6 +88,16 @@ extension MobileWorkspaceListFilter {
         return pruneMachines(notIn: Array(presentMachineIDSet))
     }
 
+    /// The Mac title picker owns the machine dimension when it is scoped to one
+    /// Mac, so filter-menu machine selections would be hidden no-ops.
+    @discardableResult
+    mutating func pruneMachinesForFilterMenu(visibleMacSelection: WorkspaceMacSelection) -> Bool {
+        guard case .machine = visibleMacSelection else { return false }
+        guard !machines.isEmpty else { return false }
+        machines.removeAll()
+        return true
+    }
+
     /// The localized copy for "this filter hid every workspace". `nil` for the
     /// identity filter, which can never hide anything. Reflects whichever
     /// dimension(s) are active.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
@@ -74,6 +74,19 @@ extension MobileWorkspaceReadStateFilter {
 }
 
 extension MobileWorkspaceListFilter {
+    /// Keep the menu-owned machine selection visible and recoverable. The
+    /// machine section hides below two present machines, so any selected machine
+    /// must be cleared before it becomes hidden state.
+    @discardableResult
+    mutating func pruneMachinesForFilterMenu(presentMachineIDs: [String]) -> Bool {
+        guard presentMachineIDs.count > 1 else {
+            guard !machines.isEmpty else { return false }
+            machines.removeAll()
+            return true
+        }
+        return pruneMachines(notIn: presentMachineIDs)
+    }
+
     /// The localized copy for "this filter hid every workspace". `nil` for the
     /// identity filter, which can never hide anything. Reflects whichever
     /// dimension(s) are active.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -65,6 +65,18 @@ extension WorkspaceListView {
         return names
     }
 
+    func filterMenuMachines(
+        machineSnapshots: WorkspaceMachineSnapshots,
+        visibleSelection: WorkspaceMacSelection
+    ) -> [WorkspaceFilterMachine] {
+        switch visibleSelection {
+        case .machine:
+            return []
+        case .all, .automatic:
+            return machineSnapshots.filterMachines
+        }
+    }
+
     var canCreateWorkspaceForMacSelection: Bool {
         macSelectionScope.canCreateWorkspace(base: canCreateWorkspace)
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -28,10 +28,6 @@ extension WorkspaceListView {
         macSelectionScope.visibleSelection
     }
 
-    var macPickerMachines: [WorkspaceFilterMachine] {
-        liveMachineSnapshots.macPickerMachines
-    }
-
     var liveMachineSnapshots: WorkspaceMachineSnapshots {
         WorkspaceMachineSnapshots(
             workspaces: workspaces,
@@ -78,7 +74,7 @@ extension WorkspaceListView {
         macSelectionScope.canRenderGroupsForSelection
     }
 
-    var macTitlePickerTitle: String {
+    func macTitlePickerTitle(machineSnapshots: WorkspaceMachineSnapshots) -> String {
         switch visibleMacSelection {
         case .all, .automatic:
             L10n.string("mobile.workspaces.macPicker.allMacs", defaultValue: "All Macs")
@@ -87,7 +83,7 @@ extension WorkspaceListView {
         }
     }
 
-    var macTitlePicker: some View {
+    func macTitlePicker(machineSnapshots: WorkspaceMachineSnapshots) -> some View {
         Menu {
             Picker(
                 L10n.string("mobile.workspaces.macPicker.title", defaultValue: "Choose Mac"),
@@ -114,7 +110,7 @@ extension WorkspaceListView {
                 .accessibilityIdentifier("MobileWorkspaceMacPickerAdd")
             }
         } label: {
-            WorkspaceMacTitlePickerLabel(title: macTitlePickerTitle)
+            WorkspaceMacTitlePickerLabel(title: macTitlePickerTitle(machineSnapshots: machineSnapshots))
         }
         .buttonStyle(.plain)
         .tint(.white)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -29,17 +29,16 @@ extension WorkspaceListView {
     }
 
     var macPickerMachines: [WorkspaceFilterMachine] {
-        let scope = macSelectionScope
-        let names = macDisplayNamesByID()
-        return scope.machineIDs
-            .map { WorkspaceFilterMachine(id: $0, name: names[$0] ?? fallbackMacPickerName) }
-            .sorted { lhs, rhs in
-                let nameOrder = lhs.name.localizedStandardCompare(rhs.name)
-                if nameOrder != .orderedSame {
-                    return nameOrder == .orderedAscending
-                }
-                return lhs.id < rhs.id
-            }
+        liveMachineSnapshots.macPickerMachines
+    }
+
+    var liveMachineSnapshots: WorkspaceMachineSnapshots {
+        WorkspaceMachineSnapshots(
+            workspaces: workspaces,
+            macPickerMachineIDs: macSelectionScope.machineIDs,
+            namesByID: macDisplayNamesByID(),
+            fallbackName: fallbackMacPickerName
+        )
     }
 
     var fallbackMacPickerName: String {
@@ -84,7 +83,7 @@ extension WorkspaceListView {
         case .all, .automatic:
             L10n.string("mobile.workspaces.macPicker.allMacs", defaultValue: "All Macs")
         case .machine(let id):
-            macPickerMachines.first { $0.id == id }?.name ?? fallbackMacPickerName
+            machineSnapshots.macPickerMachines.first { $0.id == id }?.name ?? fallbackMacPickerName
         }
     }
 
@@ -96,7 +95,7 @@ extension WorkspaceListView {
             ) {
                 Text(L10n.string("mobile.workspaces.macPicker.allMacs", defaultValue: "All Macs"))
                     .tag(WorkspaceMacSelection.all)
-                ForEach(macPickerMachines) { machine in
+                ForEach(machineSnapshots.macPickerMachines) { machine in
                     Text(machine.name)
                         .tag(WorkspaceMacSelection.machine(machine.id))
                 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -29,9 +29,11 @@ extension WorkspaceListView {
     }
 
     var liveMachineSnapshots: WorkspaceMachineSnapshots {
+        let scope = macSelectionScope
         WorkspaceMachineSnapshots(
             workspaces: workspaces,
-            macPickerMachineIDs: macSelectionScope.machineIDs,
+            filterMachineIDFor: { scope.aliasIndex.representativeID(for: $0) },
+            macPickerMachineIDs: scope.machineIDs,
             namesByID: macDisplayNamesByID(),
             fallbackName: fallbackMacPickerName
         )
@@ -63,6 +65,19 @@ extension WorkspaceListView {
             names[mac.macDeviceID] = mac.resolvedName
         }
         return names
+    }
+
+    var filterMenuPresentMachineIDs: [String] {
+        let aliasIndex = macSelectionScope.aliasIndex
+        var seen = Set<String>()
+        var present: [String] = []
+        for id in MobileWorkspaceListFilter.machineIDs(in: workspaces) {
+            let representativeID = aliasIndex.representativeID(for: id)
+            if seen.insert(representativeID).inserted {
+                present.append(representativeID)
+            }
+        }
+        return present
     }
 
     func filterMenuMachines(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -30,7 +30,7 @@ extension WorkspaceListView {
 
     var liveMachineSnapshots: WorkspaceMachineSnapshots {
         let scope = macSelectionScope
-        WorkspaceMachineSnapshots(
+        return WorkspaceMachineSnapshots(
             workspaces: workspaces,
             filterMachineIDFor: { scope.aliasIndex.representativeID(for: $0) },
             macPickerMachineIDs: scope.machineIDs,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -164,6 +164,7 @@ struct WorkspaceListView: View {
     var body: some View {
         let currentMachineSnapshots = liveMachineSnapshots
         let currentVisibleMacSelection = visibleMacSelection
+        let currentFilterMenuPresentMachineIDs = filterMenuPresentMachineIDs
         let displayedMachineSnapshots = machineSnapshots ?? currentMachineSnapshots
         let displayedFilterMachines = filterMenuMachines(
             machineSnapshots: displayedMachineSnapshots,
@@ -228,7 +229,7 @@ struct WorkspaceListView: View {
         }
         .listStyle(.plain)
         .workspaceListRefreshable(refresh)
-        .onChange(of: MobileWorkspaceListFilter.machineIDs(in: workspaces)) { _, present in
+        .onChange(of: currentFilterMenuPresentMachineIDs) { _, present in
             // Drop machine filters whose Mac left the aggregated list (a secondary
             // Mac disconnected, or the list fell below two machines so the filter
             // menu's machine section hid). Otherwise a stale machine id rejects

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -163,7 +163,12 @@ struct WorkspaceListView: View {
 
     var body: some View {
         let currentMachineSnapshots = liveMachineSnapshots
+        let currentVisibleMacSelection = visibleMacSelection
         let displayedMachineSnapshots = machineSnapshots ?? currentMachineSnapshots
+        let displayedFilterMachines = filterMenuMachines(
+            machineSnapshots: displayedMachineSnapshots,
+            visibleSelection: currentVisibleMacSelection
+        )
         List {
             if let store, showsConnectionRecoveryRow {
                 Section {
@@ -248,14 +253,14 @@ struct WorkspaceListView: View {
                 }
             }
             ToolbarItemGroup(placement: .topBarTrailing) {
-                WorkspaceListFilterMenu(filter: $filter, machines: displayedMachineSnapshots.filterMachines)
+                WorkspaceListFilterMenu(filter: $filter, machines: displayedFilterMachines)
                 if canCreateWorkspace {
                     newWorkspaceButton
                 }
             }
             #else
             ToolbarItemGroup {
-                WorkspaceListFilterMenu(filter: $filter, machines: displayedMachineSnapshots.filterMachines)
+                WorkspaceListFilterMenu(filter: $filter, machines: displayedFilterMachines)
                 if canCreateWorkspace {
                     newWorkspaceButton
                 }
@@ -265,9 +270,13 @@ struct WorkspaceListView: View {
         .accessibilityIdentifier("MobileWorkspaceList")
         .onAppear {
             updateMachineSnapshots(currentMachineSnapshots)
+            filter.pruneMachinesForFilterMenu(visibleMacSelection: currentVisibleMacSelection)
         }
         .onChange(of: currentMachineSnapshots) { _, snapshots in
             updateMachineSnapshots(snapshots)
+        }
+        .onChange(of: currentVisibleMacSelection) { _, selection in
+            filter.pruneMachinesForFilterMenu(visibleMacSelection: selection)
         }
         #if os(iOS)
         .sheet(isPresented: $showingShortcutsSettings) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -88,8 +88,10 @@ struct WorkspaceListView: View {
     @State var filter: MobileWorkspaceListFilter = .all
     /// Stable machine-menu content. Kept as value state so live workspace or
     /// device-tree updates that do not change the actual machine set/name
-    /// snapshot do not rebuild an open native Menu.
-    @State var machineSnapshots: WorkspaceMachineSnapshots = .empty
+    /// snapshot do not rebuild an open native Menu. `nil` only before the first
+    /// appearance callback, when the body can still display the live snapshot
+    /// without resetting an already-open menu.
+    @State var machineSnapshots: WorkspaceMachineSnapshots?
     /// The workspace whose destructive close action is awaiting confirmation.
     /// Stored at list scope so reusable rows do not own transient presentation
     /// state while `List` is recycling swipe-action rows.
@@ -161,6 +163,7 @@ struct WorkspaceListView: View {
 
     var body: some View {
         let currentMachineSnapshots = liveMachineSnapshots
+        let displayedMachineSnapshots = machineSnapshots ?? currentMachineSnapshots
         List {
             if let store, showsConnectionRecoveryRow {
                 Section {
@@ -237,7 +240,7 @@ struct WorkspaceListView: View {
                 settingsMenu
             }
             ToolbarItem(placement: .principal) {
-                macTitlePicker
+                macTitlePicker(machineSnapshots: displayedMachineSnapshots)
             }
             if showsDevicesButton {
                 ToolbarItem(placement: .topBarLeading) {
@@ -245,14 +248,14 @@ struct WorkspaceListView: View {
                 }
             }
             ToolbarItemGroup(placement: .topBarTrailing) {
-                WorkspaceListFilterMenu(filter: $filter, machines: machineSnapshots.filterMachines)
+                WorkspaceListFilterMenu(filter: $filter, machines: displayedMachineSnapshots.filterMachines)
                 if canCreateWorkspace {
                     newWorkspaceButton
                 }
             }
             #else
             ToolbarItemGroup {
-                WorkspaceListFilterMenu(filter: $filter, machines: machineSnapshots.filterMachines)
+                WorkspaceListFilterMenu(filter: $filter, machines: displayedMachineSnapshots.filterMachines)
                 if canCreateWorkspace {
                     newWorkspaceButton
                 }
@@ -298,8 +301,9 @@ struct WorkspaceListView: View {
     }
 
     private func updateMachineSnapshots(_ snapshots: WorkspaceMachineSnapshots) {
-        guard machineSnapshots != snapshots else { return }
-        machineSnapshots = snapshots
+        if machineSnapshots != snapshots {
+            machineSnapshots = snapshots
+        }
     }
 
     #if os(iOS)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -54,15 +54,6 @@ struct WorkspaceListView: View {
     /// `nil` in previews.
     var store: CMUXMobileShellStore?
 
-    /// Machines present in the (aggregated) workspace list, for the filter's
-    /// machine multi-select. Single-machine yields no machine section. Names
-    /// come from the device tree (registry or paired Macs), falling back to id.
-    private var filterMachines: [WorkspaceFilterMachine] {
-        let ids = MobileWorkspaceListFilter.machineIDs(in: workspaces)
-        guard ids.count > 1 else { return [] }
-        let names = macDisplayNamesByID()
-        return ids.map { WorkspaceFilterMachine(id: $0, name: names[$0] ?? fallbackMacPickerName) }
-    }
     /// Optional: rename a workspace on the Mac. When present, each row offers a
     /// Rename context-menu action.
     var renameWorkspace: ((MobileWorkspacePreview.ID, String) -> Void)?
@@ -95,6 +86,10 @@ struct WorkspaceListView: View {
     /// The active row filter (All / Unread), shared-model state behind the
     /// toolbar ``WorkspaceListFilterMenu``. Session-transient like a search.
     @State var filter: MobileWorkspaceListFilter = .all
+    /// Stable machine-menu content. Kept as value state so live workspace or
+    /// device-tree updates that do not change the actual machine set/name
+    /// snapshot do not rebuild an open native Menu.
+    @State var machineSnapshots: WorkspaceMachineSnapshots = .empty
     /// The workspace whose destructive close action is awaiting confirmation.
     /// Stored at list scope so reusable rows do not own transient presentation
     /// state while `List` is recycling swipe-action rows.
@@ -112,7 +107,7 @@ struct WorkspaceListView: View {
     /// not flatten sections the list already has (it would only lose the chevron
     /// action). A search flattens to a single matched, pinned-first list so
     /// members can be found across groups; floating pinned members out of their
-    /// group is acceptable while filtering. An active row filter (Unread)
+    /// group is acceptable while filtering. An active filter-menu dimension
     /// flattens the same way, for the same reason. A single-Mac picker scope
     /// still renders groups only for the foreground Mac whose group metadata is
     /// available here; "All Macs" and secondary Mac selections flatten because
@@ -121,6 +116,7 @@ struct WorkspaceListView: View {
         !groups.isEmpty
             && trimmedQuery.isEmpty
             && filter.readState == .all
+            && filter.machines.isEmpty
             && canRenderGroupsForSelection
     }
 
@@ -164,6 +160,7 @@ struct WorkspaceListView: View {
     }
 
     var body: some View {
+        let currentMachineSnapshots = liveMachineSnapshots
         List {
             if let store, showsConnectionRecoveryRow {
                 Section {
@@ -248,14 +245,14 @@ struct WorkspaceListView: View {
                 }
             }
             ToolbarItemGroup(placement: .topBarTrailing) {
-                WorkspaceListFilterMenu(filter: $filter, machines: [])
+                WorkspaceListFilterMenu(filter: $filter, machines: machineSnapshots.filterMachines)
                 if canCreateWorkspace {
                     newWorkspaceButton
                 }
             }
             #else
             ToolbarItemGroup {
-                WorkspaceListFilterMenu(filter: $filter, machines: filterMachines)
+                WorkspaceListFilterMenu(filter: $filter, machines: machineSnapshots.filterMachines)
                 if canCreateWorkspace {
                     newWorkspaceButton
                 }
@@ -263,6 +260,12 @@ struct WorkspaceListView: View {
             #endif
         }
         .accessibilityIdentifier("MobileWorkspaceList")
+        .onAppear {
+            updateMachineSnapshots(currentMachineSnapshots)
+        }
+        .onChange(of: currentMachineSnapshots) { _, snapshots in
+            updateMachineSnapshots(snapshots)
+        }
         #if os(iOS)
         .sheet(isPresented: $showingShortcutsSettings) {
             TerminalShortcutsSettingsView()
@@ -292,6 +295,11 @@ struct WorkspaceListView: View {
         return store.connectionRequiresReauth
             || store.connectionRecoveryFailed
             || store.isRecoveringConnection
+    }
+
+    private func updateMachineSnapshots(_ snapshots: WorkspaceMachineSnapshots) {
+        guard machineSnapshots != snapshots else { return }
+        machineSnapshots = snapshots
     }
 
     #if os(iOS)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -226,7 +226,7 @@ struct WorkspaceListView: View {
             // menu's machine section hid). Otherwise a stale machine id rejects
             // every row and strands the user on a blank list with no visible
             // control to clear the filter.
-            filter.pruneMachines(notIn: present)
+            filter.pruneMachinesForFilterMenu(presentMachineIDs: present)
         }
         .navigationTitle(L10n.string("mobile.workspaces.title", defaultValue: "Workspaces"))
         .mobileInlineNavigationTitle()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacSelectionScope.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacSelectionScope.swift
@@ -59,7 +59,7 @@ struct WorkspaceMacSelectionScope {
         case .automatic:
             break
         case .all:
-            active.machines.removeAll()
+            break
         case .machine(let id):
             active.machines = aliasIndex.filterMachineIDs(for: id)
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacSelectionScope.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacSelectionScope.swift
@@ -57,9 +57,9 @@ struct WorkspaceMacSelectionScope {
         var active = filter
         switch visibleSelection {
         case .automatic:
-            break
+            active.machines = expandedFilterMachineIDs(active.machines)
         case .all:
-            break
+            active.machines = expandedFilterMachineIDs(active.machines)
         case .machine(let id):
             active.machines = aliasIndex.filterMachineIDs(for: id)
         }
@@ -92,5 +92,14 @@ struct WorkspaceMacSelectionScope {
             guard let macDeviceID = workspace.macDeviceID else { return false }
             return foregroundMachineIDs.contains(macDeviceID)
         }
+    }
+
+    private func expandedFilterMachineIDs(_ machineIDs: Set<String>) -> Set<String> {
+        guard !machineIDs.isEmpty else { return [] }
+        var expanded = Set<String>()
+        for id in machineIDs {
+            expanded.formUnion(aliasIndex.filterMachineIDs(for: id))
+        }
+        return expanded
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMachineSnapshots.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMachineSnapshots.swift
@@ -19,25 +19,11 @@ struct WorkspaceMachineSnapshots: Equatable {
     ) {
         let filterMachineIDs = Set(MobileWorkspaceListFilter.machineIDs(in: workspaces))
         self.filterMachines = filterMachineIDs.count > 1
-            ? Self.machines(
-                ids: filterMachineIDs,
-                namesByID: namesByID,
-                fallbackName: fallbackName
-            )
+            ? filterMachineIDs
+                .map { WorkspaceFilterMachine(id: $0, namesByID: namesByID, fallbackName: fallbackName) }
+                .sortedForMenuDisplay()
             : []
-        self.macPickerMachines = Self.machines(
-            ids: macPickerMachineIDs,
-            namesByID: namesByID,
-            fallbackName: fallbackName
-        )
-    }
-
-    private static func machines(
-        ids: Set<String>,
-        namesByID: [String: String],
-        fallbackName: String
-    ) -> [WorkspaceFilterMachine] {
-        ids
+        self.macPickerMachines = macPickerMachineIDs
             .map { WorkspaceFilterMachine(id: $0, namesByID: namesByID, fallbackName: fallbackName) }
             .sortedForMenuDisplay()
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMachineSnapshots.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMachineSnapshots.swift
@@ -1,0 +1,44 @@
+import CmuxMobileShellModel
+
+struct WorkspaceMachineSnapshots: Equatable {
+    var filterMachines: [WorkspaceFilterMachine]
+    var macPickerMachines: [WorkspaceFilterMachine]
+
+    static let empty = WorkspaceMachineSnapshots(filterMachines: [], macPickerMachines: [])
+
+    init(filterMachines: [WorkspaceFilterMachine], macPickerMachines: [WorkspaceFilterMachine]) {
+        self.filterMachines = filterMachines
+        self.macPickerMachines = macPickerMachines
+    }
+
+    init(
+        workspaces: [MobileWorkspacePreview],
+        macPickerMachineIDs: Set<String>,
+        namesByID: [String: String],
+        fallbackName: String
+    ) {
+        let filterMachineIDs = Set(MobileWorkspaceListFilter.machineIDs(in: workspaces))
+        self.filterMachines = filterMachineIDs.count > 1
+            ? Self.machines(
+                ids: filterMachineIDs,
+                namesByID: namesByID,
+                fallbackName: fallbackName
+            )
+            : []
+        self.macPickerMachines = Self.machines(
+            ids: macPickerMachineIDs,
+            namesByID: namesByID,
+            fallbackName: fallbackName
+        )
+    }
+
+    private static func machines(
+        ids: Set<String>,
+        namesByID: [String: String],
+        fallbackName: String
+    ) -> [WorkspaceFilterMachine] {
+        ids
+            .map { WorkspaceFilterMachine(id: $0, namesByID: namesByID, fallbackName: fallbackName) }
+            .sortedForMenuDisplay()
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMachineSnapshots.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMachineSnapshots.swift
@@ -13,11 +13,14 @@ struct WorkspaceMachineSnapshots: Equatable {
 
     init(
         workspaces: [MobileWorkspacePreview],
+        filterMachineIDFor: (String) -> String = { $0 },
         macPickerMachineIDs: Set<String>,
         namesByID: [String: String],
         fallbackName: String
     ) {
-        let filterMachineIDs = Set(MobileWorkspaceListFilter.machineIDs(in: workspaces))
+        let filterMachineIDs = Set(
+            MobileWorkspaceListFilter.machineIDs(in: workspaces).map(filterMachineIDFor)
+        )
         self.filterMachines = filterMachineIDs.count > 1
             ? filterMachineIDs
                 .map { WorkspaceFilterMachine(id: $0, namesByID: namesByID, fallbackName: fallbackName) }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -122,6 +122,51 @@ import Testing
         #expect(active.machines == ["mac-b"])
     }
 
+    @Test func allMacFilterMenuMachineScopeMatchesAliasWorkspaceRows() throws {
+        let route = try route(host: "100.82.214.112")
+        let aliasWorkspace = workspace(id: "ws-old", macDeviceID: "mac-old")
+        let scope = WorkspaceMacSelectionScope(
+            selection: .all,
+            workspaces: [aliasWorkspace],
+            displayPairedMacs: [
+                pairedMac(id: "mac-fresh", name: "Desk Mac", route: route, lastSeenAt: 20),
+            ],
+            foregroundMacDeviceID: nil,
+            aliasesFor: { id in
+                id == "mac-fresh" ? ["mac-fresh", "mac-old"] : [id]
+            }
+        )
+
+        let active = scope.activeFilter(base: MobileWorkspaceListFilter(machines: ["mac-fresh"]))
+
+        #expect(active.matches(aliasWorkspace))
+    }
+
+    @Test func filterMenuMachinesUseRepresentativeIDsForAliasWorkspaces() async throws {
+        let route = try route(host: "100.82.214.112")
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-old", name: "Desk Mac", route: route, lastSeenAt: 10),
+            pairedMac(id: "mac-fresh", name: "Desk Mac", route: route, lastSeenAt: 20, isActive: true),
+            pairedMac(id: "mac-b", name: "Air", lastSeenAt: 15),
+        ])
+        let view = workspaceListView(
+            workspaces: [
+                workspace(id: "ws-old", macDeviceID: "mac-old"),
+                workspace(id: "ws-b", macDeviceID: "mac-b"),
+            ],
+            store: store
+        )
+
+        let machines = view.filterMenuMachines(
+            machineSnapshots: view.liveMachineSnapshots,
+            visibleSelection: view.visibleMacSelection
+        )
+
+        #expect(Set(machines.map(\.id)) == ["mac-b", "mac-fresh"])
+        #expect(!machines.map(\.id).contains("mac-old"))
+        #expect(view.filterMenuPresentMachineIDs == ["mac-fresh", "mac-b"])
+    }
+
     @Test func filterMenuMachinesHideWhenMacPickerOwnsMachineScope() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -122,6 +122,22 @@ import Testing
         #expect(active.machines == ["mac-b"])
     }
 
+    @Test func filterMenuPruningClearsSelectionWhenMachineSectionWouldHide() {
+        var filter = MobileWorkspaceListFilter(machines: ["mac-a"])
+        let changed = filter.pruneMachinesForFilterMenu(presentMachineIDs: ["mac-a"])
+
+        #expect(changed)
+        #expect(filter.machines.isEmpty)
+    }
+
+    @Test func filterMenuPruningKeepsVisibleMachineSelection() {
+        var filter = MobileWorkspaceListFilter(machines: ["mac-a"])
+        let changed = filter.pruneMachinesForFilterMenu(presentMachineIDs: ["mac-a", "mac-b"])
+
+        #expect(!changed)
+        #expect(filter.machines == ["mac-a"])
+    }
+
     private func workspaceListView(
         workspaces: [MobileWorkspacePreview],
         store: CMUXMobileShellStore

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -122,6 +122,65 @@ import Testing
         #expect(active.machines == ["mac-b"])
     }
 
+    @Test func filterMenuMachinesHideWhenMacPickerOwnsMachineScope() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        var view = workspaceListView(
+            workspaces: [
+                workspace(id: "ws-a", macDeviceID: "mac-a"),
+                workspace(id: "ws-b", macDeviceID: "mac-b"),
+            ],
+            store: store
+        )
+        view.macSelection = .machine("mac-a")
+
+        let machines = view.filterMenuMachines(
+            machineSnapshots: view.liveMachineSnapshots,
+            visibleSelection: view.visibleMacSelection
+        )
+
+        #expect(machines.isEmpty)
+    }
+
+    @Test func filterMenuMachinesShowWhenAllMacsCanUseMachineScope() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        let view = workspaceListView(
+            workspaces: [
+                workspace(id: "ws-a", macDeviceID: "mac-a"),
+                workspace(id: "ws-b", macDeviceID: "mac-b"),
+            ],
+            store: store
+        )
+
+        let machines = view.filterMenuMachines(
+            machineSnapshots: view.liveMachineSnapshots,
+            visibleSelection: view.visibleMacSelection
+        )
+
+        #expect(machines.map(\.id) == ["mac-a", "mac-b"])
+    }
+
+    @Test func filterMenuPruningClearsMachineSelectionWhenMacPickerOwnsMachineScope() {
+        var filter = MobileWorkspaceListFilter(machines: ["mac-b"])
+        let changed = filter.pruneMachinesForFilterMenu(visibleMacSelection: .machine("mac-a"))
+
+        #expect(changed)
+        #expect(filter.machines.isEmpty)
+    }
+
+    @Test func filterMenuPruningKeepsMachineSelectionWhenAllMacsCanUseMachineScope() {
+        var filter = MobileWorkspaceListFilter(machines: ["mac-b"])
+        let changed = filter.pruneMachinesForFilterMenu(visibleMacSelection: .all)
+
+        #expect(!changed)
+        #expect(filter.machines == ["mac-b"])
+    }
+
     @Test func filterMenuPruningClearsSelectionWhenMachineSectionWouldHide() {
         var filter = MobileWorkspaceListFilter(machines: ["mac-a"])
         let changed = filter.pruneMachinesForFilterMenu(presentMachineIDs: ["mac-a"])

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -19,7 +19,7 @@ import Testing
             store: store
         )
 
-        #expect(view.macPickerMachines.map(\.id) == ["mac-a", "mac-b"])
+        #expect(view.liveMachineSnapshots.macPickerMachines.map(\.id) == ["mac-a", "mac-b"])
     }
 
     @Test func selectingCoalescedPairedMacMatchesAliasWorkspaceRows() async throws {
@@ -52,7 +52,7 @@ import Testing
 
         let view = workspaceListView(workspaces: [], store: store)
 
-        #expect(view.macPickerMachines.map(\.name) == ["Desk setup"])
+        #expect(view.liveMachineSnapshots.macPickerMachines.map(\.name) == ["Desk setup"])
     }
 
     @Test func createWorkspaceIsGatedWhenSpecificSelectedMacIsNotForeground() async throws {
@@ -125,6 +125,14 @@ import Testing
     @Test func filterMenuPruningClearsSelectionWhenMachineSectionWouldHide() {
         var filter = MobileWorkspaceListFilter(machines: ["mac-a"])
         let changed = filter.pruneMachinesForFilterMenu(presentMachineIDs: ["mac-a"])
+
+        #expect(changed)
+        #expect(filter.machines.isEmpty)
+    }
+
+    @Test func filterMenuPruningClearsSelectionWhenOnlyDuplicateMachineIDsArePresent() {
+        var filter = MobileWorkspaceListFilter(machines: ["mac-a"])
+        let changed = filter.pruneMachinesForFilterMenu(presentMachineIDs: ["mac-a", "mac-a"])
 
         #expect(changed)
         #expect(filter.machines.isEmpty)

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -106,6 +106,22 @@ import Testing
         #expect(scope.canCreateWorkspace(base: true))
     }
 
+    @Test func allMacSelectionPreservesFilterMenuMachineScope() {
+        let scope = WorkspaceMacSelectionScope(
+            selection: .all,
+            workspaces: [
+                workspace(id: "ws-a", macDeviceID: "mac-a"),
+                workspace(id: "ws-b", macDeviceID: "mac-b"),
+            ],
+            displayPairedMacs: [],
+            foregroundMacDeviceID: nil,
+            aliasesFor: { [$0] }
+        )
+        let active = scope.activeFilter(base: MobileWorkspaceListFilter(machines: ["mac-b"]))
+
+        #expect(active.machines == ["mac-b"])
+    }
+
     private func workspaceListView(
         workspaces: [MobileWorkspacePreview],
         store: CMUXMobileShellStore

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMachineSnapshotsTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMachineSnapshotsTests.swift
@@ -1,0 +1,78 @@
+import CmuxMobileShellModel
+import Testing
+@testable import CmuxMobileShellUI
+
+@Suite struct WorkspaceMachineSnapshotsTests {
+    @Test func filterMachinesAreStableAcrossEquivalentWorkspaceChurn() {
+        let first = machineSnapshots(workspaces: [
+            workspace("recent-b", macDeviceID: "mac-b", macDisplayName: "Beta", hasUnread: true),
+            workspace("older-a", macDeviceID: "mac-a", macDisplayName: "Alpha", hasUnread: false),
+            workspace("recent-c", macDeviceID: "mac-c", macDisplayName: "Alpha", hasUnread: true),
+        ])
+        let second = machineSnapshots(workspaces: [
+            workspace("new-c", macDeviceID: "mac-c", macDisplayName: "Alpha", hasUnread: false),
+            workspace("new-a", macDeviceID: "mac-a", macDisplayName: "Alpha", hasUnread: true),
+            workspace("new-b", macDeviceID: "mac-b", macDisplayName: "Beta", hasUnread: false),
+        ])
+
+        #expect(first.filterMachines == second.filterMachines)
+        #expect(first.filterMachines.map(\.id) == ["mac-a", "mac-c", "mac-b"])
+        #expect(first.filterMachines.map(\.name) == ["Alpha", "Alpha", "Beta"])
+    }
+
+    @Test func filterMachinesHideSingleMachineSection() {
+        let snapshots = machineSnapshots(workspaces: [
+            workspace("only-a", macDeviceID: "mac-a", macDisplayName: "Alpha", hasUnread: false),
+            workspace("also-a", macDeviceID: "mac-a", macDisplayName: "Alpha", hasUnread: true),
+        ])
+
+        #expect(snapshots.filterMachines.isEmpty)
+    }
+
+    @Test func macPickerMachinesUseStableDisplaySortForSetInput() {
+        let snapshots = WorkspaceMachineSnapshots(
+            workspaces: [],
+            macPickerMachineIDs: ["mac-z", "mac-a", "mac-b"],
+            namesByID: [
+                "mac-a": "Studio",
+                "mac-b": "Air",
+                "mac-z": "Air",
+            ],
+            fallbackName: "Mac"
+        )
+
+        #expect(snapshots.macPickerMachines.map(\.id) == ["mac-b", "mac-z", "mac-a"])
+        #expect(snapshots.macPickerMachines.map(\.name) == ["Air", "Air", "Studio"])
+    }
+
+    private func machineSnapshots(workspaces: [MobileWorkspacePreview]) -> WorkspaceMachineSnapshots {
+        var namesByID: [String: String] = [:]
+        for workspace in workspaces {
+            if let macDeviceID = workspace.macDeviceID, let macDisplayName = workspace.macDisplayName {
+                namesByID[macDeviceID] = macDisplayName
+            }
+        }
+        return WorkspaceMachineSnapshots(
+            workspaces: workspaces,
+            macPickerMachineIDs: [],
+            namesByID: namesByID,
+            fallbackName: "Mac"
+        )
+    }
+
+    private func workspace(
+        _ id: String,
+        macDeviceID: String,
+        macDisplayName: String,
+        hasUnread: Bool
+    ) -> MobileWorkspacePreview {
+        MobileWorkspacePreview(
+            id: .init(rawValue: id),
+            macDeviceID: macDeviceID,
+            macDisplayName: macDisplayName,
+            name: "Workspace \(id)",
+            hasUnread: hasUnread,
+            terminals: []
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- stabilizes workspace machine menu snapshots by sorting machines by display name then id
- feeds the filter menu and Mac picker from an equatable @State snapshot so equivalent live workspace/device updates do not churn open native menus
- restores filter-menu machine scope under All Macs and adds behavior coverage for stable snapshots

## Verification
- `git diff --cached --check` before commit
- `swift test` in `Packages/iOS/CmuxMobileShellUI` attempted; SwiftPM stopped before compile because the iOS-only package resolves as macOS 10.13 while dependencies require macOS 14. CI is the verification gate.
- no app, macOS build, iOS simulator, or window launch run

## Localization
- no user-facing strings added
- changed surfaces reuse existing localized filter/Mac picker copy
- audited changed Swift diff for added Text/Button/Label/accessibility/L10n additions; only test fixture strings were new

## Notes
The native iOS Menu scroll reset itself is not cleanly unit-testable without driving a presented UIKit menu in an app/simulator. The added package tests cover the root cause: equivalent machine states now produce equal, stably ordered menu snapshots.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785401358&installation_id=133855650&pr_number=7095&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7095&signature=b44f6df9a30441e2ac37ca9239ea512cc97f1603ce9be66c064da831d57c5e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS filter and Mac picker menu scroll resets by using stable, Equatable machine snapshots that only update when content changes. Coalesces alias Macs to a single representative so menus and filters stay consistent.

- **Bug Fixes**
  - Build both menus from `WorkspaceMachineSnapshots` kept in `@State`; update only when the snapshot changes.
  - Stable ordering and names via `sortedForMenuDisplay()` with fallback names.
  - Hide the machine filter when the Mac picker is scoped to one Mac; keep it under “All Macs.” Clear hidden/non-actionable selections via `pruneMachinesForFilterMenu`. Under `.all`/`.automatic`, expand machine filters to alias sets so rows match alias workspaces.
  - Tests cover snapshot stability across churn, sorting, alias coalescing/expansion, visibility rules, and pruning (including duplicate IDs).

<sup>Written for commit e0bccbc29d5fcf5d138d63ea0888b6ec30e74ed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace and Mac picker options now use a stable, snapshot-based ordering.
  * Improved sorting for menu display, using localized name comparison with ID tie-breaking.
* **Bug Fixes**
  * Preserved machine selections when switching to the “All” workspace view.
  * Refined filter pruning so selections clear only when the machine section is hidden (or remain when visible).
* **Tests**
  * Added new test suites covering machine snapshot ordering and updated pruning/selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->