### PR TITLE
Keep iOS chat top edge visible during keyboard

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController+Debug.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController+Debug.swift
@@ -16,7 +16,9 @@ extension ChatKeyboardTrackingViewController {
                 guard let self,
                       tableView != nil
                 else { return nil }
-                return self.presentationAdjustedFrameInWindow(for: self.transcriptClipView)?.maxY
+                return self.presentationAdjustedFrameInWindow(
+                    for: self.transcriptHostingController.view.superview
+                )?.maxY
             }
             tableView.keyboardDebugComposerPresentationMinYProvider = { [weak self] in
                 guard let self else { return nil }
@@ -62,7 +64,7 @@ extension ChatKeyboardTrackingViewController {
         guard let targetView,
               let window = targetView.window
         else {
-            return targetView.flatMap { frameInWindow(for: $0) }
+            return nil
         }
         let sourceLayer = targetView.layer.presentation() ?? targetView.layer
         let targetLayer = window.layer.presentation() ?? window.layer

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController+Debug.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController+Debug.swift
@@ -68,7 +68,7 @@ extension ChatKeyboardTrackingViewController {
         }
         let sourceLayer = targetView.layer.presentation() ?? targetView.layer
         let targetLayer = window.layer.presentation() ?? window.layer
-        return sourceLayer.convert(targetView.bounds, to: targetLayer)
+        return sourceLayer.convert(sourceLayer.bounds, to: targetLayer)
     }
 }
 #endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController+Debug.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController+Debug.swift
