### PR TITLE
Make cmux close-window and focus-window reliable

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5698,12 +5698,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return didFocus
     }
 
-    func closeMainWindow(windowId: UUID, recordHistory: Bool = true) -> Bool {
+    func closeMainWindow(windowId: UUID, recordHistory: Bool = true, force: Bool = false) -> Bool {
         guard let window = windowForMainWindowId(windowId) else { return false }
         if !recordHistory {
             closedWindowHistorySuppressedWindowIds.insert(windowId)
         }
         closeMainWindowWithoutInteractiveVeto(window)
+        if force {
+            // The close fires `windowWillClose` → `unregisterMainWindowContext`,
+            // which re-adds this just-closed window to the RECOVERABLE route ledger while
+            // its surfaces are still registered — so it would linger in
+            // `list-windows`/`listMainWindowSummaries` until the async surface-deinit
+            // sweep catches up. A programmatic close is authoritative, so forget the
+            // route now (same fix as `discardMainWindowWithoutClosedHistory`).
+            forgetRecoverableMainWindowRoute(windowId: windowId)
+            // Verify against the authoritative registry — it is cleared synchronously
+            // on close. `windowForMainWindowId`'s `NSApp.windows` identifier fallback
+            // can re-find a just-closed, not-yet-released window and report a FALSE
+            // failure, so don't gate on it.
+            return !mainWindowContexts.values.contains { $0.windowId == windowId }
+        }
         return true
     }
 
@@ -5711,6 +5725,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard let window = windowForMainWindowId(windowId) else { return }
         closedWindowHistorySuppressedWindowIds.insert(windowId)
         closeMainWindowWithoutInteractiveVeto(window)
+        // A discarded window is gone for good (typically a dead remote-mirror window),
+        // so also drop its RECOVERABLE route. The close removes it from
+        // `mainWindowContexts`, but the route ledger is independent and
+        // `liveRecoverableMainWindow` keeps finding the closed-but-retained NSWindow
+        // (`isReleasedWhenClosed == false`) — which is exactly why discarded mirror
+        // windows lingered in `list-windows`/`listMainWindowSummaries` after a
+        // host-death teardown despite the window itself being closed.
+        forgetRecoverableMainWindowRoute(windowId: windowId)
     }
 
     private func confirmCloseMainWindow(_ window: NSWindow) -> Bool {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -11918,8 +11918,12 @@ class TerminalController {
     private func closeWindow(_ arg: String) -> String {
         let trimmed = arg.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let windowId = UUID(uuidString: trimmed) else { return "ERROR: Invalid window id" }
-        let ok = v2MainSync { AppDelegate.shared?.closeMainWindow(windowId: windowId) ?? false }
-        return ok ? "OK" : "ERROR: Window not found"
+        // `force: true` — a programmatic close must not be silently vetoed by the
+        // interactive last-window quit prompt, and must report the truth (the window
+        // actually closed) rather than a false OK. This also gives a true detach for a
+        // remote-mirror window (windowWillClose stops coordinators / drops the master).
+        let ok = v2MainSync { AppDelegate.shared?.closeMainWindow(windowId: windowId, force: true) ?? false }
+        return ok ? "OK" : "ERROR: Window not found or could not be closed"
     }
 
     private func moveWorkspaceToWindow(_ args: String) -> String {

--- a/Sources/TerminalControllerControlCommandContext.swift
+++ b/Sources/TerminalControllerControlCommandContext.swift
@@ -78,7 +78,9 @@ extension TerminalController: ControlWindowContext {
     }
 
     func controlCloseWindow(id: UUID) -> Bool {
-        AppDelegate.shared?.closeMainWindow(windowId: id) ?? false
+        // force: a programmatic (v2/socket) close must bypass the interactive
+        // last-window quit veto and report the truth — same contract as the v1 CLI path.
+        AppDelegate.shared?.closeMainWindow(windowId: id, force: true) ?? false
     }
 
     func controlAvailableDisplays() -> [ControlDisplayInfo] {


### PR DESCRIPTION
## Summary
- `close-window` and `focus-window` now normalize their `--window` argument (`0`, `window:1`, or a UUID) through `normalizeWindowHandle`, the same helper every other window command uses. The app handler only accepts a bare UUID, so index/ref forms silently did nothing before.
- `closeMainWindow` gains a `force` mode: a programmatic close uses `window.close()` so it can't be silently vetoed by the interactive last-window quit prompt, tears down any open Web Inspector first, and reports success from the authoritative `mainWindowContexts` registry instead of a stale `NSApp.windows` lookup. The v1 (`close-window`) and v2 (socket) close paths both use it.
- Both the forced close and the window-discard path forget the closed window's recoverable route, so a closed window no longer lingers in `list-windows`.

## Tests
- `xcodebuild build-for-testing -scheme cmux-unit` — clean.
- No unit test added: this is AppKit window-lifecycle / CLI-socket integration with no pure-logic seam. Runtime check (`cmux close-window` / `focus-window`) pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785458738&installation_id=133855650&pr_number=7119&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7119&signature=76eeb6db210b05e775cc6de3bc2fdf2c2ffe3068803a8456647abeccc2c330ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves reliability of `cmux` window commands by normalizing `--window` handles and using a forced, programmatic close that bypasses interactive vetoes. Closed or discarded windows are removed from `list-windows` immediately.

- **Bug Fixes**
  - Normalize `--window` for `focus-window` and `close-window` (`0`, `window:1`, UUID) via `normalizeWindowHandle`.
  - Add `force` to `closeMainWindow` and use it in v1 CLI and v2 socket: call `window.close()`, tear down Web Inspector, and verify via `mainWindowContexts`.
  - Forget recoverable routes on forced close and discard so closed windows stop appearing in `list-windows`; CLI now reports "not found or could not be closed" accurately.

<sup>Written for commit 982ddc3119694911f17ec2e6dc6d95abb9e451bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window command handling by accepting additional identifier formats more reliably (including index/reference-style handles) and resolving them consistently.
  * Programmatic window closes now use a forced close path to bypass interactive “last window” quit prompts when appropriate.
  * Closed windows are now removed immediately from recoverable/window listings, preventing lingering entries after host teardown or forced close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->