### PR TITLE
Fix iOS workspace toolbar leading glass chrome

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
@@ -62,27 +62,24 @@ struct AgentChatDemoScreen: View {
             baseChatScreen(for: stack)
                 .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
                 .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        WorkspaceBackButton(
+                    WorkspaceLeadingToolbarChrome(
+                        backButtonConfiguration: WorkspaceBackButtonConfiguration(
                             unreadCount: 0,
                             badgeContrast: .darkBackground,
                             action: {}
-                        )
-                    }
-                    ToolbarItem(placement: .principal) {
-                        WorkspaceTitleMenu(
-                            contentWidth: contentWidth,
-                            hasBackButton: true,
-                            hasTrailingCluster: true,
-                            hasChatToggle: true
-                        ) {
+                        ),
+                        contentWidth: contentWidth,
+                        hasTrailingCluster: true,
+                        hasChatToggle: true,
+                        isTitleMenuEnabled: true,
+                        menuContent: {
                             Button(L10n.string("mobile.workspace.rename.title", defaultValue: "Rename Workspace")) {}
                                 .accessibilityIdentifier("MobileWorkspaceTitleRenameMenuItem")
                             Button(L10n.string("mobile.workspace.markRead", defaultValue: "Mark as Read")) {}
                                 .accessibilityIdentifier("MobileWorkspaceTitleReadStateMenuItem")
-                        } label: {
-                            header(for: stack)
                         }
+                    ) {
+                        header(for: stack)
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileNavTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileNavTitleWidth.swift
@@ -1,39 +1,44 @@
 import CoreGraphics
 
-/// Width math for the centered glass nav-bar title pill, factored out so the
-/// "grow the middle as much as possible" rule is pure and testable.
+/// Width math for the leading glass workspace title pill, factored out so the
+/// "grow until the trailing chrome would overlap" rule is pure and testable.
 ///
-/// The title is a screen-centered `.principal` toolbar item, so it is bound by
-/// TWICE the wider of the two visible side clusters (the leading custom back
-/// button vs. the trailing terminal picker plus, when present, the chat toggle).
-/// Reserving only the visible side chrome lets a long title use as much of the
-/// center as it safely can before truncating.
+/// The title lives in the same leading toolbar item as the custom back button.
+/// Its cap therefore reserves the leading margin/back button once and the
+/// trailing terminal picker/chat controls once. It must not use centered
+/// principal-title math, because that lets SwiftUI re-own placement and pull the
+/// title away from the back button.
 struct MobileNavTitleWidth {
     let contentWidth: CGFloat
     let hasBackButton: Bool
     let hasTrailingCluster: Bool
     let hasChatToggle: Bool
 
-    /// Reserved width of the leading cluster: the custom back button (chevron +
-    /// optional unread-count pill) plus the bar's leading margin.
-    static let leadingReserve: CGFloat = 84
+    /// Left edge margin inside the navigation bar.
+    static let leadingMargin: CGFloat = 16
+    /// Custom back button reserve: chevron + optional unread-count pill.
+    static let backButtonReserve: CGFloat = 58
+    /// Space between the back button glass and title glass.
+    static let interControlSpacing: CGFloat = 8
     /// Reserved width of the trailing cluster with just the terminal picker.
     static let trailingReserveBase: CGFloat = 60
     /// Extra width the agent-chat toggle adds to the trailing cluster.
     static let chatToggleReserve: CGFloat = 56
+    /// Gap between the leading title pill and trailing controls.
+    static let trailingSafetyGap: CGFloat = 12
     /// Fallback before the pane width has been measured.
     static let unmeasuredFallback: CGFloat = 180
-    /// Preferred minimum width when the safe centered slot can fit it.
+    /// Preferred minimum width when the safe leading slot can fit it.
     static let floor: CGFloat = 96
 
-    /// Max safe width for the centered title pill.
+    /// Max safe width for the leading title pill.
     var cap: CGFloat {
         guard contentWidth > 0 else { return Self.unmeasuredFallback }
-        let leading = hasBackButton ? Self.leadingReserve : 0
+        let leading = Self.leadingMargin
+            + (hasBackButton ? Self.backButtonReserve + Self.interControlSpacing : 0)
         let trailing = hasTrailingCluster
             ? Self.trailingReserveBase + (hasChatToggle ? Self.chatToggleReserve : 0)
             : 0
-        let widerSide = max(leading, trailing)
-        return max(0, contentWidth - 2 * widerSide)
+        return max(0, contentWidth - leading - trailing - Self.trailingSafetyGap)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChatPane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChatPane.swift
@@ -38,7 +38,7 @@ struct WorkspaceChatPane<TitleMenuContent: View>: View {
 
     @State private var accessoryConfiguration = TerminalAccessoryConfiguration.shared
     @State private var isShowingShortcutSettings = false
-    /// Full content width, used to bound the centered toolbar header so a long
+    /// Full content width, used to bound the leading toolbar header so a long
     /// workspace name truncates before the trailing toolbar buttons.
     @State private var contentWidth: CGFloat = 0
 
@@ -58,48 +58,29 @@ struct WorkspaceChatPane<TitleMenuContent: View>: View {
             // which would be dropped under the workspace's own chrome.
             .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
             .toolbar {
-                if backButtonConfiguration != nil {
-                    ToolbarItem(placement: .topBarLeading) {
-                        workspaceBackToolbarButton
-                    }
-                }
-                ToolbarItem(placement: .principal) {
-                    // WorkspaceDetailView mounts the terminal picker/chat
-                    // toggle in a sibling trailing toolbar item.
-                    WorkspaceTitleMenu(
-                        contentWidth: contentWidth,
-                        hasBackButton: backButtonConfiguration != nil,
-                        hasTrailingCluster: true,
-                        hasChatToggle: true,
-                        isEnabled: isTitleMenuEnabled,
-                        menuContent: titleMenuContent
-                    ) {
-                        ChatSessionHeaderView(
-                            descriptor: conversation.descriptor,
-                            agentState: conversation.agentState,
-                            isConnected: conversation.isConnected,
-                            titleOverride: workspaceName,
-                            subtitle: tabName,
-                            style: .toolbarCompact
-                        )
-                    }
+                // WorkspaceDetailView mounts the terminal picker/chat toggle in a
+                // sibling trailing toolbar item.
+                WorkspaceLeadingToolbarChrome(
+                    backButtonConfiguration: backButtonConfiguration,
+                    contentWidth: contentWidth,
+                    hasTrailingCluster: true,
+                    hasChatToggle: true,
+                    isTitleMenuEnabled: isTitleMenuEnabled,
+                    menuContent: titleMenuContent
+                ) {
+                    ChatSessionHeaderView(
+                        descriptor: conversation.descriptor,
+                        agentState: conversation.agentState,
+                        isConnected: conversation.isConnected,
+                        titleOverride: workspaceName,
+                        subtitle: tabName,
+                        style: .toolbarCompact
+                    )
                 }
             }
         }
         .sheet(isPresented: $isShowingShortcutSettings) {
             TerminalShortcutsSettingsView(scope: .agentChat)
-        }
-    }
-
-    @ViewBuilder
-    private var workspaceBackToolbarButton: some View {
-        if let backButtonConfiguration {
-            WorkspaceBackButton(
-                unreadCount: backButtonConfiguration.unreadCount,
-                badgeContrast: backButtonConfiguration.badgeContrast,
-                action: backButtonConfiguration.action
-            )
-            .mobileGlassCompactToolbarControl()
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+DerivedState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+DerivedState.swift
@@ -15,8 +15,8 @@ extension WorkspaceDetailView {
 
     var terminalTopPadding: CGFloat { 4 }
 
-    /// iOS renders the workspace title as a custom principal toolbar item. Keep
-    /// the system title empty there so it does not draw a second centered title.
+    /// iOS renders the workspace title as custom toolbar chrome. Keep the system
+    /// title empty there so it does not draw a second centered title.
     var systemNavigationTitle: String {
         #if os(iOS)
         ""

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -49,7 +49,7 @@ struct WorkspaceDetailView: View {
     /// editable text (seeded with the current name when presented).
     @State var isRenamePresented = false
     @State var renameText = ""
-    /// Live pane width, used to width-cap the centered glass title pill so a long
+    /// Live pane width, used to width-cap the leading glass title pill so a long
     /// workspace name truncates instead of underlapping the toolbar buttons.
     @State private var contentWidth: CGFloat = 0
     /// Captured at the moment the "View as Text" action is tapped so the
@@ -140,24 +140,19 @@ struct WorkspaceDetailView: View {
         .navigationTitle("")
         .mobileTerminalNavigationChrome()
         .toolbar {
-            if backButtonConfiguration != nil {
-                ToolbarItem(placement: .topBarLeading) { workspaceBackToolbarButton }
-            }
-            ToolbarItem(placement: .principal) {
-                WorkspaceTitleMenu(
-                    contentWidth: contentWidth,
-                    hasBackButton: backButtonConfiguration != nil,
-                    hasTrailingCluster: true,
-                    hasChatToggle: shouldShowChatToggle,
-                    isEnabled: hasTitleMenuActions,
-                    menuContent: { titleMenuContent }
-                ) {
-                    Text(browser.title ?? workspace.name)
-                        .font(.headline)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .foregroundStyle(TerminalPalette.foreground)
-                }
+            WorkspaceLeadingToolbarChrome(
+                backButtonConfiguration: backButtonConfiguration,
+                contentWidth: contentWidth,
+                hasTrailingCluster: true,
+                hasChatToggle: shouldShowChatToggle,
+                isTitleMenuEnabled: hasTitleMenuActions,
+                menuContent: { titleMenuContent }
+            ) {
+                Text(browser.title ?? workspace.name)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .foregroundStyle(TerminalPalette.foreground)
             }
             ToolbarItem(placement: .topBarTrailing) {
                 toolbarTrailingCluster
@@ -307,20 +302,15 @@ struct WorkspaceDetailView: View {
         #endif
         .toolbar {
             #if os(iOS)
-            if backButtonConfiguration != nil {
-                ToolbarItem(placement: .topBarLeading) { workspaceBackToolbarButton }
-            }
-            ToolbarItem(placement: .principal) {
-                WorkspaceTitleMenu(
-                    contentWidth: contentWidth,
-                    hasBackButton: backButtonConfiguration != nil,
-                    hasTrailingCluster: true,
-                    hasChatToggle: shouldShowChatToggle,
-                    isEnabled: hasTitleMenuActions,
-                    menuContent: { titleMenuContent }
-                ) {
-                    WorkspaceToolbarTitleView(title: workspace.name, subtitle: selectedToolbarSubtitle)
-                }
+            WorkspaceLeadingToolbarChrome(
+                backButtonConfiguration: backButtonConfiguration,
+                contentWidth: contentWidth,
+                hasTrailingCluster: true,
+                hasChatToggle: shouldShowChatToggle,
+                isTitleMenuEnabled: hasTitleMenuActions,
+                menuContent: { titleMenuContent }
+            ) {
+                WorkspaceToolbarTitleView(title: workspace.name, subtitle: selectedToolbarSubtitle)
             }
             ToolbarItem(placement: .topBarTrailing) {
                 toolbarTrailingCluster
@@ -357,19 +347,6 @@ struct WorkspaceDetailView: View {
     }
 
     #if os(iOS)
-    /// Compact-stack back button rendered as its own leading toolbar island.
-    @ViewBuilder
-    private var workspaceBackToolbarButton: some View {
-        if let backButtonConfiguration {
-            WorkspaceBackButton(
-                unreadCount: backButtonConfiguration.unreadCount,
-                badgeContrast: backButtonConfiguration.badgeContrast,
-                action: backButtonConfiguration.action
-            )
-            .mobileGlassCompactToolbarControl()
-        }
-    }
-
     var titleMenuContent: some View {
         WorkspaceTitleMenuContent(
             workspace: workspace,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceLeadingToolbarChrome.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceLeadingToolbarChrome.swift
@@ -1,0 +1,44 @@
+import CmuxMobileSupport
+import SwiftUI
+
+/// Single owner for the workspace detail's leading navigation chrome.
+///
+/// Keep the back button and title in one leading toolbar content owner so
+/// SwiftUI cannot promote the title into the centered principal slot. Each
+/// control keeps its own island styling, while the shared toolbar item keeps
+/// the cluster left-aligned across detail transitions.
+struct WorkspaceLeadingToolbarChrome<TitleLabel: View, MenuContent: View>: ToolbarContent {
+    let backButtonConfiguration: WorkspaceBackButtonConfiguration?
+    let contentWidth: CGFloat
+    let hasTrailingCluster: Bool
+    let hasChatToggle: Bool
+    let isTitleMenuEnabled: Bool
+    @ViewBuilder let menuContent: () -> MenuContent
+    @ViewBuilder let titleLabel: () -> TitleLabel
+
+    var body: some ToolbarContent {
+        ToolbarItem(placement: .topBarLeading) {
+            HStack(spacing: MobileNavTitleWidth.interControlSpacing) {
+                if let backButtonConfiguration {
+                    WorkspaceBackButton(
+                        unreadCount: backButtonConfiguration.unreadCount,
+                        badgeContrast: backButtonConfiguration.badgeContrast,
+                        action: backButtonConfiguration.action
+                    )
+                    .mobileGlassCompactToolbarControl()
+                    .fixedSize(horizontal: true, vertical: false)
+                }
+
+                WorkspaceTitleMenu(
+                    contentWidth: contentWidth,
+                    hasBackButton: backButtonConfiguration != nil,
+                    hasTrailingCluster: hasTrailingCluster,
+                    hasChatToggle: hasChatToggle,
+                    isEnabled: isTitleMenuEnabled,
+                    menuContent: menuContent,
+                    label: titleLabel
+                )
+            }
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileNavTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileNavTitleWidthTests.swift
@@ -33,9 +33,12 @@ import Testing
         #expect(withoutToggle > withToggle)
     }
 
-    @Test func measuredCapNeverExceedsSafeCenteredSlot() {
+    @Test func measuredCapReservesLeadingAndTrailingChrome() {
         let trailing = MobileNavTitleWidth.trailingReserveBase + MobileNavTitleWidth.chatToggleReserve
-        #expect(cap(320) == 320 - 2 * trailing)
+        let leading = MobileNavTitleWidth.leadingMargin
+            + MobileNavTitleWidth.backButtonReserve
+            + MobileNavTitleWidth.interControlSpacing
+        #expect(cap(320) == 320 - leading - trailing - MobileNavTitleWidth.trailingSafetyGap)
     }
 
     @Test func moreRoomWithoutBackButton() {
@@ -44,12 +47,15 @@ import Testing
         #expect(withoutBack > withBack)
     }
 
-    @Test func centeredCapReservesWiderSideSymmetrically() {
+    @Test func leadingCapDoesNotReserveSymmetrically() {
         let measured = cap(393)
-        let expected = 393 - 2 * max(
-            MobileNavTitleWidth.leadingReserve,
-            MobileNavTitleWidth.trailingReserveBase + MobileNavTitleWidth.chatToggleReserve
-        )
+        let expected = 393
+            - MobileNavTitleWidth.leadingMargin
+            - MobileNavTitleWidth.backButtonReserve
+            - MobileNavTitleWidth.interControlSpacing
+            - MobileNavTitleWidth.trailingReserveBase
+            - MobileNavTitleWidth.chatToggleReserve
+            - MobileNavTitleWidth.trailingSafetyGap
         #expect(measured == expected)
     }
 
@@ -64,12 +70,19 @@ import Testing
     @Test func noTrailingClusterDoesNotReserveChatToggle() {
         let withTrailing = cap(393)
         let withoutTrailing = cap(393, hasTrailingCluster: false)
+        let expected = 393
+            - MobileNavTitleWidth.leadingMargin
+            - MobileNavTitleWidth.backButtonReserve
+            - MobileNavTitleWidth.interControlSpacing
+            - MobileNavTitleWidth.trailingSafetyGap
 
-        #expect(withoutTrailing == 393 - 2 * MobileNavTitleWidth.leadingReserve)
+        #expect(withoutTrailing == expected)
         #expect(withoutTrailing > withTrailing)
     }
 
     @Test func noSideClustersCanUseMeasuredWidth() {
-        #expect(cap(393, hasBackButton: false, hasTrailingCluster: false) == 393)
+        #expect(cap(393, hasBackButton: false, hasTrailingCluster: false) == 393
+            - MobileNavTitleWidth.leadingMargin
+            - MobileNavTitleWidth.trailingSafetyGap)
     }
 }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -285,10 +285,23 @@ final class cmuxUITests: XCTestCase {
 
         let app = try launchConnectedApp(port: port)
         try openSelectedWorkspaceIfNeeded(app)
-        XCTAssertTrue(app.buttons["MobileWorkspaceBackButton"].waitForExistence(timeout: 4))
-        XCTAssertTrue(app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 4))
+        let backButton = app.buttons["MobileWorkspaceBackButton"]
+        let titleMenu = app.buttons["MobileWorkspaceTitleMenu"]
+        let terminalDropdown = app.buttons["MobileTerminalDropdown"]
+        XCTAssertTrue(backButton.waitForExistence(timeout: 4))
+        XCTAssertTrue(titleMenu.waitForExistence(timeout: 4))
+        XCTAssertTrue(terminalDropdown.waitForExistence(timeout: 4))
+        XCTAssertTrue(
+            waitForWorkspaceTitleLeadingAndSeparated(
+                titleMenu: titleMenu,
+                backButton: backButton,
+                trailingControl: terminalDropdown,
+                in: app,
+                timeout: 4
+            )
+        )
 
-        tapCompactToolbarTitleMenu(app.buttons["MobileWorkspaceTitleMenu"], in: app)
+        tapCompactToolbarTitleMenu(titleMenu, in: app)
         XCTAssertTrue(app.buttons["MobileWorkspaceTitleRenameMenuItem"].waitForExistence(timeout: 4))
         XCTAssertTrue(app.buttons["MobileWorkspaceTitleReadStateMenuItem"].exists)
         XCTAssertTrue(app.buttons["MobileWorkspaceTitleCloseMenuItem"].exists)
@@ -598,7 +611,7 @@ final class cmuxUITests: XCTestCase {
             )
         )
         XCTAssertTrue(
-            waitForWorkspaceTitleCenteredAndSeparated(
+            waitForWorkspaceTitleLeadingAndSeparated(
                 titleMenu: titleMenu,
                 backButton: backButton,
                 trailingControl: chatToggle,
@@ -2135,7 +2148,7 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    private func waitForWorkspaceTitleCenteredAndSeparated(
+    private func waitForWorkspaceTitleLeadingAndSeparated(
         titleMenu: XCUIElement,
         backButton: XCUIElement,
         trailingControl: XCUIElement,
@@ -2145,9 +2158,8 @@ final class cmuxUITests: XCTestCase {
         line: UInt = #line
     ) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
-        let window = app.windows.firstMatch
-        let windowFrame = window.exists ? window.frame : app.frame
-        let centerTolerance = max(windowFrame.width * 0.10, 28)
+        _ = app
+        let horizontalGapRange: ClosedRange<CGFloat> = 18...42
         var lastTitleFrame = titleMenu.frame
         var lastBackFrame = backButton.frame
         var lastTrailingFrame = trailingControl.frame
@@ -2156,9 +2168,10 @@ final class cmuxUITests: XCTestCase {
             lastTitleFrame = titleMenu.frame
             lastBackFrame = backButton.frame
             lastTrailingFrame = trailingControl.frame
+            let gap = lastTitleFrame.minX - lastBackFrame.maxX
             if lastTitleFrame.midY > 60,
-               abs(lastTitleFrame.midX - windowFrame.midX) <= centerTolerance,
-               lastTitleFrame.minX > lastBackFrame.maxX + 16,
+               abs(lastTitleFrame.midY - lastBackFrame.midY) <= 4,
+               horizontalGapRange.contains(gap),
                lastTitleFrame.maxX < lastTrailingFrame.minX - 2 {
                 return true
             }
@@ -2166,7 +2179,7 @@ final class cmuxUITests: XCTestCase {
         }
 
         XCTFail(
-            "Workspace title must be centered as its own toolbar island, separated from leading and trailing controls. title=\(lastTitleFrame), back=\(lastBackFrame), trailing=\(lastTrailingFrame), window=\(windowFrame)",
+            "Workspace title must remain a leading glass island immediately after the back button, separated from trailing controls. title=\(lastTitleFrame), back=\(lastBackFrame), trailing=\(lastTrailingFrame)",
             file: file,
             line: line
         )

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2159,7 +2159,7 @@ final class cmuxUITests: XCTestCase {
     ) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         _ = app
-        let horizontalGapRange: ClosedRange<CGFloat> = 18...42
+        let horizontalGapRange: ClosedRange<CGFloat> = 4...18
         var lastTitleFrame = titleMenu.frame
         var lastBackFrame = backButton.frame
         var lastTrailingFrame = trailingControl.frame


### PR DESCRIPTION
## Summary
- keep the iOS workspace back button and title in one leading toolbar owner so SwiftUI cannot recenter or drop the title during transitions
- render the back and title as separate compact glass islands with shared leading width math
- update UI coverage to require a leading, separated title instead of accepting a centered principal title

## Verification
- ./ios/scripts/reload.sh --tag leadtb --no-launch
- xcodebuild test -workspace ios/cmux.xcworkspace -scheme cmux-ios -destination 'id=C9D82663-886D-4EBD-92A0-96CF38A42FF3' -derivedDataPath /Users/abdulazizalbahar/Library/Developer/Xcode/DerivedData/cmux-ios-leadtb -only-testing:cmuxUITests/cmuxUITests/testInlineWorkspaceTitleMenuShowsWorkspaceActions
- Simulator screenshots: /tmp/cmux-leadtb-inline-preview-final2-1s.png, /tmp/cmux-leadtb-inline-preview-final2-5s.png
- Simulator video/contact sheet: /tmp/cmux-leadtb-toolbar-final.mov, /tmp/cmux-leadtb-toolbar-contact.png

## Notes
- The connected no-agent UI test was updated to assert leading toolbar chrome, but the local run hung before reaching toolbar setup in the existing mock-host attach path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785426615&installation_id=133855650&pr_number=7110&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7110&signature=a44a7ce752175751800e6d6622d502cd4a84973def13c6cf53162e162f5174fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS workspace toolbar so the back button and title stay locked together on the left and remain stable during transitions. Switches title width to leading-based caps with a safety gap to prevent overlap with trailing controls.

- **Bug Fixes**
  - Keep back button and title in one leading toolbar item to prevent principal recentering or title drops.
  - Apply leading width cap that reserves margin, back button, spacing, trailing cluster, and a safety gap so long titles truncate before the terminal picker/chat toggle.
  - Strengthened UI tests to require a leading, separated title aligned with the back button and clear of trailing controls.

- **Refactors**
  - Added `WorkspaceLeadingToolbarChrome` and adopted it in workspace detail, chat pane, and the demo screen to own the leading cluster (back + title).
  - Rewrote `MobileNavTitleWidth` for leading rules with explicit `leadingMargin`, `backButtonReserve`, `interControlSpacing`, and `trailingSafetyGap` constants; updated unit tests accordingly.

<sup>Written for commit 5f5cecaa47a82155ab1231b700390b059a77c35f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated workspace top-bar layout to use a unified leading toolbar area for the back button, title, and actions.
  * Improved title sizing so the workspace header can expand until it would overlap other toolbar controls.

* **Bug Fixes**
  * Refined iOS toolbar spacing and alignment for workspace, chat, and terminal views.
  * Adjusted UI tests to verify the new leading-and-separated toolbar behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->