### PR TITLE
feat(cmuxd-remote): expand relay CLI — v2-only protocol, new commands and flags

### DIFF
--- a/daemon/remote/README.md
+++ b/daemon/remote/README.md
@@ -133,7 +133,7 @@ The command prints the exact release asset URL, expected SHA-256, local cache st
 
 ## CLI relay
 
-The `cli` subcommand (or `cmux` wrapper/symlink) connects to the local cmux app through an SSH reverse forward and relays commands. It supports both v1 text protocol and v2 JSON-RPC commands.
+The `cli` subcommand (or `cmux` wrapper/symlink) connects to the local cmux app through an SSH reverse forward and relays commands using the v2 JSON-RPC protocol.
 
 Cloud VM images install `/usr/local/bin/cmux` as a symlink to `cmuxd-remote`,
 so `cmux --help` works before a user-specific SSH bootstrap has written
@@ -157,6 +157,22 @@ Integration additions for the relay path:
 2. A background `ssh -N -R` process reverse-forwards a TCP port to the authenticated local relay server. The relay address is written to `~/.cmux/socket_addr` on the remote.
 3. Relay startup writes `~/.cmux/relay/<port>.daemon_path` so the wrapper can route each shell to the correct daemon binary when multiple local cmux instances or versions coexist.
 4. Relay startup writes `~/.cmux/relay/<port>.auth` with the relay ID and token needed for HMAC authentication.
+
+### Protocol and flags
+
+All relay commands use v2 JSON-RPC. Flags map to JSON params via `flagToParamKey` (e.g. `--workspace` → `workspace_id`). Boolean flags (`--focus`) accept `true`/`false`/`1`/`0`/`yes`/`no` and are sent as JSON booleans.
+
+Environment fallbacks:
+- `CMUX_WORKSPACE_ID` — used as `workspace_id` when `--workspace` is not provided
+- `CMUX_SURFACE_ID` — used as `surface_id` when `--surface` is not provided
+
+### Migration notes
+
+**`new-workspace`**: The flag `--working-directory` was removed. It was accepted by the old relay but sent the wrong param name (`working_directory` instead of `cwd`), so the server silently ignored it. Use `--cwd` for the working directory. The flag `--command` is now supported: it sends the command text to the new workspace's default surface after creation.
+
+**`send` / `send-key`**: The `--text` and `--key` flags were removed. Both commands now take their argument positionally, matching the Mac CLI convention: `cmux send "hello world"` and `cmux send-key ctrl+c`.
+
+**Window commands**: Prior to this release, `list-windows`, `current-window`, `new-window`, `focus-window`, and `close-window` used a v1 text protocol and returned plain-text responses (e.g. `window:abc123` per line). They now use v2 JSON-RPC and return JSON. Scripts parsing that output will need updating.
 
 Browser relay behavior:
 

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -60,36 +60,6 @@ type browserCommandSpec struct {
 	useSurfaceEnv         bool
 }
 
