### PR TITLE
Prevent partial Codex hook installs

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28295,6 +28295,18 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
         let previousHookFileData = fm.contents(atPath: filePath)
         var wroteHookFile = false
+        func restoreHookFileAfterFailedPostInstallAction() {
+            guard wroteHookFile else { return }
+            do {
+                if let previousHookFileData {
+                    try previousHookFileData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
+                } else if fm.fileExists(atPath: filePath) {
+                    try fm.removeItem(atPath: filePath)
+                }
+            } catch {
+                cliWriteStderr("Warning: failed to restore hook configuration; hook setup may be incomplete.\n")
+            }
+        }
 
         let newData = try JSONSerialization.data(withJSONObject: existing, options: [.prettyPrinted, .sortedKeys])
         let newString = String(data: newData, encoding: .utf8) ?? "{}"
@@ -28344,57 +28356,52 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             switch action {
             case .codexConfigToml:
                 let configPath = "\(configDir)/config.toml"
-                let existingContent: String
-                if fm.fileExists(atPath: configPath) {
-                    existingContent = try String(contentsOfFile: configPath, encoding: .utf8)
-                } else {
-                    existingContent = ""
-                }
-                let trustClean = Self.codexConfigTomlRemovingHookTrust(
-                    in: existingContent,
-                    entries: codexHookTrustEntries,
-                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes,
-                    removingTrustedHashes: codexLegacyHookTrustHashes
-                )
-                let featureContent = Self.codexConfigTomlInstallingHooksFeature(in: trustClean)
-                let trustInstall = Self.codexConfigTomlInstallingHookTrust(
-                    in: featureContent,
-                    entries: codexHookTrustEntries,
-                    removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes,
-                    removingTrustedHashes: codexLegacyHookTrustHashes
-                )
-                let newContent = trustInstall.content
-                if newContent != existingContent {
-                    if !skipConfirm {
-                        Self.printInstallPreview(
-                            path: configPath,
-                            oldContent: existingContent,
-                            newContent: newContent,
-                            fallbackContent: newContent
-                        )
-                        print("\nProceed? [y/N] ", terminator: "")
-                        guard readLine()?.lowercased().hasPrefix("y") == true else {
-                            if wroteHookFile {
-                                do {
-                                    if let previousHookFileData {
-                                        try previousHookFileData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
-                                    } else if fm.fileExists(atPath: filePath) {
-                                        try fm.removeItem(atPath: filePath)
-                                    }
-                                } catch {
-                                    cliWriteStderr("Warning: failed to restore hook configuration after abort; hook setup may be incomplete.\n")
-                                }
+                do {
+                    let existingContent: String
+                    if fm.fileExists(atPath: configPath) {
+                        existingContent = try String(contentsOfFile: configPath, encoding: .utf8)
+                    } else {
+                        existingContent = ""
+                    }
+                    let trustClean = Self.codexConfigTomlRemovingHookTrust(
+                        in: existingContent,
+                        entries: codexHookTrustEntries,
+                        removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes,
+                        removingTrustedHashes: codexLegacyHookTrustHashes
+                    )
+                    let featureContent = Self.codexConfigTomlInstallingHooksFeature(in: trustClean)
+                    let trustInstall = Self.codexConfigTomlInstallingHookTrust(
+                        in: featureContent,
+                        entries: codexHookTrustEntries,
+                        removingEscapedKeyPrefixes: codexHookTrustEscapedKeyPrefixes,
+                        removingTrustedHashes: codexLegacyHookTrustHashes
+                    )
+                    let newContent = trustInstall.content
+                    if newContent != existingContent {
+                        if !skipConfirm {
+                            Self.printInstallPreview(
+                                path: configPath,
+                                oldContent: existingContent,
+                                newContent: newContent,
+                                fallbackContent: newContent
+                            )
+                            print("\nProceed? [y/N] ", terminator: "")
+                            guard readLine()?.lowercased().hasPrefix("y") == true else {
+                                restoreHookFileAfterFailedPostInstallAction()
+                                print("Aborted (\(configPath) unchanged).")
+                                return
                             }
-                            print("Aborted (\(configPath) unchanged).")
-                            return
+                        }
+                        try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
+                        if def.name == "codex", !codexHookTrustEntries.isEmpty, trustInstall.installedTrust {
+                            print("Enabled hooks and approved cmux hooks in \(configPath)")
+                        } else {
+                            print("Enabled hooks in \(configPath)")
                         }
                     }
-                    try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
-                    if def.name == "codex", !codexHookTrustEntries.isEmpty, trustInstall.installedTrust {
-                        print("Enabled hooks and approved cmux hooks in \(configPath)")
-                    } else {
-                        print("Enabled hooks in \(configPath)")
-                    }
+                } catch {
+                    restoreHookFileAfterFailedPostInstallAction()
+                    throw error
                 }
             }
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28293,10 +28293,13 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         )
         let codexLegacyHookTrustHashes = Self.codexLegacyHookTrustHashes(def: def)
 
+        let previousHookFileData = fm.contents(atPath: filePath)
+        var wroteHookFile = false
+
         let newData = try JSONSerialization.data(withJSONObject: existing, options: [.prettyPrinted, .sortedKeys])
         let newString = String(data: newData, encoding: .utf8) ?? "{}"
         let oldString: String = {
-            if let data = fm.contents(atPath: filePath),
+            if let data = previousHookFileData,
                let json = try? JSONSerialization.jsonObject(with: data),
                let pretty = try? JSONSerialization.data(
                     withJSONObject: json, options: [.prettyPrinted, .sortedKeys]
@@ -28326,6 +28329,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 }
             }
             try newData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
+            wroteHookFile = true
             print("\(def.displayName) hooks installed at \(filePath)")
         }
 
@@ -28370,6 +28374,14 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                         )
                         print("\nProceed? [y/N] ", terminator: "")
                         guard readLine()?.lowercased().hasPrefix("y") == true else {
+                            if wroteHookFile {
+                                if let previousHookFileData {
+                                    try previousHookFileData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
+                                } else if fm.fileExists(atPath: filePath) {
+                                    try fm.removeItem(atPath: filePath)
+                                }
+                                print("Rolled back \(def.displayName) hooks at \(filePath).")
+                            }
                             print("Aborted (\(configPath) unchanged).")
                             return
                         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28375,12 +28375,15 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                         print("\nProceed? [y/N] ", terminator: "")
                         guard readLine()?.lowercased().hasPrefix("y") == true else {
                             if wroteHookFile {
-                                if let previousHookFileData {
-                                    try previousHookFileData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
-                                } else if fm.fileExists(atPath: filePath) {
-                                    try fm.removeItem(atPath: filePath)
+                                do {
+                                    if let previousHookFileData {
+                                        try previousHookFileData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
+                                    } else if fm.fileExists(atPath: filePath) {
+                                        try fm.removeItem(atPath: filePath)
+                                    }
+                                } catch {
+                                    cliWriteStderr("Warning: failed to restore hook configuration after abort; hook setup may be incomplete.\n")
                                 }
-                                print("Rolled back \(def.displayName) hooks at \(filePath).")
                             }
                             print("Aborted (\(configPath) unchanged).")
                             return

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3175,6 +3175,46 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(try String(contentsOf: configURL, encoding: .utf8), "model = \"gpt-5.4\"\n")
     }
 
+    func testCodexHookInstallRestoresExistingHooksFileBytesWhenConfigTomlApprovalIsDeclined() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-hook-install-restore-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let hookURL = codexHome.appendingPathComponent("hooks.json", isDirectory: false)
+        let configURL = codexHome.appendingPathComponent("config.toml", isDirectory: false)
+        let originalHooksData = Data("""
+        {"version":1,"hooks":{"SessionStart":[{"hooks":[{"command":"echo user-hook"}]}]}}
+
+        """.utf8)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try originalHooksData.write(to: hookURL, options: .atomic)
+        try "model = \"gpt-5.4\"\n".write(to: configURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "install"],
+            environment: [
+                "HOME": root.path,
+                "CODEX_HOME": codexHome.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            standardInput: "y\nn\n",
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertTrue(result.stdout.contains("Aborted"), result.stdout)
+        XCTAssertEqual(
+            try Data(contentsOf: hookURL),
+            originalHooksData,
+            "Declining the Codex config.toml update must restore the exact previous hooks.json bytes"
+        )
+        XCTAssertEqual(try String(contentsOf: configURL, encoding: .utf8), "model = \"gpt-5.4\"\n")
+    }
+
     func testGrokHookInstallRejectsFileAtHooksDirectory() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3215,6 +3215,47 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(try String(contentsOf: configURL, encoding: .utf8), "model = \"gpt-5.4\"\n")
     }
 
+    func testCodexHookInstallRestoresHooksFileWhenConfigTomlReadFails() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-hook-install-config-read-fails-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let hookURL = codexHome.appendingPathComponent("hooks.json", isDirectory: false)
+        let configURL = codexHome.appendingPathComponent("config.toml", isDirectory: true)
+        let originalHooksData = Data("""
+        {"version":1,"hooks":{"SessionStart":[{"hooks":[{"command":"echo user-hook"}]}]}}
+
+        """.utf8)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try originalHooksData.write(to: hookURL, options: .atomic)
+        try FileManager.default.createDirectory(at: configURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "install", "--yes"],
+            environment: [
+                "HOME": root.path,
+                "CODEX_HOME": codexHome.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            standardInput: "",
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertNotEqual(result.status, 0, result.stdout)
+        XCTAssertEqual(
+            try Data(contentsOf: hookURL),
+            originalHooksData,
+            "A config.toml read failure after writing hooks.json must restore the exact previous hooks.json bytes"
+        )
+        var isConfigDirectory = ObjCBool(false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: configURL.path, isDirectory: &isConfigDirectory))
+        XCTAssertTrue(isConfigDirectory.boolValue)
+    }
+
     func testGrokHookInstallRejectsFileAtHooksDirectory() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3141,6 +3141,40 @@ extension CLINotifyProcessIntegrationRegressionTests {
         )
     }
 