@@ -14,10 +14,9 @@ extension ChatKeyboardTrackingViewController {
             let tableFrame = frameInWindow(for: tableView)
             tableView.keyboardDebugPresentationFrameMaxYProvider = { [weak self, weak tableView] in
                 guard let self,
-                      let tableView,
-                      let frame = self.frameInWindow(for: tableView)
+                      tableView != nil
                 else { return nil }
-                return frame.maxY + self.presentationDeltaY() - tableView.composerOverlayBottomInset
+                return self.presentationAdjustedFrameInWindow(for: self.transcriptClipView)?.maxY
             }
             tableView.keyboardDebugComposerPresentationMinYProvider = { [weak self] in
                 guard let self else { return nil }
@@ -30,7 +29,7 @@ extension ChatKeyboardTrackingViewController {
             tableView.keyboardDebugBottomConstraint = -overlap
             tableView.keyboardDebugComposerMinY = composerFrame?.minY ?? 0
             tableView.keyboardDebugComposerPresentationMinY = composerPresentationFrame?.minY ?? 0
-            tableView.keyboardDebugPresentationFrameMaxY = (tableFrame?.maxY ?? 0) + presentationDeltaY()
+            tableView.keyboardDebugPresentationFrameMaxY = tableFrame?.maxY ?? 0
             tableView.keyboardDebugAnimationID = keyboardTransitionID
             tableView.keyboardDebugAnimationActive = isKeyboardAnimationActive
             tableView.keyboardDebugAnimationProgress = animationProgress
@@ -54,10 +53,6 @@ extension ChatKeyboardTrackingViewController {
         return max(0, view.bounds.maxY - guideFrame.minY)
     }
 
-    private func presentationDeltaY() -> CGFloat {
-        keyboardOverlap - currentVisibleKeyboardOverlap()
-    }
-
     private func frameInWindow(for targetView: UIView) -> CGRect? {
         guard let window = targetView.window else { return nil }
         return targetView.convert(targetView.bounds, to: window)
@@ -65,9 +60,13 @@ extension ChatKeyboardTrackingViewController {
 
     private func presentationAdjustedFrameInWindow(for targetView: UIView?) -> CGRect? {
         guard let targetView,
-              let frame = frameInWindow(for: targetView)
-        else { return nil }
-        return frame.offsetBy(dx: 0, dy: presentationDeltaY())
+              let window = targetView.window
+        else {
+            return targetView.flatMap { frameInWindow(for: $0) }
+        }
+        let sourceLayer = targetView.layer.presentation() ?? targetView.layer
+        let targetLayer = window.layer.presentation() ?? window.layer
+        return sourceLayer.convert(targetView.bounds, to: targetLayer)
     }
 }
 #endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
@@ -129,7 +129,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
     private func installLayoutConstraints() {
         let composerHeightConstraint = composerHostingController.view.heightAnchor.constraint(equalToConstant: 0)
         let transcriptClipTopConstraint = transcriptClipView.topAnchor.constraint(equalTo: keyboardContentView.topAnchor)
-        let transcriptClipBottomConstraint = transcriptClipView.bottomAnchor.constraint(equalTo: composerHostingController.view.topAnchor)
+        let transcriptClipBottomConstraint = transcriptClipView.bottomAnchor.constraint(equalTo: keyboardContentView.bottomAnchor)
         let transcriptHeightConstraint = transcriptHostingController.view.heightAnchor.constraint(equalToConstant: 0)
         let composerBottomConstraint = composerHostingController.view.bottomAnchor.constraint(equalTo: keyboardContentView.bottomAnchor)
         self.composerHeightConstraint = composerHeightConstraint
@@ -324,10 +324,14 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
             bottomSafeAreaUnderlap: safeAreaUnderlap
         )
         let adjustedBottomInset = overlayBottomInset + keyboardOverlap
+        let clipBottomConstant = transcriptClipBottomConstant(
+            composerHeight: composerHeight,
+            bottomSafeAreaUnderlap: safeAreaUnderlap
+        )
         let fullTranscriptHeight = max(0, layoutHeight)
         updateConstraint(composerHeightConstraint, to: composerHeight)
         updateConstraint(transcriptClipTopConstraint, to: 0)
-        updateConstraint(transcriptClipBottomConstraint, to: 0)
+        updateConstraint(transcriptClipBottomConstraint, to: clipBottomConstant)
         updateConstraint(transcriptHeightConstraint, to: fullTranscriptHeight)
         if let transcriptOverlayGeometry,
            abs(transcriptOverlayGeometry.composerBottomInset - overlayBottomInset) > 0.5 {
@@ -380,6 +384,16 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
     ) -> CGFloat {
         let visibleComposerHeight = showsComposer ? composerHeight : 0
         return max(0, ceil(visibleComposerHeight + bottomSafeAreaUnderlap))
+    }
+
+    private func transcriptClipBottomConstant(
+        composerHeight: CGFloat,
+        bottomSafeAreaUnderlap: CGFloat
+    ) -> CGFloat {
+        guard keyboardOverlap > 0.5 else {
+            return max(0, ceil(bottomSafeAreaUnderlap))
+        }
+        return -max(0, ceil(keyboardOverlap + composerHeight))
     }
 
     private func updateConstraint(_ constraint: NSLayoutConstraint?, to constant: CGFloat) {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
@@ -22,7 +22,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
     var excludedKeyboardDismissFrame: CGRect = .zero
 
     private let keyboardContentView = UIView(frame: .zero)
-    let transcriptClipView = UIView(frame: .zero)
+    private let transcriptClipView = UIView(frame: .zero)
     private let composerBackgroundView = UIVisualEffectView(effect: nil)
     let transcriptHostingController: UIHostingController<Transcript>
     let composerHostingController: UIHostingController<Composer>

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
@@ -302,12 +302,16 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
     private func stopKeyboardAnimation(removeAnimations: Bool) {
         isKeyboardAnimationActive = false
         if removeAnimations {
-            keyboardContentView.layer.removeAllAnimations()
-            transcriptClipView.layer.removeAllAnimations()
-            transcriptHostingController.view.layer.removeAllAnimations()
-            composerBackgroundView.layer.removeAllAnimations()
-            composerHostingController.view.layer.removeAllAnimations()
+            removeKeyboardTrackingAnimations()
         }
+    }
+
+    private func removeKeyboardTrackingAnimations() {
+        keyboardContentView.layer.removeAllAnimations()
+        transcriptClipView.layer.removeAllAnimations()
+        transcriptHostingController.view.layer.removeAllAnimations()
+        composerBackgroundView.layer.removeAllAnimations()
+        composerHostingController.view.layer.removeAllAnimations()
     }
 
     private func updateMeasuredGeometryConstants() {
@@ -346,7 +350,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
         UIView.performWithoutAnimation {
             applyKeyboardOverlap(overlap)
             view.layoutIfNeeded()
-            keyboardContentView.layer.removeAllAnimations()
+            removeKeyboardTrackingAnimations()
         }
         CATransaction.commit()
     }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
@@ -22,7 +22,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
     var excludedKeyboardDismissFrame: CGRect = .zero
 
     private let keyboardContentView = UIView(frame: .zero)
-    private let transcriptClipView = UIView(frame: .zero)
+    let transcriptClipView = UIView(frame: .zero)
     private let composerBackgroundView = UIVisualEffectView(effect: nil)
     let transcriptHostingController: UIHostingController<Transcript>
     let composerHostingController: UIHostingController<Composer>
@@ -31,6 +31,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
     private var transcriptClipTopConstraint: NSLayoutConstraint?
     private var transcriptClipBottomConstraint: NSLayoutConstraint?
     private var transcriptHeightConstraint: NSLayoutConstraint?
+    private var composerBottomConstraint: NSLayoutConstraint?
     private let scrollEdgeCoordinator = ChatScrollEdgeCoordinator()
 
     var keyboardOverlap: CGFloat = 0
@@ -128,12 +129,14 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
     private func installLayoutConstraints() {
         let composerHeightConstraint = composerHostingController.view.heightAnchor.constraint(equalToConstant: 0)
         let transcriptClipTopConstraint = transcriptClipView.topAnchor.constraint(equalTo: keyboardContentView.topAnchor)
-        let transcriptClipBottomConstraint = transcriptClipView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let transcriptClipBottomConstraint = transcriptClipView.bottomAnchor.constraint(equalTo: composerHostingController.view.topAnchor)
         let transcriptHeightConstraint = transcriptHostingController.view.heightAnchor.constraint(equalToConstant: 0)
+        let composerBottomConstraint = composerHostingController.view.bottomAnchor.constraint(equalTo: keyboardContentView.bottomAnchor)
         self.composerHeightConstraint = composerHeightConstraint
         self.transcriptClipTopConstraint = transcriptClipTopConstraint
         self.transcriptClipBottomConstraint = transcriptClipBottomConstraint
         self.transcriptHeightConstraint = transcriptHeightConstraint
+        self.composerBottomConstraint = composerBottomConstraint
 
         NSLayoutConstraint.activate([
             keyboardContentView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -148,7 +151,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
 
             transcriptHostingController.view.leadingAnchor.constraint(equalTo: transcriptClipView.leadingAnchor),
             transcriptHostingController.view.trailingAnchor.constraint(equalTo: transcriptClipView.trailingAnchor),
-            transcriptHostingController.view.bottomAnchor.constraint(equalTo: transcriptClipView.bottomAnchor),
+            transcriptHostingController.view.topAnchor.constraint(equalTo: transcriptClipView.topAnchor),
             transcriptHeightConstraint,
 
             composerBackgroundView.topAnchor.constraint(equalTo: composerHostingController.view.topAnchor),
@@ -158,7 +161,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
 
             composerHostingController.view.leadingAnchor.constraint(equalTo: keyboardContentView.leadingAnchor),
             composerHostingController.view.trailingAnchor.constraint(equalTo: keyboardContentView.trailingAnchor),
-            composerHostingController.view.bottomAnchor.constraint(equalTo: keyboardContentView.bottomAnchor),
+            composerBottomConstraint,
             composerHeightConstraint,
         ])
     }
@@ -319,7 +322,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
         let fullTranscriptHeight = max(0, layoutHeight)
         updateConstraint(composerHeightConstraint, to: composerHeight)
         updateConstraint(transcriptClipTopConstraint, to: 0)
-        updateConstraint(transcriptClipBottomConstraint, to: safeAreaUnderlap)
+        updateConstraint(transcriptClipBottomConstraint, to: 0)
         updateConstraint(transcriptHeightConstraint, to: fullTranscriptHeight)
         if let transcriptOverlayGeometry,
            abs(transcriptOverlayGeometry.composerBottomInset - overlayBottomInset) > 0.5 {
@@ -334,7 +337,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
     private func applyKeyboardOverlap(_ overlap: CGFloat) {
         let clampedOverlap = min(max(0, overlap), max(0, view.bounds.height))
         keyboardOverlap = clampedOverlap
-        keyboardContentView.transform = CGAffineTransform(translationX: 0, y: -clampedOverlap)
+        updateConstraint(composerBottomConstraint, to: -clampedOverlap)
     }
 
     private func pinAnimationToVisibleOverlap(_ overlap: CGFloat) {
@@ -349,22 +352,16 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
     }
 
     func currentVisibleKeyboardOverlap() -> CGFloat {
-        if let rawTranslation = keyboardContentView.layer.presentation()?.value(
-            forKeyPath: "transform.translation.y"
-        ) {
-            let translation: CGFloat?
-            if let value = rawTranslation as? CGFloat {
-                translation = value
-            } else if let value = rawTranslation as? NSNumber {
-                translation = CGFloat(truncating: value)
-            } else {
-                translation = nil
-            }
-            if let translation {
-                return min(max(0, -translation), max(0, view.bounds.height))
-            }
+        if let composerFrame = presentationFrameInOwnViewCoordinates(for: composerHostingController.view) {
+            return min(max(0, view.bounds.maxY - composerFrame.maxY), max(0, view.bounds.height))
         }
         return keyboardOverlap
+    }
+
+    private func presentationFrameInOwnViewCoordinates(for targetView: UIView) -> CGRect? {
+        let sourceLayer = targetView.layer.presentation() ?? targetView.layer
+        let targetLayer = view.layer.presentation() ?? view.layer
+        return sourceLayer.convert(targetView.bounds, to: targetLayer)
     }
 
     private var bottomSafeAreaUnderlap: CGFloat {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
@@ -269,8 +269,8 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
         transitionID: Int
     ) {
         guard duration > 0, abs(targetOverlap - startOverlap) > 0.5 else {
-            stopKeyboardAnimation(removeAnimations: true)
-            applyKeyboardOverlap(targetOverlap)
+            stopKeyboardAnimation(removeAnimations: false)
+            pinAnimationToVisibleOverlap(targetOverlap)
             return
         }
 

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
@@ -323,6 +323,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
             composerHeight: composerHeight,
             bottomSafeAreaUnderlap: safeAreaUnderlap
         )
+        let adjustedBottomInset = overlayBottomInset + keyboardOverlap
         let fullTranscriptHeight = max(0, layoutHeight)
         updateConstraint(composerHeightConstraint, to: composerHeight)
         updateConstraint(transcriptClipTopConstraint, to: 0)
@@ -333,7 +334,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
             transcriptOverlayGeometry.composerBottomInset = overlayBottomInset
         }
         updateTranscriptViewportInsets(
-            adjustedBottomInset: overlayBottomInset,
+            adjustedBottomInset: adjustedBottomInset,
             composerOverlayBottomInset: overlayBottomInset
         )
     }
@@ -349,6 +350,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
         CATransaction.setDisableActions(true)
         UIView.performWithoutAnimation {
             applyKeyboardOverlap(overlap)
+            updateMeasuredGeometryConstants()
             view.layoutIfNeeded()
             removeKeyboardTrackingAnimations()
         }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1247,6 +1247,11 @@ final class cmuxUITests: XCTestCase {
             windowFrame.maxY - 2,
             "The transcript table must physically extend to the device bottom so the bottom scroll-edge effect can continue through the safe area. metrics=\(metrics) window=\(windowFrame)"
         )
+        XCTAssertGreaterThanOrEqual(
+            metrics.presentationFrameMaxY,
+            windowFrame.maxY - 2,
+            "The rendered transcript clip must also reach the device bottom when the keyboard is down. Clipping at the composer top hides the iOS 26 bottom underlap even when the table frame is full height. metrics=\(metrics) window=\(windowFrame)"
+        )
         XCTAssertLessThanOrEqual(
             composerBar.frame.maxY,
             metrics.frameMaxY - 20,

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -869,8 +869,7 @@ final class cmuxUITests: XCTestCase {
             "Interrupted show-dismiss must capture partially visible keyboard motion, not only down state. samples=\(animationSamples)"
         )
         guard let keyboardDown = animationSamples.reversed().first(where: {
-            $0.metrics.keyboardOverlap == 0
-                && abs($0.metrics.presentationFrameMaxY - $0.metrics.effectiveFrameMaxY) < 4
+            isKeyboardDownClipSettled($0.metrics)
                 && abs($0.metrics.frameMaxY - beforeKeyboard.frameMaxY) < 8
         })?.metrics else {
             XCTFail("Interrupted show-dismiss evidence must end with the keyboard down. samples=\(animationSamples)")
@@ -1013,8 +1012,7 @@ final class cmuxUITests: XCTestCase {
                 minimumDistinctFrameBuckets: 2
             )
             guard let refocused = interruptedSamples.reversed().first(where: {
-                $0.metrics.keyboardOverlap > 120
-                    && abs($0.metrics.presentationFrameMaxY - $0.metrics.effectiveFrameMaxY) < 4
+                isKeyboardUpClipSettled($0.metrics)
             })?.metrics else {
                 XCTFail("\(refocusCase.label) evidence must end with the keyboard visible. samples=\(interruptedSamples)")
                 return
@@ -1094,8 +1092,7 @@ final class cmuxUITests: XCTestCase {
             // attachment/pinning. Dense in-flight frames come from the external
             // simulator recording used for dogfood evidence.
             guard let refocused = samples.reversed().first(where: {
-                $0.metrics.keyboardOverlap > 120
-                    && abs($0.metrics.presentationFrameMaxY - $0.metrics.effectiveFrameMaxY) < 4
+                isKeyboardUpClipSettled($0.metrics)
             })?.metrics else {
                 XCTFail("\(refocusCase.label) evidence must end with the keyboard visible. samples=\(samples)")
                 return
@@ -2633,6 +2630,16 @@ final class cmuxUITests: XCTestCase {
         metrics.keyboardAnimationActive
             || metrics.keyboardOverlap > 0
             || abs(metrics.presentationFrameMaxY - metrics.effectiveFrameMaxY) > 4
+    }
+
+    private func isKeyboardUpClipSettled(_ metrics: ChatTranscriptMetrics) -> Bool {
+        metrics.keyboardOverlap > 120
+            && abs(metrics.presentationFrameMaxY - metrics.effectiveFrameMaxY) < 4
+    }
+
+    private func isKeyboardDownClipSettled(_ metrics: ChatTranscriptMetrics) -> Bool {
+        abs(metrics.keyboardOverlap) <= 0.5
+            && metrics.presentationFrameMaxY >= metrics.effectiveFrameMaxY - 6
     }
 
     private struct TranscriptMetricsWaitError: Error, CustomStringConvertible {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -654,7 +654,7 @@ final class cmuxUITests: XCTestCase {
     /// stays full height behind a keyboard-owned clip view, so the bottom content
     /// remains visible and keyboard motion clips only from the top.
     @MainActor
-    func testAgentChatTranscriptFrameMovesUpWithKeyboardAcrossScrollPositions() throws {
+    func testAgentChatTranscriptKeepsTopEdgeVisibleWithKeyboardAcrossScrollPositions() throws {
         do {
             let app = launchAgentChatInlinePreviewApp()
             let table = app.tables["ChatTranscriptTableView"]
@@ -1323,7 +1323,8 @@ final class cmuxUITests: XCTestCase {
             line: line
         )
         let afterKeyboard = try waitForTranscriptMetrics(table, timeout: 6) {
-            $0.frameMaxY < beforeKeyboard.frameMaxY - 120
+            $0.keyboardOverlap > 120
+                && $0.presentationFrameMaxY < beforeKeyboard.presentationFrameMaxY - 120
         }
         let metricsAttachment = XCTAttachment(
             string: "scrollPosition=\(scrollPosition)\nbefore=\(beforeKeyboard)\nafter=\(afterKeyboard)"
@@ -1347,6 +1348,14 @@ final class cmuxUITests: XCTestCase {
             file: file,
             line: line
         )
+        XCTAssertEqual(
+            afterKeyboard.frameMinY,
+            beforeKeyboard.frameMinY,
+            accuracy: 4,
+            "Chat transcript UITableView top must stay at the visible nav underlap while the keyboard is up from \(scrollPosition). Moving the table to a negative Y keeps the flags enabled but renders the native top edge blur offscreen. before=\(beforeKeyboard) after=\(afterKeyboard)",
+            file: file,
+            line: line
+        )
         let keyboardFrame = keyboardFrameAfterFocus(
             in: app,
             overlap: afterKeyboard.keyboardOverlap,
@@ -1363,9 +1372,9 @@ final class cmuxUITests: XCTestCase {
         }
 
         XCTAssertLessThan(
-            afterKeyboard.frameMaxY,
-            beforeKeyboard.frameMaxY - 120,
-            "Chat transcript UITableView bottom must move up with the keyboard from \(scrollPosition). before=\(beforeKeyboard) after=\(afterKeyboard) keyboard=\(keyboardFrame)",
+            afterKeyboard.presentationFrameMaxY,
+            beforeKeyboard.presentationFrameMaxY - 120,
+            "Chat transcript visible clipped bottom must move up with the keyboard from \(scrollPosition). The table frame itself stays at the top so the native top scroll-edge blur remains visible. before=\(beforeKeyboard) after=\(afterKeyboard) keyboard=\(keyboardFrame)",
             file: file,
             line: line
         )
@@ -1417,14 +1426,6 @@ final class cmuxUITests: XCTestCase {
             composerFieldFrame.height,
             18,
             "Chat composer field must retain a usable text-entry frame after keyboard opens from \(scrollPosition). field=\(composerFieldFrame)",
-            file: file,
-            line: line
-        )
-        XCTAssertEqual(
-            afterKeyboard.visibleBottomY,
-            beforeKeyboard.visibleBottomY,
-            accuracy: 36,
-            "Visible transcript bottom should stay pinned while the keyboard opens from \(scrollPosition). before=\(beforeKeyboard) after=\(afterKeyboard)",
             file: file,
             line: line
         )
@@ -2208,7 +2209,7 @@ final class cmuxUITests: XCTestCase {
         }
 
         var effectiveFrameMaxY: CGFloat {
-            frameMaxY - composerOverlayBottomInset
+            composerPresentationMinY
         }
 
         init?(_ rawValue: String) {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1408,6 +1408,14 @@ final class cmuxUITests: XCTestCase {
             file: file,
             line: line
         )
+        XCTAssertEqual(
+            afterKeyboard.adjustedBottomInset,
+            afterKeyboard.composerOverlayBottomInset + afterKeyboard.keyboardOverlap,
+            accuracy: 6,
+            "Keyboard-up transcript inset must include the keyboard-clipped viewport below the composer. Otherwise bottom-pinned state can report success while the newest content is hidden. after=\(afterKeyboard)",
+            file: file,
+            line: line
+        )
         XCTAssertGreaterThan(
             composerBarFrame.height,
             52,

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2820,7 +2820,7 @@ final class cmuxUITests: XCTestCase {
         while Date() < deadline {
             if let metrics = transcriptMetrics(from: table),
                abs(metrics.keyboardOverlap) <= 0.5,
-               abs(metrics.presentationFrameMaxY - metrics.effectiveFrameMaxY) <= 6 {
+               metrics.presentationFrameMaxY >= metrics.effectiveFrameMaxY - 6 {
                 return true
             }
             if !didRequestDismiss {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1315,13 +1315,15 @@ final class cmuxUITests: XCTestCase {
             file: file,
             line: line
         )
-        assertChatKeyboardVisibleBottomStayedPinned(
-            animationSamples,
-            baselineVisibleBottomY: beforeKeyboard.visibleBottomY,
-            scrollPosition: scrollPosition,
-            file: file,
-            line: line
-        )
+        if beforeKeyboard.distanceFromBottom <= 40 {
+            assertChatKeyboardVisibleBottomStayedPinned(
+                animationSamples,
+                baselineVisibleBottomY: beforeKeyboard.visibleBottomY,
+                scrollPosition: scrollPosition,
+                file: file,
+                line: line
+            )
+        }
         let afterKeyboard = try waitForTranscriptMetrics(table, timeout: 6) {
             $0.keyboardOverlap > 120
                 && $0.presentationFrameMaxY < beforeKeyboard.presentationFrameMaxY - 120

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -861,7 +861,7 @@ final class cmuxUITests: XCTestCase {
             minimumDistinctFrameBuckets: 2
         )
         let maxVisibleMotion = animationSamples
-            .map { abs($0.metrics.presentationFrameMaxY - $0.metrics.effectiveFrameMaxY) }
+            .map { activeKeyboardPresentationMotion($0.metrics) }
             .max() ?? 0
         XCTAssertGreaterThan(
             maxVisibleMotion,
@@ -2613,7 +2613,7 @@ final class cmuxUITests: XCTestCase {
     ) {
         let capturedPresentationMotion = samples.contains {
             isChatKeyboardVisiblyMoving($0.metrics)
-                && abs($0.metrics.presentationFrameMaxY - $0.metrics.effectiveFrameMaxY) > 8
+                && activeKeyboardPresentationMotion($0.metrics) > 8
         }
         XCTAssertTrue(
             capturedPresentationMotion,
@@ -2626,7 +2626,11 @@ final class cmuxUITests: XCTestCase {
     private func isChatKeyboardVisiblyMoving(_ metrics: ChatTranscriptMetrics) -> Bool {
         metrics.keyboardAnimationActive
             || metrics.keyboardOverlap > 0
-            || abs(metrics.presentationFrameMaxY - metrics.effectiveFrameMaxY) > 4
+    }
+
+    private func activeKeyboardPresentationMotion(_ metrics: ChatTranscriptMetrics) -> CGFloat {
+        guard isChatKeyboardVisiblyMoving(metrics) else { return 0 }
+        return abs(metrics.presentationFrameMaxY - metrics.effectiveFrameMaxY)
     }
 
     private func isKeyboardUpClipSettled(_ metrics: ChatTranscriptMetrics) -> Bool {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2635,6 +2635,10 @@ final class cmuxUITests: XCTestCase {
             || abs(metrics.presentationFrameMaxY - metrics.effectiveFrameMaxY) > 4
     }
 
+    private struct TranscriptMetricsWaitError: Error, CustomStringConvertible {
+        let description: String
+    }
+
     @MainActor
     private func waitForTranscriptMetrics(
         _ table: XCUIElement,
@@ -2661,17 +2665,12 @@ final class cmuxUITests: XCTestCase {
             object: table
         )
         let result = XCTWaiter.wait(for: [expectation], timeout: timeout)
-        XCTAssertEqual(
-            result,
-            .completed,
-            "Timed out waiting for transcript metrics. Last metrics: \(String(describing: lastMetrics)); raw: \(lastRawValue)",
-            file: file,
-            line: line
-        )
-        if let metrics = lastMetrics {
-            return metrics
+        guard result == .completed, let metrics = lastMetrics else {
+            let message = "Timed out waiting for transcript metrics. Last metrics: \(String(describing: lastMetrics)); raw: \(lastRawValue)"
+            XCTFail(message, file: file, line: line)
+            throw TranscriptMetricsWaitError(description: message)
         }
-        throw XCTSkip("Transcript metrics were unavailable")
+        return metrics
     }
 
     @MainActor

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -868,10 +868,9 @@ final class cmuxUITests: XCTestCase {
             80,
             "Interrupted show-dismiss must capture partially visible keyboard motion, not only down state. samples=\(animationSamples)"
         )
-        guard let keyboardDown = animationSamples.reversed().first(where: {
-            isKeyboardDownClipSettled($0.metrics)
-                && abs($0.metrics.frameMaxY - beforeKeyboard.frameMaxY) < 8
-        })?.metrics else {
+        guard let keyboardDown = animationSamples.last?.metrics,
+              isKeyboardDownClipSettled(keyboardDown),
+              abs(keyboardDown.frameMaxY - beforeKeyboard.frameMaxY) < 8 else {
             XCTFail("Interrupted show-dismiss evidence must end with the keyboard down. samples=\(animationSamples)")
             return
         }
@@ -1011,9 +1010,8 @@ final class cmuxUITests: XCTestCase {
                 scrollPosition: refocusCase.label,
                 minimumDistinctFrameBuckets: 2
             )
-            guard let refocused = interruptedSamples.reversed().first(where: {
-                isKeyboardUpClipSettled($0.metrics)
-            })?.metrics else {
+            guard let refocused = interruptedSamples.last?.metrics,
+                  isKeyboardUpClipSettled(refocused) else {
                 XCTFail("\(refocusCase.label) evidence must end with the keyboard visible. samples=\(interruptedSamples)")
                 return
             }
@@ -1091,9 +1089,8 @@ final class cmuxUITests: XCTestCase {
             // intentionally asserts the observed transition events and final
             // attachment/pinning. Dense in-flight frames come from the external
             // simulator recording used for dogfood evidence.
-            guard let refocused = samples.reversed().first(where: {
-                isKeyboardUpClipSettled($0.metrics)
-            })?.metrics else {
+            guard let refocused = samples.last?.metrics,
+                  isKeyboardUpClipSettled(refocused) else {
                 XCTFail("\(refocusCase.label) evidence must end with the keyboard visible. samples=\(samples)")
                 return
             }
@@ -2639,7 +2636,7 @@ final class cmuxUITests: XCTestCase {
 
     private func isKeyboardDownClipSettled(_ metrics: ChatTranscriptMetrics) -> Bool {
         abs(metrics.keyboardOverlap) <= 0.5
-            && metrics.presentationFrameMaxY >= metrics.effectiveFrameMaxY - 6
+            && metrics.presentationFrameMaxY >= metrics.frameMaxY - 6
     }
 
     private struct TranscriptMetricsWaitError: Error, CustomStringConvertible {
@@ -2825,8 +2822,7 @@ final class cmuxUITests: XCTestCase {
         var didRequestDismiss = false
         while Date() < deadline {
             if let metrics = transcriptMetrics(from: table),
-               abs(metrics.keyboardOverlap) <= 0.5,
-               metrics.presentationFrameMaxY >= metrics.effectiveFrameMaxY - 6 {
+               isKeyboardDownClipSettled(metrics) {
                 return true
             }
             if !didRequestDismiss {


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/7072.

The previous keyboard fix could keep the top edge flags enabled while translating the whole chat container, which rendered the native top edge material offscreen. This keeps the transcript anchored at the visible top and moves only the composer with keyboard overlap.

Verification:
- `swift test --package-path Packages/iOS/CmuxAgentChatUI`
- `xcodebuild test -workspace ios/cmux.xcworkspace -scheme cmux-ios -destination platform=iOS Simulator,id=AF7D75D8-C76E-4870-A66C-BADAD18399F4 -derivedDataPath /tmp/cmux-ios-scroll-edge-proof4 -only-testing:cmuxUITests/cmuxUITests/testAgentChatTranscriptKeepsTopEdgeVisibleWithKeyboardAcrossScrollPositions`
- Proof artifact: `cmux-assets/fix-ios-scroll-edge/keyboard-scroll-edge-proof/index.html`
- Reloaded mac tag `edg6`, simulator tag `edg6`, and physical iPhone tag `edg6`.

Note: web dev warmup could not run on this machine because `web/scripts/db-local.sh` requires Docker and `docker` is not installed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785436345&installation_id=133855650&pr_number=7112&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7112&signature=0b65b8db3b4ce59253b0e4f0a0d92beb2fd344767696f0ee6d777168de793c4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the iOS chat’s native top scroll-edge visible during the keyboard by anchoring the transcript at the top and moving only the composer. Fixes clip underlap with presentation‑aware geometry and updates correctly on snap/no‑animation keyboard changes.

- **Bug Fixes**
  - Replace container translation with a composer bottom constraint; pin transcript to clip top; drive clip bottom from keyboard content using presentation‑based overlap + composer height; include keyboard overlap in the transcript inset; use presentation frames for overlap and debug bounds; clear keyboard‑tracking animations on interrupt/settle; keep the transcript clip private.

- **Tests**
  - Rename to keep-top-edge-visible; assert table top stays pinned while the visible bottom tracks presentation bounds; only pin visible bottom near the end; add up/down settled predicates and ignore down‑state underlap; tighten end‑state checks (incl. iOS 26 down underlap) and verify keyboard‑up inset math; timeouts now throw with context.

<sup>Written for commit b401fc76bd9506f54101ca905c654390233c8652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-chat keyboard overlap behavior by switching to constraint-based layout updates, clamping extreme overlap values, and recalculating transcript/composer clipping using presentation-aware geometry for smoother transitions.
  * Refined keyboard animation tracking and cleanup to reduce unintended jumps and clipping while the keyboard shows/hides.

* **Tests**
  * Updated UI regression coverage with tighter keyboard tracking invariants, added iOS 26 bottom-edge verification, and improved transcript metrics timeout/error reporting for clearer failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->