### PR TITLE
Fix main window recovery when an external display disconnects

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -230,4 +230,42 @@ extension CmuxMainWindow {
             height: height
         )
     }
+
+    /// Move a main window back onto a connected display when its frame would be
+    /// stranded off-screen (e.g. the display it lived on was disconnected).
+    /// Uses the same target-screen selection as Settings multi-monitor recovery
+    /// (#5770). No-op when the frame already has a grabbable on-screen slice.
+    static func applyOffscreenRecoveryIfNeeded(
+        _ window: NSWindow,
+        mouseLocation: NSPoint? = NSEvent.mouseLocation
+    ) {
+        guard !window.styleMask.contains(.fullScreen) else { return }
+
+        let visibleFrames = NSScreen.screens.map(\.visibleFrame)
+        guard !shouldPreserveFrameDuringConstrain(window.frame, visibleFrames: visibleFrames) else {
+            return
+        }
+
+        let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
+        let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
+        guard let targetVisibleFrame = SettingsWindowPresenter.targetVisibleFrame(
+            windowFrame: window.frame,
+            screens: screens,
+            mouseLocation: mouseLocation,
+            fallbackVisibleFrame: fallbackVisibleFrame
+        ) else { return }
+
+        let minimumFrameSize = NSSize(
+            width: max(window.minSize.width, minimumContentSize.width),
+            height: max(window.minSize.height, minimumContentSize.height)
+        )
+        let recovered = SettingsWindowPresenter.clampedFrame(
+            window.frame,
+            minimumSize: minimumFrameSize,
+            into: targetVisibleFrame,
+            inset: 0
+        )
+        guard recovered != window.frame else { return }
+        window.setFrame(recovered, display: true, animate: false)
+    }
 }

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -178,7 +178,10 @@ final class CmuxMainWindow: NSWindow {
         ) {
             return frameRect
         }
-        return super.constrainFrameRect(frameRect, to: screen)
+        return Self.recoveredOffscreenFrame(
+            frameRect,
+            mouseLocation: NSEvent.mouseLocation
+        ) ?? super.constrainFrameRect(frameRect, to: screen)
     }
 
     /// Whether `proposedFrame` is reachable enough across `visibleFrames` that
@@ -233,10 +236,9 @@ extension CmuxMainWindow {
 
     /// Move a main window back onto a connected display when its frame would be
     /// stranded off-screen (e.g. the display it lived on was disconnected).
-    /// Uses the same target-screen selection as Settings multi-monitor recovery
-    /// (#5770). No-op when the frame already has a grabbable on-screen slice.
+    /// No-op when the frame already has a grabbable on-screen slice.
     static func applyOffscreenRecoveryIfNeeded(
-        _ window: NSWindow,
+        _ window: CmuxMainWindow,
         mouseLocation: NSPoint? = NSEvent.mouseLocation
     ) {
         guard !window.styleMask.contains(.fullScreen) else { return }
@@ -246,26 +248,30 @@ extension CmuxMainWindow {
             return
         }
 
-        let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
-        let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
-        guard let targetVisibleFrame = SettingsWindowPresenter.targetVisibleFrame(
-            windowFrame: window.frame,
-            screens: screens,
-            mouseLocation: mouseLocation,
-            fallbackVisibleFrame: fallbackVisibleFrame
-        ) else { return }
-
-        let minimumFrameSize = NSSize(
-            width: max(window.minSize.width, minimumContentSize.width),
-            height: max(window.minSize.height, minimumContentSize.height)
-        )
-        let recovered = SettingsWindowPresenter.clampedFrame(
-            window.frame,
-            minimumSize: minimumFrameSize,
-            into: targetVisibleFrame,
-            inset: 0
-        )
+        guard let recovered = recoveredOffscreenFrame(window.frame, mouseLocation: mouseLocation) else {
+            return
+        }
         guard recovered != window.frame else { return }
         window.setFrame(recovered, display: true, animate: false)
+    }
+
+    static func recoveredOffscreenFrame(
+        _ frame: NSRect,
+        mouseLocation: NSPoint?
+    ) -> NSRect? {
+        let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
+        let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
+        let minimumFrameSize = NSSize(
+            width: minimumContentSize.width,
+            height: minimumContentSize.height
+        )
+        return MultiMonitorWindowGeometry.recoveredFrame(
+            frame,
+            minimumSize: minimumFrameSize,
+            screens: screens,
+            mouseLocation: mouseLocation,
+            fallbackVisibleFrame: fallbackVisibleFrame,
+            inset: 0
+        )
     }
 }

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -180,6 +180,8 @@ final class CmuxMainWindow: NSWindow {
         }
         return Self.recoveredOffscreenFrame(
             frameRect,
+            styleMask: styleMask,
+            windowMinSize: minSize,
             mouseLocation: NSEvent.mouseLocation
         ) ?? super.constrainFrameRect(frameRect, to: screen)
     }