+    func testCodexHookInstallRollsBackHooksFileWhenConfigTomlApprovalIsDeclined() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-hook-install-rollback-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let hookURL = codexHome.appendingPathComponent("hooks.json", isDirectory: false)
+        let configURL = codexHome.appendingPathComponent("config.toml", isDirectory: false)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try "model = \"gpt-5.4\"\n".write(to: configURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "install"],
+            environment: [
+                "HOME": root.path,
+                "CODEX_HOME": codexHome.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            standardInput: "y\nn\n",
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertTrue(result.stdout.contains("Aborted"), result.stdout)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: hookURL.path),
+            "Declining the Codex config.toml update must not leave hooks.json installed but disabled"
+        )
+        XCTAssertEqual(try String(contentsOf: configURL, encoding: .utf8), "model = \"gpt-5.4\"\n")
+    }
+
     func testGrokHookInstallRejectsFileAtHooksDirectory() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Summary
- Roll back `hooks.json` when interactive `cmux hooks codex install` is aborted or the later `config.toml` update fails
- Restore exact previous hook file bytes for updates, or remove the newly-created hook file for fresh installs
- Add regression tests for fresh hook-file rollback, existing hook-file byte restoration, and config update failures

## Related Issues
- Refs #4420. This PR does not close it: #4420 asks for automatic Codex setup via a wrapper; this change only prevents manual `cmux hooks codex install` from leaving `hooks.json` installed while Codex hooks remain disabled.
- Related to #3749, but does not close it because #3749 asks for fallback status detection when hooks miss entirely.

