### PR TITLE
Coalesce pending iOS terminal raw output bytes

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
@@ -73,9 +73,11 @@ struct TerminalOutputDelivery: Equatable, Sendable {
 
 /// Backpressure queue for one mounted mobile terminal output stream.
 ///
-/// Raw byte chunks are nonreplaceable barriers. Render-grid chunks that repaint
-/// the whole viewport are replaceable while the iOS surface is still applying a
-/// prior chunk, so fast scroll gestures can skip obsolete intermediate frames.
+/// Raw byte chunks are nonreplaceable barriers, but contiguous raw chunks with
+/// the same viewport policy can be appended into one VT byte stream while
+/// backpressured. Render-grid chunks that repaint the whole viewport are
+/// replaceable while the iOS surface is still applying a prior chunk, so fast
+/// scroll gestures can skip obsolete intermediate frames.
 struct TerminalOutputDeliveryQueue: Sendable {
     private var inFlight = false
     private var pending: [TerminalOutputDelivery] = []

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
@@ -53,6 +53,22 @@ struct TerminalOutputDelivery: Equatable, Sendable {
             frame.vtPatchBytes()
         }
     }
+
+    mutating func appendBytes(from delivery: TerminalOutputDelivery) -> Bool {
+        guard replacementScope == nil,
+              delivery.replacementScope == nil,
+              viewportPolicy == delivery.viewportPolicy else {
+            return false
+        }
+        switch (payload, delivery.payload) {
+        case (.bytes(var bytes), .bytes(let nextBytes)):
+            bytes.append(nextBytes)
+            payload = .bytes(bytes)
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 /// Backpressure queue for one mounted mobile terminal output stream.
@@ -112,6 +128,10 @@ struct TerminalOutputDeliveryQueue: Sendable {
            lastIndex >= pendingHeadIndex,
            pending[lastIndex].replacementScope == replacementScope {
             pending[lastIndex] = delivery
+        } else if let lastIndex = pending.indices.last,
+                  lastIndex >= pendingHeadIndex,
+                  pending[lastIndex].appendBytes(from: delivery) {
+            return
         } else {
             pending.append(delivery)
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
@@ -54,20 +54,21 @@ struct TerminalOutputDelivery: Equatable, Sendable {
         }
     }
 
-    mutating func appendBytes(from delivery: TerminalOutputDelivery) -> Bool {
+    fileprivate mutating func appendBytes(from delivery: TerminalOutputDelivery) -> Bool {
         guard replacementScope == nil,
               delivery.replacementScope == nil,
               viewportPolicy == delivery.viewportPolicy else {
             return false
         }
-        switch (payload, delivery.payload) {
-        case (.bytes(var bytes), .bytes(let nextBytes)):
-            bytes.append(nextBytes)
-            payload = .bytes(bytes)
-            return true
-        default:
+        guard case .bytes(var bytes) = payload,
+              case .bytes(let nextBytes) = delivery.payload else {
             return false
         }
+        // Drop the enum's owner before append so Data can grow without copying the accumulated buffer.
+        payload = .bytes(Data())
+        bytes.append(nextBytes)
+        payload = .bytes(bytes)
+        return true
     }
 }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
@@ -184,20 +184,24 @@ import Testing
     #expect(queue.completeInFlight() == nil)
 }
 
-@Test func terminalOutputQueueDrainsRawFallbackBacklogInOrder() {
+@Test func terminalOutputQueueDrainsMixedBacklogInOrderAcrossBarriers() {
     var queue = TerminalOutputDeliveryQueue()
     let inFlight = TerminalOutputDelivery(bytes: Data("in-flight".utf8), replaceable: false)
+    let firstRawBytes = TerminalOutputDelivery(bytes: Data("raw-a".utf8), replaceable: false)
+    let viewport = TerminalOutputDelivery(bytes: Data("viewport".utf8), replaceable: true)
+    let secondRawBytes = TerminalOutputDelivery(bytes: Data("raw-b".utf8), replaceable: false)
+    let thirdRawBytes = TerminalOutputDelivery(bytes: Data("raw-c".utf8), replaceable: false)
 
     #expect(queue.enqueue(inFlight) == inFlight)
-    for index in 0..<128 {
-        let delivery = TerminalOutputDelivery(bytes: Data("raw-\(index)".utf8), replaceable: false)
-        #expect(queue.enqueue(delivery) == nil)
-    }
+    #expect(queue.enqueue(firstRawBytes) == nil)
+    #expect(queue.enqueue(viewport) == nil)
+    #expect(queue.enqueue(secondRawBytes) == nil)
+    #expect(queue.enqueue(thirdRawBytes) == nil)
 
-    #expect(queue.pendingCount == 1)
-    let expectedText = (0..<128).map { "raw-\($0)" }.joined()
-    let delivered = queue.completeInFlight()
-    #expect(delivered?.bytes == Data(expectedText.utf8))
+    #expect(queue.pendingCount == 3)
+    #expect(queue.completeInFlight() == firstRawBytes)
+    #expect(queue.completeInFlight() == viewport)
+    #expect(queue.completeInFlight()?.bytes == Data("raw-braw-c".utf8))
     #expect(queue.completeInFlight() == nil)
     #expect(queue.isIdle)
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
@@ -141,6 +141,25 @@ import Testing
     #expect(queue.completeInFlight() == nil)
 }
 
+@Test func terminalOutputQueueCoalescesContiguousRawBytesBehindBackpressure() throws {
+    var queue = TerminalOutputDeliveryQueue()
+    let inFlight = TerminalOutputDelivery(bytes: Data("in-flight".utf8), replaceable: false)
+
+    #expect(queue.enqueue(inFlight) == inFlight)
+    for index in 0..<128 {
+        let delivery = TerminalOutputDelivery(bytes: Data("raw-\(index)\n".utf8), replaceable: false)
+        #expect(queue.enqueue(delivery) == nil)
+    }
+
+    #expect(queue.pendingCount == 1)
+    let delivered = try #require(queue.completeInFlight())
+    let deliveredText = String(decoding: delivered.bytes, as: UTF8.self)
+    let expectedText = (0..<128).map { "raw-\($0)\n" }.joined()
+    #expect(deliveredText == expectedText)
+    #expect(queue.completeInFlight() == nil)
+    #expect(queue.isIdle)
+}
+
 @Test func terminalOutputQueueDrainsRawFallbackBacklogInOrder() {
     var queue = TerminalOutputDeliveryQueue()
     let inFlight = TerminalOutputDelivery(bytes: Data("in-flight".utf8), replaceable: false)
@@ -151,11 +170,10 @@ import Testing
         #expect(queue.enqueue(delivery) == nil)
     }
 
-    #expect(queue.pendingCount == 128)
-    for index in 0..<128 {
-        let expected = TerminalOutputDelivery(bytes: Data("raw-\(index)".utf8), replaceable: false)
-        #expect(queue.completeInFlight() == expected)
-    }
+    #expect(queue.pendingCount == 1)
+    let expectedText = (0..<128).map { "raw-\($0)" }.joined()
+    let delivered = queue.completeInFlight()
+    #expect(delivered?.bytes == Data(expectedText.utf8))
     #expect(queue.completeInFlight() == nil)
     #expect(queue.isIdle)
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
@@ -153,7 +153,7 @@ import Testing
 
     #expect(queue.pendingCount == 1)
     let delivered = try #require(queue.completeInFlight())
-    let deliveredText = String(decoding: delivered.bytes, as: UTF8.self)
+    let deliveredText = try #require(String(data: delivered.bytes, encoding: .utf8))
     let expectedText = (0..<128).map { "raw-\($0)\n" }.joined()
     #expect(deliveredText == expectedText)
     #expect(queue.completeInFlight() == nil)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
@@ -160,6 +160,30 @@ import Testing
     #expect(queue.isIdle)
 }
 
+@Test func terminalOutputQueueDoesNotCoalesceRawBytesAcrossViewportPolicyChanges() {
+    var queue = TerminalOutputDeliveryQueue()
+    let inFlight = TerminalOutputDelivery(bytes: Data("in-flight".utf8), replaceable: false)
+    let naturalBytes = TerminalOutputDelivery(
+        bytes: Data("natural".utf8),
+        replaceable: false,
+        viewportPolicy: .natural
+    )
+    let remoteGridBytes = TerminalOutputDelivery(
+        bytes: Data("remote".utf8),
+        replaceable: false,
+        viewportPolicy: .remoteGrid(columns: 16, rows: 4)
+    )
+
+    #expect(queue.enqueue(inFlight) == inFlight)
+    #expect(queue.enqueue(naturalBytes) == nil)
+    #expect(queue.enqueue(remoteGridBytes) == nil)
+
+    #expect(queue.pendingCount == 2)
+    #expect(queue.completeInFlight() == naturalBytes)
+    #expect(queue.completeInFlight() == remoteGridBytes)
+    #expect(queue.completeInFlight() == nil)
+}
+
 @Test func terminalOutputQueueDrainsRawFallbackBacklogInOrder() {
     var queue = TerminalOutputDeliveryQueue()
     let inFlight = TerminalOutputDelivery(bytes: Data("in-flight".utf8), replaceable: false)


### PR DESCRIPTION
## Summary
- Coalesce contiguous raw terminal byte deliveries while the iOS surface is backpressured.
- Preserve render-grid, viewport-policy, and non-byte barriers so terminal state ordering stays intact.
- Add regression coverage for raw byte ordering, backlog depth, and viewport-policy boundaries.

## Scope
This reduces the queue pressure that can build up during sustained iOS typing when the surface is slower to ack output chunks. It does not claim to fix every possible renderer/output-queue wedge path; a true libghostty/render stall would still need separate watchdog or renderer-side investigation.

## Testing
- `swift build --package-path Packages/iOS/CmuxMobileShell`
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter TerminalOutputDeliveryQueue` *(fails locally before running assertions: Command Line Tools Swift cannot import `Testing`)*
- `./scripts/reload.sh --tag fix-ios-render-freeze-7093` *(fails locally: `zig is not installed`)*

Mitigates #7093.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal output queuing by coalescing compatible consecutive raw byte deliveries into a single payload, reducing backlog while maintaining correct ordering.
  * Prevented coalescing when viewport policy changes to ensure outputs remain properly separated.
  * Updated in-flight draining so coalesced raw bytes are emitted together rather than in many smaller chunks, including correct behavior across replaceable barriers.
* **Tests**
  * Added coverage for byte coalescing behind backpressure, non-coalescing across viewport policy changes, and mixed backlog draining order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->