@@ -248,7 +250,12 @@ extension CmuxMainWindow {
             return
         }
 
-        guard let recovered = recoveredOffscreenFrame(window.frame, mouseLocation: mouseLocation) else {
+        guard let recovered = recoveredOffscreenFrame(
+            window.frame,
+            styleMask: window.styleMask,
+            windowMinSize: window.minSize,
+            mouseLocation: mouseLocation
+        ) else {
             return
         }
         guard recovered != window.frame else { return }
@@ -257,13 +264,15 @@ extension CmuxMainWindow {
 
     static func recoveredOffscreenFrame(
         _ frame: NSRect,
+        styleMask: NSWindow.StyleMask,
+        windowMinSize: NSSize = .zero,
         mouseLocation: NSPoint?
     ) -> NSRect? {
         let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
         let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
-        let minimumFrameSize = NSSize(
-            width: minimumContentSize.width,
-            height: minimumContentSize.height
+        let minimumFrameSize = minimumFrameSize(
+            for: styleMask,
+            windowMinSize: windowMinSize
         )
         return MultiMonitorWindowGeometry.recoveredFrame(
             frame,
@@ -272,6 +281,21 @@ extension CmuxMainWindow {
             mouseLocation: mouseLocation,
             fallbackVisibleFrame: fallbackVisibleFrame,
             inset: 0
+        )
+    }
+
+    private static func minimumFrameSize(
+        for styleMask: NSWindow.StyleMask,
+        windowMinSize: NSSize
+    ) -> NSSize {
+        let contentMinimum = NSRect(origin: .zero, size: minimumContentSize)
+        let convertedMinimum = NSWindow.frameRect(
+            forContentRect: contentMinimum,
+            styleMask: styleMask
+        ).size
+        return NSSize(
+            width: max(windowMinSize.width, convertedMinimum.width),
+            height: max(windowMinSize.height, convertedMinimum.height)
         )
     }
 }

--- a/Sources/App/MultiMonitorWindowGeometry.swift
+++ b/Sources/App/MultiMonitorWindowGeometry.swift
@@ -1,0 +1,96 @@
+import AppKit
+
+/// Shared multi-monitor window placement geometry used by main windows,
+/// settings recovery, and other AppKit presenters that clamp frames onto a
+/// connected display.
+enum MultiMonitorWindowGeometry {
+    /// Pure selection of the visible-screen frame a window should be clamped
+    /// into. When the window's saved frame is off every active screen (e.g.
+    /// restored onto a now-disconnected display) it recovers onto the screen
+    /// under the cursor, then the main/first screen. Cursor hit-testing uses
+    /// each screen's *full* frame: `visibleFrame` excludes the menu bar and
+    /// Dock strips, and the cursor sits exactly there when a window is opened
+    /// from the menu bar, which would misroute recovery to the main screen.
+    static func targetVisibleFrame(
+        windowFrame: NSRect,
+        screens: [(frame: NSRect, visibleFrame: NSRect)],
+        mouseLocation: NSPoint?,
+        fallbackVisibleFrame: NSRect?
+    ) -> NSRect? {
+        guard !screens.isEmpty else { return fallbackVisibleFrame }
+
+        // Prefer the screen the window already overlaps the most so a window
+        // that is mostly visible stays where the user put it.
+        var bestFrame: NSRect?
+        var bestArea: CGFloat = 0
+        for screen in screens {
+            let intersection = screen.visibleFrame.intersection(windowFrame)
+            let area = intersection.isNull ? 0 : intersection.width * intersection.height
+            if area > bestArea {
+                bestArea = area
+                bestFrame = screen.visibleFrame
+            }
+        }
+        if let bestFrame, bestArea > 0 {
+            return bestFrame
+        }
+
+        // The window is off every active screen. Recover onto the screen under
+        // the cursor when possible so the window appears where the user is looking.
+        if let mouseLocation,
+           let mouseScreen = screens.first(where: { $0.frame.contains(mouseLocation) }) {
+            return mouseScreen.visibleFrame
+        }
+        return fallbackVisibleFrame ?? screens.first?.visibleFrame
+    }
+
+    /// Pure clamp geometry: fit `frame` within `visibleFrame` (honoring `inset`
+    /// and a minimum size).
+    static func clampedFrame(
+        _ frame: NSRect,
+        minimumSize: NSSize,
+        into visibleFrame: NSRect,
+        inset: CGFloat
+    ) -> NSRect {
+        var result = frame
+        let maxVisibleSize = NSSize(
+            width: max(minimumSize.width, visibleFrame.width - 2 * inset),
+            height: max(minimumSize.height, visibleFrame.height - 2 * inset)
+        )
+        result.size.width = min(result.size.width, maxVisibleSize.width)
+        result.size.height = min(result.size.height, maxVisibleSize.height)
+        let minX = visibleFrame.minX + inset
+        let minY = visibleFrame.minY + inset
+        let maxX = max(minX, visibleFrame.maxX - inset - result.width)
+        let maxY = max(minY, visibleFrame.maxY - inset - result.height)
+        result.origin = NSPoint(
+            x: min(max(result.origin.x, minX), maxX),
+            y: min(max(result.origin.y, minY), maxY)
+        )
+        return result
+    }
+
+    /// Clamp `frame` onto a connected display using the shared target-screen
+    /// selection and clamp geometry. Returns `nil` when no screen is available.
+    static func recoveredFrame(
+        _ frame: NSRect,
+        minimumSize: NSSize,
+        screens: [(frame: NSRect, visibleFrame: NSRect)],
+        mouseLocation: NSPoint?,
+        fallbackVisibleFrame: NSRect?,
+        inset: CGFloat
+    ) -> NSRect? {
+        guard let targetVisibleFrame = targetVisibleFrame(
+            windowFrame: frame,
+            screens: screens,
+            mouseLocation: mouseLocation,
+            fallbackVisibleFrame: fallbackVisibleFrame
+        ) else { return nil }
+        return clampedFrame(
+            frame,
+            minimumSize: minimumSize,
+            into: targetVisibleFrame,
+            inset: inset
+        )
+    }
+}

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -382,24 +382,19 @@ struct SettingsWindowPresenter {
     private func clampToVisibleAreaIfNeeded(_ window: NSWindow) {
         let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
         let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
-        guard let visibleFrame = Self.targetVisibleFrame(
-            windowFrame: window.frame,
-            screens: screens,
-            mouseLocation: NSEvent.mouseLocation,
-            fallbackVisibleFrame: fallbackVisibleFrame
-        ) else { return }
-
         let minimumFrameSize = NSSize(
             width: max(window.minSize.width, window.contentMinSize.width),
             height: max(window.minSize.height, window.contentMinSize.height)
         )
         let originalFrame = window.frame
-        let clamped = Self.clampedFrame(
+        guard let clamped = MultiMonitorWindowGeometry.recoveredFrame(
             originalFrame,
             minimumSize: minimumFrameSize,
-            into: visibleFrame,
+            screens: screens,
+            mouseLocation: NSEvent.mouseLocation,
+            fallbackVisibleFrame: fallbackVisibleFrame,
             inset: Self.visibleAreaInset
-        )
+        ) else { return }
         guard clamped != originalFrame else { return }
 
         let wasOffAllScreens = window.screen == nil
@@ -415,72 +410,4 @@ struct SettingsWindowPresenter {
         }
     }
 
-    /// Pure selection of the visible-screen frame the settings window should be
-    /// clamped into. When the window's saved frame is off every active screen
-    /// (e.g. restored onto a now-disconnected display in a multi-monitor setup)
-    /// it recovers onto the screen under the cursor, then the main/first screen.
-    /// Cursor hit-testing uses each screen's *full* frame: `visibleFrame`
-    /// excludes the menu bar and Dock strips, and the cursor sits exactly there
-    /// when Settings is opened from the menu bar, which would misroute the
-    /// recovery to the main screen. The returned rect is always a visible
-    /// frame. Factored out so multi-monitor recovery is unit-testable.
-    static func targetVisibleFrame(
-        windowFrame: NSRect,
-        screens: [(frame: NSRect, visibleFrame: NSRect)],
-        mouseLocation: NSPoint?,
-        fallbackVisibleFrame: NSRect?
-    ) -> NSRect? {
-        guard !screens.isEmpty else { return fallbackVisibleFrame }
-
-        // Prefer the screen the window already overlaps the most so a window
-        // that is mostly visible stays where the user put it.
-        var bestFrame: NSRect?
-        var bestArea: CGFloat = 0
-        for screen in screens {
-            let intersection = screen.visibleFrame.intersection(windowFrame)
-            let area = intersection.isNull ? 0 : intersection.width * intersection.height
-            if area > bestArea {
-                bestArea = area
-                bestFrame = screen.visibleFrame
-            }
-        }
-        if let bestFrame, bestArea > 0 {
-            return bestFrame
-        }
-
-        // The window is off every active screen. Recover onto the screen under
-        // the cursor when possible so Settings appears where the user is looking.
-        if let mouseLocation,
-           let mouseScreen = screens.first(where: { $0.frame.contains(mouseLocation) }) {
-            return mouseScreen.visibleFrame
-        }
-        return fallbackVisibleFrame ?? screens.first?.visibleFrame
-    }
-
-    /// Pure clamp geometry: fit `frame` within `visibleFrame` (honoring `inset`
-    /// and a minimum size). Factored out of `clampToVisibleAreaIfNeeded` so the
-    /// geometry is unit-testable independent of `NSWindow`/`NSScreen`.
-    static func clampedFrame(
-        _ frame: NSRect,
-        minimumSize: NSSize,
-        into visibleFrame: NSRect,
-        inset: CGFloat
-    ) -> NSRect {
-        var result = frame
-        let maxVisibleSize = NSSize(
-            width: max(minimumSize.width, visibleFrame.width - 2 * inset),
-            height: max(minimumSize.height, visibleFrame.height - 2 * inset)
-        )
-        result.size.width = min(result.size.width, maxVisibleSize.width)
-        result.size.height = min(result.size.height, maxVisibleSize.height)
-        let minX = visibleFrame.minX + inset
-        let minY = visibleFrame.minY + inset
-        let maxX = max(minX, visibleFrame.maxX - inset - result.width)
-        let maxY = max(minY, visibleFrame.maxY - inset - result.height)
-        result.origin = NSPoint(
-            x: min(max(result.origin.x, minX), maxX),
-            y: min(max(result.origin.y, minY), maxY)
-        )
-        return result
-    }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -17906,7 +17906,8 @@ extension AppDelegate {
 
     private func recoverMainWindowsAfterDisplayChange() {
         for window in mainWindowsForVisibilityController() where window.isVisible {
-            CmuxMainWindow.applyOffscreenRecoveryIfNeeded(window)
+            guard let mainWindow = window as? CmuxMainWindow else { continue }
+            CmuxMainWindow.applyOffscreenRecoveryIfNeeded(mainWindow)
         }
     }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -810,6 +810,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var shortcutDefaultsObserver: NSObjectProtocol?
     private var menuBarVisibilityObserver: NSObjectProtocol?
     private var mobileHostSettingsObserver: NSObjectProtocol?
+    private var screenParametersObserver: NSObjectProtocol?
     private var reloadConfigurationMenuItemRefreshScheduled = false
     /// Orchestrates per-window cmux config-store reloads + window-title refresh.
     /// Holds `self` weakly through the environment seam to avoid a retain cycle.
@@ -1341,6 +1342,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             name: .feedRequestSendText,
             object: nil
         )
+        installMainWindowScreenParametersObserver()
 
 #if DEBUG
         // UI tests run on a shared VM user profile, so persisted shortcuts can drift and make
@@ -17883,6 +17885,29 @@ extension AppDelegate: UpdateActionDelegate, UpdateActionsHost {
 
     var updateLogPath: String {
         updateLog.logPath()
+    }
+}
+
+// MARK: - Main-window display recovery
+
+extension AppDelegate {
+    private func installMainWindowScreenParametersObserver() {
+        guard screenParametersObserver == nil else { return }
+        screenParametersObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.recoverMainWindowsAfterDisplayChange()
+            }
+        }
+    }
+
+    private func recoverMainWindowsAfterDisplayChange() {
+        for window in mainWindowsForVisibilityController() where window.isVisible {
+            CmuxMainWindow.applyOffscreenRecoveryIfNeeded(window)
+        }
     }
 }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -692,6 +692,7 @@
 		F6448F377504F33956E7E03B /* MobileWorkspaceListFidelityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86544CEFA1CA33CA9225FB6E /* MobileWorkspaceListFidelityTests.swift */; };
 		00C3AA443F6DA8D94E28CE17 /* MobileWorkspaceListObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */; };
 		13AB1A2E5DA6AD02DCAE971D /* MockBridgeInputCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3B5F249DECAB446CC71D32 /* MockBridgeInputCapture.swift */; };
