### PR TITLE
Fix iOS workspace back button rendering as an oversized glass square

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChatPane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChatPane.swift
@@ -94,12 +94,15 @@ struct WorkspaceChatPane<TitleMenuContent: View>: View {
     @ViewBuilder
     private var workspaceBackToolbarButton: some View {
         if let backButtonConfiguration {
+            // No explicit `.buttonStyle(.glass)`: the system already backs this
+            // `.topBarLeading` item in Liquid Glass on iOS 26. A second glass
+            // layer renders as an oversized square. See the matching note on
+            // `WorkspaceDetailView.workspaceBackToolbarButton`.
             WorkspaceBackButton(
                 unreadCount: backButtonConfiguration.unreadCount,
                 badgeContrast: backButtonConfiguration.badgeContrast,
                 action: backButtonConfiguration.action
             )
-            .mobileGlassCompactToolbarControl()
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -357,13 +357,8 @@ struct WorkspaceDetailView: View {
     }
 
     #if os(iOS)
-    /// Compact-stack back button rendered as its own leading toolbar island.
-    ///
-    /// On iOS 26 the system already backs a `.topBarLeading` toolbar item in
-    /// Liquid Glass (the trailing cluster relies on exactly this), so do NOT add
-    /// an explicit `.buttonStyle(.glass)` here. Stacking a second glass layer on
-    /// top of the system's automatic toolbar glass renders as an oversized square
-    /// blob instead of a capsule that matches the trailing buttons.
+    /// Leading back-button island. No explicit `.buttonStyle(.glass)`: iOS 26 backs
+    /// toolbar items in glass; a 2nd layer renders as an oversized square (see chat pane).
     @ViewBuilder
     private var workspaceBackToolbarButton: some View {
         if let backButtonConfiguration {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -358,6 +358,12 @@ struct WorkspaceDetailView: View {
 
     #if os(iOS)
     /// Compact-stack back button rendered as its own leading toolbar island.
+    ///
+    /// On iOS 26 the system already backs a `.topBarLeading` toolbar item in
+    /// Liquid Glass (the trailing cluster relies on exactly this), so do NOT add
+    /// an explicit `.buttonStyle(.glass)` here. Stacking a second glass layer on
+    /// top of the system's automatic toolbar glass renders as an oversized square
+    /// blob instead of a capsule that matches the trailing buttons.
     @ViewBuilder
     private var workspaceBackToolbarButton: some View {
         if let backButtonConfiguration {
@@ -366,7 +372,6 @@ struct WorkspaceDetailView: View {
                 badgeContrast: backButtonConfiguration.badgeContrast,
                 action: backButtonConfiguration.action
             )
-            .mobileGlassCompactToolbarControl()
         }
     }
 


### PR DESCRIPTION
The workspace back button (top-left, chevron + unread count) rendered as an oversized rounded square on iOS 26 instead of a capsule matching the trailing button cluster.

Cause: on iOS 26 the system already backs a `.topBarLeading` toolbar item in Liquid Glass. That is why `toolbarTrailingCluster` renders as a clean capsule with no explicit glass style. The leading back button additionally applied `.mobileGlassCompactToolbarControl()` (`.buttonStyle(.glass)`), stacking a second glass layer on top of the system's automatic toolbar-item glass, which drew as a square blob.

Fix: drop the redundant explicit glass from both the terminal (`WorkspaceDetailView`) and chat (`WorkspaceChatPane`) back buttons, so the system owns one consistent glass background. This matches `toolbarTrailingCluster` and `AgentChatDemoScreen`, which already place the bare button in the leading item.

Principled: yes. It removes a redundant style that fought the system, converging all three leading/trailing/demo placements on one glass source. No behavior change to the button action or the unread badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785538032&installation_id=133855650&pr_number=7148&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7148&signature=9133fcace219408886e9c3d307d234e7c39de8f3dd18cdd5bb944baf176d2471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toolbar styling on iOS with no logic or data changes; behavior of the back action and badge is unchanged.
> 
> **Overview**
> Fixes the workspace **back** control (chevron + unread badge) rendering as an **oversized rounded square** on iOS 26 instead of a capsule like the trailing toolbar cluster.
> 
> **Change:** Stops applying `.mobileGlassCompactToolbarControl()` (explicit `.buttonStyle(.glass)`) on `WorkspaceBackButton` in **`WorkspaceDetailView`** and **`WorkspaceChatPane`**. On iOS 26, `.topBarLeading` toolbar items already get Liquid Glass from the system; a second glass layer stacked on top produced the square blob. Trailing controls were already relying on system glass only.
> 
> Comments document the rationale and cross-reference both call sites. **No** changes to tap handling or the unread badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a35120f41ce98c0f3fca5f0a5bece7255656ab5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS workspace back button rendering as an oversized glass square by removing redundant glass styling on `.topBarLeading`. The back button now renders as a matching capsule like the trailing cluster.

- **Bug Fixes**
  - Removed explicit glass style from back buttons in `WorkspaceDetailView` and `WorkspaceChatPane` so iOS 26 provides the single glass background.
  - Kept a short inline note and trimmed it to pass the Swift file-length guard.
  - No changes to actions or unread badge.

<sup>Written for commit a35120f41ce98c0f3fca5f0a5bece7255656ab5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated compact toolbar back buttons on iOS to rely on the system’s native glass styling (iOS 26 Liquid Glass), ensuring the back button matches the expected capsule appearance.
  * Removed an extra styling layer that could cause the back button to render as an oversized square in the top bar.
  * Improved consistency between different leading compact toolbar layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->