### PR TITLE
Preserve sr Claude profile config on resume

### DIFF
--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -851,7 +851,12 @@ fi
 # For an explicit `--resume <id>`, point CLAUDE_CONFIG_DIR at the config root that
 # actually holds the transcript so an inherited/foreign config dir cannot turn the
 # resume into "No conversation found". https://github.com/manaflow-ai/cmux/issues/6194
-reconcile_claude_config_dir_for_resume "$(extract_claude_resume_session_id "$@")"
+# Account managers such as `sr claude` can intentionally pin CLAUDE_CONFIG_DIR to
+# a different auth/profile root and ask cmux to preserve it.
+if ! should_preserve_claude_auth_selection_key "CLAUDE_CONFIG_DIR"; then
+    resume_session_id="$(extract_claude_resume_session_id "$@" || true)"
+    reconcile_claude_config_dir_for_resume "$resume_session_id"
+fi
 
 # Export the wrapper's PID. Because we exec claude below, this PID becomes
 # the actual claude process PID, which hooks use for stale-session detection.

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -548,6 +548,13 @@ reconcile_claude_config_dir_for_resume() {
     done
 }
 
+reconcile_claude_config_dir_for_resume_unless_preserved() {
+    should_preserve_claude_auth_selection_key "CLAUDE_CONFIG_DIR" && return 0
+    local resume_session_id
+    resume_session_id="$(extract_claude_resume_session_id "$@" || true)"
+    reconcile_claude_config_dir_for_resume "$resume_session_id"
+}
+
 clear_inherited_claude_auth_selection_env() {
     if [[ "${IN_CMUX:-0}" == "1" ]]; then
         local key
@@ -585,7 +592,7 @@ if [[ "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]]; then
     fi
     clear_inherited_claude_auth_selection_env
     if [[ "$IN_CMUX" == "1" ]]; then
-        reconcile_claude_config_dir_for_resume "$(extract_claude_resume_session_id "$@")"
+        reconcile_claude_config_dir_for_resume_unless_preserved "$@"
     fi
     REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" "$@"
@@ -599,7 +606,7 @@ if [[ "$IN_CMUX" == "0" ]] || ! cmux_socket_available; then
     fi
     clear_inherited_claude_auth_selection_env
     if [[ "$IN_CMUX" == "1" ]]; then
-        reconcile_claude_config_dir_for_resume "$(extract_claude_resume_session_id "$@")"
+        reconcile_claude_config_dir_for_resume_unless_preserved "$@"
     fi
     REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
     exec_real_claude_passthrough "$@"
@@ -853,10 +860,7 @@ fi
 # resume into "No conversation found". https://github.com/manaflow-ai/cmux/issues/6194
 # Account managers such as `sr claude` can intentionally pin CLAUDE_CONFIG_DIR to
 # a different auth/profile root and ask cmux to preserve it.
-if ! should_preserve_claude_auth_selection_key "CLAUDE_CONFIG_DIR"; then
-    resume_session_id="$(extract_claude_resume_session_id "$@" || true)"
-    reconcile_claude_config_dir_for_resume "$resume_session_id"
-fi
+reconcile_claude_config_dir_for_resume_unless_preserved "$@"
 
 # Export the wrapper's PID. Because we exec claude below, this PID becomes
 # the actual claude process PID, which hooks use for stale-session detection.

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -1410,6 +1410,42 @@ def test_live_socket_preserves_claude_auth_for_resume_launch(failures: list[str]
     expect("--session-id" not in real_argv, f"resume auth env: expected no injected session id, got {real_argv}", failures)
 
 
+def test_live_socket_preserved_claude_config_dir_skips_resume_self_heal(failures: list[str]) -> None:
+    session_id = "582054f9-2f87-4e90-ad8d-2f532ed8c61b"
+    expected: dict[str, str] = {}
+
+    def setup_env(tmp: Path) -> dict[str, str]:
+        home = tmp / "home"
+        default_root = home / ".claude"
+        (default_root / "projects" / "-work").mkdir(parents=True)
+        (default_root / "projects" / "-work" / f"{session_id}.jsonl").write_text(
+            "{}\n", encoding="utf-8"
+        )
+        selected_root = home / ".subrouter" / "codex" / "claude" / "aziz-claude-1"
+        (selected_root / "projects").mkdir(parents=True)
+        expected["path"] = str(selected_root)
+        return {
+            "HOME": str(home),
+            "CLAUDE_CONFIG_DIR": str(selected_root),
+            "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV": "1",
+            "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS": "CLAUDE_CONFIG_DIR",
+        }
+
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["--resume", session_id, "--fork-session"],
+        inherited_env={},
+        setup_env=setup_env,
+    )
+    expect(code == 0, f"preserved resume config dir: wrapper exited {code}: {stderr}", failures)
+    expect(
+        auth_env.get("CLAUDE_CONFIG_DIR") == expected["path"],
+        "preserved resume config dir: expected CLAUDE_CONFIG_DIR to remain on the selected profile root "
+        f"{expected['path']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}",
+        failures,
+    )
+    expect(real_argv[-3:] == ["--resume", session_id, "--fork-session"], f"preserved resume config dir: expected resume+fork argv, got {real_argv}", failures)
+
+
 def test_live_socket_preserves_only_listed_claude_auth_keys(failures: list[str]) -> None:
     inherited = {
         "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
@@ -1883,6 +1919,7 @@ def main() -> int:
     test_live_socket_resume_keeps_correct_claude_config_dir(failures)
     test_live_socket_resume_self_heal_ignores_prompt_text_after_double_dash(failures)
     test_live_socket_preserves_claude_auth_for_resume_launch(failures)
+    test_live_socket_preserved_claude_config_dir_skips_resume_self_heal(failures)
     test_live_socket_preserves_only_listed_claude_auth_keys(failures)
     test_live_socket_auto_preserves_vertex_auth_when_truthy(failures)
     test_live_socket_auto_preserves_bedrock_auth_when_truthy(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -1410,40 +1410,43 @@ def test_live_socket_preserves_claude_auth_for_resume_launch(failures: list[str]
     expect("--session-id" not in real_argv, f"resume auth env: expected no injected session id, got {real_argv}", failures)
 
 
-def test_live_socket_preserved_claude_config_dir_skips_resume_self_heal(failures: list[str]) -> None:
+def test_preserved_claude_config_dir_skips_resume_self_heal(failures: list[str]) -> None:
     session_id = "582054f9-2f87-4e90-ad8d-2f532ed8c61b"
-    expected: dict[str, str] = {}
 
-    def setup_env(tmp: Path) -> dict[str, str]:
-        home = tmp / "home"
-        default_root = home / ".claude"
-        (default_root / "projects" / "-work").mkdir(parents=True)
-        (default_root / "projects" / "-work" / f"{session_id}.jsonl").write_text(
-            "{}\n", encoding="utf-8"
+    for socket_state in ("live", "stale"):
+        expected: dict[str, str] = {}
+
+        def setup_env(tmp: Path) -> dict[str, str]:
+            home = tmp / "home"
+            default_root = home / ".claude"
+            (default_root / "projects" / "-work").mkdir(parents=True)
+            (default_root / "projects" / "-work" / f"{session_id}.jsonl").write_text(
+                "{}\n", encoding="utf-8"
+            )
+            selected_root = home / ".subrouter" / "codex" / "claude" / "aziz-claude-1"
+            (selected_root / "projects").mkdir(parents=True)
+            expected["path"] = str(selected_root)
+            return {
+                "HOME": str(home),
+                "CLAUDE_CONFIG_DIR": str(selected_root),
+                "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV": "1",
+                "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS": "CLAUDE_CONFIG_DIR",
+            }
+
+        code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+            argv=["--resume", session_id, "--fork-session"],
+            inherited_env={},
+            socket_state=socket_state,
+            setup_env=setup_env,
         )
-        selected_root = home / ".subrouter" / "codex" / "claude" / "aziz-claude-1"
-        (selected_root / "projects").mkdir(parents=True)
-        expected["path"] = str(selected_root)
-        return {
-            "HOME": str(home),
-            "CLAUDE_CONFIG_DIR": str(selected_root),
-            "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV": "1",
-            "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS": "CLAUDE_CONFIG_DIR",
-        }
-
-    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
-        argv=["--resume", session_id, "--fork-session"],
-        inherited_env={},
-        setup_env=setup_env,
-    )
-    expect(code == 0, f"preserved resume config dir: wrapper exited {code}: {stderr}", failures)
-    expect(
-        auth_env.get("CLAUDE_CONFIG_DIR") == expected["path"],
-        "preserved resume config dir: expected CLAUDE_CONFIG_DIR to remain on the selected profile root "
-        f"{expected['path']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}",
-        failures,
-    )
-    expect(real_argv[-3:] == ["--resume", session_id, "--fork-session"], f"preserved resume config dir: expected resume+fork argv, got {real_argv}", failures)
+        expect(code == 0, f"preserved resume config dir {socket_state}: wrapper exited {code}: {stderr}", failures)
+        expect(
+            auth_env.get("CLAUDE_CONFIG_DIR") == expected["path"],
+            f"preserved resume config dir {socket_state}: expected CLAUDE_CONFIG_DIR to remain on the selected profile root "
+            f"{expected['path']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}",
+            failures,
+        )
+        expect(real_argv[-3:] == ["--resume", session_id, "--fork-session"], f"preserved resume config dir {socket_state}: expected resume+fork argv, got {real_argv}", failures)
 
 
 def test_live_socket_preserves_only_listed_claude_auth_keys(failures: list[str]) -> None:
@@ -1919,7 +1922,7 @@ def main() -> int:
     test_live_socket_resume_keeps_correct_claude_config_dir(failures)
     test_live_socket_resume_self_heal_ignores_prompt_text_after_double_dash(failures)
     test_live_socket_preserves_claude_auth_for_resume_launch(failures)
-    test_live_socket_preserved_claude_config_dir_skips_resume_self_heal(failures)
+    test_preserved_claude_config_dir_skips_resume_self_heal(failures)
     test_live_socket_preserves_only_listed_claude_auth_keys(failures)
     test_live_socket_auto_preserves_vertex_auth_when_truthy(failures)
     test_live_socket_auto_preserves_bedrock_auth_when_truthy(failures)


### PR DESCRIPTION
## Summary
- keep cmux Claude resume self-heal from overriding an explicitly preserved CLAUDE_CONFIG_DIR
- add a regression test for resume+fork launched from a Subrouter profile while the old transcript lives under ~/.claude

## Test
- env -u CMUX_CUSTOM_CLAUDE_PATH -u CMUX_CLAUDE_WRAPPER_SHIM -u CMUX_CLAUDE_WRAPPER_SHIM_ROOT python3 tests/test_claude_wrapper_hooks.py

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785460670&installation_id=133855650&pr_number=7121&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7121&signature=52671828fc7a3e46b1188d98128a68ce39fc08221e7cbc409de907aa0f01bfdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the selected Claude profile config on resume by skipping self-heal when `CLAUDE_CONFIG_DIR` is explicitly preserved, preventing auth root switches and "No conversation found" errors. Applies this behavior across all wrapper paths (including hooks-disabled and socket passthrough) and adds a resume+fork test to confirm the pinned config dir and argv remain unchanged for live and stale sockets.

<sup>Written for commit 309a417e736e38e357ea3dde3d1cb32b4e06b29c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume behavior to avoid overwriting a preserved Claude configuration setting during resumed sessions.
  * Kept the selected configuration directory intact when resume/auth preservation settings request it.
* **Tests**
  * Added a regression test covering `--resume` + `--fork-session`, ensuring the preserved configuration remains unchanged and the resume arguments are forwarded correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->