+		D36090040000000000000001 /* MultiMonitorWindowGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090040000000000000002 /* MultiMonitorWindowGeometry.swift */; };
 		B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
 		596100000000000000000003 /* NativeNotificationDeliveryHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596100000000000000000004 /* NativeNotificationDeliveryHooks.swift */; };
 		596100000000000000000001 /* NativeNotificationFallbackCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596100000000000000000002 /* NativeNotificationFallbackCommandTests.swift */; };
@@ -1926,6 +1927,7 @@
 		86544CEFA1CA33CA9225FB6E /* MobileWorkspaceListFidelityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileWorkspaceListFidelityTests.swift; sourceTree = "<group>"; };
 		C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileWorkspaceListObserver.swift; sourceTree = "<group>"; };
 		CD3B5F249DECAB446CC71D32 /* MockBridgeInputCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBridgeInputCapture.swift; sourceTree = "<group>"; };
+		D36090040000000000000002 /* MultiMonitorWindowGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MultiMonitorWindowGeometry.swift; sourceTree = "<group>"; };
 		B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsUITests.swift; sourceTree = "<group>"; };
 		596100000000000000000004 /* NativeNotificationDeliveryHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeNotificationDeliveryHooks.swift; sourceTree = "<group>"; };
 		596100000000000000000002 /* NativeNotificationFallbackCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeNotificationFallbackCommandTests.swift; sourceTree = "<group>"; };
@@ -2741,6 +2743,7 @@
 				D3610C010000000000000002 /* CmuxSettingsJSONPathSupport.swift */,
 				D36090030000000000000002 /* SettingsWindowOpenOutcome.swift */,
 				D36090010000000000000002 /* SettingsWindowPresenter.swift */,
