### PR TITLE
Fix iOS Mac switching from workspace picker

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -127,7 +127,7 @@
 762	Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkByteTransport.swift
 761	Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
 760	Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
-756	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+759	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 756	Sources/Panels/AgentSessionWebRendererCoordinator.swift
 754	Sources/TerminalController+ControlWorkspaceContext.swift
 753	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -161,6 +161,7 @@
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
+642	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 642	cmuxTests/RemoteTmuxControlParserTests.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 635	cmuxUITests/RightSidebarChromeHeightUITests.swift
@@ -170,7 +171,6 @@
 624	Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
 620	cmuxTests/FinderFileDropRegressionTests.swift
 620	cmuxTests/TerminalNotificationQueueTests.swift
-616	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 615	Sources/SettingsNavigation.swift
 608	cmuxUITests/FeedSidebarUITests.swift
 607	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,8 +13,8 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
+7228	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-7213	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7358	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7343	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -3,7 +3,7 @@
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 34427	CLI/cmux.swift
 17978	Sources/AppDelegate.swift
-16521	Sources/ContentView.swift
+16500	Sources/ContentView.swift
 14224	Sources/TerminalController.swift
 12913	Sources/Workspace.swift
 12348	cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -14,7 +14,7 @@
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-7022	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7070	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -14,7 +14,7 @@
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-7158	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7161	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -14,7 +14,7 @@
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-7140	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7158	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift
@@ -192,6 +192,7 @@
 580	cmuxTests/CLIHookNoResponseTests.swift
 577	cmuxTests/AppearanceSettingsTests.swift
 574	Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+573	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 572	Sources/Feed/FeedTextEditorDebugWindowController.swift
 568	Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileTerminalRenderGrid.swift
 567	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BrowserSection.swift
@@ -199,7 +200,6 @@
 563	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
 562	cmuxTests/AgentExecutableResolverTests.swift
 561	cmuxTests/GhosttyConfigPathResolverTests.swift
-560	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 560	cmuxTests/CLISSHPTYResizeInputTests.swift
 558	Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Config.swift
 553	Sources/RightSidebarPanelView.swift
@@ -212,6 +212,7 @@
 538	Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeSession.swift
 536	cmuxTests/CmuxConfigContextMenuTests.swift
 534	Sources/TerminalController+ControlSurfaceContext2.swift
+533	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 532	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
 531	Sources/App/WorkspaceRuntimeSettings.swift
 530	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7343	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7349	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7231	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7249	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7355	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7358	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
@@ -154,6 +154,7 @@
 672	cmuxTests/SessionPersistenceResumeBindingTests.swift
 668	cmuxTests/FeedCoordinatorTests.swift
 668	cmuxTests/SettingsWindowPresenterTests.swift
+667	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 664	Sources/CmuxTopSnapshot.swift
 663	Sources/PortScanner.swift
 655	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -166,10 +167,10 @@
 632	cmuxTests/AgentSessionAutoResumeSwiftTests.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
 627	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
-626	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 624	Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
 620	cmuxTests/FinderFileDropRegressionTests.swift
 620	cmuxTests/TerminalNotificationQueueTests.swift
+615	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 615	Sources/SettingsNavigation.swift
 608	cmuxUITests/FeedSidebarUITests.swift
 607	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -179,7 +180,6 @@
 602	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
 601	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
 599	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
-598	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 596	cmuxTests/CmuxEventBusTests.swift
 594	cmuxTests/PortalTabDragRoutingTests.swift
 591	Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/DefaultsValueModelLifecycleTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7302	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7320	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -152,8 +152,8 @@
 681	Sources/Panels/AgentSessionProcessStore.swift
 680	Sources/FileExplorerSearchController.swift
 677	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
-673	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 672	cmuxTests/SessionPersistenceResumeBindingTests.swift
+668	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 668	cmuxTests/FeedCoordinatorTests.swift
 668	cmuxTests/SettingsWindowPresenterTests.swift
 664	Sources/CmuxTopSnapshot.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7303	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7302	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -14,7 +14,7 @@
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-7070	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7094	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift
@@ -199,6 +199,7 @@
 563	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
 562	cmuxTests/AgentExecutableResolverTests.swift
 561	cmuxTests/GhosttyConfigPathResolverTests.swift
+560	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 560	cmuxTests/CLISSHPTYResizeInputTests.swift
 558	Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Config.swift
 553	Sources/RightSidebarPanelView.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -127,6 +127,7 @@
 762	Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkByteTransport.swift
 761	Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
 760	Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+756	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 756	Sources/Panels/AgentSessionWebRendererCoordinator.swift
 754	Sources/TerminalController+ControlWorkspaceContext.swift
 753	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -154,7 +155,6 @@
 672	cmuxTests/SessionPersistenceResumeBindingTests.swift
 668	cmuxTests/FeedCoordinatorTests.swift
 668	cmuxTests/SettingsWindowPresenterTests.swift
-667	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 664	Sources/CmuxTopSnapshot.swift
 663	Sources/PortScanner.swift
 655	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -170,7 +170,7 @@
 624	Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
 620	cmuxTests/FinderFileDropRegressionTests.swift
 620	cmuxTests/TerminalNotificationQueueTests.swift
-615	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+616	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 615	Sources/SettingsNavigation.swift
 608	cmuxUITests/FeedSidebarUITests.swift
 607	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -97,6 +97,7 @@
 947	Sources/TerminalNotificationPolicy.swift
 945	Sources/SessionIndexRegisteredAgents.swift
 944	Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+942	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 937	Sources/TextBoxMentionIndexStore.swift
 928	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
 918	Sources/Panels/BrowserPopupWindowController.swift
@@ -109,7 +110,6 @@
 868	Sources/Panels/BrowserScreenshotSnapshotter.swift
 864	Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Store/ChatConversationStore.swift
 859	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlCommandCoordinator+Workspace.swift
-853	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 847	cmuxTests/AgentSessionAutoResumeSettingsTests.swift
 845	cmuxTests/SSHStartupSignalLifecycleTests.swift
 834	Sources/MainWindowFocusController.swift
@@ -152,6 +152,7 @@
 681	Sources/Panels/AgentSessionProcessStore.swift
 680	Sources/FileExplorerSearchController.swift
 677	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+673	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 672	cmuxTests/SessionPersistenceResumeBindingTests.swift
 668	cmuxTests/FeedCoordinatorTests.swift
 668	cmuxTests/SettingsWindowPresenterTests.swift
@@ -161,7 +162,6 @@
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
-649	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 642	cmuxTests/RemoteTmuxControlParserTests.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 635	cmuxUITests/RightSidebarChromeHeightUITests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -14,7 +14,7 @@
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-7195	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7208	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -166,6 +166,7 @@
 632	cmuxTests/AgentSessionAutoResumeSwiftTests.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
 627	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
+626	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 624	Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
 620	cmuxTests/FinderFileDropRegressionTests.swift
 620	cmuxTests/TerminalNotificationQueueTests.swift
@@ -178,8 +179,8 @@
 602	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
 601	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
 599	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+598	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 596	cmuxTests/CmuxEventBusTests.swift
-595	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 594	cmuxTests/PortalTabDragRoutingTests.swift
 591	Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/DefaultsValueModelLifecycleTests.swift
 590	Sources/Panels/BrowserNavigationDelegate.swift
@@ -187,7 +188,6 @@
 588	cmuxTests/CommandPaletteShortcutCustomizationTests.swift
 586	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+PortScan.swift
 586	Sources/JSONCParser.swift
-585	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 585	Sources/Cloud/VMClient.swift
 583	cmuxTests/GhosttyTerminalStartupEnvironmentTests.swift
 580	Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CmuxExtensionKitTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7274	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7276	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7276	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7289	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -14,7 +14,7 @@
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-7208	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7213	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift
@@ -192,8 +192,8 @@
 580	cmuxTests/CLIHookNoResponseTests.swift
 577	cmuxTests/AppearanceSettingsTests.swift
 574	Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
-573	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 572	Sources/Feed/FeedTextEditorDebugWindowController.swift
+571	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 568	Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileTerminalRenderGrid.swift
 567	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BrowserSection.swift
 567	Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/ConfigDiscovery/GhosttyConfigDiscovery.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7337	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7355	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7250	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7274	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7289	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7302	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -12,8 +12,8 @@
 9497	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
+7371	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7349	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -14,7 +14,7 @@
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-7094	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7137	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7320	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7326	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7249	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7250	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -192,8 +192,8 @@
 580	cmuxTests/CLIHookNoResponseTests.swift
 577	cmuxTests/AppearanceSettingsTests.swift
 574	Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+572	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 572	Sources/Feed/FeedTextEditorDebugWindowController.swift
-571	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 568	Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileTerminalRenderGrid.swift
 567	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BrowserSection.swift
 567	Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/ConfigDiscovery/GhosttyConfigDiscovery.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7228	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7231	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
@@ -179,6 +179,7 @@
 601	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
 599	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
 596	cmuxTests/CmuxEventBusTests.swift
+595	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 594	cmuxTests/PortalTabDragRoutingTests.swift
 591	Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/DefaultsValueModelLifecycleTests.swift
 590	Sources/Panels/BrowserNavigationDelegate.swift
@@ -186,13 +187,13 @@
 588	cmuxTests/CommandPaletteShortcutCustomizationTests.swift
 586	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+PortScan.swift
 586	Sources/JSONCParser.swift
+585	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 585	Sources/Cloud/VMClient.swift
 583	cmuxTests/GhosttyTerminalStartupEnvironmentTests.swift
 580	Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CmuxExtensionKitTests.swift
 580	cmuxTests/CLIHookNoResponseTests.swift
 577	cmuxTests/AppearanceSettingsTests.swift
 574	Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
-572	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 572	Sources/Feed/FeedTextEditorDebugWindowController.swift
 568	Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileTerminalRenderGrid.swift
 567	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BrowserSection.swift
@@ -212,7 +213,6 @@
 538	Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeSession.swift
 536	cmuxTests/CmuxConfigContextMenuTests.swift
 534	Sources/TerminalController+ControlSurfaceContext2.swift
-533	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 532	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
 531	Sources/App/WorkspaceRuntimeSettings.swift
 530	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7331	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7337	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7326	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7331	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -13,7 +13,7 @@
 8032	Sources/Panels/BrowserPanelView.swift
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
-7302	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7303	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -14,7 +14,7 @@
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-7137	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7140	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -14,7 +14,7 @@
 8016	CLI/cmux_open.swift
 7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
-7161	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+7195	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6180	Sources/TabManager.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -109,6 +109,7 @@
 868	Sources/Panels/BrowserScreenshotSnapshotter.swift
 864	Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Store/ChatConversationStore.swift
 859	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlCommandCoordinator+Workspace.swift
+853	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 847	cmuxTests/AgentSessionAutoResumeSettingsTests.swift
 845	cmuxTests/SSHStartupSignalLifecycleTests.swift
 834	Sources/MainWindowFocusController.swift
@@ -127,7 +128,6 @@
 762	Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkByteTransport.swift
 761	Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
 760	Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
-759	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 756	Sources/Panels/AgentSessionWebRendererCoordinator.swift
 754	Sources/TerminalController+ControlWorkspaceContext.swift
 753	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -161,7 +161,7 @@
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
-642	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+649	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
 642	cmuxTests/RemoteTmuxControlParserTests.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 635	cmuxUITests/RightSidebarChromeHeightUITests.swift

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
@@ -59,6 +59,29 @@ extension MobileShellComposite {
         }.map(\.macDeviceID)
         return matching.isEmpty ? [macDeviceID] : matching
     }
