### PR TITLE
Route terminal file URL links to the OS

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalOpenURLFileRoutingPolicy.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalOpenURLFileRoutingPolicy.swift
@@ -1,0 +1,30 @@
+public import Foundation
+
+/// Decides whether a terminal open-URL target may be handled by cmux's file UI.
+public struct TerminalOpenURLFileRoutingPolicy: Sendable {
+    /// Creates the file-routing policy.
+    public init() {}
+
+    /// Returns whether cmux may attempt to open the target in its file preview UI.
+    ///
+    /// The caller still owns settings, file existence, workspace locality, and
+    /// split creation checks. This policy only answers whether the raw terminal
+    /// open-URL payload represents a local file shape that cmux is allowed to
+    /// intercept before the normal URL routing decision.
+    ///
+    /// - Parameters:
+    ///   - rawOpenURLValue: The raw open-URL payload from the terminal runtime.
+    ///   - target: The parsed terminal link target.
+    public func shouldAttemptCmuxFileRouting(
+        rawOpenURLValue _: String,
+        target: TerminalOpenURLTarget
+    ) -> Bool {
+        guard target.url.isFileURL else { return false }
+        return Self.isLocalFileURL(target.url)
+    }
+
+    private static func isLocalFileURL(_ url: URL) -> Bool {
+        let host = url.host
+        return host == nil || host?.isEmpty == true || host == "localhost"
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalOpenURLFileRoutingPolicy.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalOpenURLFileRoutingPolicy.swift
@@ -19,18 +19,18 @@ public struct TerminalOpenURLFileRoutingPolicy: Sendable {
         rawOpenURLValue: String,
         target: TerminalOpenURLTarget
     ) -> Bool {
-        guard !Self.hasExplicitURLScheme(rawOpenURLValue) else { return false }
+        guard !hasExplicitURLScheme(rawOpenURLValue) else { return false }
         guard target.url.isFileURL else { return false }
-        return Self.isLocalFileURL(target.url)
+        return isLocalFileURL(target.url)
     }
 
-    private static func hasExplicitURLScheme(_ rawValue: String) -> Bool {
+    private func hasExplicitURLScheme(_ rawValue: String) -> Bool {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let scheme = URL(string: trimmed)?.scheme else { return false }
         return !scheme.isEmpty
     }
 
-    private static func isLocalFileURL(_ url: URL) -> Bool {
+    private func isLocalFileURL(_ url: URL) -> Bool {
         let host = url.host
         return host == nil || host?.isEmpty == true || host == "localhost"
     }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalOpenURLFileRoutingPolicy.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalOpenURLFileRoutingPolicy.swift
@@ -31,7 +31,6 @@ public struct TerminalOpenURLFileRoutingPolicy: Sendable {
     }
 
     private func isLocalFileURL(_ url: URL) -> Bool {
-        let host = url.host
-        return host == nil || host?.isEmpty == true || host == "localhost"
+        url.host?.isEmpty ?? true
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalOpenURLFileRoutingPolicy.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalOpenURLFileRoutingPolicy.swift
@@ -16,11 +16,18 @@ public struct TerminalOpenURLFileRoutingPolicy: Sendable {
     ///   - rawOpenURLValue: The raw open-URL payload from the terminal runtime.
     ///   - target: The parsed terminal link target.
     public func shouldAttemptCmuxFileRouting(
-        rawOpenURLValue _: String,
+        rawOpenURLValue: String,
         target: TerminalOpenURLTarget
     ) -> Bool {
+        guard !Self.hasExplicitURLScheme(rawOpenURLValue) else { return false }
         guard target.url.isFileURL else { return false }
         return Self.isLocalFileURL(target.url)
+    }
+
+    private static func hasExplicitURLScheme(_ rawValue: String) -> Bool {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let scheme = URL(string: trimmed)?.scheme else { return false }
+        return !scheme.isEmpty
     }
 
     private static func isLocalFileURL(_ url: URL) -> Bool {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalOpenURLFileRoutingPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalOpenURLFileRoutingPolicyTests.swift
@@ -5,8 +5,7 @@ import CmuxTerminalCore
 @Suite struct TerminalOpenURLFileRoutingPolicyTests {
     private let policy = TerminalOpenURLFileRoutingPolicy()
 
-    @Test(arguments: [true, false])
-    func explicitFileSchemeBypassesCmuxFileRouting(_: Bool) throws {
+    @Test func explicitFileSchemeBypassesCmuxFileRouting() throws {
         let url = try #require(URL(string: "file:///Users/dev/out/ab_cosyvoice_emo.wav"))
         #expect(
             policy.shouldAttemptCmuxFileRouting(

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalOpenURLFileRoutingPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalOpenURLFileRoutingPolicyTests.swift
@@ -16,6 +16,16 @@ import CmuxTerminalCore
         )
     }
 
+    @Test func localhostFileSchemeBypassesCmuxFileRouting() throws {
+        let url = try #require(URL(string: "file://localhost/Users/dev/out/ab_cosyvoice_emo.wav"))
+        #expect(
+            policy.shouldAttemptCmuxFileRouting(
+                rawOpenURLValue: url.absoluteString,
+                target: .external(url)
+            ) == false
+        )
+    }
+
     @Test func absolutePathCanStillUseCmuxFileRouting() {
         let url = URL(fileURLWithPath: "/Users/dev/project/README.md")
         #expect(

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalOpenURLFileRoutingPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalOpenURLFileRoutingPolicyTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+import CmuxTerminalCore
+
+@Suite struct TerminalOpenURLFileRoutingPolicyTests {
+    private let policy = TerminalOpenURLFileRoutingPolicy()
+
+    @Test(arguments: [true, false])
+    func explicitFileSchemeBypassesCmuxFileRouting(_: Bool) throws {
+        let url = try #require(URL(string: "file:///Users/dev/out/ab_cosyvoice_emo.wav"))
+        #expect(
+            policy.shouldAttemptCmuxFileRouting(
+                rawOpenURLValue: url.absoluteString,
+                target: .external(url)
+            ) == false
+        )
+    }
+
+    @Test func absolutePathCanStillUseCmuxFileRouting() {
+        let url = URL(fileURLWithPath: "/Users/dev/project/README.md")
+        #expect(
+            policy.shouldAttemptCmuxFileRouting(
+                rawOpenURLValue: "/Users/dev/project/README.md",
+                target: .external(url)
+            )
+        )
+    }
+
+    @Test func nonFileTargetsBypassCmuxFileRouting() throws {
+        let url = try #require(URL(string: "https://example.com/audio.wav"))
+        #expect(
+            policy.shouldAttemptCmuxFileRouting(
+                rawOpenURLValue: url.absoluteString,
+                target: .embeddedBrowser(url)
+            ) == false
+        )
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalOpenURLFileRoutingPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalOpenURLFileRoutingPolicyTests.swift
@@ -25,6 +25,16 @@ import CmuxTerminalCore
         )
     }
 
+    @Test func hostedFileTargetBypassesCmuxFileRoutingEvenWithoutRawScheme() throws {
+        let url = try #require(URL(string: "file://remote-host/Users/dev/out/ab_cosyvoice_emo.wav"))
+        #expect(
+            policy.shouldAttemptCmuxFileRouting(
+                rawOpenURLValue: "/Users/dev/out/ab_cosyvoice_emo.wav",
+                target: .external(url)
+            ) == false
+        )
+    }
+
     @Test func absolutePathCanStillUseCmuxFileRouting() {
         let url = URL(fileURLWithPath: "/Users/dev/project/README.md")
         #expect(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3093,9 +3093,10 @@ class GhosttyApp {
             // file URL, remote workspace, unreadable file, split creation
             // failure) falls through to the existing NSWorkspace path below so
             // URL semantics are preserved.
-            let fileURLHost = target.url.host
-            if target.url.isFileURL,
-               fileURLHost == nil || fileURLHost?.isEmpty == true || fileURLHost == "localhost" {
+            if TerminalOpenURLFileRoutingPolicy().shouldAttemptCmuxFileRouting(
+                rawOpenURLValue: normalizedOpenURLString,
+                target: target
+            ) {
                 let fileURL = target.url
                 let routed: Bool = performOnMain {
                     guard let termSurface = surfaceView.terminalSurface,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3086,15 +3086,12 @@ class GhosttyApp {
                 return true
             }
             #endif
-            // Route local file URLs into cmux when the file-routing toggle is on.
-            // URL fragments/queries are stripped (the panel only needs the file
-            // path), so links emitted by tools like Claude Code (`foo.md#L42`)
-            // still route into the viewer. Anything else (toggle off, hosted
-            // file URL, remote workspace, unreadable file, split creation
-            // failure) falls through to the existing NSWorkspace path below so
-            // URL semantics are preserved.
+            // Route local file paths into cmux when the file-routing toggle is on.
+            // Explicit URL schemes (including file://) stay on the URL route so
+            // the OS owns non-web schemes, while bare paths like `foo.md#L42`
+            // still route into the viewer when eligible.
             if TerminalOpenURLFileRoutingPolicy().shouldAttemptCmuxFileRouting(
-                rawOpenURLValue: normalizedOpenURLString,
+                rawOpenURLValue: trimmedUrlString,
                 target: target
             ) {
                 let fileURL = target.url


### PR DESCRIPTION
Closes #7104

## Summary
- Add a terminal open-URL file-routing policy for the pre-browser cmux file-preview interception gate.
- Keep bare absolute path cmd-clicks eligible for cmux file preview.
- Ensure explicit URL schemes, including `file://`, bypass cmux file preview and continue to the external URL route.

## Tests
- `git diff --check origin/main...HEAD`
- `python3 scripts/swift_file_length_budget.py`
- `python3 scripts/check-package-resolved-policy.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `/Users/austinwang/manaflow/cmuxterm-hq/skills/autoreview/scripts/cmux-policy-check --mode branch --base origin/main`
- Attempted: `swift test --filter TerminalOpenURLFileRoutingPolicyTests` from `Packages/macOS/CmuxTerminalCore` (blocked locally because `GhosttyKit.xcframework` is missing a binary artifact; did not run setup/build per no-build instruction).

## Regression structure
- Commit 1 adds the regression around the extracted policy while preserving the old interception behavior, so the new `file://` assertion is red.
- Commit 2 adds the scheme short-circuit so the regression goes green.
- Commit 3 addresses the local cmux policy review by using private instance helpers instead of private static helpers.
- Commit 4 addresses Greptile feedback by removing the unreachable localhost branch and unused test parameterization.
- Commit 5 addresses CodeRabbit/Cubic coverage feedback for hosted file targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved open-link handling so local file paths are routed to the file viewer/editor more consistently.
  * Centralized routing decisions for open-URL handling to ensure consistent behavior across cases.
* **Bug Fixes**
  * Refined “local file” detection and bypass rules, including clearer treatment of explicit URL schemes and `file://` URL hosts.
  * Preserves support for absolute file paths and paths with fragments.
* **Tests**
  * Added/expanded coverage for file vs non-file links, scheme-handling, and local vs non-local file routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->