+				D36090040000000000000002 /* MultiMonitorWindowGeometry.swift */,
 					D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */,
 					C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */,
 					A5001012 /* ContentView.swift */,
@@ -4608,6 +4611,7 @@
 				AB57F0C27BECE8EDFC6B2B97 /* MobileTerminalByteTee.swift in Sources */,
 				C9CFB398DF94D6DDEAF42D67 /* MobileTerminalRenderObserver.swift in Sources */,
 				00C3AA443F6DA8D94E28CE17 /* MobileWorkspaceListObserver.swift in Sources */,
+				D36090040000000000000001 /* MultiMonitorWindowGeometry.swift in Sources */,
 				596100000000000000000003 /* NativeNotificationDeliveryHooks.swift in Sources */,
 				C06552010000000000000003 /* NotificationBurstCoalescer.swift in Sources */,
 				B7F00002 /* NotificationSoundSettings.swift in Sources */,

--- a/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
+++ b/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
@@ -111,8 +111,9 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
             window.close()
         }
 
-        // Frame on a now-disconnected external display to the right.
-        window.setFrame(NSRect(x: 5000, y: 200, width: 800, height: 600), display: false)
+        let size = NSSize(width: 800, height: 600)
+        let offscreenFrame = try guaranteedOffscreenFrame(size: size)
+        window.setFrame(offscreenFrame, display: false)
 
         CmuxMainWindow.applyOffscreenRecoveryIfNeeded(window, mouseLocation: NSPoint(x: 400, y: 400))
 
