### PR TITLE
Add clean sidebar workspace statuses

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6979,9 +6979,11 @@ struct CMUXCLI {
         let (titleOpt, rem2) = parseOption(rem1, name: "--title")
         let (colorOpt, rem3) = parseOption(rem2, name: "--color")
         let (descriptionOpt, rem4) = parseOption(rem3, name: "--description")
-        let (windowOpt, rem5) = parseOption(rem4, name: "--window")
+        let (statusOpt, rem5) = parseOption(rem4, name: "--status")
+        let (statusIdOpt, rem6) = parseOption(rem5, name: "--status-id")
+        let (windowOpt, rem7) = parseOption(rem6, name: "--window")
 
-        var positional = rem5
+        var positional = rem7
         let actionRaw: String
         if let actionOpt {
             actionRaw = actionOpt
@@ -7029,6 +7031,13 @@ struct CMUXCLI {
             throw CLIError(message: "workspace-action set-description requires --description <text> (or trailing text)")
         }
 
+        let statusId = (
+            statusIdOpt ?? statusOpt ?? (action == "set_sidebar_status" ? (inferredPositional.isEmpty ? nil : inferredPositional) : nil)
+        )?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if action == "set_sidebar_status", (statusId?.isEmpty ?? true) {
+            throw CLIError(message: "workspace-action set-sidebar-status requires --status <open|active|done|blocked> (or trailing status)")
+        }
+
         var params: [String: Any] = ["action": action]
         if let windowHandle {
             params["window_id"] = windowHandle
@@ -7044,6 +7053,9 @@ struct CMUXCLI {
         }
         if let description, !description.isEmpty {
             params["description"] = description
+        }
+        if let statusId, !statusId.isEmpty {
+            params["status_id"] = statusId
         }
 
         let payload = try client.sendV2(method: "workspace.action", params: params)
@@ -7062,6 +7074,13 @@ struct CMUXCLI {
         }
         if let color = payload["color"] as? String {
             summaryParts.append("color=\(color)")
+        }
+        if payload.keys.contains("status_id") {
+            if let statusId = payload["status_id"] as? String {
+                summaryParts.append("status=\(statusId)")
+            } else {
+                summaryParts.append("status=clear")
+            }
         }
         printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: summaryParts.joined(separator: " "))
     }
@@ -14695,6 +14714,7 @@ struct CMUXCLI {
               close-others | close-above | close-below
               mark-read | mark-unread
               set-color | clear-color
+              set-sidebar-status | clear-sidebar-status
 
             Flags:
               --action <name>              Action name (required if not positional)
@@ -14703,6 +14723,7 @@ struct CMUXCLI {
               --title <text>               Title for rename
               --color <name|#hex>          Color for set-color (name or #RRGGBB hex)
               --description <text>         Description for set-description
+              --status <id>                Status for set-sidebar-status: open, active, done, blocked
 
             Named colors:
               Red, Crimson, Orange, Amber, Olive, Green, Teal, Aqua,
@@ -14718,6 +14739,8 @@ struct CMUXCLI {
               cmux workspace-action --action set-description --description "Ship checklist"
               cmux workspace-action --action set-description $'Ship checklist\n- verify build\n- post notes'
               cmux workspace-action clear-color
+              cmux workspace-action --action set-sidebar-status --status active
+              cmux workspace-action clear-sidebar-status
             """
         case "tab-action":
             return """
@@ -34254,7 +34277,7 @@ export default CMUXSessionRestore;
           move-workspace-to-window --workspace <id|ref> --window <id|ref>
           reorder-workspace --workspace <id|ref|index> (--index <n> | --before <id|ref|index> | --after <id|ref|index>) [--window <id|ref|index>] [--dry-run]
           reorder-workspaces --order <id|ref|index>,<id|ref|index>,... [--window <id|ref|index>] [--dry-run]
-          workspace-action --action <name> [--workspace <id|ref|index>] [--window <id|ref|index>] [--title <text>] [--color <name|#hex>] [--description <text>]
+          workspace-action --action <name> [--workspace <id|ref|index>] [--window <id|ref|index>] [--title <text>] [--color <name|#hex>] [--description <text>] [--status <id>]
           move-tab-to-new-workspace [--tab <id|ref|index>] [--surface <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--title <text>] [--focus <true|false>]
           list-workspaces [--window <id|ref|index>]
           new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--window <id|ref|index>] [--focus <true|false>] [--group <id|ref>] [--group-placement afterCurrent|top|end] [--group-reference <workspace>]

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6340,6 +6340,14 @@ struct ContentView: View {
             }
         }
 
+        func workspaceStatusCommandTitle(_ status: WorkspaceSidebarStatus) -> String {
+            let format = String(
+                localized: "command.workspaceStatus.named",
+                defaultValue: "Workspace Status: %@"
+            )
+            return String(format: format, locale: .current, status.label)
+        }
+
         var contributions: [CommandPaletteCommandContribution] = []
 
         contributions.append(
@@ -6764,6 +6772,26 @@ struct ContentView: View {
                     title: constant(workspaceColorCommandTitle(entry.name)),
                     subtitle: workspaceSubtitle,
                     keywords: ["workspace", "color", "palette", entry.name.lowercased()],
+                    when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) }
+                )
+            )
+        }
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.clearWorkspaceStatus",
+                title: constant(String(localized: "command.clearWorkspaceStatus.title", defaultValue: "Clear Workspace Status")),
+                subtitle: workspaceSubtitle,
+                keywords: ["workspace", "status", "clear", "reset"],
+                when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) }
+            )
+        )
+        for status in WorkspaceSidebarStatusCatalog.statuses {
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: commandPaletteWorkspaceStatusCommandID(status.id),
+                    title: constant(workspaceStatusCommandTitle(status)),
+                    subtitle: workspaceSubtitle,
+                    keywords: ["workspace", "status", status.id, status.label.lowercased()],
                     when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) }
                 )
             )