-var commands = []commandSpec{
-	// V1 text protocol commands
-	{name: "ping", proto: protoV1, v1Cmd: "ping", noParams: true},
-	{name: "new-window", proto: protoV1, v1Cmd: "new_window", noParams: true},
-	{name: "current-window", proto: protoV1, v1Cmd: "current_window", noParams: true},
-	{name: "close-window", proto: protoV1, v1Cmd: "close_window", flagKeys: []string{"window"}},
-	{name: "focus-window", proto: protoV1, v1Cmd: "focus_window", flagKeys: []string{"window"}},
-	{name: "list-windows", proto: protoV1, v1Cmd: "list_windows", noParams: true},
-
-	// V2 JSON-RPC commands
-	{name: "capabilities", proto: protoV2, v2Method: "system.capabilities", noParams: true},
-	{name: "list-workspaces", proto: protoV2, v2Method: "workspace.list", noParams: true},
-	{name: "new-workspace", proto: protoV2, v2Method: "workspace.create", flagKeys: []string{"command", "working-directory", "name"}},
-	{name: "close-workspace", proto: protoV2, v2Method: "workspace.close", flagKeys: []string{"workspace"}},
-	{name: "select-workspace", proto: protoV2, v2Method: "workspace.select", flagKeys: []string{"workspace"}},
-	{name: "current-workspace", proto: protoV2, v2Method: "workspace.current", noParams: true},
-	{name: "list-panels", proto: protoV2, v2Method: "surface.list", flagKeys: []string{"workspace"}},
-	{name: "focus-panel", proto: protoV2, v2Method: "surface.focus", flagKeys: []string{"panel", "workspace"}, paramKeyOverrides: map[string]string{"panel": "surface_id"}},
-	{name: "list-panes", proto: protoV2, v2Method: "pane.list", flagKeys: []string{"workspace"}},
-	{name: "list-pane-surfaces", proto: protoV2, v2Method: "pane.surfaces", flagKeys: []string{"pane"}},
-	{name: "new-pane", proto: protoV2, v2Method: "pane.create", flagKeys: []string{"workspace", "direction", "type", "url"}, defaultParams: map[string]any{"direction": "right"}},
-	{name: "new-surface", proto: protoV2, v2Method: "surface.create", flagKeys: []string{"workspace", "pane", "type", "url"}},
-	{name: "new-split", proto: protoV2, v2Method: "surface.split", flagKeys: []string{"surface", "direction"}},
-	{name: "close-surface", proto: protoV2, v2Method: "surface.close", flagKeys: []string{"surface"}},
-	{name: "send", proto: protoV2, v2Method: "surface.send_text", flagKeys: []string{"surface", "text"}},
-	{name: "send-key", proto: protoV2, v2Method: "surface.send_key", flagKeys: []string{"surface", "key"}},
-	{name: "notify", proto: protoV2, v2Method: "notification.create", flagKeys: []string{"title", "body", "workspace"}},
-	{name: "refresh-surfaces", proto: protoV2, v2Method: "surface.refresh", noParams: true},
-}
-
 var browserCommands = map[string]browserCommandSpec{
 	"open":       {method: "browser.open_split", flagKeys: []string{"url", "workspace", "surface"}, allowPositionalURL: true, useWorkspaceEnv: true},
 	"open-split": {method: "browser.open_split", flagKeys: []string{"url", "workspace", "surface"}, allowPositionalURL: true, useWorkspaceEnv: true},
@@ -123,6 +93,22 @@ var browserCommands = map[string]browserCommandSpec{
 var commandIndex map[string]*commandSpec
 
 func init() {
+	// Apply per-command overrides from cli_overrides.go onto the generated specs.
+	for i := range commands {
+		ov, ok := commandOverrides[commands[i].name]
+		if !ok {
+			continue
+		}
+		if ov.paramKeyOverrides != nil {
+			commands[i].paramKeyOverrides = ov.paramKeyOverrides
+		}
+		if ov.positionalKey != "" {
+			commands[i].positionalKey = ov.positionalKey
+		}
+		if ov.defaultParams != nil {
+			commands[i].defaultParams = ov.defaultParams
+		}
+	}
 	commandIndex = make(map[string]*commandSpec, len(commands))
 	for i := range commands {
 		commandIndex[commands[i].name] = &commands[i]
@@ -183,6 +169,15 @@ doneFlags:
 	// Special case: "rpc" passthrough
 	if cmdName == "rpc" {
 		return runRPC(socketPath, cmdArgs, jsonOutput, refreshAddr)
+	}
+
+	// Commands with specialDispatch=true in cli_overrides.go have dedicated
+	// handler functions for client-side logic the generic path cannot express.
+	if commandOverrides[cmdName].specialDispatch {
+		switch cmdName {
+		case "new-workspace":
+			return runNewWorkspaceRelay(socketPath, cmdArgs, jsonOutput, refreshAddr)
+		}
 	}
 
 	// Browser subcommand delegation
@@ -749,19 +744,31 @@ func flagToParamKey(key string) string {
 
 // parsedFlags holds the results of flag parsing.
 type parsedFlags struct {
-	flags      map[string]string // --key value pairs
-	positional []string          // non-flag arguments
+	flags      map[string]string   // --key value pairs (last wins for duplicates)
+	repeated   map[string][]string // --key values for repeat-allowed keys
+	positional []string            // non-flag arguments
 }
 
 // parseFlags extracts --key value pairs from args for the given allowed keys.
-// Non-flag arguments are collected in positional.
-func parseFlags(args []string, keys []string) (parsedFlags, error) {
+// Keys listed in repeatKeys may appear more than once; their values accumulate
+// in repeated rather than flags. Non-flag arguments are collected in positional.
+func parseFlags(args []string, keys []string, repeatKeys ...[]string) (parsedFlags, error) {
 	allowed := make(map[string]bool, len(keys))
 	for _, k := range keys {
 		allowed[k] = true
 	}
+	repeat := make(map[string]bool)
+	if len(repeatKeys) > 0 {
+		for _, k := range repeatKeys[0] {
+			repeat[k] = true
+			allowed[k] = true
+		}
+	}
 
-	result := parsedFlags{flags: make(map[string]string)}
+	result := parsedFlags{
+		flags:    make(map[string]string),
+		repeated: make(map[string][]string),
+	}
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--" {
 			result.positional = append(result.positional, args[i+1:]...)
@@ -778,8 +785,13 @@ func parseFlags(args []string, keys []string) (parsedFlags, error) {
 		if i+1 >= len(args) {
 			return parsedFlags{}, fmt.Errorf("flag --%s requires a value", key)
 		}
-		result.flags[key] = args[i+1]
+		val := args[i+1]
 		i++
+		if repeat[key] {
+			result.repeated[key] = append(result.repeated[key], val)
+		} else {
+			result.flags[key] = val
+		}
 	}
 	return result, nil
 }
@@ -1008,26 +1020,66 @@ func cliUsage() {
 	fmt.Fprintln(os.Stderr, "Usage: cmux [--socket <path>] [--json] <command> [args...]")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Commands:")
-	fmt.Fprintln(os.Stderr, "  ping                     Check connectivity")
+	fmt.Fprintln(os.Stderr, "  ping                      Check connectivity")
 	fmt.Fprintln(os.Stderr, "  capabilities              List server capabilities")
 	fmt.Fprintln(os.Stderr, "  list-workspaces           List all workspaces")
-	fmt.Fprintln(os.Stderr, "  new-window                Create a new window")
 	fmt.Fprintln(os.Stderr, "  new-workspace             Create a new workspace")
+	fmt.Fprintln(os.Stderr, "    --name <title>          Workspace title")
+	fmt.Fprintln(os.Stderr, "    --cwd <dir>             Working directory")
+	fmt.Fprintln(os.Stderr, "    --description <text>    Workspace description")
+	fmt.Fprintln(os.Stderr, "    --focus true|false      Focus the workspace after creation")
+	fmt.Fprintln(os.Stderr, "    --window <id>           Target window")
+	fmt.Fprintln(os.Stderr, "    --group <id>            Workspace group to place into")
+	fmt.Fprintln(os.Stderr, "    --group-placement <p>   Placement within the group (before|after|...)")
+	fmt.Fprintln(os.Stderr, "    --group-reference <id>  Reference workspace for placement")
+	fmt.Fprintln(os.Stderr, "    --layout <json>         Pane layout JSON object")
+	fmt.Fprintln(os.Stderr, "    --env KEY=VALUE         Environment variable (repeatable)")
+	fmt.Fprintln(os.Stderr, "    --env-file <path>       File of KEY=VALUE environment variables")
+	fmt.Fprintln(os.Stderr, "    --command <cmd>         Command to send to the new workspace after creation")
+	fmt.Fprintln(os.Stderr, "  rename-workspace          Rename a workspace")
+	fmt.Fprintln(os.Stderr, "  close-workspace           Close a workspace")
+	fmt.Fprintln(os.Stderr, "  select-workspace          Select a workspace")
+	fmt.Fprintln(os.Stderr, "  next-workspace            Switch to next workspace")
+	fmt.Fprintln(os.Stderr, "  previous-workspace        Switch to previous workspace")
+	fmt.Fprintln(os.Stderr, "  last-workspace            Switch to last-used workspace")
+	fmt.Fprintln(os.Stderr, "  current-workspace         Show the active workspace ID")
+	fmt.Fprintln(os.Stderr, "  move-workspace-to-window  Move workspace to another window")
+	fmt.Fprintln(os.Stderr, "  equalize-splits           Equalize pane splits in a workspace")
+	fmt.Fprintln(os.Stderr, "  list-panes                List panes in a workspace")
+	fmt.Fprintln(os.Stderr, "  new-pane                  Create a new pane")
+	fmt.Fprintln(os.Stderr, "  last-pane                 Switch to last-used pane")
+	fmt.Fprintln(os.Stderr, "  join-pane                 Join a pane into another")
+	fmt.Fprintln(os.Stderr, "  swap-pane                 Swap two panes")
+	fmt.Fprintln(os.Stderr, "  break-pane                Break a pane into its own workspace")
+	fmt.Fprintln(os.Stderr, "  resize-pane               Resize a pane")
+	fmt.Fprintln(os.Stderr, "  list-panels               List surfaces in a workspace")
+	fmt.Fprintln(os.Stderr, "  list-pane-surfaces        List surfaces in a pane")
 	fmt.Fprintln(os.Stderr, "  new-surface               Create a new surface")
 	fmt.Fprintln(os.Stderr, "  new-split                 Split an existing surface")
 	fmt.Fprintln(os.Stderr, "  close-surface             Close a surface")
-	fmt.Fprintln(os.Stderr, "  close-workspace           Close a workspace")
-	fmt.Fprintln(os.Stderr, "  select-workspace          Select a workspace")
+	fmt.Fprintln(os.Stderr, "  focus-panel               Focus a surface")
+	fmt.Fprintln(os.Stderr, "  refresh-surfaces          Refresh all surfaces")
 	fmt.Fprintln(os.Stderr, "  send                      Send text to a surface")
 	fmt.Fprintln(os.Stderr, "  send-key                  Send a key to a surface")
+	fmt.Fprintln(os.Stderr, "  read-screen               Read terminal output from a surface")
+	fmt.Fprintln(os.Stderr, "  clear-history             Clear scrollback history for a surface")
+	fmt.Fprintln(os.Stderr, "  list-windows              List all windows")
+	fmt.Fprintln(os.Stderr, "  new-window                Create a new window")
+	fmt.Fprintln(os.Stderr, "  close-window              Close a window")
+	fmt.Fprintln(os.Stderr, "  current-window            Show the active window ID")
+	fmt.Fprintln(os.Stderr, "  focus-window              Focus a window")
 	fmt.Fprintln(os.Stderr, "  notify                    Create a notification")
+	fmt.Fprintln(os.Stderr, "  jump-to-unread            Jump to first unread notification")
+	fmt.Fprintln(os.Stderr, "  dismiss-notification      Dismiss a notification")
+	fmt.Fprintln(os.Stderr, "  mark-notification-read    Mark a notification as read")
+	fmt.Fprintln(os.Stderr, "  open-notification         Open a notification")
 	fmt.Fprintln(os.Stderr, "  workspace group <sub>     Manage sidebar workspace groups (list, create, ungroup,")
 	fmt.Fprintln(os.Stderr, "                            delete, rename, collapse, expand, pin, unpin, add, remove,")
 	fmt.Fprintln(os.Stderr, "                            set-anchor, new-workspace, set-color, set-icon, move, focus)")
 	fmt.Fprintln(os.Stderr, "  browser <sub>             Browser commands through the local cmux browser relay")
-	fmt.Fprintln(os.Stderr, "  claude-teams [args...]     Launch Claude Code in teammate mode")
-	fmt.Fprintln(os.Stderr, "  omo [args...]              Launch OpenCode with cmux integration")
-	fmt.Fprintln(os.Stderr, "  omx [args...]              Launch Oh My Codex with cmux integration")
-	fmt.Fprintln(os.Stderr, "  omc [args...]              Launch Oh My Claude Code with cmux integration")
+	fmt.Fprintln(os.Stderr, "  claude-teams [args...]    Launch Claude Code in teammate mode")
+	fmt.Fprintln(os.Stderr, "  omo [args...]             Launch OpenCode with cmux integration")
+	fmt.Fprintln(os.Stderr, "  omx [args...]             Launch Oh My Codex with cmux integration")
+	fmt.Fprintln(os.Stderr, "  omc [args...]             Launch Oh My Claude Code with cmux integration")
 	fmt.Fprintln(os.Stderr, "  rpc <method> [json-params] Send arbitrary JSON-RPC")
 }

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -23,29 +23,28 @@ type relayAuthState struct {
 	RelayToken string `json:"relay_token"`
 }
 
-// protocolVersion indicates whether a command uses the v1 text or v2 JSON-RPC protocol.
-type protocolVersion int
-
-const (
-	protoV1 protocolVersion = iota
-	protoV2
-)
-
 // commandSpec describes a single CLI command and how to relay it.
 type commandSpec struct {
-	name     string          // CLI command name (e.g. "ping", "new-window")
-	proto    protocolVersion // v1 text or v2 JSON-RPC
-	v1Cmd    string          // v1: literal command string sent over the socket
-	v2Method string          // v2: JSON-RPC method name
+	name     string // CLI command name (e.g. "ping", "new-window")
+	v2Method string // JSON-RPC method name
 	// flagKeys lists parameter keys this command accepts.
 	// They are extracted from --key flags and added to params.
 	flagKeys []string
+	// boolFlags lists flag keys whose values should be sent as JSON booleans
+	// rather than strings. Accepted values: "true", "false", "1", "0".
+	boolFlags []string
 	// noParams means the command takes no parameters at all.
 	noParams bool
 	// paramKeyOverrides remaps specific flags for compatibility aliases.
 	paramKeyOverrides map[string]string
 	// defaultParams are applied before flags/env fallbacks.
 	defaultParams map[string]any
+	// positionalKey is the param name that receives positional arguments.
+	// All positional args are joined with a space and assigned to this key.
+	positionalKey string
+	// repeatKeys lists flags that may appear multiple times. Their values
+	// accumulate in parsedFlags.repeated rather than parsedFlags.flags.
+	repeatKeys []string
 }
 
 type browserCommandSpec struct {
@@ -224,44 +223,7 @@ doneFlags:
 		return 2
 	}
 
-	switch spec.proto {
-	case protoV1:
-		return execV1(socketPath, spec, cmdArgs, refreshAddr)
-	case protoV2:
-		return execV2(socketPath, spec, cmdArgs, jsonOutput, refreshAddr)
-	default:
-		fmt.Fprintf(os.Stderr, "cmux: internal error: unknown protocol for %q\n", cmdName)
-		return 1
-	}
-}
-
-// execV1 sends a v1 text command over the socket.
-func execV1(socketPath string, spec *commandSpec, args []string, refreshAddr func() string) int {
-	cmd := spec.v1Cmd
-
-	if !spec.noParams {
-		parsed, err := parseFlags(args, spec.flagKeys)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
-			return 2
-		}
-		for _, key := range spec.flagKeys {
-			if val, ok := parsed.flags[key]; ok {
-				cmd += " " + val
-			}
-		}
-	}
-
-	resp, err := socketRoundTrip(socketPath, cmd, refreshAddr)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
-		return 1
-	}
-	fmt.Print(resp)
-	if !strings.HasSuffix(resp, "\n") {
-		fmt.Println()
-	}
-	return 0
+	return execV2(socketPath, spec, cmdArgs, jsonOutput, refreshAddr)
 }
 
 // execV2 sends a v2 JSON-RPC request over the socket.
@@ -272,35 +234,186 @@ func execV2(socketPath string, spec *commandSpec, args []string, jsonOutput bool
 	}
 
 	if !spec.noParams {
-		parsed, err := parseFlags(args, spec.flagKeys)
+		parsed, err := parseFlags(args, spec.flagKeys, spec.repeatKeys)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
 			return 2
 		}
-		// Map flag keys to JSON param keys (e.g. "workspace" → "workspace_id" where appropriate)
+		// Build a set of bool flags for O(1) lookup.
+		boolFlagSet := make(map[string]struct{}, len(spec.boolFlags))
+		for _, k := range spec.boolFlags {
+			boolFlagSet[k] = struct{}{}
+		}
+
+		// Map flag keys to JSON param keys (e.g. "workspace" → "workspace_id" where appropriate).
+		// Flags listed in boolFlags are coerced to JSON booleans instead of sent as strings.
 		for _, key := range spec.flagKeys {
 			if val, ok := parsed.flags[key]; ok {
 				paramKey := flagToParamKey(key)
 				if override, ok := spec.paramKeyOverrides[key]; ok {
 					paramKey = override
 				}
-				params[paramKey] = val
+				if _, isBool := boolFlagSet[key]; isBool {
+					switch strings.ToLower(val) {
+					case "true", "1", "yes":
+						params[paramKey] = true
+					case "false", "0", "no":
+						params[paramKey] = false
+					default:
+						fmt.Fprintf(os.Stderr, "cmux: --%s must be true or false\n", key)
+						return 2
+					}
+				} else {
+					params[paramKey] = val
+				}
 			}
 		}
 
-		// First positional arg is used as initial_command if --command wasn't given
-		if _, ok := params["initial_command"]; !ok && len(parsed.positional) > 0 {
-			params["initial_command"] = parsed.positional[0]
+		if len(parsed.positional) > 0 {
+			if spec.positionalKey != "" {
+				params[spec.positionalKey] = strings.Join(parsed.positional, " ")
+			} else {
+				fmt.Fprintf(os.Stderr, "cmux: %s does not accept positional arguments\n", spec.name)
+				return 2
+			}
 		}
 
-		applyWorkspaceEnvFallback(params)
-		applySurfaceEnvFallback(params)
+		if specUsesParam(spec, "workspace_id") {
+			applyWorkspaceEnvFallback(params)
+		}
+		if specUsesParam(spec, "surface_id") {
+			applySurfaceEnvFallback(params)
+		}
 	}
 
 	resp, err := socketRoundTripV2(socketPath, spec.v2Method, params, refreshAddr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
 		return 1
+	}
+
+	if jsonOutput {
+		fmt.Println(resp)
+	} else {
+		fmt.Println(defaultRelayOutput(resp))
+	}
+	return 0
+}
+
+// runNewWorkspaceRelay handles "cmux new-workspace" with full flag parity to the
+// macOS CLI: --layout (JSON object), --env (repeatable KEY=VALUE), --env-file
+// (file of KEY=VALUE lines), and --command (post-create send+return).
+func runNewWorkspaceRelay(socketPath string, args []string, jsonOutput bool, refreshAddr func() string) int {
+	flagKeys := []string{"name", "cwd", "description", "focus", "window", "group", "group-placement", "group-reference", "layout", "env-file", "command"}
+	repeatKeys := []string{"env"}
+
+	parsed, err := parseFlags(args, flagKeys, repeatKeys)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux new-workspace: %v\n", err)
+		return 2
+	}
+	if len(parsed.positional) > 0 {
+		fmt.Fprintln(os.Stderr, "cmux: new-workspace does not accept positional arguments")
+		return 2
+	}
+
+	params := make(map[string]any)
+
+	for _, key := range []string{"name", "cwd", "description", "window", "group", "group-placement", "group-reference", "command"} {
+		if val, ok := parsed.flags[key]; ok {
+			paramKey := flagToParamKey(key)
+			switch key {
+			case "name":
+				paramKey = "title"
+			case "group-placement":
+				paramKey = "placement"
+			case "group-reference":
+				paramKey = "group_reference_workspace_id"
+			case "command":
+				// handled post-create; do not send to workspace.create
+				continue
+			}
+			params[paramKey] = val
+		}
+	}
+
+	if val, ok := parsed.flags["focus"]; ok {
+		switch strings.ToLower(val) {
+		case "true", "1", "yes":
+			params["focus"] = true
+		case "false", "0", "no":
+			params["focus"] = false
+		default:
+			fmt.Fprintf(os.Stderr, "cmux: --focus must be true or false\n")
+			return 2
+		}
+	}
+
+	if val, ok := parsed.flags["layout"]; ok {
+		var layout any
+		if err := json.Unmarshal([]byte(val), &layout); err != nil {
+			fmt.Fprintf(os.Stderr, "cmux new-workspace: --layout must be valid JSON: %v\n", err)
+			return 2
+		}
+		params["layout"] = layout
+	}
+
+	// Build env dict from --env KEY=VALUE pairs and --env-file lines.
+	env := make(map[string]string)
+	for _, kv := range parsed.repeated["env"] {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			fmt.Fprintf(os.Stderr, "cmux new-workspace: --env %q must be KEY=VALUE\n", kv)
+			return 2
+		}
+		env[k] = v
+	}
+	if envFile, ok := parsed.flags["env-file"]; ok {
+		data, err := os.ReadFile(envFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "cmux new-workspace: --env-file: %v\n", err)
+			return 2
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			k, v, ok := strings.Cut(line, "=")
+			if !ok {
+				fmt.Fprintf(os.Stderr, "cmux new-workspace: --env-file line %q must be KEY=VALUE\n", line)
+				return 2
+			}
+			env[k] = v
+		}
+	}
+	if len(env) > 0 {
+		params["env"] = env
+	}
+
+	resp, err := socketRoundTripV2(socketPath, "workspace.create", params, refreshAddr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
+		return 1
+	}
+
+	// --command: send text + Enter to the new workspace's surface.
+	if cmd, ok := parsed.flags["command"]; ok {
+		var result map[string]any
+		if err := json.Unmarshal([]byte(resp), &result); err == nil {
+			if surfaceID, _ := result["surface_id"].(string); surfaceID != "" {
+				sendParams := map[string]any{"surface_id": surfaceID, "text": cmd}
+				if _, err := socketRoundTripV2(socketPath, "surface.send_text", sendParams, refreshAddr); err != nil {
+					fmt.Fprintf(os.Stderr, "cmux new-workspace: --command send failed: %v\n", err)
+					return 1
+				}
+				keyParams := map[string]any{"surface_id": surfaceID, "key": "return"}
+				if _, err := socketRoundTripV2(socketPath, "surface.send_key", keyParams, refreshAddr); err != nil {
+					fmt.Fprintf(os.Stderr, "cmux new-workspace: --command send-key failed: %v\n", err)
+					return 1
+				}
+			}
+		}
 	}
 
 	if jsonOutput {
@@ -651,6 +764,21 @@ func applyBrowserValuePositionals(params map[string]any, positionals []string, a
 	}
 }
 
