### PR TITLE
remote-tmux: fix mirror seed render (preserve capture-pane blank lines + size-aware seed)

### DIFF
--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -472,11 +472,14 @@ final class RemoteTmuxControlConnection {
         // connected — while reconnecting/ended there is no live stdin (the send would
         // silently drop); `reseedAfterReconnect` re-applies the stored size.
         lastClientSize = (columns, rows)
+        guard connectionState == .connected else { return }
         // The client height is now known — re-seed any pane whose seed was deferred
         // waiting for it (e.g. the first seed at mount, before the rendered size was
-        // reported).
+        // reported). Kept AFTER the connected guard: a re-seed issues capture-pane
+        // sends, which silently drop while reconnecting/ended (no live stdin, see
+        // above) and would leave the command-correlation FIFO stale. `reseedAfter
+        // reconnect` re-seeds on the reconnect path instead.
         reseedAllDeferredPanes()
-        guard connectionState == .connected else { return }
         // Coalesce the layout-settle oscillation into a single send: (re)arm a short
         // trailing timer; only the last size in a burst actually goes out. The fired
         // timer is also the "settled" edge that consumes the attach redraw kick.
@@ -1386,7 +1389,18 @@ final class RemoteTmuxControlConnection {
             // follows this in the command FIFO, so the wait is one reply.
             pendingPaneSeedRows[paneId] = lines
         case let .paneState(paneId):
-            guard let line = lines.first else { pendingPaneSeedRows[paneId] = nil; break }
+            guard let line = lines.first else {
+                // Empty .paneState: the state query returned no line (pane vanished, or a
+                // transient empty reply). Drop the stashed capture rows and release the
+                // seed-race bookkeeping so baseline/retries can't accumulate for an idle
+                // pane. Keep the pane in pendingGeometrySettleReseedPanes: unlike the
+                // command-error path (a dead pane), an empty reply may be transient, so a
+                // later geometry settle should still retry the seed.
+                pendingPaneSeedRows[paneId] = nil
+                paneSeedByteBaseline[paneId] = nil
+                paneSeedRetries[paneId] = nil
+                break
+            }
             // If live %output raced the seed round-trip (capture + state), the pane was
             // actively redrawing (e.g. a freshly-started shell still painting its first
             // prompt) so the captured grid + cursor are stale. Painting them strands
@@ -1517,6 +1531,10 @@ final class RemoteTmuxControlConnection {
         // refresh-client -C cmux drove, or a co-attached client resized): the seed
         // painted at the old height is stale, so re-queue the window's panes for a
         // re-capture. reseedDeferredPanes then re-captures those that now fit the surface.
+        // Every pane in the window is re-queued, including split (multi-pane) windows —
+        // those re-paint UNPADDED (the size-aware padding in `.paneState` is single-pane
+        // only), which is intentional: an idempotent, bounded re-capture keeps split panes
+        // faithful after a reflow. Single-pane windows additionally re-pad on settle.
         if let previousHeight, previousHeight != node.height {
             for paneId in node.paneIDsInOrder { pendingGeometrySettleReseedPanes.insert(paneId) }
         }
@@ -1533,13 +1551,17 @@ final class RemoteTmuxControlConnection {
 
     /// Re-capture panes queued for a geometry re-seed (surface unknown at mount, or a
     /// single-pane pane that was painted best-effort before reflowing to the surface)
-    /// once the pane fits the surface (`desired rows >= pane height`) — only then does
-    /// the padded seed render correctly. Gated on fit + removed from the set on fire; the
-    /// `.paneState` re-queue is height-change-gated, so a pinned pane can't storm.
+    /// once the window fits the surface (`desired rows >= window height`) — only then does
+    /// a single-pane padded seed render correctly. `windowHeight` is the whole window's
+    /// height (== the pane height only for a single-pane window); the padding gate itself
+    /// lives in `.paneState` under `isSinglePaneWindow`, so this coarse
+    /// window-fits-surface check just avoids re-capturing before the reflow lands. Gated
+    /// on fit + removed from the set on fire; the `.paneState` re-queue is
+    /// height-change-gated, so a pinned pane can't storm.
     private func reseedDeferredPanes(inWindow windowId: Int) {
         guard !pendingGeometrySettleReseedPanes.isEmpty,
               let surfaceRows = desiredSurfaceRows(),
-              let paneRows = windowsByID[windowId]?.height, surfaceRows >= paneRows else { return }
+              let windowHeight = windowsByID[windowId]?.height, surfaceRows >= windowHeight else { return }
         let toReseed = pendingGeometrySettleReseedPanes.intersection(
             Set(windowsByID[windowId]?.paneIDsInOrder ?? []))
         guard !toReseed.isEmpty else { return }

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -65,6 +65,33 @@ final class RemoteTmuxControlConnection {
     private(set) var activePaneByWindow: [Int: Int] = [:]
     private(set) var paneOutputByteCounts: [Int: Int] = [:]
     private(set) var totalOutputBytes = 0
+    /// Per-pane `paneOutputByteCounts` snapshot taken when a `capture-pane` seed is
+    /// REQUESTED. If the count moved by the time the result lands, live `%output`
+    /// raced the round-trip — the pane was actively redrawing (e.g. a freshly-started
+    /// shell still painting its first prompt), so the captured grid AND its cursor are
+    /// already stale. Painting that stale seed both double-draws the prompt and strands
+    /// zsh's `PROMPT_SP` "%" at the seeded cursor (col > 0, so it can't self-erase). We
+    /// re-seed instead; see the `.capturePane` handler.
+    private var paneSeedByteBaseline: [Int: Int] = [:]
+    /// Per-pane count of consecutive raced re-seeds, bounded by ``maxPaneSeedRetries``
+    /// so a continuously-streaming pane can't loop.
+    private var paneSeedRetries: [Int: Int] = [:]
+    private static let maxPaneSeedRetries = 2
+    /// Captured rows awaiting paint. The capture paint is deferred from `.capturePane`
+    /// to `.paneState` so `pane_height` (only in the `.paneState` reply) is available to
+    /// pad the seed for top-alignment (see `capturePaneSeedSequence`).
+    private var pendingPaneSeedRows: [Int: [String]] = [:]
+    /// Panes queued for a geometry re-seed: a single-pane pane painted before it reflowed
+    /// to the surface cmux drives it to, or one whose surface size wasn't known yet.
+    /// Re-captured via `setClientSize` / `%layout-change` (see `reseedDeferredPanes`).
+    private var pendingGeometrySettleReseedPanes: Set<Int> = []
+    /// Per single-pane-window pane: the captured `pane_height` the last best-effort seed
+    /// was painted at. The reflow re-seed in `.paneState` re-queues a pane only when its
+    /// height CHANGED since this — i.e. it is genuinely reflowing toward the surface — so
+    /// a pane a co-attached client pins at a non-surface size can't drive an unbounded
+    /// re-capture loop on `%layout-change` churn. Cleared once the pane settles
+    /// (`pane_height == surface`) so a later genuine resize re-seeds.
+    private var lastBestEffortSeedHeight: [Int: Int] = [:]
     /// Last-known foreground classification per pane, kept current by the same
     /// one-shot query + live subscription that drive reflow classification
     /// (`#{alternate_on}` + `#{pane_current_command}`, see
@@ -445,6 +472,10 @@ final class RemoteTmuxControlConnection {
         // connected — while reconnecting/ended there is no live stdin (the send would
         // silently drop); `reseedAfterReconnect` re-applies the stored size.
         lastClientSize = (columns, rows)
+        // The client height is now known — re-seed any pane whose seed was deferred
+        // waiting for it (e.g. the first seed at mount, before the rendered size was
+        // reported).
+        reseedAllDeferredPanes()
         guard connectionState == .connected else { return }
         // Coalesce the layout-settle oscillation into a single send: (re)arm a short
         // trailing timer; only the last size in a burst actually goes out. The fired
@@ -606,6 +637,9 @@ final class RemoteTmuxControlConnection {
         // comes from LIVE %output (which already carries real soft-wraps), not from
         // the seed — so `-J`'s only upside (pre-attach rejoin-on-grow) isn't worth
         // corrupting every TUI seed. Capture faithful visual rows instead.
+        // Snapshot the live-output counter so the result handler can tell whether the
+        // pane redrew during this round-trip (a raced, stale seed). See the field doc.
+        paneSeedByteBaseline[paneId] = paneOutputByteCounts[paneId, default: 0]
         sendInternal("capture-pane -p -e -S -\(Self.scrollbackCaptureLines) -t %\(paneId)", kind: .capturePane(paneId))
         // Query the pane's terminal STATE; tmux exposes it all as formats. Sent
         // after capture-pane so it applies on top of the painted rows (the seed
@@ -1083,7 +1117,11 @@ final class RemoteTmuxControlConnection {
         scheduleAttachRedrawKickIfNeeded()
         for window in windowsByID.values {
             for paneId in window.paneIDsInOrder {
-                observers.emitPaneOutput(paneId, Data("\u{1b}[H\u{1b}[2J\u{1b}[3J".utf8))
+                // Blank the stale screen + scrollback immediately on reconnect (before
+                // the async capture-pane round-trip repaints), using the shared escape
+                // the seed paint also emits.
+                observers.emitPaneOutput(
+                    paneId, Data(RemoteTmuxControlMessageDecoding.homeClearScreenAndScrollback.utf8))
                 seedPane(paneId: paneId)
             }
         }
@@ -1145,17 +1183,13 @@ final class RemoteTmuxControlConnection {
             record("window-add @\(id)")
             requestWindows()
         case let .windowClose(id):
-            // Release the closed window's per-pane/per-window diagnostic state so
-            // it doesn't accumulate across window churn.
-            if let closing = windowsByID[id] {
-                for pane in closing.paneIDsInOrder {
-                    paneOutputByteCounts[pane] = nil
-                    paneForegroundStates[pane] = nil
-                }
-            }
             activePaneByWindow[id] = nil
             windowsByID[id] = nil
             windowOrder.removeAll { $0 == id }
+            // Release every per-pane map (byte baselines, foreground states, pending
+            // seed rows, the geometry re-seed queue, best-effort heights) for panes the
+            // closed window owned, so nothing accumulates across window churn.
+            prunePaneState(keeping: Set(windowsByID.values.flatMap { $0.paneIDsInOrder }))
             record("window-close @\(id)")
             observers.notifyTopologyChanged()
         case let .windowRenamed(id, name):
@@ -1259,6 +1293,20 @@ final class RemoteTmuxControlConnection {
                let completion = activityQueryCompletions.removeValue(forKey: token) {
                 completion(nil)
             }
+            // A seed command that errors (e.g. the pane exited between the capture
+            // and the state query) must release that pane's in-flight seed state —
+            // otherwise rows stashed by a successful `.capturePane` leak for a dead
+            // pane until some later prune happens to run.
+            switch kind {
+            case let .capturePane(paneId), let .paneState(paneId):
+                pendingPaneSeedRows[paneId] = nil
+                pendingGeometrySettleReseedPanes.remove(paneId)
+                paneSeedRetries[paneId] = nil
+                paneSeedByteBaseline[paneId] = nil
+                lastBestEffortSeedHeight[paneId] = nil
+            default:
+                break
+            }
             // Errors are dropped by design (results correlate positionally), but
             // an invisible %error has already hidden one real bug — an unquoted
             // refresh-client -B that never subscribed — so leave a trace.
@@ -1331,27 +1379,93 @@ final class RemoteTmuxControlConnection {
                 scheduleAttachRedrawKickIfNeeded()
             }
         case let .capturePane(paneId):
-            // capture-pane -e -S output is the pane's history + visible rows (with
-            // SGR escapes). Home + clear the VISIBLE SCREEN (ESC[2J — NOT ESC[3J,
-            // which would erase the scrollback we are seeding), then write every
-            // captured row joined by CR LF: rows that overflow the screen scroll up
-            // into the surface's scrollback buffer, which is what makes the mirrored
-            // tab scrollable from the start. The last row (the visible bottom) gets
-            // no trailing newline so the cursor lands at its END, lining up with
-            // tmux's real prompt cursor — otherwise echoed input lands a line below
-            // the prompt. The `.paneState` seed then repositions the cursor within
-            // the visible screen.
-            let painted = "\u{1b}[H\u{1b}[2J" + lines.joined(separator: "\r\n")
-            if let data = painted.data(using: .utf8) {
-                observers.emitPaneOutput(paneId, data)
-            }
+            // Stash the captured rows; the actual paint is deferred to `.paneState`,
+            // which is the first point we know `pane_height` — needed to pad the seed so
+            // the captured scrollback scrolls into the surface's scrollback and the
+            // visible rows land top-aligned (see capturePaneSeedSequence). `.paneState`
+            // follows this in the command FIFO, so the wait is one reply.
+            pendingPaneSeedRows[paneId] = lines
         case let .paneState(paneId):
+            guard let line = lines.first else { pendingPaneSeedRows[paneId] = nil; break }
+            // If live %output raced the seed round-trip (capture + state), the pane was
+            // actively redrawing (e.g. a freshly-started shell still painting its first
+            // prompt) so the captured grid + cursor are stale. Painting them strands
+            // zsh's PROMPT_SP "%" and double-draws. Re-seed (bounded) instead; the
+            // live-rendered bytes already on the surface stay visible meanwhile.
+            if paneOutputByteCounts[paneId, default: 0] > (paneSeedByteBaseline[paneId] ?? 0),
+               paneSeedRetries[paneId, default: 0] < Self.maxPaneSeedRetries {
+                paneSeedRetries[paneId, default: 0] += 1
+                pendingPaneSeedRows[paneId] = nil
+                capturePane(paneId: paneId)
+                break
+            }
+            paneSeedRetries[paneId] = 0
+            let paneHeight = decoding.paneHeight(from: line)
+            let surfaceHeight = desiredSurfaceRows()
+            // Top-align padding (`surface - pane` blank rows) is only correct for a
+            // single-pane window, where the shared-client surface height IS the pane's
+            // rendered height (matching the mount path's `shouldSeedSinglePaneDisplay`).
+            // In a split the pane is shorter than the client, so padding would scroll the
+            // captured content off-screen — and a pane whose height tmux didn't report
+            // (or reported implausibly) has no valid pad. Such panes paint UNPADDED
+            // rather than over-padding or deferring forever; only a single-pane window
+            // with a known pane height defers. `reseedAfterReconnect` re-seeds EVERY pane,
+            // so multi-pane panes reach here (the mount path seeds single-pane only).
+            let isSinglePaneWindow = windowsByID.values
+                .first { $0.paneIDsInOrder.contains(paneId) }?.paneIDsInOrder.count == 1
+            var padPane: Int?, padSurface: Int?
+            var reseedAfterReflow = false
+            if isSinglePaneWindow, let paneHeight {
+                guard let surfaceHeight else {
+                    // Surface size not reported yet (just mounted): defer rather than
+                    // paint — without it we can't tell whether to pad, and painting now
+                    // would risk the history-in-visible / cursor-too-high flash. The
+                    // first setClientSize re-seeds (see reseedAllDeferredPanes).
+                    pendingPaneSeedRows[paneId] = nil
+                    pendingGeometrySettleReseedPanes.insert(paneId)
+                    break
+                }
+                // Always paint a best-effort frame once the surface size is known, so the
+                // mirror is NEVER blank — even when a co-attached client pins the remote
+                // pane at a size cmux can't change. Pad to top-align only when the surface
+                // is TALLER than the captured pane (push the captured scrollback into the
+                // surface's scrollback so the visible rows + absolute cursor line up);
+                // when it's shorter or equal, paint unpadded (the capture's bottom rows
+                // show, as a real terminal would).
+                if surfaceHeight > paneHeight { (padPane, padSurface) = (paneHeight, surfaceHeight) }
+                // The seed is EXACT only once the pane has reflowed to the surface height
+                // cmux drives a single-pane window to (refresh-client -C); before that the
+                // paint is a placeholder of the pre-reflow grid (e.g. an 80x12 session
+                // attached into a 97x37 window). Re-queue for re-capture — but ONLY when
+                // the height CHANGED since the last best-effort paint, so a pane a
+                // co-attached client pins at a non-surface size re-captures at most once
+                // instead of on every %layout-change (convergence + no storm). A genuine
+                // later reflow re-queues via applyLayout's height-change check.
+                reseedAfterReflow = paneHeight != surfaceHeight &&
+                    lastBestEffortSeedHeight[paneId] != paneHeight
+                lastBestEffortSeedHeight[paneId] = paneHeight
+            }
+            // Paint the capture (padded for a single-pane window so the visible rows
+            // top-align; unpadded for a split, a shorter/equal surface, or unknown
+            // height) THEN the cursor.
+            if let rows = pendingPaneSeedRows.removeValue(forKey: paneId) {
+                observers.emitPaneOutput(paneId, decoding.capturePaneSeedSequence(
+                    rows: rows, paneHeight: padPane, surfaceHeight: padSurface))
+            }
             // Restore the pane's terminal state (scroll region + DEC modes + cursor)
             // onto the mirror surface, applied after the capture paint. The scroll
             // region (DECSTBM) is the important one: without it an inline TUI's
             // region-relative redraws land on the wrong rows even at a static size.
-            if let line = lines.first {
-                observers.emitPaneOutput(paneId, decoding.paneStateSeedSequence(from: line))
+            observers.emitPaneOutput(paneId, decoding.paneStateSeedSequence(from: line))
+            // Queue a reflow re-seed (see above); otherwise drop the pane from the queue.
+            // Forget the best-effort height only once SETTLED (pane == surface) so a
+            // future genuine resize re-seeds, while a pinned (unchanged) pane keeps it and
+            // doesn't re-queue on the next %layout-change.
+            if reseedAfterReflow {
+                pendingGeometrySettleReseedPanes.insert(paneId)
+            } else {
+                pendingGeometrySettleReseedPanes.remove(paneId)
+                if paneHeight == surfaceHeight { lastBestEffortSeedHeight[paneId] = nil }
             }
         case let .panePath(paneId):
             if let path = lines.first?.trimmingCharacters(in: .whitespaces), !path.isEmpty {
@@ -1391,6 +1505,7 @@ final class RemoteTmuxControlConnection {
 
     private func applyLayout(windowId: Int, layout: String) {
         guard let node = RemoteTmuxRawLayoutParser.parse(layout) else { return }
+        let previousHeight = windowsByID[windowId]?.height
         // Preserve any name tmux already reported (a %layout-change carries no name).
         let existingName = windowsByID[windowId]?.name ?? ""
         windowsByID[windowId] = RemoteTmuxWindow(
@@ -1398,11 +1513,55 @@ final class RemoteTmuxControlConnection {
         )
         if !windowOrder.contains(windowId) { windowOrder.append(windowId) }
         prunePaneState(keeping: Set(windowsByID.values.flatMap { $0.paneIDsInOrder }))
+        // The window's pane grid reflowed to a new height (the remote processed the
+        // refresh-client -C cmux drove, or a co-attached client resized): the seed
+        // painted at the old height is stale, so re-queue the window's panes for a
+        // re-capture. reseedDeferredPanes then re-captures those that now fit the surface.
+        if let previousHeight, previousHeight != node.height {
+            for paneId in node.paneIDsInOrder { pendingGeometrySettleReseedPanes.insert(paneId) }
+        }
+        reseedDeferredPanes(inWindow: windowId)
+    }
+
+    /// Desired surface (rendered) height in rows that cmux is driving the mirror to. The
+    /// per-session mirror sizes the shared control client (`refresh-client -C`), so every
+    /// window/pane surface tracks `lastClientSize`. `nil` until the surface has reported
+    /// its size.
+    private func desiredSurfaceRows() -> Int? {
+        lastClientSize?.rows
+    }
+
+    /// Re-capture panes queued for a geometry re-seed (surface unknown at mount, or a
+    /// single-pane pane that was painted best-effort before reflowing to the surface)
+    /// once the pane fits the surface (`desired rows >= pane height`) — only then does
+    /// the padded seed render correctly. Gated on fit + removed from the set on fire; the
+    /// `.paneState` re-queue is height-change-gated, so a pinned pane can't storm.
+    private func reseedDeferredPanes(inWindow windowId: Int) {
+        guard !pendingGeometrySettleReseedPanes.isEmpty,
+              let surfaceRows = desiredSurfaceRows(),
+              let paneRows = windowsByID[windowId]?.height, surfaceRows >= paneRows else { return }
+        let toReseed = pendingGeometrySettleReseedPanes.intersection(
+            Set(windowsByID[windowId]?.paneIDsInOrder ?? []))
+        guard !toReseed.isEmpty else { return }
+        pendingGeometrySettleReseedPanes.subtract(toReseed)
+        for paneId in toReseed { capturePane(paneId: paneId) }
+    }
+
+    /// Re-seed every deferred pane that now fits its surface — used when the client
+    /// size becomes known (`setClientSize`).
+    private func reseedAllDeferredPanes() {
+        guard !pendingGeometrySettleReseedPanes.isEmpty else { return }
+        for windowId in windowsByID.keys { reseedDeferredPanes(inWindow: windowId) }
     }
 
     private func prunePaneState(keeping livePanes: Set<Int>) {
         paneOutputByteCounts = paneOutputByteCounts.filter { livePanes.contains($0.key) }
         paneForegroundStates = paneForegroundStates.filter { livePanes.contains($0.key) }
+        pendingPaneSeedRows = pendingPaneSeedRows.filter { livePanes.contains($0.key) }
+        pendingGeometrySettleReseedPanes = pendingGeometrySettleReseedPanes.filter { livePanes.contains($0) }
+        paneSeedByteBaseline = paneSeedByteBaseline.filter { livePanes.contains($0.key) }
+        paneSeedRetries = paneSeedRetries.filter { livePanes.contains($0.key) }
+        lastBestEffortSeedHeight = lastBestEffortSeedHeight.filter { livePanes.contains($0.key) }
     }
 
     private func record(_ event: String) {

--- a/Sources/RemoteTmuxControlMessageDecoding.swift
+++ b/Sources/RemoteTmuxControlMessageDecoding.swift
@@ -9,6 +9,75 @@ import Foundation
 /// context; ``RemoteTmuxControlConnection`` owns an instance and routes its
 /// internal call sites through it.
 struct RemoteTmuxControlMessageDecoding {
+    /// Builds the seed paint that replays a `capture-pane -p -e -S` result onto a
+    /// freshly-created mirror surface: home, clear the visible screen (ESC[2J) AND
+    /// clear the scrollback (ESC[3J), then write every captured row joined by CR LF.
+    ///
+    /// The scrollback clear (ESC[3J) is correctness, not cosmetics. A mirror surface
+    /// receives live `%output` from the moment it mounts — BEFORE this capture result
+    /// lands — and tmux control mode forwards the raw, pre-emulation pty bytes. That
+    /// early stream carries zsh's PROMPT_SP / PROMPT_EOL_MARK partial-line marker (an
+    /// inverse-video "%" zsh paints at the cursor, then erases with CR+space+CR):
+    /// tmux's own grid model collapses it to a clean final state, but on the mirror
+    /// the marker can scroll up into the surface's scrollback, stranding a spurious
+    /// "%" on its own line ABOVE the seeded prompt. ESC[3J wipes that pre-seed garbage.
+    ///
+    /// ESC[3J does NOT erase the rows we are about to seed: it runs BEFORE the writes,
+    /// so the captured rows that overflow the screen scroll into a FRESH scrollback
+    /// afterward and the mirrored tab stays scrollable from the start (the reconnect
+    /// re-seed path already clears scrollback the same way and remains scrollable).
+    ///
+    /// The last row gets no trailing newline so the cursor lands at its END, lining up
+    /// with tmux's real prompt cursor; the `.paneState` seed then repositions it.
+    ///
+    /// `paneHeight`/`surfaceHeight` fix the "stacked prompts + misplaced cursor" bug:
+    /// `capture-pane -S` returns the pane's SCROLLBACK history followed by its visible
+    /// screen as one block (`historyLines + paneHeight` rows — tmux does NOT trim
+    /// trailing blanks, so the split is exact). Replaying that block relies on overflow
+    /// to scroll history into the surface's scrollback, leaving the visible rows on
+    /// screen. That only lands the visible rows TOP-ALIGNED (row 0) — the invariant the
+    /// absolute cursor restore (`paneStateSeedSequence`) assumes — when the painted
+    /// block overflows the surface by exactly `historyLines`. When the mirror surface is
+    /// TALLER than the captured pane (`surfaceHeight > paneHeight`, common during the
+    /// attach/resize size-sync window) it doesn't, so the history rows sit in the
+    /// visible area and the visible-relative cursor lands `historyLines` rows too high.
+    /// Appending `surfaceHeight - paneHeight` blank rows makes the block `historyLines +
+    /// surfaceHeight` tall, so exactly `historyLines` rows scroll off and the visible
+    /// rows top-align with blank space below — matching a real terminal grown past its
+    /// content. A surface SHORTER than the pane is handled by the caller (it defers the
+    /// seed until the pane resizes down), so no padding is applied there.
+    nonisolated func capturePaneSeedSequence(rows: [String], paneHeight: Int?, surfaceHeight: Int?) -> Data {
+        var seedRows = rows
+        if let p = paneHeight, let h = surfaceHeight, h > p, rows.count >= p {
+            seedRows.append(contentsOf: repeatElement("", count: h - p))
+        }
+        return Data((Self.homeClearScreenAndScrollback + seedRows.joined(separator: "\r\n")).utf8)
+    }
+
+    /// Parses `pane_height` out of a `.paneState` `display-message` line (the same
+    /// `key=value,…` format `paneStateSeedSequence` consumes). Used to pad the capture
+    /// seed so the visible rows land top-aligned (see `capturePaneSeedSequence`).
+    nonisolated func paneHeight(from line: String) -> Int? {
+        for pair in line.split(separator: ",") {
+            let kv = pair.split(separator: "=", maxSplits: 1)
+            if kv.count == 2, kv[0] == "pane_height" {
+                // Clamp to a plausible terminal-row range. The value is untrusted remote
+                // output; a negative or absurd height would otherwise drive a huge (or
+                // negative) blank-row pad in `capturePaneSeedSequence`. An out-of-range
+                // value reads as "unknown", so the caller paints the seed unpadded.
+                // Mirrors the bounded numeric parsing in `paneStateSeedSequence`.
+                return Int(kv[1]).flatMap { (1...65535).contains($0) ? $0 : nil }
+            }
+        }
+        return nil
+    }
+
+    /// Home the cursor + clear the visible screen (ESC[2J) AND the scrollback (ESC[3J).
+    /// The one place this escape sequence is spelled, shared by the capture-pane seed
+    /// paint above and the reconnect re-seed pre-clear in ``RemoteTmuxControlConnection``
+    /// so the two can't drift.
+    nonisolated static let homeClearScreenAndScrollback = "\u{1b}[H\u{1b}[2J\u{1b}[3J"
+
     /// Builds the escape sequence that restores a pane's terminal state onto the
     /// mirror surface, from a `display-message` `key=value,…` line. Sets the scroll
     /// region (DECSTBM), the DEC private modes (wrap/cursor/insert/app-cursor-keys/

--- a/Sources/RemoteTmuxControlStreamParser.swift
+++ b/Sources/RemoteTmuxControlStreamParser.swift
@@ -78,13 +78,12 @@ struct RemoteTmuxControlStreamParser {
         if !inBlock {
             bytes = Self.removingST(bytes)
         }
-        if bytes.isEmpty {
-            guard inBlock else { return prefixMessages }
-            if blockBufferedBytes + 1 > maxCommandBlockBytes {
-                return prefixMessages + [streamError("command block exceeded \(maxCommandBlockBytes) bytes")]
-            }
-            blockBufferedBytes += 1
-            blockLines.append("")
+        // A blank line OUTSIDE a block is not a notification — drop it. A blank line
+        // INSIDE a block is a real captured row (`capture-pane` emits an empty line for a
+        // blank pane row, the dropped-blank-lines bug this fixes); let it fall through to
+        // the generic block-content path below, which budgets (+1 for the newline) and
+        // appends the empty line identically — no need to duplicate that arithmetic here.
+        if bytes.isEmpty && !inBlock {
             return prefixMessages
         }
 

--- a/Sources/RemoteTmuxControlStreamParser.swift
+++ b/Sources/RemoteTmuxControlStreamParser.swift
@@ -78,7 +78,15 @@ struct RemoteTmuxControlStreamParser {
         if !inBlock {
             bytes = Self.removingST(bytes)
         }
-        if bytes.isEmpty { return prefixMessages }
+        if bytes.isEmpty {
+            guard inBlock else { return prefixMessages }
+            if blockBufferedBytes + 1 > maxCommandBlockBytes {
+                return prefixMessages + [streamError("command block exceeded \(maxCommandBlockBytes) bytes")]
+            }
+            blockBufferedBytes += 1
+            blockLines.append("")
+            return prefixMessages
+        }
 
         // `%output` is the only notification whose payload carries raw, possibly
         // multi-byte UTF-8 pane bytes. Parse it straight from the raw bytes so a

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -199,7 +199,7 @@ import Testing
 
     // MARK: - Capture-pane seed paint (scrollback clear)
 
-    @Test func capturePaneSeedClearsScrollbackBeforePaintingRows() {
+    @Test func capturePaneSeedClearsScrollbackBeforePaintingRows() throws {
         // The seed must home + clear the VISIBLE screen (ESC[2J) AND the scrollback
         // (ESC[3J) before writing the captured rows. The scrollback clear wipes any
         // zsh PROMPT_SP "%" partial-line marker that early live %output stranded in
@@ -209,7 +209,7 @@ import Testing
         let rows = ["row one", "row two", "➜  ~"]
         let d = RemoteTmuxControlMessageDecoding()
         // No padding when surfaceHeight/paneHeight are unknown (nil) — backward shape.
-        let seq = String(decoding: d.capturePaneSeedSequence(rows: rows, paneHeight: nil, surfaceHeight: nil), as: UTF8.self)
+        let seq = try #require(String(bytes: d.capturePaneSeedSequence(rows: rows, paneHeight: nil, surfaceHeight: nil), encoding: .utf8))
         // The exact, full sequence: home + clear screen (ESC[2J) + clear scrollback
         // (ESC[3J) — in that order, BEFORE the rows so the rows are preserved — then
         // the captured rows joined by CR LF with no trailing newline on the last row.
@@ -218,11 +218,11 @@ import Testing
         #expect(seq.hasPrefix("\u{1b}[H\u{1b}[2J\u{1b}[3J"))   // scrollback cleared, before rows
         #expect(seq.hasSuffix("row one\r\nrow two\r\n➜  ~"))    // rows preserved, joined by CR LF
         // Empty capture → exactly the clear prefix (no rows, no trailing CRLF).
-        #expect(String(decoding: d.capturePaneSeedSequence(rows: [], paneHeight: nil, surfaceHeight: nil),
-                       as: UTF8.self) == "\u{1b}[H\u{1b}[2J\u{1b}[3J")
+        #expect(String(bytes: d.capturePaneSeedSequence(rows: [], paneHeight: nil, surfaceHeight: nil),
+                       encoding: .utf8) == "\u{1b}[H\u{1b}[2J\u{1b}[3J")
         // Single row → prefix + the row, with NO trailing CRLF (cursor lands at its end).
-        #expect(String(decoding: d.capturePaneSeedSequence(rows: ["x"], paneHeight: nil, surfaceHeight: nil),
-                       as: UTF8.self) == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "x")
+        #expect(String(bytes: d.capturePaneSeedSequence(rows: ["x"], paneHeight: nil, surfaceHeight: nil),
+                       encoding: .utf8) == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "x")
     }
 
     /// The padding fix for "stacked prompts + misplaced cursor": when the mirror surface
@@ -230,31 +230,44 @@ import Testing
     /// padded with `surfaceHeight - paneHeight` blank rows so exactly the history rows
     /// scroll into scrollback and the visible rows land top-aligned (where the absolute
     /// cursor restore expects them).
-    @Test func capturePaneSeedPadsBlankRowsWhenSurfaceTallerThanPane() {
+    @Test func capturePaneSeedPadsBlankRowsWhenSurfaceTallerThanPane() throws {
         let d = RemoteTmuxControlMessageDecoding()
         // pane_height=2 visible; capture = 1 history + 2 visible = 3 rows; surface=5.
         // Pad 5-2=3 blanks → 6 logical rows; top 1 (history) scrolls off, visible tops out.
         let rows = ["hist", "vis0", "vis1"]
-        let seq = String(decoding: d.capturePaneSeedSequence(rows: rows, paneHeight: 2, surfaceHeight: 5), as: UTF8.self)
+        let seq = try #require(String(bytes: d.capturePaneSeedSequence(rows: rows, paneHeight: 2, surfaceHeight: 5), encoding: .utf8))
         #expect(seq == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "hist\r\nvis0\r\nvis1\r\n\r\n\r\n")
     }
 
     /// No padding when surface == pane (the already-correct case): overflow scroll
     /// already top-aligns the visible rows.
-    @Test func capturePaneSeedDoesNotPadWhenSurfaceEqualsPane() {
+    @Test func capturePaneSeedDoesNotPadWhenSurfaceEqualsPane() throws {
         let d = RemoteTmuxControlMessageDecoding()
         let rows = ["hist", "vis0", "vis1"]   // 1 history + 2 visible, pane_height=2
-        let seq = String(decoding: d.capturePaneSeedSequence(rows: rows, paneHeight: 2, surfaceHeight: 2), as: UTF8.self)
+        let seq = try #require(String(bytes: d.capturePaneSeedSequence(rows: rows, paneHeight: 2, surfaceHeight: 2), encoding: .utf8))
         #expect(seq == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "hist\r\nvis0\r\nvis1")
     }
 
     /// No padding when the surface is SHORTER than the pane (the caller defers the seed
     /// to a geometry-settle reseed instead; the decoder must not invent rows).
-    @Test func capturePaneSeedDoesNotPadWhenSurfaceShorterThanPane() {
+    @Test func capturePaneSeedDoesNotPadWhenSurfaceShorterThanPane() throws {
         let d = RemoteTmuxControlMessageDecoding()
         let rows = ["v0", "v1", "v2", "v3"]   // pane_height=4
-        let seq = String(decoding: d.capturePaneSeedSequence(rows: rows, paneHeight: 4, surfaceHeight: 2), as: UTF8.self)
+        let seq = try #require(String(bytes: d.capturePaneSeedSequence(rows: rows, paneHeight: 4, surfaceHeight: 2), encoding: .utf8))
         #expect(seq == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "v0\r\nv1\r\nv2\r\nv3")
+    }
+
+    /// No padding when the capture returned FEWER rows than the reported pane height, even
+    /// though the surface is taller — the `rows.count >= paneHeight` guard in
+    /// `capturePaneSeedSequence` protects against a bogus (over-)pad when the capture is
+    /// short (e.g. a pane that hasn't filled its height yet), so it paints unpadded.
+    @Test func capturePaneSeedDoesNotPadWhenCapturedRowsFewerThanPane() throws {
+        let d = RemoteTmuxControlMessageDecoding()
+        // pane_height=5, surface=8 (taller → would normally pad 3), but only 2 captured
+        // rows: rows.count(2) < paneHeight(5) fails the pad guard → no blank rows appended.
+        let rows = ["only", "two"]
+        let seq = try #require(String(bytes: d.capturePaneSeedSequence(rows: rows, paneHeight: 5, surfaceHeight: 8), encoding: .utf8))
+        #expect(seq == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "only\r\ntwo")
     }
 
     /// `paneHeight(from:)` extracts pane_height from the `.paneState` display-message line.

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -197,6 +197,82 @@ import Testing
         #expect(messages == [.layoutChange(windowId: 4, layout: "f92f,80x24,0,0,1")])
     }
 
+    // MARK: - Capture-pane seed paint (scrollback clear)
+
+    @Test func capturePaneSeedClearsScrollbackBeforePaintingRows() {
+        // The seed must home + clear the VISIBLE screen (ESC[2J) AND the scrollback
+        // (ESC[3J) before writing the captured rows. The scrollback clear wipes any
+        // zsh PROMPT_SP "%" partial-line marker that early live %output stranded in
+        // the fresh mirror surface's scrollback above the seeded prompt (the reported
+        // "spurious %" symptom). ESC[3J runs BEFORE the rows, so the captured rows are
+        // preserved and still scroll into a fresh scrollback.
+        let rows = ["row one", "row two", "➜  ~"]
+        let d = RemoteTmuxControlMessageDecoding()
+        // No padding when surfaceHeight/paneHeight are unknown (nil) — backward shape.
+        let seq = String(decoding: d.capturePaneSeedSequence(rows: rows, paneHeight: nil, surfaceHeight: nil), as: UTF8.self)
+        // The exact, full sequence: home + clear screen (ESC[2J) + clear scrollback
+        // (ESC[3J) — in that order, BEFORE the rows so the rows are preserved — then
+        // the captured rows joined by CR LF with no trailing newline on the last row.
+        #expect(seq == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "row one\r\nrow two\r\n➜  ~")
+        // Spelled-out guards (these fail loudly against the pre-fix ESC[2J-only paint).
+        #expect(seq.hasPrefix("\u{1b}[H\u{1b}[2J\u{1b}[3J"))   // scrollback cleared, before rows
+        #expect(seq.hasSuffix("row one\r\nrow two\r\n➜  ~"))    // rows preserved, joined by CR LF
+        // Empty capture → exactly the clear prefix (no rows, no trailing CRLF).
+        #expect(String(decoding: d.capturePaneSeedSequence(rows: [], paneHeight: nil, surfaceHeight: nil),
+                       as: UTF8.self) == "\u{1b}[H\u{1b}[2J\u{1b}[3J")
+        // Single row → prefix + the row, with NO trailing CRLF (cursor lands at its end).
+        #expect(String(decoding: d.capturePaneSeedSequence(rows: ["x"], paneHeight: nil, surfaceHeight: nil),
+                       as: UTF8.self) == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "x")
+    }
+
+    /// The padding fix for "stacked prompts + misplaced cursor": when the mirror surface
+    /// is TALLER than the captured pane, the captured block (history + visible) must be
+    /// padded with `surfaceHeight - paneHeight` blank rows so exactly the history rows
+    /// scroll into scrollback and the visible rows land top-aligned (where the absolute
+    /// cursor restore expects them).
+    @Test func capturePaneSeedPadsBlankRowsWhenSurfaceTallerThanPane() {
+        let d = RemoteTmuxControlMessageDecoding()
+        // pane_height=2 visible; capture = 1 history + 2 visible = 3 rows; surface=5.
+        // Pad 5-2=3 blanks → 6 logical rows; top 1 (history) scrolls off, visible tops out.
+        let rows = ["hist", "vis0", "vis1"]
+        let seq = String(decoding: d.capturePaneSeedSequence(rows: rows, paneHeight: 2, surfaceHeight: 5), as: UTF8.self)
+        #expect(seq == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "hist\r\nvis0\r\nvis1\r\n\r\n\r\n")
+    }
+
+    /// No padding when surface == pane (the already-correct case): overflow scroll
+    /// already top-aligns the visible rows.
+    @Test func capturePaneSeedDoesNotPadWhenSurfaceEqualsPane() {
+        let d = RemoteTmuxControlMessageDecoding()
+        let rows = ["hist", "vis0", "vis1"]   // 1 history + 2 visible, pane_height=2
+        let seq = String(decoding: d.capturePaneSeedSequence(rows: rows, paneHeight: 2, surfaceHeight: 2), as: UTF8.self)
+        #expect(seq == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "hist\r\nvis0\r\nvis1")
+    }
+
+    /// No padding when the surface is SHORTER than the pane (the caller defers the seed
+    /// to a geometry-settle reseed instead; the decoder must not invent rows).
+    @Test func capturePaneSeedDoesNotPadWhenSurfaceShorterThanPane() {
+        let d = RemoteTmuxControlMessageDecoding()
+        let rows = ["v0", "v1", "v2", "v3"]   // pane_height=4
+        let seq = String(decoding: d.capturePaneSeedSequence(rows: rows, paneHeight: 4, surfaceHeight: 2), as: UTF8.self)
+        #expect(seq == "\u{1b}[H\u{1b}[2J\u{1b}[3J" + "v0\r\nv1\r\nv2\r\nv3")
+    }
+
+    /// `paneHeight(from:)` extracts pane_height from the `.paneState` display-message line.
+    @Test func paneHeightParsedFromPaneStateLine() {
+        let d = RemoteTmuxControlMessageDecoding()
+        #expect(d.paneHeight(from: "cursor_x=5,cursor_y=0,wrap_flag=1,pane_height=35,mouse_sgr_flag=0") == 35)
+        #expect(d.paneHeight(from: "cursor_x=5,cursor_y=0") == nil)
+        // Untrusted remote values outside a plausible terminal-row range read as
+        // "unknown" (nil) so the caller paints the seed unpadded instead of driving a
+        // negative / enormous blank-row pad in capturePaneSeedSequence.
+        #expect(d.paneHeight(from: "pane_height=-5") == nil)
+        #expect(d.paneHeight(from: "pane_height=0") == nil)
+        #expect(d.paneHeight(from: "pane_height=999999999") == nil)
+        #expect(d.paneHeight(from: "pane_height=abc") == nil)
+        #expect(d.paneHeight(from: "pane_height=1") == 1)
+        #expect(d.paneHeight(from: "pane_height=65535") == 65535)
+    }
+
     // MARK: - Pane state seeding (cursor / region / origin ordering)
 
     @Test func paneStateSeedPlacesCursorLastWithOriginRelativeRow() {

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -73,6 +73,25 @@ import Testing
         ])
     }
 
+    @Test func blockContentPreservesBlankLines() {
+        // `capture-pane -p -S` emits physical blank rows inside the command block.
+        // Those rows are part of the terminal grid and must not be treated like
+        // ignorable empty notification lines; dropping them compacts prompt redraw
+        // scrollback into a stack at the top of the mirror.
+        let messages = parse(
+            "%begin 1700000000 5 0\r\n"
+            + "\r\n"
+            + "prompt one\r\n"
+            + "\r\n"
+            + "\r\n"
+            + "prompt two\r\n"
+            + "%end 1700000000 5 0\r\n"
+        )
+        #expect(messages == [
+            .commandResult(commandNumber: 5, lines: ["", "prompt one", "", "", "prompt two"], isError: false)
+        ])
+    }
+
     @Test func enterDCSIsStrippedAndEmittedBeforeFirstBlock() {
         // The real stream prepends the `ESC P 1000 p` enter sequence to the
         // first %begin line; the parser emits `.enter` and strips the framing.

--- a/scripts/remote-tmux-render-harness.sh
+++ b/scripts/remote-tmux-render-harness.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# ============================================================================
+# Remote-tmux mirror RENDER-FIDELITY harness.
+#
+# Asserts the strong oracle that a weaker "is there a stray %?" check can't:
+#
+#     the mirror's rendered VISIBLE screen  ==  the remote pane's VISIBLE screen
+#
+# (after the attach/resize settles, at matched size). This catches the LAYOUT/CONTENT
+# class of mirror render bugs at once: stacked/compacted prompts, the spurious zsh
+# PROMPT_SP "%", history-in-the-visible-area, and any content drift — which is how a
+# mis-seeded cursor usually surfaces too. It does NOT compare the cursor cell directly
+# (read-screen returns text only); the cursor-placement logic is covered by the
+# paneStateSeedSequence unit tests. It drives every edge that has regressed: fresh
+# attach, prompt-redraw scrollback, mirror taller than the pane (H>P), mirror shorter
+# (H<P), rapid re-attach, reconnect, and a mid-size pane.
+#
+# PREREQUISITES:
+#   - A tagged Debug app built + running:  ./scripts/reload.sh --tag <tag> --launch
+#     then run this with CMUX_TAG=<tag>.
+#   - An ssh alias to localhost whose forced-command pins an isolated TMUX_TMPDIR,
+#     so the harness never touches your real tmux. Defaults to `cmux-srvA` ->
+#     /tmp/cmux-srvA. Example ~/.ssh/config:
+#         Host cmux-srvA
+#             HostName 127.0.0.1
+#             RemoteCommand TMUX_TMPDIR=/tmp/cmux-srvA $SHELL -l
+#             RequestTTY yes
+#     Override with CMUX_RENDER_SRV / CMUX_RENDER_SRV_TMPDIR.
+#
+# Exit code is the number of failed scenarios (0 = all green).
+# ============================================================================
+set -u
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+: "${CMUX_TAG:?set CMUX_TAG to the tagged debug app (e.g. CMUX_TAG=lv-all)}"
+TMUXBIN="${CMUX_RENDER_TMUX:-/opt/homebrew/bin/tmux}"
+SRV="${CMUX_RENDER_SRV:-cmux-srvA}"
+SRVDIR="${CMUX_RENDER_SRV_TMPDIR:-/tmp/cmux-srvA}"
+UUID='[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
+
+cli() { CMUX_TAG="$CMUX_TAG" timeout 25 "$REPO/scripts/cmux-debug-cli.sh" "$@" 2>&1; }
+win_ids() { cli list-windows | awk '{for(i=1;i<=NF;i++) if($i ~ /^selected_workspace=/) print $(i-1)}'; }
+# Normalize for comparison: right-trim each line, drop trailing blank lines.
+norm() { sed 's/[[:space:]]*$//' | awk '{a[NR]=$0} END{last=NR; while(last>0 && a[last]=="") last--; for(i=1;i<=last;i++) print a[i]}'; }
+remote_visible() { TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" capture-pane -p -t "$1" 2>/dev/null | norm; }
+mirror_visible() { cli read-screen --window "$1" 2>/dev/null | norm; }
+remote_pane_info() { TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" display-message -p -t "$1" 'size=#{pane_width}x#{pane_height} cursor=#{cursor_x},#{cursor_y} hist=#{history_size}' 2>/dev/null; }
+
+reset_srv() { TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" kill-server 2>/dev/null; sleep 0.3; mkdir -p "$SRVDIR"; }
+gen_scrollback() { local s="$1" n="$2" i; for ((i=0;i<n;i++)); do TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" send-keys -t "$s" Enter; done; sleep 0.6; }
+attach_window() {
+  local before; before=$(win_ids | sort -u)
+  cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1; sleep 3
+  win_ids | sort -u | comm -13 <(printf '%s\n' "$before") - | grep -iE "$UUID" | head -1
+}
+
+PASS=0; FAIL=0; FAILED=""
+assert_match() {  # $1=label  $2=remote_session  $3=mirror_window
+  local label="$1" rs="$2" w="$3" r m i
+  if [ -z "$w" ]; then FAIL=$((FAIL+1)); FAILED="$FAILED $label(no-window)"; echo "  FAIL  $label  (no mirror window)"; return; fi
+  # Re-compare a few times before failing: the mirror sizes the remote client on
+  # attach (refresh-client -C) and the pane reflows asynchronously, so the settled
+  # frame can land a beat after the initial 3s wait. A real render bug stays
+  # mismatched across every retry; only a slow settle is absorbed here.
+  for i in 1 2 3 4 5; do
+    r=$(remote_visible "$rs"); m=$(mirror_visible "$w")
+    [ "$r" = "$m" ] && break
+    sleep 1.5
+  done
+  if [ "$r" = "$m" ]; then
+    PASS=$((PASS+1)); echo "  PASS  $label"
+  else
+    FAIL=$((FAIL+1)); FAILED="$FAILED $label"
+    echo "  FAIL  $label  ($(remote_pane_info "$rs"))"
+    echo "        remote=$(printf '%s' "$r" | grep -c .) non-blank lines  mirror=$(printf '%s' "$m" | grep -c .) non-blank lines"
+    paste <(printf '%s\n' "$r" | cat -n) <(printf '%s\n' "$m" | cat -n) | head -8 | sed 's/^/        /'
+  fi
+  cli close-window --window "$w" >/dev/null 2>&1; sleep 0.4
+}
+
+echo "=== remote-tmux render-fidelity harness  tag=$CMUX_TAG  srv=$SRV ==="
+
+reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s1; sleep 0.8
+assert_match "fresh-empty" s1 "$(attach_window)"
+
+reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s2; sleep 0.8; gen_scrollback s2 8
+assert_match "scrollback-history" s2 "$(attach_window)"
+
+reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s3 -x 80 -y 12; sleep 0.8; gen_scrollback s3 6
+assert_match "mirror-taller-HgtP" s3 "$(attach_window)"
+
+reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s4 -x 80 -y 60; sleep 0.8; gen_scrollback s4 4
+assert_match "mirror-shorter-HltP" s4 "$(attach_window)"
+
+reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s6; sleep 0.8; gen_scrollback s6 5
+before=$(win_ids | sort -u)
+cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1; cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1; sleep 3
+assert_match "rapid-reattach" s6 "$(win_ids | sort -u | comm -13 <(printf '%s\n' "$before") - | grep -iE "$UUID" | head -1)"
+
+reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s7; sleep 0.8; gen_scrollback s7 5
+before=$(win_ids | sort -u); cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1; sleep 3
+W7=$(win_ids | sort -u | comm -13 <(printf '%s\n' "$before") - | grep -iE "$UUID" | head -1)
+pkill -f "ssh.*$SRV" 2>/dev/null; sleep 6
+r=$(remote_visible s7); m=$(mirror_visible "$W7")
+if [ "$r" = "$m" ]; then PASS=$((PASS+1)); echo "  PASS  reconnect-reseed"; else FAIL=$((FAIL+1)); FAILED="$FAILED reconnect-reseed"; echo "  FAIL  reconnect-reseed"; fi
+cli close-window --window "$W7" >/dev/null 2>&1; sleep 0.4
+
+reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s8 -x 100 -y 20; sleep 0.8; gen_scrollback s8 6
+assert_match "midsize-pane" s8 "$(attach_window)"
+
+echo "=== RESULT: PASS=$PASS FAIL=$FAIL ==="
+[ "$FAIL" -gt 0 ] && echo "FAILED:$FAILED"
+TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" kill-server 2>/dev/null
+exit "$FAIL"

--- a/scripts/remote-tmux-render-harness.sh
+++ b/scripts/remote-tmux-render-harness.sh
@@ -29,7 +29,7 @@
 #
 # Exit code is the number of failed scenarios (0 = all green).
 # ============================================================================
-set -u
+set -uo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 : "${CMUX_TAG:?set CMUX_TAG to the tagged debug app (e.g. CMUX_TAG=lv-all)}"
 TMUXBIN="${CMUX_RENDER_TMUX:-/opt/homebrew/bin/tmux}"
@@ -37,77 +37,134 @@ SRV="${CMUX_RENDER_SRV:-cmux-srvA}"
 SRVDIR="${CMUX_RENDER_SRV_TMPDIR:-/tmp/cmux-srvA}"
 UUID='[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
 
-cli() { CMUX_TAG="$CMUX_TAG" timeout 25 "$REPO/scripts/cmux-debug-cli.sh" "$@" 2>&1; }
+# `timeout` is GNU coreutils; on macOS it's absent unless coreutils is installed
+# (as `gtimeout`). Resolve one up front, fail fast with a clear prerequisite error.
+TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
+[ -n "$TIMEOUT_BIN" ] || { echo "ERROR: neither 'timeout' nor 'gtimeout' found — install GNU coreutils (brew install coreutils)"; exit 2; }
+
+# Poll a predicate until it succeeds or a deadline passes (no fixed sleeps to
+# paper over readiness — the loop returns the instant the real signal is true).
+wait_until() {  # $1=timeout_s  $2.. = predicate command
+  local timeout_s="$1"; shift
+  local deadline=$(( SECONDS + timeout_s ))
+  until "$@"; do
+    [ "$SECONDS" -ge "$deadline" ] && return 1
+    sleep 0.2
+  done
+}
+
+srv() { TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" "$@"; }
+cli() { CMUX_TAG="$CMUX_TAG" "$TIMEOUT_BIN" 25 "$REPO/scripts/cmux-debug-cli.sh" "$@" 2>&1; }
 win_ids() { cli list-windows | awk '{for(i=1;i<=NF;i++) if($i ~ /^selected_workspace=/) print $(i-1)}'; }
 # Normalize for comparison: right-trim each line, drop trailing blank lines.
 norm() { sed 's/[[:space:]]*$//' | awk '{a[NR]=$0} END{last=NR; while(last>0 && a[last]=="") last--; for(i=1;i<=last;i++) print a[i]}'; }
-remote_visible() { TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" capture-pane -p -t "$1" 2>/dev/null | norm; }
+# Capture helpers: `pipefail` propagates a failed capture-pane/read-screen so callers
+# can tell "screen was empty" from "capture failed" instead of silently comparing "".
+remote_visible() { srv capture-pane -p -t "$1" 2>/dev/null | norm; }
 mirror_visible() { cli read-screen --window "$1" 2>/dev/null | norm; }
-remote_pane_info() { TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" display-message -p -t "$1" 'size=#{pane_width}x#{pane_height} cursor=#{cursor_x},#{cursor_y} hist=#{history_size}' 2>/dev/null; }
+remote_pane_info() { srv display-message -p -t "$1" 'size=#{pane_width}x#{pane_height} cursor=#{cursor_x},#{cursor_y} hist=#{history_size}' 2>/dev/null; }
 
-reset_srv() { TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" kill-server 2>/dev/null; sleep 0.3; mkdir -p "$SRVDIR"; }
-gen_scrollback() { local s="$1" n="$2" i; for ((i=0;i<n;i++)); do TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" send-keys -t "$s" Enter; done; sleep 0.6; }
+# ---- readiness predicates ----------------------------------------------------
+srv_down() { ! srv list-sessions >/dev/null 2>&1; }
+session_painted() { srv has-session -t "$1" 2>/dev/null && [ -n "$(remote_visible "$1")" ]; }
+hist_at_least() { local h; h=$(srv display-message -p -t "$1" '#{history_size}' 2>/dev/null || echo 0); [ "${h:-0}" -ge "$2" ]; }
+window_gone() { ! win_ids 2>/dev/null | grep -qF "$1"; }
+new_window() { win_ids | sort -u | comm -13 <(printf '%s\n' "$1") - | grep -qiE "$UUID"; }
+newest_window() { win_ids | sort -u | comm -13 <(printf '%s\n' "$1") - | grep -iE "$UUID" | head -1; }
+
+reset_srv() { srv kill-server 2>/dev/null || true; wait_until 5 srv_down || true; mkdir -p "$SRVDIR"; }
+new_session() {  # $1=session name, $2.. = extra new-session args; waits for prompt paint
+  local s="$1"; shift; srv new-session -d -s "$s" "$@"; wait_until 10 session_painted "$s" || true;
+}
+gen_scrollback() {  # send n Enters, wait until history actually grows to n rows
+  local s="$1" n="$2" i; for ((i=0;i<n;i++)); do srv send-keys -t "$s" Enter; done
+  wait_until 10 hist_at_least "$s" "$n" || true
+}
 attach_window() {
   local before; before=$(win_ids | sort -u)
-  cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1; sleep 3
-  win_ids | sort -u | comm -13 <(printf '%s\n' "$before") - | grep -iE "$UUID" | head -1
+  cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1
+  wait_until 25 new_window "$before" || true
+  newest_window "$before"
+}
+# Kill ONLY the cmux-owned ssh ControlMaster for this server (used to force a
+# reconnect). A broad `pkill -f "ssh.*$SRV"` treats the alias as a regex and can
+# match unrelated user ssh; instead resolve specific PIDs whose command line
+# carries the cmux ssh ControlPath (~/.cmux/ssh) AND this server's alias, and kill
+# only those PIDs.
+kill_srv_ssh() {
+  local pids
+  pids=$(pgrep -fl ssh 2>/dev/null | awk -v s="$SRV" '/\.cmux\/ssh\// && index($0, s) {print $1}')
+  if [ -z "$pids" ]; then echo "  (reconnect: no cmux ssh for $SRV found)"; return 0; fi
+  # shellcheck disable=SC2086
+  kill $pids 2>/dev/null || true
+}
+
+R=""; M=""
+# Compare the mirror's visible screen to the remote pane's, retrying until they
+# match or a deadline passes (attach/reflow settles asynchronously). Requires a
+# NON-EMPTY remote capture so a failed capture (both empty) can never false-PASS.
+compare_settled() {  # $1=remote_session  $2=mirror_window ; sets R,M ; 0 on match
+  local rs="$1" w="$2" deadline=$(( SECONDS + 20 ))
+  while :; do
+    R=$(remote_visible "$rs") || R=""
+    M=$(mirror_visible "$w") || M=""
+    { [ -n "$R" ] && [ "$R" = "$M" ]; } && return 0
+    [ "$SECONDS" -ge "$deadline" ] && return 1
+    sleep 0.5
+  done
 }
 
 PASS=0; FAIL=0; FAILED=""
 assert_match() {  # $1=label  $2=remote_session  $3=mirror_window
-  local label="$1" rs="$2" w="$3" r m i
+  local label="$1" rs="$2" w="$3"
   if [ -z "$w" ]; then FAIL=$((FAIL+1)); FAILED="$FAILED $label(no-window)"; echo "  FAIL  $label  (no mirror window)"; return; fi
-  # Re-compare a few times before failing: the mirror sizes the remote client on
-  # attach (refresh-client -C) and the pane reflows asynchronously, so the settled
-  # frame can land a beat after the initial 3s wait. A real render bug stays
-  # mismatched across every retry; only a slow settle is absorbed here.
-  for i in 1 2 3 4 5; do
-    r=$(remote_visible "$rs"); m=$(mirror_visible "$w")
-    [ "$r" = "$m" ] && break
-    sleep 1.5
-  done
-  if [ "$r" = "$m" ]; then
+  if compare_settled "$rs" "$w"; then
     PASS=$((PASS+1)); echo "  PASS  $label"
   else
     FAIL=$((FAIL+1)); FAILED="$FAILED $label"
     echo "  FAIL  $label  ($(remote_pane_info "$rs"))"
-    echo "        remote=$(printf '%s' "$r" | grep -c .) non-blank lines  mirror=$(printf '%s' "$m" | grep -c .) non-blank lines"
-    paste <(printf '%s\n' "$r" | cat -n) <(printf '%s\n' "$m" | cat -n) | head -8 | sed 's/^/        /'
+    echo "        remote=$(printf '%s' "$R" | grep -c .) non-blank lines  mirror=$(printf '%s' "$M" | grep -c .) non-blank lines"
+    paste <(printf '%s\n' "$R" | cat -n) <(printf '%s\n' "$M" | cat -n) | head -8 | sed 's/^/        /'
   fi
-  cli close-window --window "$w" >/dev/null 2>&1; sleep 0.4
+  cli close-window --window "$w" >/dev/null 2>&1; wait_until 5 window_gone "$w" || true
 }
 
 echo "=== remote-tmux render-fidelity harness  tag=$CMUX_TAG  srv=$SRV ==="
 
-reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s1; sleep 0.8
+reset_srv; new_session s1
 assert_match "fresh-empty" s1 "$(attach_window)"
 
-reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s2; sleep 0.8; gen_scrollback s2 8
+reset_srv; new_session s2; gen_scrollback s2 8
 assert_match "scrollback-history" s2 "$(attach_window)"
 
-reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s3 -x 80 -y 12; sleep 0.8; gen_scrollback s3 6
+reset_srv; new_session s3 -x 80 -y 12; gen_scrollback s3 6
 assert_match "mirror-taller-HgtP" s3 "$(attach_window)"
 
-reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s4 -x 80 -y 60; sleep 0.8; gen_scrollback s4 4
+reset_srv; new_session s4 -x 80 -y 60; gen_scrollback s4 4
 assert_match "mirror-shorter-HltP" s4 "$(attach_window)"
 
-reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s6; sleep 0.8; gen_scrollback s6 5
+reset_srv; new_session s6; gen_scrollback s6 5
 before=$(win_ids | sort -u)
-cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1; cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1; sleep 3
-assert_match "rapid-reattach" s6 "$(win_ids | sort -u | comm -13 <(printf '%s\n' "$before") - | grep -iE "$UUID" | head -1)"
+cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1; cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1
+wait_until 25 new_window "$before" || true
+assert_match "rapid-reattach" s6 "$(newest_window "$before")"
 
-reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s7; sleep 0.8; gen_scrollback s7 5
-before=$(win_ids | sort -u); cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1; sleep 3
-W7=$(win_ids | sort -u | comm -13 <(printf '%s\n' "$before") - | grep -iE "$UUID" | head -1)
-pkill -f "ssh.*$SRV" 2>/dev/null; sleep 6
-r=$(remote_visible s7); m=$(mirror_visible "$W7")
-if [ "$r" = "$m" ]; then PASS=$((PASS+1)); echo "  PASS  reconnect-reseed"; else FAIL=$((FAIL+1)); FAILED="$FAILED reconnect-reseed"; echo "  FAIL  reconnect-reseed"; fi
-cli close-window --window "$W7" >/dev/null 2>&1; sleep 0.4
+reset_srv; new_session s7; gen_scrollback s7 5
+before=$(win_ids | sort -u); cli ssh-tmux "$SRV" --no-focus >/dev/null 2>&1
+wait_until 25 new_window "$before" || true
+W7=$(newest_window "$before")
+kill_srv_ssh
+if [ -n "$W7" ] && compare_settled s7 "$W7"; then
+  PASS=$((PASS+1)); echo "  PASS  reconnect-reseed"
+else
+  FAIL=$((FAIL+1)); FAILED="$FAILED reconnect-reseed"; echo "  FAIL  reconnect-reseed"
+fi
+cli close-window --window "$W7" >/dev/null 2>&1; wait_until 5 window_gone "$W7" || true
 
-reset_srv; TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" new-session -d -s s8 -x 100 -y 20; sleep 0.8; gen_scrollback s8 6
+reset_srv; new_session s8 -x 100 -y 20; gen_scrollback s8 6
 assert_match "midsize-pane" s8 "$(attach_window)"
 
 echo "=== RESULT: PASS=$PASS FAIL=$FAIL ==="
 [ "$FAIL" -gt 0 ] && echo "FAILED:$FAILED"
-TMUX_TMPDIR="$SRVDIR" "$TMUXBIN" kill-server 2>/dev/null
+srv kill-server 2>/dev/null || true
 exit "$FAIL"


### PR DESCRIPTION
When cmux mirrors a remote tmux session, the mirror sometimes paints wrong the moment it appears: prompts pile up at the top of the screen, old scrollback shows where the live screen should be, the cursor sits a few rows too high, or a stray zsh `%` is left behind.

It's easiest to reproduce when the cmux window isn't the same size as the remote session — attach an 80×12 session into a tall window and you'll see it — but a normal prompt with blank lines around it is enough to trigger the first bug on its own, and reconnecting runs the whole path again.

### Background

tmux control mode (`-CC`) only streams output produced *after* you attach; it never replays what's already on the pane. So on attach cmux rebuilds the screen itself from a `capture-pane` snapshot and then restores the cursor and modes. Two things were wrong with that snapshot.

### Blank lines were dropped

The control-stream parser bailed on empty lines before adding them to the command's output block, so the snapshot came back missing its blank rows and the prompts collapsed into a stack. Blank lines inside a block are now kept (and counted against the block's byte budget).

### The snapshot ignored the window size

`capture-pane` returns the pane at its own size. When the cmux window is taller, the snapshot is shorter than the screen, so old scrollback ends up visible and the cursor lands too high. The seed now pads the snapshot with enough blank rows to push the history back into scrollback and line the visible rows up with the restored cursor.

A single pane grows to whatever size cmux asks for (`refresh-client -C`), so the first paint is a best-effort guess; cmux re-captures once the pane actually reflows, but only when its height really changed, so a noisy window can't spin up a capture loop. The mirror never goes blank in between, even if another client is holding the pane smaller. Remote `pane_height` is range-checked before it's trusted.

### Alternatives considered

**Resize first, then capture once.** Push the size, wait for it to settle, take one snapshot that already matches — no padding and far less state. The problem is `refresh-client` only tells you tmux processed the resize, not that the program in the pane saw SIGWINCH and repainted. That isn't enough for full-screen apps, "wait until output goes quiet" never settles under something like `top` or a running build, and the first paint gets slower. The byte-count check here is a tighter guarantee — it catches real output arriving between the snapshot and the cursor restore — so capture-first stayed.

**Letterbox the mirror to the pane's size** instead of driving the remote to the window size. Avoids the mismatch but wastes the window and fights how cmux sizes everything else.

**Let live output redraw it.** Works for full-screen apps that repaint on resize, useless for a shell, which never re-emits its scrollback — which is the original bug.

### Tests

- A failing test for the dropped blank lines lands first; the fix turns it green.
- Unit tests for the padding (taller, equal, shorter), the screen clear, the `pane_height` parse and range check, and the single-pane gate.
- `scripts/remote-tmux-render-harness.sh` diffs the mirror against the real pane after a fresh attach, scrollback redraw, taller and shorter windows, fast re-attach, reconnect, and a mid-size pane.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved remote tmux pane seeding/re-seeding for consistent rendering across initial connect, reconnects, and layout/resize changes, including deferred geometry reseeds.
  * Added shared clear-and-home escape sequencing plus pane-height-aware padding for accurate cursor restoration.
  * Added a render verification harness to compare normalized remote vs mirror output across multiple scenarios.

* **Bug Fixes**
  * Preserved blank lines inside tmux command blocks and extended seed-related error cleanup and bounded reseed retries.
  * Fixed reconnect reseed clear behavior and refined pane-state painting/deferred row handling.

* **Tests**
  * Expanded coverage for stream parsing, seed painting/padding, and pane-height parsing rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->