@@ -7515,6 +7543,10 @@ struct ContentView: View {
         return "palette.workspaceColor.\(String(hash, radix: 16))"
     }
 
+    private func commandPaletteWorkspaceStatusCommandID(_ statusId: String) -> String {
+        "palette.workspaceStatus.\(statusId)"
+    }
+
     private func commandPaletteExtensionSidebarCommandID(_ providerId: String) -> String {
         var hash: UInt64 = 1_469_598_103_934_665_603
         for byte in providerId.utf8 {
@@ -7835,6 +7867,30 @@ struct ContentView: View {
                     return
                 }
                 tabManager.applyWorkspacePaletteColor(named: entry.name, toWorkspaceIds: [workspace.id])
+            }
+        }
+        registry.register(commandId: "palette.clearWorkspaceStatus") {
+            guard let workspace = tabManager.selectedWorkspace else {
+                NSSound.beep()
+                return
+            }
+            WorkspaceActionDispatcher.setSidebarStatus(
+                nil,
+                in: tabManager,
+                target: .single(workspace.id)
+            )
+        }
+        for status in WorkspaceSidebarStatusCatalog.statuses {
+            registry.register(commandId: commandPaletteWorkspaceStatusCommandID(status.id)) {
+                guard let workspace = tabManager.selectedWorkspace else {
+                    NSSound.beep()
+                    return
+                }
+                WorkspaceActionDispatcher.setSidebarStatus(
+                    status.id,
+                    in: tabManager,
+                    target: .single(workspace.id)
+                )
             }
         }
         registry.register(commandId: "palette.nextWorkspace") {
@@ -13240,6 +13296,7 @@ struct SidebarWorkspaceSnapshotBuilder {
         let customDescription: String?
         let isPinned: Bool
         let customColorHex: String?
+        let sidebarStatus: WorkspaceSidebarStatus?
         let remoteWorkspaceSidebarText: String?
         let remoteConnectionStatusText: String
         let remoteStateHelpText: String
@@ -13774,6 +13831,18 @@ struct TabItemView: View, Equatable {
                         .foregroundColor(.green)
                         .safeHelp(cameraInUseTooltip)
                         .accessibilityLabel(cameraInUseTooltip)
+                }
+
+                if workspaceSnapshot.sidebarStatus != nil || rowInteractionState.isPointerHovering {
+                    SidebarWorkspaceStatusButton(
+                        status: workspaceSnapshot.sidebarStatus,
+                        isActive: usesInvertedActiveForeground,
+                        fallbackColor: activeSecondaryColor(0.7),
+                        fontScale: fontScale
+                    ) {
+                        cycleWorkspaceStatus()
+                    }
+                    .transition(.opacity)
                 }
 
                 Text(displayedTitle)
@@ -14422,6 +14491,27 @@ struct TabItemView: View, Equatable {
             }
         }
 
+        Menu(String(localized: "contextMenu.workspaceStatus", defaultValue: "Workspace Status")) {
+            Button {
+                applyWorkspaceStatus(nil, targetIds: targetIds)
+            } label: {
+                Label(String(localized: "contextMenu.clearWorkspaceStatus", defaultValue: "Clear Status"), systemImage: "xmark.circle")
+            }
+            .disabled(targetIds.isEmpty || !targetIds.contains { workspaceId in
+                tabManager.tabs.first { $0.id == workspaceId }?.sidebarStatusId != nil
+            })
+
+            Divider()
+
+            ForEach(WorkspaceSidebarStatusCatalog.statuses, id: \.id) { status in
+                Button {
+                    applyWorkspaceStatus(status.id, targetIds: targetIds)
+                } label: {
+                    Label(status.label, systemImage: status.systemImage)
+                }
+            }
+        }
+
         if let copyableSidebarSSHError = workspaceSnapshot.copyableSidebarSSHError {
             Divider()
 
@@ -14841,6 +14931,7 @@ struct TabItemView: View, Equatable {
             customDescription: settings.showsWorkspaceDescription ? sidebarVisibleCustomDescription : nil,
             isPinned: tab.isPinned,
             customColorHex: tab.customColor,
+            sidebarStatus: WorkspaceSidebarStatusCatalog.status(for: tab.sidebarStatusId),
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,
@@ -15230,6 +15321,25 @@ struct TabItemView: View, Equatable {
         tabManager.applyWorkspaceColor(hex, toWorkspaceIds: targetIds)
     }
 
+    private func applyWorkspaceStatus(_ statusId: String?, targetIds: [UUID]) {
+        guard !targetIds.isEmpty else { return }
+        _ = WorkspaceActionDispatcher.setSidebarStatus(
+            statusId,
+            in: tabManager,
+            target: WorkspaceActionDispatcher.Target(workspaceIds: targetIds, anchorWorkspaceId: tab.id)
+        )
+        refreshWorkspaceSnapshot(force: true)
+    }
+
+    private func cycleWorkspaceStatus() {
+        let targetIds = selectedTabIds.contains(tab.id) ? contextMenuWorkspaceIds : [tab.id]
+        _ = WorkspaceActionDispatcher.cycleSidebarStatus(
+            in: tabManager,
+            target: WorkspaceActionDispatcher.Target(workspaceIds: targetIds, anchorWorkspaceId: tab.id)
+        )
+        refreshWorkspaceSnapshot(force: true)
+    }
+
     private func promptCustomColor(targetIds: [UUID]) {
         let alert = NSAlert()
         alert.messageText = String(localized: "alert.customColor.title", defaultValue: "Custom Workspace Color")
@@ -15400,6 +15510,48 @@ private extension String {
         guard truncated else { return self }
         let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "..." : trimmed + "..."
+    }
+}
+
+private struct SidebarWorkspaceStatusButton: View {
+    let status: WorkspaceSidebarStatus?
+    let isActive: Bool
+    let fallbackColor: Color
+    let fontScale: CGFloat
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            CmuxSystemSymbolImage(
+                magnified: status?.systemImage ?? "circle.dashed",
+                pointSize: 10 * fontScale,
+                weight: .semibold
+            )
+            .foregroundColor(iconColor)
+            .frame(width: max(14, 14 * fontScale), height: max(14, 14 * fontScale), alignment: .center)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .safeHelp(helpText)
+        .accessibilityLabel(helpText)
+    }
+
+    private var iconColor: Color {
+        guard let status, let color = Color(hex: status.colorHex) else {
+            return fallbackColor.opacity(0.65)
+        }
+        return isActive ? color.opacity(0.95) : color
+    }
+
+    private var helpText: String {
+        guard let status else {
+            return String(localized: "sidebar.workspaceStatus.set.tooltip", defaultValue: "Set Workspace Status")
+        }
+        let format = String(
+            localized: "sidebar.workspaceStatus.current.tooltip",
+            defaultValue: "Workspace Status: %@. Click to change."
+        )
+        return String(format: format, locale: .current, status.label)
     }
 }
 

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1830,6 +1830,9 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var customTitleSource: Workspace.CustomTitleSource? = nil
     var customDescription: String?
     var customColor: String?
+    /// Manual sidebar status slot selected by the user. Optional so older
+    /// snapshots decode unchanged.
+    var sidebarStatusId: String? = nil
     var isPinned: Bool
     var groupId: UUID? = nil
     var isManuallyUnread: Bool? = nil

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -4,6 +4,7 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
         let customDescription: String?
         let isPinned: Bool
         let customColorHex: String?
+        let sidebarStatus: WorkspaceSidebarStatus?
         let finderDirectoryPath: String?
         let mediaActivity: BrowserMediaActivity
     }
@@ -14,6 +15,7 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             customDescription: customDescription,
             isPinned: isPinned,
             customColorHex: customColorHex,
+            sidebarStatus: sidebarStatus,
             finderDirectoryPath: finderDirectoryPath,
             mediaActivity: mediaActivity
         )