+// specUsesParam reports whether any of spec's flagKeys resolves to paramKey
+// after applying flagToParamKey and any paramKeyOverrides.
+func specUsesParam(spec *commandSpec, paramKey string) bool {
+	for _, k := range spec.flagKeys {
+		resolved := flagToParamKey(k)
+		if override, ok := spec.paramKeyOverrides[k]; ok {
+			resolved = override
+		}
+		if resolved == paramKey {
+			return true
+		}
+	}
+	return false
+}
+
 func applyWorkspaceEnvFallback(params map[string]any) {
 	if _, ok := params["workspace_id"]; ok {
 		return
@@ -723,6 +851,8 @@ func flagToParamKey(key string) string {
 		return "pane_id"
 	case "window":
 		return "window_id"
+	case "group":
+		return "group_id"
 	case "command":
 		return "initial_command"
 	case "name":

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -935,56 +934,6 @@ func computeRelayMAC(token []byte, relayID, nonce string, version int) []byte {
 	mac := hmac.New(sha256.New, token)
 	_, _ = io.WriteString(mac, fmt.Sprintf("relay_id=%s\nnonce=%s\nversion=%d", relayID, nonce, version))
 	return mac.Sum(nil)
-}
-
-// socketRoundTrip sends a raw text line and reads a raw text response (v1).
-func socketRoundTrip(socketPath, command string, refreshAddr func() string) (string, error) {
-	conn, err := dialSocket(socketPath, refreshAddr)
-	if err != nil {
-		return "", fmt.Errorf("failed to connect to %s: %w", socketPath, err)
-	}
-	defer conn.Close()
-
-	if _, err := fmt.Fprintf(conn, "%s\n", command); err != nil {
-		return "", fmt.Errorf("failed to send command: %w", err)
-	}
-
-	// V1 handlers may return multiple lines (e.g. list_windows). Read until
-	// the stream goes idle briefly after seeing at least one newline.
-	reader := bufio.NewReader(conn)
-	var response strings.Builder
-	sawNewline := false
-
-	for {
-		readTimeout := 15 * time.Second
-		if sawNewline {
-			readTimeout = 120 * time.Millisecond
-		}
-		_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
-
-		chunk, err := reader.ReadString('\n')
-		if chunk != "" {
-			response.WriteString(chunk)
-			if strings.Contains(chunk, "\n") {
-				sawNewline = true
-			}
-		}
-
-		if err != nil {
-			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-				if sawNewline {
-					break
-				}
-				return "", fmt.Errorf("failed to read response: timeout waiting for response")
-			}
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return "", fmt.Errorf("failed to read response: %w", err)
-		}
-	}
-
-	return strings.TrimRight(response.String(), "\n"), nil
 }
 
 // socketRoundTripV2 sends a JSON-RPC request and returns the result JSON.

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -899,7 +899,8 @@ func flagToParamKey(key string) string {
 	case "load-state":
 		return "load_state"
 	default:
-		return key
+		// Hyphenated flag names map to underscore param keys by convention.
+		return strings.ReplaceAll(key, "-", "_")
 	}
 }
 

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -101,8 +101,8 @@ func init() {
 		if ov.paramKeyOverrides != nil {
 			commands[i].paramKeyOverrides = ov.paramKeyOverrides
 		}
-		if ov.positionalKey != "" {
-			commands[i].positionalKey = ov.positionalKey
+		if ov.disablePositional {
+			commands[i].positionalKey = ""
 		}
 		if ov.defaultParams != nil {
 			commands[i].defaultParams = ov.defaultParams
@@ -245,9 +245,21 @@ func execV2(socketPath string, spec *commandSpec, args []string, jsonOutput bool
 			boolFlagSet[k] = struct{}{}
 		}
 
+		// Build clientOnlyFlags set so they are accepted by parseFlags but never forwarded.
+		clientOnly := make(map[string]struct{})
+		if ov, ok := commandOverrides[spec.name]; ok {
+			for _, f := range ov.clientOnlyFlags {
+				clientOnly[f] = struct{}{}
+			}
+		}
+
 		// Map flag keys to JSON param keys (e.g. "workspace" → "workspace_id" where appropriate).
 		// Flags listed in boolFlags are coerced to JSON booleans instead of sent as strings.
+		// Flags listed in clientOnlyFlags are skipped — they are consumed client-side only.
 		for _, key := range spec.flagKeys {
+			if _, skip := clientOnly[key]; skip {
+				continue
+			}
 			if val, ok := parsed.flags[key]; ok {
 				paramKey := flagToParamKey(key)
 				if override, ok := spec.paramKeyOverrides[key]; ok {
@@ -266,6 +278,20 @@ func execV2(socketPath string, spec *commandSpec, args []string, jsonOutput bool
 				} else {
 					params[paramKey] = val
 				}
+			}
+		}
+
+		// Forward repeated flag values (e.g. --env KEY=VALUE accumulates into a list).
+		for _, key := range spec.repeatKeys {
+			if _, skip := clientOnly[key]; skip {
+				continue
+			}
+			if vals, ok := parsed.repeated[key]; ok {
+				paramKey := flagToParamKey(key)
+				if override, ok := spec.paramKeyOverrides[key]; ok {
+					paramKey = override
+				}
+				params[paramKey] = vals
 			}
 		}
 
@@ -400,19 +426,24 @@ func runNewWorkspaceRelay(socketPath string, args []string, jsonOutput bool, ref
 	// --command: send text + Enter to the new workspace's surface.
 	if cmd, ok := parsed.flags["command"]; ok {
 		var result map[string]any
-		if err := json.Unmarshal([]byte(resp), &result); err == nil {
-			if surfaceID, _ := result["surface_id"].(string); surfaceID != "" {
-				sendParams := map[string]any{"surface_id": surfaceID, "text": cmd}
-				if _, err := socketRoundTripV2(socketPath, "surface.send_text", sendParams, refreshAddr); err != nil {
-					fmt.Fprintf(os.Stderr, "cmux new-workspace: --command send failed: %v\n", err)
-					return 1
-				}
-				keyParams := map[string]any{"surface_id": surfaceID, "key": "return"}
-				if _, err := socketRoundTripV2(socketPath, "surface.send_key", keyParams, refreshAddr); err != nil {
-					fmt.Fprintf(os.Stderr, "cmux new-workspace: --command send-key failed: %v\n", err)
-					return 1
-				}
-			}
+		if err := json.Unmarshal([]byte(resp), &result); err != nil {
+			fmt.Fprintf(os.Stderr, "cmux new-workspace: --command skipped: could not parse create response: %v\n", err)
+			return 1
+		}
+		surfaceID, _ := result["surface_id"].(string)
+		if surfaceID == "" {
+			fmt.Fprintf(os.Stderr, "cmux new-workspace: --command skipped: workspace.create response missing surface_id\n")
+			return 1
+		}
+		sendParams := map[string]any{"surface_id": surfaceID, "text": cmd}
+		if _, err := socketRoundTripV2(socketPath, "surface.send_text", sendParams, refreshAddr); err != nil {
+			fmt.Fprintf(os.Stderr, "cmux new-workspace: --command send failed: %v\n", err)
+			return 1
+		}
+		keyParams := map[string]any{"surface_id": surfaceID, "key": "return"}
+		if _, err := socketRoundTripV2(socketPath, "surface.send_key", keyParams, refreshAddr); err != nil {
+			fmt.Fprintf(os.Stderr, "cmux new-workspace: --command send-key failed: %v\n", err)
+			return 1
 		}
 	}
 

--- a/daemon/remote/cmd/cmuxd-remote/cli_overrides.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_overrides.go
@@ -1,0 +1,66 @@
+package main
+
+// commandOverride describes relay-specific behaviour that cannot be expressed
+// in the system.command_spec JSON and therefore cannot be generated.
+// The generator produces the base commandSpec from the spec; init() applies
+// these overrides on top.
+type commandOverride struct {
+	// paramKeyOverrides maps a CLI flag name to the JSON param key sent to the
+	// server when they differ (e.g. "--name" must be sent as "title").
+	paramKeyOverrides map[string]string
+
+	// positionalKey is the param key for a positional argument. Takes precedence
+	// over the positionalKey in the generated spec (for cases where the override
+	// needs to differ from the Mac CLI convention).
+	positionalKey string
+
+	// defaultParams are params always included in the RPC call even when the
+	// corresponding flag is absent.
+	defaultParams map[string]any
+
+	// specialDispatch marks the command as having a custom runXxxRelay function
+	// in cli.go. runCLI dispatches to it instead of the generic relay path.
+	specialDispatch bool
+
+	// clientOnlyFlags are flag names that are handled client-side and must NOT
+	// be forwarded to the server as RPC params. They are still accepted by
+	// parseFlags so the user can pass them; the special dispatch function reads
+	// them from parsedFlags.flags before building the params map.
+	clientOnlyFlags []string
+}
+
+// commandOverrides is consulted by init() and by runCLI for dispatch.
+// Add an entry here whenever the relay needs to deviate from the generated spec.
+var commandOverrides = map[string]commandOverride{
+
+	// --name is the CLI flag; the server param is "title".
+	// --command, --env-file, and --layout are handled client-side by
+	// runNewWorkspaceRelay (post-create send, file read, JSON parse).
+	"new-workspace": {
+		paramKeyOverrides: map[string]string{"name": "title"},
+		clientOnlyFlags:   []string{"command", "env-file", "layout"},
+		specialDispatch:   true,
+	},
+
+	// Mac CLI help shows "title" as a positional arg; relay accepts --title as a
+	// flag instead (both paths exist on the server side).
+	"rename-workspace": {
+		positionalKey: "", // flag only in relay; positional not wired
+	},
+
+	// new-pane defaults direction to "right" when the flag is omitted, matching
+	// the Mac CLI default.
+	"new-pane": {
+		defaultParams: map[string]any{"direction": "right"},
+	},
+
+	// --panel is an alias for --surface that maps to surface_id.
+	"focus-panel": {
+		paramKeyOverrides: map[string]string{"panel": "surface_id"},
+	},
+
+	// --target-pane maps to the server param target_pane_id.
+	"join-pane": {
+		paramKeyOverrides: map[string]string{"target-pane": "target_pane_id"},
+	},
+}

--- a/daemon/remote/cmd/cmuxd-remote/cli_overrides.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_overrides.go
@@ -9,10 +9,9 @@ type commandOverride struct {
 	// server when they differ (e.g. "--name" must be sent as "title").
 	paramKeyOverrides map[string]string
 
-	// positionalKey is the param key for a positional argument. Takes precedence
-	// over the positionalKey in the generated spec (for cases where the override
-	// needs to differ from the Mac CLI convention).
-	positionalKey string
+	// disablePositional clears any positionalKey inherited from commands.go,
+	// making the command accept the positional value only via an explicit flag.
+	disablePositional bool
 
 	// defaultParams are params always included in the RPC call even when the
 	// corresponding flag is absent.
@@ -22,10 +21,8 @@ type commandOverride struct {
 	// in cli.go. runCLI dispatches to it instead of the generic relay path.
 	specialDispatch bool
 
-	// clientOnlyFlags are flag names that are handled client-side and must NOT
-	// be forwarded to the server as RPC params. They are still accepted by
-	// parseFlags so the user can pass them; the special dispatch function reads
-	// them from parsedFlags.flags before building the params map.
+	// clientOnlyFlags are flag names handled client-side that must NOT be
+	// forwarded as RPC params. execV2 filters these out before building params.
 	clientOnlyFlags []string
 }
 
@@ -42,10 +39,10 @@ var commandOverrides = map[string]commandOverride{
 		specialDispatch:   true,
 	},
 
-	// Mac CLI help shows "title" as a positional arg; relay accepts --title as a
-	// flag instead (both paths exist on the server side).
+	// Mac CLI shows "title" as a positional arg; relay accepts --title as a
+	// flag instead, so positional args should be rejected.
 	"rename-workspace": {
-		positionalKey: "", // flag only in relay; positional not wired
+		disablePositional: true,
 	},
 
 	// new-pane defaults direction to "right" when the flag is omitted, matching
@@ -56,6 +53,12 @@ var commandOverrides = map[string]commandOverride{
 
 	// --panel is an alias for --surface that maps to surface_id.
 	"focus-panel": {
+		paramKeyOverrides: map[string]string{"panel": "surface_id"},
+	},
+	"close-surface": {
+		paramKeyOverrides: map[string]string{"panel": "surface_id"},
+	},
+	"new-split": {
 		paramKeyOverrides: map[string]string{"panel": "surface_id"},
 	},
 

--- a/daemon/remote/cmd/cmuxd-remote/cli_relay_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_relay_test.go
@@ -301,13 +301,8 @@ func TestNewWorkspaceCommand(t *testing.T) {
 			}
 			go func(conn net.Conn) {
 				defer conn.Close()
-				buf := make([]byte, 4096)
-				n, _ := conn.Read(buf)
-				if n == 0 {
-					return
-				}
 				var req map[string]any
-				if err := json.Unmarshal(buf[:n], &req); err != nil {
+				if err := json.NewDecoder(conn).Decode(&req); err != nil {
 					conn.Write([]byte(`{"ok":false,"error":{"code":"parse","message":"bad json"}}` + "\n"))
 					return
 				}

--- a/daemon/remote/cmd/cmuxd-remote/cli_relay_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_relay_test.go
@@ -1,0 +1,443 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+// receiveRequest reads one captured request from the channel with a timeout.
+func receiveRequest(t *testing.T, ch <-chan map[string]any) map[string]any {
+	t.Helper()
+	select {
+	case req := <-ch:
+		return req
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for request")
+		return nil
+	}
+}
+
+func params(req map[string]any) map[string]any {
+	t := req["params"]
+	if t == nil {
+		return map[string]any{}
+	}
+	p, ok := t.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	return p
+}
+
+// TestBoolFlagCoercionFocusTrue verifies that --focus true is sent as a JSON
+// boolean true, not the string "true".
+func TestBoolFlagCoercionFocusTrue(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "--focus", "true"})
+	if code != 0 {
+		t.Fatalf("new-workspace --focus true: exit %d", code)
+	}
+	req := receiveRequest(t, requests)
+	p := params(req)
+	focus, ok := p["focus"]
+	if !ok {
+		t.Fatal("expected 'focus' param to be set")
+	}
+	if focus != true {
+		t.Fatalf("expected focus=true (bool), got %T(%v)", focus, focus)
+	}
+}
+
+// TestBoolFlagCoercionFocusFalse verifies false is sent as JSON false.
+func TestBoolFlagCoercionFocusFalse(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "--focus", "false"})
+	if code != 0 {
+		t.Fatalf("new-workspace --focus false: exit %d", code)
+	}
+	req := receiveRequest(t, requests)
+	p := params(req)
+	focus, ok := p["focus"]
+	if !ok {
+		t.Fatal("expected 'focus' param to be set")
+	}
+	if focus != false {
+		t.Fatalf("expected focus=false (bool), got %T(%v)", focus, focus)
+	}
+}
+
+// TestBoolFlagCoercionInvalidValue verifies that an invalid --focus value
+// returns a non-zero exit code without sending a request.
+func TestBoolFlagCoercionInvalidValue(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "--focus", "maybe"})
+	if code == 0 {
+		t.Fatal("new-workspace --focus maybe: expected non-zero exit")
+	}
+	select {
+	case req := <-requests:
+		t.Fatalf("expected no request to be sent on invalid flag value, got: %v", req)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestNewWorkspaceParamNames verifies that --name maps to "title" and --cwd maps
+// to "cwd" (not "name" and "working_directory").
+func TestNewWorkspaceParamNames(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "--name", "My WS", "--cwd", "/home/dev/code"})
+	if code != 0 {
+		t.Fatalf("new-workspace: exit %d", code)
+	}
+	req := receiveRequest(t, requests)
+	if req["method"] != "workspace.create" {
+		t.Fatalf("expected method workspace.create, got %v", req["method"])
+	}
+	p := params(req)
+	if p["title"] != "My WS" {
+		t.Fatalf("expected title='My WS', got %v (wrong param name?)", p["title"])
+	}
+	if p["name"] != nil {
+		t.Fatalf("unexpected 'name' param (should be 'title'): %v", p["name"])
+	}
+	if p["cwd"] != "/home/dev/code" {
+		t.Fatalf("expected cwd='/home/dev/code', got %v", p["cwd"])
+	}
+	if p["working_directory"] != nil {
+		t.Fatalf("unexpected 'working_directory' param (should be 'cwd'): %v", p["working_directory"])
+	}
+}
+
+// TestRenameWorkspace verifies method and params.
+func TestRenameWorkspace(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "rename-workspace", "--title", "devbox"})
+	if code != 0 {
+		t.Fatalf("rename-workspace: exit %d", code)
+	}
+	req := receiveRequest(t, requests)
+	if req["method"] != "workspace.rename" {
+		t.Fatalf("expected workspace.rename, got %v", req["method"])
+	}
+	if params(req)["title"] != "devbox" {
+		t.Fatalf("expected title='devbox', got %v", params(req)["title"])
+	}
+}
+
+// TestJoinPaneTargetPaneParam verifies that --target-pane maps to target_pane_id.
+func TestJoinPaneTargetPaneParam(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "join-pane", "--pane", "pane-1", "--target-pane", "pane-2"})
+	if code != 0 {
+		t.Fatalf("join-pane: exit %d", code)
+	}
+	req := receiveRequest(t, requests)
+	if req["method"] != "pane.join" {
+		t.Fatalf("expected pane.join, got %v", req["method"])
+	}
+	p := params(req)
+	if p["target_pane_id"] != "pane-2" {
+		t.Fatalf("expected target_pane_id='pane-2', got %v", p["target_pane_id"])
+	}
+	if p["target-pane"] != nil {
+		t.Fatalf("unexpected 'target-pane' param (should be 'target_pane_id'): %v", p["target-pane"])
+	}
+}
+
+// TestNewWorkspaceRemovedFlags verifies that --working-directory is no longer
+// accepted. It was previously accepted but sent the wrong param name
+// (working_directory instead of cwd) so the server silently ignored it.
+func TestNewWorkspaceRemovedFlags(t *testing.T) {
+	sockPath := startMockV2Socket(t)
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "--working-directory", "/home/dev"})
+	if code == 0 {
+		t.Fatal("new-workspace --working-directory: expected non-zero exit (flag was removed)")
+	}
+}
+
+// TestNewWorkspaceLayout verifies that --layout parses the JSON value and sends
+// it as a nested object, not a string.
+func TestNewWorkspaceLayout(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	layout := `{"splits":[{"direction":"vertical","ratio":0.5}]}`
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "--layout", layout})
+	if code != 0 {
+		t.Fatalf("new-workspace --layout: exit %d", code)
+	}
+	req := receiveRequest(t, requests)
+	if req["method"] != "workspace.create" {
+		t.Fatalf("expected workspace.create, got %v", req["method"])
+	}
+	p := params(req)
+	if p["layout"] == nil {
+		t.Fatal("expected 'layout' param to be set")
+	}
+	// layout must be a map, not a raw string
+	if _, ok := p["layout"].(map[string]any); !ok {
+		t.Fatalf("expected layout to be a JSON object, got %T", p["layout"])
+	}
+}
+
+// TestNewWorkspaceLayoutInvalid verifies that non-JSON --layout returns exit 2.
+func TestNewWorkspaceLayoutInvalid(t *testing.T) {
+	sockPath := startMockV2Socket(t)
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "--layout", "not-json"})
+	if code == 0 {
+		t.Fatal("new-workspace --layout not-json: expected non-zero exit")
+	}
+}
+
+// TestNewWorkspaceEnv verifies that --env KEY=VALUE pairs are collected into a
+// dict under the "env" param.
+func TestNewWorkspaceEnv(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "new-workspace",
+		"--env", "FOO=bar",
+		"--env", "BAZ=qux",
+	})
+	if code != 0 {
+		t.Fatalf("new-workspace --env: exit %d", code)
+	}
+	req := receiveRequest(t, requests)
+	p := params(req)
+	env, ok := p["env"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected env to be a map, got %T: %v", p["env"], p["env"])
+	}
+	if env["FOO"] != "bar" {
+		t.Fatalf("expected env.FOO='bar', got %v", env["FOO"])
+	}
+	if env["BAZ"] != "qux" {
+		t.Fatalf("expected env.BAZ='qux', got %v", env["BAZ"])
+	}
+}
+
+// TestNewWorkspaceEnvBadFormat verifies that --env values without '=' return exit 2.
+func TestNewWorkspaceEnvBadFormat(t *testing.T) {
+	sockPath := startMockV2Socket(t)
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "--env", "NOEQUALS"})
+	if code == 0 {
+		t.Fatal("new-workspace --env NOEQUALS: expected non-zero exit")
+	}
+}
+
+// TestNewWorkspaceEnvFile verifies that --env-file reads a file of KEY=VALUE
+// lines (ignoring blank lines and comments) and merges them into the env param.
+func TestNewWorkspaceEnvFile(t *testing.T) {
+	f, err := os.CreateTemp("", "cmux-env-*.env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(f.Name()) })
+	f.WriteString("# comment\nHOST=localhost\nPORT=5432\n\n")
+	f.Close()
+
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "--env-file", f.Name()})
+	if code != 0 {
+		t.Fatalf("new-workspace --env-file: exit %d", code)
+	}
+	req := receiveRequest(t, requests)
+	env, ok := params(req)["env"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected env map, got %T", params(req)["env"])
+	}
+	if env["HOST"] != "localhost" || env["PORT"] != "5432" {
+		t.Fatalf("unexpected env contents: %v", env)
+	}
+}
+
+// TestNewWorkspaceWindowGroupFlags verifies that --window, --group,
+// --group-placement, and --group-reference map to the correct param names.
+func TestNewWorkspaceWindowGroupFlags(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{
+		"--socket", sockPath, "new-workspace",
+		"--window", "win-1",
+		"--group", "grp-1",
+		"--group-placement", "before",
+		"--group-reference", "ws-ref-1",
+	})
+	if code != 0 {
+		t.Fatalf("new-workspace with group flags: exit %d", code)
+	}
+	req := receiveRequest(t, requests)
+	p := params(req)
+	if p["window_id"] != "win-1" {
+		t.Fatalf("expected window_id='win-1', got %v", p["window_id"])
+	}
+	if p["group_id"] != "grp-1" {
+		t.Fatalf("expected group_id='grp-1', got %v", p["group_id"])
+	}
+	if p["placement"] != "before" {
+		t.Fatalf("expected placement='before', got %v", p["placement"])
+	}
+	if p["group_reference_workspace_id"] != "ws-ref-1" {
+		t.Fatalf("expected group_reference_workspace_id='ws-ref-1', got %v", p["group_reference_workspace_id"])
+	}
+}
+
+// TestNewWorkspaceCommand verifies that --command triggers two follow-up calls
+// (surface.send_text and surface.send_key return) using the surface_id returned
+// by workspace.create.
+func TestNewWorkspaceCommand(t *testing.T) {
+	// Custom mock: workspace.create returns surface_id; other methods echo normally.
+	sockPath := makeShortUnixSocketPath(t)
+	requests := make(chan map[string]any, 8)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				buf := make([]byte, 4096)
+				n, _ := conn.Read(buf)
+				if n == 0 {
+					return
+				}
+				var req map[string]any
+				if err := json.Unmarshal(buf[:n], &req); err != nil {
+					conn.Write([]byte(`{"ok":false,"error":{"code":"parse","message":"bad json"}}` + "\n"))
+					return
+				}
+				requests <- req
+				var result any
+				if req["method"] == "workspace.create" {
+					result = map[string]any{"workspace_id": "ws-1", "surface_id": "surf-1"}
+				} else {
+					result = map[string]any{"ok": true}
+				}
+				resp := map[string]any{"id": req["id"], "ok": true, "result": result}
+				payload, _ := json.Marshal(resp)
+				conn.Write(append(payload, '\n'))
+			}(conn)
+		}
+	}()
+
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "--command", "claude ."})
+	if code != 0 {
+		t.Fatalf("new-workspace --command: exit %d", code)
+	}
+
+	create := receiveRequest(t, requests)
+	if create["method"] != "workspace.create" {
+		t.Fatalf("expected workspace.create, got %v", create["method"])
+	}
+
+	sendText := receiveRequest(t, requests)
+	if sendText["method"] != "surface.send_text" {
+		t.Fatalf("expected surface.send_text, got %v", sendText["method"])
+	}
+	sp := params(sendText)
+	if sp["surface_id"] != "surf-1" {
+		t.Fatalf("expected surface_id='surf-1', got %v", sp["surface_id"])
+	}
+	if sp["text"] != "claude ." {
+		t.Fatalf("expected text='claude .', got %v", sp["text"])
+	}
+
+	sendKey := receiveRequest(t, requests)
+	if sendKey["method"] != "surface.send_key" {
+		t.Fatalf("expected surface.send_key, got %v", sendKey["method"])
+	}
+	kp := params(sendKey)
+	if kp["surface_id"] != "surf-1" {
+		t.Fatalf("expected surface_id='surf-1', got %v", kp["surface_id"])
+	}
+	if kp["key"] != "return" {
+		t.Fatalf("expected key='return', got %v", kp["key"])
+	}
+}
+
+// TestSendPositional verifies that send and send-key take text/key as positional args,
+// matching the Mac CLI convention (not --text/--key flags).
+func TestSendPositional(t *testing.T) {
+	t.Run("send", func(t *testing.T) {
+		sockPath, requests := startMockV2SocketWithRequestCapture(t)
+		code := runCLI([]string{"--socket", sockPath, "send", "hello world"})
+		if code != 0 {
+			t.Fatalf("send: exit %d", code)
+		}
+		req := receiveRequest(t, requests)
+		if params(req)["text"] != "hello world" {
+			t.Fatalf("expected text='hello world', got %v", params(req)["text"])
+		}
+	})
+	t.Run("send-key", func(t *testing.T) {
+		sockPath, requests := startMockV2SocketWithRequestCapture(t)
+		code := runCLI([]string{"--socket", sockPath, "send-key", "ctrl+c"})
+		if code != 0 {
+			t.Fatalf("send-key: exit %d", code)
+		}
+		req := receiveRequest(t, requests)
+		if params(req)["key"] != "ctrl+c" {
+			t.Fatalf("expected key='ctrl+c', got %v", params(req)["key"])
+		}
+	})
+	t.Run("send rejects --text flag", func(t *testing.T) {
+		sockPath := startMockV2Socket(t)
+		code := runCLI([]string{"--socket", sockPath, "send", "--text", "hello"})
+		if code == 0 {
+			t.Fatal("send --text: expected non-zero exit (--text is not a flag; use positional)")
+		}
+	})
+}
+
+// TestPositionalRejectedOnFlagOnlyCommands verifies that commands without positionalKey
+// reject unexpected positional arguments instead of silently ignoring them.
+func TestPositionalRejectedOnFlagOnlyCommands(t *testing.T) {
+	sockPath := startMockV2Socket(t)
+	code := runCLI([]string{"--socket", sockPath, "new-workspace", "unexpected-positional"})
+	if code == 0 {
+		t.Fatal("new-workspace with positional arg: expected non-zero exit")
+	}
+}
+
+// TestNewCommandsMethod is a table-driven smoke test verifying that each new
+// command sends the correct v2 method.
+func TestNewCommandsMethod(t *testing.T) {
+	tests := []struct {
+		args   []string
+		method string
+	}{
+		{[]string{"next-workspace"}, "workspace.next"},
+		{[]string{"previous-workspace"}, "workspace.previous"},
+		{[]string{"last-workspace"}, "workspace.last"},
+		{[]string{"equalize-splits"}, "workspace.equalize_splits"},
+		{[]string{"last-pane"}, "pane.last"},
+		{[]string{"swap-pane", "--pane", "p1"}, "pane.swap"},
+		{[]string{"break-pane", "--pane", "p1"}, "pane.break"},
+		{[]string{"read-screen"}, "surface.read_text"},
+		{[]string{"clear-history"}, "surface.clear_history"},
+		{[]string{"jump-to-unread"}, "notification.jump_to_unread"},
+		{[]string{"dismiss-notification", "--id", "n1"}, "notification.dismiss"},
+		{[]string{"mark-notification-read", "--id", "n1"}, "notification.mark_read"},
+		{[]string{"open-notification", "--id", "n1"}, "notification.open"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.args[0], func(t *testing.T) {
+			sockPath, requests := startMockV2SocketWithRequestCapture(t)
+			args := append([]string{"--socket", sockPath}, tt.args...)
+			code := runCLI(args)
+			if code != 0 {
+				t.Fatalf("%s: exit %d", tt.args[0], code)
+			}
+			req := receiveRequest(t, requests)
+			if req["method"] != tt.method {
+				t.Fatalf("%s: expected method %q, got %v", tt.args[0], tt.method, req["method"])
+			}
+		})
+	}
+}

