### PR TITLE
diff: add --here to open the diff viewer in the calling pane

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34224,7 +34224,7 @@ export default CMUXSessionRestore;
           agent-hibernation <on|off>
           restore-session
           open <path-or-url>... [--workspace <id|ref|index>] [--surface <id|ref|index>] [--pane <id|ref|index>] [--window <id|ref|index>] [--focus <true|false>] [--no-focus]
-          diff [patch-file|-] [--source <unstaged|staged|branch|last-turn>] [--unstaged|--staged|--branch|--last-turn] [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--cwd <path>] [--base <ref>] [--focus <true|false>] [--no-focus] [--title <text>] [--layout <split|unified>] [--font-size <points>]
+          diff [patch-file|-] [--source <unstaged|staged|branch|last-turn>] [--unstaged|--staged|--branch|--last-turn] [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--cwd <path>] [--base <ref>] [--focus <true|false>] [--no-focus] [--here] [--title <text>] [--layout <split|unified>] [--font-size <points>]
           feedback [--email <email> --body <text> [--image <path> ...]]
           feed tui|clear
           themes [list|set|clear]
@@ -34342,7 +34342,7 @@ export default CMUXSessionRestore;
           display-message [-p|--print] <text>
 
           markdown [open] <path> [--focus <true|false>] (open markdown file in formatted viewer panel with live reload)
-          diff [patch-file|-] [--source <unstaged|staged|branch|last-turn>] [--cwd <path>] [--base <ref>] [--focus <true|false>] [--no-focus] [--title <text>] [--layout <split|unified>] [--font-size <points>] (open patch input or git source in a browser split)
+          diff [patch-file|-] [--source <unstaged|staged|branch|last-turn>] [--cwd <path>] [--base <ref>] [--focus <true|false>] [--no-focus] [--here] [--title <text>] [--layout <split|unified>] [--font-size <points>] (open patch input or git source in a browser split)
 
           browser [--surface <id|ref|index> | <surface>] <subcommand> ...
           browser disable | enable | status

--- a/CLI/cmux_open.swift
+++ b/CLI/cmux_open.swift
@@ -157,6 +157,7 @@ extension CMUXCLI {
         var surface: String?
         var focus: String?
         var noFocus = false
+        var here = false
         var title: String?
         var layout: String?
         var fontSize: String?
@@ -931,7 +932,9 @@ extension CMUXCLI {
             }
             focus = parsed
         } else {
-            focus = false
+            // `--here` opens the diff in the current pane, so focus it by default
+            // (still overridable with --no-focus / --focus false).
+            focus = parsedArgs.here
         }
 
         let resolvedLayout = try resolveDiffViewerLayout(rawLayout: parsedArgs.layout)