@@ -27,6 +29,7 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             customDescription: snapshot.customDescription,
             isPinned: snapshot.isPinned,
             customColorHex: snapshot.customColorHex,
+            sidebarStatus: snapshot.sidebarStatus,
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1719,6 +1719,28 @@ class TabManager: ObservableObject {
         tab.setCustomColor(color)
     }
 
+    @discardableResult
+    func setWorkspaceSidebarStatus(tabId: UUID, statusId: String?) -> Bool {
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return false }
+        tab.setSidebarStatusId(statusId)
+        return true
+    }
+
+    @discardableResult
+    func applyWorkspaceSidebarStatus(_ statusId: String?, toWorkspaceIds workspaceIds: [UUID]) -> [UUID] {
+        guard !workspaceIds.isEmpty else { return [] }
+        var changedWorkspaceIds: [UUID] = []
+        let targetIds = Set(workspaceIds)
+        for tab in tabs where targetIds.contains(tab.id) {
+            let previous = tab.sidebarStatusId
+            tab.setSidebarStatusId(statusId)
+            if tab.sidebarStatusId != previous {
+                changedWorkspaceIds.append(tab.id)
+            }
+        }
+        return changedWorkspaceIds
+    }
+
     func applyWorkspaceColor(_ color: String?, toWorkspaceIds workspaceIds: [UUID]) {
         guard !workspaceIds.isEmpty else { return }
         if workspaceIds.count == 1, let workspaceId = workspaceIds.first {
@@ -5582,6 +5604,7 @@ extension TabManager {
             hasher.combine(workspace.customTitle ?? "")
             hasher.combine(workspace.customDescription ?? "")
             hasher.combine(workspace.customColor ?? "")
+            hasher.combine(workspace.sidebarStatusId ?? "")
             hasher.combine(workspace.isPinned)
             hasher.combine(workspace.panels.count)
             hasher.combine(workspace.statusEntries.count)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4010,7 +4010,8 @@ class TerminalController {
             "move_up", "move_down", "move_top",
             "close_others", "close_above", "close_below",
             "mark_read", "mark_unread",
-            "set_color", "clear_color"
+            "set_color", "clear_color",
+            "set_sidebar_status", "clear_sidebar_status"
         ]
 
         var result: V2CallResult = .err(code: "invalid_params", message: "Unknown workspace action", data: [
@@ -4178,6 +4179,41 @@ class TerminalController {
             case "clear_color":
                 tabManager.setTabColor(tabId: workspace.id, color: nil)
                 finish(["color": NSNull()])
+
+            case "set_sidebar_status":
+                guard let statusRaw = v2String(params, "status_id") ?? v2String(params, "status"),
+                      let statusId = WorkspaceSidebarStatusCatalog.normalizedStatusId(statusRaw) else {
+                    result = .err(code: "invalid_params", message: "Missing or invalid sidebar status", data: [
+                        "status_ids": WorkspaceSidebarStatusCatalog.statuses.map(\.id)
+                    ])
+                    return
+                }
+                guard let statusResult = WorkspaceActionDispatcher.setSidebarStatus(
+                    statusId,
+                    in: tabManager,
+                    target: .single(workspace.id)
+                ) else {
+                    result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                    return
+                }
+                finish([
+                    "status_id": statusResult.statusId as Any,
+                    "changed_workspace_ids": statusResult.changedWorkspaceIds.map(\.uuidString)
+                ])
+
+            case "clear_sidebar_status":
+                guard let statusResult = WorkspaceActionDispatcher.setSidebarStatus(
+                    nil,
+                    in: tabManager,
+                    target: .single(workspace.id)
+                ) else {
+                    result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                    return
+                }
+                finish([
+                    "status_id": NSNull(),
+                    "changed_workspace_ids": statusResult.changedWorkspaceIds.map(\.uuidString)
+                ])
 
             default:
                 result = .err(code: "invalid_params", message: "Unknown workspace action", data: [

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -123,6 +123,7 @@ extension Workspace {
             customTitleSource: effectiveCustomTitleSource,
             customDescription: customDescription,
             customColor: customColor,
+            sidebarStatusId: sidebarStatusId,
             isPinned: isPinned,
             groupId: groupId,
             isManuallyUnread: isWorkspaceManuallyUnread,
@@ -212,6 +213,7 @@ extension Workspace {
         setCustomTitle(snapshot.customTitle, source: snapshot.customTitleSource ?? .user)
         setCustomDescription(snapshot.customDescription)
         setCustomColor(snapshot.customColor)
+        setSidebarStatusId(snapshot.sidebarStatusId)
         isPinned = snapshot.isPinned
         groupId = snapshot.groupId
 
@@ -2219,6 +2221,7 @@ final class Workspace: Identifiable, ObservableObject {
     /// The group entity itself lives in `TabManager.workspaceGroups`.
     @Published var groupId: UUID?
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
+    @Published private(set) var sidebarStatusId: String?
     /// User-defined environment variables applied to every shell spawned in this
     /// workspace: the initial terminal, every later pane/surface/split, and every
     /// surface recreated on session restore. Managed `CMUX_*` and terminal-identity
@@ -4435,6 +4438,10 @@ final class Workspace: Identifiable, ObservableObject {
         } else {
             customColor = nil
         }
+    }
+
+    func setSidebarStatusId(_ statusId: String?) {
+        sidebarStatusId = WorkspaceSidebarStatusCatalog.normalizedStatusId(statusId)
     }
 
     func setTerminalScrollBarHidden(_ hidden: Bool) {

--- a/Sources/WorkspaceActionDispatcher.swift
+++ b/Sources/WorkspaceActionDispatcher.swift
@@ -45,6 +45,12 @@ enum WorkspaceActionDispatcher {
         let pinned: Bool
     }
 
+    struct SidebarStatusResult: Equatable {
+        let targetWorkspaceIds: [UUID]
+        let changedWorkspaceIds: [UUID]
+        let statusId: String?
+    }
+
     @MainActor
     static func pinState(
         in tabManager: TabManager,
@@ -102,6 +108,46 @@ enum WorkspaceActionDispatcher {
             targetWorkspaceIds: targetWorkspaceIds,
             changedWorkspaceIds: changedWorkspaceIds,
             pinned: state.pinned
+        )
+    }
+
+    @discardableResult
+    @MainActor
+    static func setSidebarStatus(
+        _ statusId: String?,
+        in tabManager: TabManager,
+        target: Target
+    ) -> SidebarStatusResult? {
+        let targetWorkspaceIds = liveWorkspaceIds(in: tabManager, from: target.workspaceIds)
+        guard !targetWorkspaceIds.isEmpty else { return nil }
+        let normalizedStatusId = WorkspaceSidebarStatusCatalog.normalizedStatusId(statusId)
+        let changedWorkspaceIds = tabManager.applyWorkspaceSidebarStatus(
+            normalizedStatusId,
+            toWorkspaceIds: targetWorkspaceIds
+        )
+        return SidebarStatusResult(
+            targetWorkspaceIds: targetWorkspaceIds,
+            changedWorkspaceIds: changedWorkspaceIds,
+            statusId: normalizedStatusId
+        )
+    }
+
+    @discardableResult
+    @MainActor
+    static func cycleSidebarStatus(
+        in tabManager: TabManager,
+        target: Target
+    ) -> SidebarStatusResult? {
+        let targetWorkspaceIds = liveWorkspaceIds(in: tabManager, from: target.workspaceIds)
+        guard !targetWorkspaceIds.isEmpty else { return nil }
+        let anchorWorkspaceId = target.anchorWorkspaceId.flatMap { anchorId in
+            targetWorkspaceIds.contains(anchorId) ? anchorId : nil
+        } ?? targetWorkspaceIds[0]
+        let currentStatusId = tabManager.tabs.first { $0.id == anchorWorkspaceId }?.sidebarStatusId
+        return setSidebarStatus(
+            WorkspaceSidebarStatusCatalog.nextStatusId(after: currentStatusId),
+            in: tabManager,
+            target: Target(workspaceIds: targetWorkspaceIds, anchorWorkspaceId: anchorWorkspaceId)
         )
     }
 

--- a/Sources/WorkspaceSidebarStatus.swift
+++ b/Sources/WorkspaceSidebarStatus.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+struct WorkspaceSidebarStatus: Equatable, Identifiable, Sendable {
+    let id: String
+    let label: String
+    let systemImage: String
+    let colorHex: String
+}
+
+enum WorkspaceSidebarStatusCatalog {
+    static let statuses: [WorkspaceSidebarStatus] = [
+        WorkspaceSidebarStatus(
+            id: "open",
+            label: String(localized: "workspaceStatus.open.label", defaultValue: "Open"),
+            systemImage: "circle",
+            colorHex: "#8E8E93"
+        ),
+        WorkspaceSidebarStatus(
+            id: "active",
+            label: String(localized: "workspaceStatus.active.label", defaultValue: "Active"),
+            systemImage: "play.circle.fill",
+            colorHex: "#0A84FF"
+        ),
+        WorkspaceSidebarStatus(
+            id: "done",
+            label: String(localized: "workspaceStatus.done.label", defaultValue: "Done"),
+            systemImage: "checkmark.circle.fill",
+            colorHex: "#30D158"
+        ),
+        WorkspaceSidebarStatus(
+            id: "blocked",
+            label: String(localized: "workspaceStatus.blocked.label", defaultValue: "Blocked"),
+            systemImage: "exclamationmark.octagon.fill",
+            colorHex: "#FF9F0A"
+        ),
+    ]
+
+    static func status(for id: String?) -> WorkspaceSidebarStatus? {
+        guard let normalized = normalizedStatusId(id) else { return nil }
+        return statuses.first { $0.id == normalized }
+    }
+
+    static func normalizedStatusId(_ raw: String?) -> String? {
+        let normalized = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        guard !normalized.isEmpty else { return nil }
+        guard statuses.contains(where: { $0.id == normalized }) else { return nil }
+        return normalized
+    }
+
+    static func nextStatusId(after currentId: String?) -> String? {
+        guard !statuses.isEmpty else { return nil }
+        guard let current = normalizedStatusId(currentId),
+              let index = statuses.firstIndex(where: { $0.id == current }) else {
+            return statuses[0].id
+        }
+        let nextIndex = statuses.index(after: index)
+        guard nextIndex < statuses.endIndex else { return nil }
+        return statuses[nextIndex].id
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1211,6 +1211,7 @@
 		5659A0015659A0015659A001 /* WorkspaceSidebarObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */; };
 		5659A0035659A0035659A003 /* WorkspaceSidebarObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659A0045659A0045659A004 /* WorkspaceSidebarObservationTests.swift */; };
 		F0F0A001A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */; };
+		A7F4E2000000000000000001 /* WorkspaceSidebarStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F4E2000000000000000002 /* WorkspaceSidebarStatus.swift */; };
 		6B524A0CB34FD46A771335AB /* WorkspaceSplitStartupCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */; };
 		F6120000A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6120001A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift */; };
 		FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
@@ -2437,6 +2438,7 @@
 		5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarObservation.swift; sourceTree = "<group>"; };
 		5659A0045659A0045659A004 /* WorkspaceSidebarObservationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarObservationTests.swift; sourceTree = "<group>"; };
 		F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarScrollUITests.swift; sourceTree = "<group>"; };
+		A7F4E2000000000000000002 /* WorkspaceSidebarStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarStatus.swift; sourceTree = "<group>"; };
 		71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSplitStartupCommandTests.swift; sourceTree = "<group>"; };
 		F6120001A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSSHFishShellTests.swift; sourceTree = "<group>"; };
 		FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStressProfileTests.swift; sourceTree = "<group>"; };
@@ -2903,6 +2905,7 @@
 				E30750000000000000000001 /* WorkspaceTabColorResolution.swift */,
 				E3B7A4000000000000000002 /* WorkspaceTabColorSettings.swift */,
 				E3B7A4000000000000000004 /* WorkspaceTabColorEntry.swift */,
+				A7F4E2000000000000000002 /* WorkspaceSidebarStatus.swift */,
 				E3B7A4000000000000000006 /* WorkspacePlacement+Resolution.swift */,
 				E3B7A4000000000000000008 /* WorkspaceIndicatorStyle+Display.swift */,
 				E3B7A400000000000000000A /* TabManager+NotificationDismissalHosting.swift */,
@@ -4964,6 +4967,7 @@
 				6799A0016799A0016799A001 /* WorkspaceSidebarAgentRuntimeObservationModel.swift in Sources */,
 				5659B0015659B0015659B001 /* WorkspaceSidebarLogEntryLimitProvider.swift in Sources */,
 				5659A0015659A0015659A001 /* WorkspaceSidebarObservation.swift in Sources */,
+				A7F4E2000000000000000001 /* WorkspaceSidebarStatus.swift in Sources */,
 				D7AB34400000000000000001 /* WorkspaceSurfaceConfig.swift in Sources */,
 				C0DE32470000000000000003 /* WorkspaceSurfaceIdentifierClipboardText.swift in Sources */,
 				E3B7A4000000000000000003 /* WorkspaceTabColorEntry.swift in Sources */,

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -7228,6 +7228,69 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testWorkspaceActionSetSidebarStatusSendsStatusId() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("action-status")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let workspaceId = "22222222-2222-2222-2222-222222222222"
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+
+            switch method {
+            case "workspace.action":
+                let params = payload["params"] as? [String: Any] ?? [:]
+                XCTAssertEqual(params["workspace_id"] as? String, workspaceId)
+                XCTAssertEqual(params["action"] as? String, "set_sidebar_status")
+                XCTAssertEqual(params["status_id"] as? String, "active")
+                return self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: [
+                        "workspace_id": workspaceId,
+                        "action": "set_sidebar_status",
+                        "status_id": "active",
+                    ]
+                )
+            default:
+                return self.v2Response(id: id, ok: false, error: ["code": "unexpected", "message": "unexpected method: \(method)"])
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["workspace-action", "set-sidebar-status", "active"],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertTrue(result.stderr.isEmpty, result.stderr)
+        XCTAssertEqual(result.stdout, "OK action=set_sidebar_status workspace=\(workspaceId) status=active\n")
+        XCTAssertEqual(
+            state.commands.compactMap { self.jsonObject($0)?["method"] as? String },
+            ["workspace.action"]
+        )
+    }
+
     func testClearNotificationsWindowFlagFailsWhenWindowHasNoCurrentWorkspace() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("clear-window-empty")

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -107,6 +107,33 @@ import Testing
         #expect(decision.hasDeferredWorkspaceObservationInvalidation)
     }
 
+    @Test func contextMenuStatusChangeUpdatesDisplayedBadgeImmediately() throws {
+        let done = try #require(WorkspaceSidebarStatusCatalog.status(for: "done"))
+        let current = Self.snapshot(
+            sidebarStatus: nil,
+            remoteConnectionStatusText: "Connected",
+            latestConversationMessage: "old message"
+        )
+        let next = Self.snapshot(
+            sidebarStatus: done,
+            remoteConnectionStatusText: "Disconnected",
+            latestConversationMessage: "new message"
+        )
+
+        let decision = SidebarWorkspaceSnapshotRefreshPolicy().decision(
+            current: current,
+            next: next,
+            force: false,
+            contextMenuVisible: true
+        )
+
+        #expect(decision.workspaceSnapshotStorage?.sidebarStatus == done)
+        #expect(decision.workspaceSnapshotStorage?.remoteConnectionStatusText == "Connected")
+        #expect(decision.workspaceSnapshotStorage?.latestConversationMessage == "old message")
+        #expect(decision.pendingWorkspaceSnapshot == next)
+        #expect(decision.hasDeferredWorkspaceObservationInvalidation)
+    }
+
     @Test func closedContextMenuStoresNextAndClearsPending() {
         let current = Self.snapshot(title: "old", isPinned: false)
         let next = Self.snapshot(title: "new", isPinned: true)
@@ -129,6 +156,7 @@ import Testing
         customDescription: String? = nil,
         isPinned: Bool = false,
         customColorHex: String? = nil,
+        sidebarStatus: WorkspaceSidebarStatus? = nil,
         remoteConnectionStatusText: String = "Disconnected",
         latestConversationMessage: String? = nil,
         listeningPorts: [Int] = [],
@@ -141,6 +169,7 @@ import Testing
             customDescription: customDescription,
             isPinned: isPinned,
             customColorHex: customColorHex,
+            sidebarStatus: sidebarStatus,
             remoteWorkspaceSidebarText: nil,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: "",

--- a/cmuxTests/WorkspaceActionDispatcherTests.swift
+++ b/cmuxTests/WorkspaceActionDispatcherTests.swift
@@ -96,4 +96,64 @@ final class WorkspaceActionDispatcherTests: XCTestCase {
         XCTAssertTrue(workspace.isPinned)
         XCTAssertTrue(result.changedWorkspaceIds.isEmpty)
     }
+
+    func testSidebarStatusActionAppliesToMultipleTargets() throws {
+        let manager = TabManager()
+        let first = try XCTUnwrap(manager.tabs.first)
+        let second = manager.addWorkspace()
+        let third = manager.addWorkspace()
+
+        let result = try XCTUnwrap(
+            WorkspaceActionDispatcher.setSidebarStatus(
+                "done",
+                in: manager,
+                target: WorkspaceActionDispatcher.Target(
+                    workspaceIds: [first.id, second.id],
+                    anchorWorkspaceId: first.id
+                )
+            )
+        )
+
+        XCTAssertEqual(result.targetWorkspaceIds, [first.id, second.id])
+        XCTAssertEqual(result.changedWorkspaceIds, [first.id, second.id])
+        XCTAssertEqual(result.statusId, "done")
+        XCTAssertEqual(first.sidebarStatusId, "done")
+        XCTAssertEqual(second.sidebarStatusId, "done")
+        XCTAssertNil(third.sidebarStatusId)
+    }
+
+    func testSidebarStatusActionNormalizesInvalidStatusToClear() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.tabs.first)
+        workspace.setSidebarStatusId("active")
+
+        let result = try XCTUnwrap(
+            WorkspaceActionDispatcher.setSidebarStatus(
+                "ship-it",
+                in: manager,
+                target: .single(workspace.id)
+            )
+        )
+
+        XCTAssertEqual(result.statusId, nil)
+        XCTAssertEqual(result.changedWorkspaceIds, [workspace.id])
+        XCTAssertNil(workspace.sidebarStatusId)
+    }
+
+    func testSidebarStatusCycleMovesThroughDefaultSlotsAndClearsAfterLast() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.tabs.first)
+
+        XCTAssertEqual(
+            WorkspaceActionDispatcher.cycleSidebarStatus(in: manager, target: .single(workspace.id))?.statusId,
+            "open"
+        )
+        XCTAssertEqual(
+            WorkspaceActionDispatcher.cycleSidebarStatus(in: manager, target: .single(workspace.id))?.statusId,
+            "active"
+        )
+        workspace.setSidebarStatusId("blocked")
+        XCTAssertNil(WorkspaceActionDispatcher.cycleSidebarStatus(in: manager, target: .single(workspace.id))?.statusId)
+        XCTAssertNil(workspace.sidebarStatusId)
+    }
 }

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2861,6 +2861,26 @@ final class WorkspaceCustomDescriptionTests: XCTestCase {
         XCTAssertNil(workspace.customDescription)
         XCTAssertFalse(workspace.hasCustomDescription)
     }
