### PR TITLE
Do not attribute surface-less desktop notifications to the active workspace

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2623,9 +2623,9 @@ class GhosttyApp {
 
     /// Workspace a raw terminal (OSC 9/777) desktop notification is recorded against:
     /// the emitting surface's workspace, or nil when the origin is unknown. A surface-less
-    /// (app-target) notification passes `surfaceTabId == nil` and must not fall back to
-    /// `activeTabId`, which would misfile it onto the focused row.
-    static func rawNotificationRecordingTabId(surfaceTabId: UUID?, activeTabId: UUID?) -> UUID? {
+    /// (app-target) notification passes `surfaceTabId == nil` and records nothing, rather
+    /// than being misfiled onto the focused row.
+    static func rawNotificationRecordingTabId(surfaceTabId: UUID?) -> UUID? {
         surfaceTabId
     }
 
@@ -2647,11 +2647,8 @@ class GhosttyApp {
                         return false
                     }
                     // The app target carries no originating surface, so the emitting
-                    // workspace is unknown. Never fall back to the active workspace.
-                    guard let tabId = GhosttyApp.rawNotificationRecordingTabId(
-                        surfaceTabId: nil,
-                        activeTabId: tabManager.selectedTabId
-                    ) else {
+                    // workspace is unknown and nothing is recorded (never the active one).
+                    guard let tabId = GhosttyApp.rawNotificationRecordingTabId(surfaceTabId: nil) else {
                         return true
                     }
                     let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? tabManager
@@ -2915,10 +2912,7 @@ class GhosttyApp {
             }
             return true
         case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
-            guard let tabId = GhosttyApp.rawNotificationRecordingTabId(
-                surfaceTabId: surfaceView.tabId,
-                activeTabId: nil
-            ) else { return true }
+            guard let tabId = GhosttyApp.rawNotificationRecordingTabId(surfaceTabId: surfaceView.tabId) else { return true }
             let surfaceId = surfaceView.terminalSurface?.id
             let actionTitle = action.action.desktop_notification.title
                 .flatMap { String(cString: $0) } ?? ""

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2621,6 +2621,14 @@ class GhosttyApp {
         return initializingRuntimeApp
     }
 
+    /// Workspace a raw terminal (OSC 9/777) desktop notification is recorded against:
+    /// the emitting surface's workspace, or nil when the origin is unknown. A surface-less
+    /// (app-target) notification passes `surfaceTabId == nil` and must not fall back to
+    /// `activeTabId`, which would misfile it onto the focused row.
+    static func rawNotificationRecordingTabId(surfaceTabId: UUID?, activeTabId: UUID?) -> UUID? {
+        surfaceTabId
+    }
+
     private func handleAction(target: ghostty_target_s, action: ghostty_action_s) -> Bool {
         if target.tag != GHOSTTY_TARGET_SURFACE {
             if action.tag == GHOSTTY_ACTION_RELOAD_CONFIG ||
@@ -2635,9 +2643,16 @@ class GhosttyApp {
                 let actionBody = action.action.desktop_notification.body
                     .flatMap { String(cString: $0) } ?? ""
                 return performOnMain {
-                    guard let tabManager = AppDelegate.shared?.tabManager,
-                          let tabId = tabManager.selectedTabId else {
+                    guard let tabManager = AppDelegate.shared?.tabManager else {
                         return false
+                    }
+                    // The app target carries no originating surface, so the emitting
+                    // workspace is unknown. Never fall back to the active workspace.
+                    guard let tabId = GhosttyApp.rawNotificationRecordingTabId(
+                        surfaceTabId: nil,
+                        activeTabId: tabManager.selectedTabId
+                    ) else {
+                        return true
                     }
                     let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? tabManager
                     let surfaceId = tabManager.focusedSurfaceId(for: tabId)
@@ -2900,7 +2915,10 @@ class GhosttyApp {
             }
             return true
         case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
-            guard let tabId = surfaceView.tabId else { return true }
+            guard let tabId = GhosttyApp.rawNotificationRecordingTabId(
+                surfaceTabId: surfaceView.tabId,
+                activeTabId: nil
+            ) else { return true }
             let surfaceId = surfaceView.terminalSurface?.id
             let actionTitle = action.action.desktop_notification.title
                 .flatMap { String(cString: $0) } ?? ""

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -573,6 +573,7 @@
 		D7AB00000000000000000005 /* GhosttyNSView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */; };
 		BDFCA25C0CE77A299C915E26 /* GhosttyOptionAsAltModsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F34462AE2F2EECEF5298031 /* GhosttyOptionAsAltModsTests.swift */; };
 		3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */; };
+		C0DE49960000000000000001 /* GhosttyRawNotificationAttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE49960000000000000002 /* GhosttyRawNotificationAttributionTests.swift */; };
 		5C0011AA0000000000000001 /* GhosttyScrollPreciseBoostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0011AA0000000000000002 /* GhosttyScrollPreciseBoostTests.swift */; };
 		B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */; };
 		A11EAC000000000000000000 /* GhosttyTerminalAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */; };
@@ -1813,6 +1814,7 @@
 		D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		4F34462AE2F2EECEF5298031 /* GhosttyOptionAsAltModsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyOptionAsAltModsTests.swift; sourceTree = "<group>"; };
 		3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPasteboardFidelityTests.swift; sourceTree = "<group>"; };
+		C0DE49960000000000000002 /* GhosttyRawNotificationAttributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyRawNotificationAttributionTests.swift; sourceTree = "<group>"; };
 		5C0011AA0000000000000002 /* GhosttyScrollPreciseBoostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyScrollPreciseBoostTests.swift; sourceTree = "<group>"; };
 		9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/GhosttySurfaceConfigurationRefresh.swift; sourceTree = "<group>"; };
 		A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalAppearance.swift; sourceTree = "<group>"; };
@@ -3666,6 +3668,7 @@
 				2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */,
 				E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */,
 		C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */,
+		C0DE49960000000000000002 /* GhosttyRawNotificationAttributionTests.swift */,
 				120A1EF846214C938416846E /* FileExplorerRootSyncPolicyTests.swift */,
 				4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */,
 				A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */,
@@ -5223,6 +5226,7 @@
 				A11EAF000000000000000000 /* GhosttyNotificationDispatcherTests.swift in Sources */,
 				BDFCA25C0CE77A299C915E26 /* GhosttyOptionAsAltModsTests.swift in Sources */,
 				3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */,
+				C0DE49960000000000000001 /* GhosttyRawNotificationAttributionTests.swift in Sources */,
 				5C0011AA0000000000000001 /* GhosttyScrollPreciseBoostTests.swift in Sources */,
 				C13519000000000000000003 /* GhosttyTerminalStartupEnvironmentTests.swift in Sources */,
 				D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */,

--- a/cmuxTests/GhosttyRawNotificationAttributionTests.swift
+++ b/cmuxTests/GhosttyRawNotificationAttributionTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Ghostty raw notification attribution")
+struct GhosttyRawNotificationAttributionTests {
+    @Test("Surface-less notifications are not attributed to the active workspace")
+    func surfacelessNotificationIsNotAttributedToActiveWorkspace() {
+        let activeWorkspace = UUID()
+        #expect(
+            GhosttyApp.rawNotificationRecordingTabId(surfaceTabId: nil, activeTabId: activeWorkspace) == nil,
+            "A surface-less (app-target) notification has no known origin and must not fall back to the active workspace."
+        )
+    }
+
+    @Test("Surface notifications are attributed to the emitting workspace")
+    func surfaceNotificationIsAttributedToEmittingWorkspace() {
+        let emittingWorkspace = UUID()
+        let activeWorkspace = UUID()
+        #expect(
+            GhosttyApp.rawNotificationRecordingTabId(
+                surfaceTabId: emittingWorkspace,
+                activeTabId: activeWorkspace
+            ) == emittingWorkspace
+        )
+    }
+}