@@ -124,6 +125,22 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
         XCTAssertFalse(intersection.isNull)
         XCTAssertGreaterThanOrEqual(intersection.width, 60)
         XCTAssertGreaterThanOrEqual(intersection.height, 60)
+    }
+
+    private func guaranteedOffscreenFrame(size: NSSize) throws -> NSRect {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else {
+            throw XCTSkip("No screen available for offscreen recovery regression")
+        }
+
+        let maxX = screens.map(\.frame.maxX).max() ?? 0
+        let maxY = screens.map(\.frame.maxY).max() ?? 0
+        let offscreen = NSRect(x: maxX + 1_000, y: maxY / 2, width: size.width, height: size.height)
+        let visibleFrames = screens.map(\.visibleFrame)
+        guard !CmuxMainWindow.shouldPreserveFrameDuringConstrain(offscreen, visibleFrames: visibleFrames) else {
+            throw XCTSkip("Could not construct a guaranteed off-screen frame on this display layout")
+        }
+        return offscreen
     }
 }
 #endif

--- a/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
+++ b/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
@@ -97,5 +97,33 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
             CmuxMainWindow.shouldPreserveFrameDuringConstrain(frame, visibleFrames: [])
         )
     }
+
+    func testOffscreenRecoveryMovesWindowOntoConnectedDisplay() throws {
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        // Frame on a now-disconnected external display to the right.
+        window.setFrame(NSRect(x: 5000, y: 200, width: 800, height: 600), display: false)
+
+        CmuxMainWindow.applyOffscreenRecoveryIfNeeded(window, mouseLocation: NSPoint(x: 400, y: 400))
+
+        guard let screen = NSScreen.main ?? NSScreen.screens.first else {
+            throw XCTSkip("No screen available for offscreen recovery regression")
+        }
+        let visible = screen.visibleFrame
+        let intersection = window.frame.intersection(visible)
+        XCTAssertFalse(intersection.isNull)
+        XCTAssertGreaterThanOrEqual(intersection.width, 60)
+        XCTAssertGreaterThanOrEqual(intersection.height, 60)
+    }
 }
 #endif

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -357,7 +357,7 @@ struct SettingsWindowPresenterTests {
         // Saved on a third display to the far left that is no longer connected.
         let orphanFrame = NSRect(x: -2400, y: 400, width: 980, height: 680)
 
-        let target = SettingsWindowPresenter.targetVisibleFrame(
+        let target = MultiMonitorWindowGeometry.targetVisibleFrame(
             windowFrame: orphanFrame,
             screens: [Self.primaryScreen, Self.secondaryScreen],
             mouseLocation: NSPoint(x: 2000, y: 450), // cursor is on the secondary screen
@@ -377,7 +377,7 @@ struct SettingsWindowPresenterTests {
         #expect(!Self.secondaryScreen.visibleFrame.contains(menuBarCursor))
         #expect(Self.secondaryScreen.frame.contains(menuBarCursor))
 
-        let target = SettingsWindowPresenter.targetVisibleFrame(
+        let target = MultiMonitorWindowGeometry.targetVisibleFrame(
             windowFrame: orphanFrame,
             screens: [Self.primaryScreen, Self.secondaryScreen],
             mouseLocation: menuBarCursor,
@@ -391,7 +391,7 @@ struct SettingsWindowPresenterTests {
     @Test func targetVisibleFrameFallsBackWhenOffscreenAndCursorElsewhere() {
         let orphanFrame = NSRect(x: -2400, y: 400, width: 980, height: 680)
 
-        let target = SettingsWindowPresenter.targetVisibleFrame(
+        let target = MultiMonitorWindowGeometry.targetVisibleFrame(
             windowFrame: orphanFrame,
             screens: [Self.primaryScreen],
             mouseLocation: NSPoint(x: -3000, y: 9000), // cursor off all screens too
@@ -405,7 +405,7 @@ struct SettingsWindowPresenterTests {
     @Test func targetVisibleFramePrefersScreenWithMostOverlap() {
         let mostlyOnSecondary = NSRect(x: 1900, y: 100, width: 980, height: 680)
 
-        let target = SettingsWindowPresenter.targetVisibleFrame(
+        let target = MultiMonitorWindowGeometry.targetVisibleFrame(
             windowFrame: mostlyOnSecondary,
             screens: [Self.primaryScreen, Self.secondaryScreen],
             mouseLocation: NSPoint(x: 10, y: 10), // cursor on primary, but window is on secondary
@@ -421,7 +421,7 @@ struct SettingsWindowPresenterTests {
         // Origin far to the left/below the target screen.
         let offscreen = NSRect(x: -5000, y: -5000, width: 980, height: 680)
 
-        let clamped = SettingsWindowPresenter.clampedFrame(
+        let clamped = MultiMonitorWindowGeometry.clampedFrame(
             offscreen,
             minimumSize: SettingsWindowPresenter.minimumSize,
             into: visible,
@@ -440,7 +440,7 @@ struct SettingsWindowPresenterTests {
         let inset: CGFloat = 18
         let oversized = NSRect(x: 0, y: 0, width: 4000, height: 4000)
 
-        let clamped = SettingsWindowPresenter.clampedFrame(
+        let clamped = MultiMonitorWindowGeometry.clampedFrame(
             oversized,
             minimumSize: SettingsWindowPresenter.minimumSize,
             into: visible,


### PR DESCRIPTION
## Summary

- **What changed:** Main windows now recover onto a connected display when `NSApplication.didChangeScreenParametersNotification` fires (e.g. unplugging an external monitor). Reuses the same target-screen selection and clamp geometry as Settings multi-monitor recovery (#5770).
- **Why:** After display disconnect, cmux main windows could remain stranded off-screen. `CmuxMainWindow.constrainFrameRect` only helps when AppKit runs a constrain pass; Settings already had proactive recovery on open, but main windows did not.

## Testing

- `./scripts/setup.sh`
- `CMUX_ZIG=/opt/homebrew/opt/zig@0.15/bin/zig ./scripts/reload.sh --tag display-fix --launch`
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-display-fix test -only-testing:cmuxTests/CmuxMainWindowConstrainFrameTests` — **TEST SUCCEEDED**
- Manual: move `cmux DEV display-fix` to external monitor, unplug monitor → window snaps back onto laptop screen

## Demo Video

- Pending manual capture after multi-monitor repro (automated unit test covers off-screen recovery logic)

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785471248&installation_id=133855650&pr_number=7127&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7127&signature=586458fbcc9808a0beb01188415a352a35b840df4fb45136f01d189c74dc9957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Main windows now snap back onto a connected display when a monitor disconnects. Recovery uses shared multi‑monitor geometry and true frame minimums to prevent off‑screen windows.

- **Bug Fixes**
  - Listen for `NSApplication.didChangeScreenParametersNotification` in `AppDelegate` and recover all visible main windows; reuse the same recovery in `CmuxMainWindow.constrainFrameRect`.
  - Clamp using the true frame minimum by converting content minimums with `NSWindow.frameRect(forContentRect:styleMask:)`, so recovered frames respect window chrome.

- **Refactors**
  - Extract target-screen selection and clamping into `MultiMonitorWindowGeometry`; update `SettingsWindowPresenter` and tests to use `recoveredFrame`.

<sup>Written for commit d1f438b10574ee106fcd46575bd033f7dbebe5b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Main windows now automatically recover to an on-screen visible area after display changes, preventing off-screen placement.
  * Improved frame preservation and offscreen recovery logic ensures windows keep appropriate placement when already sufficiently reachable.
  * Settings windows now use the same shared multi-monitor recovery/clamping rules to stay within the visible area.
* **Tests**
  * Added an offscreen-recovery regression test for main windows.
  * Updated multi-monitor geometry recovery tests to cover the shared recovery/clamping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->