+
+    static func macDeviceIDAliasSetsByPairedMacID(
+        in macs: [MobilePairedMac],
+        supportedKinds: [CmxAttachTransportKind],
+        preferNonLoopback: Bool
+    ) -> [String: Set<String>] {
+        var groupKeyByMacID: [String: String] = [:]
+        var idsByGroupKey: [String: Set<String>] = [:]
+        for mac in macs {
+            let key = mac.dialEndpointKey(
+                supportedKinds: supportedKinds,
+                preferNonLoopback: preferNonLoopback
+            ) ?? "device:\(mac.macDeviceID)"
+            groupKeyByMacID[mac.macDeviceID] = key
+            idsByGroupKey[key, default: Set<String>()].insert(mac.macDeviceID)
+        }
+
+        var result: [String: Set<String>] = [:]
+        for (macID, groupKey) in groupKeyByMacID {
+            result[macID] = idsByGroupKey[groupKey] ?? Set([macID])
+        }
+        return result
+    }
 }
 
 private extension MobilePairedMac {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
@@ -60,7 +60,7 @@ extension MobileShellComposite {
         return matching.isEmpty ? [macDeviceID] : matching
     }
 
-    static func macDeviceIDAliasSetsByPairedMacID(
+    func macDeviceIDAliasSetsByPairedMacID(
         in macs: [MobilePairedMac],
         supportedKinds: [CmxAttachTransportKind],
         preferNonLoopback: Bool
@@ -72,7 +72,7 @@ extension MobileShellComposite {
         ).mapValues(Set.init)
     }
 
-    static func macDeviceIDAliasesByPairedMacID(
+    func macDeviceIDAliasesByPairedMacID(
         in macs: [MobilePairedMac],
         supportedKinds: [CmxAttachTransportKind],
         preferNonLoopback: Bool

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
@@ -65,20 +65,32 @@ extension MobileShellComposite {
         supportedKinds: [CmxAttachTransportKind],
         preferNonLoopback: Bool
     ) -> [String: Set<String>] {
+        macDeviceIDAliasesByPairedMacID(
+            in: macs,
+            supportedKinds: supportedKinds,
+            preferNonLoopback: preferNonLoopback
+        ).mapValues(Set.init)
+    }
+
+    static func macDeviceIDAliasesByPairedMacID(
+        in macs: [MobilePairedMac],
+        supportedKinds: [CmxAttachTransportKind],
+        preferNonLoopback: Bool
+    ) -> [String: [String]] {
         var groupKeyByMacID: [String: String] = [:]
-        var idsByGroupKey: [String: Set<String>] = [:]
+        var idsByGroupKey: [String: [String]] = [:]
         for mac in macs {
             let key = mac.dialEndpointKey(
                 supportedKinds: supportedKinds,
                 preferNonLoopback: preferNonLoopback
             ) ?? "device:\(mac.macDeviceID)"
             groupKeyByMacID[mac.macDeviceID] = key
-            idsByGroupKey[key, default: Set<String>()].insert(mac.macDeviceID)
+            idsByGroupKey[key, default: []].append(mac.macDeviceID)
         }
 
-        var result: [String: Set<String>] = [:]
+        var result: [String: [String]] = [:]
         for (macID, groupKey) in groupKeyByMacID {
-            result[macID] = idsByGroupKey[groupKey] ?? Set([macID])
+            result[macID] = idsByGroupKey[groupKey] ?? [macID]
         }
         return result
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -447,12 +447,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// across terminals, enforced as a hard reject in the same atomic add path.
     public nonisolated static let maxPendingAttachmentCountAllTerminals = 20
     /// Monotonic token bumped by ``signOut()``, identifying the current signed-in
-    /// session. The composer's photo-staging path captures it before its
-    /// (off-main) load + encode and re-checks it just before mutating the store:
-    /// a sign-out that lands while a photo is in flight bumps the token, so the
-    /// stale continuation is dropped instead of re-staging the previous user's
-    /// photo bytes under a terminal id the next account may reuse. Not observed:
-    /// it gates an async hand-back, not view state.
+    /// session. Async paths that can suspend across an auth boundary capture it
+    /// before leaving the main actor and re-check it just before mutating the store:
+    /// a sign-out bumps the token, so stale continuations are dropped instead of
+    /// writing the previous user's state under ids the next account may reuse. Not
+    /// observed: it gates async hand-backs, not view state.
     @ObservationIgnored private var signInGeneration = 0
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
@@ -685,6 +684,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var connectionGeneration: UUID
     private var connectionAttemptGeneration: UUID
     @ObservationIgnored private var macSwitchAttemptID: UUID?
+    @ObservationIgnored private var macSwitchAttemptSignInGeneration: Int?
     @ObservationIgnored private var macSwitchRestorePreviousOnCancelAttemptIDs: Set<UUID> = []
     @ObservationIgnored private var macSwitchRestoreBaseline: MobilePairedMac?
     private var chatEventSourceGeneration: UUID
@@ -976,6 +976,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         suppressNextConnectionOutageEdge = true
         invalidatePairingAttempt()
+        clearMacSwitchAttemptState()
         connectionGeneration = UUID()
         connectionAttemptGeneration = UUID()
         isSignedIn = false
@@ -1128,7 +1129,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // (account, team) scope, and a suspended old-team restore can't resume.
         // Invalidate the shared boundary synchronously first; actor cleanup is
         // fire-and-forget (this method is sync) and does not wipe the local store.
-        macSwitchRestoreBaseline = nil
+        clearMacSwitchAttemptState()
         pairedMacRestoreBoundary?.invalidate()
         if let refresher = pairedMacStore as? any PairedMacBackupRefreshing {
             Task { await refresher.cancelInFlightRestores() }
@@ -3096,6 +3097,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             macSwitchRestorePreviousOnCancelAttemptIDs.insert(attemptID)
         }
         macSwitchAttemptID = nil
+        macSwitchAttemptSignInGeneration = nil
         invalidatePairingAttempt()
         connectionAttemptGeneration = UUID()
     }
@@ -5183,20 +5185,31 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let attemptID = UUID()
         macSwitchRestorePreviousOnCancelAttemptIDs.removeAll(keepingCapacity: true)
         macSwitchAttemptID = attemptID
+        macSwitchAttemptSignInGeneration = signInGeneration
         invalidatePairingAttempt()
         connectionAttemptGeneration = UUID()
         return attemptID
     }
 
     private func isCurrentMacSwitchAttempt(_ attemptID: UUID) -> Bool {
-        macSwitchAttemptID == attemptID && isSignedIn
+        macSwitchAttemptID == attemptID
+            && macSwitchAttemptSignInGeneration == signInGeneration
+            && isSignedIn
     }
 
     private func finishMacSwitchAttempt(_ attemptID: UUID) {
         if macSwitchAttemptID == attemptID {
             macSwitchAttemptID = nil
+            macSwitchAttemptSignInGeneration = nil
         }
         macSwitchRestorePreviousOnCancelAttemptIDs.remove(attemptID)
+    }
+
+    private func clearMacSwitchAttemptState() {
+        macSwitchAttemptID = nil
+        macSwitchAttemptSignInGeneration = nil
+        macSwitchRestorePreviousOnCancelAttemptIDs.removeAll(keepingCapacity: true)
+        macSwitchRestoreBaseline = nil
     }
 
     private func consumeMacSwitchRestorePreviousOnCancel(_ attemptID: UUID) -> Bool {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2584,7 +2584,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let previousStillForeground = connectionState == .connected
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
-            && activeRouteMatchesPairedMac(previousActive)
         guard !previousStillForeground else { return true }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         guard let (host, port) = Self.firstReconnectHostPortRoute(
@@ -2629,20 +2628,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             await task.value
         }
         return restored
-    }
-
-    private func activeRouteMatchesPairedMac(_ mac: MobilePairedMac) -> Bool {
-        guard case let .hostPort(liveHost, livePort)? = activeRoute?.endpoint,
-              let normalizedLiveHost = MobileShellRouteAuthPolicy.normalizedManualHost(liveHost) else {
-            return false
-        }
-        return mac.routes.contains { route in
-            guard case let .hostPort(host, port) = route.endpoint,
-                  let normalizedHost = MobileShellRouteAuthPolicy.normalizedManualHost(host) else {
-                return false
-            }
-            return normalizedHost == normalizedLiveHost && port == livePort
-        }
     }
 
     func clearSavedMacHintAfterDeletingLastVisibleMacIfNeeded() {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2377,16 +2377,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         stopTerminalRefreshPolling()
         startTerminalRefreshPolling()
         syncSelectedTerminalForWorkspace()
-        if let pairedMacStore {
-            Task { [weak self] in
-                guard let self, await self.isScopeCurrent(activeWriteScope) else { return }
-                try? await pairedMacStore.setActive(
-                    macDeviceID: macID,
-                    stackUserID: activeWriteScope.userID,
-                    teamID: activeWriteScope.teamID
-                )
-            }
-        }
+        enqueueActivePairedMacWrite(
+            macDeviceID: macID,
+            scope: activeWriteScope,
+            reloadAfterWrite: false
+        )
         // Re-aggregate so the PREVIOUS foreground Mac comes back as a secondary.
         scheduleSecondaryAggregation()
         return true
@@ -2464,9 +2459,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             switchingTo: macDeviceID,
             storeMacs: storeMacs
         )
-        if macSwitchRestoreBaseline == nil {
-            macSwitchRestoreBaseline = previousForegroundMac
-        }
+        macSwitchRestoreBaseline = previousForegroundMac
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         guard let (host, port) = Self.firstReconnectHostPortRoute(
             refreshedTarget.routes,
@@ -2498,29 +2491,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if switched {
             macSwitchRestoreBaseline = nil
             finishMacSwitchAttempt(switchAttemptID)
-            let activeWriteScope = scope
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                if let activeWriteScope {
-                    guard await self.isScopeCurrent(activeWriteScope) else { return }
-                }
-                guard self.connectionState == .connected,
-                      self.remoteClient != nil,
-                      self.foregroundMacDeviceID == macDeviceID else { return }
-                do {
-                    try await pairedMacStore.setActive(
-                        macDeviceID: macDeviceID,
-                        stackUserID: activeWriteScope?.userID,
-                        teamID: activeWriteScope?.teamID
-                    )
-                    guard self.connectionState == .connected,
-                          self.remoteClient != nil,
-                          self.foregroundMacDeviceID == macDeviceID else { return }
-                    await self.loadPairedMacs()
-                } catch {
-                    mobileShellLog.error("paired mac store setActive failed mac=\(macDeviceID, privacy: .private) error=\(String(describing: error), privacy: .public)")
-                }
-            }
+            enqueueActivePairedMacWrite(
+                macDeviceID: macDeviceID,
+                scope: scope,
+                reloadAfterWrite: true
+            )
             return true
         } else if macSwitchRestoreBaseline != nil || previousForegroundMac != nil, !hasActiveMacConnection {
             // The switch did not connect and the destructive connect path dropped
@@ -2612,21 +2587,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let restored = connectionState == .connected
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
-        guard restored, let pairedMacStore else { return restored }
+        guard restored else { return restored }
         let scope = await currentScopeSnapshot()
         if let scope {
             guard await isScopeCurrent(scope), isCancelRestoreCurrent() else { return restored }
         }
-        do {
-            try await pairedMacStore.setActive(
-                macDeviceID: previousActive.macDeviceID,
-                stackUserID: scope?.userID,
-                teamID: scope?.teamID
-            )
-            guard isCancelRestoreCurrent() else { return restored }
-            await loadPairedMacs()
-        } catch {
-            mobileShellLog.error("restorePreviousMacIfNeeded: setActive failed mac=\(previousActive.macDeviceID, privacy: .private) error=\(String(describing: error), privacy: .public)")
+        if let task = enqueueActivePairedMacWrite(
+            macDeviceID: previousActive.macDeviceID,
+            scope: scope,
+            reloadAfterWrite: true
+        ) {
+            await task.value
         }
         return restored
     }
@@ -2729,7 +2700,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
-    /// Runs one paired-Mac store mutation on the serialized write chain.
+    /// Enqueues one paired-Mac store mutation on the serialized write chain.
     ///
     /// All `markActive` writes go through here so they execute strictly in
     /// submission order, and `ifStillCurrent` is re-evaluated at EXECUTION
@@ -2739,10 +2710,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// and any newer connection's write is queued strictly behind it and
     /// overwrites the active mark. The chain is deliberately not cancelled
     /// on disconnect; in-flight writes complete or skip via their own check.
-    private func performSerializedPairedMacWrite(
+    @discardableResult
+    private func enqueueSerializedPairedMacWrite(
         ifStillCurrent: (() -> Bool)?,
         _ operation: @escaping @MainActor () async -> Void
-    ) async {
+    ) -> Task<Void, Never> {
         let previous = pairedMacWriteChain
         let task = Task { @MainActor in
             await previous?.value
@@ -2750,7 +2722,52 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             await operation()
         }
         pairedMacWriteChain = task
+        return task
+    }
+
+    /// Runs one paired-Mac store mutation on the serialized write chain.
+    private func performSerializedPairedMacWrite(
+        ifStillCurrent: (() -> Bool)?,
+        _ operation: @escaping @MainActor () async -> Void
+    ) async {
+        let task = enqueueSerializedPairedMacWrite(
+            ifStillCurrent: ifStillCurrent,
+            operation
+        )
         await task.value
+    }
+
+    @discardableResult
+    private func enqueueActivePairedMacWrite(
+        macDeviceID: String,
+        scope: MobileShellScopeSnapshot?,
+        reloadAfterWrite: Bool
+    ) -> Task<Void, Never>? {
+        guard let pairedMacStore else { return nil }
+        return enqueueSerializedPairedMacWrite(ifStillCurrent: nil) { [weak self, pairedMacStore] in
+            guard let self else { return }
+            if let scope {
+                guard await self.isScopeCurrent(scope) else { return }
+            }
+            guard self.connectionState == .connected,
+                  self.remoteClient != nil,
+                  self.foregroundMacDeviceID == macDeviceID else { return }
+            do {
+                try await pairedMacStore.setActive(
+                    macDeviceID: macDeviceID,
+                    stackUserID: scope?.userID,
+                    teamID: scope?.teamID
+                )
+                guard self.connectionState == .connected,
+                      self.remoteClient != nil,
+                      self.foregroundMacDeviceID == macDeviceID else { return }
+                if reloadAfterWrite {
+                    await self.loadPairedMacs()
+                }
+            } catch {
+                mobileShellLog.error("paired mac store setActive failed mac=\(macDeviceID, privacy: .private) error=\(String(describing: error), privacy: .public)")
+            }
+        }
     }
 
     /// Persists `ticket` as the active paired Mac.
@@ -5262,6 +5279,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         macSwitchRestorePreviousOnCancelAttemptIDs.removeAll(keepingCapacity: true)
         macSwitchAttemptID = attemptID
         macSwitchAttemptSignInGeneration = signInGeneration
+        macSwitchRestoreBaseline = nil
         invalidatePairingAttempt()
         connectionAttemptGeneration = UUID()
         return attemptID

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2585,11 +2585,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             port: port,
             pairedMacDeviceID: previousActive.macDeviceID
         )
-        guard await isScopeCurrent(restoreScope), isCancelRestoreCurrent() else {
-            if connectionState == .connected,
+        let restoreScopeIsCurrent = await isScopeCurrent(restoreScope)
+        guard restoreScopeIsCurrent, isCancelRestoreCurrent() else {
+            if !restoreScopeIsCurrent,
+               connectionState == .connected,
                remoteClient != nil,
                foregroundMacDeviceID.map({ previousIDs.contains($0) }) == true {
-                disconnectLiveConnection()
+                suppressNextConnectionOutageEdge = true
+                connectionState = .disconnected
+                macConnectionStatus = .unavailable
+                clearRemoteConnectionContext()
                 workspacesByMac = workspacesByMac.filter { !previousIDs.contains($0.key) }
             }
             return false

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3200,6 +3200,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     func disconnectLiveConnection(preservingOtherMacWorkspaceState: Bool = false) {
         suppressNextConnectionOutageEdge = true
         invalidatePairingAttempt()
+        clearMacSwitchAttemptState()
         clearPairingError()
         connectionRequiresReauth = false
         connectionState = .disconnected

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1441,7 +1441,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Connect to a manually-entered Mac host and optionally associate the
     /// resulting session with an existing paired-Mac device id.
     public func connectManualHost(
-        name: String, host: String, port: Int, pairedMacDeviceID: String? = nil
+        name: String,
+        host: String,
+        port: Int,
+        pairedMacDeviceID: String? = nil
     ) async {
         await connectManualHost(
             name: name,
@@ -1477,7 +1480,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         host: String,
         port: Int,
         pairedMacDeviceID: String? = nil,
-        recordsPairingAttempt: Bool
+        recordsPairingAttempt: Bool,
+        ifStillCurrent: (() -> Bool)? = nil
     ) async {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let normalizedHost = MobileShellRouteAuthPolicy.normalizedManualHost(host) else {
@@ -1525,7 +1529,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             )
             guard isCurrentPairingAttempt(attemptID) else { return }
             let noThrowFailure = try await connect(
-                ticket: ticket, allowsStackAuthFallback: true, pairedMacDeviceID: pairedMacDeviceID)
+                ticket: ticket,
+                allowsStackAuthFallback: true,
+                pairedMacDeviceID: pairedMacDeviceID,
+                ifStillCurrent: ifStillCurrent
+            )
             guard isCurrentPairingAttempt(attemptID) else { return }
             if connectionState == .connected {
                 recordPairingSucceeded()
@@ -2479,7 +2487,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         await connectManualHost(
             name: refreshedTarget.displayName ?? host, host: host, port: port,
-            pairedMacDeviceID: macDeviceID)
+            pairedMacDeviceID: macDeviceID,
+            recordsPairingAttempt: true,
+            ifStillCurrent: { [weak self] in
+                self?.isCurrentMacSwitchAttempt(switchAttemptID) == true
+            }
+        )
         guard isCurrentMacSwitchAttempt(switchAttemptID) else {
             await restoreMacSwitchBaselineIfCancelled(switchAttemptID, fallback: previousForegroundMac)
             return false
@@ -4825,9 +4838,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func connect(
         ticket: CmxAttachTicket,
         allowsStackAuthFallback: Bool? = nil,
-        pairedMacDeviceID: String? = nil
+        pairedMacDeviceID: String? = nil,
+        ifStillCurrent: (() -> Bool)? = nil
     ) async throws -> MobilePairingFailureCategory? {
         let generation = UUID()
+        func isConnectCurrent() -> Bool {
+            isCurrentConnectionAttempt(generation) && (ifStillCurrent?() ?? true)
+        }
         connectionAttemptGeneration = generation
         connectionGeneration = generation
         diagnosticLog?.record(DiagnosticEvent(.connect))
@@ -4855,7 +4872,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         replaceRemoteClient(with: nil)
 
         guard let runtime else {
-            guard isCurrentConnectionAttempt(generation) else { return nil }
+            guard isConnectCurrent() else { return nil }
             clearPairingError()
             applyPreviewTicket(ticket, route: firstRoute)
             connectionState = .connected
@@ -4902,7 +4919,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         timeoutNanoseconds: requestTimeoutNanoseconds
                     )
                     let response = try MobileSyncWorkspaceListResponse.decode(resultData)
-                    guard isCurrentConnectionAttempt(generation) else { return nil }
+                    guard isConnectCurrent() else { return nil }
+                    await persistPairedMacFromTicket(ticket, ifStillCurrent: isConnectCurrent)
+                    guard isConnectCurrent() else { return nil }
                     replaceRemoteClient(with: client)
                     startTerminalRefreshPolling()
                     // The connect seam guarantees identity recovery for an
@@ -4918,7 +4937,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         scheduleHostIdentityAdoptionIfNeeded(client: client)
                     }
                     clearPairingError()
-                    await persistPairedMacFromTicket(ticket)
                     // Set the foreground Mac id BEFORE applying the list so the
                     // per-Mac state is keyed to THIS Mac, not the previously-
                     // foreground Mac (or the anonymous key). Otherwise switching
@@ -4977,7 +4995,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     return nil
                 } catch {
                     lastError = error
-                    guard isCurrentConnectionAttempt(generation) else { return nil }
+                    guard isConnectCurrent() else { return nil }
                     mobileShellLog.error(
                         "pairing route failed kind=\(route.kind.rawValue, privacy: .public) endpoint=\(route.endpoint.logDescription, privacy: .private) scoped=\(workspaceListRequest.isScoped ? 1 : 0, privacy: .public): \(String(describing: error), privacy: .private)"
                     )

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1129,7 +1129,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // (account, team) scope, and a suspended old-team restore can't resume.
         // Invalidate the shared boundary synchronously first; actor cleanup is
         // fire-and-forget (this method is sync) and does not wipe the local store.
-        clearMacSwitchAttemptState()
+        clearMacSwitchAttemptState(invalidateUnderlyingConnectionAttempt: true)
         pairedMacRestoreBoundary?.invalidate()
         if let refresher = pairedMacStore as? any PairedMacBackupRefreshing {
             Task { await refresher.cancelInFlightRestores() }
@@ -2466,7 +2466,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             supportedKinds: supportedKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         ), MobileShellRouteAuthPolicy.normalizedManualHost(host) != nil else {
-            mobileShellLog.error("switchToMac: no reconnectable route mac=\(macDeviceID, privacy: .public)")
+            mobileShellLog.error("switchToMac: no reconnectable route mac=\(macDeviceID, privacy: .private)")
             if !hasActiveMacConnection,
                await restorePreviousMacIfNeeded(macSwitchRestoreBaseline ?? previousForegroundMac) {
                 macSwitchRestoreBaseline = nil
@@ -2501,7 +2501,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     teamID: scope?.teamID
                 )
             } catch {
-                mobileShellLog.error("paired mac store setActive failed mac=\(macDeviceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
+                mobileShellLog.error("paired mac store setActive failed mac=\(macDeviceID, privacy: .private) error=\(String(describing: error), privacy: .public)")
             }
         } else if macSwitchRestoreBaseline != nil || previousForegroundMac != nil, !hasActiveMacConnection {
             // The switch did not connect and the destructive connect path dropped
@@ -2566,7 +2566,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             supportedKinds: supportedKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         ), MobileShellRouteAuthPolicy.normalizedManualHost(host) != nil else {
-            mobileShellLog.error("restorePreviousMacIfNeeded: no reconnectable route mac=\(previousActive.macDeviceID, privacy: .public)")
+            mobileShellLog.error("restorePreviousMacIfNeeded: no reconnectable route mac=\(previousActive.macDeviceID, privacy: .private)")
             return false
         }
         await connectStoredMacHost(
@@ -2591,7 +2591,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             )
             await loadPairedMacs()
         } catch {
-            mobileShellLog.error("restorePreviousMacIfNeeded: setActive failed mac=\(previousActive.macDeviceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
+            mobileShellLog.error("restorePreviousMacIfNeeded: setActive failed mac=\(previousActive.macDeviceID, privacy: .private) error=\(String(describing: error), privacy: .public)")
         }
         return restored
     }
@@ -5205,11 +5205,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         macSwitchRestorePreviousOnCancelAttemptIDs.remove(attemptID)
     }
 
-    private func clearMacSwitchAttemptState() {
+    private func clearMacSwitchAttemptState(invalidateUnderlyingConnectionAttempt: Bool = false) {
+        let hadAttempt = macSwitchAttemptID != nil
         macSwitchAttemptID = nil
         macSwitchAttemptSignInGeneration = nil
         macSwitchRestorePreviousOnCancelAttemptIDs.removeAll(keepingCapacity: true)
         macSwitchRestoreBaseline = nil
+        if invalidateUnderlyingConnectionAttempt && hadAttempt {
+            invalidatePairingAttempt()
+            connectionAttemptGeneration = UUID()
+        }
     }
 
     private func consumeMacSwitchRestorePreviousOnCancel(_ attemptID: UUID) -> Bool {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2613,7 +2613,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
         guard restored, let pairedMacStore else { return restored }
-        guard cancelRestoreGeneration == nil else { return restored }
         let scope = await currentScopeSnapshot()
         if let scope {
             guard await isScopeCurrent(scope), isCancelRestoreCurrent() else { return restored }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2577,9 +2577,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let previousStillForeground = connectionState == .connected
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
-        if cancelRestoreGeneration == nil {
-            guard !previousStillForeground else { return true }
-        }
+            && activeRouteMatchesPairedMac(previousActive)
+        guard !previousStillForeground else { return true }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         guard let (host, port) = Self.firstReconnectHostPortRoute(
             previousActive.routes,
@@ -2618,6 +2617,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             mobileShellLog.error("restorePreviousMacIfNeeded: setActive failed mac=\(previousActive.macDeviceID, privacy: .private) error=\(String(describing: error), privacy: .public)")
         }
         return restored
+    }
+
+    private func activeRouteMatchesPairedMac(_ mac: MobilePairedMac) -> Bool {
+        guard case let .hostPort(liveHost, livePort)? = activeRoute?.endpoint,
+              let normalizedLiveHost = MobileShellRouteAuthPolicy.normalizedManualHost(liveHost) else {
+            return false
+        }
+        return mac.routes.contains { route in
+            guard case let .hostPort(host, port) = route.endpoint,
+                  let normalizedHost = MobileShellRouteAuthPolicy.normalizedManualHost(host) else {
+                return false
+            }
+            return normalizedHost == normalizedLiveHost && port == livePort
+        }
     }
 
     func clearSavedMacHintAfterDeletingLastVisibleMacIfNeeded() {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1459,14 +1459,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         name: String,
         host: String,
         port: Int,
-        pairedMacDeviceID: String
+        pairedMacDeviceID: String,
+        ifStillCurrent: (() -> Bool)? = nil
     ) async {
         await connectManualHost(
             name: name,
             host: host,
             port: port,
             pairedMacDeviceID: pairedMacDeviceID,
-            recordsPairingAttempt: false
+            recordsPairingAttempt: false,
+            ifStillCurrent: ifStillCurrent
         )
     }
 
@@ -1852,9 +1854,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Prefers the active attach ticket's real `macDeviceID`. A manual (`manual-…`)
     /// ticket has no real device id (the host lacks `mobile.attach_ticket.create`,
     /// so the connect synthesizes a manual ticket even on success); in that case,
-    /// fall back to the active paired Mac's device id, which the registry/switch
-    /// connect paths persist on success. This keeps the connected device — and its
-    /// live workspaces — visible in the tree even when the live ticket is manual.
+    /// fall back to the live foreground id stamped by switch/reconnect paths before
+    /// using the persisted active row. This keeps the connected device — and its
+    /// live workspaces — visible even while the active-row write is still settling.
     /// Yields `nil` only when there is genuinely no real device id to correlate.
     public var connectedMacDeviceID: String? {
         guard connectionState == .connected else { return nil }
@@ -1863,8 +1865,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
            !macDeviceID.hasPrefix("manual-") {
             return macDeviceID
         }
-        // Manual/synthetic ticket but a live connection: correlate via the active
-        // paired Mac the connect path persisted (its id is the real device id).
+        if let foregroundMacID = foregroundMacDeviceID,
+           !foregroundMacID.isEmpty,
+           !foregroundMacID.hasPrefix("manual-") {
+            return foregroundMacID
+        }
+        // Manual/synthetic ticket but a live connection without a foreground id:
+        // correlate via the active paired Mac the connect path persisted.
         if let activeMacID = pairedMacs.first(where: { $0.isActive })?.macDeviceID,
            !activeMacID.isEmpty,
            !activeMacID.hasPrefix("manual-") {
@@ -2446,7 +2453,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard let refreshedTarget = storeMacs.first(where: { $0.macDeviceID == macDeviceID })
             ?? pairedMacs.first(where: { $0.macDeviceID == macDeviceID }) else {
             if !hasActiveMacConnection,
-               await restorePreviousMacIfNeeded(macSwitchRestoreBaseline) {
+               await restorePreviousMacIfNeeded(macSwitchRestoreBaseline, switchAttemptID: switchAttemptID) {
                 macSwitchRestoreBaseline = nil
             }
             return false
@@ -2485,7 +2492,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         ), MobileShellRouteAuthPolicy.normalizedManualHost(host) != nil else {
             mobileShellLog.error("switchToMac: no reconnectable route mac=\(macDeviceID, privacy: .private)")
             if !hasActiveMacConnection,
-               await restorePreviousMacIfNeeded(macSwitchRestoreBaseline ?? previousForegroundMac) {
+               await restorePreviousMacIfNeeded(
+                   macSwitchRestoreBaseline ?? previousForegroundMac,
+                   switchAttemptID: switchAttemptID
+               ) {
                 macSwitchRestoreBaseline = nil
             }
             return false
@@ -2513,12 +2523,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if switched {
             macSwitchRestoreBaseline = nil
             finishMacSwitchAttempt(switchAttemptID)
-            enqueueActivePairedMacWrite(
+            if let task = enqueueActivePairedMacWrite(
                 macDeviceID: macDeviceID,
                 scope: scope,
                 reloadAfterWrite: true
-            )
-            return true
+            ) {
+                await task.value
+            }
+            return connectionState == .connected
+                && remoteClient != nil
+                && foregroundMacDeviceID == macDeviceID
         } else if macSwitchRestoreBaseline != nil || previousForegroundMac != nil, !hasActiveMacConnection {
             // The switch did not connect and the destructive connect path dropped
             // the previous session; reconnect to the still-active previous Mac so
@@ -2527,7 +2541,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // picker selection can either cancel this rollback while preserving
             // its baseline, or replace it with a new live foreground baseline.
             let restoreTarget = macSwitchRestoreBaseline ?? previousForegroundMac
-            if await restorePreviousMacIfNeeded(restoreTarget) {
+            if await restorePreviousMacIfNeeded(restoreTarget, switchAttemptID: switchAttemptID) {
                 macSwitchRestoreBaseline = nil
             }
         }
@@ -2572,19 +2586,22 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     @discardableResult
     private func restorePreviousMacIfNeeded(
         _ previousActive: MobilePairedMac?,
+        switchAttemptID: UUID? = nil,
         cancelRestoreGeneration: UInt64? = nil
     ) async -> Bool {
-        func isCancelRestoreCurrent() -> Bool {
+        func isRestoreCurrent() -> Bool {
+            guard isSignedIn else { return false }
+            if let switchAttemptID {
+                return isCurrentMacSwitchAttempt(switchAttemptID)
+            }
             guard let cancelRestoreGeneration else { return true }
             return macSwitchCancelRestoreGeneration == cancelRestoreGeneration
                 && macSwitchAttemptID == nil
-                && isSignedIn
         }
-        guard isCancelRestoreCurrent() else { return false }
-        guard isSignedIn else { return false }
+        guard isRestoreCurrent() else { return false }
         guard let previousActive else { return false }
         guard let restoreScope = await currentScopeSnapshot() else { return false }
-        guard await isScopeCurrent(restoreScope), isCancelRestoreCurrent() else { return false }
+        guard await isScopeCurrent(restoreScope), isRestoreCurrent() else { return false }
         let previousIDs = Set(pairedMacAliasIDs(for: previousActive.macDeviceID))
         let previousStillForeground = connectionState == .connected
             && remoteClient != nil
@@ -2599,15 +2616,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             mobileShellLog.error("restorePreviousMacIfNeeded: no reconnectable route mac=\(previousActive.macDeviceID, privacy: .private)")
             return false
         }
-        guard await isScopeCurrent(restoreScope), isCancelRestoreCurrent() else { return false }
+        guard await isScopeCurrent(restoreScope), isRestoreCurrent() else { return false }
         await connectStoredMacHost(
             name: previousActive.displayName ?? host,
             host: host,
             port: port,
-            pairedMacDeviceID: previousActive.macDeviceID
+            pairedMacDeviceID: previousActive.macDeviceID,
+            ifStillCurrent: isRestoreCurrent
         )
         let restoreScopeIsCurrent = await isScopeCurrent(restoreScope)
-        guard restoreScopeIsCurrent, isCancelRestoreCurrent() else {
+        guard restoreScopeIsCurrent, isRestoreCurrent() else {
             if !restoreScopeIsCurrent,
                connectionState == .connected,
                remoteClient != nil,
@@ -2624,7 +2642,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
         guard restored else { return restored }
-        guard await isScopeCurrent(restoreScope), isCancelRestoreCurrent() else { return restored }
+        guard await isScopeCurrent(restoreScope), isRestoreCurrent() else { return restored }
         if let task = enqueueActivePairedMacWrite(
             macDeviceID: previousActive.macDeviceID,
             scope: restoreScope,
@@ -5348,7 +5366,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         fallback: MobilePairedMac? = nil
     ) async -> Bool {
         guard consumeMacSwitchRestorePreviousOnCancel(attemptID) else { return false }
-        let restored = await restorePreviousMacIfNeeded(macSwitchRestoreBaseline ?? fallback)
+        let restoreGeneration = macSwitchCancelRestoreGeneration
+        let restored = await restorePreviousMacIfNeeded(
+            macSwitchRestoreBaseline ?? fallback,
+            cancelRestoreGeneration: restoreGeneration
+        )
         macSwitchRestoreBaseline = nil
         return restored
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3115,7 +3115,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 guard let self else { return }
                 guard self.isSignedIn,
                       self.signInGeneration == restoreSignInGeneration,
-                      self.secondaryAggregationScopeGeneration == restoreScopeGeneration else { return }
+                      self.secondaryAggregationScopeGeneration == restoreScopeGeneration,
+                      self.macSwitchAttemptID == nil else { return }
                 _ = await self.restorePreviousMacIfNeeded(restoreTarget)
                 if self.macSwitchAttemptID == nil,
                    self.signInGeneration == restoreSignInGeneration,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2560,6 +2560,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     @discardableResult
     private func restorePreviousMacIfNeeded(_ previousActive: MobilePairedMac?) async -> Bool {
+        guard isSignedIn else { return false }
         guard let previousActive else { return false }
         let previousIDs = Set(pairedMacAliasIDs(for: previousActive.macDeviceID))
         let previousStillForeground = connectionState == .connected
@@ -3099,13 +3100,30 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// request before it reaches the foreground mutation point.
     public func cancelPendingMacSwitch(restorePreviousOnCancel: Bool = false) {
         guard let attemptID = macSwitchAttemptID else { return }
-        if restorePreviousOnCancel {
+        let restoreTarget = restorePreviousOnCancel ? macSwitchRestoreBaseline : nil
+        let restoreSignInGeneration = signInGeneration
+        let restoreScopeGeneration = secondaryAggregationScopeGeneration
+        if restorePreviousOnCancel, restoreTarget == nil {
             macSwitchRestorePreviousOnCancelAttemptIDs.insert(attemptID)
         }
         macSwitchAttemptID = nil
         macSwitchAttemptSignInGeneration = nil
         invalidatePairingAttempt()
         connectionAttemptGeneration = UUID()
+        if let restoreTarget {
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                guard self.isSignedIn,
+                      self.signInGeneration == restoreSignInGeneration,
+                      self.secondaryAggregationScopeGeneration == restoreScopeGeneration else { return }
+                _ = await self.restorePreviousMacIfNeeded(restoreTarget)
+                if self.macSwitchAttemptID == nil,
+                   self.signInGeneration == restoreSignInGeneration,
+                   self.secondaryAggregationScopeGeneration == restoreScopeGeneration {
+                    self.macSwitchRestoreBaseline = nil
+                }
+            }
+        }
     }
 
     /// Accepts the pending version mismatch warning and retries the stored pairing URL.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3186,8 +3186,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Supersede the in-flight paired-Mac switch without applying the broader
     /// pairing-cancel UI teardown. Used by picker surfaces that abandon a switch
     /// request before it reaches the foreground mutation point.
-    public func cancelPendingMacSwitch(restorePreviousOnCancel: Bool = false) {
-        guard let attemptID = macSwitchAttemptID else { return }
+    @discardableResult
+    public func cancelPendingMacSwitch(restorePreviousOnCancel: Bool = false) -> Task<Bool, Never>? {
+        guard let attemptID = macSwitchAttemptID else { return nil }
         let restoreTarget = restorePreviousOnCancel ? macSwitchRestoreBaseline : nil
         let restoreSignInGeneration = signInGeneration
         let restoreScopeGeneration = secondaryAggregationScopeGeneration
@@ -3201,14 +3202,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         invalidatePairingAttempt()
         connectionAttemptGeneration = UUID()
         if let restoreTarget {
-            Task { @MainActor [weak self] in
-                guard let self else { return }
+            return Task { @MainActor [weak self] in
+                guard let self else { return false }
                 guard self.isSignedIn,
                       self.signInGeneration == restoreSignInGeneration,
                       self.secondaryAggregationScopeGeneration == restoreScopeGeneration,
                       self.macSwitchAttemptID == nil,
-                      self.macSwitchCancelRestoreGeneration == restoreGeneration else { return }
-                _ = await self.restorePreviousMacIfNeeded(
+                      self.macSwitchCancelRestoreGeneration == restoreGeneration else { return false }
+                let restored = await self.restorePreviousMacIfNeeded(
                     restoreTarget,
                     cancelRestoreGeneration: restoreGeneration
                 )
@@ -3218,8 +3219,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                    self.macSwitchCancelRestoreGeneration == restoreGeneration {
                     self.macSwitchRestoreBaseline = nil
                 }
+                return restored
             }
         }
+        return nil
     }
 
     /// Accepts the pending version mismatch warning and retries the stored pairing URL.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2422,9 +2422,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // stale during reconnect/switch races). Trusting it could make `openWorkspace`
         // proceed without switching and route input/mutations to the wrong Mac.
         if foregroundMacDeviceID == macDeviceID, connectionState == .connected { return true }
-        // The currently-active Mac to fall back to if the switch fails.
-        let previousActive = storeMacs.first { $0.isActive && $0.macDeviceID != macDeviceID }
-            ?? pairedMacs.first { $0.isActive && $0.macDeviceID != macDeviceID }
+        // The LIVE foreground Mac to fall back to if the destructive switch fails.
+        // Persisted `isActive` can lag the connection, so use the foreground id
+        // captured before `connectManualHost` clears/replaces the live context.
+        let previousForegroundMacDeviceID = foregroundMacDeviceID
+        let previousForegroundMac = previousForegroundMacForSwitchRestore(
+            previousForegroundMacDeviceID: previousForegroundMacDeviceID,
+            switchingTo: macDeviceID,
+            storeMacs: storeMacs
+        )
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         guard let (host, port) = Self.firstReconnectHostPortRoute(
             refreshedTarget.routes,
@@ -2439,7 +2445,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             pairedMacDeviceID: macDeviceID)
         guard isCurrentMacSwitchAttempt(switchAttemptID) else {
             if consumeMacSwitchRestorePreviousOnCancel(switchAttemptID) {
-                await restorePreviousMacIfNeeded(previousActive)
+                await restorePreviousMacIfNeeded(previousForegroundMac)
             }
             return false
         }
@@ -2460,14 +2466,51 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             } catch {
                 mobileShellLog.error("paired mac store setActive failed mac=\(macDeviceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
             }
-        } else if previousActive != nil, connectionState != .connected {
+        } else if previousForegroundMac != nil, connectionState != .connected {
             // The switch did not connect and the destructive connect path dropped
             // the previous session; reconnect to the still-active previous Mac so
             // the user is not left stranded on a failed switch.
-            await restorePreviousMacIfNeeded(previousActive)
+            // The target switch is over before this restore starts; picker
+            // cancellation must not invalidate the restore's connection generation.
+            finishMacSwitchAttempt(switchAttemptID)
+            await restorePreviousMacIfNeeded(previousForegroundMac)
         }
         await loadPairedMacs()
         return switched
+    }
+
+    /// Resolves the live foreground Mac that a failed destructive switch should restore.
+    func previousForegroundMacForSwitchRestore(
+        previousForegroundMacDeviceID: String?,
+        switchingTo macDeviceID: String,
+        storeMacs: [MobilePairedMac]
+    ) -> MobilePairedMac? {
+        guard let previousForegroundMacDeviceID,
+              !previousForegroundMacDeviceID.isEmpty,
+              previousForegroundMacDeviceID != macDeviceID else { return nil }
+        var seenIDs = Set<String>()
+        // Fresh store rows are authoritative. The in-memory list is appended as a
+        // cold/read-failure fallback and deduped after store rows, so it cannot
+        // override a current store record for the same Mac id.
+        let rawCandidates = storeMacs.isEmpty ? pairedMacs : storeMacs + pairedMacs
+        let candidates = rawCandidates.filter { mac in
+            seenIDs.insert(mac.macDeviceID).inserted
+        }
+        if let direct = candidates.first(where: {
+            $0.macDeviceID == previousForegroundMacDeviceID && $0.macDeviceID != macDeviceID
+        }) {
+            return direct
+        }
+        let supportedKinds = runtime?.supportedRouteKinds ?? []
+        return candidates.first { candidate in
+            guard candidate.macDeviceID != macDeviceID else { return false }
+            return Self.macDeviceIDsForLogicalPairedMac(
+                candidate.macDeviceID,
+                in: candidates,
+                supportedKinds: supportedKinds,
+                preferNonLoopback: Self.prefersNonLoopbackRoutes
+            ).contains(previousForegroundMacDeviceID)
+        }
     }
 
     private func restorePreviousMacIfNeeded(_ previousActive: MobilePairedMac?) async {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2459,7 +2459,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             switchingTo: macDeviceID,
             storeMacs: storeMacs
         )
-        macSwitchRestoreBaseline = previousForegroundMac
+        if let previousForegroundMac {
+            macSwitchRestoreBaseline = previousForegroundMac
+        } else if hasActiveMacConnection {
+            macSwitchRestoreBaseline = nil
+        }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         guard let (host, port) = Self.firstReconnectHostPortRoute(
             refreshedTarget.routes,
@@ -2501,10 +2505,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // The switch did not connect and the destructive connect path dropped
             // the previous session; reconnect to the still-active previous Mac so
             // the user is not left stranded on a failed switch.
-            // The target switch is over before this restore starts; picker
-            // cancellation must not invalidate the restore's connection generation.
+            // Keep the attempt alive through the restore so a rapid follow-up
+            // picker selection can either cancel this rollback while preserving
+            // its baseline, or replace it with a new live foreground baseline.
             let restoreTarget = macSwitchRestoreBaseline ?? previousForegroundMac
-            finishMacSwitchAttempt(switchAttemptID)
             if await restorePreviousMacIfNeeded(restoreTarget) {
                 macSwitchRestoreBaseline = nil
             }
@@ -5291,7 +5295,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         macSwitchRestorePreviousOnCancelAttemptIDs.removeAll(keepingCapacity: true)
         macSwitchAttemptID = attemptID
         macSwitchAttemptSignInGeneration = signInGeneration
-        macSwitchRestoreBaseline = nil
+        if hasActiveMacConnection {
+            macSwitchRestoreBaseline = nil
+        }
         invalidatePairingAttempt()
         connectionAttemptGeneration = UUID()
         return attemptID

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2421,7 +2421,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // `promoteSecondaryToForeground` writes it via an unawaited Task, and it is
         // stale during reconnect/switch races). Trusting it could make `openWorkspace`
         // proceed without switching and route input/mutations to the wrong Mac.
-        if foregroundMacDeviceID == macDeviceID, connectionState == .connected { return true }
+        if foregroundMacDeviceID == macDeviceID,
+           connectionState == .connected,
+           remoteClient != nil { return true }
         // The LIVE foreground Mac to fall back to if the destructive switch fails.
         // Persisted `isActive` can lag the connection, so use the foreground id
         // captured before `connectManualHost` clears/replaces the live context.
@@ -2455,6 +2457,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // a different foreground id. Trust that identity instead of exact host/port
         // text equality, which can differ across normalized routes.
         let switched = connectionState == .connected
+            && remoteClient != nil
             && foregroundMacDeviceID == macDeviceID
         if switched {
             do {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2496,6 +2496,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             && foregroundMacDeviceID == macDeviceID
         if switched {
             macSwitchRestoreBaseline = nil
+            // The foreground connection has already landed on the target Mac. From
+            // here on, persistence/list refresh should not be cancellable as a switch.
+            finishMacSwitchAttempt(switchAttemptID)
             do {
                 try await pairedMacStore.setActive(
                     macDeviceID: macDeviceID,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2325,8 +2325,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard let previews = await fetchSecondaryWorkspaces(on: sub.client, macDeviceID: macID),
               secondaryMacSubscriptions[macID] === sub,
               isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
-        let activeWriteScope = await currentScopeSnapshot()
-        guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
+        guard let activeWriteScope = await currentScopeSnapshot(),
+              secondaryMacSubscriptions[macID] === sub,
+              activeWriteScope.generation == secondaryAggregationScopeGeneration,
+              isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
         mobileShellLog.info("promote: reusing live secondary connection as foreground mac=\(macID, privacy: .public)")
         // Take a fresh connection generation so the foreground machinery (polling,
         // event listener, in-flight request guards) treats this client as current.
@@ -2372,11 +2374,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         startTerminalRefreshPolling()
         syncSelectedTerminalForWorkspace()
         if let pairedMacStore {
-            Task {
+            Task { [weak self] in
+                guard let self, await self.isScopeCurrent(activeWriteScope) else { return }
                 try? await pairedMacStore.setActive(
                     macDeviceID: macID,
-                    stackUserID: activeWriteScope?.userID,
-                    teamID: activeWriteScope?.teamID
+                    stackUserID: activeWriteScope.userID,
+                    teamID: activeWriteScope.teamID
                 )
             }
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -686,6 +686,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var connectionAttemptGeneration: UUID
     @ObservationIgnored private var macSwitchAttemptID: UUID?
     @ObservationIgnored private var macSwitchRestorePreviousOnCancelAttemptIDs: Set<UUID> = []
+    @ObservationIgnored private var macSwitchRestoreBaseline: MobilePairedMac?
     private var chatEventSourceGeneration: UUID
     /// The per-Mac connection pool (P2 of the multi-Mac work), keyed by
     /// `macDeviceID`. Today it tracks the single foreground connection; P3 adds
@@ -1127,6 +1128,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // (account, team) scope, and a suspended old-team restore can't resume.
         // Invalidate the shared boundary synchronously first; actor cleanup is
         // fire-and-forget (this method is sync) and does not wipe the local store.
+        macSwitchRestoreBaseline = nil
         pairedMacRestoreBoundary?.invalidate()
         if let refresher = pairedMacStore as? any PairedMacBackupRefreshing {
             Task { await refresher.cancelInFlightRestores() }
@@ -2396,8 +2398,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         defer { finishMacSwitchAttempt(switchAttemptID) }
         // FAST PATH: if a live read-only connection to this Mac already exists,
         // promote it to the foreground (reuse the client) instead of re-dialing.
-        if await promoteSecondaryToForeground(macDeviceID, switchAttemptID: switchAttemptID) { return true }
-        guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
+        if await promoteSecondaryToForeground(macDeviceID, switchAttemptID: switchAttemptID) {
+            macSwitchRestoreBaseline = nil
+            return true
+        }
+        guard isCurrentMacSwitchAttempt(switchAttemptID) else {
+            if consumeMacSwitchRestorePreviousOnCancel(switchAttemptID),
+               await restorePreviousMacIfNeeded(macSwitchRestoreBaseline) {
+                macSwitchRestoreBaseline = nil
+            }
+            return false
+        }
         // Refresh routes from the per-user backup so a Mac that relaunched on a
         // new port is reachable — the same freshness guarantee auto-connect and
         // aggregation use — then resolve the target from the STORE (authoritative).
@@ -2417,7 +2428,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         )) ?? []
         guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
         guard let refreshedTarget = storeMacs.first(where: { $0.macDeviceID == macDeviceID })
-            ?? pairedMacs.first(where: { $0.macDeviceID == macDeviceID }) else { return false }
+            ?? pairedMacs.first(where: { $0.macDeviceID == macDeviceID }) else {
+            if !hasActiveMacConnection,
+               await restorePreviousMacIfNeeded(macSwitchRestoreBaseline) {
+                macSwitchRestoreBaseline = nil
+            }
+            return false
+        }
         // Already foreground on this exact Mac: skip the re-dial. Gate on the LIVE
         // foreground identity, not the persisted `isActive` flag — `isActive` is
         // stored preference state that can lag the real connection (e.g.
@@ -2426,7 +2443,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // proceed without switching and route input/mutations to the wrong Mac.
         if foregroundMacDeviceID == macDeviceID,
            connectionState == .connected,
-           remoteClient != nil { return true }
+           remoteClient != nil {
+            macSwitchRestoreBaseline = nil
+            return true
+        }
         // The LIVE foreground Mac to fall back to if the destructive switch fails.
         // Persisted `isActive` can lag the connection, so use the foreground id
         // captured before `connectManualHost` clears/replaces the live context.
@@ -2436,6 +2456,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             switchingTo: macDeviceID,
             storeMacs: storeMacs
         )
+        if macSwitchRestoreBaseline == nil {
+            macSwitchRestoreBaseline = previousForegroundMac
+        }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         guard let (host, port) = Self.firstReconnectHostPortRoute(
             refreshedTarget.routes,
@@ -2443,6 +2466,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         ), MobileShellRouteAuthPolicy.normalizedManualHost(host) != nil else {
             mobileShellLog.error("switchToMac: no reconnectable route mac=\(macDeviceID, privacy: .public)")
+            if !hasActiveMacConnection,
+               await restorePreviousMacIfNeeded(macSwitchRestoreBaseline ?? previousForegroundMac) {
+                macSwitchRestoreBaseline = nil
+            }
             return false
         }
         await connectManualHost(
@@ -2450,7 +2477,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             pairedMacDeviceID: macDeviceID)
         guard isCurrentMacSwitchAttempt(switchAttemptID) else {
             if consumeMacSwitchRestorePreviousOnCancel(switchAttemptID) {
-                await restorePreviousMacIfNeeded(previousForegroundMac)
+                if await restorePreviousMacIfNeeded(macSwitchRestoreBaseline ?? previousForegroundMac) {
+                    macSwitchRestoreBaseline = nil
+                }
             }
             return false
         }
@@ -2463,6 +2492,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             && remoteClient != nil
             && foregroundMacDeviceID == macDeviceID
         if switched {
+            macSwitchRestoreBaseline = nil
             do {
                 try await pairedMacStore.setActive(
                     macDeviceID: macDeviceID,
@@ -2472,14 +2502,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             } catch {
                 mobileShellLog.error("paired mac store setActive failed mac=\(macDeviceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
             }
-        } else if previousForegroundMac != nil, connectionState != .connected {
+        } else if macSwitchRestoreBaseline != nil || previousForegroundMac != nil, !hasActiveMacConnection {
             // The switch did not connect and the destructive connect path dropped
             // the previous session; reconnect to the still-active previous Mac so
             // the user is not left stranded on a failed switch.
             // The target switch is over before this restore starts; picker
             // cancellation must not invalidate the restore's connection generation.
             finishMacSwitchAttempt(switchAttemptID)
-            await restorePreviousMacIfNeeded(previousForegroundMac)
+            if await restorePreviousMacIfNeeded(macSwitchRestoreBaseline ?? previousForegroundMac) {
+                macSwitchRestoreBaseline = nil
+            }
         }
         await loadPairedMacs()
         return switched
@@ -2519,13 +2551,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
-    private func restorePreviousMacIfNeeded(_ previousActive: MobilePairedMac?) async {
-        guard let previousActive else { return }
+    @discardableResult
+    private func restorePreviousMacIfNeeded(_ previousActive: MobilePairedMac?) async -> Bool {
+        guard let previousActive else { return false }
         let previousIDs = Set(pairedMacAliasIDs(for: previousActive.macDeviceID))
         let previousStillForeground = connectionState == .connected
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
-        guard !previousStillForeground else { return }
+        guard !previousStillForeground else { return true }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         guard let (host, port) = Self.firstReconnectHostPortRoute(
             previousActive.routes,
@@ -2533,7 +2566,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         ), MobileShellRouteAuthPolicy.normalizedManualHost(host) != nil else {
             mobileShellLog.error("restorePreviousMacIfNeeded: no reconnectable route mac=\(previousActive.macDeviceID, privacy: .public)")
-            return
+            return false
         }
         await connectStoredMacHost(
             name: previousActive.displayName ?? host,
@@ -2544,10 +2577,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let restored = connectionState == .connected
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
-        guard restored, let pairedMacStore else { return }
+        guard restored, let pairedMacStore else { return restored }
         let scope = await currentScopeSnapshot()
         if let scope {
-            guard await isScopeCurrent(scope) else { return }
+            guard await isScopeCurrent(scope) else { return restored }
         }
         do {
             try await pairedMacStore.setActive(
@@ -2559,6 +2592,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } catch {
             mobileShellLog.error("restorePreviousMacIfNeeded: setActive failed mac=\(previousActive.macDeviceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
         }
+        return restored
     }
 
     func clearSavedMacHintAfterDeletingLastVisibleMacIfNeeded() {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2561,14 +2561,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return direct
         }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
+        let aliasSetsByMacID = Self.macDeviceIDAliasSetsByPairedMacID(
+            in: candidates,
+            supportedKinds: supportedKinds,
+            preferNonLoopback: Self.prefersNonLoopbackRoutes
+        )
         return candidates.first { candidate in
             guard candidate.macDeviceID != macDeviceID else { return false }
-            return Self.macDeviceIDsForLogicalPairedMac(
-                candidate.macDeviceID,
-                in: candidates,
-                supportedKinds: supportedKinds,
-                preferNonLoopback: Self.prefersNonLoopbackRoutes
-            ).contains(previousForegroundMacDeviceID)
+            return aliasSetsByMacID[candidate.macDeviceID]?.contains(previousForegroundMacDeviceID) == true
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -687,6 +687,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     @ObservationIgnored private var macSwitchAttemptSignInGeneration: Int?
     @ObservationIgnored private var macSwitchRestorePreviousOnCancelAttemptIDs: Set<UUID> = []
     @ObservationIgnored private var macSwitchRestoreBaseline: MobilePairedMac?
+    @ObservationIgnored private var macSwitchCancelRestoreGeneration: UInt64 = 0
     private var chatEventSourceGeneration: UUID
     /// The per-Mac connection pool (P2 of the multi-Mac work), keyed by
     /// `macDeviceID`. Today it tracks the single foreground connection; P3 adds
@@ -2559,7 +2560,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     @discardableResult
-    private func restorePreviousMacIfNeeded(_ previousActive: MobilePairedMac?) async -> Bool {
+    private func restorePreviousMacIfNeeded(
+        _ previousActive: MobilePairedMac?,
+        cancelRestoreGeneration: UInt64? = nil
+    ) async -> Bool {
+        func isCancelRestoreCurrent() -> Bool {
+            guard let cancelRestoreGeneration else { return true }
+            return macSwitchCancelRestoreGeneration == cancelRestoreGeneration
+                && macSwitchAttemptID == nil
+                && isSignedIn
+        }
+        guard isCancelRestoreCurrent() else { return false }
         guard isSignedIn else { return false }
         guard let previousActive else { return false }
         let previousIDs = Set(pairedMacAliasIDs(for: previousActive.macDeviceID))
@@ -2576,19 +2587,22 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             mobileShellLog.error("restorePreviousMacIfNeeded: no reconnectable route mac=\(previousActive.macDeviceID, privacy: .private)")
             return false
         }
+        guard isCancelRestoreCurrent() else { return false }
         await connectStoredMacHost(
             name: previousActive.displayName ?? host,
             host: host,
             port: port,
             pairedMacDeviceID: previousActive.macDeviceID
         )
+        guard isCancelRestoreCurrent() else { return false }
         let restored = connectionState == .connected
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
         guard restored, let pairedMacStore else { return restored }
+        guard cancelRestoreGeneration == nil else { return restored }
         let scope = await currentScopeSnapshot()
         if let scope {
-            guard await isScopeCurrent(scope) else { return restored }
+            guard await isScopeCurrent(scope), isCancelRestoreCurrent() else { return restored }
         }
         do {
             try await pairedMacStore.setActive(
@@ -2596,6 +2610,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 stackUserID: scope?.userID,
                 teamID: scope?.teamID
             )
+            guard isCancelRestoreCurrent() else { return restored }
             await loadPairedMacs()
         } catch {
             mobileShellLog.error("restorePreviousMacIfNeeded: setActive failed mac=\(previousActive.macDeviceID, privacy: .private) error=\(String(describing: error), privacy: .public)")
@@ -3103,6 +3118,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let restoreTarget = restorePreviousOnCancel ? macSwitchRestoreBaseline : nil
         let restoreSignInGeneration = signInGeneration
         let restoreScopeGeneration = secondaryAggregationScopeGeneration
+        macSwitchCancelRestoreGeneration &+= 1
+        let restoreGeneration = macSwitchCancelRestoreGeneration
         if restorePreviousOnCancel, restoreTarget == nil {
             macSwitchRestorePreviousOnCancelAttemptIDs.insert(attemptID)
         }
@@ -3116,11 +3133,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 guard self.isSignedIn,
                       self.signInGeneration == restoreSignInGeneration,
                       self.secondaryAggregationScopeGeneration == restoreScopeGeneration,
-                      self.macSwitchAttemptID == nil else { return }
-                _ = await self.restorePreviousMacIfNeeded(restoreTarget)
+                      self.macSwitchAttemptID == nil,
+                      self.macSwitchCancelRestoreGeneration == restoreGeneration else { return }
+                _ = await self.restorePreviousMacIfNeeded(
+                    restoreTarget,
+                    cancelRestoreGeneration: restoreGeneration
+                )
                 if self.macSwitchAttemptID == nil,
                    self.signInGeneration == restoreSignInGeneration,
-                   self.secondaryAggregationScopeGeneration == restoreScopeGeneration {
+                   self.secondaryAggregationScopeGeneration == restoreScopeGeneration,
+                   self.macSwitchCancelRestoreGeneration == restoreGeneration {
                     self.macSwitchRestoreBaseline = nil
                 }
             }
@@ -5208,6 +5230,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private func beginMacSwitchAttempt() -> UUID {
         let attemptID = UUID()
+        macSwitchCancelRestoreGeneration &+= 1
         macSwitchRestorePreviousOnCancelAttemptIDs.removeAll(keepingCapacity: true)
         macSwitchAttemptID = attemptID
         macSwitchAttemptSignInGeneration = signInGeneration
@@ -5233,6 +5256,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private func clearMacSwitchAttemptState(invalidateUnderlyingConnectionAttempt: Bool = false) {
         let hadAttempt = macSwitchAttemptID != nil
+        macSwitchCancelRestoreGeneration &+= 1
         macSwitchAttemptID = nil
         macSwitchAttemptSignInGeneration = nil
         macSwitchRestorePreviousOnCancelAttemptIDs.removeAll(keepingCapacity: true)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2561,6 +2561,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard isCancelRestoreCurrent() else { return false }
         guard isSignedIn else { return false }
         guard let previousActive else { return false }
+        guard let restoreScope = await currentScopeSnapshot() else { return false }
+        guard await isScopeCurrent(restoreScope), isCancelRestoreCurrent() else { return false }
         let previousIDs = Set(pairedMacAliasIDs(for: previousActive.macDeviceID))
         let previousStillForeground = connectionState == .connected
             && remoteClient != nil
@@ -2576,25 +2578,30 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             mobileShellLog.error("restorePreviousMacIfNeeded: no reconnectable route mac=\(previousActive.macDeviceID, privacy: .private)")
             return false
         }
-        guard isCancelRestoreCurrent() else { return false }
+        guard await isScopeCurrent(restoreScope), isCancelRestoreCurrent() else { return false }
         await connectStoredMacHost(
             name: previousActive.displayName ?? host,
             host: host,
             port: port,
             pairedMacDeviceID: previousActive.macDeviceID
         )
-        guard isCancelRestoreCurrent() else { return false }
+        guard await isScopeCurrent(restoreScope), isCancelRestoreCurrent() else {
+            if connectionState == .connected,
+               remoteClient != nil,
+               foregroundMacDeviceID.map({ previousIDs.contains($0) }) == true {
+                disconnectLiveConnection()
+                workspacesByMac = workspacesByMac.filter { !previousIDs.contains($0.key) }
+            }
+            return false
+        }
         let restored = connectionState == .connected
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
         guard restored else { return restored }
-        let scope = await currentScopeSnapshot()
-        if let scope {
-            guard await isScopeCurrent(scope), isCancelRestoreCurrent() else { return restored }
-        }
+        guard await isScopeCurrent(restoreScope), isCancelRestoreCurrent() else { return restored }
         if let task = enqueueActivePairedMacWrite(
             macDeviceID: previousActive.macDeviceID,
-            scope: scope,
+            scope: restoreScope,
             reloadAfterWrite: true
         ) {
             await task.value
@@ -5301,13 +5308,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     private func clearMacSwitchAttemptState(invalidateUnderlyingConnectionAttempt: Bool = false) {
-        let hadAttempt = macSwitchAttemptID != nil
         macSwitchCancelRestoreGeneration &+= 1
         macSwitchAttemptID = nil
         macSwitchAttemptSignInGeneration = nil
         macSwitchRestorePreviousOnCancelAttemptIDs.removeAll(keepingCapacity: true)
         macSwitchRestoreBaseline = nil
-        if invalidateUnderlyingConnectionAttempt && hadAttempt {
+        if invalidateUnderlyingConnectionAttempt {
             invalidatePairingAttempt()
             connectionAttemptGeneration = UUID()
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2511,8 +2511,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // the user is not left stranded on a failed switch.
             // The target switch is over before this restore starts; picker
             // cancellation must not invalidate the restore's connection generation.
+            let restoreTarget = macSwitchRestoreBaseline ?? previousForegroundMac
             finishMacSwitchAttempt(switchAttemptID)
-            if await restorePreviousMacIfNeeded(macSwitchRestoreBaseline ?? previousForegroundMac) {
+            if await restorePreviousMacIfNeeded(restoreTarget) {
                 macSwitchRestoreBaseline = nil
             }
         }
@@ -5203,6 +5204,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if macSwitchAttemptID == attemptID {
             macSwitchAttemptID = nil
             macSwitchAttemptSignInGeneration = nil
+            macSwitchRestoreBaseline = nil
         }
         macSwitchRestorePreviousOnCancelAttemptIDs.remove(attemptID)
     }
@@ -5226,9 +5228,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ) async -> Bool {
         guard consumeMacSwitchRestorePreviousOnCancel(attemptID) else { return false }
         let restored = await restorePreviousMacIfNeeded(macSwitchRestoreBaseline ?? fallback)
-        if restored {
-            macSwitchRestoreBaseline = nil
-        }
+        macSwitchRestoreBaseline = nil
         return restored
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -684,6 +684,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var createTerminalTaskID: UUID?
     private var connectionGeneration: UUID
     private var connectionAttemptGeneration: UUID
+    @ObservationIgnored private var macSwitchAttemptID: UUID?
+    @ObservationIgnored private var macSwitchRestorePreviousOnCancelAttemptIDs: Set<UUID> = []
     private var chatEventSourceGeneration: UUID
     /// The per-Mac connection pool (P2 of the multi-Mac work), keyed by
     /// `macDeviceID`. Today it tracks the single foreground connection; P3 adds
@@ -2316,12 +2318,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// any of which strands the user even though a working client to that exact Mac
     /// already sits in `secondaryMacSubscriptions`. Reusing it makes that failure
     /// unrepresentable for an already-aggregated Mac.
-    private func promoteSecondaryToForeground(_ macID: String) async -> Bool {
+    private func promoteSecondaryToForeground(_ macID: String, switchAttemptID: UUID) async -> Bool {
         guard runtime != nil, let sub = secondaryMacSubscriptions[macID] else { return false }
         // Probe the live client so we only promote a connection that responds NOW
         // (the read-only stream can have silently dropped); on failure, re-dial.
         guard let previews = await fetchSecondaryWorkspaces(on: sub.client, macDeviceID: macID),
-              secondaryMacSubscriptions[macID] === sub else { return false }
+              secondaryMacSubscriptions[macID] === sub,
+              isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
+        let activeWriteScope = await currentScopeSnapshot()
+        guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
         mobileShellLog.info("promote: reusing live secondary connection as foreground mac=\(macID, privacy: .public)")
         // Take a fresh connection generation so the foreground machinery (polling,
         // event listener, in-flight request guards) treats this client as current.
@@ -2367,12 +2372,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         startTerminalRefreshPolling()
         syncSelectedTerminalForWorkspace()
         if let pairedMacStore {
-            let scope = await currentScopeSnapshot()
             Task {
                 try? await pairedMacStore.setActive(
                     macDeviceID: macID,
-                    stackUserID: scope?.userID,
-                    teamID: scope?.teamID
+                    stackUserID: activeWriteScope?.userID,
+                    teamID: activeWriteScope?.teamID
                 )
             }
         }
@@ -2385,9 +2389,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     @discardableResult
     public func switchToMac(macDeviceID: String) async -> Bool {
         guard let pairedMacStore else { return false }
+        let switchAttemptID = beginMacSwitchAttempt()
+        defer { finishMacSwitchAttempt(switchAttemptID) }
         // FAST PATH: if a live read-only connection to this Mac already exists,
         // promote it to the foreground (reuse the client) instead of re-dialing.
-        if await promoteSecondaryToForeground(macDeviceID) { return true }
+        if await promoteSecondaryToForeground(macDeviceID, switchAttemptID: switchAttemptID) { return true }
+        guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
         // Refresh routes from the per-user backup so a Mac that relaunched on a
         // new port is reachable — the same freshness guarantee auto-connect and
         // aggregation use — then resolve the target from the STORE (authoritative).
@@ -2397,12 +2404,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // the open and strand the user on a workspace whose Mac never connected.
         if let refresher = pairedMacStore as? any PairedMacBackupRefreshing {
             await refresher.refreshFromBackup(stackUserID: identityProvider?.currentUserID)
+            guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
         }
         let scope = await currentScopeSnapshot()
+        guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
         let storeMacs = (try? await pairedMacStore.loadAll(
             stackUserID: scope?.userID ?? identityProvider?.currentUserID,
             teamID: scope?.teamID
         )) ?? []
+        guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
         guard let refreshedTarget = storeMacs.first(where: { $0.macDeviceID == macDeviceID })
             ?? pairedMacs.first(where: { $0.macDeviceID == macDeviceID }) else { return false }
         // Already foreground on this exact Mac: skip the re-dial. Gate on the LIVE
@@ -2420,25 +2430,27 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             refreshedTarget.routes,
             supportedKinds: supportedKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
-        ), let normalizedHost = MobileShellRouteAuthPolicy.normalizedManualHost(host) else {
+        ), MobileShellRouteAuthPolicy.normalizedManualHost(host) != nil else {
             mobileShellLog.error("switchToMac: no reconnectable route mac=\(macDeviceID, privacy: .public)")
             return false
         }
         await connectManualHost(
             name: refreshedTarget.displayName ?? host, host: host, port: port,
             pairedMacDeviceID: macDeviceID)
-        // The switch succeeded only if the live connection is to THIS Mac's route.
-        // A different switch tapped while this connect was in flight supersedes it
-        // via `beginPairingAttempt`, leaving `connectionState` `.connected` for the
-        // other Mac; matching the live route prevents this superseded task from
-        // persisting a stale active target or reporting a false success.
+        guard isCurrentMacSwitchAttempt(switchAttemptID) else {
+            if consumeMacSwitchRestorePreviousOnCancel(switchAttemptID),
+               previousActive != nil {
+                _ = await reconnectActiveMacIfAvailable(stackUserID: identityProvider?.currentUserID)
+            }
+            return false
+        }
+        // The switch succeeded only if the live foreground identity is THIS Mac.
+        // `connect(..., pairedMacDeviceID:)` stamps the foreground state with the
+        // target id after a successful connection, while a superseding switch leaves
+        // a different foreground id. Trust that identity instead of exact host/port
+        // text equality, which can differ across normalized routes.
         let switched = connectionState == .connected
-            && {
-                if case let .hostPort(liveHost, livePort)? = activeRoute?.endpoint {
-                    return liveHost == normalizedHost && livePort == port
-                }
-                return false
-            }()
+            && foregroundMacDeviceID == macDeviceID
         if switched {
             do {
                 try await pairedMacStore.setActive(
@@ -2949,6 +2961,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         connectionState = .disconnected
         macConnectionStatus = .unavailable
         clearRemoteConnectionContext()
+    }
+
+    /// Supersede the in-flight paired-Mac switch without applying the broader
+    /// pairing-cancel UI teardown. Used by picker surfaces that abandon a switch
+    /// request before it reaches the foreground mutation point.
+    public func cancelPendingMacSwitch(restorePreviousOnCancel: Bool = false) {
+        guard let attemptID = macSwitchAttemptID else { return }
+        if restorePreviousOnCancel {
+            macSwitchRestorePreviousOnCancelAttemptIDs.insert(attemptID)
+        }
+        macSwitchAttemptID = nil
+        invalidatePairingAttempt()
+        connectionAttemptGeneration = UUID()
     }
 
     /// Accepts the pending version mismatch warning and retries the stored pairing URL.
@@ -5028,6 +5053,29 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private func isCurrentConnectionAttempt(_ generation: UUID) -> Bool {
         generation == connectionAttemptGeneration && isSignedIn
+    }
+
+    private func beginMacSwitchAttempt() -> UUID {
+        let attemptID = UUID()
+        macSwitchAttemptID = attemptID
+        invalidatePairingAttempt()
+        connectionAttemptGeneration = UUID()
+        return attemptID
+    }
+
+    private func isCurrentMacSwitchAttempt(_ attemptID: UUID) -> Bool {
+        macSwitchAttemptID == attemptID && isSignedIn
+    }
+
+    private func finishMacSwitchAttempt(_ attemptID: UUID) {
+        if macSwitchAttemptID == attemptID {
+            macSwitchAttemptID = nil
+        }
+        macSwitchRestorePreviousOnCancelAttemptIDs.remove(attemptID)
+    }
+
+    private func consumeMacSwitchRestorePreviousOnCancel(_ attemptID: UUID) -> Bool {
+        macSwitchRestorePreviousOnCancelAttemptIDs.remove(attemptID) != nil
     }
 
     /// Invalidate the in-flight attempt outside ``beginPairingAttempt(method:)``

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2577,7 +2577,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let previousStillForeground = connectionState == .connected
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
-        guard !previousStillForeground else { return true }
+        if cancelRestoreGeneration == nil {
+            guard !previousStillForeground else { return true }
+        }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         guard let (host, port) = Self.firstReconnectHostPortRoute(
             previousActive.routes,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2497,18 +2497,31 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             && foregroundMacDeviceID == macDeviceID
         if switched {
             macSwitchRestoreBaseline = nil
-            // The foreground connection has already landed on the target Mac. From
-            // here on, persistence/list refresh should not be cancellable as a switch.
             finishMacSwitchAttempt(switchAttemptID)
-            do {
-                try await pairedMacStore.setActive(
-                    macDeviceID: macDeviceID,
-                    stackUserID: scope?.userID,
-                    teamID: scope?.teamID
-                )
-            } catch {
-                mobileShellLog.error("paired mac store setActive failed mac=\(macDeviceID, privacy: .private) error=\(String(describing: error), privacy: .public)")
+            let activeWriteScope = scope
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if let activeWriteScope {
+                    guard await self.isScopeCurrent(activeWriteScope) else { return }
+                }
+                guard self.connectionState == .connected,
+                      self.remoteClient != nil,
+                      self.foregroundMacDeviceID == macDeviceID else { return }
+                do {
+                    try await pairedMacStore.setActive(
+                        macDeviceID: macDeviceID,
+                        stackUserID: activeWriteScope?.userID,
+                        teamID: activeWriteScope?.teamID
+                    )
+                    guard self.connectionState == .connected,
+                          self.remoteClient != nil,
+                          self.foregroundMacDeviceID == macDeviceID else { return }
+                    await self.loadPairedMacs()
+                } catch {
+                    mobileShellLog.error("paired mac store setActive failed mac=\(macDeviceID, privacy: .private) error=\(String(describing: error), privacy: .public)")
+                }
             }
+            return true
         } else if macSwitchRestoreBaseline != nil || previousForegroundMac != nil, !hasActiveMacConnection {
             // The switch did not connect and the destructive connect path dropped
             // the previous session; reconnect to the still-active previous Mac so
@@ -2522,7 +2535,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             }
         }
         await loadPairedMacs()
-        return switched
+        return false
     }
 
     /// Resolves the live foreground Mac that a failed destructive switch should restore.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2538,6 +2538,24 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             port: port,
             pairedMacDeviceID: previousActive.macDeviceID
         )
+        let restored = connectionState == .connected
+            && remoteClient != nil
+            && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
+        guard restored, let pairedMacStore else { return }
+        let scope = await currentScopeSnapshot()
+        if let scope {
+            guard await isScopeCurrent(scope) else { return }
+        }
+        do {
+            try await pairedMacStore.setActive(
+                macDeviceID: previousActive.macDeviceID,
+                stackUserID: scope?.userID,
+                teamID: scope?.teamID
+            )
+            await loadPairedMacs()
+        } catch {
+            mobileShellLog.error("restorePreviousMacIfNeeded: setActive failed mac=\(previousActive.macDeviceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        }
     }
 
     func clearSavedMacHintAfterDeletingLastVisibleMacIfNeeded() {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2404,10 +2404,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return true
         }
         guard isCurrentMacSwitchAttempt(switchAttemptID) else {
-            if consumeMacSwitchRestorePreviousOnCancel(switchAttemptID),
-               await restorePreviousMacIfNeeded(macSwitchRestoreBaseline) {
-                macSwitchRestoreBaseline = nil
-            }
+            await restoreMacSwitchBaselineIfCancelled(switchAttemptID)
             return false
         }
         // Refresh routes from the per-user backup so a Mac that relaunched on a
@@ -2419,15 +2416,24 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // the open and strand the user on a workspace whose Mac never connected.
         if let refresher = pairedMacStore as? any PairedMacBackupRefreshing {
             await refresher.refreshFromBackup(stackUserID: identityProvider?.currentUserID)
-            guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
+            guard isCurrentMacSwitchAttempt(switchAttemptID) else {
+                await restoreMacSwitchBaselineIfCancelled(switchAttemptID)
+                return false
+            }
         }
         let scope = await currentScopeSnapshot()
-        guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
+        guard isCurrentMacSwitchAttempt(switchAttemptID) else {
+            await restoreMacSwitchBaselineIfCancelled(switchAttemptID)
+            return false
+        }
         let storeMacs = (try? await pairedMacStore.loadAll(
             stackUserID: scope?.userID ?? identityProvider?.currentUserID,
             teamID: scope?.teamID
         )) ?? []
-        guard isCurrentMacSwitchAttempt(switchAttemptID) else { return false }
+        guard isCurrentMacSwitchAttempt(switchAttemptID) else {
+            await restoreMacSwitchBaselineIfCancelled(switchAttemptID)
+            return false
+        }
         guard let refreshedTarget = storeMacs.first(where: { $0.macDeviceID == macDeviceID })
             ?? pairedMacs.first(where: { $0.macDeviceID == macDeviceID }) else {
             if !hasActiveMacConnection,
@@ -2477,11 +2483,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             name: refreshedTarget.displayName ?? host, host: host, port: port,
             pairedMacDeviceID: macDeviceID)
         guard isCurrentMacSwitchAttempt(switchAttemptID) else {
-            if consumeMacSwitchRestorePreviousOnCancel(switchAttemptID) {
-                if await restorePreviousMacIfNeeded(macSwitchRestoreBaseline ?? previousForegroundMac) {
-                    macSwitchRestoreBaseline = nil
-                }
-            }
+            await restoreMacSwitchBaselineIfCancelled(switchAttemptID, fallback: previousForegroundMac)
             return false
         }
         // The switch succeeded only if the live foreground identity is THIS Mac.
@@ -5215,6 +5217,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             invalidatePairingAttempt()
             connectionAttemptGeneration = UUID()
         }
+    }
+
+    @discardableResult
+    private func restoreMacSwitchBaselineIfCancelled(
+        _ attemptID: UUID,
+        fallback: MobilePairedMac? = nil
+    ) async -> Bool {
+        guard consumeMacSwitchRestorePreviousOnCancel(attemptID) else { return false }
+        let restored = await restorePreviousMacIfNeeded(macSwitchRestoreBaseline ?? fallback)
+        if restored {
+            macSwitchRestoreBaseline = nil
+        }
+        return restored
     }
 
     private func consumeMacSwitchRestorePreviousOnCancel(_ attemptID: UUID) -> Bool {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2438,9 +2438,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             name: refreshedTarget.displayName ?? host, host: host, port: port,
             pairedMacDeviceID: macDeviceID)
         guard isCurrentMacSwitchAttempt(switchAttemptID) else {
-            if consumeMacSwitchRestorePreviousOnCancel(switchAttemptID),
-               previousActive != nil {
-                _ = await reconnectActiveMacIfAvailable(stackUserID: identityProvider?.currentUserID)
+            if consumeMacSwitchRestorePreviousOnCancel(switchAttemptID) {
+                await restorePreviousMacIfNeeded(previousActive)
             }
             return false
         }
@@ -2465,10 +2464,34 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // The switch did not connect and the destructive connect path dropped
             // the previous session; reconnect to the still-active previous Mac so
             // the user is not left stranded on a failed switch.
-            _ = await reconnectActiveMacIfAvailable(stackUserID: identityProvider?.currentUserID)
+            await restorePreviousMacIfNeeded(previousActive)
         }
         await loadPairedMacs()
         return switched
+    }
+
+    private func restorePreviousMacIfNeeded(_ previousActive: MobilePairedMac?) async {
+        guard let previousActive else { return }
+        let previousIDs = Set(pairedMacAliasIDs(for: previousActive.macDeviceID))
+        let previousStillForeground = connectionState == .connected
+            && remoteClient != nil
+            && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
+        guard !previousStillForeground else { return }
+        let supportedKinds = runtime?.supportedRouteKinds ?? []
+        guard let (host, port) = Self.firstReconnectHostPortRoute(
+            previousActive.routes,
+            supportedKinds: supportedKinds,
+            preferNonLoopback: Self.prefersNonLoopbackRoutes
+        ), MobileShellRouteAuthPolicy.normalizedManualHost(host) != nil else {
+            mobileShellLog.error("restorePreviousMacIfNeeded: no reconnectable route mac=\(previousActive.macDeviceID, privacy: .public)")
+            return
+        }
+        await connectStoredMacHost(
+            name: previousActive.displayName ?? host,
+            host: host,
+            port: port,
+            pairedMacDeviceID: previousActive.macDeviceID
+        )
     }
 
     func clearSavedMacHintAfterDeletingLastVisibleMacIfNeeded() {
@@ -5057,6 +5080,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private func beginMacSwitchAttempt() -> UUID {
         let attemptID = UUID()
+        macSwitchRestorePreviousOnCancelAttemptIDs.removeAll(keepingCapacity: true)
         macSwitchAttemptID = attemptID
         invalidatePairingAttempt()
         connectionAttemptGeneration = UUID()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2296,14 +2296,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         storedPairedMacs = visibleLoaded
-        let coalesced = Self.coalescePairedMacsByDialEndpoint(visibleLoaded, supportedKinds: runtime?.supportedRouteKinds ?? [], preferNonLoopback: Self.prefersNonLoopbackRoutes)
+        let supportedRouteKinds = runtime?.supportedRouteKinds ?? []
+        let coalesced = Self.coalescePairedMacsByDialEndpoint(
+            visibleLoaded,
+            supportedKinds: supportedRouteKinds,
+            preferNonLoopback: Self.prefersNonLoopbackRoutes
+        )
+        let aliasIDsByMacID = Self.macDeviceIDAliasesByPairedMacID(
+            in: visibleLoaded,
+            supportedKinds: supportedRouteKinds,
+            preferNonLoopback: Self.prefersNonLoopbackRoutes
+        )
         pairedMacAliasIDsByRepresentativeID = coalesced.reduce(into: [String: [String]]()) { result, mac in
-            result[mac.macDeviceID] = Self.macDeviceIDsForLogicalPairedMac(
-                mac.macDeviceID,
-                in: visibleLoaded,
-                supportedKinds: runtime?.supportedRouteKinds ?? [],
-                preferNonLoopback: Self.prefersNonLoopbackRoutes
-            )
+            result[mac.macDeviceID] = aliasIDsByMacID[mac.macDeviceID] ?? [mac.macDeviceID]
         }
         pairedMacs = visibleLoaded
     }
@@ -3500,18 +3505,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     private func secondaryAggregationCandidateMacs(from visibleLoadedMacs: [MobilePairedMac]) -> [MobilePairedMac] {
+        let supportedRouteKinds = runtime?.supportedRouteKinds ?? []
         let macs = Self.coalescePairedMacsByDialEndpoint(
             visibleLoadedMacs,
-            supportedKinds: runtime?.supportedRouteKinds ?? [],
+            supportedKinds: supportedRouteKinds,
+            preferNonLoopback: Self.prefersNonLoopbackRoutes
+        )
+        let aliasIDsByMacID = Self.macDeviceIDAliasesByPairedMacID(
+            in: visibleLoadedMacs,
+            supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         )
         let foregroundMacDeviceIDs = foregroundMacDeviceID.map {
-            Self.macDeviceIDsForLogicalPairedMac(
-                $0,
-                in: visibleLoadedMacs,
-                supportedKinds: runtime?.supportedRouteKinds ?? [],
-                preferNonLoopback: Self.prefersNonLoopbackRoutes
-            )
+            aliasIDsByMacID[$0] ?? [$0]
         } ?? []
         let foregroundIDSet = Set(foregroundMacDeviceIDs)
         return macs.filter { !$0.macDeviceID.isEmpty && !foregroundIDSet.contains($0.macDeviceID) }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2309,7 +2309,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         )
-        let aliasIDsByMacID = Self.macDeviceIDAliasesByPairedMacID(
+        let aliasIDsByMacID = macDeviceIDAliasesByPairedMacID(
             in: visibleLoaded,
             supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
@@ -2572,7 +2572,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return direct
         }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
-        let aliasSetsByMacID = Self.macDeviceIDAliasSetsByPairedMacID(
+        let aliasSetsByMacID = macDeviceIDAliasSetsByPairedMacID(
             in: candidates,
             supportedKinds: supportedKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
@@ -3529,7 +3529,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         )
-        let aliasIDsByMacID = Self.macDeviceIDAliasesByPairedMacID(
+        let aliasIDsByMacID = macDeviceIDAliasesByPairedMacID(
             in: visibleLoadedMacs,
             supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedTeamPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedTeamPairedMacStore.swift
@@ -86,7 +86,14 @@ actor DelayedTeamPairedMacStore: MobilePairedMacStoring {
     }
 
     func activeMac(stackUserID: String?, teamID: String?) async throws -> MobilePairedMac? { nil }
-    func setActive(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {}
+    func setActive(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {
+        let key = teamID ?? ""
+        recordsByTeam[key] = recordsByTeam[key]?.map { mac in
+            var copy = mac
+            copy.isActive = copy.macDeviceID == macDeviceID
+            return copy
+        }
+    }
     func clearActive(stackUserID: String?, teamID: String?) async throws {}
     func setCustomization(
         macDeviceID: String,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePairedMacCoalescingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePairedMacCoalescingTests.swift
@@ -176,6 +176,53 @@ import Testing
         #expect(store.displayPairedMacs.map(\.macDeviceID) == ["mac-fresh", "mac-other"])
     }
 
+    @Test func switchRestoreTargetUsesLiveForegroundInsteadOfPersistedActiveMac() async throws {
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "mac-live",
+                        displayName: "Live Mac",
+                        host: "100.82.214.112",
+                        lastSeenAt: Date(timeIntervalSince1970: 30),
+                        isActive: false
+                    ),
+                    try Self.pairedMac(
+                        id: "mac-stale-active",
+                        displayName: "Stale Active Mac",
+                        host: "100.82.214.113",
+                        lastSeenAt: Date(timeIntervalSince1970: 20),
+                        isActive: true
+                    ),
+                    try Self.pairedMac(
+                        id: "mac-target",
+                        displayName: "Target Mac",
+                        host: "100.82.214.114",
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" }
+        )
+        await store.loadPairedMacs()
+        let storeMacs = try await pairedStore.loadAll(stackUserID: "user-1", teamID: "team-a")
+
+        let restoreTarget = store.previousForegroundMacForSwitchRestore(
+            previousForegroundMacDeviceID: "mac-live",
+            switchingTo: "mac-target",
+            storeMacs: storeMacs
+        )
+
+        #expect(restoreTarget?.macDeviceID == "mac-live")
+    }
+
     @Test func presenceRouteWriteFinishingAfterForgetDoesNotReviveDeletedMac() async throws {
         let oldRoute = try CmxAttachRoute(
             id: "old",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
@@ -19,8 +19,6 @@ struct WorkspaceGroupHeaderRow: View {
     let navigationStyle: WorkspaceNavigationStyle
     /// Whether the anchor workspace is the current selection (sidebar style only).
     let isAnchorSelected: Bool
-    /// Prepare for selecting the anchor workspace, without mutating navigation.
-    let prepareWorkspaceSelection: () -> Void
     /// Select the anchor workspace in sidebar layouts.
     let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
     /// Toggle the group's collapsed state on the Mac. When `nil` (previews, or a
@@ -90,12 +88,12 @@ struct WorkspaceGroupHeaderRow: View {
     private var anchorTarget: some View {
         switch navigationStyle {
         case .push:
-            NavigationLink(value: group.anchorWorkspaceID) {
+            Button {
+                selectWorkspace(group.anchorWorkspaceID)
+            } label: {
                 nameLabel
             }
-            .simultaneousGesture(TapGesture().onEnded {
-                prepareWorkspaceSelection()
-            })
+            .buttonStyle(.plain)
         case .sidebar:
             Button {
                 selectWorkspace(group.anchorWorkspaceID)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
@@ -19,7 +19,9 @@ struct WorkspaceGroupHeaderRow: View {
     let navigationStyle: WorkspaceNavigationStyle
     /// Whether the anchor workspace is the current selection (sidebar style only).
     let isAnchorSelected: Bool
-    /// Select (and, in push style, navigate to) the anchor workspace.
+    /// Prepare for selecting the anchor workspace, without mutating navigation.
+    let prepareWorkspaceSelection: () -> Void
+    /// Select the anchor workspace in sidebar layouts.
     let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
     /// Toggle the group's collapsed state on the Mac. When `nil` (previews, or a
     /// Mac without the groups capability), the chevron renders without a tap
@@ -91,6 +93,9 @@ struct WorkspaceGroupHeaderRow: View {
             NavigationLink(value: group.anchorWorkspaceID) {
                 nameLabel
             }
+            .simultaneousGesture(TapGesture().onEnded {
+                prepareWorkspaceSelection()
+            })
         case .sidebar:
             Button {
                 selectWorkspace(group.anchorWorkspaceID)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -88,11 +88,77 @@ extension WorkspaceListView {
         }
     }
 
+    var macTitlePickerSelection: Binding<WorkspaceMacSelection> {
+        Binding(
+            get: { visibleMacSelection },
+            set: { handleMacTitlePickerSelection($0) }
+        )
+    }
+
+    func handleMacTitlePickerSelection(_ selection: WorkspaceMacSelection) {
+        let startsMachineSwitch: Bool
+        if case .machine = selection, switchMac != nil {
+            startsMachineSwitch = true
+        } else {
+            startsMachineSwitch = false
+        }
+        cancelMacTitlePickerSwitch(restorePreviousOnCancel: !startsMachineSwitch)
+        let generation = macTitlePickerSwitchGeneration
+        guard startsMachineSwitch else {
+            macSelection = selection
+            return
+        }
+        macTitlePickerSwitchTask = Task { @MainActor in
+            defer {
+                if macTitlePickerSwitchGeneration == generation {
+                    macTitlePickerSwitchTask = nil
+                }
+            }
+            await applyMacTitlePickerSelection(selection, switchGeneration: generation)
+        }
+    }
+
+    func cancelMacTitlePickerSwitch(restorePreviousOnCancel: Bool = true) {
+        let hadPendingSwitch = macTitlePickerSwitchTask != nil
+        macTitlePickerSwitchTask?.cancel()
+        macTitlePickerSwitchTask = nil
+        macTitlePickerSwitchGeneration &+= 1
+        if hadPendingSwitch {
+            cancelMacSwitch?(restorePreviousOnCancel)
+        }
+    }
+
+    @MainActor
+    func applyMacTitlePickerSelection(
+        _ selection: WorkspaceMacSelection,
+        switchGeneration: UInt64? = nil
+    ) async {
+        func isCurrentSwitchRequest() -> Bool {
+            guard !Task.isCancelled else { return false }
+            guard let switchGeneration else { return true }
+            return macTitlePickerSwitchGeneration == switchGeneration
+        }
+
+        switch selection {
+        case .all, .automatic:
+            guard isCurrentSwitchRequest() else { return }
+            macSelection = selection
+        case .machine(let id):
+            guard isCurrentSwitchRequest() else { return }
+            guard let switchMac else {
+                macSelection = selection
+                return
+            }
+            guard await switchMac(id), isCurrentSwitchRequest() else { return }
+            macSelection = .machine(id)
+        }
+    }
+
     var macTitlePicker: some View {
         Menu {
             Picker(
                 L10n.string("mobile.workspaces.macPicker.title", defaultValue: "Choose Mac"),
-                selection: $macSelection
+                selection: macTitlePickerSelection
             ) {
                 Text(L10n.string("mobile.workspaces.macPicker.allMacs", defaultValue: "All Macs"))
                     .tag(WorkspaceMacSelection.all)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -112,7 +112,7 @@ extension WorkspaceListView {
 
     var macTitlePickerSelection: Binding<WorkspaceMacSelection> {
         Binding(
-            get: { visibleMacSelection },
+            get: { currentMacTitlePickerSelection },
             set: { _ = handleMacTitlePickerSelection($0) }
         )
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -113,67 +113,8 @@ extension WorkspaceListView {
     var macTitlePickerSelection: Binding<WorkspaceMacSelection> {
         Binding(
             get: { visibleMacSelection },
-            set: { handleMacTitlePickerSelection($0) }
+            set: { _ = handleMacTitlePickerSelection($0) }
         )
-    }
-
-    func handleMacTitlePickerSelection(_ selection: WorkspaceMacSelection) {
-        let startsMachineSwitch: Bool
-        if case .machine = selection, switchMac != nil {
-            startsMachineSwitch = true
-        } else {
-            startsMachineSwitch = false
-        }
-        cancelMacTitlePickerSwitch(restorePreviousOnCancel: !startsMachineSwitch)
-        let generation = macTitlePickerSwitchGeneration
-        guard startsMachineSwitch else {
-            macSelection = selection
-            return
-        }
-        macTitlePickerSwitchTask = Task { @MainActor in
-            defer {
-                if macTitlePickerSwitchGeneration == generation {
-                    macTitlePickerSwitchTask = nil
-                }
-            }
-            await applyMacTitlePickerSelection(selection, switchGeneration: generation)
-        }
-    }
-
-    func cancelMacTitlePickerSwitch(restorePreviousOnCancel: Bool = true) {
-        let hadPendingSwitch = macTitlePickerSwitchTask != nil
-        macTitlePickerSwitchTask?.cancel()
-        macTitlePickerSwitchTask = nil
-        macTitlePickerSwitchGeneration &+= 1
-        if hadPendingSwitch {
-            cancelMacSwitch?(restorePreviousOnCancel)
-        }
-    }
-
-    @MainActor
-    func applyMacTitlePickerSelection(
-        _ selection: WorkspaceMacSelection,
-        switchGeneration: UInt64? = nil
-    ) async {
-        func isCurrentSwitchRequest() -> Bool {
-            guard !Task.isCancelled else { return false }
-            guard let switchGeneration else { return true }
-            return macTitlePickerSwitchGeneration == switchGeneration
-        }
-
-        switch selection {
-        case .all, .automatic:
-            guard isCurrentSwitchRequest() else { return }
-            macSelection = selection
-        case .machine(let id):
-            guard isCurrentSwitchRequest() else { return }
-            guard let switchMac else {
-                macSelection = selection
-                return
-            }
-            guard await switchMac(id), isCurrentSwitchRequest() else { return }
-            macSelection = .machine(id)
-        }
     }
 
     func macTitlePicker(machineSnapshots: WorkspaceMachineSnapshots) -> some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -323,8 +323,8 @@ struct WorkspaceListView: View {
     @discardableResult
     func handleMacTitlePickerSelection(_ selection: WorkspaceMacSelection) -> Task<Void, Never>? {
         let startsMachineSwitch: Bool
-        if case .machine = selection, switchMac != nil {
-            startsMachineSwitch = true
+        if case .machine(let id) = selection {
+            startsMachineSwitch = shouldSwitchForMacTitlePickerMachine(id)
         } else {
             startsMachineSwitch = false
         }
@@ -346,6 +346,19 @@ struct WorkspaceListView: View {
         }
         macTitlePickerSwitchTask = task
         return task
+    }
+
+    private func shouldSwitchForMacTitlePickerMachine(_ id: String) -> Bool {
+        guard switchMac != nil, let store else { return false }
+        let scope = macSelectionScope
+        let targetIDs = scope.aliasIndex.filterMachineIDs(for: id)
+        if !scope.foregroundMachineIDs.isDisjoint(with: targetIDs) {
+            return false
+        }
+        return store.displayPairedMacs.contains { mac in
+            let pairedMacIDs = scope.aliasIndex.filterMachineIDs(for: mac.macDeviceID)
+            return !pairedMacIDs.isDisjoint(with: targetIDs)
+        }
     }
 
     func cancelMacTitlePickerSwitch(restorePreviousOnCancel: Bool = true) {
@@ -378,7 +391,7 @@ struct WorkspaceListView: View {
             macSelection = selection
         case .machine(let id):
             guard isCurrentSwitchRequest() else { return }
-            guard let switchMac else {
+            guard shouldSwitchForMacTitlePickerMachine(id), let switchMac else {
                 macTitlePickerPendingSelection = nil
                 macSelection = selection
                 return

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -8,6 +8,11 @@ import AppKit
 #endif
 
 struct WorkspaceListView: View {
+    private enum MacTitlePickerTaskKind: Equatable {
+        case switchRequest
+        case cancellation
+    }
+
     let workspaces: [MobileWorkspacePreview]
     /// The Mac's workspace groups, in section order. Empty when the Mac reports no
     /// groups; the list then renders flat. Passed as value snapshots so no
@@ -93,6 +98,7 @@ struct WorkspaceListView: View {
     /// toolbar ``WorkspaceListFilterMenu``. Session-transient like a search.
     @State var filter: MobileWorkspaceListFilter = .all
     @State private var macTitlePickerSwitchTask: Task<Void, Never>?
+    @State private var macTitlePickerSwitchTaskKind: MacTitlePickerTaskKind?
     @State private var macTitlePickerSwitchGeneration: UInt64 = 0
     @State private var macTitlePickerPendingSelection: WorkspaceMacSelection?
     /// Stable machine-menu content. Kept as value state so live workspace or
@@ -333,23 +339,26 @@ struct WorkspaceListView: View {
             startsMachineSwitch = false
         }
         let cancelTask = cancelMacTitlePickerSwitch(restorePreviousOnCancel: !startsMachineSwitch)
-        let generation = macTitlePickerSwitchGeneration
         guard startsMachineSwitch else {
             macTitlePickerPendingSelection = nil
             macSelection = selection
             return nil
         }
+        macTitlePickerSwitchGeneration &+= 1
+        let generation = macTitlePickerSwitchGeneration
         macTitlePickerPendingSelection = selection
         let task = Task { @MainActor in
             defer {
                 if macTitlePickerSwitchGeneration == generation {
                     macTitlePickerSwitchTask = nil
+                    macTitlePickerSwitchTaskKind = nil
                 }
             }
             await cancelTask?.value
             await applyMacTitlePickerSelection(selection, switchGeneration: generation)
         }
         macTitlePickerSwitchTask = task
+        macTitlePickerSwitchTaskKind = .switchRequest
         return task
     }
 
@@ -369,15 +378,32 @@ struct WorkspaceListView: View {
     @discardableResult
     func cancelMacTitlePickerSwitch(restorePreviousOnCancel: Bool = true) -> Task<Void, Never>? {
         let pendingSwitchTask = macTitlePickerSwitchTask
-        pendingSwitchTask?.cancel()
+        let pendingSwitchTaskKind = macTitlePickerSwitchTaskKind
+        if pendingSwitchTaskKind == .cancellation {
+            return pendingSwitchTask
+        }
+        if pendingSwitchTaskKind == .switchRequest {
+            pendingSwitchTask?.cancel()
+        }
         macTitlePickerSwitchTask = nil
+        macTitlePickerSwitchTaskKind = nil
         macTitlePickerPendingSelection = nil
         macTitlePickerSwitchGeneration &+= 1
+        let generation = macTitlePickerSwitchGeneration
         guard pendingSwitchTask != nil else { return nil }
         let cancelMacSwitch = cancelMacSwitch
-        return Task { @MainActor in
+        let task = Task { @MainActor in
+            defer {
+                if macTitlePickerSwitchGeneration == generation {
+                    macTitlePickerSwitchTask = nil
+                    macTitlePickerSwitchTaskKind = nil
+                }
+            }
             await cancelMacSwitch?(restorePreviousOnCancel)
         }
+        macTitlePickerSwitchTask = task
+        macTitlePickerSwitchTaskKind = .cancellation
+        return task
     }
 
     @MainActor

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -8,11 +8,6 @@ import AppKit
 #endif
 
 struct WorkspaceListView: View {
-    private enum MacTitlePickerTaskKind: Equatable {
-        case switchRequest
-        case cancellation
-    }
-
     let workspaces: [MobileWorkspacePreview]
     /// The Mac's workspace groups, in section order. Empty when the Mac reports no
     /// groups; the list then renders flat. Passed as value snapshots so no
@@ -98,7 +93,7 @@ struct WorkspaceListView: View {
     /// toolbar ``WorkspaceListFilterMenu``. Session-transient like a search.
     @State var filter: MobileWorkspaceListFilter = .all
     @State private var macTitlePickerSwitchTask: Task<Void, Never>?
-    @State private var macTitlePickerSwitchTaskKind: MacTitlePickerTaskKind?
+    @State private var macTitlePickerSwitchIsCancellation = false
     @State private var macTitlePickerSwitchGeneration: UInt64 = 0
     @State private var macTitlePickerPendingSelection: WorkspaceMacSelection?
     @State private var deferredWorkspaceSelectionGeneration: UInt64 = 0
@@ -370,14 +365,14 @@ struct WorkspaceListView: View {
             defer {
                 if macTitlePickerSwitchGeneration == generation {
                     macTitlePickerSwitchTask = nil
-                    macTitlePickerSwitchTaskKind = nil
+                    macTitlePickerSwitchIsCancellation = false
                 }
             }
             await cancelTask?.value
             await applyMacTitlePickerSelection(selection, switchGeneration: generation)
         }
         macTitlePickerSwitchTask = task
-        macTitlePickerSwitchTaskKind = .switchRequest
+        macTitlePickerSwitchIsCancellation = false
         return task
     }
 
@@ -400,15 +395,15 @@ struct WorkspaceListView: View {
         cancelStoreSwitch: Bool = true
     ) -> Task<Void, Never>? {
         let pendingSwitchTask = macTitlePickerSwitchTask
-        let pendingSwitchTaskKind = macTitlePickerSwitchTaskKind
-        if pendingSwitchTaskKind == .cancellation {
+        let pendingSwitchIsCancellation = pendingSwitchTask != nil && macTitlePickerSwitchIsCancellation
+        if pendingSwitchIsCancellation {
             return pendingSwitchTask
         }
-        if pendingSwitchTaskKind == .switchRequest {
+        if pendingSwitchTask != nil {
             pendingSwitchTask?.cancel()
         }
         macTitlePickerSwitchTask = nil
-        macTitlePickerSwitchTaskKind = nil
+        macTitlePickerSwitchIsCancellation = false
         macTitlePickerPendingSelection = nil
         macTitlePickerSwitchGeneration &+= 1
         let generation = macTitlePickerSwitchGeneration
@@ -419,13 +414,13 @@ struct WorkspaceListView: View {
             defer {
                 if macTitlePickerSwitchGeneration == generation {
                     macTitlePickerSwitchTask = nil
-                    macTitlePickerSwitchTaskKind = nil
+                    macTitlePickerSwitchIsCancellation = false
                 }
             }
             await cancelMacSwitch?(restorePreviousOnCancel)
         }
         macTitlePickerSwitchTask = task
-        macTitlePickerSwitchTaskKind = .cancellation
+        macTitlePickerSwitchIsCancellation = true
         return task
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -33,6 +33,12 @@ struct WorkspaceListView: View {
     /// Which Mac's workspaces the list is focused on. Owned by the shell so
     /// every create-workspace entrypoint shares the same selected-Mac gate.
     @Binding var macSelection: WorkspaceMacSelection
+    /// Switch the foreground Mac before applying a machine-scoped title-picker
+    /// filter. `nil` in previews, where the picker remains a pure local filter.
+    var switchMac: (@MainActor (String) async -> Bool)? = nil
+    /// Cancels a title-picker switch that is still in flight. `nil` in previews,
+    /// where no real foreground connection exists.
+    var cancelMacSwitch: (@MainActor (_ restorePreviousOnCancel: Bool) -> Void)? = nil
     /// Pull-to-refresh action. Awaits the real workspace-list re-sync from the
     /// paired Mac so the system refresh spinner reflects actual completion (and
     /// ends gracefully, leaving the list intact, when the Mac is offline). Passed
@@ -95,6 +101,8 @@ struct WorkspaceListView: View {
     /// The active row filter (All / Unread), shared-model state behind the
     /// toolbar ``WorkspaceListFilterMenu``. Session-transient like a search.
     @State var filter: MobileWorkspaceListFilter = .all
+    @State var macTitlePickerSwitchTask: Task<Void, Never>?
+    @State var macTitlePickerSwitchGeneration: UInt64 = 0
     /// The workspace whose destructive close action is awaiting confirmation.
     /// Stored at list scope so reusable rows do not own transient presentation
     /// state while `List` is recycling swipe-action rows.
@@ -263,6 +271,9 @@ struct WorkspaceListView: View {
             #endif
         }
         .accessibilityIdentifier("MobileWorkspaceList")
+        .onDisappear {
+            cancelMacTitlePickerSwitch()
+        }
         #if os(iOS)
         .sheet(isPresented: $showingShortcutsSettings) {
             TerminalShortcutsSettingsView()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -38,7 +38,7 @@ struct WorkspaceListView: View {
     var switchMac: (@MainActor (String) async -> Bool)? = nil
     /// Cancels a title-picker switch that is still in flight. `nil` in previews,
     /// where no real foreground connection exists.
-    var cancelMacSwitch: (@MainActor (_ restorePreviousOnCancel: Bool) -> Void)? = nil
+    var cancelMacSwitch: (@MainActor (_ restorePreviousOnCancel: Bool) async -> Void)? = nil
     /// Pull-to-refresh action. Awaits the real workspace-list re-sync from the
     /// paired Mac so the system refresh spinner reflects actual completion (and
     /// ends gracefully, leaving the list intact, when the Mac is offline). Passed
@@ -313,7 +313,11 @@ struct WorkspaceListView: View {
         // leaving a parent sheet covering it.
         .sheet(isPresented: $showingDeviceTree) {
             if let store {
-                DeviceTreeView(store: store, selectWorkspace: selectWorkspaceFromList, showAddDevice: showAddDevice)
+                DeviceTreeView(
+                    store: store,
+                    selectWorkspace: { id in _ = selectWorkspaceFromList(id) },
+                    showAddDevice: showAddDevice
+                )
             }
         }
         #endif
@@ -328,7 +332,7 @@ struct WorkspaceListView: View {
         } else {
             startsMachineSwitch = false
         }
-        cancelMacTitlePickerSwitch(restorePreviousOnCancel: !startsMachineSwitch)
+        _ = cancelMacTitlePickerSwitch(restorePreviousOnCancel: !startsMachineSwitch)
         let generation = macTitlePickerSwitchGeneration
         guard startsMachineSwitch else {
             macTitlePickerPendingSelection = nil
@@ -361,15 +365,17 @@ struct WorkspaceListView: View {
         }
     }
 
-    func cancelMacTitlePickerSwitch(restorePreviousOnCancel: Bool = true) {
-        let hadPendingSwitch = macTitlePickerSwitchTask != nil
-        // Leave the task uncancelled: the store may need that continuation to
-        // restore the foreground Mac after invalidating a destructive switch.
+    @discardableResult
+    func cancelMacTitlePickerSwitch(restorePreviousOnCancel: Bool = true) -> Task<Void, Never>? {
+        let pendingSwitchTask = macTitlePickerSwitchTask
+        pendingSwitchTask?.cancel()
         macTitlePickerSwitchTask = nil
         macTitlePickerPendingSelection = nil
         macTitlePickerSwitchGeneration &+= 1
-        if hadPendingSwitch {
-            cancelMacSwitch?(restorePreviousOnCancel)
+        guard pendingSwitchTask != nil else { return nil }
+        let cancelMacSwitch = cancelMacSwitch
+        return Task { @MainActor in
+            await cancelMacSwitch?(restorePreviousOnCancel)
         }
     }
 
@@ -452,7 +458,7 @@ struct WorkspaceListView: View {
                     navigationStyle: navigationStyle,
                     isAnchorSelected: navigationStyle == .sidebar
                         && selectedWorkspaceID == group.anchorWorkspaceID,
-                    selectWorkspace: selectWorkspaceFromList,
+                    selectWorkspace: { id in _ = selectWorkspaceFromList(id) },
                     toggleCollapsed: toggleGroupCollapsed,
                     unreadIndicatorLeftShift: unreadIndicatorLeftShift
                 )
@@ -477,7 +483,7 @@ struct WorkspaceListView: View {
             unreadIndicatorLeftShift: unreadIndicatorLeftShift,
             profilePictureLeftShift: profilePictureLeftShift,
             profilePictureSize: profilePictureSize,
-            selectWorkspace: selectWorkspaceFromList,
+            selectWorkspace: { id in _ = selectWorkspaceFromList(id) },
             renameWorkspace: capabilities.supportsWorkspaceActions ? renameWorkspace : nil,
             setPinned: capabilities.supportsWorkspaceActions ? setPinned : nil,
             setUnread: capabilities.supportsReadStateActions ? setUnread : nil,
@@ -503,15 +509,26 @@ struct WorkspaceListView: View {
         .accessibilityIdentifier("MobileNewWorkspaceButton")
     }
 
-    func prepareWorkspaceSelectionFromList() {
+    @discardableResult
+    func prepareWorkspaceSelectionFromList() -> Task<Void, Never>? {
         #if os(iOS)
-        cancelMacTitlePickerSwitch()
+        return cancelMacTitlePickerSwitch()
+        #else
+        return nil
         #endif
     }
 
-    func selectWorkspaceFromList(_ id: MobileWorkspacePreview.ID) {
-        prepareWorkspaceSelectionFromList()
-        selectWorkspace(id)
+    @discardableResult
+    func selectWorkspaceFromList(_ id: MobileWorkspacePreview.ID) -> Task<Void, Never>? {
+        guard let cancelTask = prepareWorkspaceSelectionFromList() else {
+            selectWorkspace(id)
+            return nil
+        }
+        let task = Task { @MainActor in
+            await cancelTask.value
+            selectWorkspace(id)
+        }
+        return task
     }
 
     private var settingsMenu: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -338,7 +338,10 @@ struct WorkspaceListView: View {
         } else {
             startsMachineSwitch = false
         }
-        let cancelTask = cancelMacTitlePickerSwitch(restorePreviousOnCancel: !startsMachineSwitch)
+        let cancelTask = cancelMacTitlePickerSwitch(
+            restorePreviousOnCancel: true,
+            cancelStoreSwitch: !startsMachineSwitch
+        )
         guard startsMachineSwitch else {
             macTitlePickerPendingSelection = nil
             macSelection = selection
@@ -376,7 +379,10 @@ struct WorkspaceListView: View {
     }
 
     @discardableResult
-    func cancelMacTitlePickerSwitch(restorePreviousOnCancel: Bool = true) -> Task<Void, Never>? {
+    func cancelMacTitlePickerSwitch(
+        restorePreviousOnCancel: Bool = true,
+        cancelStoreSwitch: Bool = true
+    ) -> Task<Void, Never>? {
         let pendingSwitchTask = macTitlePickerSwitchTask
         let pendingSwitchTaskKind = macTitlePickerSwitchTaskKind
         if pendingSwitchTaskKind == .cancellation {
@@ -391,6 +397,7 @@ struct WorkspaceListView: View {
         macTitlePickerSwitchGeneration &+= 1
         let generation = macTitlePickerSwitchGeneration
         guard pendingSwitchTask != nil else { return nil }
+        guard cancelStoreSwitch else { return nil }
         let cancelMacSwitch = cancelMacSwitch
         let task = Task { @MainActor in
             defer {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -94,6 +94,7 @@ struct WorkspaceListView: View {
     @State var filter: MobileWorkspaceListFilter = .all
     @State private var macTitlePickerSwitchTask: Task<Void, Never>?
     @State private var macTitlePickerSwitchGeneration: UInt64 = 0
+    @State private var macTitlePickerPendingSelection: WorkspaceMacSelection?
     /// Stable machine-menu content. Kept as value state so live workspace or
     /// device-tree updates that do not change the actual machine set/name
     /// snapshot do not rebuild an open native Menu. `nil` only before the first
@@ -107,6 +108,10 @@ struct WorkspaceListView: View {
 
     private var trimmedQuery: String {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var currentMacTitlePickerSelection: WorkspaceMacSelection {
+        macTitlePickerPendingSelection ?? visibleMacSelection
     }
 
     /// Whether the list renders grouped sections. Groups are honored whenever the
@@ -326,9 +331,11 @@ struct WorkspaceListView: View {
         cancelMacTitlePickerSwitch(restorePreviousOnCancel: !startsMachineSwitch)
         let generation = macTitlePickerSwitchGeneration
         guard startsMachineSwitch else {
+            macTitlePickerPendingSelection = nil
             macSelection = selection
             return nil
         }
+        macTitlePickerPendingSelection = selection
         let task = Task { @MainActor in
             defer {
                 if macTitlePickerSwitchGeneration == generation {
@@ -346,6 +353,7 @@ struct WorkspaceListView: View {
         // Leave the task uncancelled: the store may need that continuation to
         // restore the foreground Mac after invalidating a destructive switch.
         macTitlePickerSwitchTask = nil
+        macTitlePickerPendingSelection = nil
         macTitlePickerSwitchGeneration &+= 1
         if hadPendingSwitch {
             cancelMacSwitch?(restorePreviousOnCancel)
@@ -366,14 +374,19 @@ struct WorkspaceListView: View {
         switch selection {
         case .all, .automatic:
             guard isCurrentSwitchRequest() else { return }
+            macTitlePickerPendingSelection = nil
             macSelection = selection
         case .machine(let id):
             guard isCurrentSwitchRequest() else { return }
             guard let switchMac else {
+                macTitlePickerPendingSelection = nil
                 macSelection = selection
                 return
             }
-            guard await switchMac(id), isCurrentSwitchRequest() else { return }
+            let switched = await switchMac(id)
+            guard isCurrentSwitchRequest() else { return }
+            macTitlePickerPendingSelection = nil
+            guard switched else { return }
             macSelection = .machine(id)
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -332,7 +332,7 @@ struct WorkspaceListView: View {
         } else {
             startsMachineSwitch = false
         }
-        _ = cancelMacTitlePickerSwitch(restorePreviousOnCancel: !startsMachineSwitch)
+        let cancelTask = cancelMacTitlePickerSwitch(restorePreviousOnCancel: !startsMachineSwitch)
         let generation = macTitlePickerSwitchGeneration
         guard startsMachineSwitch else {
             macTitlePickerPendingSelection = nil
@@ -346,6 +346,7 @@ struct WorkspaceListView: View {
                     macTitlePickerSwitchTask = nil
                 }
             }
+            await cancelTask?.value
             await applyMacTitlePickerSelection(selection, switchGeneration: generation)
         }
         macTitlePickerSwitchTask = task

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -343,7 +343,8 @@ struct WorkspaceListView: View {
 
     func cancelMacTitlePickerSwitch(restorePreviousOnCancel: Bool = true) {
         let hadPendingSwitch = macTitlePickerSwitchTask != nil
-        macTitlePickerSwitchTask?.cancel()
+        // Leave the task uncancelled: the store may need that continuation to
+        // restore the foreground Mac after invalidating a destructive switch.
         macTitlePickerSwitchTask = nil
         macTitlePickerSwitchGeneration &+= 1
         if hadPendingSwitch {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -92,8 +92,8 @@ struct WorkspaceListView: View {
     /// The active row filter (All / Unread), shared-model state behind the
     /// toolbar ``WorkspaceListFilterMenu``. Session-transient like a search.
     @State var filter: MobileWorkspaceListFilter = .all
-    @State var macTitlePickerSwitchTask: Task<Void, Never>?
-    @State var macTitlePickerSwitchGeneration: UInt64 = 0
+    @State private var macTitlePickerSwitchTask: Task<Void, Never>?
+    @State private var macTitlePickerSwitchGeneration: UInt64 = 0
     /// Stable machine-menu content. Kept as value state so live workspace or
     /// device-tree updates that do not change the actual machine set/name
     /// snapshot do not rebuild an open native Menu. `nil` only before the first
@@ -313,6 +313,70 @@ struct WorkspaceListView: View {
         }
         #endif
     }
+
+    #if os(iOS)
+    @discardableResult
+    func handleMacTitlePickerSelection(_ selection: WorkspaceMacSelection) -> Task<Void, Never>? {
+        let startsMachineSwitch: Bool
+        if case .machine = selection, switchMac != nil {
+            startsMachineSwitch = true
+        } else {
+            startsMachineSwitch = false
+        }
+        cancelMacTitlePickerSwitch(restorePreviousOnCancel: !startsMachineSwitch)
+        let generation = macTitlePickerSwitchGeneration
+        guard startsMachineSwitch else {
+            macSelection = selection
+            return nil
+        }
+        let task = Task { @MainActor in
+            defer {
+                if macTitlePickerSwitchGeneration == generation {
+                    macTitlePickerSwitchTask = nil
+                }
+            }
+            await applyMacTitlePickerSelection(selection, switchGeneration: generation)
+        }
+        macTitlePickerSwitchTask = task
+        return task
+    }
+
+    func cancelMacTitlePickerSwitch(restorePreviousOnCancel: Bool = true) {
+        let hadPendingSwitch = macTitlePickerSwitchTask != nil
+        macTitlePickerSwitchTask?.cancel()
+        macTitlePickerSwitchTask = nil
+        macTitlePickerSwitchGeneration &+= 1
+        if hadPendingSwitch {
+            cancelMacSwitch?(restorePreviousOnCancel)
+        }
+    }
+
+    @MainActor
+    func applyMacTitlePickerSelection(
+        _ selection: WorkspaceMacSelection,
+        switchGeneration: UInt64? = nil
+    ) async {
+        func isCurrentSwitchRequest() -> Bool {
+            guard !Task.isCancelled else { return false }
+            guard let switchGeneration else { return true }
+            return macTitlePickerSwitchGeneration == switchGeneration
+        }
+
+        switch selection {
+        case .all, .automatic:
+            guard isCurrentSwitchRequest() else { return }
+            macSelection = selection
+        case .machine(let id):
+            guard isCurrentSwitchRequest() else { return }
+            guard let switchMac else {
+                macSelection = selection
+                return
+            }
+            guard await switchMac(id), isCurrentSwitchRequest() else { return }
+            macSelection = .machine(id)
+        }
+    }
+    #endif
 
     private var showsConnectionRecoveryRow: Bool {
         guard let store else { return false }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -425,7 +425,8 @@ struct WorkspaceListView: View {
                     navigationStyle: navigationStyle,
                     isAnchorSelected: navigationStyle == .sidebar
                         && selectedWorkspaceID == group.anchorWorkspaceID,
-                    selectWorkspace: selectWorkspace,
+                    prepareWorkspaceSelection: prepareWorkspaceSelectionFromList,
+                    selectWorkspace: selectWorkspaceFromList,
                     toggleCollapsed: toggleGroupCollapsed,
                     unreadIndicatorLeftShift: unreadIndicatorLeftShift
                 )
@@ -450,7 +451,8 @@ struct WorkspaceListView: View {
             unreadIndicatorLeftShift: unreadIndicatorLeftShift,
             profilePictureLeftShift: profilePictureLeftShift,
             profilePictureSize: profilePictureSize,
-            selectWorkspace: selectWorkspace,
+            prepareWorkspaceSelection: prepareWorkspaceSelectionFromList,
+            selectWorkspace: selectWorkspaceFromList,
             renameWorkspace: capabilities.supportsWorkspaceActions ? renameWorkspace : nil,
             setPinned: capabilities.supportsWorkspaceActions ? setPinned : nil,
             setUnread: capabilities.supportsReadStateActions ? setUnread : nil,
@@ -474,6 +476,17 @@ struct WorkspaceListView: View {
         .disabled(!canCreateWorkspaceForMacSelection)
         .accessibilityLabel(L10n.string("mobile.workspace.new", defaultValue: "New Workspace"))
         .accessibilityIdentifier("MobileNewWorkspaceButton")
+    }
+
+    func prepareWorkspaceSelectionFromList() {
+        #if os(iOS)
+        cancelMacTitlePickerSwitch()
+        #endif
+    }
+
+    func selectWorkspaceFromList(_ id: MobileWorkspacePreview.ID) {
+        prepareWorkspaceSelectionFromList()
+        selectWorkspace(id)
     }
 
     private var settingsMenu: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -313,7 +313,7 @@ struct WorkspaceListView: View {
         // leaving a parent sheet covering it.
         .sheet(isPresented: $showingDeviceTree) {
             if let store {
-                DeviceTreeView(store: store, selectWorkspace: selectWorkspace, showAddDevice: showAddDevice)
+                DeviceTreeView(store: store, selectWorkspace: selectWorkspaceFromList, showAddDevice: showAddDevice)
             }
         }
         #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -425,7 +425,6 @@ struct WorkspaceListView: View {
                     navigationStyle: navigationStyle,
                     isAnchorSelected: navigationStyle == .sidebar
                         && selectedWorkspaceID == group.anchorWorkspaceID,
-                    prepareWorkspaceSelection: prepareWorkspaceSelectionFromList,
                     selectWorkspace: selectWorkspaceFromList,
                     toggleCollapsed: toggleGroupCollapsed,
                     unreadIndicatorLeftShift: unreadIndicatorLeftShift
@@ -451,7 +450,6 @@ struct WorkspaceListView: View {
             unreadIndicatorLeftShift: unreadIndicatorLeftShift,
             profilePictureLeftShift: profilePictureLeftShift,
             profilePictureSize: profilePictureSize,
-            prepareWorkspaceSelection: prepareWorkspaceSelectionFromList,
             selectWorkspace: selectWorkspaceFromList,
             renameWorkspace: capabilities.supportsWorkspaceActions ? renameWorkspace : nil,
             setPinned: capabilities.supportsWorkspaceActions ? setPinned : nil,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -101,6 +101,7 @@ struct WorkspaceListView: View {
     @State private var macTitlePickerSwitchTaskKind: MacTitlePickerTaskKind?
     @State private var macTitlePickerSwitchGeneration: UInt64 = 0
     @State private var macTitlePickerPendingSelection: WorkspaceMacSelection?
+    @State private var deferredWorkspaceSelectionGeneration: UInt64 = 0
     /// Stable machine-menu content. Kept as value state so live workspace or
     /// device-tree updates that do not change the actual machine set/name
     /// snapshot do not rebuild an open native Menu. `nil` only before the first
@@ -114,6 +115,17 @@ struct WorkspaceListView: View {
 
     private var trimmedQuery: String {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var deferredWorkspaceSelectionIdentity: [String] {
+        var identity = [
+            "host:\(host)",
+            "mac:\(store?.connectedMacDeviceID ?? "")",
+        ]
+        identity.append(contentsOf: workspaces.map {
+            "workspace:\($0.id.rawValue):mac:\($0.macDeviceID ?? "")"
+        })
+        return identity
     }
 
     var currentMacTitlePickerSelection: WorkspaceMacSelection {
@@ -289,6 +301,7 @@ struct WorkspaceListView: View {
         }
         .accessibilityIdentifier("MobileWorkspaceList")
         .onDisappear {
+            invalidateDeferredWorkspaceSelection()
             cancelMacTitlePickerSwitch()
         }
         .onAppear {
@@ -297,6 +310,9 @@ struct WorkspaceListView: View {
         }
         .onChange(of: currentMachineSnapshots) { _, snapshots in
             updateMachineSnapshots(snapshots)
+        }
+        .onChange(of: deferredWorkspaceSelectionIdentity) { _, _ in
+            invalidateDeferredWorkspaceSelection()
         }
         .onChange(of: currentVisibleMacSelection) { _, selection in
             filter.pruneMachinesForFilterMenu(visibleMacSelection: selection)
@@ -554,15 +570,23 @@ struct WorkspaceListView: View {
 
     @discardableResult
     func selectWorkspaceFromList(_ id: MobileWorkspacePreview.ID) -> Task<Void, Never>? {
+        invalidateDeferredWorkspaceSelection()
+        let selectionGeneration = deferredWorkspaceSelectionGeneration
         guard let cancelTask = prepareWorkspaceSelectionFromList() else {
             selectWorkspace(id)
             return nil
         }
         let task = Task { @MainActor in
             await cancelTask.value
+            guard !Task.isCancelled,
+                  deferredWorkspaceSelectionGeneration == selectionGeneration else { return }
             selectWorkspace(id)
         }
         return task
+    }
+
+    private func invalidateDeferredWorkspaceSelection() {
+        deferredWorkspaceSelectionGeneration &+= 1
     }
 
     private var settingsMenu: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacSelectionScope.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacSelectionScope.swift
@@ -66,8 +66,9 @@ struct WorkspaceMacSelectionScope {
         return active
     }
 
-    func canCreateWorkspace(base canCreateWorkspace: Bool) -> Bool {
+    func canCreateWorkspace(base canCreateWorkspace: Bool, switchPending: Bool = false) -> Bool {
         guard canCreateWorkspace else { return false }
+        guard !switchPending else { return false }
         switch visibleSelection {
         case .machine(let id):
             return !foregroundMachineIDs.isDisjoint(with: aliasIndex.filterMachineIDs(for: id))

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -14,6 +14,7 @@ struct WorkspaceNavigationRow: View {
     var unreadIndicatorLeftShift: Double = MobileDisplaySettings.defaultUnreadIndicatorLeftShift
     var profilePictureLeftShift: Double = MobileDisplaySettings.defaultProfilePictureLeftShift
     var profilePictureSize: Double = MobileDisplaySettings.defaultProfilePictureSize
+    let prepareWorkspaceSelection: () -> Void
     let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
     /// Rename the workspace on the Mac. When `nil` (e.g. previews) the rename
     /// affordance is hidden.
@@ -98,6 +99,9 @@ struct WorkspaceNavigationRow: View {
             NavigationLink(value: workspace.id) {
                 rowLabel
             }
+            .simultaneousGesture(TapGesture().onEnded {
+                prepareWorkspaceSelection()
+            })
         case .sidebar:
             Button {
                 selectWorkspace(workspace.id)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -14,7 +14,6 @@ struct WorkspaceNavigationRow: View {
     var unreadIndicatorLeftShift: Double = MobileDisplaySettings.defaultUnreadIndicatorLeftShift
     var profilePictureLeftShift: Double = MobileDisplaySettings.defaultProfilePictureLeftShift
     var profilePictureSize: Double = MobileDisplaySettings.defaultProfilePictureSize
-    let prepareWorkspaceSelection: () -> Void
     let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
     /// Rename the workspace on the Mac. When `nil` (e.g. previews) the rename
     /// affordance is hidden.
@@ -96,12 +95,12 @@ struct WorkspaceNavigationRow: View {
     private var rowTarget: some View {
         switch navigationStyle {
         case .push:
-            NavigationLink(value: workspace.id) {
+            Button {
+                selectWorkspace(workspace.id)
+            } label: {
                 rowLabel
             }
-            .simultaneousGesture(TapGesture().onEnded {
-                prepareWorkspaceSelection()
-            })
+            .buttonStyle(.plain)
         case .sidebar:
             Button {
                 selectWorkspace(workspace.id)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -50,7 +50,7 @@ struct WorkspaceShellView: View {
     }
 
     private var canCreateWorkspaceOnForegroundConnection: Bool {
-        store.connectionState == .connected
+        store.hasActiveMacConnection
     }
 
     var body: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -50,7 +50,7 @@ struct WorkspaceShellView: View {
     }
 
     private var canCreateWorkspaceOnForegroundConnection: Bool {
-        store.hasActiveMacConnection
+        store.connectionState == .connected
     }
 
     var body: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -321,6 +321,8 @@ struct WorkspaceShellView: View {
 
     @MainActor
     private func cancelMacSwitchFromWorkspacePicker(restorePreviousOnCancel: Bool) {
+        pendingMacSwitchGeneration &+= 1
+        pendingMacSwitchID = nil
         store.cancelPendingMacSwitch(restorePreviousOnCancel: restorePreviousOnCancel)
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -322,10 +322,13 @@ struct WorkspaceShellView: View {
     @MainActor
     private func cancelMacSwitchFromWorkspacePicker(restorePreviousOnCancel: Bool) async {
         pendingMacSwitchGeneration &+= 1
-        pendingMacSwitchID = nil
+        let generation = pendingMacSwitchGeneration
         let restoreTask = store.cancelPendingMacSwitch(restorePreviousOnCancel: restorePreviousOnCancel)
         if restorePreviousOnCancel, let restoreTask {
             _ = await restoreTask.value
+        }
+        if pendingMacSwitchGeneration == generation {
+            pendingMacSwitchID = nil
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -320,10 +320,13 @@ struct WorkspaceShellView: View {
     }
 
     @MainActor
-    private func cancelMacSwitchFromWorkspacePicker(restorePreviousOnCancel: Bool) {
+    private func cancelMacSwitchFromWorkspacePicker(restorePreviousOnCancel: Bool) async {
         pendingMacSwitchGeneration &+= 1
         pendingMacSwitchID = nil
-        store.cancelPendingMacSwitch(restorePreviousOnCancel: restorePreviousOnCancel)
+        let restoreTask = store.cancelPendingMacSwitch(restorePreviousOnCancel: restorePreviousOnCancel)
+        if restorePreviousOnCancel, let restoreTask {
+            _ = await restoreTask.value
+        }
     }
 
     private var macSelectionScope: WorkspaceMacSelectionScope {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -321,8 +321,6 @@ struct WorkspaceShellView: View {
 
     @MainActor
     private func cancelMacSwitchFromWorkspacePicker(restorePreviousOnCancel: Bool) {
-        pendingMacSwitchGeneration &+= 1
-        pendingMacSwitchID = nil
         store.cancelPendingMacSwitch(restorePreviousOnCancel: restorePreviousOnCancel)
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -24,6 +24,8 @@ struct WorkspaceShellView: View {
     @State private var hasPresentedSplitDetail = false
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var macSelection: WorkspaceMacSelection = .all
+    @State private var pendingMacSwitchID: String?
+    @State private var pendingMacSwitchGeneration: UInt64 = 0
     #if os(iOS)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.verticalSizeClass) private var verticalSizeClass
@@ -103,6 +105,10 @@ struct WorkspaceShellView: View {
                 createWorkspace: createWorkspaceInCompactStack,
                 canCreateWorkspace: canCreateWorkspaceForMacSelection,
                 macSelection: $macSelection,
+                switchMac: { macDeviceID in
+                    await switchMacFromWorkspacePicker(macDeviceID: macDeviceID)
+                },
+                cancelMacSwitch: cancelMacSwitchFromWorkspacePicker,
                 refresh: refreshWorkspacesClosure,
                 rescanQR: { store.disconnectAndForgetActiveMac() },
                 signOut: signOut,
@@ -191,6 +197,10 @@ struct WorkspaceShellView: View {
                 createWorkspace: createWorkspaceIfConnected,
                 canCreateWorkspace: canCreateWorkspaceForMacSelection,
                 macSelection: $macSelection,
+                switchMac: { macDeviceID in
+                    await switchMacFromWorkspacePicker(macDeviceID: macDeviceID)
+                },
+                cancelMacSwitch: cancelMacSwitchFromWorkspacePicker,
                 refresh: refreshWorkspacesClosure,
                 rescanQR: { store.disconnectAndForgetActiveMac() },
                 signOut: signOut,
@@ -290,7 +300,30 @@ struct WorkspaceShellView: View {
     }
 
     private var canCreateWorkspaceForMacSelection: Bool {
-        macSelectionScope.canCreateWorkspace(base: canCreateWorkspace)
+        macSelectionScope.canCreateWorkspace(
+            base: canCreateWorkspace,
+            switchPending: pendingMacSwitchID != nil
+        )
+    }
+
+    @MainActor
+    private func switchMacFromWorkspacePicker(macDeviceID: String) async -> Bool {
+        pendingMacSwitchGeneration &+= 1
+        let generation = pendingMacSwitchGeneration
+        pendingMacSwitchID = macDeviceID
+        defer {
+            if pendingMacSwitchGeneration == generation {
+                pendingMacSwitchID = nil
+            }
+        }
+        return await store.switchToMac(macDeviceID: macDeviceID)
+    }
+
+    @MainActor
+    private func cancelMacSwitchFromWorkspacePicker(restorePreviousOnCancel: Bool) {
+        pendingMacSwitchGeneration &+= 1
+        pendingMacSwitchID = nil
+        store.cancelPendingMacSwitch(restorePreviousOnCancel: restorePreviousOnCancel)
     }
 
     private var macSelectionScope: WorkspaceMacSelectionScope {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -134,6 +134,70 @@ import Testing
         #expect(selected == .all)
     }
 
+    @Test func selectingWorkspaceCancelsPendingTitlePickerSwitch() async throws {
+        let workspaceID = MobileWorkspacePreview.ID(rawValue: "ws-a")
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20, isActive: true),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        var selected = WorkspaceMacSelection.all
+        var selectedWorkspaces: [MobileWorkspacePreview.ID] = []
+        var requestedSwitches: [String] = []
+        var cancelRestoreRequests: [Bool] = []
+        var switchContinuation: CheckedContinuation<Bool, Never>?
+        var switchDidStart = false
+        var switchStartedContinuation: CheckedContinuation<Void, Never>?
+        func markSwitchStarted() {
+            guard !switchDidStart else { return }
+            switchDidStart = true
+            switchStartedContinuation?.resume()
+            switchStartedContinuation = nil
+        }
+        func waitForSwitchStart() async {
+            guard !switchDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if switchDidStart {
+                    continuation.resume()
+                } else {
+                    switchStartedContinuation = continuation
+                }
+            }
+        }
+        let view = workspaceListView(
+            workspaces: [workspace(id: workspaceID.rawValue, macDeviceID: "mac-a")],
+            store: store,
+            selectWorkspace: { selectedWorkspaces.append($0) },
+            macSelection: Binding(
+                get: { selected },
+                set: { selected = $0 }
+            ),
+            switchMac: { macDeviceID in
+                requestedSwitches.append(macDeviceID)
+                markSwitchStarted()
+                return await withCheckedContinuation { continuation in
+                    switchContinuation = continuation
+                }
+            },
+            cancelMacSwitch: { restorePreviousOnCancel in
+                cancelRestoreRequests.append(restorePreviousOnCancel)
+            }
+        )
+
+        let pendingSwitchTask = view.handleMacTitlePickerSelection(.machine("mac-b"))
+        await waitForSwitchStart()
+
+        view.selectWorkspaceFromList(workspaceID)
+
+        #expect(requestedSwitches == ["mac-b"])
+        #expect(cancelRestoreRequests == [true])
+        #expect(selectedWorkspaces == [workspaceID])
+
+        switchContinuation?.resume(returning: true)
+        await pendingSwitchTask?.value
+
+        #expect(selected == .all)
+    }
+
     @Test func selectingCoalescedPairedMacMatchesAliasWorkspaceRows() async throws {
         let route = try route(host: "100.82.214.112")
         let store = await shellStore(pairedMacs: [
@@ -380,6 +444,7 @@ import Testing
     private func workspaceListView(
         workspaces: [MobileWorkspacePreview],
         store: CMUXMobileShellStore,
+        selectWorkspace: @escaping (MobileWorkspacePreview.ID) -> Void = { _ in },
         macSelection: Binding<WorkspaceMacSelection>? = nil,
         switchMac: (@MainActor (String) async -> Bool)? = nil,
         cancelMacSwitch: (@MainActor (Bool) -> Void)? = nil
@@ -391,7 +456,7 @@ import Testing
             connectionStatus: .unavailable,
             navigationStyle: .push,
             wrapWorkspaceTitles: false,
-            selectWorkspace: { _ in },
+            selectWorkspace: selectWorkspace,
             createWorkspace: {},
             macSelection: macSelection ?? binding(initialValue: .all),
             switchMac: switchMac,

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -22,6 +22,32 @@ import Testing
         #expect(view.macPickerMachines.map(\.id) == ["mac-a", "mac-b"])
     }
 
+    @Test func titlePickerMachineSelectionSwitchesBeforeApplyingFilter() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20, isActive: true),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        var selected = WorkspaceMacSelection.all
+        var requestedSwitches: [String] = []
+        let view = workspaceListView(
+            workspaces: [workspace(id: "ws-a", macDeviceID: "mac-a")],
+            store: store,
+            macSelection: Binding(
+                get: { selected },
+                set: { selected = $0 }
+            ),
+            switchMac: { macDeviceID in
+                requestedSwitches.append(macDeviceID)
+                return true
+            }
+        )
+
+        await view.applyMacTitlePickerSelection(.machine("mac-b"))
+
+        #expect(requestedSwitches == ["mac-b"])
+        #expect(selected == .machine("mac-b"))
+    }
+
     @Test func selectingCoalescedPairedMacMatchesAliasWorkspaceRows() async throws {
         let route = try route(host: "100.82.214.112")
         let store = await shellStore(pairedMacs: [
@@ -108,7 +134,9 @@ import Testing
 
     private func workspaceListView(
         workspaces: [MobileWorkspacePreview],
-        store: CMUXMobileShellStore
+        store: CMUXMobileShellStore,
+        macSelection: Binding<WorkspaceMacSelection>? = nil,
+        switchMac: ((String) async -> Bool)? = nil
     ) -> WorkspaceListView {
         WorkspaceListView(
             workspaces: workspaces,
@@ -119,7 +147,8 @@ import Testing
             wrapWorkspaceTitles: false,
             selectWorkspace: { _ in },
             createWorkspace: {},
-            macSelection: binding(initialValue: .all),
+            macSelection: macSelection ?? binding(initialValue: .all),
+            switchMac: switchMac,
             store: store
         )
     }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -48,6 +48,37 @@ import Testing
         #expect(selected == .machine("mac-b"))
     }
 
+    @Test func titlePickerWorkspaceOnlyMachineSelectionAppliesLocalFilterWithoutSwitch() async throws {
+        let manualID = "manual-127.0.0.1:50922"
+        let store = await shellStore(pairedMacs: [])
+        var selected = WorkspaceMacSelection.all
+        var requestedSwitches: [String] = []
+        let view = workspaceListView(
+            workspaces: [workspace(id: "ws-manual", macDeviceID: manualID)],
+            store: store,
+            macSelection: Binding(
+                get: { selected },
+                set: { selected = $0 }
+            ),
+            switchMac: { macDeviceID in
+                requestedSwitches.append(macDeviceID)
+                return false
+            }
+        )
+
+        let pendingSwitchTask = view.handleMacTitlePickerSelection(.machine(manualID))
+        let startedSwitchTask: Bool
+        if case .some = pendingSwitchTask {
+            startedSwitchTask = true
+        } else {
+            startedSwitchTask = false
+        }
+
+        #expect(!startedSwitchTask)
+        #expect(requestedSwitches.isEmpty)
+        #expect(selected == .machine(manualID))
+    }
+
     @Test func staleTitlePickerMachineSelectionDoesNotSwitch() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20, isActive: true),

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -518,6 +518,95 @@ import Testing
         #expect(selected == .all)
     }
 
+    @Test func newerWorkspaceSelectionInvalidatesDeferredRowSelection() async throws {
+        let firstWorkspaceID = MobileWorkspacePreview.ID(rawValue: "ws-a")
+        let secondWorkspaceID = MobileWorkspacePreview.ID(rawValue: "ws-b")
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20, isActive: true),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        var selected = WorkspaceMacSelection.all
+        var selectedWorkspaces: [MobileWorkspacePreview.ID] = []
+        var switchContinuation: CheckedContinuation<Bool, Never>?
+        var switchDidStart = false
+        var switchStartedContinuation: CheckedContinuation<Void, Never>?
+        var cancelContinuation: CheckedContinuation<Void, Never>?
+        var cancelDidStart = false
+        var cancelStartedContinuation: CheckedContinuation<Void, Never>?
+        func markSwitchStarted() {
+            guard !switchDidStart else { return }
+            switchDidStart = true
+            switchStartedContinuation?.resume()
+            switchStartedContinuation = nil
+        }
+        func waitForSwitchStart() async {
+            guard !switchDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if switchDidStart {
+                    continuation.resume()
+                } else {
+                    switchStartedContinuation = continuation
+                }
+            }
+        }
+        func markCancelStarted() {
+            guard !cancelDidStart else { return }
+            cancelDidStart = true
+            cancelStartedContinuation?.resume()
+            cancelStartedContinuation = nil
+        }
+        func waitForCancelStart() async {
+            guard !cancelDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if cancelDidStart {
+                    continuation.resume()
+                } else {
+                    cancelStartedContinuation = continuation
+                }
+            }
+        }
+        let view = workspaceListView(
+            workspaces: [
+                workspace(id: firstWorkspaceID.rawValue, macDeviceID: "mac-a"),
+                workspace(id: secondWorkspaceID.rawValue, macDeviceID: "mac-a"),
+            ],
+            store: store,
+            selectWorkspace: { selectedWorkspaces.append($0) },
+            macSelection: Binding(
+                get: { selected },
+                set: { selected = $0 }
+            ),
+            switchMac: { _ in
+                markSwitchStarted()
+                return await withCheckedContinuation { continuation in
+                    switchContinuation = continuation
+                }
+            },
+            cancelMacSwitch: { _ in
+                markCancelStarted()
+                await withCheckedContinuation { continuation in
+                    cancelContinuation = continuation
+                }
+            }
+        )
+
+        let pendingSwitchTask = view.handleMacTitlePickerSelection(.machine("mac-b"))
+        await waitForSwitchStart()
+
+        let firstSelectionTask = view.selectWorkspaceFromList(firstWorkspaceID)
+        await waitForCancelStart()
+        let secondSelectionTask = view.selectWorkspaceFromList(secondWorkspaceID)
+
+        cancelContinuation?.resume()
+        await firstSelectionTask?.value
+        await secondSelectionTask?.value
+
+        #expect(selectedWorkspaces == [secondWorkspaceID])
+
+        switchContinuation?.resume(returning: true)
+        await pendingSwitchTask?.value
+    }
+
     @Test func selectingCoalescedPairedMacMatchesAliasWorkspaceRows() async throws {
         let route = try route(host: "100.82.214.112")
         let store = await shellStore(pairedMacs: [

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -113,6 +113,8 @@ import Testing
         var selected = WorkspaceMacSelection.all
         var requestedSwitches: [String] = []
         var cancelRestoreRequests: [Bool] = []
+        var cancelDidStart = false
+        var cancelStartedContinuation: CheckedContinuation<Void, Never>?
         var switchContinuation: CheckedContinuation<Bool, Never>?
         var switchDidStart = false
         var switchStartedContinuation: CheckedContinuation<Void, Never>?
@@ -132,6 +134,22 @@ import Testing
                 }
             }
         }
+        func markCancelStarted() {
+            guard !cancelDidStart else { return }
+            cancelDidStart = true
+            cancelStartedContinuation?.resume()
+            cancelStartedContinuation = nil
+        }
+        func waitForCancelStart() async {
+            guard !cancelDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if cancelDidStart {
+                    continuation.resume()
+                } else {
+                    cancelStartedContinuation = continuation
+                }
+            }
+        }
         let view = workspaceListView(
             workspaces: [workspace(id: "ws-a", macDeviceID: "mac-a")],
             store: store,
@@ -148,6 +166,7 @@ import Testing
             },
             cancelMacSwitch: { restorePreviousOnCancel in
                 cancelRestoreRequests.append(restorePreviousOnCancel)
+                markCancelStarted()
             }
         )
 
@@ -155,6 +174,7 @@ import Testing
         await waitForSwitchStart()
 
         view.handleMacTitlePickerSelection(.all)
+        await waitForCancelStart()
         #expect(requestedSwitches == ["mac-b"])
         #expect(cancelRestoreRequests == [true])
         #expect(selected == .all)
@@ -173,6 +193,8 @@ import Testing
         var selected = WorkspaceMacSelection.all
         var requestedSwitches: [String] = []
         var cancelRestoreRequests: [Bool] = []
+        var cancelDidStart = false
+        var cancelStartedContinuation: CheckedContinuation<Void, Never>?
         var switchContinuation: CheckedContinuation<Bool, Never>?
         var switchDidStart = false
         var switchStartedContinuation: CheckedContinuation<Void, Never>?
@@ -192,6 +214,22 @@ import Testing
                 }
             }
         }
+        func markCancelStarted() {
+            guard !cancelDidStart else { return }
+            cancelDidStart = true
+            cancelStartedContinuation?.resume()
+            cancelStartedContinuation = nil
+        }
+        func waitForCancelStart() async {
+            guard !cancelDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if cancelDidStart {
+                    continuation.resume()
+                } else {
+                    cancelStartedContinuation = continuation
+                }
+            }
+        }
         let view = workspaceListView(
             workspaces: [workspace(id: "ws-a", macDeviceID: "mac-a")],
             store: store,
@@ -208,6 +246,7 @@ import Testing
             },
             cancelMacSwitch: { restorePreviousOnCancel in
                 cancelRestoreRequests.append(restorePreviousOnCancel)
+                markCancelStarted()
             }
         )
 
@@ -216,6 +255,7 @@ import Testing
 
         #expect(view.macTitlePickerSelection.wrappedValue == .machine("mac-b"))
         view.macTitlePickerSelection.wrappedValue = .all
+        await waitForCancelStart()
 
         #expect(requestedSwitches == ["mac-b"])
         #expect(cancelRestoreRequests == [true])
@@ -279,7 +319,8 @@ import Testing
         let pendingSwitchTask = view.handleMacTitlePickerSelection(.machine("mac-b"))
         await waitForSwitchStart()
 
-        view.selectWorkspaceFromList(workspaceID)
+        let selectionTask = view.selectWorkspaceFromList(workspaceID)
+        await selectionTask?.value
 
         #expect(requestedSwitches == ["mac-b"])
         #expect(cancelRestoreRequests == [true])
@@ -540,7 +581,7 @@ import Testing
         selectWorkspace: @escaping (MobileWorkspacePreview.ID) -> Void = { _ in },
         macSelection: Binding<WorkspaceMacSelection>? = nil,
         switchMac: (@MainActor (String) async -> Bool)? = nil,
-        cancelMacSwitch: (@MainActor (Bool) -> Void)? = nil
+        cancelMacSwitch: (@MainActor (Bool) async -> Void)? = nil
     ) -> WorkspaceListView {
         WorkspaceListView(
             workspaces: workspaces,

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -359,6 +359,100 @@ import Testing
         await firstTask?.value
     }
 
+    @Test func replacingPendingTitlePickerMachineSelectionKeepsRollbackArmed() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 30, isActive: true),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 20),
+            pairedMac(id: "mac-c", name: "Mac C", lastSeenAt: 10),
+        ])
+        var selected = WorkspaceMacSelection.all
+        var requestedSwitches: [String] = []
+        var cancelRestoreRequests: [Bool] = []
+        var firstSwitchContinuation: CheckedContinuation<Bool, Never>?
+        var secondSwitchContinuation: CheckedContinuation<Bool, Never>?
+        var firstSwitchDidStart = false
+        var firstSwitchStartedContinuation: CheckedContinuation<Void, Never>?
+        var cancelDidStart = false
+        var cancelStartedContinuation: CheckedContinuation<Void, Never>?
+        func markFirstSwitchStarted() {
+            guard !firstSwitchDidStart else { return }
+            firstSwitchDidStart = true
+            firstSwitchStartedContinuation?.resume()
+            firstSwitchStartedContinuation = nil
+        }
+        func waitForFirstSwitchStart() async {
+            guard !firstSwitchDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if firstSwitchDidStart {
+                    continuation.resume()
+                } else {
+                    firstSwitchStartedContinuation = continuation
+                }
+            }
+        }
+        func markCancelStarted() {
+            guard !cancelDidStart else { return }
+            cancelDidStart = true
+            cancelStartedContinuation?.resume()
+            cancelStartedContinuation = nil
+        }
+        func waitForCancelStart() async {
+            guard !cancelDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if cancelDidStart {
+                    continuation.resume()
+                } else {
+                    cancelStartedContinuation = continuation
+                }
+            }
+        }
+        let view = workspaceListView(
+            workspaces: [workspace(id: "ws-a", macDeviceID: "mac-a")],
+            store: store,
+            macSelection: Binding(
+                get: { selected },
+                set: { selected = $0 }
+            ),
+            switchMac: { macDeviceID in
+                requestedSwitches.append(macDeviceID)
+                if macDeviceID == "mac-b" {
+                    markFirstSwitchStarted()
+                    return await withCheckedContinuation { continuation in
+                        firstSwitchContinuation = continuation
+                    }
+                }
+                return await withCheckedContinuation { continuation in
+                    secondSwitchContinuation = continuation
+                }
+            },
+            cancelMacSwitch: { restorePreviousOnCancel in
+                cancelRestoreRequests.append(restorePreviousOnCancel)
+                markCancelStarted()
+            }
+        )
+
+        let firstTask = view.handleMacTitlePickerSelection(.machine("mac-b"))
+        await waitForFirstSwitchStart()
+
+        let secondTask = view.handleMacTitlePickerSelection(.machine("mac-c"))
+        await Task.yield()
+
+        #expect(!cancelRestoreRequests.contains(false))
+
+        view.handleMacTitlePickerSelection(.all)
+        await waitForCancelStart()
+
+        #expect(cancelRestoreRequests == [true])
+        #expect(selected == .all)
+
+        firstSwitchContinuation?.resume(returning: false)
+        secondSwitchContinuation?.resume(returning: false)
+        await firstTask?.value
+        await secondTask?.value
+
+        #expect(selected == .all)
+    }
+
     @Test func selectingWorkspaceCancelsPendingTitlePickerSwitch() async throws {
         let workspaceID = MobileWorkspacePreview.ID(rawValue: "ws-a")
         let store = await shellStore(pairedMacs: [

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -267,6 +267,95 @@ import Testing
         #expect(selected == .all)
     }
 
+    @Test func titlePickerWaitsForCancelBeforeStartingNextMachineSwitch() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 30, isActive: true),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 20),
+            pairedMac(id: "mac-c", name: "Mac C", lastSeenAt: 10),
+        ])
+        var selected = WorkspaceMacSelection.all
+        var requestedSwitches: [String] = []
+        var firstSwitchContinuation: CheckedContinuation<Bool, Never>?
+        var cancelContinuation: CheckedContinuation<Void, Never>?
+        var switchDidStart = false
+        var switchStartedContinuation: CheckedContinuation<Void, Never>?
+        var cancelDidStart = false
+        var cancelStartedContinuation: CheckedContinuation<Void, Never>?
+        func markSwitchStarted() {
+            guard !switchDidStart else { return }
+            switchDidStart = true
+            switchStartedContinuation?.resume()
+            switchStartedContinuation = nil
+        }
+        func waitForSwitchStart() async {
+            guard !switchDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if switchDidStart {
+                    continuation.resume()
+                } else {
+                    switchStartedContinuation = continuation
+                }
+            }
+        }
+        func markCancelStarted() {
+            guard !cancelDidStart else { return }
+            cancelDidStart = true
+            cancelStartedContinuation?.resume()
+            cancelStartedContinuation = nil
+        }
+        func waitForCancelStart() async {
+            guard !cancelDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if cancelDidStart {
+                    continuation.resume()
+                } else {
+                    cancelStartedContinuation = continuation
+                }
+            }
+        }
+        let view = workspaceListView(
+            workspaces: [workspace(id: "ws-a", macDeviceID: "mac-a")],
+            store: store,
+            macSelection: Binding(
+                get: { selected },
+                set: { selected = $0 }
+            ),
+            switchMac: { macDeviceID in
+                requestedSwitches.append(macDeviceID)
+                if macDeviceID == "mac-b" {
+                    markSwitchStarted()
+                    return await withCheckedContinuation { continuation in
+                        firstSwitchContinuation = continuation
+                    }
+                }
+                return true
+            },
+            cancelMacSwitch: { _ in
+                markCancelStarted()
+                await withCheckedContinuation { continuation in
+                    cancelContinuation = continuation
+                }
+            }
+        )
+
+        let firstTask = view.handleMacTitlePickerSelection(.machine("mac-b"))
+        await waitForSwitchStart()
+
+        let secondTask = view.handleMacTitlePickerSelection(.machine("mac-c"))
+        await waitForCancelStart()
+
+        #expect(requestedSwitches == ["mac-b"])
+
+        cancelContinuation?.resume()
+        await secondTask?.value
+
+        #expect(requestedSwitches == ["mac-b", "mac-c"])
+        #expect(selected == .machine("mac-c"))
+
+        firstSwitchContinuation?.resume(returning: false)
+        await firstTask?.value
+    }
+
     @Test func selectingWorkspaceCancelsPendingTitlePickerSwitch() async throws {
         let workspaceID = MobileWorkspacePreview.ID(rawValue: "ws-a")
         let store = await shellStore(pairedMacs: [

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -267,7 +267,7 @@ import Testing
         #expect(selected == .all)
     }
 
-    @Test func titlePickerWaitsForCancelBeforeStartingNextMachineSwitch() async throws {
+    @Test func titlePickerWaitsForAllMacsCancelBeforeStartingNextMachineSwitch() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 30, isActive: true),
             pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 20),
@@ -341,10 +341,13 @@ import Testing
         let firstTask = view.handleMacTitlePickerSelection(.machine("mac-b"))
         await waitForSwitchStart()
 
-        let secondTask = view.handleMacTitlePickerSelection(.machine("mac-c"))
+        view.handleMacTitlePickerSelection(.all)
         await waitForCancelStart()
 
+        let secondTask = view.handleMacTitlePickerSelection(.machine("mac-c"))
+
         #expect(requestedSwitches == ["mac-b"])
+        #expect(selected == .all)
 
         cancelContinuation?.resume()
         await secondTask?.value

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -134,6 +134,68 @@ import Testing
         #expect(selected == .all)
     }
 
+    @Test func pendingTitlePickerMachineSelectionLetsAllMacsCancelSwitch() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20, isActive: true),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        var selected = WorkspaceMacSelection.all
+        var requestedSwitches: [String] = []
+        var cancelRestoreRequests: [Bool] = []
+        var switchContinuation: CheckedContinuation<Bool, Never>?
+        var switchDidStart = false
+        var switchStartedContinuation: CheckedContinuation<Void, Never>?
+        func markSwitchStarted() {
+            guard !switchDidStart else { return }
+            switchDidStart = true
+            switchStartedContinuation?.resume()
+            switchStartedContinuation = nil
+        }
+        func waitForSwitchStart() async {
+            guard !switchDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if switchDidStart {
+                    continuation.resume()
+                } else {
+                    switchStartedContinuation = continuation
+                }
+            }
+        }
+        let view = workspaceListView(
+            workspaces: [workspace(id: "ws-a", macDeviceID: "mac-a")],
+            store: store,
+            macSelection: Binding(
+                get: { selected },
+                set: { selected = $0 }
+            ),
+            switchMac: { macDeviceID in
+                requestedSwitches.append(macDeviceID)
+                markSwitchStarted()
+                return await withCheckedContinuation { continuation in
+                    switchContinuation = continuation
+                }
+            },
+            cancelMacSwitch: { restorePreviousOnCancel in
+                cancelRestoreRequests.append(restorePreviousOnCancel)
+            }
+        )
+
+        let pendingSwitchTask = view.handleMacTitlePickerSelection(.machine("mac-b"))
+        await waitForSwitchStart()
+
+        #expect(view.macTitlePickerSelection.wrappedValue == .machine("mac-b"))
+        view.macTitlePickerSelection.wrappedValue = .all
+
+        #expect(requestedSwitches == ["mac-b"])
+        #expect(cancelRestoreRequests == [true])
+        #expect(selected == .all)
+
+        switchContinuation?.resume(returning: true)
+        await pendingSwitchTask?.value
+
+        #expect(selected == .all)
+    }
+
     @Test func selectingWorkspaceCancelsPendingTitlePickerSwitch() async throws {
         let workspaceID = MobileWorkspacePreview.ID(rawValue: "ws-a")
         let store = await shellStore(pairedMacs: [

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -120,9 +120,8 @@ import Testing
             }
         )
 
-        view.handleMacTitlePickerSelection(.machine("mac-b"))
+        let pendingSwitchTask = view.handleMacTitlePickerSelection(.machine("mac-b"))
         await waitForSwitchStart()
-        let pendingSwitchTask = view.macTitlePickerSwitchTask
 
         view.handleMacTitlePickerSelection(.all)
         #expect(requestedSwitches == ["mac-b"])

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
@@ -48,6 +48,93 @@ import Testing
         #expect(selected == .machine("mac-b"))
     }
 
+    @Test func staleTitlePickerMachineSelectionDoesNotSwitch() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20, isActive: true),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        var selected = WorkspaceMacSelection.all
+        var requestedSwitches: [String] = []
+        let view = workspaceListView(
+            workspaces: [workspace(id: "ws-a", macDeviceID: "mac-a")],
+            store: store,
+            macSelection: Binding(
+                get: { selected },
+                set: { selected = $0 }
+            ),
+            switchMac: { macDeviceID in
+                requestedSwitches.append(macDeviceID)
+                return true
+            }
+        )
+
+        await view.applyMacTitlePickerSelection(.machine("mac-b"), switchGeneration: 1)
+
+        #expect(requestedSwitches.isEmpty)
+        #expect(selected == .all)
+    }
+
+    @Test func cancelingPendingTitlePickerSwitchCancelsUnderlyingSwitch() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20, isActive: true),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        var selected = WorkspaceMacSelection.all
+        var requestedSwitches: [String] = []
+        var cancelRestoreRequests: [Bool] = []
+        var switchContinuation: CheckedContinuation<Bool, Never>?
+        var switchDidStart = false
+        var switchStartedContinuation: CheckedContinuation<Void, Never>?
+        func markSwitchStarted() {
+            guard !switchDidStart else { return }
+            switchDidStart = true
+            switchStartedContinuation?.resume()
+            switchStartedContinuation = nil
+        }
+        func waitForSwitchStart() async {
+            guard !switchDidStart else { return }
+            await withCheckedContinuation { continuation in
+                if switchDidStart {
+                    continuation.resume()
+                } else {
+                    switchStartedContinuation = continuation
+                }
+            }
+        }
+        let view = workspaceListView(
+            workspaces: [workspace(id: "ws-a", macDeviceID: "mac-a")],
+            store: store,
+            macSelection: Binding(
+                get: { selected },
+                set: { selected = $0 }
+            ),
+            switchMac: { macDeviceID in
+                requestedSwitches.append(macDeviceID)
+                markSwitchStarted()
+                return await withCheckedContinuation { continuation in
+                    switchContinuation = continuation
+                }
+            },
+            cancelMacSwitch: { restorePreviousOnCancel in
+                cancelRestoreRequests.append(restorePreviousOnCancel)
+            }
+        )
+
+        view.handleMacTitlePickerSelection(.machine("mac-b"))
+        await waitForSwitchStart()
+        let pendingSwitchTask = view.macTitlePickerSwitchTask
+
+        view.handleMacTitlePickerSelection(.all)
+        #expect(requestedSwitches == ["mac-b"])
+        #expect(cancelRestoreRequests == [true])
+        #expect(selected == .all)
+
+        switchContinuation?.resume(returning: true)
+        await pendingSwitchTask?.value
+
+        #expect(selected == .all)
+    }
+
     @Test func selectingCoalescedPairedMacMatchesAliasWorkspaceRows() async throws {
         let route = try route(host: "100.82.214.112")
         let store = await shellStore(pairedMacs: [
@@ -118,6 +205,21 @@ import Testing
         #expect(scope.canCreateWorkspace(base: true))
     }
 
+    @Test func sharedSelectionScopeDisablesCreateWhileMacSwitchPending() {
+        let scope = WorkspaceMacSelectionScope(
+            selection: .all,
+            workspaces: [workspace(id: "ws-a", macDeviceID: "mac-a")],
+            displayPairedMacs: [
+                pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+                pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+            ],
+            foregroundMacDeviceID: "mac-a",
+            aliasesFor: { [$0] }
+        )
+
+        #expect(!scope.canCreateWorkspace(base: true, switchPending: true))
+    }
+
     @Test func sharedSelectionScopeAllowsCreateWhenManualForegroundMacIsSelected() {
         let manualID = "manual-127.0.0.1:50922"
         let scope = WorkspaceMacSelectionScope(
@@ -136,7 +238,8 @@ import Testing
         workspaces: [MobileWorkspacePreview],
         store: CMUXMobileShellStore,
         macSelection: Binding<WorkspaceMacSelection>? = nil,
-        switchMac: ((String) async -> Bool)? = nil
+        switchMac: (@MainActor (String) async -> Bool)? = nil,
+        cancelMacSwitch: (@MainActor (Bool) -> Void)? = nil
     ) -> WorkspaceListView {
         WorkspaceListView(
             workspaces: workspaces,
@@ -149,6 +252,7 @@ import Testing
             createWorkspace: {},
             macSelection: macSelection ?? binding(initialValue: .all),
             switchMac: switchMac,
+            cancelMacSwitch: cancelMacSwitch,
             store: store
         )
     }


### PR DESCRIPTION
## Summary
- make the iOS workspace title Mac picker use the shared switch/promote path before applying a machine filter
- treat `switchToMac` as successful when the foreground Mac identity matches the target instead of requiring exact host/port text equality
- add a focused WorkspaceMacSelection regression test for the picker switch request

## Tests
- Not run locally per instruction; CI should exercise the iOS package tests.

Closes #7094


## Demo
- Not recorded: this is an iOS-only workflow that requires a physical iPhone paired with 2+ Macs. Per issue instructions, no local device repro, simulator dogfood, macOS reload, or build was run.

## Review trigger
- Ready for review after CI and bot review gates on the pushed head.

## Checklist
- [x] Focused regression coverage added for the title picker switch/filter ordering.
- [x] No new user-facing strings were added.
- [x] Local tests/builds were not run per instruction; CI owns validation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785401671&installation_id=133855650&pr_number=7096&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7096&signature=d7ab3282c1dc596659e4438bf2f188ccdae0d4d197fe26a70ed93ed292bb2fa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS Mac switching from the workspace title picker by switching the foreground Mac before filtering. Adds attempt-scoped cancel/restore with UI-level cancellation so in-flight switches can be safely stopped or replaced, restoring the previous Mac without disrupting a live session. Closes #7094.

- **Bug Fixes**
  - Title picker uses a custom binding: machine picks switch first; All/Automatic, workspace taps, view disappear, and disconnect cancel in‑flight switches; cancellation is serialized, tracked, and awaited; the next switch waits for cancel/restore; replacing a pending machine selection keeps rollback armed; workspace‑only machine IDs apply a local filter (no switch); row selection is deferred until cancel completes, and a newer tap invalidates older deferred selections.
  - Switching and restore are guarded by attempt IDs, cancel/restore generations, and sign‑in/scope checks; success keys off the live foreground identity; secondary‑to‑foreground promotion revalidates scope and attempt; restore reconnects are scoped and do not tear down an already‑live Mac; rollback runs only for the canceled attempt and targets the previous foreground via precomputed alias sets.
  - Persistence and identity: active‑Mac writes are enqueued on a serialized chain and only execute if still current; restored Macs are persisted after cancel; connect paths accept `ifStillCurrent` checks; `connectedMacDeviceID` prefers the live foreground id before persisted active; switch state clears on disconnect/sign‑out.
  - UI and eligibility: push rows use Buttons to allow cancellation before navigation; workspace creation is disabled without a live client and while a switch is pending. Tests cover picker ordering, waiting for cancel before the next switch, All‑Macs cancel behavior, workspace‑selection cancellation, deferred selection invalidation, rollback preservation on replaced picks, restore preferring the live foreground over persisted active, alias‑based restore targeting, and create gating.

<sup>Written for commit 5c0bfec25cd877a79756d4edc48a387ae3cef7a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS Mac foreground switching from the title-picker, including safer in-flight handling.
  * Introduced the ability to cancel a pending Mac switch, optionally restoring the previous foreground Mac.
* **Bug Fixes**
  * Improved correctness for stale in-flight requests using up-to-date connection state and generation checks.
  * Prevented mismatched promotion/restore behavior and avoided inconsistent write-scope updates during switching.
  * Updated workspace selection/creation eligibility while a switch is pending.
* **UI Improvements**
  * Refined picker selection binding and adjusted push-style workspace navigation to select via actions.
* **Tests**
  * Expanded coverage for switching, cancellation/restore behavior, stale generations, and new eligibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