--- a/cmuxTests/GhosttyRawNotificationAttributionTests.swift
+++ b/cmuxTests/GhosttyRawNotificationAttributionTests.swift
@@ -9,24 +9,17 @@ import Testing
 
 @Suite("Ghostty raw notification attribution")
 struct GhosttyRawNotificationAttributionTests {
-    @Test("Surface-less notifications are not attributed to the active workspace")
-    func surfacelessNotificationIsNotAttributedToActiveWorkspace() {
-        let activeWorkspace = UUID()
+    @Test("Surface-less notifications are not attributed to any workspace")
+    func surfacelessNotificationRecordsNothing() {
         #expect(
-            GhosttyApp.rawNotificationRecordingTabId(surfaceTabId: nil, activeTabId: activeWorkspace) == nil,
-            "A surface-less (app-target) notification has no known origin and must not fall back to the active workspace."
+            GhosttyApp.rawNotificationRecordingTabId(surfaceTabId: nil) == nil,
+            "A surface-less (app-target) notification has no known origin and must record nothing."
         )
     }
 
     @Test("Surface notifications are attributed to the emitting workspace")
     func surfaceNotificationIsAttributedToEmittingWorkspace() {
         let emittingWorkspace = UUID()
-        let activeWorkspace = UUID()
-        #expect(
-            GhosttyApp.rawNotificationRecordingTabId(
-                surfaceTabId: emittingWorkspace,
-                activeTabId: activeWorkspace
-            ) == emittingWorkspace
-        )
+        #expect(GhosttyApp.rawNotificationRecordingTabId(surfaceTabId: emittingWorkspace) == emittingWorkspace)
     }
 }


