### PR TITLE
Coalesce terminal title updates by default

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
@@ -69,19 +69,21 @@ public struct TerminalCatalogSection: SettingCatalogSection {
         userDefaultsKey: "terminal.rendererRealization.maxWarmRenderers"
     )
 
-    /// Opt-in throttle for high-frequency terminal title changes. Default-off
-    /// so existing title freshness stays unchanged unless users choose the
-    /// performance tradeoff.
+    /// Throttle for high-frequency terminal title changes. Default-on so
+    /// output-heavy terminals cannot drive workspace/sidebar display-title
+    /// refresh at the raw OSC title source cadence. Control decisions such as
+    /// agent routing and session identity must not depend on coalesced OSC
+    /// title propagation.
     public let titleUpdateCoalescingEnabled = DefaultsKey<Bool>(
         id: "terminal.titleUpdates.coalescing.enabled",
-        defaultValue: false,
+        defaultValue: true,
         userDefaultsKey: "terminal.titleUpdates.coalescing.enabled"
     )
 
     /// Delay used when title-update coalescing is enabled.
     public let titleUpdateCoalescingMilliseconds = DefaultsKey<Int>(
         id: "terminal.titleUpdates.coalescing.delayMilliseconds",
-        defaultValue: 500,
+        defaultValue: 1_000,
         userDefaultsKey: "terminal.titleUpdates.coalescing.delayMilliseconds",
         legacyUserDefaultsKeys: ["terminal.titleUpdates.coalescingMilliseconds"]
     )

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsClientTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsClientTests.swift
@@ -33,8 +33,8 @@ struct UserDefaultsSettingsClientTests {
         #expect(client.value(for: catalog.workspaceColors.indicatorStyle) == .leftRail)
         #expect(client.value(for: catalog.workspaceGroups.anchorCloseSuppressed) == false)
         #expect(client.value(for: catalog.workspaceGroups.newWorkspacePlacement) == .afterCurrent)
-        #expect(client.value(for: catalog.terminal.titleUpdateCoalescingEnabled) == false)
-        #expect(client.value(for: catalog.terminal.titleUpdateCoalescingMilliseconds) == 500)
+        #expect(client.value(for: catalog.terminal.titleUpdateCoalescingEnabled) == true)
+        #expect(client.value(for: catalog.terminal.titleUpdateCoalescingMilliseconds) == 1_000)
         #expect(client.value(for: catalog.terminal.titleUpdateDiagnostics) == false)
     }
 

--- a/cmuxTests/TabManagerTitleUpdateTests.swift
+++ b/cmuxTests/TabManagerTitleUpdateTests.swift
@@ -397,7 +397,7 @@ struct TabManagerTitleUpdateTests {
     }
 
     @Test
-    func rawTitleRefreshGateKeepsDefaultBehaviorUntilCoalescingIsEnabled() throws {
+    func rawTitleRefreshGateOnlyRunsWhenCoalescingIsDisabled() throws {
         let suiteName = "TabManagerTitleRawRefreshGate.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
@@ -409,18 +409,18 @@ struct TabManagerTitleUpdateTests {
         let workspace = try #require(manager.selectedWorkspace)
 
         settings.set(1_000, for: catalog.terminal.titleUpdateCoalescingMilliseconds)
-        #expect(manager.shouldScheduleRawTitleRefresh(forWorkspaceId: workspace.id))
-        #expect(!manager.shouldScheduleRawTitleRefresh(forWorkspaceId: UUID()))
-
-        settings.set(true, for: catalog.terminal.titleUpdateCoalescingEnabled)
         #expect(!manager.shouldScheduleRawTitleRefresh(forWorkspaceId: workspace.id))
+        #expect(!manager.shouldScheduleRawTitleRefresh(forWorkspaceId: UUID()))
 
         settings.set(false, for: catalog.terminal.titleUpdateCoalescingEnabled)
         #expect(manager.shouldScheduleRawTitleRefresh(forWorkspaceId: workspace.id))
+
+        settings.set(true, for: catalog.terminal.titleUpdateCoalescingEnabled)
+        #expect(!manager.shouldScheduleRawTitleRefresh(forWorkspaceId: workspace.id))
     }
 
     @Test
-    func titleCoalescingDelayIsDefaultOffAndClampedWhenEnabled() throws {
+    func titleCoalescingDelayIsDefaultOnAndClampedWhenEnabled() throws {
         let suiteName = "TabManagerTitleCoalescingClamp.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
@@ -429,7 +429,14 @@ struct TabManagerTitleUpdateTests {
         let settings = UserDefaultsSettingsClient(defaults: defaults)
         let catalog = SettingCatalog()
 
-        settings.set(1_000, for: catalog.terminal.titleUpdateCoalescingMilliseconds)
+        #expect(
+            abs(
+                PanelTitleUpdateCoalescingSettings.delay(settings: settings) -
+                    1.0
+            ) < 0.000_1
+        )
+
+        settings.set(false, for: catalog.terminal.titleUpdateCoalescingEnabled)
         #expect(
             abs(
                 PanelTitleUpdateCoalescingSettings.delay(settings: settings) -


### PR DESCRIPTION
## Summary

Reduce main-thread UI churn from noisy terminal title updates by enabling terminal title-update coalescing by default.

## Problem

After the offscreen renderer hibernation work in #5857, heavy visible terminal output can still make the app feel laggy. One remaining high-frequency path is OSC/title changes: terminals can emit title updates at source cadence, and each raw update can refresh workspace/sidebar/window title state.

## Changes

- Enable `terminal.titleUpdates.coalescing.enabled` by default.
- Set the default coalescing delay to `1000 ms`.
- Keep the existing disabled-path behavior available: disabling coalescing uses the raw title refresh path with the existing frame-delay default.
- Update settings defaults and title-update tests for the new behavior.

## Correctness Notes

The coalesced path updates panel/workspace display titles and selected-window title text. It does not drive control decisions such as agent routing or session identity. Pending title updates are keyed by workspace/panel and guarded by the source `TerminalSurface`, so stale queued title changes from a removed or respawned terminal are ignored.

The PR intentionally no longer changes `Workspace` layout follow-up scheduling. The previous timing-based layout throttle was removed after review because that path handles render/focus repair state and should stay signal/backoff driven.

## Validation

- `git diff --check`
- `swift test --package-path Packages/macOS/CmuxSettings`
- `swift test --package-path Packages/macOS/CmuxFoundation`
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -only-testing:cmuxTests/TabManagerTitleUpdateTests -only-testing:cmuxTests/TabManagerTitleUpdateStalenessTests`

Note: Xcode emitted an out-of-date CoreSimulator warning while running the macOS test scheme, but the selected macOS tests completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal title update coalescing is now enabled by default, with a longer default delay for smoother title changes.
  * Title refresh scheduling now follows the updated coalescing behavior consistently.
* **Tests**
  * Updated automated checks to match the new default settings and timing expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->