## Test Plan
- `CMUX_ZIG=/tmp/cmux-zig/zig-aarch64-macos-0.15.2/zig xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-root-cause-derived test -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testCodexHookInstallRollsBackHooksFileWhenConfigTomlApprovalIsDeclined`
- `CMUX_ZIG=/tmp/cmux-zig/zig-aarch64-macos-0.15.2/zig xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-root-cause-derived test -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testCodexHookInstallPrefersLaunchingAppBundledCLI -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testCodexHookInstallRollsBackHooksFileWhenConfigTomlApprovalIsDeclined -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testCodexHookInstallRestoresExistingHooksFileBytesWhenConfigTomlApprovalIsDeclined -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testCodexHookInstallRestoresHooksFileWhenConfigTomlReadFails -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testGrokHookInstallRejectsFileAtHooksDirectory`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785493853&installation_id=133855650&pr_number=7135&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7135&signature=5858eb64af982e27d295f02c2a5fbbed89658d8769bbc6299a80a68ee676bf3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents partial Codex hook installs by rolling back `hooks.json` when `cmux hooks codex install` is aborted at the `config.toml` prompt or errors during `config.toml` processing. Keeps the filesystem consistent and avoids leaving a disabled `hooks.json`.

- **Bug Fixes**
  - Capture previous `hooks.json` bytes and track writes; on declined approval or `config.toml` read/write errors, restore the file or remove the new one.
  - If rollback fails, print a warning to stderr; on abort, exit without changing `config.toml`.
  - Add regression tests for declined approval and config read-failure rollback.

<sup>Written for commit 17c416b939d3d36b6054925315c2ea912aecbf81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent hook installation from leaving partial changes behind if setup is canceled.
  * If you decline the final confirmation, the previous hook state is restored, or the new hook file is removed if it didn’t exist before.
  * If rollback fails, a warning is shown to stderr.
* **Tests**
  * Added end-to-end coverage to verify canceled installs do not modify `hooks.json` and that `config.toml` remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