### PR DESCRIPTION
## Summary

App-target (surface-less) OSC 9/777 desktop notifications were recorded against `tabManager.selectedTabId` (the active workspace). A raw terminal notification's body is written to the per-workspace notification store, and the sidebar subtitle is `latestNotificationSubtitle ?? conversationMessageSubtitle`, so this stamped an unrelated notification onto whichever workspace was focused and hid that row's real conversation subtitle. A surface-less notification has no originating surface, so its emitting workspace is unknown; it must not fall back to the active workspace.

## Root cause

`handleAction` has two `GHOSTTY_ACTION_DESKTOP_NOTIFICATION` paths. The surface-target branch attributes by `surfaceView.tabId` (correct); the app-target branch (`target.tag != GHOSTTY_TARGET_SURFACE`) used `tabManager.selectedTabId`. The two have diverged since the original implementation.

## Fix

Add `GhosttyApp.rawNotificationRecordingTabId(surfaceTabId:)` as the single attribution rule — a notification is recorded against its emitting surface's workspace, or nowhere when the surface is unknown — and route both paths through it. The app-target path passes `surfaceTabId: nil`, so it records nothing instead of stamping the active workspace; the surface-target path is unchanged.

## Verification

Added `cmuxTests/GhosttyRawNotificationAttributionTests.swift` (wired into the `cmuxTests` target):

```
rawNotificationRecordingTabId(surfaceTabId: nil)    == nil
rawNotificationRecordingTabId(surfaceTabId: origin) == origin
```

```
xcodebuild test -scheme cmux-unit -only-testing:cmuxTests/GhosttyRawNotificationAttributionTests
** TEST SUCCEEDED **
```

## Note

Surface-targeted notifications (the normal path, including Claude Code) are unaffected. A surface-less notification is now dropped rather than mis-homed; delivering an OS banner for that rare, unattributable case without recording it to a workspace would be a follow-up.

## Related

Found while investigating #7132 (sidebar conversation subtitle attributed to the wrong workspace), which is a separate, upstream cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop notification tab attribution so notifications are tied to the originating workspace when available.
  - Prevented notifications from being attributed to the currently selected tab when no source tab is available.
  - Added automated tests to verify correct behavior for both attributed and non-attributed notification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->