### PR TITLE
iOS: rebuild the disconnected Your Computers screen as a real list

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+MacSwitchState.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+MacSwitchState.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension MobileShellComposite {
+    /// Whether any foreground Mac switch attempt is currently in flight.
+    ///
+    /// `switchToMac` returns `false` both for a genuine connection failure and
+    /// for an attempt superseded by a newer switch (which leaves the newer
+    /// attempt's id in place; `finishMacSwitchAttempt` only clears a matching
+    /// id). Reconnect UIs read this at result time to avoid showing a
+    /// "couldn't connect" alert for an attempt that merely lost the race to a
+    /// switch the user started elsewhere.
+    ///
+    /// Lives in an extension file (with `macSwitchAttemptID` made internal)
+    /// instead of `MobileShellComposite.swift` to respect that file's length
+    /// budget.
+    public var isMacSwitchInFlight: Bool { macSwitchAttemptID != nil }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -5354,6 +5354,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         generation == connectionAttemptGeneration && isSignedIn
     }
 
+    /// Whether any foreground Mac switch attempt is currently in flight.
+    ///
+    /// `switchToMac` returns `false` both for a genuine connection failure and
+    /// for an attempt superseded by a newer switch (which leaves the newer
+    /// attempt's id in place). Reconnect UIs read this at result time to avoid
+    /// showing a "couldn't connect" alert for an attempt that merely lost the
+    /// race to a switch the user started elsewhere.
+    public var isMacSwitchInFlight: Bool { macSwitchAttemptID != nil }
+
     private func beginMacSwitchAttempt() -> UUID {
         let attemptID = UUID()
         macSwitchCancelRestoreGeneration &+= 1

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -686,7 +686,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var createTerminalTaskID: UUID?
     private var connectionGeneration: UUID
     private var connectionAttemptGeneration: UUID
-    @ObservationIgnored private var macSwitchAttemptID: UUID?
+    @ObservationIgnored var macSwitchAttemptID: UUID?
     @ObservationIgnored private var macSwitchAttemptSignInGeneration: Int?
     @ObservationIgnored private var macSwitchRestorePreviousOnCancelAttemptIDs: Set<UUID> = []
     @ObservationIgnored private var macSwitchRestoreBaseline: MobilePairedMac?
@@ -5353,15 +5353,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func isCurrentConnectionAttempt(_ generation: UUID) -> Bool {
         generation == connectionAttemptGeneration && isSignedIn
     }
-
-    /// Whether any foreground Mac switch attempt is currently in flight.
-    ///
-    /// `switchToMac` returns `false` both for a genuine connection failure and
-    /// for an attempt superseded by a newer switch (which leaves the newer
-    /// attempt's id in place). Reconnect UIs read this at result time to avoid
-    /// showing a "couldn't connect" alert for an attempt that merely lost the
-    /// race to a switch the user started elsewhere.
-    public var isMacSwitchInFlight: Bool { macSwitchAttemptID != nil }
 
     private func beginMacSwitchAttempt() -> UUID {
         let attemptID = UUID()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -36,33 +36,11 @@ struct DeviceTreeView: View {
     /// actually removes. (Building from `deviceTreeDevices`, which prefers the team
     /// registry, would make Remove ineffective: a registry-backed row reappears on
     /// the next registry load.) Each is enriched with presence, live status, and how
-    /// many aggregated workspaces it contributes.
+    /// many aggregated workspaces it contributes. Built by the shared
+    /// ``MacComputerSnapshot/snapshots(from:)`` so the disconnected reconnect
+    /// list shows exactly the same computer set.
     private var computers: [MacComputerSnapshot] {
-        let colorIndex = store.machineColorIndex
-        // The PHONE's own per-Mac connection (foreground or live secondary) — the
-        // source of truth for the dot, distinct from presence.
-        let connectionStatuses = store.macConnectionStatuses
-        return store.displayPairedMacs.map { mac in
-            let aliases = store.pairedMacAliasIDs(for: mac.macDeviceID)
-            let summary = store.presenceSummary(for: mac.macDeviceID)
-            let presence: DeviceTreePresence? = summary
-                .map { $0.online ? .online : .offline(lastSeenAt: $0.lastSeenAt) }
-            return MacComputerSnapshot(
-                deviceId: mac.macDeviceID,
-                title: mac.resolvedName,
-                platform: "mac",
-                colorIndex: aliases.compactMap { colorIndex[$0] }.first,
-                customColor: mac.customColor,
-                customIcon: mac.customIcon,
-                connectionStatus: connectionStatuses[mac.macDeviceID],
-                presence: presence,
-                buildLabel: summary?.buildLabel,
-                routeDescription: CmxAttachRoute.deviceTreeRouteDescription(for: mac.routes),
-                lastSeenAt: mac.lastSeenAt,
-                workspaceCount: store.workspaceCount(for: mac.macDeviceID),
-                aliasIDs: aliases
-            )
-        }
+        MacComputerSnapshot.snapshots(from: store)
     }
 
     var body: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -81,12 +81,15 @@ struct DisconnectedWorkspaceShellView: View {
                     }
                     #if os(iOS)
                     // Registry + presence enrich the rows (online dots, build
-                    // labels). The timer then keeps presence and last-seen fresh
+                    // labels). The loop then keeps presence and last-seen fresh
                     // while the app is parked on this screen; like the Computers
                     // screen it deliberately does NOT dial offline Macs (see
                     // `refreshComputersScreen()`), so no reconnect storm.
+                    // Cancellation is wired to this `.task`'s lifecycle.
                     await store?.loadRegistryDevices()
-                    for await _ in Timer.publish(every: 10, on: .main, in: .common).autoconnect().values {
+                    while !Task.isCancelled {
+                        try? await Task.sleep(for: .seconds(10))
+                        guard !Task.isCancelled else { break }
                         await store?.refreshComputersScreen()
                     }
                     #endif
@@ -202,7 +205,10 @@ struct DisconnectedWorkspaceShellView: View {
         }
         .listStyle(.insetGrouped)
         .refreshable {
-            await store?.loadPairedMacs()
+            // Same refresh the 10s loop performs (plus registry), so a pull
+            // updates the presence/last-seen the rows lead with, not just the
+            // stored Mac list.
+            await store?.refreshComputersScreen()
             await store?.loadRegistryDevices()
         }
         .accessibilityIdentifier("MobileDisconnectedSavedMacList")
@@ -245,14 +251,19 @@ struct DisconnectedWorkspaceShellView: View {
     /// Reconnect this row's computer. `switchToMac` promotes a live secondary
     /// connection or re-dials the Mac after refreshing its routes from the
     /// per-user backup; on failure the user gets an explicit alert instead of a
-    /// silently ignored tap.
+    /// silently ignored tap. `switchToMac` also returns `false` when a newer
+    /// switch (e.g. from the Settings sheet's host picker) supersedes this one;
+    /// in that case the newer attempt is still in flight or has already
+    /// connected, and alerting "couldn't connect" would be wrong — skip it.
     private func connect(to macDeviceID: String, named name: String) {
         guard connectingMacID == nil, let store else { return }
         connectingMacID = macDeviceID
         Task {
             let connected = await store.switchToMac(macDeviceID: macDeviceID)
             connectingMacID = nil
-            if !connected {
+            if !connected,
+               store.connectionState != .connected,
+               !store.isMacSwitchInFlight {
                 connectFailedComputerName = name
             }
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -32,112 +32,65 @@ struct DisconnectedWorkspaceShellView: View {
 
     @State private var showingSettings = false
 
-    /// Saved Macs restored/known on this device. Surfaced here so a returning or
-    /// freshly-restored user can pick a known Mac directly instead of being
-    /// dropped into the bare "add device" pairing flow when auto-reconnect did
-    /// not land (e.g. the Mac is momentarily unreachable).
-    private var savedMacs: [MobilePairedMac] { store?.pairedMacs ?? [] }
-
     #if os(iOS)
     @State private var isShowingSetupHelp = false
+    /// The computer whose destructive remove action is awaiting confirmation.
+    /// Stored at list scope so reusable rows do not own transient presentation
+    /// state while `List` is recycling swipe-action rows.
+    @State private var computerPendingRemovalID: String?
+    /// The computer a reconnect attempt is in flight for. Also the re-entry
+    /// guard: while non-nil, row taps are ignored.
+    @State private var connectingMacID: String?
+    /// The display name of the computer whose reconnect just failed, driving
+    /// the failure alert. `nil` = no alert.
+    @State private var connectFailedComputerName: String?
     #endif
 
     var body: some View {
         NavigationStack {
-            ContentUnavailableView {
-                Label(
-                    savedMacs.isEmpty
-                        ? L10n.string("mobile.devices.emptyTitle", defaultValue: "No devices")
-                        : L10n.string("mobile.devices.savedTitle", defaultValue: "Your Computers"),
-                    systemImage: "desktopcomputer.and.iphone"
-                )
-            } description: {
-                Text(
-                    savedMacs.isEmpty
-                        ? L10n.string("mobile.devices.emptyDescription", defaultValue: "Add a computer to start syncing terminal workspaces.")
-                        : L10n.string("mobile.devices.savedDescription", defaultValue: "Tap a saved computer to reconnect, or add another.")
-                )
-            } actions: {
-                // When a paired Mac is unreachable and this device has no
-                // active tailnet, lead with that explanation instead of
-                // leaving the user staring at a generic empty state. Skip it
-                // when no Mac was ever paired: the disconnected copy assumes a
-                // Mac exists, and the pairing sheet carries its own callout.
-                if hasKnownPairedMac, tailscaleStatusMonitor?.status == .inactiveOrNotInstalled {
-                    TailscaleInactiveCallout(context: .disconnected)
-                        .frame(maxWidth: 320, alignment: .leading)
-                        .padding(.bottom, 4)
-                }
-                // Restored/known saved Macs, tappable to reconnect. A small fixed
-                // set (bounded by the per-user backup cap), so a plain VStack is
-                // fine; rows take value snapshots + a closure action, never the
-                // store, honoring the list snapshot-boundary rule.
-                if let store, !savedMacs.isEmpty {
-                    VStack(spacing: 8) {
-                        ForEach(savedMacs) { mac in
-                            Button {
-                                Task { await store.switchToMac(macDeviceID: mac.macDeviceID) }
-                            } label: {
-                                Label(mac.displayName ?? mac.macDeviceID, systemImage: "desktopcomputer")
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                            }
-                            .buttonStyle(.bordered)
-                            .accessibilityIdentifier("MobileDisconnectedSavedMac-\(mac.macDeviceID)")
-                        }
+            content
+                .navigationTitle(L10n.string("mobile.workspaces.title", defaultValue: "Workspaces"))
+                .mobileInlineNavigationTitle()
+                .toolbar {
+                    #if os(iOS)
+                    ToolbarItem(placement: .topBarLeading) {
+                        settingsMenu
                     }
-                    .frame(maxWidth: 320)
-                    .padding(.bottom, 4)
+                    ToolbarItem(placement: .topBarTrailing) {
+                        addDeviceToolbarButton
+                    }
+                    #else
+                    ToolbarItem {
+                        settingsMenu
+                    }
+                    ToolbarItem {
+                        addDeviceToolbarButton
+                    }
+                    #endif
                 }
-                Button(action: showAddDevice) {
-                    Text(
-                        savedMacs.isEmpty
-                            ? L10n.string("mobile.addDevice.title", defaultValue: "Add Computer")
-                            : L10n.string("mobile.addDevice.another", defaultValue: "Add another Computer")
-                    )
+                .accessibilityIdentifier("MobileDisconnectedWorkspaceShell")
+                .task {
+                    // Load (and, via the backup decorator, restore) saved Macs so a
+                    // known/restored Mac shows up here for one-tap reconnect. Only
+                    // auto-present the pairing sheet when there is nothing to pick,
+                    // so a returning user is not buried under the add-device flow.
+                    await store?.loadPairedMacs()
+                    if store?.pairedMacs.isEmpty ?? true {
+                        showAddDevice()
+                        return
+                    }
+                    #if os(iOS)
+                    // Registry + presence enrich the rows (online dots, build
+                    // labels). The timer then keeps presence and last-seen fresh
+                    // while the app is parked on this screen; like the Computers
+                    // screen it deliberately does NOT dial offline Macs (see
+                    // `refreshComputersScreen()`), so no reconnect storm.
+                    await store?.loadRegistryDevices()
+                    for await _ in Timer.publish(every: 10, on: .main, in: .common).autoconnect().values {
+                        await store?.refreshComputersScreen()
+                    }
+                    #endif
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(.blue)
-                .accessibilityIdentifier("MobileShowAddDeviceButton")
-                #if os(iOS)
-                Button {
-                    isShowingSetupHelp = true
-                } label: {
-                    Text(L10n.string("mobile.devices.setupHelp", defaultValue: "Trouble connecting?"))
-                }
-                .font(.callout)
-                .accessibilityIdentifier("MobileDisconnectedSetupHelpButton")
-                #endif
-            }
-            .navigationTitle(L10n.string("mobile.workspaces.title", defaultValue: "Workspaces"))
-            .mobileInlineNavigationTitle()
-            .toolbar {
-                #if os(iOS)
-                ToolbarItem(placement: .topBarLeading) {
-                    settingsMenu
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    addDeviceToolbarButton
-                }
-                #else
-                ToolbarItem {
-                    settingsMenu
-                }
-                ToolbarItem {
-                    addDeviceToolbarButton
-                }
-                #endif
-            }
-            .accessibilityIdentifier("MobileDisconnectedWorkspaceShell")
-            .task {
-                // Load (and, via the backup decorator, restore) saved Macs so a
-                // known/restored Mac shows up here for one-tap reconnect. Only
-                // auto-present the pairing sheet when there is nothing to pick,
-                // so a returning user is not buried under the add-device flow.
-                await store?.loadPairedMacs()
-                if store?.pairedMacs.isEmpty ?? true {
-                    showAddDevice()
-                }
-            }
         }
         #if os(iOS)
         .sheet(isPresented: $isShowingSetupHelp) {
@@ -160,8 +113,237 @@ struct DisconnectedWorkspaceShellView: View {
                 store: store
             )
         }
+        .alert(
+            connectFailedTitle,
+            isPresented: Binding(
+                get: { connectFailedComputerName != nil },
+                set: { if !$0 { connectFailedComputerName = nil } }
+            )
+        ) {
+            Button(L10n.string("mobile.common.ok", defaultValue: "OK"), role: .cancel) {}
+        } message: {
+            Text(L10n.string(
+                "mobile.disconnected.connectFailedMessage",
+                defaultValue: "Make sure the computer is awake and online, then try again."
+            ))
+        }
         #endif
     }
+
+    #if os(iOS)
+    /// Saved computers as the same coalesced snapshots the Computers screen
+    /// shows, so a Mac paired under several stored ids is one row here too.
+    private var savedComputers: [MacComputerSnapshot] {
+        store.map { MacComputerSnapshot.snapshots(from: $0) } ?? []
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if !savedComputers.isEmpty {
+            savedComputersList(savedComputers)
+        } else {
+            emptyState
+        }
+    }
+
+    /// The returning-user state: a real list of the saved computers, one row per
+    /// logical Mac, with presence, last-seen, tap-to-reconnect, and
+    /// swipe-to-remove — the same row component as the Computers screen.
+    /// Snapshot boundary (see AGENTS.md): rows receive immutable
+    /// ``MacComputerSnapshot`` values and closures only, never the store.
+    private func savedComputersList(_ computers: [MacComputerSnapshot]) -> some View {
+        List {
+            // When a paired Mac is unreachable and this device has no active
+            // tailnet, lead with that explanation instead of leaving the user
+            // to tap dead rows.
+            if hasKnownPairedMac, tailscaleStatusMonitor?.status == .inactiveOrNotInstalled {
+                Section {
+                    TailscaleInactiveCallout(context: .disconnected)
+                }
+            }
+            Section {
+                ForEach(computers) { computer in
+                    MacComputerRow(
+                        computer: computer,
+                        requestRemove: { computerPendingRemovalID = $0 },
+                        isConfirmingRemove: removalConfirmationBinding(for: computer.deviceId),
+                        confirmRemove: { _ in confirmComputerRemoval() },
+                        style: .reconnect,
+                        connect: { connect(to: $0, named: computer.title) },
+                        isConnecting: connectingMacID == computer.deviceId
+                    )
+                }
+            } header: {
+                Text(L10n.string("mobile.devices.savedTitle", defaultValue: "Your Computers"))
+            } footer: {
+                Text(L10n.string(
+                    "mobile.disconnected.listFooter",
+                    defaultValue: "Tap a computer to reconnect. Swipe left to remove one."
+                ))
+            }
+            Section {
+                Button(action: showAddDevice) {
+                    Label(
+                        L10n.string("mobile.computers.add", defaultValue: "Add Computer"),
+                        systemImage: "plus"
+                    )
+                }
+                .accessibilityIdentifier("MobileShowAddDeviceButton")
+                Button {
+                    isShowingSetupHelp = true
+                } label: {
+                    Label(
+                        L10n.string("mobile.devices.setupHelp", defaultValue: "Trouble connecting?"),
+                        systemImage: "questionmark.circle"
+                    )
+                }
+                .accessibilityIdentifier("MobileDisconnectedSetupHelpButton")
+            }
+        }
+        .listStyle(.insetGrouped)
+        .refreshable {
+            await store?.loadPairedMacs()
+            await store?.loadRegistryDevices()
+        }
+        .accessibilityIdentifier("MobileDisconnectedSavedMacList")
+    }
+
+    /// The never-paired/empty state (also previews, where `store` is `nil`).
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label(
+                L10n.string("mobile.devices.emptyTitle", defaultValue: "No devices"),
+                systemImage: "desktopcomputer.and.iphone"
+            )
+        } description: {
+            Text(L10n.string(
+                "mobile.devices.emptyDescription",
+                defaultValue: "Add a computer to start syncing terminal workspaces."
+            ))
+        } actions: {
+            if hasKnownPairedMac, tailscaleStatusMonitor?.status == .inactiveOrNotInstalled {
+                TailscaleInactiveCallout(context: .disconnected)
+                    .frame(maxWidth: 320, alignment: .leading)
+                    .padding(.bottom, 4)
+            }
+            Button(action: showAddDevice) {
+                Text(L10n.string("mobile.addDevice.title", defaultValue: "Add Computer"))
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.blue)
+            .accessibilityIdentifier("MobileShowAddDeviceButton")
+            Button {
+                isShowingSetupHelp = true
+            } label: {
+                Text(L10n.string("mobile.devices.setupHelp", defaultValue: "Trouble connecting?"))
+            }
+            .font(.callout)
+            .accessibilityIdentifier("MobileDisconnectedSetupHelpButton")
+        }
+    }
+
+    /// Reconnect this row's computer. `switchToMac` promotes a live secondary
+    /// connection or re-dials the Mac after refreshing its routes from the
+    /// per-user backup; on failure the user gets an explicit alert instead of a
+    /// silently ignored tap.
+    private func connect(to macDeviceID: String, named name: String) {
+        guard connectingMacID == nil, let store else { return }
+        connectingMacID = macDeviceID
+        Task {
+            let connected = await store.switchToMac(macDeviceID: macDeviceID)
+            connectingMacID = nil
+            if !connected {
+                connectFailedComputerName = name
+            }
+        }
+    }
+
+    private var connectFailedTitle: String {
+        String(
+            format: L10n.string(
+                "mobile.disconnected.connectFailedTitleFormat",
+                defaultValue: "Couldn't connect to %@"
+            ),
+            connectFailedComputerName ?? ""
+        )
+    }
+
+    private func removalConfirmationBinding(for deviceID: String) -> Binding<Bool> {
+        Binding(
+            get: { computerPendingRemovalID == deviceID },
+            set: { isPresented in
+                if isPresented {
+                    computerPendingRemovalID = deviceID
+                } else if computerPendingRemovalID == deviceID {
+                    computerPendingRemovalID = nil
+                }
+            }
+        )
+    }
+
+    private func confirmComputerRemoval() {
+        guard let deviceID = computerPendingRemovalID else {
+            return
+        }
+        computerPendingRemovalID = nil
+        Task {
+            await store?.forgetMac(macDeviceID: deviceID)
+            await store?.loadPairedMacs()
+        }
+    }
+    #else
+    /// Saved Macs restored/known on this device (macOS fallback shell).
+    private var savedMacs: [MobilePairedMac] { store?.pairedMacs ?? [] }
+
+    private var content: some View {
+        ContentUnavailableView {
+            Label(
+                savedMacs.isEmpty
+                    ? L10n.string("mobile.devices.emptyTitle", defaultValue: "No devices")
+                    : L10n.string("mobile.devices.savedTitle", defaultValue: "Your Computers"),
+                systemImage: "desktopcomputer.and.iphone"
+            )
+        } description: {
+            Text(
+                savedMacs.isEmpty
+                    ? L10n.string("mobile.devices.emptyDescription", defaultValue: "Add a computer to start syncing terminal workspaces.")
+                    : L10n.string("mobile.devices.savedDescription", defaultValue: "Tap a saved computer to reconnect, or add another.")
+            )
+        } actions: {
+            if hasKnownPairedMac, tailscaleStatusMonitor?.status == .inactiveOrNotInstalled {
+                TailscaleInactiveCallout(context: .disconnected)
+                    .frame(maxWidth: 320, alignment: .leading)
+                    .padding(.bottom, 4)
+            }
+            if let store, !savedMacs.isEmpty {
+                VStack(spacing: 8) {
+                    ForEach(savedMacs) { mac in
+                        Button {
+                            Task { await store.switchToMac(macDeviceID: mac.macDeviceID) }
+                        } label: {
+                            Label(mac.displayName ?? mac.macDeviceID, systemImage: "desktopcomputer")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .buttonStyle(.bordered)
+                        .accessibilityIdentifier("MobileDisconnectedSavedMac-\(mac.macDeviceID)")
+                    }
+                }
+                .frame(maxWidth: 320)
+                .padding(.bottom, 4)
+            }
+            Button(action: showAddDevice) {
+                Text(
+                    savedMacs.isEmpty
+                        ? L10n.string("mobile.addDevice.title", defaultValue: "Add Computer")
+                        : L10n.string("mobile.addDevice.another", defaultValue: "Add another Computer")
+                )
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.blue)
+            .accessibilityIdentifier("MobileShowAddDeviceButton")
+        }
+    }
+    #endif
 
     /// The top-left 3-dots overflow, matching ``WorkspaceListView``'s
     /// `settingsMenu` so switching between the connected and no-devices screens

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -8,7 +8,20 @@ import SwiftUI
 /// the Mac's name, a primary line for the PHONE'S connection state + workspace
 /// count, and a diagnostic line for presence + route. The trailing dot reflects
 /// the phone's connection (green = the phone is talking to this Mac now).
+///
+/// The `.reconnect` style reuses the same row on the disconnected screen, where
+/// no phone connection exists: the row becomes a tap-to-reconnect button, the
+/// primary line and dot switch to presence (green = the Mac is online and worth
+/// tapping), and the workspace count is dropped (it is stale while disconnected).
 struct MacComputerRow: View {
+    /// How the row behaves and which status it leads with.
+    enum Style {
+        /// Computers screen: navigation to the detail view, phone-connection dot.
+        case computers
+        /// Disconnected screen: tap reconnects, presence dot.
+        case reconnect
+    }
+
     let computer: MacComputerSnapshot
     /// Request confirmation before removing this computer. When `nil`, the
     /// destructive affordances are hidden.
@@ -20,11 +33,17 @@ struct MacComputerRow: View {
     /// Performs the confirmed removal. Separate from ``requestRemove`` so a
     /// full-swipe can request confirmation without directly removing the row.
     var confirmRemove: ((String) -> Void)? = nil
+    var style: Style = .computers
+    /// Reconnect action for `.reconnect` rows; tapping the row calls this with
+    /// the device id instead of navigating.
+    var connect: ((String) -> Void)? = nil
+    /// Whether a connect attempt for this row is in flight (spinner replaces the
+    /// status dot). Re-entry is guarded by the owning list, not by disabling the
+    /// button, so the row does not flash a dimmed state.
+    var isConnecting: Bool = false
 
     var body: some View {
-        NavigationLink(value: computer.deviceId) {
-            rowLabel
-        }
+        rowContainer
         .contextMenu { removeMenuButton }
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             removeSwipeButton
@@ -50,6 +69,23 @@ struct MacComputerRow: View {
             }
         } message: {
             Text(removeMessage)
+        }
+    }
+
+    @ViewBuilder
+    private var rowContainer: some View {
+        switch style {
+        case .computers:
+            NavigationLink(value: computer.deviceId) {
+                rowLabel
+            }
+        case .reconnect:
+            Button {
+                connect?(computer.deviceId)
+            } label: {
+                rowLabel
+            }
+            .buttonStyle(.plain)
         }
     }
 
@@ -149,13 +185,21 @@ struct MacComputerRow: View {
     /// The connection dot: green only when the PHONE is actually connected to this
     /// Mac. Orange while reconnecting, grey when the phone is not connected (even
     /// if presence says the Mac is online — that's the route/tailscale signal).
+    /// `.reconnect` rows show a spinner while their connect attempt is in flight.
     @ViewBuilder
     private var badge: some View {
-        Image(systemName: "circle.fill")
-            .font(.caption2)
-            .foregroundStyle(dotColor)
-            .accessibilityLabel(connectionPhrase)
-            .accessibilityIdentifier("MobileComputerStatus-\(computer.deviceId)-\(isConnected ? "connected" : "disconnected")")
+        if isConnecting {
+            ProgressView()
+                .controlSize(.small)
+                .accessibilityLabel(
+                    L10n.string("mobile.deviceTree.reconnecting", defaultValue: "Reconnecting…"))
+        } else {
+            Image(systemName: "circle.fill")
+                .font(.caption2)
+                .foregroundStyle(dotColor)
+                .accessibilityLabel(primaryStatusPhrase)
+                .accessibilityIdentifier("MobileComputerStatus-\(computer.deviceId)-\(isConnected ? "connected" : "disconnected")")
+        }
     }
 
     /// A small build-channel pill (e.g. "DEV · teams", "Nightly"). DEV/RC/Staging
@@ -180,10 +224,18 @@ struct MacComputerRow: View {
     }
 
     private var dotColor: Color {
-        switch computer.connectionStatus {
-        case .connected: return .green
-        case .reconnecting: return .orange
-        case .unavailable, nil: return .secondary.opacity(0.5)
+        switch style {
+        case .computers:
+            switch computer.connectionStatus {
+            case .connected: return .green
+            case .reconnecting: return .orange
+            case .unavailable, nil: return .secondary.opacity(0.5)
+            }
+        case .reconnect:
+            // Disconnected screen: the phone talks to no Mac, so the phone
+            // connection is uniformly grey and carries no signal. Presence is
+            // the signal that matters — green marks the Macs worth tapping.
+            return computer.presence == .online ? .green : .secondary.opacity(0.5)
         }
     }
 
@@ -205,10 +257,40 @@ struct MacComputerRow: View {
         }
     }
 
-    /// Primary line: the phone's connection to this Mac + workspace count.
+    /// Primary line. `.computers`: the phone's connection to this Mac + workspace
+    /// count. `.reconnect`: presence ("Online" / "Last seen …") — the phone is
+    /// connected to nothing and the cached workspace count is stale, so neither
+    /// carries information there.
     private var connectionLine: String {
-        let count = L10n.terminalCountWorkspaces(computer.workspaceCount)
-        return "\(connectionPhrase) · \(count)"
+        switch style {
+        case .computers:
+            let count = L10n.terminalCountWorkspaces(computer.workspaceCount)
+            return "\(connectionPhrase) · \(count)"
+        case .reconnect:
+            return reconnectStatusPhrase
+        }
+    }
+
+    /// What the status dot means, for accessibility: the phone connection on the
+    /// Computers screen, presence on the disconnected screen.
+    private var primaryStatusPhrase: String {
+        switch style {
+        case .computers: return connectionPhrase
+        case .reconnect: return reconnectStatusPhrase
+        }
+    }
+
+    /// Presence with a last-seen fallback from the paired store, so a
+    /// `.reconnect` row always shows something more useful than "unknown".
+    private var reconnectStatusPhrase: String {
+        switch computer.presence {
+        case .online:
+            return L10n.string("mobile.deviceTree.online", defaultValue: "Online")
+        case .offline(let lastSeenAt):
+            return lastSeenLine(max(lastSeenAt, computer.lastSeenAt))
+        case nil:
+            return lastSeenLine(computer.lastSeenAt)
+        }
     }
 
     private var connectionPhrase: String {
@@ -232,6 +314,11 @@ struct MacComputerRow: View {
     /// seen) still shows, and the full presence state is always in the detail sheet.
     private var diagnosticLine: String {
         let route = computer.routeDescription ?? L10n.string("mobile.computers.noRoute", defaultValue: "no route")
+        // `.reconnect` rows lead with presence on the primary line, so repeating
+        // it here would be noise — the diagnostic line is just the route.
+        if style == .reconnect {
+            return route
+        }
         if isConnected, computer.presence == nil {
             return route
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -324,18 +324,23 @@ struct MacComputerRow: View {
     /// seen) still shows, and the full presence state is always in the detail sheet.
     private var diagnosticLine: String {
         let route = computer.routeDescription ?? L10n.string("mobile.computers.noRoute", defaultValue: "no route")
+        var line: String
         // `.reconnect` rows lead with presence on the primary line, so repeating
         // it here would be noise — the diagnostic line is just the route.
-        if style == .reconnect {
-            return route
+        if style == .reconnect || (isConnected && computer.presence == nil) {
+            line = route
+        } else {
+            line = String(
+                format: L10n.string("mobile.computers.diagnosticFormat", defaultValue: "Presence: %@ · %@"),
+                presencePhrase, route
+            )
         }
-        if isConnected, computer.presence == nil {
-            return route
+        // A stale same-named record (usually an old dev-build pairing) says so,
+        // so several identically named rows stop looking interchangeable.
+        if computer.isOlderDuplicate {
+            line = "\(L10n.string("mobile.computers.olderPairing", defaultValue: "Older pairing")) · \(line)"
         }
-        return String(
-            format: L10n.string("mobile.computers.diagnosticFormat", defaultValue: "Presence: %@ · %@"),
-            presencePhrase, route
-        )
+        return line
     }
 
     private var presencePhrase: String {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -198,7 +198,7 @@ struct MacComputerRow: View {
                 .font(.caption2)
                 .foregroundStyle(dotColor)
                 .accessibilityLabel(primaryStatusPhrase)
-                .accessibilityIdentifier("MobileComputerStatus-\(computer.deviceId)-\(isConnected ? "connected" : "disconnected")")
+                .accessibilityIdentifier("MobileComputerStatus-\(computer.deviceId)-\(statusIdentifierSuffix)")
         }
     }
 
@@ -240,6 +240,16 @@ struct MacComputerRow: View {
     }
 
     private var isConnected: Bool { computer.connectionStatus == .connected }
+
+    /// The dot's automation suffix, derived from the same signal as its color so
+    /// UI tests and debugging never disagree with the visible state: phone
+    /// connection on the Computers screen, presence on the reconnect list.
+    private var statusIdentifierSuffix: String {
+        switch style {
+        case .computers: return isConnected ? "connected" : "disconnected"
+        case .reconnect: return computer.presence == .online ? "online" : "offline"
+        }
+    }
 
     private var avatarGradient: LinearGradient {
         MachineAvatarColors.gradient(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
@@ -18,7 +18,7 @@ extension MacComputerSnapshot {
         // The PHONE's own per-Mac connection (foreground or live secondary) — the
         // source of truth for the dot, distinct from presence.
         let connectionStatuses = store.macConnectionStatuses
-        return store.displayPairedMacs.map { mac in
+        var snapshots = store.displayPairedMacs.map { mac in
             let aliases = store.pairedMacAliasIDs(for: mac.macDeviceID)
             let summary = store.presenceSummary(for: mac.macDeviceID)
             let presence: DeviceTreePresence? = summary
@@ -38,6 +38,33 @@ extension MacComputerSnapshot {
                 workspaceCount: store.workspaceCount(for: mac.macDeviceID),
                 aliasIDs: aliases
             )
+        }
+        markOlderDuplicates(&snapshots)
+        return snapshots
+    }
+
+    /// Flag rows that share a fresher row's name and are not online.
+    ///
+    /// A Mac that re-paired across dev builds before the shared device id
+    /// (cmux PR https://github.com/manaflow-ai/cmux/pull/6772) left one stored
+    /// record per old build UUID, all named after the same computer. They do
+    /// not coalesce (each dials a different port), so without a marker the
+    /// list reads as interchangeable duplicates. `displayPairedMacs` arrives
+    /// last-seen-newest-first, so the first occurrence of a name is the live
+    /// record and later non-online occurrences get labeled "Older pairing".
+    /// An online row is never labeled: a running instance is not stale even
+    /// if a fresher same-named record exists.
+    private static func markOlderDuplicates(_ snapshots: inout [MacComputerSnapshot]) {
+        var seenNames: Set<String> = []
+        for index in snapshots.indices {
+            let name = snapshots[index].title
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            if seenNames.contains(name), snapshots[index].presence != .online {
+                snapshots[index].isOlderDuplicate = true
+            } else {
+                seenNames.insert(name)
+            }
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
@@ -1,0 +1,44 @@
+#if os(iOS)
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileShell
+import CmuxMobileShellModel
+import Foundation
+
+extension MacComputerSnapshot {
+    /// The user's computers as immutable snapshots, sourced from the paired-Mac
+    /// backup (`displayPairedMacs`) — the coalesced set the Computers screen
+    /// shows and the one ``CMUXMobileShellStore/forgetMac`` actually removes.
+    /// Shared by the Computers screen and the disconnected reconnect list so
+    /// both surfaces show the same deduplicated computers with the same
+    /// presence, color, and customization data.
+    @MainActor
+    static func snapshots(from store: CMUXMobileShellStore) -> [MacComputerSnapshot] {
+        let colorIndex = store.machineColorIndex
+        // The PHONE's own per-Mac connection (foreground or live secondary) — the
+        // source of truth for the dot, distinct from presence.
+        let connectionStatuses = store.macConnectionStatuses
+        return store.displayPairedMacs.map { mac in
+            let aliases = store.pairedMacAliasIDs(for: mac.macDeviceID)
+            let summary = store.presenceSummary(for: mac.macDeviceID)
+            let presence: DeviceTreePresence? = summary
+                .map { $0.online ? .online : .offline(lastSeenAt: $0.lastSeenAt) }
+            return MacComputerSnapshot(
+                deviceId: mac.macDeviceID,
+                title: mac.resolvedName,
+                platform: "mac",
+                colorIndex: aliases.compactMap { colorIndex[$0] }.first,
+                customColor: mac.customColor,
+                customIcon: mac.customIcon,
+                connectionStatus: connectionStatuses[mac.macDeviceID],
+                presence: presence,
+                buildLabel: summary?.buildLabel,
+                routeDescription: CmxAttachRoute.deviceTreeRouteDescription(for: mac.routes),
+                lastSeenAt: mac.lastSeenAt,
+                workspaceCount: store.workspaceCount(for: mac.macDeviceID),
+                aliasIDs: aliases
+            )
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot.swift
@@ -26,6 +26,13 @@ struct MacComputerSnapshot: Equatable, Identifiable {
     let workspaceCount: Int
     /// Stored paired-Mac ids represented by this visible row.
     let aliasIDs: [String]
+    /// Whether a fresher row with the same computer name exists and this row is
+    /// not online: almost always a stale pairing record from an older dev-build
+    /// device id (pre-shared-device-id, cmux PR
+    /// https://github.com/manaflow-ai/cmux/pull/6772), kept so the user can
+    /// still reconnect or remove it. Labeled so several identically named
+    /// entries stop looking interchangeable.
+    var isOlderDuplicate: Bool = false
 
     var id: String { deviceId }
 }

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -46,6 +46,7 @@ The top entry's version MUST equal the checked-in `MARKETING_VERSION` in
 
 ### Internal
 
+- Disconnected "Your Computers" screen rebuilt: coalesced one-row-per-Mac list (no more duplicate dev-build pills), online/last-seen status, tap to reconnect with spinner and failure alert, swipe to remove.
 - Composer: iMessage-style terminal composer, open by default, inline send, drafts saved per terminal (#5876).
 - View as Text sheet for copy-pasting raw terminal output (#5875).
 - Pairing QR is now minimal and full-width (routes-only payload, Copy IP/Port, no expiry); scans faster (#5872, #5727).
@@ -57,6 +58,7 @@ The top entry's version MUST equal the checked-in `MARKETING_VERSION` in
 
 ### External
 
+- The reconnect screen now shows each of your computers once, with online status and last-seen time. Tap to reconnect, swipe to remove.
 - New terminal composer: type and send like a message, with drafts saved per terminal.
 - View as Text: copy raw terminal output from a clean sheet.
 - Faster, simpler Mac pairing QR, with Copy IP/Port if scanning is awkward.

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1412,6 +1412,23 @@
         }
       }
     },
+    "mobile.computers.olderPairing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Older pairing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古いペアリング"
+          }
+        }
+      }
+    },
     "mobile.computers.presenceFooter": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -681,6 +681,23 @@
         }
       }
     },
+    "mobile.common.ok": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
     "mobile.common.retry": {
       "extractionState": "manual",
       "localizations": {
@@ -2309,6 +2326,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "デバッグログをコピー"
+          }
+        }
+      }
+    },
+    "mobile.disconnected.connectFailedMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Make sure the computer is awake and online, then try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンピュータがスリープしておらずオンラインであることを確認してから、もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "mobile.disconnected.connectFailedTitleFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't connect to %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@に接続できませんでした"
+          }
+        }
+      }
+    },
+    "mobile.disconnected.listFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap a computer to reconnect. Swipe left to remove one."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンピュータをタップすると再接続します。左にスワイプすると削除できます。"
           }
         }
       }


### PR DESCRIPTION
Before: the disconnected screen rendered every stored paired-Mac record as a centered bordered pill inside a ContentUnavailableView. A device that re-paired across dev builds showed dozens of identical "lawrence's MacBook Pro (2)" rows with no online status, no last-seen time, no way to remove a stale entry, and no feedback when a tap failed.

Now the screen shares the Computers screen's data path. Rows come from the coalesced `displayPairedMacs` snapshots (one row per logical Mac) through a shared `MacComputerSnapshot.snapshots(from:)` builder, and render with `MacComputerRow` in a new `.reconnect` style: machine-colored avatar, presence-led status line (Online / Last seen 2 hours ago), route diagnostic line, a green dot for Macs that are actually online, a spinner while a reconnect attempt is in flight, and an alert when the attempt fails instead of a silently ignored tap. Swipe or long-press removes the computer with the same alias-wide `forgetMac` confirmation the Computers screen uses. Presence and last-seen refresh on the same gentle 10-second `refreshComputersScreen()` cadence (no offline re-dial storm), plus pull-to-refresh. The never-paired empty state keeps the previous ContentUnavailableView layout and auto-presented pairing sheet.

New localized strings (`mobile.common.ok`, `mobile.disconnected.*`) have en + ja entries; all other row strings reuse existing Computers-screen keys. `ios/CHANGELOG.md` top entry updated.

Compile-verified with `swift build --triple arm64-apple-ios18.0-simulator` on `CmuxMobileShellUI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches foreground Mac switching UX and reconnect error handling; changes are UI-focused but `switchToMac` failure semantics must stay correct to avoid missed or false alerts.
> 
> **Overview**
> Replaces the disconnected screen’s centered **paired-Mac pills** with the same **coalesced computer list** as the Computers screen: shared `MacComputerSnapshot.snapshots(from:)`, `MacComputerRow` in a new **`.reconnect`** style (presence-led status, tap-to-reconnect, spinner, swipe/remove), plus **10s presence refresh**, pull-to-refresh, and a **failure alert** when reconnect truly fails.
> 
> Adds **`isMacSwitchInFlight`** on `MobileShellComposite` so reconnect UI does not show “couldn’t connect” when `switchToMac` returns false because a **newer switch** is still in flight. Marks **older duplicate** same-named offline pairings as “Older pairing” on row diagnostics. **macOS** disconnected shell keeps the prior ContentUnavailable layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18792a4966ef1a76464521d8ddd895a388fadd3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785544122&installation_id=133855650&pr_number=7156&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7156&signature=827638bc0090889d94712e3669d3af99ab23f11386735ebcda718b35fa063518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the iOS disconnected “Your Computers” screen into a real list that shows one row per Mac, leads with presence/last-seen, and adds clear reconnect/remove feedback. Stale same‑named records now show an “Older pairing” label so duplicates are obvious to clean up.

- **New Features**
  - Shares the Computers screen’s coalesced data path via `MacComputerSnapshot.snapshots(from:)`; flags stale same‑named entries as “Older pairing”.
  - New `.reconnect` style in `MacComputerRow`: presence-led status and dot, spinner while connecting, supersession‑aware failure alert.
  - Tap to reconnect; swipe or long‑press to remove with alias‑wide `forgetMac` confirmation.
  - Presence and last‑seen refresh every 10s via `refreshComputersScreen()`, plus pull‑to‑refresh; no offline re‑dial storm.
  - Empty state retained; added localizations `mobile.common.ok`, `mobile.disconnected.*`, and `mobile.computers.olderPairing` (en + ja).

- **Refactors**
  - Moved `isMacSwitchInFlight` to `MobileShellComposite+MacSwitchState.swift` (widened `macSwitchAttemptID` to internal); no behavior change.

<sup>Written for commit 18792a4966ef1a76464521d8ddd895a388fadd3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the disconnected computers screen for iPhone/iPad with a clearer “saved Macs” list (one row per computer) and online/last-seen details.
  * Added tap-to-reconnect rows with reconnect loading feedback, plus swipe-to-remove support.
* **Bug Fixes**
  * Improved status accuracy for in-progress Mac switching and reconnect attempts, including clearer online/offline labeling.
  * Added a reconnect failure alert when reconnection does not succeed.
* **Documentation**
  * Updated iOS release notes and localized strings for the refreshed screen, reconnect messaging, and “Older pairing.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->