+
+    func testSidebarStatusPersistsThroughSessionSnapshotRestore() {
+        let source = Workspace()
+        source.setSidebarStatusId("done")
+
+        let snapshot = source.sessionSnapshot(includeScrollback: false)
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        XCTAssertEqual(snapshot.sidebarStatusId, "done")
+        XCTAssertEqual(restored.sidebarStatusId, "done")
+    }
+
+    func testSetSidebarStatusDropsUnknownStatus() {
+        let workspace = Workspace()
+
+        workspace.setSidebarStatusId("ship-it")
+
+        XCTAssertNil(workspace.sidebarStatusId)
+    }
 }
 final class WorkspacePlacementSettingsTests: XCTestCase {
     func testCurrentPlacementDefaultsToAfterCurrentWhenUnset() {


### PR DESCRIPTION
## Summary
- Adds generic per-workspace sidebar statuses: Open, Active, Done, and Blocked.
- Stores a single optional sidebarStatusId on Workspace/session snapshots instead of introducing tasks, task lists, or project state.
- Exposes the same action through sidebar click cycling, context menu, command palette, and `cmux workspace-action set-sidebar-status`.

Supersedes the old Workspace Tasks direction in https://github.com/manaflow-ai/cmux/pull/6708. This PR starts from current main and does not reuse the killed tasks project.

## Testing
- `git diff --check HEAD~1..HEAD`
- `scripts/check-pbxproj.sh`
- `ruby -rjson -e 'JSON.parse(File.read(ARGV[0])); puts "ok"' Resources/Localizable.xcstrings`\n- `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-sstat-test -only-testing:cmuxTests/WorkspaceActionDispatcherTests -only-testing:cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests -only-testing:cmuxTests/WorkspaceCustomDescriptionTests -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testWorkspaceActionSetSidebarStatusSendsStatusId`\n- `./scripts/reload-cloud.sh --tag sstat` (fell back to local tagged reload because no builder fleet is configured on this machine)\n- `scripts/launch-tagged-automation.sh sstat --mode allowAll --wait-socket 20`\n- `cmux workspace-action --workspace workspace:1 --action set-sidebar-status --status active --json --id-format both`\n\nVisual screenshot capture was blocked because all displays reported asleep and `screencapture` returned a black frame; Computer Use listed the running tagged app but could not resolve a visible window (`cgWindowNotFound`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785527854&installation_id=133855650&pr_number=7141&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7141&signature=954fe15766e37dbf9ac3e2179a0de76ee4025a564cd88f0e7e65263a8a1567b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-workspace sidebar statuses (Open, Active, Done, Blocked) to quickly label progress. Statuses are visible as a colored badge, can be set/cleared from UI, palette, or CLI, and persist in session snapshots.

- **New Features**
  - Sidebar: status badge on each workspace; click to cycle Open → Active → Done → Blocked → clear.
  - Context menu: Workspace Status submenu with Clear and explicit statuses.
  - Command palette: “Workspace Status: <status>” commands and “Clear Workspace Status”.
  - CLI: `workspace-action set-sidebar-status` and `clear-sidebar-status`; supports `--status`/`--status-id`; CLI output includes `status=<id>` or `status=clear`.
  - Persistence: new `sidebarStatusId` on session snapshots; restored on launch.
  - API: V2 `workspace.action` handles `set_sidebar_status`/`clear_sidebar_status` and returns `status_id` plus changed workspace IDs.

- **Migration**
  - No migration required; the snapshot field is optional and older snapshots load unchanged.
  - Unknown status values are ignored (treated as clear).

<sup>Written for commit 49e535c2d467548a279f4c48526b6ae6a6a6a1d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace sidebar status support in the app and CLI, including setting, clearing, and cycling statuses.
  * Workspace status is now shown in the sidebar with updated labels, icons, tooltips, and context menu actions.
  * Status selections are now saved and restored with sessions.

* **Bug Fixes**
  * Sidebar status changes now refresh immediately in the workspace view.
  * CLI output now reflects the resulting status more accurately after each action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->