--- a/daemon/remote/cmd/cmuxd-remote/cli_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_test.go
@@ -377,26 +377,31 @@ func TestDialSocketFailsFastWhenTCPAddressStaysStale(t *testing.T) {
 	}
 }
 
-func TestCLIPingV1(t *testing.T) {
-	sockPath := startMockSocket(t, "pong")
+func TestCLIPing(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
 	code := runCLI([]string{"--socket", sockPath, "ping"})
 	if code != 0 {
 		t.Fatalf("ping should return 0, got %d", code)
 	}
+	req := receiveRequest(t, requests)
+	if req["method"] != "system.ping" {
+		t.Fatalf("expected method system.ping, got %v", req["method"])
+	}
 }
 
-func TestCLIPingV1OverTCP(t *testing.T) {
-	addr := startMockTCPSocket(t, "pong")
+func TestCLIPingOverTCP(t *testing.T) {
+	addr := startMockV2TCPSocketWithResult(t, map[string]any{})
 	code := runCLI([]string{"--socket", addr, "ping"})
 	if code != 0 {
 		t.Fatalf("ping over TCP should return 0, got %d", code)
 	}
 }
 
-func TestCLIPingV1OverAuthenticatedTCPWithEnv(t *testing.T) {
+func TestCLIPingOverAuthenticatedTCPWithEnv(t *testing.T) {
 	relayID := "relay-1"
 	relayToken := strings.Repeat("a1", 32)
-	addr := startMockAuthenticatedTCPSocket(t, relayID, relayToken, "pong")
+	pingResp, _ := json.Marshal(map[string]any{"id": 1, "ok": true, "result": map[string]any{}})
+	addr := startMockAuthenticatedTCPSocket(t, relayID, relayToken, string(pingResp))
 	t.Setenv("CMUX_RELAY_ID", relayID)
 	t.Setenv("CMUX_RELAY_TOKEN", relayToken)
 
@@ -406,10 +411,11 @@ func TestCLIPingV1OverAuthenticatedTCPWithEnv(t *testing.T) {
 	}
 }
 
-func TestCLIPingV1OverAuthenticatedTCPWithRelayFile(t *testing.T) {
+func TestCLIPingOverAuthenticatedTCPWithRelayFile(t *testing.T) {
 	relayID := "relay-2"
 	relayToken := strings.Repeat("b2", 32)
-	addr := startMockAuthenticatedTCPSocket(t, relayID, relayToken, "pong")
+	pingResp, _ := json.Marshal(map[string]any{"id": 1, "ok": true, "result": map[string]any{}})
+	addr := startMockAuthenticatedTCPSocket(t, relayID, relayToken, string(pingResp))
 	_, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		t.Fatalf("split host port: %v", err)
@@ -468,61 +474,51 @@ func TestDialSocketDetection(t *testing.T) {
 	conn.Close()
 }
 
-func TestCLINewWindowV1(t *testing.T) {
-	sockPath := startMockSocket(t, "OK window_id=abc123")
+func TestCLINewWindow(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
 	code := runCLI([]string{"--socket", sockPath, "new-window"})
 	if code != 0 {
 		t.Fatalf("new-window should return 0, got %d", code)
 	}
-}
-
-func TestSocketRoundTripReadsFullMultilineV1Response(t *testing.T) {
-	addr := startMockTCPSocket(t, "window:alpha\nwindow:beta\nwindow:gamma")
-	resp, err := socketRoundTrip(addr, "list_windows", nil)
-	if err != nil {
-		t.Fatalf("socketRoundTrip should succeed, got error: %v", err)
-	}
-	want := "window:alpha\nwindow:beta\nwindow:gamma"
-	if resp != want {
-		t.Fatalf("socketRoundTrip truncated v1 response: got %q want %q", resp, want)
+	req := receiveRequest(t, requests)
+	if req["method"] != "window.create" {
+		t.Fatalf("new-window: expected method window.create, got %v", req["method"])
 	}
 }
 
-func TestCLICloseWindowV1(t *testing.T) {
-	// Verify that the flag value is appended to the v1 command
-	dir := t.TempDir()
-	sockPath := filepath.Join(dir, "cmux.sock")
-
-	receivedCh := make(chan string, 1)
-	ln, err := net.Listen("unix", sockPath)
-	if err != nil {
-		t.Fatalf("listen: %v", err)
+func TestSocketRoundTripV2ListResult(t *testing.T) {
+	windows := []any{
+		map[string]any{"id": "alpha", "ref": "@1"},
+		map[string]any{"id": "beta", "ref": "@2"},
+		map[string]any{"id": "gamma", "ref": "@3"},
 	}
-	t.Cleanup(func() { ln.Close() })
+	addr := startMockV2TCPSocketWithResult(t, map[string]any{"windows": windows})
+	resp, err := socketRoundTripV2(addr, "window.list", nil, nil)
+	if err != nil {
+		t.Fatalf("socketRoundTripV2 should succeed, got error: %v", err)
+	}
+	if !strings.Contains(resp, "alpha") || !strings.Contains(resp, "beta") || !strings.Contains(resp, "gamma") {
+		t.Fatalf("socketRoundTripV2 response missing window IDs: %q", resp)
+	}
+}
 
-	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			return
-		}
-		buf := make([]byte, 4096)
-		n, _ := conn.Read(buf)
-		receivedCh <- strings.TrimSpace(string(buf[:n]))
-		conn.Write([]byte("OK\n"))
-		conn.Close()
-	}()
-
+func TestCLICloseWindow(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
 	code := runCLI([]string{"--socket", sockPath, "close-window", "--window", "win-42"})
 	if code != 0 {
 		t.Fatalf("close-window should return 0, got %d", code)
 	}
 	select {
-	case received := <-receivedCh:
-		if received != "close_window win-42" {
-			t.Fatalf("expected 'close_window win-42', got %q", received)
+	case req := <-requests:
+		if req["method"] != "window.close" {
+			t.Fatalf("expected method window.close, got %v", req["method"])
+		}
+		p, _ := req["params"].(map[string]any)
+		if p["window_id"] != "win-42" {
+			t.Fatalf("expected window_id='win-42', got %v", p["window_id"])
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for close-window payload")
+		t.Fatal("timed out waiting for close-window request")
 	}
 }
 
@@ -593,13 +589,16 @@ func TestCLINoSocket(t *testing.T) {
 }
 
 func TestCLISocketEnvVar(t *testing.T) {
-	sockPath := startMockSocket(t, "pong")
-	os.Setenv("CMUX_SOCKET_PATH", sockPath)
-	defer os.Unsetenv("CMUX_SOCKET_PATH")
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	t.Setenv("CMUX_SOCKET_PATH", sockPath)
 
 	code := runCLI([]string{"ping"})
 	if code != 0 {
 		t.Fatalf("ping with env socket should return 0, got %d", code)
+	}
+	req := receiveRequest(t, requests)
+	if req["method"] != "system.ping" {
+		t.Fatalf("expected method system.ping, got %v", req["method"])
 	}
 }
 

--- a/daemon/remote/cmd/cmuxd-remote/commands.go
+++ b/daemon/remote/cmd/cmuxd-remote/commands.go
@@ -1,0 +1,228 @@
+package main
+
+// commands is the relay's command table. Each entry maps a CLI command name to
+// a v2 JSON-RPC method and declares which flags it accepts. Relay-specific
+// behaviour (paramKeyOverrides, specialDispatch, defaultParams) lives in
+// cli_overrides.go; init() in cli.go applies those overrides on top.
+var commands = []commandSpec{
+	{
+		name:      "break-pane",
+		v2Method:  "pane.break",
+		flagKeys:  []string{"pane", "surface", "workspace", "window", "focus", "no-focus"},
+		boolFlags: []string{"focus", "no-focus"},
+	},
+	{
+		name:     "capabilities",
+		v2Method: "system.capabilities",
+		noParams: true,
+	},
+	{
+		name:     "clear-history",
+		v2Method: "surface.clear_history",
+		flagKeys: []string{"surface", "workspace", "window"},
+	},
+	{
+		name:     "close-surface",
+		v2Method: "surface.close",
+		flagKeys: []string{"surface", "panel", "workspace", "window"},
+	},
+	{
+		name:     "close-window",
+		v2Method: "window.close",
+		flagKeys: []string{"window"},
+	},
+	{
+		name:     "close-workspace",
+		v2Method: "workspace.close",
+		flagKeys: []string{"workspace", "window"},
+	},
+	{
+		name:     "current-window",
+		v2Method: "window.current",
+		noParams: true,
+	},
+	{
+		name:     "current-workspace",
+		v2Method: "workspace.current",
+		flagKeys: []string{"window"},
+	},
+	{
+		name:      "dismiss-notification",
+		v2Method:  "notification.dismiss",
+		flagKeys:  []string{"id", "all-read"},
+		boolFlags: []string{"all-read"},
+	},
+	{
+		name:     "equalize-splits",
+		v2Method: "workspace.equalize_splits",
+		flagKeys: []string{"workspace", "window"},
+	},
+	{
+		name:     "focus-panel",
+		v2Method: "surface.focus",
+		flagKeys: []string{"panel", "workspace", "window"},
+	},
+	{
+		name:     "focus-window",
+		v2Method: "window.focus",
+		flagKeys: []string{"window"},
+	},
+	{
+		name:      "join-pane",
+		v2Method:  "pane.join",
+		flagKeys:  []string{"target-pane", "pane", "surface", "workspace", "window", "focus", "no-focus"},
+		boolFlags: []string{"focus", "no-focus"},
+	},
+	{
+		name:     "jump-to-unread",
+		v2Method: "notification.jump_to_unread",
+		noParams: true,
+	},
+	{
+		name:     "last-pane",
+		v2Method: "pane.last",
+		flagKeys: []string{"workspace", "window"},
+	},
+	{
+		name:     "last-workspace",
+		v2Method: "workspace.last",
+		flagKeys: []string{"window"},
+	},
+	{
+		name:     "list-pane-surfaces",
+		v2Method: "pane.surfaces",
+		flagKeys: []string{"pane", "workspace", "window"},
+	},
+	{
+		name:     "list-panes",
+		v2Method: "pane.list",
+		flagKeys: []string{"workspace", "window"},
+	},
+	{
+		name:     "list-panels",
+		v2Method: "surface.list",
+		flagKeys: []string{"workspace", "window"},
+	},
+	{
+		name:     "list-windows",
+		v2Method: "window.list",
+		noParams: true,
+	},
+	{
+		name:     "list-workspaces",
+		v2Method: "workspace.list",
+		flagKeys: []string{"window"},
+	},
+	{
+		name:      "mark-notification-read",
+		v2Method:  "notification.mark_read",
+		flagKeys:  []string{"id", "workspace", "surface", "window", "all"},
+		boolFlags: []string{"all"},
+	},
+	{
+		name:     "move-workspace-to-window",
+		v2Method: "workspace.move_to_window",
+		flagKeys: []string{"workspace", "window"},
+	},
+	{
+		name:      "new-pane",
+		v2Method:  "pane.create",
+		flagKeys:  []string{"type", "direction", "placement", "workspace", "window", "url", "focus"},
+		boolFlags: []string{"focus"},
+	},
+	{
+		name:          "new-split",
+		v2Method:      "surface.split",
+		flagKeys:      []string{"surface", "panel", "workspace", "window", "focus"},
+		boolFlags:     []string{"focus"},
+		positionalKey: "direction",
+	},
+	{
+		name:      "new-surface",
+		v2Method:  "surface.create",
+		flagKeys:  []string{"type", "pane", "placement", "workspace", "window", "url", "provider", "renderer", "working-directory", "focus"},
+		boolFlags: []string{"focus"},
+	},
+	{
+		name:     "new-window",
+		v2Method: "window.create",
+		noParams: true,
+	},
+	{
+		name:       "new-workspace",
+		v2Method:   "workspace.create",
+		flagKeys:   []string{"name", "cwd", "description", "focus", "window", "group", "group-placement", "group-reference", "layout", "env-file", "command"},
+		boolFlags:  []string{"focus"},
+		repeatKeys: []string{"env"},
+	},
+	{
+		name:     "next-workspace",
+		v2Method: "workspace.next",
+		flagKeys: []string{"window"},
+	},
+	{
+		name:     "notify",
+		v2Method: "notification.create",
+		flagKeys: []string{"title", "subtitle", "body", "workspace", "surface", "window"},
+	},
+	{
+		name:     "open-notification",
+		v2Method: "notification.open",
+		flagKeys: []string{"id"},
+	},
+	{
+		name:     "ping",
+		v2Method: "system.ping",
+		noParams: true,
+	},
+	{
+		name:     "previous-workspace",
+		v2Method: "workspace.previous",
+		flagKeys: []string{"window"},
+	},
+	{
+		name:      "read-screen",
+		v2Method:  "surface.read_text",
+		flagKeys:  []string{"surface", "workspace", "window", "scrollback", "lines"},
+		boolFlags: []string{"scrollback"},
+	},
+	{
+		name:     "refresh-surfaces",
+		v2Method: "surface.refresh",
+		noParams: true,
+	},
+	{
+		name:          "rename-workspace",
+		v2Method:      "workspace.rename",
+		flagKeys:      []string{"workspace", "window", "title"},
+		positionalKey: "title",
+	},
+	{
+		name:     "resize-pane",
+		v2Method: "pane.resize",
+		flagKeys: []string{"pane", "workspace", "window", "direction", "amount"},
+	},
+	{
+		name:     "select-workspace",
+		v2Method: "workspace.select",
+		flagKeys: []string{"workspace", "window"},
+	},
+	{
+		name:          "send",
+		v2Method:      "surface.send_text",
+		flagKeys:      []string{"surface", "workspace", "window"},
+		positionalKey: "text",
+	},
+	{
+		name:          "send-key",
+		v2Method:      "surface.send_key",
+		flagKeys:      []string{"surface", "workspace", "window"},
+		positionalKey: "key",
+	},
+	{
+		name:      "swap-pane",
+		v2Method:  "pane.swap",
+		flagKeys:  []string{"pane", "target-pane", "workspace", "window", "focus"},
+		boolFlags: []string{"focus"},
+	},
+}


### PR DESCRIPTION
## Summary

- Migrates the relay to v2-only JSON-RPC (drops legacy v1 path)
- Adds `runNewWorkspaceRelay` with full flag support: `--layout`, `--env` (repeatable), `--env-file`, `--command`, `--window`, `--group`, `--group-placement`, `--group-reference`
- Fills missing flags across all relay commands (`--window` on most, `--direction`/`--amount` for resize-pane, `--scrollback`/`--lines` for read-screen, `--subtitle` for notify, `--all-read` for dismiss-notification, `--provider`/`--renderer`/`--working-directory` for new-surface, `--placement` for new-pane)
- Adds `cli_overrides.go` for relay-specific deltas (paramKeyOverrides, specialDispatch, clientOnlyFlags, defaultParams)
- Adds `commands.go` as a plain hand-written command table

## Files changed

- `cli.go` — v2-only protocol, runNewWorkspaceRelay, repeatable flag parsing
- `commands.go` — complete command table with all flags (new file)
- `cli_overrides.go` — relay-specific behaviour delta (new file)
- `cli_relay_test.go` — tests for new-workspace flags (new file)
- `cli_test.go` — minor test renames and fixes
- `README.md` — updated

## Test plan

- [ ] `go test ./cmd/cmuxd-remote/` passes
- [ ] `cmux new-workspace --command "claude ." --env FOO=bar --layout '{"splits":[]}' --focus true` works end-to-end
- [ ] `cmux rename-workspace "my name"` works positionally and via `--title`
- [ ] `cmux resize-pane --direction right --amount 10` works
- [ ] `cmux read-screen --scrollback --lines 200` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DptUngF74uTzPgqDJrDKoU

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785507384&installation_id=133855650&pr_number=7139&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7139&signature=97f97abdfb8f2ab09688b12d23a33d77ea89101e4a5de83933fa3de45db83d1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the `cmuxd-remote` relay CLI to v2-only JSON-RPC and expands command/flag coverage to near parity with the Mac CLI. Adds a richer `new-workspace` flow, smarter flag handling (booleans, repeatables, positionals), env fallbacks, and snake_case mapping for hyphenated flags.

- **New Features**
  - All commands use v2 JSON-RPC; window APIs return JSON. Includes a complete table (41 commands) with full flags across workspace nav, panes, screens, notifications, and windows.
  - `new-workspace`: supports `--layout` (JSON), `--env` (repeatable), `--env-file`, and `--command`; plus `--window`, `--group`, `--group-placement`, `--group-reference`, `--focus`; `--name` maps to `title`; use `--cwd` for working dir.
  - Flag handling: booleans (`true/false/1/0/yes/no`) coerce to JSON; repeatable flags accumulate; positional args for `send` (text), `send-key` (key), `new-split` (direction); `--panel` maps to `surface_id`; hyphenated flags map to snake_case; env fallbacks from `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID`; client-only flags are filtered; `--command` validates `surface_id`.

- **Migration**
  - Removed v1 text protocol. Window commands now return JSON; update any parsing.
  - `new-workspace`: drop `--working-directory`; use `--cwd`.
  - `send`/`send-key`: `--text`/`--key` removed; pass values positionally (e.g., `cmux send "hello"`).

<sup>Written for commit e7b396dc23fcf5cbaeaa3a0990edfa42e2aeeca8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay commands now use v2 JSON-RPC end to end.
  * Enhanced CLI option handling: boolean flags, repeatable values, positional arguments, default parameters, and richer param remapping (including `--command` flow).
* **Bug Fixes**
  * Stricter request encoding/validation with corrected parameter names and types (e.g., boolean coercion) and updated routing behavior.
* **Documentation**
  * Updated relay CLI documentation and migration notes, including `--working-directory` → `--cwd` and v1-to-v2 behavior changes.
* **Tests**
  * Expanded v2-focused CLI relay tests for methods, flag parsing, env/layout handling, and end-to-end request sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->