@@ -1041,6 +1044,7 @@ extension CMUXCLI {
         if let windowHandle { params["window_id"] = windowHandle }
         if let workspaceHandle { params["workspace_id"] = workspaceHandle }
         if let surfaceHandle { params["surface_id"] = surfaceHandle }
+        if parsedArgs.here { params["place_in_source_pane"] = true }
 
         let payload = try activeClient.sendV2(method: "browser.open_split", params: params)
 
@@ -1329,6 +1333,10 @@ extension CMUXCLI {
                     parsed.noFocus = true
                     index += 1
                     continue
+                case "--here":
+                    parsed.here = true
+                    index += 1
+                    continue
                 case "--title":
                     parsed.title = try openOptionValue(commandArgs, index: index, name: arg)
                     index += 2
@@ -1375,7 +1383,7 @@ extension CMUXCLI {
                     continue
                 default:
                     if arg.hasPrefix("-"), arg != "-" {
-                        throw CLIError(message: "diff: unknown flag '\(arg)'. Usage: cmux diff [patch-file|-] [--source <unstaged|staged|branch|last-turn>] [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--session <id>] [--cwd <path>] [--base <ref>] [--focus true|false] [--no-focus] [--title <text>] [--layout split|unified] [--font-size <points>]")
+                        throw CLIError(message: "diff: unknown flag '\(arg)'. Usage: cmux diff [patch-file|-] [--source <unstaged|staged|branch|last-turn>] [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--session <id>] [--cwd <path>] [--base <ref>] [--focus true|false] [--no-focus] [--here] [--title <text>] [--layout split|unified] [--font-size <points>]")
                     }
                 }
             }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6180,10 +6180,20 @@ class TerminalController {
             var createdSplit = true
             var placementStrategy = "split_right"
             let createdPanel: BrowserPanel?
-            if placeInSourcePane, let sourcePane = ws.paneId(forPanelId: sourceSurfaceId) {
+            if placeInSourcePane {
                 // Caller asked to open the viewer as a tab in its OWN pane
                 // (e.g. `cmux diff --here`): skip the reuse-right-sibling heuristic
                 // so the diff lands where the command was run, not in a neighbour pane.
+                // If the source pane can't be resolved, fail loudly instead of
+                // silently falling back to a neighbour (which would ignore --here).
+                guard let sourcePane = ws.paneId(forPanelId: sourceSurfaceId) else {
+                    result = .err(
+                        code: "not_found",
+                        message: "Could not resolve the pane for the current surface.",
+                        data: ["surface_id": sourceSurfaceId.uuidString]
+                    )
+                    return
+                }
                 createdPanel = ws.newBrowserSurface(
                     inPane: sourcePane,
                     url: url,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6176,10 +6176,27 @@ class TerminalController {
             let transparentBackground = v2Bool(params, "transparent_background") ?? false
             let bypassRemoteProxy = v2Bool(params, "bypass_remote_proxy") ?? v2IsDiffViewerURL(url)
 
+            let placeInSourcePane = v2Bool(params, "place_in_source_pane") ?? false
             var createdSplit = true
             var placementStrategy = "split_right"
             let createdPanel: BrowserPanel?
-            if let targetPane = ws.preferredRightSideTargetPane(fromPanelId: sourceSurfaceId) {
+            if placeInSourcePane, let sourcePane = ws.paneId(forPanelId: sourceSurfaceId) {
+                // Caller asked to open the viewer as a tab in its OWN pane
+                // (e.g. `cmux diff --here`): skip the reuse-right-sibling heuristic
+                // so the diff lands where the command was run, not in a neighbour pane.
+                createdPanel = ws.newBrowserSurface(
+                    inPane: sourcePane,
+                    url: url,
+                    focus: focus,
+                    selectWhenNotFocused: true,
+                    creationPolicy: .automationPreload,
+                    omnibarVisible: omnibarVisible,
+                    transparentBackground: transparentBackground,
+                    bypassRemoteProxy: bypassRemoteProxy
+                )
+                createdSplit = false
+                placementStrategy = "source_pane_tab"
+            } else if let targetPane = ws.preferredRightSideTargetPane(fromPanelId: sourceSurfaceId) {
                 createdPanel = ws.newBrowserSurface(
                     inPane: targetPane,
                     url: url,


### PR DESCRIPTION
Closes #7102.

### What
Add a `--here` flag to `cmux diff` that opens the diff viewer as a tab in the
pane the command was run from, instead of routing it to a neighbouring pane.

### Why
`cmux diff` always placed its viewer via `preferredRightSideTargetPane`, i.e. it
reused/split a right-side sibling pane regardless of `--surface`. For
CLI/agent-driven review workflows (a dedicated shell pane for reviewing changes),
the diff kept landing in a different pane. The only workaround was to open the
viewer and then `move-surface` it back, which is racy (async surface creation,
short-ref reindexing).

### How
- CLI (`cmux diff`): new `--here` flag → sends `place_in_source_pane: true` on the
  `browser.open_split` call. When `--here` is set and neither `--focus` nor
  `--no-focus` is given, focus defaults to true (open here ⇒ show it), still
  overridable with `--no-focus` / `--focus false`.
- App (`v2BrowserOpenSplit`): when `place_in_source_pane` is set, open the browser
  surface as a tab in the source surface's own pane (`newBrowserSurface(inPane:)`),
  bypassing the `preferredRightSideTargetPane` reuse heuristic. `placement_strategy`
  is reported as `source_pane_tab`. Default behaviour is unchanged.

### Testing
Built a tagged dev app (`CMUX_SKIP_ZIG_BUILD=1 scripts/reload.sh --tag here --launch`)
and verified from a split layout:
- `cmux diff --unstaged --here` → diff opens as a focused tab in the current pane.
- `cmux diff --unstaged --here --no-focus` → opens as a background tab in the current pane.
- `cmux diff --unstaged` (no flag) → unchanged (neighbour pane).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785486056&installation_id=133855650&pr_number=7134&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7134&signature=45fbc159fa726d32ea9ef62366624da3c9a83933616827103139dbfa92730c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `--here` flag to `cmux diff` that opens the diff viewer as a tab in the pane you ran the command from. This keeps reviews in your current pane instead of moving to a neighbor.

- **New Features**
  - `cmux diff --here` opens the viewer in the calling pane; focuses by default unless `--no-focus` or `--focus false` is set (help/usage updated to show `--here`).
  - `browser.open_split` accepts `place_in_source_pane`; when set, the app opens the tab in the source pane and reports `placement_strategy: source_pane_tab` (default placement unchanged).

- **Bug Fixes**
  - With `--here`, if the source pane can’t be resolved, return a `not_found` error instead of falling back to a neighbor pane.

<sup>Written for commit 349604279fea19eb6366d78261e464340873a71e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--here` option to `diff` to open the diff viewer in the current pane.
* **Improvements**
  * When `--here` is used, the diff viewer is placed in the source pane when available; otherwise it falls back to the existing placement behavior.
* **Documentation**
  * Updated `diff` help/usage text to include the `--here` flag in the relevant command synopsis variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->