### PR TITLE
Allow account switching after native sign-in

### DIFF
--- a/web/app/handler/after-sign-in/handler.ts
+++ b/web/app/handler/after-sign-in/handler.ts
@@ -211,13 +211,17 @@ async function afterSignInMessages(request: NextRequest): Promise<LocalizedAfter
 function nativeReturnResponse(
   href: string,
   localized: LocalizedAfterSignInMessages,
-  clearHandoffCookie: boolean,
+  autoOpen: boolean,
   switchAccountHref: string | null
 ): NextResponse {
   const { locale, messages } = localized;
   const escapedHref = escapeHtml(href);
+  const scriptHref = JSON.stringify(href).replaceAll("<", "\\u003c");
   const switchAccountAction = switchAccountHref
     ? `      <a class="secondary" href="${escapeHtml(switchAccountHref)}">${escapeHtml(messages.switchAccountButton)}</a>\n`
+    : "";
+  const autoOpenScript = autoOpen
+    ? `  <script>\n    const cmuxAutoOpen = window.setTimeout(() => window.location.replace(${scriptHref}), 1200);\n    document.querySelector("a.secondary")?.addEventListener("click", () => window.clearTimeout(cmuxAutoOpen));\n  </script>\n`
     : "";
   const escapedTitle = escapeHtml(messages.title);
   const escapedBody = escapeHtml(messages.body);
@@ -286,6 +290,7 @@ function nativeReturnResponse(
       <a class="primary" href="${escapedHref}">${escapedButton}</a>
 ${switchAccountAction}    </div>
   </main>
+${autoOpenScript}
 </body>
 </html>`,
     {
@@ -295,7 +300,7 @@ ${switchAccountAction}    </div>
       },
     }
   );
-  if (clearHandoffCookie) {
+  if (autoOpen) {
     response.cookies.set(NATIVE_HANDOFF_COOKIE, "", {
       httpOnly: true,
       maxAge: 0,
@@ -370,9 +375,9 @@ export function makeAfterSignInHandler(dependencies: AfterSignInHandlerDependenc
     ) {
       if (isAllowedNativeReturnTo(nativeReturnTo, request)) {
         const href = buildNativeHref(nativeReturnTo, refreshToken, accessCookie);
-        const clearHandoffCookie = verifiedAutoOpen(request, stackCookies, nativeReturnTo);
+        const autoOpen = verifiedAutoOpen(request, stackCookies, nativeReturnTo);
         if (href) {
-          return nativeReturnResponse(href, localizedMessages, clearHandoffCookie, switchAccountHref(request));
+          return nativeReturnResponse(href, localizedMessages, autoOpen, switchAccountHref(request));
         }
       }
       return NextResponse.redirect(new URL("/", request.url));

--- a/web/app/handler/after-sign-in/handler.ts
+++ b/web/app/handler/after-sign-in/handler.ts
@@ -212,15 +212,16 @@ function nativeReturnResponse(
   href: string,
   localized: LocalizedAfterSignInMessages,
   clearHandoffCookie: boolean,
-  switchAccountHref: string
+  switchAccountHref: string | null
 ): NextResponse {
   const { locale, messages } = localized;
   const escapedHref = escapeHtml(href);
-  const escapedSwitchAccountHref = escapeHtml(switchAccountHref);
+  const switchAccountAction = switchAccountHref
+    ? `      <a class="secondary" href="${escapeHtml(switchAccountHref)}">${escapeHtml(messages.switchAccountButton)}</a>\n`
+    : "";
   const escapedTitle = escapeHtml(messages.title);
   const escapedBody = escapeHtml(messages.body);
   const escapedButton = escapeHtml(messages.button);
-  const escapedSwitchAccountButton = escapeHtml(messages.switchAccountButton);
   const response = new NextResponse(
     `<!doctype html>
 <html lang="${escapeHtml(locale)}">
@@ -283,8 +284,7 @@ function nativeReturnResponse(
     <p>${escapedBody}</p>
     <div class="actions">
       <a class="primary" href="${escapedHref}">${escapedButton}</a>
-      <a class="secondary" href="${escapedSwitchAccountHref}">${escapedSwitchAccountButton}</a>
-    </div>
+${switchAccountAction}    </div>
   </main>
 </body>
 </html>`,
@@ -314,7 +314,8 @@ function currentAfterSignInPath(request: NextRequest): string {
   return `${afterSignIn.pathname}${afterSignIn.search}`;
 }
 
-function switchAccountHref(request: NextRequest): string {
+function switchAccountHref(request: NextRequest): string | null {
+  if (!request.nextUrl.searchParams.has("native_app_return_to")) return null;
   const nativeSignIn = new URL("/handler/native-sign-in", request.nextUrl.origin);
   nativeSignIn.searchParams.set("after_auth_return_to", currentAfterSignInPath(request));
 

--- a/web/app/handler/after-sign-in/handler.ts
+++ b/web/app/handler/after-sign-in/handler.ts
@@ -211,20 +211,16 @@ async function afterSignInMessages(request: NextRequest): Promise<LocalizedAfter
 function nativeReturnResponse(
   href: string,
   localized: LocalizedAfterSignInMessages,
-  autoOpen: boolean,
+  clearHandoffCookie: boolean,
   switchAccountHref: string
 ): NextResponse {
   const { locale, messages } = localized;
   const escapedHref = escapeHtml(href);
   const escapedSwitchAccountHref = escapeHtml(switchAccountHref);
-  const scriptHref = JSON.stringify(href).replaceAll("<", "\\u003c");
   const escapedTitle = escapeHtml(messages.title);
   const escapedBody = escapeHtml(messages.body);
   const escapedButton = escapeHtml(messages.button);
   const escapedSwitchAccountButton = escapeHtml(messages.switchAccountButton);
-  const autoOpenScript = autoOpen
-    ? `  <script>\n    window.location.replace(${scriptHref});\n  </script>\n`
-    : "";
   const response = new NextResponse(
     `<!doctype html>
 <html lang="${escapeHtml(locale)}">
@@ -290,7 +286,6 @@ function nativeReturnResponse(
       <a class="secondary" href="${escapedSwitchAccountHref}">${escapedSwitchAccountButton}</a>
     </div>
   </main>
-${autoOpenScript}
 </body>
 </html>`,
     {
@@ -300,7 +295,7 @@ ${autoOpenScript}
       },
     }
   );
-  if (autoOpen) {
+  if (clearHandoffCookie) {
     response.cookies.set(NATIVE_HANDOFF_COOKIE, "", {
       httpOnly: true,
       maxAge: 0,
@@ -313,7 +308,10 @@ ${autoOpenScript}
 }
 
 function currentAfterSignInPath(request: NextRequest): string {
-  return `${request.nextUrl.pathname}${request.nextUrl.search}`;
+  const afterSignIn = new URL(request.nextUrl.pathname, request.nextUrl.origin);
+  const nativeReturnTo = request.nextUrl.searchParams.get("native_app_return_to");
+  if (nativeReturnTo) afterSignIn.searchParams.set("native_app_return_to", nativeReturnTo);
+  return `${afterSignIn.pathname}${afterSignIn.search}`;
 }
 
 function switchAccountHref(request: NextRequest): string {
@@ -371,9 +369,9 @@ export function makeAfterSignInHandler(dependencies: AfterSignInHandlerDependenc
     ) {
       if (isAllowedNativeReturnTo(nativeReturnTo, request)) {
         const href = buildNativeHref(nativeReturnTo, refreshToken, accessCookie);
-        const autoOpen = verifiedAutoOpen(request, stackCookies, nativeReturnTo);
+        const clearHandoffCookie = verifiedAutoOpen(request, stackCookies, nativeReturnTo);
         if (href) {
-          return nativeReturnResponse(href, localizedMessages, autoOpen, switchAccountHref(request));
+          return nativeReturnResponse(href, localizedMessages, clearHandoffCookie, switchAccountHref(request));
         }
       }
       return NextResponse.redirect(new URL("/", request.url));

--- a/web/app/handler/after-sign-in/handler.ts
+++ b/web/app/handler/after-sign-in/handler.ts
@@ -221,7 +221,7 @@ function nativeReturnResponse(
     ? `      <a class="secondary" href="${escapeHtml(switchAccountHref)}">${escapeHtml(messages.switchAccountButton)}</a>\n`
     : "";
   const autoOpenScript = autoOpen
-    ? `  <script>\n    const cmuxAutoOpen = window.setTimeout(() => window.location.replace(${scriptHref}), 1200);\n    document.querySelector("a.secondary")?.addEventListener("click", () => window.clearTimeout(cmuxAutoOpen));\n  </script>\n`
+    ? `  <script>\n    const cmuxAutoOpen = window.setTimeout(() => window.location.replace(${scriptHref}), 1200);\n    document.querySelectorAll("a").forEach((action) => action.addEventListener("click", () => window.clearTimeout(cmuxAutoOpen)));\n  </script>\n`
     : "";
   const escapedTitle = escapeHtml(messages.title);
   const escapedBody = escapeHtml(messages.body);

--- a/web/app/handler/after-sign-in/handler.ts
+++ b/web/app/handler/after-sign-in/handler.ts
@@ -11,6 +11,7 @@ type AfterSignInMessages = {
   title: string;
   body: string;
   button: string;
+  switchAccountButton: string;
 };
 
 type LocalizedAfterSignInMessages = {
@@ -210,14 +211,17 @@ async function afterSignInMessages(request: NextRequest): Promise<LocalizedAfter
 function nativeReturnResponse(
   href: string,
   localized: LocalizedAfterSignInMessages,
-  autoOpen: boolean
+  autoOpen: boolean,
+  switchAccountHref: string
 ): NextResponse {
   const { locale, messages } = localized;
   const escapedHref = escapeHtml(href);
+  const escapedSwitchAccountHref = escapeHtml(switchAccountHref);
   const scriptHref = JSON.stringify(href).replaceAll("<", "\\u003c");
   const escapedTitle = escapeHtml(messages.title);
   const escapedBody = escapeHtml(messages.body);
   const escapedButton = escapeHtml(messages.button);
+  const escapedSwitchAccountButton = escapeHtml(messages.switchAccountButton);
   const autoOpenScript = autoOpen
     ? `  <script>\n    window.location.replace(${scriptHref});\n  </script>\n`
     : "";
@@ -254,15 +258,26 @@ function nativeReturnResponse(
       line-height: 1.5;
       margin: 0 0 24px;
     }
+    .actions {
+      align-items: center;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
     a {
-      background: #111;
       border-radius: 8px;
-      color: #fff;
       display: inline-block;
       font-size: 14px;
       font-weight: 500;
       padding: 10px 18px;
       text-decoration: none;
+    }
+    a.primary {
+      background: #111;
+      color: #fff;
+    }
+    a.secondary {
+      color: #555;
     }
   </style>
 </head>
@@ -270,7 +285,10 @@ function nativeReturnResponse(
   <main>
     <h1>${escapedTitle}</h1>
     <p>${escapedBody}</p>
-    <a href="${escapedHref}">${escapedButton}</a>
+    <div class="actions">
+      <a class="primary" href="${escapedHref}">${escapedButton}</a>
+      <a class="secondary" href="${escapedSwitchAccountHref}">${escapedSwitchAccountButton}</a>
+    </div>
   </main>
 ${autoOpenScript}
 </body>
@@ -292,6 +310,19 @@ ${autoOpenScript}
     });
   }
   return response;
+}
+
+function currentAfterSignInPath(request: NextRequest): string {
+  return `${request.nextUrl.pathname}${request.nextUrl.search}`;
+}
+
+function switchAccountHref(request: NextRequest): string {
+  const nativeSignIn = new URL("/handler/native-sign-in", request.nextUrl.origin);
+  nativeSignIn.searchParams.set("after_auth_return_to", currentAfterSignInPath(request));
+
+  const signOut = new URL("/handler/sign-out-and-sign-in", request.nextUrl.origin);
+  signOut.searchParams.set("after_auth_return_to", `${nativeSignIn.pathname}${nativeSignIn.search}`);
+  return `${signOut.pathname}${signOut.search}`;
 }
 
 function requestIsSecure(): boolean {
@@ -342,7 +373,7 @@ export function makeAfterSignInHandler(dependencies: AfterSignInHandlerDependenc
         const href = buildNativeHref(nativeReturnTo, refreshToken, accessCookie);
         const autoOpen = verifiedAutoOpen(request, stackCookies, nativeReturnTo);
         if (href) {
-          return nativeReturnResponse(href, localizedMessages, autoOpen);
+          return nativeReturnResponse(href, localizedMessages, autoOpen, switchAccountHref(request));
         }
       }
       return NextResponse.redirect(new URL("/", request.url));
@@ -355,7 +386,7 @@ export function makeAfterSignInHandler(dependencies: AfterSignInHandlerDependenc
 
     if (refreshToken && accessCookie) {
       const fallback = buildNativeHref(null, refreshToken, accessCookie);
-      if (fallback) return nativeReturnResponse(fallback, localizedMessages, false);
+      if (fallback) return nativeReturnResponse(fallback, localizedMessages, false, switchAccountHref(request));
     }
 
     return NextResponse.redirect(new URL("/", request.url));

--- a/web/app/handler/sign-out-and-sign-in/route.ts
+++ b/web/app/handler/sign-out-and-sign-in/route.ts
@@ -77,9 +77,10 @@ function decodeStackBase32Text(value: string): string | null {
 }
 
 function stackCustomRefreshCookieDomain(name: string, projectId: string): string | null {
+  const cookieName = name.startsWith("__Secure-") ? name.slice("__Secure-".length) : name;
   const prefix = `stack-refresh-${projectId}${STACK_CUSTOM_REFRESH_COOKIE_MARKER}`;
-  if (!name.startsWith(prefix)) return null;
-  return decodeStackBase32Text(name.slice(prefix.length));
+  if (!cookieName.startsWith(prefix)) return null;
+  return decodeStackBase32Text(cookieName.slice(prefix.length));
 }
 
 function clearStackAuthCookies(response: NextResponse, request: NextRequest, projectId: string) {

--- a/web/app/handler/sign-out-and-sign-in/route.ts
+++ b/web/app/handler/sign-out-and-sign-in/route.ts
@@ -11,6 +11,8 @@ type SignOutAndSignInDependencies = {
 
 const STACK_ACCESS_COOKIE = "stack-access";
 const LEGACY_STACK_REFRESH_COOKIE = "stack-refresh";
+const STACK_CUSTOM_REFRESH_COOKIE_MARKER = "--custom-";
+const CROCKFORD_BASE32_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
 function sameOriginURL(value: string | null, request: NextRequest): URL | null {
   if (!value) return null;
@@ -55,11 +57,38 @@ function isStackAuthCookie(name: string, projectId: string): boolean {
   );
 }
 
+function decodeStackBase32Text(value: string): string | null {
+  let bits = 0;
+  let buffer = 0;
+  const bytes: number[] = [];
+
+  for (const character of value) {
+    const index = CROCKFORD_BASE32_ALPHABET.indexOf(character.toUpperCase());
+    if (index === -1) return null;
+    buffer = (buffer << 5) | index;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((buffer >>> (bits - 8)) & 255);
+      bits -= 8;
+    }
+  }
+
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+function stackCustomRefreshCookieDomain(name: string, projectId: string): string | null {
+  const prefix = `stack-refresh-${projectId}${STACK_CUSTOM_REFRESH_COOKIE_MARKER}`;
+  if (!name.startsWith(prefix)) return null;
+  return decodeStackBase32Text(name.slice(prefix.length));
+}
+
 function clearStackAuthCookies(response: NextResponse, request: NextRequest, projectId: string) {
   const secure = request.nextUrl.protocol === "https:";
   for (const cookie of request.cookies.getAll()) {
     if (!isStackAuthCookie(cookie.name, projectId)) continue;
+    const domain = stackCustomRefreshCookieDomain(cookie.name, projectId);
     response.cookies.set(cookie.name, "", {
+      ...(domain ? { domain } : {}),
       maxAge: 0,
       path: "/",
       sameSite: "lax",

--- a/web/app/handler/sign-out-and-sign-in/route.ts
+++ b/web/app/handler/sign-out-and-sign-in/route.ts
@@ -30,6 +30,8 @@ function validatedNativeSignInTarget(request: NextRequest): string | null {
 
   const afterAuth = sameOriginURL(target.searchParams.get("after_auth_return_to"), request);
   if (!afterAuth || afterAuth.pathname !== "/handler/after-sign-in") return null;
+  if (!afterAuth.searchParams.has("native_app_return_to")) return null;
+  if (afterAuth.searchParams.has("after_auth_return_to")) return null;
 
   return `${target.pathname}${target.search}${target.hash}`;
 }

--- a/web/app/handler/sign-out-and-sign-in/route.ts
+++ b/web/app/handler/sign-out-and-sign-in/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "../../env";
+import { stackServerApp } from "../../lib/stack";
+
+export const dynamic = "force-dynamic";
+
+type SignOutAndSignInDependencies = {
+  projectId: string | undefined;
+  signOut: ((options: { redirectUrl: string }) => Promise<void>) | null;
+};
+
+const STACK_ACCESS_COOKIE = "stack-access";
+const LEGACY_STACK_REFRESH_COOKIE = "stack-refresh";
+
+function sameOriginURL(value: string | null, request: NextRequest): URL | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value, request.nextUrl.origin);
+    return url.origin === request.nextUrl.origin ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function validatedNativeSignInTarget(request: NextRequest): string | null {
+  const target = sameOriginURL(request.nextUrl.searchParams.get("after_auth_return_to"), request);
+  if (!target || target.pathname !== "/handler/native-sign-in") return null;
+
+  const afterAuth = sameOriginURL(target.searchParams.get("after_auth_return_to"), request);
+  if (!afterAuth || afterAuth.pathname !== "/handler/after-sign-in") return null;
+
+  return `${target.pathname}${target.search}${target.hash}`;
+}
+
+function isStackAuthCookie(name: string, projectId: string): boolean {
+  const refreshName = `stack-refresh-${projectId}`;
+  return (
+    name === STACK_ACCESS_COOKIE ||
+    name === LEGACY_STACK_REFRESH_COOKIE ||
+    name === refreshName ||
+    name.startsWith(`${refreshName}--`) ||
+    name.startsWith(`__Host-${refreshName}--`) ||
+    name.startsWith(`__Secure-${refreshName}--`)
+  );
+}
+
+function clearStackAuthCookies(response: NextResponse, request: NextRequest, projectId: string) {
+  const secure = request.nextUrl.protocol === "https:";
+  for (const cookie of request.cookies.getAll()) {
+    if (!isStackAuthCookie(cookie.name, projectId)) continue;
+    response.cookies.set(cookie.name, "", {
+      maxAge: 0,
+      path: "/",
+      sameSite: "lax",
+      secure: cookie.name.startsWith("__") || secure,
+    });
+  }
+}
+
+export function makeSignOutAndSignInHandler(dependencies: SignOutAndSignInDependencies) {
+  return async function GET(request: NextRequest) {
+    const target = validatedNativeSignInTarget(request);
+    if (!target) return NextResponse.redirect(new URL("/", request.url));
+
+    const redirectUrl = new URL(target, request.nextUrl.origin).toString();
+    await dependencies.signOut?.({ redirectUrl });
+
+    const response = NextResponse.redirect(new URL(target, request.url));
+    if (dependencies.projectId) clearStackAuthCookies(response, request, dependencies.projectId);
+    return response;
+  };
+}
+
+const configuredStackServerApp = stackServerApp;
+
+export const GET = makeSignOutAndSignInHandler({
+  projectId: env.NEXT_PUBLIC_STACK_PROJECT_ID,
+  signOut: configuredStackServerApp ? (options) => configuredStackServerApp.signOut(options) : null,
+});

--- a/web/app/handler/sign-out-and-sign-in/route.ts
+++ b/web/app/handler/sign-out-and-sign-in/route.ts
@@ -38,7 +38,7 @@ function validatedNativeSignInTarget(request: NextRequest): string | null {
 
 function canStartSignOut(request: NextRequest): boolean {
   const fetchSite = request.headers.get("sec-fetch-site");
-  return fetchSite === "none" || fetchSite === "same-origin" || fetchSite === "same-site";
+  return fetchSite === "none" || fetchSite === "same-origin";
 }
 
 function isStackAuthCookie(name: string, projectId: string): boolean {

--- a/web/app/handler/sign-out-and-sign-in/route.ts
+++ b/web/app/handler/sign-out-and-sign-in/route.ts
@@ -36,7 +36,7 @@ function validatedNativeSignInTarget(request: NextRequest): string | null {
 
 function canStartSignOut(request: NextRequest): boolean {
   const fetchSite = request.headers.get("sec-fetch-site");
-  return fetchSite === null || fetchSite === "none" || fetchSite === "same-origin" || fetchSite === "same-site";
+  return fetchSite === "none" || fetchSite === "same-origin" || fetchSite === "same-site";
 }
 
 function isStackAuthCookie(name: string, projectId: string): boolean {

--- a/web/app/handler/sign-out-and-sign-in/route.ts
+++ b/web/app/handler/sign-out-and-sign-in/route.ts
@@ -32,11 +32,20 @@ function validatedNativeSignInTarget(request: NextRequest): string | null {
   return `${target.pathname}${target.search}${target.hash}`;
 }
 
+function canStartSignOut(request: NextRequest): boolean {
+  const fetchSite = request.headers.get("sec-fetch-site");
+  return fetchSite === null || fetchSite === "none" || fetchSite === "same-origin" || fetchSite === "same-site";
+}
+
 function isStackAuthCookie(name: string, projectId: string): boolean {
   const refreshName = `stack-refresh-${projectId}`;
   return (
     name === STACK_ACCESS_COOKIE ||
+    name === `__Host-${STACK_ACCESS_COOKIE}` ||
+    name === `__Secure-${STACK_ACCESS_COOKIE}` ||
     name === LEGACY_STACK_REFRESH_COOKIE ||
+    name === `__Host-${LEGACY_STACK_REFRESH_COOKIE}` ||
+    name === `__Secure-${LEGACY_STACK_REFRESH_COOKIE}` ||
     name === refreshName ||
     name.startsWith(`${refreshName}--`) ||
     name.startsWith(`__Host-${refreshName}--`) ||
@@ -57,16 +66,32 @@ function clearStackAuthCookies(response: NextResponse, request: NextRequest, pro
   }
 }
 
+function isNextRedirectError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "digest" in error &&
+    typeof error.digest === "string" &&
+    error.digest.startsWith("NEXT_REDIRECT;")
+  );
+}
+
 export function makeSignOutAndSignInHandler(dependencies: SignOutAndSignInDependencies) {
   return async function GET(request: NextRequest) {
     const target = validatedNativeSignInTarget(request);
-    if (!target) return NextResponse.redirect(new URL("/", request.url));
-
-    const redirectUrl = new URL(target, request.nextUrl.origin).toString();
-    await dependencies.signOut?.({ redirectUrl });
+    if (!target || !canStartSignOut(request)) return NextResponse.redirect(new URL("/", request.url));
 
     const response = NextResponse.redirect(new URL(target, request.url));
     if (dependencies.projectId) clearStackAuthCookies(response, request, dependencies.projectId);
+
+    const redirectUrl = new URL(target, request.nextUrl.origin).toString();
+    try {
+      await dependencies.signOut?.({ redirectUrl });
+    } catch (error) {
+      if (!isNextRedirectError(error)) {
+        console.warn("[Sign Out and Sign In] Continuing after Stack sign-out did not complete normally", error);
+      }
+    }
     return response;
   };
 }

--- a/web/app/handler/sign-out-and-sign-in/route.ts
+++ b/web/app/handler/sign-out-and-sign-in/route.ts
@@ -92,6 +92,7 @@ function clearStackAuthCookies(response: NextResponse, request: NextRequest, pro
     const domain = stackCustomRefreshCookieDomain(cookie.name, projectId);
     response.cookies.set(cookie.name, "", {
       ...(domain ? { domain } : {}),
+      httpOnly: true,
       maxAge: 0,
       path: "/",
       sameSite: "lax",

--- a/web/app/handler/sign-out-and-sign-in/route.ts
+++ b/web/app/handler/sign-out-and-sign-in/route.ts
@@ -47,6 +47,8 @@ function isStackAuthCookie(name: string, projectId: string): boolean {
     name === `__Host-${LEGACY_STACK_REFRESH_COOKIE}` ||
     name === `__Secure-${LEGACY_STACK_REFRESH_COOKIE}` ||
     name === refreshName ||
+    name === `__Host-${refreshName}` ||
+    name === `__Secure-${refreshName}` ||
     name.startsWith(`${refreshName}--`) ||
     name.startsWith(`__Host-${refreshName}--`) ||
     name.startsWith(`__Secure-${refreshName}--`)

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "تم تسجيل الدخول إلى cmux",
     "body": "إذا لم يفتح cmux تلقائيًا، استخدم الزر أدناه.",
-    "button": "العودة إلى cmux"
+    "button": "العودة إلى cmux",
+    "switchAccountButton": "استخدام حساب مختلف"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/bs.json
+++ b/web/messages/bs.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "Prijavljeni ste u cmux",
     "body": "Ako se cmux nije automatski otvorio, koristite dugme ispod.",
-    "button": "Vrati se u cmux"
+    "button": "Vrati se u cmux",
+    "switchAccountButton": "Koristi drugi račun"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "Logget ind på cmux",
     "body": "Hvis cmux ikke åbnede automatisk, skal du bruge knappen nedenfor.",
-    "button": "Tilbage til cmux"
+    "button": "Tilbage til cmux",
+    "switchAccountButton": "Brug en anden konto"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "Bei cmux angemeldet",
     "body": "Wenn cmux nicht automatisch geöffnet wurde, verwende die Schaltfläche unten.",
-    "button": "Zurück zu cmux"
+    "button": "Zurück zu cmux",
+    "switchAccountButton": "Anderes Konto verwenden"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2001,7 +2001,8 @@
   "afterSignIn": {
     "title": "Signed in to cmux",
     "body": "If cmux did not open automatically, use the button below.",
-    "button": "Return to cmux"
+    "button": "Return to cmux",
+    "switchAccountButton": "Use a different account"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "Sesión iniciada en cmux",
     "body": "Si cmux no se abrió automáticamente, usa el botón de abajo.",
-    "button": "Volver a cmux"
+    "button": "Volver a cmux",
+    "switchAccountButton": "Usar otra cuenta"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "Connecté à cmux",
     "body": "Si cmux ne s’est pas ouvert automatiquement, utilisez le bouton ci-dessous.",
-    "button": "Retourner à cmux"
+    "button": "Retourner à cmux",
+    "switchAccountButton": "Utiliser un autre compte"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "Accesso a cmux effettuato",
     "body": "Se cmux non si è aperto automaticamente, usa il pulsante qui sotto.",
-    "button": "Torna a cmux"
+    "button": "Torna a cmux",
+    "switchAccountButton": "Usa un altro account"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1947,7 +1947,8 @@
   "afterSignIn": {
     "title": "cmux にサインインしました",
     "body": "cmux が自動的に開かない場合は、下のボタンを使用してください。",
-    "button": "cmux に戻る"
+    "button": "cmux に戻る",
+    "switchAccountButton": "別のアカウントを使用"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/km.json
+++ b/web/messages/km.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "បានចូល cmux ហើយ",
     "body": "ប្រសិនបើ cmux មិនបានបើកដោយស្វ័យប្រវត្តិ សូមប្រើប៊ូតុងខាងក្រោម។",
-    "button": "ត្រឡប់ទៅ cmux"
+    "button": "ត្រឡប់ទៅ cmux",
+    "switchAccountButton": "ប្រើគណនីផ្សេងទៀត"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "cmux에 로그인했습니다",
     "body": "cmux가 자동으로 열리지 않으면 아래 버튼을 사용하세요.",
-    "button": "cmux로 돌아가기"
+    "button": "cmux로 돌아가기",
+    "switchAccountButton": "다른 계정 사용"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/no.json
+++ b/web/messages/no.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "Logget på cmux",
     "body": "Hvis cmux ikke åpnet automatisk, bruk knappen nedenfor.",
-    "button": "Gå tilbake til cmux"
+    "button": "Gå tilbake til cmux",
+    "switchAccountButton": "Bruk en annen konto"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "Zalogowano do cmux",
     "body": "Jeśli cmux nie otworzył się automatycznie, użyj przycisku poniżej.",
-    "button": "Wróć do cmux"
+    "button": "Wróć do cmux",
+    "switchAccountButton": "Użyj innego konta"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "Conectado ao cmux",
     "body": "Se o cmux não abriu automaticamente, use o botão abaixo.",
-    "button": "Voltar ao cmux"
+    "button": "Voltar ao cmux",
+    "switchAccountButton": "Usar outra conta"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "Вход в cmux выполнен",
     "body": "Если cmux не открылся автоматически, используйте кнопку ниже.",
-    "button": "Вернуться в cmux"
+    "button": "Вернуться в cmux",
+    "switchAccountButton": "Использовать другой аккаунт"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "ลงชื่อเข้าใช้ cmux แล้ว",
     "body": "หาก cmux ไม่เปิดโดยอัตโนมัติ ให้ใช้ปุ่มด้านล่าง",
-    "button": "กลับไปที่ cmux"
+    "button": "กลับไปที่ cmux",
+    "switchAccountButton": "ใช้บัญชีอื่น"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "cmux oturumu açıldı",
     "body": "cmux otomatik olarak açılmadıysa aşağıdaki düğmeyi kullanın.",
-    "button": "cmux’a dön"
+    "button": "cmux’a dön",
+    "switchAccountButton": "Farklı bir hesap kullan"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -1677,7 +1677,8 @@
   "afterSignIn": {
     "title": "Вхід у cmux виконано",
     "body": "Якщо cmux не відкрився автоматично, скористайтеся кнопкою нижче.",
-    "button": "Повернутися до cmux"
+    "button": "Повернутися до cmux",
+    "switchAccountButton": "Використати інший обліковий запис"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "已登录 cmux",
     "body": "如果 cmux 没有自动打开，请使用下面的按钮。",
-    "button": "返回 cmux"
+    "button": "返回 cmux",
+    "switchAccountButton": "使用其他账号"
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -1594,7 +1594,8 @@
   "afterSignIn": {
     "title": "已登入 cmux",
     "body": "如果 cmux 沒有自動開啟，請使用下方按鈕。",
-    "button": "返回 cmux"
+    "button": "返回 cmux",
+    "switchAccountButton": "使用其他帳號"
   },
   "landing": {
     "bestTerminal": {

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -258,6 +258,17 @@ describe("sign out and sign back in", () => {
     expect(response.headers.get("location")).toBe("https://cmux.test/");
   });
 
+  test("rejects same-site attempts to force sign-out", async () => {
+    const afterSignIn = "/handler/after-sign-in?native_app_return_to=cmux%3A%2F%2Fauth-callback%3Fcmux_auth_state%3Dstate-123";
+    const nativeSignIn = `/handler/native-sign-in?after_auth_return_to=${encodeURIComponent(afterSignIn)}`;
+
+    const response = await GET(switchRequest(nativeSignIn, { "sec-fetch-site": "same-site" }));
+
+    expect(signOut).not.toHaveBeenCalled();
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://cmux.test/");
+  });
+
   test("rejects sign-out attempts without a fetch metadata signal", async () => {
     const afterSignIn = "/handler/after-sign-in?native_app_return_to=cmux%3A%2F%2Fauth-callback%3Fcmux_auth_state%3Dstate-123";
     const nativeSignIn = `/handler/native-sign-in?after_auth_return_to=${encodeURIComponent(afterSignIn)}`;

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -77,6 +77,7 @@ describe("after sign-in native handoff", () => {
     expect(html).toContain("Return to cmux");
     expect(html).toContain("window.location.replace");
     expect(html).toContain("window.clearTimeout");
+    expect(html).toContain("document.querySelectorAll(\"a\")");
     expect(html).not.toContain("http-equiv=\"refresh\"");
 
     const callbackURL = new URL(returnHref(html));
@@ -194,6 +195,7 @@ describe("sign out and sign back in", () => {
 
     const setCookie = response.headers.get("set-cookie");
     expect(setCookie).toContain("stack-access=;");
+    expect(setCookie).toContain("HttpOnly");
     expect(setCookie).toContain("__Host-stack-access=;");
     expect(setCookie).toContain("stack-refresh-test-project=;");
     expect(setCookie).toContain("__Host-stack-refresh-test-project=;");

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -145,13 +145,14 @@ describe("sign out and sign back in", () => {
     signOut.mockClear();
   });
 
-  function switchRequest(afterAuthReturnTo: string): NextRequest {
+  function switchRequest(afterAuthReturnTo: string, headers: Record<string, string> = {}): NextRequest {
     return new NextRequest(
       `https://cmux.test/handler/sign-out-and-sign-in?after_auth_return_to=${encodeURIComponent(afterAuthReturnTo)}`,
       {
         headers: {
           cookie:
-            "stack-access=access-token; stack-refresh-test-project--default=refresh-token; __Host-stack-refresh-test-project--default=secure-refresh-token; unrelated=value",
+            "stack-access=access-token; __Host-stack-access=secure-access-token; stack-refresh-test-project--default=refresh-token; __Host-stack-refresh-test-project--default=secure-refresh-token; unrelated=value",
+          ...headers,
         },
       }
     );
@@ -171,13 +172,44 @@ describe("sign out and sign back in", () => {
 
     const setCookie = response.headers.get("set-cookie");
     expect(setCookie).toContain("stack-access=;");
+    expect(setCookie).toContain("__Host-stack-access=;");
     expect(setCookie).toContain("stack-refresh-test-project--default=;");
     expect(setCookie).toContain("__Host-stack-refresh-test-project--default=;");
     expect(setCookie).not.toContain("unrelated=;");
   });
 
+  test("still clears cookies and redirects when Stack sign-out throws", async () => {
+    const GET = makeSignOutAndSignInHandler({
+      projectId: "test-project",
+      signOut: async () => {
+        throw new Error("stack unavailable");
+      },
+    });
+    const afterSignIn = "/handler/after-sign-in?native_app_return_to=cmux%3A%2F%2Fauth-callback%3Fcmux_auth_state%3Dstate-123";
+    const nativeSignIn = `/handler/native-sign-in?after_auth_return_to=${encodeURIComponent(afterSignIn)}`;
+
+    const response = await GET(switchRequest(nativeSignIn));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(`https://cmux.test${nativeSignIn}`);
+    const setCookie = response.headers.get("set-cookie");
+    expect(setCookie).toContain("stack-access=;");
+    expect(setCookie).toContain("__Host-stack-access=;");
+  });
+
   test("rejects non-native sign-in redirect targets", async () => {
     const response = await GET(switchRequest("/docs"));
+
+    expect(signOut).not.toHaveBeenCalled();
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://cmux.test/");
+  });
+
+  test("rejects cross-site attempts to force sign-out", async () => {
+    const afterSignIn = "/handler/after-sign-in?native_app_return_to=cmux%3A%2F%2Fauth-callback%3Fcmux_auth_state%3Dstate-123";
+    const nativeSignIn = `/handler/native-sign-in?after_auth_return_to=${encodeURIComponent(afterSignIn)}`;
+
+    const response = await GET(switchRequest(nativeSignIn, { "sec-fetch-site": "cross-site" }));
 
     expect(signOut).not.toHaveBeenCalled();
     expect(response.status).toBe(307);

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -151,7 +151,7 @@ describe("sign out and sign back in", () => {
       {
         headers: {
           cookie:
-            "stack-access=access-token; __Host-stack-access=secure-access-token; stack-refresh-test-project--default=refresh-token; __Host-stack-refresh-test-project--default=secure-refresh-token; unrelated=value",
+            "stack-access=access-token; __Host-stack-access=secure-access-token; stack-refresh-test-project=refresh-token; __Host-stack-refresh-test-project=host-refresh-token; __Secure-stack-refresh-test-project=secure-refresh-token; stack-refresh-test-project--default=branch-refresh-token; __Host-stack-refresh-test-project--default=secure-branch-refresh-token; unrelated=value",
           ...headers,
         },
       }
@@ -173,6 +173,9 @@ describe("sign out and sign back in", () => {
     const setCookie = response.headers.get("set-cookie");
     expect(setCookie).toContain("stack-access=;");
     expect(setCookie).toContain("__Host-stack-access=;");
+    expect(setCookie).toContain("stack-refresh-test-project=;");
+    expect(setCookie).toContain("__Host-stack-refresh-test-project=;");
+    expect(setCookie).toContain("__Secure-stack-refresh-test-project=;");
     expect(setCookie).toContain("stack-refresh-test-project--default=;");
     expect(setCookie).toContain("__Host-stack-refresh-test-project--default=;");
     expect(setCookie).not.toContain("unrelated=;");

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -151,7 +151,7 @@ describe("sign out and sign back in", () => {
       {
         headers: {
           cookie:
-            "stack-access=access-token; __Host-stack-access=secure-access-token; stack-refresh-test-project=refresh-token; __Host-stack-refresh-test-project=host-refresh-token; __Secure-stack-refresh-test-project=secure-refresh-token; stack-refresh-test-project--default=branch-refresh-token; __Host-stack-refresh-test-project--default=secure-branch-refresh-token; unrelated=value",
+            "stack-access=access-token; __Host-stack-access=secure-access-token; stack-refresh-test-project=refresh-token; __Host-stack-refresh-test-project=host-refresh-token; __Secure-stack-refresh-test-project=secure-refresh-token; stack-refresh-test-project--default=branch-refresh-token; __Host-stack-refresh-test-project--default=secure-branch-refresh-token; stack-refresh-test-project--custom-CNW62VBGDHJJWRVFDM=custom-refresh-token; unrelated=value",
           ...headers,
         },
       }
@@ -178,6 +178,8 @@ describe("sign out and sign back in", () => {
     expect(setCookie).toContain("__Secure-stack-refresh-test-project=;");
     expect(setCookie).toContain("stack-refresh-test-project--default=;");
     expect(setCookie).toContain("__Host-stack-refresh-test-project--default=;");
+    expect(setCookie).toContain("stack-refresh-test-project--custom-CNW62VBGDHJJWRVFDM=;");
+    expect(setCookie).toContain("Domain=example.com");
     expect(setCookie).not.toContain("unrelated=;");
   });
 

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -64,7 +64,7 @@ describe("after sign-in native handoff", () => {
     signOut.mockClear();
   });
 
-  test("keeps a fallback page for verified native auto-open handoffs", async () => {
+  test("keeps an interactive return page for verified native handoffs", async () => {
     handoffCookie = "handoff-nonce";
     const nativeReturnTo = "cmux://auth-callback?cmux_auth_state=state-123";
 
@@ -75,7 +75,7 @@ describe("after sign-in native handoff", () => {
     const html = await response.text();
     expect(html).toContain("Signed in to cmux");
     expect(html).toContain("Return to cmux");
-    expect(html).toContain("window.location.replace");
+    expect(html).not.toContain("window.location.replace");
     expect(html).not.toContain("http-equiv=\"refresh\"");
 
     const callbackURL = new URL(returnHref(html));
@@ -104,6 +104,7 @@ describe("after sign-in native handoff", () => {
     );
     expect(afterSignInTarget.pathname).toBe("/handler/after-sign-in");
     expect(afterSignInTarget.searchParams.get("native_app_return_to")).toBe(nativeReturnTo);
+    expect(afterSignInTarget.searchParams.has("after_auth_return_to")).toBe(false);
   });
 
   test("keeps the manual return page when the handoff nonce is not verified", async () => {
@@ -213,6 +214,18 @@ describe("sign out and sign back in", () => {
 
   test("rejects non-native sign-in redirect targets", async () => {
     const response = await GET(switchRequest("/docs"));
+
+    expect(signOut).not.toHaveBeenCalled();
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://cmux.test/");
+  });
+
+  test("rejects nested after-sign-in redirect targets", async () => {
+    const afterSignIn =
+      "/handler/after-sign-in?native_app_return_to=cmux%3A%2F%2Fauth-callback%3Fcmux_auth_state%3Dstate-123&after_auth_return_to=%2Fdocs";
+    const nativeSignIn = `/handler/native-sign-in?after_auth_return_to=${encodeURIComponent(afterSignIn)}`;
+
+    const response = await GET(switchRequest(nativeSignIn));
 
     expect(signOut).not.toHaveBeenCalled();
     expect(response.status).toBe(307);

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -75,7 +75,8 @@ describe("after sign-in native handoff", () => {
     const html = await response.text();
     expect(html).toContain("Signed in to cmux");
     expect(html).toContain("Return to cmux");
-    expect(html).not.toContain("window.location.replace");
+    expect(html).toContain("window.location.replace");
+    expect(html).toContain("window.clearTimeout");
     expect(html).not.toContain("http-equiv=\"refresh\"");
 
     const callbackURL = new URL(returnHref(html));

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -145,11 +145,16 @@ describe("sign out and sign back in", () => {
     signOut.mockClear();
   });
 
-  function switchRequest(afterAuthReturnTo: string, headers: Record<string, string> = {}): NextRequest {
+  function switchRequest(
+    afterAuthReturnTo: string,
+    headers: Record<string, string> = {},
+    includeDefaultFetchSite = true
+  ): NextRequest {
     return new NextRequest(
       `https://cmux.test/handler/sign-out-and-sign-in?after_auth_return_to=${encodeURIComponent(afterAuthReturnTo)}`,
       {
         headers: {
+          ...(includeDefaultFetchSite ? { "sec-fetch-site": "same-origin" } : {}),
           cookie:
             "stack-access=access-token; __Host-stack-access=secure-access-token; stack-refresh-test-project=refresh-token; __Host-stack-refresh-test-project=host-refresh-token; __Secure-stack-refresh-test-project=secure-refresh-token; stack-refresh-test-project--default=branch-refresh-token; __Host-stack-refresh-test-project--default=secure-branch-refresh-token; stack-refresh-test-project--custom-CNW62VBGDHJJWRVFDM=custom-refresh-token; unrelated=value",
           ...headers,
@@ -178,8 +183,9 @@ describe("sign out and sign back in", () => {
     expect(setCookie).toContain("__Secure-stack-refresh-test-project=;");
     expect(setCookie).toContain("stack-refresh-test-project--default=;");
     expect(setCookie).toContain("__Host-stack-refresh-test-project--default=;");
-    expect(setCookie).toContain("stack-refresh-test-project--custom-CNW62VBGDHJJWRVFDM=;");
-    expect(setCookie).toContain("Domain=example.com");
+    expect(setCookie).toMatch(
+      /stack-refresh-test-project--custom-CNW62VBGDHJJWRVFDM=;[^,]*Domain=example\.com/
+    );
     expect(setCookie).not.toContain("unrelated=;");
   });
 
@@ -215,6 +221,17 @@ describe("sign out and sign back in", () => {
     const nativeSignIn = `/handler/native-sign-in?after_auth_return_to=${encodeURIComponent(afterSignIn)}`;
 
     const response = await GET(switchRequest(nativeSignIn, { "sec-fetch-site": "cross-site" }));
+
+    expect(signOut).not.toHaveBeenCalled();
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://cmux.test/");
+  });
+
+  test("rejects sign-out attempts without a fetch metadata signal", async () => {
+    const afterSignIn = "/handler/after-sign-in?native_app_return_to=cmux%3A%2F%2Fauth-callback%3Fcmux_auth_state%3Dstate-123";
+    const nativeSignIn = `/handler/native-sign-in?after_auth_return_to=${encodeURIComponent(afterSignIn)}`;
+
+    const response = await GET(switchRequest(nativeSignIn, {}, false));
 
     expect(signOut).not.toHaveBeenCalled();
     expect(response.status).toBe(307);

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { NextRequest } from "next/server";
 
 process.env.SKIP_ENV_VALIDATION = "1";
-process.env.NEXT_PUBLIC_STACK_PROJECT_ID = "test-project";
+process.env.NEXT_PUBLIC_STACK_PROJECT_ID = "00000000-0000-4000-8000-000000000000";
 process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY = "test-publishable-key";
 process.env.STACK_SECRET_SERVER_KEY = "test-secret-key";
 
@@ -11,8 +11,10 @@ let handoffCookie: string | undefined;
 let rawRefreshCookie: string;
 let rawAccessCookie: string;
 const getUser = mock(async () => null);
+const signOut = mock((_options?: unknown) => Promise.resolve());
 
 const { makeAfterSignInHandler } = await import("../app/handler/after-sign-in/handler");
+const { makeSignOutAndSignInHandler } = await import("../app/handler/sign-out-and-sign-in/route");
 
 const GET = makeAfterSignInHandler({
   projectId: "test-project",
@@ -43,7 +45,13 @@ function signInRequest(nativeReturnTo: string, handoffNonce: string): NextReques
 }
 
 function returnHref(html: string): string {
-  const match = html.match(/<a href="([^"]+)">Return to cmux<\/a>/);
+  const match = html.match(/<a class="primary" href="([^"]+)">Return to cmux<\/a>/);
+  expect(match).toBeTruthy();
+  return match![1].replaceAll("&amp;", "&");
+}
+
+function switchAccountHref(html: string): string {
+  const match = html.match(/<a class="secondary" href="([^"]+)">Use a different account<\/a>/);
   expect(match).toBeTruthy();
   return match![1].replaceAll("&amp;", "&");
 }
@@ -53,6 +61,7 @@ describe("after sign-in native handoff", () => {
     handoffCookie = undefined;
     rawRefreshCookie = "refresh-token";
     rawAccessCookie = "access-token";
+    signOut.mockClear();
   });
 
   test("keeps a fallback page for verified native auto-open handoffs", async () => {
@@ -81,6 +90,20 @@ describe("after sign-in native handoff", () => {
     expect(setCookie).toContain(`${HANDOFF_COOKIE}=;`);
     expect(setCookie).toContain("Max-Age=0");
     expect(setCookie).toContain("Path=/handler/after-sign-in");
+
+    const switchURL = new URL(switchAccountHref(html), "https://cmux.test");
+    expect(switchURL.pathname).toBe("/handler/sign-out-and-sign-in");
+    const nativeSignInTarget = new URL(
+      switchURL.searchParams.get("after_auth_return_to")!,
+      "https://cmux.test"
+    );
+    expect(nativeSignInTarget.pathname).toBe("/handler/native-sign-in");
+    const afterSignInTarget = new URL(
+      nativeSignInTarget.searchParams.get("after_auth_return_to")!,
+      "https://cmux.test"
+    );
+    expect(afterSignInTarget.pathname).toBe("/handler/after-sign-in");
+    expect(afterSignInTarget.searchParams.get("native_app_return_to")).toBe(nativeReturnTo);
   });
 
   test("keeps the manual return page when the handoff nonce is not verified", async () => {
@@ -105,6 +128,58 @@ describe("after sign-in native handoff", () => {
 
     const response = await GET(signInRequest(nativeReturnTo, "handoff-nonce"));
 
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://cmux.test/");
+  });
+});
+
+describe("sign out and sign back in", () => {
+  const GET = makeSignOutAndSignInHandler({
+    projectId: "test-project",
+    signOut: async (options) => {
+      await signOut(options);
+    },
+  });
+
+  beforeEach(() => {
+    signOut.mockClear();
+  });
+
+  function switchRequest(afterAuthReturnTo: string): NextRequest {
+    return new NextRequest(
+      `https://cmux.test/handler/sign-out-and-sign-in?after_auth_return_to=${encodeURIComponent(afterAuthReturnTo)}`,
+      {
+        headers: {
+          cookie:
+            "stack-access=access-token; stack-refresh-test-project--default=refresh-token; __Host-stack-refresh-test-project--default=secure-refresh-token; unrelated=value",
+        },
+      }
+    );
+  }
+
+  test("signs out and redirects back to the native sign-in flow", async () => {
+    const afterSignIn = "/handler/after-sign-in?native_app_return_to=cmux%3A%2F%2Fauth-callback%3Fcmux_auth_state%3Dstate-123";
+    const nativeSignIn = `/handler/native-sign-in?after_auth_return_to=${encodeURIComponent(afterSignIn)}`;
+
+    const response = await GET(switchRequest(nativeSignIn));
+
+    expect(signOut).toHaveBeenCalledWith({
+      redirectUrl: `https://cmux.test${nativeSignIn}`,
+    });
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(`https://cmux.test${nativeSignIn}`);
+
+    const setCookie = response.headers.get("set-cookie");
+    expect(setCookie).toContain("stack-access=;");
+    expect(setCookie).toContain("stack-refresh-test-project--default=;");
+    expect(setCookie).toContain("__Host-stack-refresh-test-project--default=;");
+    expect(setCookie).not.toContain("unrelated=;");
+  });
+
+  test("rejects non-native sign-in redirect targets", async () => {
+    const response = await GET(switchRequest("/docs"));
+
+    expect(signOut).not.toHaveBeenCalled();
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe("https://cmux.test/");
   });

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -121,6 +121,21 @@ describe("after sign-in native handoff", () => {
     expect(returnHref(html)).toContain("cmux://auth-callback");
   });
 
+  test("omits account switching when there is no native return target to preserve", async () => {
+    const response = await GET(
+      new NextRequest("https://cmux.test/handler/after-sign-in", {
+        headers: {
+          "accept-language": "en",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("Return to cmux");
+    expect(html).not.toContain("Use a different account");
+  });
+
   test("does not crash on malformed percent-encoded stack cookies", async () => {
     handoffCookie = "handoff-nonce";
     rawRefreshCookie = "%";

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -156,7 +156,7 @@ describe("sign out and sign back in", () => {
         headers: {
           ...(includeDefaultFetchSite ? { "sec-fetch-site": "same-origin" } : {}),
           cookie:
-            "stack-access=access-token; __Host-stack-access=secure-access-token; stack-refresh-test-project=refresh-token; __Host-stack-refresh-test-project=host-refresh-token; __Secure-stack-refresh-test-project=secure-refresh-token; stack-refresh-test-project--default=branch-refresh-token; __Host-stack-refresh-test-project--default=secure-branch-refresh-token; stack-refresh-test-project--custom-CNW62VBGDHJJWRVFDM=custom-refresh-token; unrelated=value",
+            "stack-access=access-token; __Host-stack-access=secure-access-token; stack-refresh-test-project=refresh-token; __Host-stack-refresh-test-project=host-refresh-token; __Secure-stack-refresh-test-project=secure-refresh-token; stack-refresh-test-project--default=branch-refresh-token; __Host-stack-refresh-test-project--default=secure-branch-refresh-token; stack-refresh-test-project--custom-CNW62VBGDHJJWRVFDM=custom-refresh-token; __Secure-stack-refresh-test-project--custom-CNW62VBGDHJJWRVFDM=secure-custom-refresh-token; unrelated=value",
           ...headers,
         },
       }
@@ -185,6 +185,9 @@ describe("sign out and sign back in", () => {
     expect(setCookie).toContain("__Host-stack-refresh-test-project--default=;");
     expect(setCookie).toMatch(
       /stack-refresh-test-project--custom-CNW62VBGDHJJWRVFDM=;[^,]*Domain=example\.com/
+    );
+    expect(setCookie).toMatch(
+      /__Secure-stack-refresh-test-project--custom-CNW62VBGDHJJWRVFDM=;[^,]*Domain=example\.com/
     );
     expect(setCookie).not.toContain("unrelated=;");
   });


### PR DESCRIPTION
## Summary
- add a secondary after-sign-in action for choosing a different account
- add a validated sign-out-and-sign-in handler that returns to the native auth flow
- localize the new action across routed message catalogs

## Tests
- bun test web/tests/after-sign-in-route.test.ts
- cd web && bun run typecheck
- local Next smoke on CMUX_PORT=4621 for /, /handler/sign-in, /handler/after-sign-in native handoff, and /handler/sign-out-and-sign-in

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785536984&installation_id=133855650&pr_number=7146&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7146&signature=b49f27318c52c44b0e017bd2743ce7b65300b841c68d345daa37a5ad9bd1edde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth session teardown, cookie clearing, and redirect validation; safeguards are in place but mistakes could affect sign-out or open redirect abuse.
> 
> **Overview**
> Adds a **Use a different account** path on the native after-sign-in HTML page when `native_app_return_to` is present, wired through a new **`/handler/sign-out-and-sign-in`** route that signs out, clears Stack auth cookies, and returns to native sign-in while preserving the handoff chain.
> 
> The after-sign-in UI now uses primary/secondary actions; verified handoffs **delay auto-open to cmux by 1.2s** and **cancel that redirect** if the user clicks any link. New `afterSignIn.switchAccountButton` strings are added across locale catalogs.
> 
> The sign-out handler validates a strict same-origin `sign-out-and-sign-in` → `native-sign-in` → `after-sign-in` (with `native_app_return_to`, no nested `after_auth_return_to`), requires `sec-fetch-site` of `none` or `same-origin`, and clears `__Host-`/`__Secure-` and `--custom-` refresh cookies before redirecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05985d01a8152d329e459782f256199162957b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables account switching on the after-sign-in page for native auth handoffs. Adds a validated sign‑out‑and‑sign‑in flow, and keeps the page interactive by auto‑opening cmux after a brief delay that cancels on any link click.

- **New Features**
  - Added GET /handler/sign-out-and-sign-in that validates a same‑origin `native-sign-in` → `after-sign-in` chain, signs out via Stack, clears project‑scoped refresh/access cookies, then redirects to native sign‑in.
  - After‑sign‑in page shows a primary “Return to cmux”, only shows “Use a different account” when `native_app_return_to` exists, clears the handoff cookie on verified handoffs, and auto‑opens cmux after a short delay canceled on any action; localized `afterSignIn.switchAccountButton`.

- **Bug Fixes**
  - Hardened redirect/sign‑out: only same‑origin targets, requires `sec-fetch-site` of `none` or `same-origin`, rejects nested/invalid targets, and falls back to `/`.
  - Stronger cookie teardown: clears `__Host-`/`__Secure-` Stack cookies, prefixed project refresh cookies (including branch variants), and `--custom-` domain refresh cookies via base32 decoding with Domain set; proceeds even if Stack sign‑out throws.

<sup>Written for commit 05985d01a8152d329e459782f256199162957b03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Switch account” secondary action to the post-sign-in screen, with localized button text across supported languages.
* **Bug Fixes**
  * Improved the native sign-out/sign-in handoff to validate return destinations, preserve the user’s intended destination, and clear relevant auth cookies.
  * Blocked unsafe cross-site sign-out attempts to prevent forced redirects.
* **Tests**
  * Expanded coverage for the switch-account link, the full redirect chain, cookie clearing behavior, and redirect validation (including sign-out error handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->