### PR TITLE
remote-tmux: fix stray "%" and cursor offset after splitting a mirror pane

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Install ffmpeg
         if: ${{ inputs.record_video }}
         run: |
-          brew install --quiet ffmpeg
+          brew install --quiet ffmpeg tmux
           FFMPEG_PATH=$(which ffmpeg)
           echo "ffmpeg: $FFMPEG_PATH"
           ffmpeg -version | head -1

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -336,7 +336,7 @@ final class RemoteTmuxControlConnection {
         enterReceived = false
 
         let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+        proc.executableURL = URL(fileURLWithPath: RemoteTmuxSSHBinary.path)
         proc.arguments = host.controlModeArguments(
             sessionName: sessionName,
             createIfMissing: createIfMissing

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -126,6 +126,13 @@ final class RemoteTmuxControlConnection {
     /// after a reconnect so the resumed session keeps the mirror's grid instead of
     /// reverting to ssh's default 80×24.
     private var lastClientSize: (columns: Int, rows: Int)?
+    /// The last size ANY writer requested via ``setClientSize(columns:rows:)`` —
+    /// the shared dedup baseline for every sizing writer on this connection. A
+    /// writer must never dedup against a private cache of what IT last pushed:
+    /// the client size is shared session state, and after another writer moves
+    /// it, a stale private cache swallows exactly the re-push that would
+    /// reconcile the window (the mismatch then persists with no recovery path).
+    var lastRequestedClientSize: (columns: Int, rows: Int)? { lastClientSize }
     private var pendingPostAttachAction: PostAttachAction?
 
     /// Trailing-edge debounce for `refresh-client -C`. SwiftUI layout settle makes the

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -7,6 +7,22 @@ import Foundation
 /// every operation against the host (discovery commands, the `tmux -CC`
 /// control client, and one-shot mutations) over a single SSH ControlMaster
 /// socket derived from the destination, so authentication happens once.
+/// The ssh binary every remote-tmux spawn uses. DEBUG builds honor
+/// `CMUX_REMOTE_TMUX_SSH_FOR_TESTING` so end-to-end tests can substitute a
+/// shim that strips the ssh framing and execs the remote command locally —
+/// the full mirror stack then runs hermetically (no sshd, no network).
+enum RemoteTmuxSSHBinary {
+    static var path: String {
+        #if DEBUG
+        if let override = ProcessInfo.processInfo.environment["CMUX_REMOTE_TMUX_SSH_FOR_TESTING"],
+           !override.isEmpty {
+            return override
+        }
+        #endif
+        return "/usr/bin/ssh"
+    }
+}
+
 struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
     /// The SSH destination: a `~/.ssh/config` alias or `user@host`.
     let destination: String
@@ -250,7 +266,7 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
     ///   end-of-options guard precedes the destination so a dash-prefixed
     ///   destination can never be parsed as an ssh option.
     func interactiveAuthInvocation(
-        sshExecutablePath: String = "/usr/bin/ssh",
+        sshExecutablePath: String = RemoteTmuxSSHBinary.path,
         controlPersistSeconds: Int = 180
     ) -> [String] {
         [sshExecutablePath]

--- a/Sources/RemoteTmuxSSHTransport.swift
+++ b/Sources/RemoteTmuxSSHTransport.swift
@@ -36,7 +36,7 @@ actor RemoteTmuxSSHTransport {
     ///   - controlPersistSeconds: idle lifetime of the shared master.
     init(
         host: RemoteTmuxHost,
-        sshExecutablePath: String = "/usr/bin/ssh",
+        sshExecutablePath: String = RemoteTmuxSSHBinary.path,
         controlPersistSeconds: Int = 180
     ) {
         self.host = host
@@ -278,7 +278,7 @@ actor RemoteTmuxSSHTransport {
     /// the mirror window. Best-effort: a missing/dead socket just fails fast.
     nonisolated static func spawnControlMasterExit(
         host: RemoteTmuxHost,
-        sshExecutablePath: String = "/usr/bin/ssh"
+        sshExecutablePath: String = RemoteTmuxSSHBinary.path
     ) {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: sshExecutablePath)

--- a/Sources/RemoteTmuxWindowMirror.swift
+++ b/Sources/RemoteTmuxWindowMirror.swift
@@ -28,8 +28,41 @@ final class RemoteTmuxWindowMirror {
 
     /// The window's current pane layout — drives the SwiftUI split container.
     private(set) var layout: RemoteTmuxLayoutNode
+    /// Bumped by ``reconcile(layout:)`` only when the layout's STRUCTURE changes
+    /// (pane set or split nesting — see ``structureSignature(of:)``), never on a
+    /// geometry-only reflow. Client sizing re-arms off this, not off ``layout``:
+    /// a geometry-only `%layout-change` is tmux's echo of our own
+    /// `refresh-client -C` (or a co-attached client's resize-pane), and the
+    /// summed grid that would be re-pushed is itself downstream of that reflow
+    /// (the split container divides pixels by tmux's cell weights). At pixel
+    /// widths where cmux's pixel division and tmux's integer cell division
+    /// disagree by a column, re-pushing on the echo has no fixed point — the
+    /// client size alternates ±1 column indefinitely, SIGWINCH-storming every
+    /// pane in the session. Structural changes must still re-push: each
+    /// split/close adds or removes a separator column/row in the summed grid.
+    private(set) var layoutStructureVersion = 0
+    /// Bumped on a geometry-only reconcile while ``geometryCorrectionBudget``
+    /// remains, re-arming ONE bounded sizing pass. Geometry-only layout changes
+    /// are usually the echo of our own `refresh-client -C` — never re-arm
+    /// unboundedly on those (that loop has no fixed point at some pixel widths)
+    /// — but they are also how genuinely FOREIGN changes arrive: a co-attached
+    /// client's `resize-pane`, or another writer (a single-pane tab) moving the
+    /// shared client size. Those must re-push or the window sticks mismatched
+    /// (panes rendering one column short of their PTY, wrapping every full-width
+    /// line). The budget resolves the ambiguity without distinguishing the two:
+    /// each geometry re-arm spends 1 of 2; the budget refills only on a
+    /// structural change or a local trigger (mount, outer resize, tab shown).
+    /// A foreign change heals in one pass (its echo then dedups to silence); an
+    /// echo storm burns the budget and goes quiet instead of oscillating.
+    private(set) var sizingCorrectionVersion = 0
+    @ObservationIgnored private var geometryCorrectionBudget = 2
     /// The tmux pane the user last focused (drives the focus overlay + splits).
     private(set) var activePaneId: Int?
+
+    /// Refills the geometry-correction budget. Called by the view on every
+    /// LOCAL sizing trigger (mount, outer-area change, tab becoming visible) —
+    /// the signals that cannot be a tmux echo.
+    func noteLocalSizingTrigger() { geometryCorrectionBudget = 2 }
 
     /// ``TerminalPanel`` per tmux pane id. Not observation-tracked: the view
     /// re-reads it whenever ``layout`` (which IS tracked) changes, and the two
@@ -94,6 +127,20 @@ final class RemoteTmuxWindowMirror {
             syntheticPaneIds[paneId] = nil
             if activePaneId == paneId { activePaneId = nil }
         }
+        // Structural change (split/close/re-nest) vs geometry-only reflow: the
+        // former always re-arms client sizing (the separator arithmetic changed)
+        // and refills the correction budget; the latter re-arms at most
+        // ``geometryCorrectionBudget`` bounded passes (see
+        // ``sizingCorrectionVersion``). `init` reconciles the layout it just
+        // stored, so the first pass never bumps — the view's onAppear owns the
+        // initial push.
+        if Self.structureSignature(of: newLayout) != Self.structureSignature(of: layout) {
+            geometryCorrectionBudget = 2
+            layoutStructureVersion += 1
+        } else if layout != newLayout, geometryCorrectionBudget > 0 {
+            geometryCorrectionBudget -= 1
+            sizingCorrectionVersion += 1
+        }
         if layout != newLayout { layout = newLayout }
     }
 
@@ -102,27 +149,191 @@ final class RemoteTmuxWindowMirror {
         panelsByPaneId[paneId]?.surface.processRemoteOutput(data)
     }
 
-    @ObservationIgnored private var lastClientSize: (cols: Int, rows: Int)?
-
     /// Tells tmux to size this session's windows to the rendered cmux area, so
-    /// captured/live pane content matches the on-screen grid. Derives cols/rows
-    /// from the content pixel area and a live pane's cell size; sends
-    /// `refresh-client -C` only when the grid actually changes (no feedback loop:
-    /// the cmux area doesn't change when tmux reflows).
-    /// Returns `true` once the pane surface is live and the size was applied (sent, or
-    /// already current via the `lastClientSize` dedup); `false` when no pane has
-    /// reported its cell size yet, so the caller should retry. Idempotent.
+    /// captured/live pane content matches the on-screen grid.
+    ///
+    /// The summed grid IS downstream of tmux's layout (the split container divides
+    /// pixels proportionally to tmux's cell weights, and the leaf grids quantize
+    /// that), so calling this from a tmux-originated layout echo closes a feedback
+    /// loop that has no fixed point at some pixel widths (±1-column oscillation,
+    /// forever). Loop safety is therefore the CALLER's job: push on local triggers
+    /// (appear, outer-area change, tab shown), on ``layoutStructureVersion``
+    /// changes, and on at most the budgeted ``sizingCorrectionVersion`` passes.
+    ///
+    /// Dedup is against the CONNECTION's last-requested size — shared session
+    /// state — never a mirror-local cache: the client size has other writers
+    /// (single-pane tabs, reconnect re-apply), and after one of them moves it, a
+    /// private cache would swallow the very re-push that reconciles this window.
+    /// Returns `true` once every pane surface is live and the size was applied
+    /// (sent, or already current); `false` while any surface has no live grid
+    /// yet, so the caller should retry. Idempotent.
     @discardableResult
-    func updateClientSize(contentSizePoints: CGSize) -> Bool {
-        guard contentSizePoints.width > 1, contentSizePoints.height > 1,
-              let cell = panelsByPaneId.values.lazy.compactMap({ $0.surface.cellSizePoints() }).first,
-              cell.width > 1, cell.height > 1 else { return false }
-        let cols = max(20, Int(contentSizePoints.width / cell.width))
-        let rows = max(5, Int(contentSizePoints.height / cell.height))
-        guard lastClientSize?.cols != cols || lastClientSize?.rows != rows else { return true }
-        lastClientSize = (cols, rows)
-        connection?.setClientSize(columns: cols, rows: rows)
+    func updateClientSize() -> Bool {
+        // Size tmux from the ACTUAL rendered leaf grids, summed through the layout
+        // tree with tmux's 1-cell pane separators — NOT from the outer content area
+        // divided by cell size. The outer/cell math counts the local SwiftUI split
+        // dividers as columns, so tmux ends up ~1 col wider than the ghostty surfaces
+        // actually render; that width disagreement wraps zsh's PROMPT_SP "%" filler and
+        // misplaces the cursor in split panes. Reporting the real summed grid makes
+        // tmux's per-pane width equal each surface's rendered width, so live %output
+        // paints faithfully. Returns false (caller retries) until every leaf is live.
+        guard let connection else { return true }
+        guard let grid = renderedLayoutGridCells(of: layout) else { return false }
+        let cols = max(20, grid.cols)
+        let rows = max(5, grid.rows)
+        if let last = connection.lastRequestedClientSize, last.columns == cols, last.rows == rows {
+            // The TOTAL is right — now make tmux's per-pane deal match. tmux
+            // redistributes a new window size with its own remainder rule, so
+            // it can hand the odd column to a different pane than the one whose
+            // pixels grew: every total can be dealt wrong pane-wise, and at
+            // some geometries no total deals right. Pin only the mismatched
+            // panes to their rendered dims (the sum is consistent by
+            // construction, so tmux can honor every pin). Ordering falls out of
+            // the settle-confirm rounds: one round pushes the total, the next
+            // finds the total deduped and pins the deal, the next verifies.
+            let pins = Self.panePins(of: layout, leafGrid: leafGridProvider(of: layout))
+            #if DEBUG
+            lastPanePinsForTesting = pins
+            #endif
+            for pin in pins {
+                var cmd = "resize-pane -t @\(windowId).%\(pin.paneId)"
+                if let c = pin.cols { cmd += " -x \(c)" }
+                if let r = pin.rows { cmd += " -y \(r)" }
+                connection.send(cmd)
+            }
+            return true
+        }
+        connection.setClientSize(columns: cols, rows: rows)
         return true
+    }
+
+    /// A pane whose tmux-dealt dims differ from its rendered grid, and the
+    /// dimension(s) to pin (`nil` = already matches).
+    struct PanePin: Equatable {
+        let paneId: Int
+        let cols: Int?
+        let rows: Int?
+    }
+
+    /// The panes tmux dealt differently than their surfaces render. Pure over
+    /// `(node, leafGrid)` — `nonisolated` and unit-testable. Leaves with no
+    /// grid are skipped (nothing trustworthy to pin to).
+    nonisolated static func panePins(
+        of node: RemoteTmuxLayoutNode,
+        leafGrid: (Int) -> (cols: Int, rows: Int)?
+    ) -> [PanePin] {
+        var pins: [PanePin] = []
+        func walk(_ n: RemoteTmuxLayoutNode) {
+            switch n.content {
+            case let .pane(id):
+                guard let grid = leafGrid(id) else { return }
+                let c = grid.cols != n.width ? grid.cols : nil
+                let r = grid.rows != n.height ? grid.rows : nil
+                if c != nil || r != nil { pins.append(PanePin(paneId: id, cols: c, rows: r)) }
+            case let .horizontal(children), let .vertical(children):
+                children.forEach(walk)
+            }
+        }
+        walk(node)
+        return pins
+    }
+
+    /// The window grid size implied by the ACTUAL rendered leaf-pane grids, folded
+    /// through the layout tree via ``summedGridCells(of:leafGrid:)``. Returns `nil`
+    /// if any leaf surface has no live rendered grid yet, so the caller retries once
+    /// it does.
+    /// The per-leaf grid source shared by the fold and the pane pins: the live
+    /// surface grid, with a sliver fallback to tmux's own dims — a pane squeezed
+    /// to a few cells (a co-attached client can resize one down to a single
+    /// cell) may never report a live grid, and one degenerate pane must not
+    /// become a total sizing outage for the window.
+    private func leafGridProvider(of node: RemoteTmuxLayoutNode) -> (Int) -> (cols: Int, rows: Int)? {
+        var tmuxDims: [Int: (cols: Int, rows: Int)] = [:]
+        func collect(_ n: RemoteTmuxLayoutNode) {
+            switch n.content {
+            case let .pane(id): tmuxDims[id] = (n.width, n.height)
+            case let .horizontal(children), let .vertical(children): children.forEach(collect)
+            }
+        }
+        collect(node)
+        let surfaceGrid: (Int) -> (cols: Int, rows: Int)?
+        #if DEBUG
+        surfaceGrid = leafGridOverrideForTesting ?? { [panelsByPaneId] paneId in
+            panelsByPaneId[paneId]?.surface.renderedGridCells()
+                .map { (cols: $0.columns, rows: $0.rows) }
+        }
+        #else
+        surfaceGrid = { [panelsByPaneId] paneId in
+            panelsByPaneId[paneId]?.surface.renderedGridCells()
+                .map { (cols: $0.columns, rows: $0.rows) }
+        }
+        #endif
+        return { paneId in
+            if let grid = surfaceGrid(paneId) { return grid }
+            if let dims = tmuxDims[paneId], dims.cols <= 3 || dims.rows <= 3 { return dims }
+            return nil
+        }
+    }
+
+    private func renderedLayoutGridCells(of node: RemoteTmuxLayoutNode) -> (cols: Int, rows: Int)? {
+        Self.summedGridCells(of: node, leafGrid: leafGridProvider(of: node))
+    }
+
+    /// Folds per-leaf grid sizes through the tmux split tree exactly as tmux lays a
+    /// window out: a horizontal split's width is the sum of its children's widths plus
+    /// one separator column between each (height = max child height); a vertical split
+    /// is the transpose (max width, summed heights + one separator row between each).
+    /// The `+ (count - 1)` separator term is what makes the window size we report equal
+    /// the leaves' rendered widths PLUS tmux's own divider columns, so tmux then splits
+    /// that window back into per-pane widths that match each surface — the invariant that
+    /// keeps zsh's PROMPT_SP "%" filler from wrapping. Returns `nil` if `leafGrid`
+    /// returns `nil` for any pane (its surface has no live grid yet), so the caller can
+    /// retry. Pure over `(node, leafGrid)` — no live-surface access — so it's
+    /// `nonisolated` and unit testable with stubbed leaf sizes.
+    nonisolated static func summedGridCells(
+        of node: RemoteTmuxLayoutNode,
+        leafGrid: (Int) -> (cols: Int, rows: Int)?
+    ) -> (cols: Int, rows: Int)? {
+        switch node.content {
+        case let .pane(paneId):
+            return leafGrid(paneId)
+        case let .horizontal(children):
+            var totalCols = 0
+            var maxRows = 0
+            for child in children {
+                guard let g = summedGridCells(of: child, leafGrid: leafGrid) else { return nil }
+                totalCols += g.cols
+                maxRows = max(maxRows, g.rows)
+            }
+            return (totalCols + max(0, children.count - 1), maxRows)
+        case let .vertical(children):
+            var maxCols = 0
+            var totalRows = 0
+            for child in children {
+                guard let g = summedGridCells(of: child, leafGrid: leafGrid) else { return nil }
+                maxCols = max(maxCols, g.cols)
+                totalRows += g.rows
+            }
+            return (maxCols, totalRows + max(0, children.count - 1))
+        }
+    }
+
+    /// The split-tree SHAPE (node kinds + pane ids, geometry stripped). Two layouts
+    /// with the same signature differ only in cell extents — the fingerprint of a
+    /// tmux-side reflow: the echo of our own `refresh-client -C`, or a co-attached
+    /// client's `resize-pane`. Those must not re-arm client sizing (see
+    /// ``layoutStructureVersion``). A split, close, or re-nest changes the
+    /// signature, and those MUST re-push: each split adds a separator column/row
+    /// to the summed grid. Pure over the node — `nonisolated` and unit-testable.
+    nonisolated static func structureSignature(of node: RemoteTmuxLayoutNode) -> String {
+        switch node.content {
+        case let .pane(paneId):
+            return "p\(paneId)"
+        case let .horizontal(children):
+            return "h(" + children.map(structureSignature(of:)).joined(separator: ",") + ")"
+        case let .vertical(children):
+            return "v(" + children.map(structureSignature(of:)).joined(separator: ",") + ")"
+        }
     }
 
     /// Records the user-focused pane and asks tmux to make it active.
@@ -168,6 +379,22 @@ final class RemoteTmuxWindowMirror {
         }
         connection.queryPaneActivity(paneId: tmuxPaneId, completion: completion)
     }
+
+    #if DEBUG
+    /// Stubs the per-pane rendered grids so sizing behavior is testable without
+    /// live surfaces: ``updateClientSize()``'s liveness/floor/dedup contract and
+    /// — critically — that ``reconcile(layout:)`` never pushes a size by itself
+    /// (pushing from the reconcile path would re-open the geometry-echo loop
+    /// that ``layoutStructureVersion`` exists to prevent).
+    @ObservationIgnored var leafGridOverrideForTesting: ((Int) -> (cols: Int, rows: Int)?)?
+    /// The shared (connection-level) last-requested size — what dedup compares
+    /// against and what a send updates. Tests read this to observe both halves.
+    var lastClientSizeForTesting: (cols: Int, rows: Int)? {
+        connection?.lastRequestedClientSize.map { (cols: $0.columns, rows: $0.rows) }
+    }
+    /// The pane pins computed by the most recent dedup-hit sizing pass.
+    @ObservationIgnored var lastPanePinsForTesting: [PanePin] = []
+    #endif
 
     /// Tears down every pane panel (called when the window-tab is removed).
     func teardown() {

--- a/Sources/RemoteTmuxWindowMirrorView.swift
+++ b/Sources/RemoteTmuxWindowMirrorView.swift
@@ -27,9 +27,37 @@ struct RemoteTmuxWindowMirrorView: View {
             )
             .frame(width: geo.size.width, height: geo.size.height)
             // Size the remote tmux window to the rendered area so pane content
-            // matches the on-screen grid.
-            .onAppear { scheduleClientSize(geo.size) }
-            .onChange(of: geo.size) { _, newSize in scheduleClientSize(newSize) }
+            // matches the on-screen grid. Local triggers (mount, outer resize,
+            // tab shown) also refill the mirror's geometry-correction budget —
+            // they cannot be tmux echoes, so they are safe reset points.
+            .onAppear { mirror.noteLocalSizingTrigger(); scheduleClientSize() }
+            .onChange(of: geo.size) { _, _ in mirror.noteLocalSizingTrigger(); scheduleClientSize() }
+            // Tabs are kept mounted across selection (keepAllAlive), so onAppear
+            // fires once per tab lifetime and never on re-select. Re-arm when the
+            // tab becomes visible again: another writer may have moved the shared
+            // client size while this tab was hidden, and the visible tab should
+            // own the size it renders at.
+            .onChange(of: isVisibleInUI) { _, visible in
+                if visible { mirror.noteLocalSizingTrigger(); scheduleClientSize() }
+            }
+            // The size we report to tmux depends on the pane COUNT — each split adds
+            // a separator column/row to the summed grid — so a split/close must
+            // re-push it. But a split changes the layout without changing the outer
+            // tab area, so onChange(geo.size) never fires for it. Re-arm on the
+            // layout's STRUCTURE version rather than the layout value: every push
+            // comes back as a geometry-only `%layout-change` (tmux reflowing the
+            // window to the size we just sent), and a size recomputed from grids
+            // that reflow just re-divided has no fixed point at some pixel widths —
+            // re-pushing on that echo oscillates the client size ±1 column
+            // indefinitely. (onAppear covers the 1→N mount into the mirror; this
+            // covers N→N±1 splits/closes within an already-mounted mirror.)
+            .onChange(of: mirror.layoutStructureVersion) { _, _ in scheduleClientSize() }
+            // Budgeted correction for geometry-only layout changes (a co-client's
+            // resize-pane, or another writer moving the shared client size). The
+            // mirror bumps this at most twice between local/structural triggers,
+            // so a foreign change heals in one bounded pass while an echo storm
+            // burns out instead of oscillating (see sizingCorrectionVersion).
+            .onChange(of: mirror.sizingCorrectionVersion) { _, _ in scheduleClientSize() }
             .onDisappear { sizingRetryTask?.cancel() }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -37,22 +65,44 @@ struct RemoteTmuxWindowMirrorView: View {
         .background(Color(nsColor: appearance.backgroundColor))
     }
 
-    /// Pushes the client size to tmux, retrying briefly while the pane surface hasn't
-    /// reported its cell size yet — so the initial `refresh-client -C` lands even when
-    /// the view size never changes after attach. Each call restarts the retry with the
-    /// LATEST size, so a resize arriving before the surface is live isn't lost and can't
-    /// be overwritten by a stale earlier size. `updateClientSize` dedups + reports
-    /// readiness, so the retry stops as soon as the surface goes live.
-    private func scheduleClientSize(_ size: CGSize) {
+    /// Pushes the client size to tmux, retrying briefly while a pane surface hasn't
+    /// reported a live grid yet — so the initial `refresh-client -C` lands even when
+    /// the view size never changes after attach. Each call restarts the retry, so a
+    /// trigger arriving before the surfaces are live isn't lost. `updateClientSize`
+    /// reads the summed rendered grids itself (no size argument needed), dedups, and
+    /// reports readiness.
+    ///
+    /// After the first successful push, a short settle-confirm pass re-samples the
+    /// grids a few more times: a push fired from a trigger (mount, outer resize,
+    /// split/close) can read grids the layout pass hasn't re-divided yet, and the
+    /// geometry-only `%layout-change` that follows is deliberately not a re-arm
+    /// trigger (see `layoutStructureVersion`) — without a confirm pass a mid-settle
+    /// read would stick until the next trigger. The pass is TIME-bounded and
+    /// trigger-scoped, never echo-triggered, so it cannot reopen the resize
+    /// feedback loop: at a width with no quantization fixed point it stops after
+    /// the last round instead of alternating forever, and everywhere else the
+    /// `lastClientSize` dedup makes the extra rounds free.
+    private func scheduleClientSize() {
         sizingRetryTask?.cancel()
-        if mirror.updateClientSize(contentSizePoints: size) { return }
         sizingRetryTask = Task { @MainActor in
-            // Retry until the pane surface reports its cell size (local layout timing,
-            // normally a frame or two; budget generously for a loaded system). do/catch
-            // (not try?) so a cancelled sleep returns immediately without a stale apply.
-            for _ in 0..<20 {
+            // Phase 1: wait for every pane surface to report a live grid (local
+            // layout timing, normally a frame or two; budget generously for a
+            // loaded system). do/catch (not try?) so a cancelled sleep returns
+            // immediately without a stale apply.
+            var ready = mirror.updateClientSize()
+            var waitRounds = 0
+            while !ready {
+                guard waitRounds < 20 else { return }
+                waitRounds += 1
                 do { try await ContinuousClock().sleep(for: .milliseconds(150)) } catch { return }
-                if mirror.updateClientSize(contentSizePoints: size) { return }
+                ready = mirror.updateClientSize()
+            }
+            // Phase 2: the settle-confirm pass always gets its full budget, no
+            // matter how late readiness arrived — truncating it re-opens the
+            // stuck-mid-settle-size window it exists to close.
+            for _ in 0..<4 {
+                do { try await ContinuousClock().sleep(for: .milliseconds(250)) } catch { return }
+                mirror.updateClientSize()
             }
         }
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -821,6 +821,7 @@
 		F11ED7AB0004000400040004 /* RemoteTmuxMirrorNewTabPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11ED7AB0003000300030003 /* RemoteTmuxMirrorNewTabPlacement.swift */; };
 		F11ED7AB0001000100010001 /* RemoteTmuxMirrorNewTabPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11ED7AB0002000200020002 /* RemoteTmuxMirrorNewTabPlacementTests.swift */; };
 		D4F8A2E61C5B39707A8E6F12 /* RemoteTmuxMirrorSplitRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */; };
+		D4F8A2E61C5B39707A8E6F13 /* RemoteTmuxMirrorSummedGridTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E1C4D2B3F09865E217D4C1 /* RemoteTmuxMirrorSummedGridTests.swift */; };
 		F861B8D7C62A0BCB252A523A /* RemoteTmuxMirrorTabActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC55CC7B42874062C64013A /* RemoteTmuxMirrorTabActivity.swift */; };
 		0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */; };
 		E9A8CC35D632F14A8669B7D1 /* RemoteTmuxPaneForegroundState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123BF93B1ADC00C5D25EE028 /* RemoteTmuxPaneForegroundState.swift */; };
@@ -2099,6 +2100,7 @@
 		F11ED7AB0003000300030003 /* RemoteTmuxMirrorNewTabPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorNewTabPlacement.swift; sourceTree = "<group>"; };
 		F11ED7AB0002000200020002 /* RemoteTmuxMirrorNewTabPlacementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorNewTabPlacementTests.swift; sourceTree = "<group>"; };
 		A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorSplitRoutingTests.swift; sourceTree = "<group>"; };
+		A7E1C4D2B3F09865E217D4C1 /* RemoteTmuxMirrorSummedGridTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorSummedGridTests.swift; sourceTree = "<group>"; };
 		6FC55CC7B42874062C64013A /* RemoteTmuxMirrorTabActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorTabActivity.swift; sourceTree = "<group>"; };
 		0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNewWindowCwdTests.swift; sourceTree = "<group>"; };
 		123BF93B1ADC00C5D25EE028 /* RemoteTmuxPaneForegroundState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPaneForegroundState.swift; sourceTree = "<group>"; };
@@ -3837,6 +3839,7 @@
 				B0555302B0555302B0555302 /* RemoteTmuxControlStreamParserBudgetTests.swift */,
 				B0555304B0555304B0555304 /* DetachedFolderPathLookupCacheTests.swift */,
 				A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */,
+				A7E1C4D2B3F09865E217D4C1 /* RemoteTmuxMirrorSummedGridTests.swift */,
 				F11ED7AB0002000200020002 /* RemoteTmuxMirrorNewTabPlacementTests.swift */,
 				FA00C0DE0002BEEF0002CAFE /* RemoteTmuxWindowRegistryTests.swift */,
 				0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */,
@@ -5448,6 +5451,7 @@
 				6732BEEF6732BEEF6732B002 /* RemoteTmuxMasterReadinessTests.swift in Sources */,
 				F11ED7AB0001000100010001 /* RemoteTmuxMirrorNewTabPlacementTests.swift in Sources */,
 				D4F8A2E61C5B39707A8E6F12 /* RemoteTmuxMirrorSplitRoutingTests.swift in Sources */,
+				D4F8A2E61C5B39707A8E6F13 /* RemoteTmuxMirrorSummedGridTests.swift in Sources */,
 				0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */,
 				7020C0DE7020C0DE7020A002 /* RemoteTmuxProxyTransportRetryTests.swift in Sources */,
 				3AC9AB9046E742B93726A405 /* RemoteTmuxSessionListParserTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -838,6 +838,7 @@
 		1255599FA91128E5925D3983 /* RemoteTmuxSessionMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D5CC45BBE157F3EF880936 /* RemoteTmuxSessionMirror.swift */; };
 		3AC9AB9046E742B93726A501 /* RemoteTmuxSessionRenameTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */; };
 		9A5CF3AA2E6462E77144F9E6 /* RemoteTmuxSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */; };
+		C0DE51DE0001C0DE0001C0DE /* RemoteTmuxSizingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE51DE0002C0DE0002C0DE /* RemoteTmuxSizingUITests.swift */; };
 		7020C0DE7020C0DE7020B002 /* RemoteTmuxSSHTransport+InteractiveRetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7020C0DE7020C0DE7020B001 /* RemoteTmuxSSHTransport+InteractiveRetry.swift */; };
 		6D3C19C2014FF9C754358EFF /* RemoteTmuxSSHTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F5DB43CBC1B7DF31B7A0C9 /* RemoteTmuxSSHTransport.swift */; };
 		4E9111628FAF490FBC51D350 /* RemoteTmuxStdoutPipeReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA9E692220B4E0C91499A05 /* RemoteTmuxStdoutPipeReader.swift */; };
@@ -2117,6 +2118,7 @@
 		D7D5CC45BBE157F3EF880936 /* RemoteTmuxSessionMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionMirror.swift; sourceTree = "<group>"; };
 		3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionRenameTitleTests.swift; sourceTree = "<group>"; };
 		31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionSnapshotTests.swift; sourceTree = "<group>"; };
+		C0DE51DE0002C0DE0002C0DE /* RemoteTmuxSizingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSizingUITests.swift; sourceTree = "<group>"; };
 		7020C0DE7020C0DE7020B001 /* RemoteTmuxSSHTransport+InteractiveRetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteTmuxSSHTransport+InteractiveRetry.swift"; sourceTree = "<group>"; };
 		E8F5DB43CBC1B7DF31B7A0C9 /* RemoteTmuxSSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSSHTransport.swift; sourceTree = "<group>"; };
 		5CA9E692220B4E0C91499A05 /* RemoteTmuxStdoutPipeReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxStdoutPipeReader.swift; sourceTree = "<group>"; };
@@ -2719,6 +2721,7 @@
 				D10000000000000000A00021 /* SettingsAccountJSONResetBehaviorUITests.swift */,
 				E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */,
 				AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */,
+				C0DE51DE0002C0DE0002C0DE /* RemoteTmuxSizingUITests.swift */,
 				AA1B2C3D4E5F60721 /* RightSidebarChromeHeightUITests.swift */,
 			);
 			path = cmuxUITests;
@@ -5221,6 +5224,7 @@
 				E1000000A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift in Sources */,
 				B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */,
 				8B1B2AB6EC6ACDB2CD39A9BB /* NewBrowserWorkspaceShortcutUITests.swift in Sources */,
+				C0DE51DE0001C0DE0001C0DE /* RemoteTmuxSizingUITests.swift in Sources */,
 				AA1B2C3D4E5F60720 /* RightSidebarChromeHeightUITests.swift in Sources */,
 				D10000000000000000A00020 /* SettingsAccountJSONResetBehaviorUITests.swift in Sources */,
 				D10000000000000000A00012 /* SettingsAppBehaviorUITests.swift in Sources */,

--- a/cmuxTests/RemoteTmuxMirrorSummedGridTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorSummedGridTests.swift
@@ -1,0 +1,595 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the remote-tmux mirror's window-sizing math.
+///
+/// The stranded-"%" failure mode: sizing the remote tmux client from the outer
+/// SwiftUI content area divided by cell size counts each local split divider as
+/// a grid column, so tmux gets a window ~1 column WIDER per split than the
+/// ghostty surfaces actually render. zsh's PROMPT_SP "%" filler is then painted
+/// past the surface's last column, wraps, and strands a lone "%" (and misplaces
+/// the cursor) in split panes.
+///
+/// Fix: size tmux by folding the ACTUAL rendered leaf grids through the layout
+/// tree with tmux's own 1-cell pane separators — a horizontal split's width is
+/// the sum of child widths plus one separator column between each (height = max
+/// child height); a vertical split is the transpose. ``summedGridCells`` reports
+/// the window size whose tmux split-back yields per-pane widths that equal each
+/// surface's rendered width, so live `%output` paints faithfully.
+///
+/// These tests pin the separator/transpose math (the "we do Y now" guard):
+/// removing the `+ (count - 1)` separator term makes every split case go red.
+@MainActor
+@Suite struct RemoteTmuxMirrorSummedGridTests {
+    /// Builds a leaf-grid lookup from a `[paneId: (cols, rows)]` map; missing
+    /// panes return `nil` (mimicking a surface that isn't live yet).
+    private func leaves(_ map: [Int: (cols: Int, rows: Int)]) -> (Int) -> (cols: Int, rows: Int)? {
+        { map[$0] }
+    }
+
+    private func node(_ content: RemoteTmuxLayoutContent) -> RemoteTmuxLayoutNode {
+        // Geometry fields are unused by summedGridCells (it reads leaf grids, not
+        // tmux's reported node width/height) — set them to obviously-distinct
+        // values so a regression that accidentally reads node.width/height fails.
+        RemoteTmuxLayoutNode(width: -1, height: -1, x: -1, y: -1, content: content)
+    }
+
+    @Test func singleLeafPassesThroughItsGrid() {
+        let result = RemoteTmuxWindowMirror.summedGridCells(
+            of: node(.pane(1)),
+            leafGrid: leaves([1: (80, 24)])
+        )
+        #expect(result?.cols == 80)
+        #expect(result?.rows == 24)
+    }
+
+    @Test func horizontalSplitSumsWidthsPlusOneSeparatorAndTakesMaxHeight() {
+        // Two panes side by side, 40 | 39 cells → window is 40 + 39 + 1 = 80 wide
+        // (NOT 79): the +1 is tmux's divider column. Heights differ → max.
+        let result = RemoteTmuxWindowMirror.summedGridCells(
+            of: node(.horizontal([node(.pane(1)), node(.pane(2))])),
+            leafGrid: leaves([1: (40, 24), 2: (39, 23)])
+        )
+        #expect(result?.cols == 80)
+        #expect(result?.rows == 24)
+    }
+
+    @Test func verticalSplitSumsHeightsPlusOneSeparatorAndTakesMaxWidth() {
+        // Transpose of the horizontal case: 12 / 11 rows stacked → 12 + 11 + 1 = 24.
+        let result = RemoteTmuxWindowMirror.summedGridCells(
+            of: node(.vertical([node(.pane(1)), node(.pane(2))])),
+            leafGrid: leaves([1: (80, 12), 2: (79, 11)])
+        )
+        #expect(result?.cols == 80)
+        #expect(result?.rows == 24)
+    }
+
+    @Test func threeWayHorizontalSplitAddsTwoSeparators() {
+        // Matches a double right-split (3 panes): 26 * 3 + 2 separators = 80.
+        let result = RemoteTmuxWindowMirror.summedGridCells(
+            of: node(.horizontal([node(.pane(1)), node(.pane(2)), node(.pane(3))])),
+            leafGrid: leaves([1: (26, 24), 2: (26, 24), 3: (26, 24)])
+        )
+        #expect(result?.cols == 80)
+        #expect(result?.rows == 24)
+    }
+
+    @Test func nestedSplitFoldsRecursively() {
+        // horizontal[ pane(1)=40x24, vertical[ pane(2)=39x12, pane(3)=39x11 ] ]
+        //   right child (vertical): max width 39, heights 12 + 11 + 1 = 24 → 39x24
+        //   root (horizontal):      40 + 39 + 1 = 80 cols, max(24, 24) = 24 rows
+        let tree = node(.horizontal([
+            node(.pane(1)),
+            node(.vertical([node(.pane(2)), node(.pane(3))])),
+        ]))
+        let result = RemoteTmuxWindowMirror.summedGridCells(
+            of: tree,
+            leafGrid: leaves([1: (40, 24), 2: (39, 12), 3: (39, 11)])
+        )
+        #expect(result?.cols == 80)
+        #expect(result?.rows == 24)
+    }
+
+    @Test func returnsNilUntilEveryLeafHasALiveGrid() {
+        // One pane's surface isn't live yet → the whole fold is nil, so the caller
+        // retries instead of reporting a partial (too-narrow) window to tmux.
+        let result = RemoteTmuxWindowMirror.summedGridCells(
+            of: node(.horizontal([node(.pane(1)), node(.pane(2))])),
+            leafGrid: leaves([1: (40, 24)]) // pane 2 missing
+        )
+        #expect(result == nil)
+    }
+}
+
+/// Pins the client-size RE-ARM contract for mirrored multi-pane windows.
+///
+/// The summed rendered grids that feed
+/// ``RemoteTmuxWindowMirror/updateClientSize()`` are downstream of tmux's own
+/// layout: the split container divides pixels proportionally to tmux's cell
+/// weights, and each leaf grid quantizes that. Every `refresh-client -C` we
+/// send therefore comes back as a geometry-only `%layout-change` (tmux
+/// reflowing the window to the size we just pushed). At pixel widths where
+/// cmux's pixel division and tmux's integer cell division disagree by a
+/// column, a push triggered by that echo has no fixed point — the client size
+/// alternates ±1 column indefinitely, SIGWINCH-storming every pane in the
+/// session.
+///
+/// The contract under test — three cooperating rules:
+/// 1. ``RemoteTmuxWindowMirror/layoutStructureVersion`` advances exactly on
+///    STRUCTURE changes (pane set / split nesting — ``structureSignature(of:)``):
+///    splits, closes, and re-nests must re-push (their separator arithmetic
+///    changes the summed grid) and refill the correction budget.
+/// 2. Geometry-only reflows advance ``sizingCorrectionVersion`` at most
+///    twice between local/structural triggers: enough for a genuinely foreign
+///    change (a co-attached client's resize-pane, another writer moving the
+///    shared size) to heal in one bounded pass, while an echo storm burns the
+///    budget and goes quiet instead of oscillating without a fixed point.
+/// 3. ``updateClientSize()`` dedups against the CONNECTION's last-requested
+///    size (shared state), never a mirror-local cache — after a foreign writer
+///    moves the client, the mirror's next trigger must actually send.
+@MainActor
+@Suite struct RemoteTmuxMirrorSizingEchoGateTests {
+    private func node(
+        _ content: RemoteTmuxLayoutContent, w: Int = -1, h: Int = -1, x: Int = -1, y: Int = -1
+    ) -> RemoteTmuxLayoutNode {
+        RemoteTmuxLayoutNode(width: w, height: h, x: x, y: y, content: content)
+    }
+
+    /// The echo pair: tmux's reflow of a 3-pane side-by-side window at client
+    /// width 123 (panes 41+40+40 + 2 separators) vs 122 (40+40+40 + 2). Same
+    /// panes, same nesting — geometry only. These are the two quantization-
+    /// consistent widths between which an echo-triggered push would alternate.
+    private var reflow123: RemoteTmuxLayoutNode {
+        node(.horizontal([
+            node(.pane(1), w: 41, h: 35, x: 0, y: 0),
+            node(.pane(2), w: 40, h: 35, x: 42, y: 0),
+            node(.pane(3), w: 40, h: 35, x: 83, y: 0),
+        ]), w: 123, h: 35, x: 0, y: 0)
+    }
+    private var reflow122: RemoteTmuxLayoutNode {
+        node(.horizontal([
+            node(.pane(1), w: 40, h: 35, x: 0, y: 0),
+            node(.pane(2), w: 40, h: 35, x: 41, y: 0),
+            node(.pane(3), w: 40, h: 35, x: 82, y: 0),
+        ]), w: 122, h: 35, x: 0, y: 0)
+    }
+
+    /// A mirror plus the connection it writes to. The connection is never
+    /// started (its init only stores fields; `setClientSize` records the
+    /// requested size without sending while unconnected) and `makePanel` yields
+    /// nil, so the pair exercises exactly the layout/version/sizing logic under
+    /// test. The caller must hold the connection — the mirror only keeps a weak
+    /// reference, mirroring production ownership.
+    private func makeMirror(
+        layout: RemoteTmuxLayoutNode
+    ) -> (mirror: RemoteTmuxWindowMirror, connection: RemoteTmuxControlConnection) {
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "test-host", port: nil, identityFile: nil),
+            sessionName: "test"
+        )
+        let mirror = RemoteTmuxWindowMirror(
+            windowId: 0,
+            panelId: UUID(),
+            connection: connection,
+            layout: layout,
+            makePanel: { _ in nil }
+        )
+        return (mirror, connection)
+    }
+
+    // MARK: structureSignature
+
+    @Test func signatureIgnoresGeometry() {
+        #expect(
+            RemoteTmuxWindowMirror.structureSignature(of: reflow123)
+                == RemoteTmuxWindowMirror.structureSignature(of: reflow122)
+        )
+    }
+
+    @Test func signatureChangesWhenAPaneIsAddedOrRemoved() {
+        let two = node(.horizontal([node(.pane(1)), node(.pane(2))]))
+        let three = node(.horizontal([node(.pane(1)), node(.pane(2)), node(.pane(3))]))
+        #expect(
+            RemoteTmuxWindowMirror.structureSignature(of: two)
+                != RemoteTmuxWindowMirror.structureSignature(of: three)
+        )
+    }
+
+    @Test func signatureChangesWhenPaneIdsChange() {
+        // Same shape, different pane: a pane replaced by a new tmux pane id is a
+        // structural event (new surface, fresh seed) even though the tree shape
+        // matches.
+        let a = node(.horizontal([node(.pane(1)), node(.pane(2))]))
+        let b = node(.horizontal([node(.pane(1)), node(.pane(9))]))
+        #expect(
+            RemoteTmuxWindowMirror.structureSignature(of: a)
+                != RemoteTmuxWindowMirror.structureSignature(of: b)
+        )
+    }
+
+    @Test func signatureChangesWhenNestingFlips() {
+        // Same pane set, horizontal vs vertical arrangement: the separator moves
+        // from a column to a row, so the summed grid changes → must re-push.
+        let horizontal = node(.horizontal([node(.pane(1)), node(.pane(2))]))
+        let vertical = node(.vertical([node(.pane(1)), node(.pane(2))]))
+        #expect(
+            RemoteTmuxWindowMirror.structureSignature(of: horizontal)
+                != RemoteTmuxWindowMirror.structureSignature(of: vertical)
+        )
+    }
+
+    @Test func signatureSeesNestedStructure() {
+        // h[1, v[2,3]] vs h[1, 2, 3]: same pane ids, different nesting.
+        let nested = node(.horizontal([
+            node(.pane(1)),
+            node(.vertical([node(.pane(2)), node(.pane(3))])),
+        ]))
+        let flat = node(.horizontal([node(.pane(1)), node(.pane(2)), node(.pane(3))]))
+        #expect(
+            RemoteTmuxWindowMirror.structureSignature(of: nested)
+                != RemoteTmuxWindowMirror.structureSignature(of: flat)
+        )
+    }
+
+    // MARK: reconcile → versions & budget
+
+    @Test func initDoesNotBumpVersions() {
+        let (mirror, _) = makeMirror(layout: reflow123)
+        #expect(mirror.layoutStructureVersion == 0)
+        #expect(mirror.sizingCorrectionVersion == 0)
+    }
+
+    @Test func geometryOnlyReflowNeverBumpsStructureAndCorrectionIsBudgeted() {
+        // Replay tmux's alternating reflow echoes. The structure version staying
+        // flat keeps the size authority from chasing its own echo between two
+        // quantization-consistent widths; the correction version advancing at
+        // most twice (the budget) is what makes foreign geometry changes
+        // healable without re-opening the unbounded loop.
+        let (mirror, _) = makeMirror(layout: reflow123)
+        for i in 0..<10 {
+            mirror.reconcile(layout: i.isMultiple(of: 2) ? reflow122 : reflow123)
+        }
+        #expect(mirror.layoutStructureVersion == 0)
+        #expect(mirror.sizingCorrectionVersion == 2) // budget-capped, not 10
+        #expect(mirror.layout == reflow123)
+    }
+
+    @Test func localTriggerRefillsTheCorrectionBudget() {
+        let (mirror, _) = makeMirror(layout: reflow123)
+        for i in 0..<6 { mirror.reconcile(layout: i.isMultiple(of: 2) ? reflow122 : reflow123) }
+        #expect(mirror.sizingCorrectionVersion == 2)
+        mirror.noteLocalSizingTrigger() // mount / outer resize / tab shown
+        mirror.reconcile(layout: reflow122)
+        #expect(mirror.sizingCorrectionVersion == 3)
+    }
+
+    @Test func structuralChangeRefillsTheCorrectionBudget() {
+        let (mirror, _) = makeMirror(layout: reflow123)
+        for i in 0..<6 { mirror.reconcile(layout: i.isMultiple(of: 2) ? reflow122 : reflow123) }
+        #expect(mirror.sizingCorrectionVersion == 2)
+        let two = node(.horizontal([node(.pane(1), w: 61, h: 35), node(.pane(2), w: 61, h: 35)]), w: 123, h: 35)
+        mirror.reconcile(layout: two) // structural: refills budget
+        mirror.reconcile(layout: node(.horizontal([node(.pane(1), w: 60, h: 35), node(.pane(2), w: 62, h: 35)]), w: 123, h: 35))
+        #expect(mirror.sizingCorrectionVersion == 3)
+    }
+
+    @Test func structureVersionIsMonotonicAcrossRepeatedStructuralChanges() {
+        // Pins the counter semantics the view's re-arm depends on: every
+        // structural change advances it (a set-to-constant or bump-once
+        // implementation would break re-arm for the second and later splits).
+        let (mirror, _) = makeMirror(layout: reflow123)
+        let two = node(.horizontal([node(.pane(1), w: 61, h: 35), node(.pane(2), w: 61, h: 35)]), w: 123, h: 35)
+        mirror.reconcile(layout: two)
+        mirror.reconcile(layout: reflow123)
+        #expect(mirror.layoutStructureVersion == 2)
+    }
+
+    @Test func splitBumpsVersionOnce() {
+        let two = node(.horizontal([node(.pane(1), w: 61, h: 35), node(.pane(2), w: 61, h: 35)]), w: 123, h: 35)
+        let (mirror, _) = makeMirror(layout: two)
+        mirror.reconcile(layout: reflow123) // pane 3 split off
+        #expect(mirror.layoutStructureVersion == 1)
+        // tmux's follow-up geometry-only reflow of the SAME 3-pane shape bumps
+        // only the (budgeted) correction version, never the structure version.
+        mirror.reconcile(layout: reflow122)
+        #expect(mirror.layoutStructureVersion == 1)
+    }
+
+    @Test func paneCloseBumpsVersion() {
+        let (mirror, _) = makeMirror(layout: reflow123)
+        let two = node(.horizontal([node(.pane(1), w: 61, h: 35), node(.pane(3), w: 61, h: 35)]), w: 123, h: 35)
+        mirror.reconcile(layout: two) // pane 2 closed
+        #expect(mirror.layoutStructureVersion == 1)
+    }
+
+    @Test func renestBumpsVersion() {
+        let (mirror, _) = makeMirror(layout: reflow123)
+        let renested = node(.horizontal([
+            node(.pane(1), w: 61, h: 35),
+            node(.vertical([node(.pane(2), w: 61, h: 17), node(.pane(3), w: 61, h: 17)]), w: 61, h: 35),
+        ]), w: 123, h: 35)
+        mirror.reconcile(layout: renested)
+        #expect(mirror.layoutStructureVersion == 1)
+    }
+
+    // MARK: sizing stays out of reconcile
+
+    /// `reconcile` must never push a size itself — not for geometry-only reflows
+    /// and not for structural changes. Sizing belongs exclusively to the
+    /// trigger-owned `updateClientSize()` path; a push from inside reconcile
+    /// would run on every `%layout-change`, which is the geometry-echo loop.
+    /// The grids are stubbed LIVE here so a rogue push would actually record a
+    /// size rather than bailing on missing grids.
+    @Test func reconcileNeverPushesASizeItself() {
+        let (mirror, connection) = makeMirror(layout: reflow123)
+        mirror.leafGridOverrideForTesting = { _ in (cols: 40, rows: 35) }
+        for i in 0..<6 {
+            mirror.reconcile(layout: i.isMultiple(of: 2) ? reflow122 : reflow123)
+        }
+        let two = node(.horizontal([node(.pane(1), w: 61, h: 35), node(.pane(2), w: 61, h: 35)]), w: 123, h: 35)
+        mirror.reconcile(layout: two) // structural — bumps versions, still no push
+        #expect(mirror.layoutStructureVersion == 1)
+        #expect(connection.lastRequestedClientSize == nil)
+    }
+
+    // MARK: updateClientSize contract (shared dedup)
+
+    @Test func updateClientSizePushesTheSummedGridAndDedups() {
+        let (mirror, connection) = makeMirror(layout: reflow123)
+        mirror.leafGridOverrideForTesting = { _ in (cols: 40, rows: 35) }
+        #expect(mirror.updateClientSize())
+        #expect(connection.lastRequestedClientSize?.columns == 122) // 40*3 + 2 separators
+        #expect(connection.lastRequestedClientSize?.rows == 35)
+        // Idempotent on unchanged grids: still true, same recorded size.
+        #expect(mirror.updateClientSize())
+        #expect(connection.lastRequestedClientSize?.columns == 122)
+    }
+
+    @Test func mirrorRecoversTheClientSizeAfterAForeignWriterMovesIt() {
+        // The starvation regression: dedup must compare against the SHARED
+        // last-requested size, not a mirror-local cache. After a foreign writer
+        // (a single-pane tab, a reconnect re-apply) moves the client, the
+        // mirror's next trigger must actually send — a private "what I last
+        // pushed" cache would swallow it and the window would stay mismatched
+        // with no recovery path.
+        let (mirror, connection) = makeMirror(layout: reflow123)
+        mirror.leafGridOverrideForTesting = { _ in (cols: 40, rows: 35) }
+        #expect(mirror.updateClientSize())
+        #expect(connection.lastRequestedClientSize?.columns == 122)
+        connection.setClientSize(columns: 140, rows: 40) // foreign writer wins
+        #expect(mirror.updateClientSize()) // mirror trigger reclaims
+        #expect(connection.lastRequestedClientSize?.columns == 122)
+        #expect(connection.lastRequestedClientSize?.rows == 35)
+    }
+
+    @Test func updateClientSizePicksUpSettledGridsAfterAGeometryOnlyReflow() {
+        // The settle-confirm path: a reflow re-divides the local pixels, the
+        // grids change, and the next explicit updateClientSize (trigger-scoped,
+        // not echo-triggered) must push the new sum even though reconcile
+        // itself stayed passive.
+        let (mirror, connection) = makeMirror(layout: reflow123)
+        var width = 40
+        mirror.leafGridOverrideForTesting = { _ in (cols: width, rows: 35) }
+        #expect(mirror.updateClientSize())
+        #expect(connection.lastRequestedClientSize?.columns == 122)
+        mirror.reconcile(layout: reflow122) // geometry-only: no push by itself
+        width = 41                          // grids settle differently
+        #expect(connection.lastRequestedClientSize?.columns == 122)
+        #expect(mirror.updateClientSize())
+        #expect(connection.lastRequestedClientSize?.columns == 125) // 41*3 + 2
+    }
+
+    @Test func updateClientSizeRespondsToRowsOnlyChanges() {
+        let (mirror, connection) = makeMirror(layout: reflow123)
+        var rows = 35
+        mirror.leafGridOverrideForTesting = { _ in (cols: 40, rows: rows) }
+        #expect(mirror.updateClientSize())
+        rows = 30
+        #expect(mirror.updateClientSize())
+        #expect(connection.lastRequestedClientSize?.rows == 30)
+        #expect(connection.lastRequestedClientSize?.columns == 122)
+    }
+
+    @Test func updateClientSizeWaitsForEveryLeafToGoLive() {
+        let (mirror, connection) = makeMirror(layout: reflow123)
+        mirror.leafGridOverrideForTesting = { paneId in
+            paneId == 2 ? nil : (cols: 40, rows: 35) // pane 2 not live yet
+        }
+        #expect(!mirror.updateClientSize())
+        #expect(connection.lastRequestedClientSize == nil)
+    }
+
+    @Test func sliverPaneFallsBackToItsTmuxDimsInsteadOfBlockingSizing() {
+        // A co-attached client can squeeze a pane to 1-2 cells; such a sliver
+        // may never report a live grid. It must contribute its tmux dims rather
+        // than turning the whole window's sizing into a permanent outage.
+        let layout = node(.horizontal([
+            node(.pane(1), w: 2, h: 35, x: 0, y: 0),   // sliver: no live grid
+            node(.pane(2), w: 60, h: 35, x: 3, y: 0),
+            node(.pane(3), w: 60, h: 35, x: 64, y: 0),
+        ]), w: 123, h: 35)
+        let (mirror, connection) = makeMirror(layout: layout)
+        mirror.leafGridOverrideForTesting = { paneId in
+            paneId == 1 ? nil : (cols: 60, rows: 35)
+        }
+        #expect(mirror.updateClientSize())
+        #expect(connection.lastRequestedClientSize?.columns == 124) // 2 + 60 + 60 + 2 separators
+    }
+
+    // MARK: per-pane pins (tmux's deal vs the rendered grids)
+
+    @Test func panePinsAreEmptyWhenTmuxDealMatchesTheRender() {
+        let pins = RemoteTmuxWindowMirror.panePins(of: reflow123) { _ in (cols: 41, rows: 35) }
+        // reflow123 deals 41/40/40; a uniform 41 render mismatches panes 2 and 3
+        // — but with the exact per-pane grids it deals, no pins:
+        let exact = RemoteTmuxWindowMirror.panePins(of: reflow123) { paneId in
+            paneId == 1 ? (cols: 41, rows: 35) : (cols: 40, rows: 35)
+        }
+        #expect(exact.isEmpty)
+        #expect(!pins.isEmpty)
+    }
+
+    @Test func panePinsFlagOnlyTheMisdealtPaneAndDimension() {
+        // tmux dealt 41/40/40 but the surfaces render 40/41/40: tmux gave the
+        // odd column to pane 1 while pane 2 has the pixels for it. Exactly two
+        // pins, width-only.
+        let pins = RemoteTmuxWindowMirror.panePins(of: reflow123) { paneId in
+            switch paneId {
+            case 1: return (cols: 40, rows: 35)
+            case 2: return (cols: 41, rows: 35)
+            default: return (cols: 40, rows: 35)
+            }
+        }
+        #expect(pins == [
+            RemoteTmuxWindowMirror.PanePin(paneId: 1, cols: 40, rows: nil),
+            RemoteTmuxWindowMirror.PanePin(paneId: 2, cols: 41, rows: nil),
+        ])
+    }
+
+    @Test func panePinsSkipLeavesWithNoLiveGrid() {
+        let pins = RemoteTmuxWindowMirror.panePins(of: reflow123) { paneId in
+            paneId == 1 ? nil : (cols: 40, rows: 35)
+        }
+        #expect(pins.allSatisfy { $0.paneId != 1 })
+    }
+
+    @Test func dedupHitPassPinsTheMisdealtPane() {
+        // The user-visible stuck state: the client TOTAL is already right
+        // (dedup hit) but tmux dealt the odd column to the wrong pane. The
+        // pass must emit pins instead of doing nothing.
+        let (mirror, connection) = makeMirror(layout: reflow123) // deals 41/40/40
+        mirror.leafGridOverrideForTesting = { paneId in
+            paneId == 2 ? (cols: 41, rows: 35) : (cols: 40, rows: 35) // render 40/41/40
+        }
+        // total = 40+41+40+2 = 123 — prime the connection so it's a dedup hit.
+        connection.setClientSize(columns: 123, rows: 35)
+        #expect(mirror.updateClientSize())
+        #expect(mirror.lastPanePinsForTesting == [
+            RemoteTmuxWindowMirror.PanePin(paneId: 1, cols: 40, rows: nil),
+            RemoteTmuxWindowMirror.PanePin(paneId: 2, cols: 41, rows: nil),
+        ])
+        // And once the deal matches the render, the same pass pins nothing.
+        mirror.leafGridOverrideForTesting = { paneId in
+            paneId == 1 ? (cols: 41, rows: 35) : (cols: 40, rows: 35)
+        }
+        #expect(mirror.updateClientSize())
+        #expect(mirror.lastPanePinsForTesting.isEmpty)
+    }
+
+    // MARK: closed-loop convergence (tmux as an adversary)
+
+    /// The bug class every open-loop truth table misses: the sizing authority
+    /// and tmux form a LOOP (render → total → tmux's deal → re-render), and
+    /// tmux's deal of a new total follows its own remainder rule — verified on
+    /// tmux 3.7 to be proportional-with-fixup from the current shape, not any
+    /// simple "first pane wins" rule. So this test does not model tmux's exact
+    /// dealer; it proves convergence against ANY consistent dealer, hostile
+    /// ones included: within a bounded number of rounds, the total dedups AND
+    /// the per-pane pins empty out (pane-exact), for every dealer and every
+    /// pixel geometry tried. Pin application uses the neighbor semantics
+    /// measured on real tmux (a pin moves the difference to the right
+    /// neighbor; the last pane takes from the left).
+    @Test func closedLoopConvergesPaneExactUnderAnyDealer() {
+        // Pixel model: 3 side-by-side panes, 2pt dividers, cellW 8pt, 3pt of
+        // horizontal chrome per pane — chosen so pixel quantization disagrees
+        // with integer deals at some widths (the hostile geometries).
+        func renders(_ deal: [Int], windowPx: Double) -> [Int] {
+            let usable = windowPx - 2.0 * 2.0
+            let total = Double(deal.reduce(0, +))
+            return deal.map { w in
+                max(1, Int(((usable * Double(w) / total) - 3.0) / 8.0))
+            }
+        }
+        // Dealers: given a new total (content cols = total - separators) and
+        // the previous deal, produce a new deal. All consistent (sum matches),
+        // all with different remainder placement.
+        typealias Dealer = (_ contentCols: Int, _ previous: [Int]) -> [Int]
+        let dealers: [(String, Dealer)] = [
+            ("firstGetsRemainder", { c, p in
+                let base = c / p.count, r = c % p.count
+                return (0..<p.count).map { base + ($0 < r ? 1 : 0) }
+            }),
+            ("lastGetsRemainder", { c, p in
+                let base = c / p.count, r = c % p.count
+                return (0..<p.count).map { base + ($0 >= p.count - r ? 1 : 0) }
+            }),
+            ("proportionalFixup", { c, p in
+                let old = p.reduce(0, +)
+                var deal = p.map { Int((Double($0) * Double(c) / Double(old)).rounded(.down)) }
+                var i = 0
+                while deal.reduce(0, +) < c { deal[i % deal.count] += 1; i += 1 }
+                while deal.reduce(0, +) > c { deal[i % deal.count] -= 1; i += 1 }
+                return deal
+            }),
+            ("adversarialRotate", { c, p in
+                let base = c / p.count, r = c % p.count
+                // Rotate the remainder to a different pane every deal.
+                let start = (p.firstIndex(of: p.max() ?? 0) ?? 0 + 1) % p.count
+                return (0..<p.count).map { base + (($0 + start) % p.count < r ? 1 : 0) }
+            }),
+        ]
+        func layoutNode(deal: [Int]) -> RemoteTmuxLayoutNode {
+            var x = 0
+            var children: [RemoteTmuxLayoutNode] = []
+            for (i, w) in deal.enumerated() {
+                children.append(node(.pane(i + 1), w: w, h: 35, x: x, y: 0))
+                x += w + 1
+            }
+            return node(.horizontal(children), w: deal.reduce(0, +) + deal.count - 1, h: 35)
+        }
+        for (name, dealer) in dealers {
+            for windowPx in stride(from: 900.0, through: 1300.0, by: 37.0) {
+                var deal = [40, 40, 40]
+                var client = deal.reduce(0, +) + 2
+                var converged = false
+                for _ in 0..<6 {
+                    let r = renders(deal, windowPx: windowPx)
+                    let grids = Dictionary(uniqueKeysWithValues: r.enumerated().map { ($0.offset + 1, (cols: $0.element, rows: 35)) })
+                    let total = RemoteTmuxWindowMirror.summedGridCells(
+                        of: layoutNode(deal: deal), leafGrid: { grids[$0] }
+                    )!.cols
+                    if total != client {
+                        client = total
+                        deal = dealer(total - (deal.count - 1), deal)
+                        continue
+                    }
+                    let pins = RemoteTmuxWindowMirror.panePins(
+                        of: layoutNode(deal: deal), leafGrid: { grids[$0] }
+                    )
+                    if pins.isEmpty { converged = true; break }
+                    // Apply pins with the measured neighbor semantics: the
+                    // delta moves to the right neighbor (left for the last).
+                    for pin in pins {
+                        guard let target = pin.cols else { continue }
+                        let idx = pin.paneId - 1
+                        let delta = deal[idx] - target
+                        deal[idx] = target
+                        let neighbor = idx == deal.count - 1 ? idx - 1 : idx + 1
+                        deal[neighbor] += delta
+                    }
+                }
+                #expect(converged, "dealer \(name) at \(windowPx)px never converged pane-exact")
+                // Pane-exact: tmux's deal equals every pane's rendered width.
+                let finalRenders = renders(deal, windowPx: windowPx)
+                #expect(deal == finalRenders, "dealer \(name) at \(windowPx)px: deal \(deal) != renders \(finalRenders)")
+            }
+        }
+    }
+
+    @Test func updateClientSizeFloorsDegenerateGrids() {
+        // A transient near-zero grid (mid-layout) must never push a tiny client
+        // size at tmux: floors are 20 cols x 5 rows.
+        let single = node(.pane(1), w: 5, h: 2)
+        let (mirror, connection) = makeMirror(layout: single)
+        mirror.leafGridOverrideForTesting = { _ in (cols: 5, rows: 2) }
+        #expect(mirror.updateClientSize())
+        #expect(connection.lastRequestedClientSize?.columns == 20)
+        #expect(connection.lastRequestedClientSize?.rows == 5)
+    }
+}

--- a/cmuxUITests/RemoteTmuxSizingUITests.swift
+++ b/cmuxUITests/RemoteTmuxSizingUITests.swift
@@ -1,0 +1,322 @@
+import XCTest
+import Foundation
+import Darwin
+
+/// End-to-end gate for remote-tmux mirror sizing, against a REAL tmux server.
+///
+/// The sizing authority and tmux form a closed loop (rendered grids → client
+/// size → tmux's per-pane deal → re-render), and every historical defect in
+/// this area was a property of that loop — invisible to open-loop unit tests.
+/// This suite drives the real loop end to end and asserts the two invariants
+/// that define "settled":
+///
+///   1. STABILITY: after any disturbance, the client size converges to a
+///      single value and stays there (no oscillation, no churn).
+///   2. COHERENCE: client == every window's size, and a split window's
+///      top-row pane widths + one separator per gap == the window width.
+///
+/// Hermetic by construction: a throwaway tmux server runs on an isolated
+/// socket directory, and the app is launched with
+/// `CMUX_REMOTE_TMUX_SSH_FOR_TESTING` pointing at a shim that strips the ssh
+/// framing and execs the remote command locally — the full mirror stack runs
+/// with no sshd and no network. Skips when no tmux binary is present (CI
+/// installs one in the e2e workflow's dependency step).
+final class RemoteTmuxSizingUITests: XCTestCase {
+    private var socketPath = ""
+    private var launchTag = ""
+    private var tmuxTmpDir = ""
+    private var shimPath = ""
+    private var tmuxBin: String?
+    private let sessionName = "sizing"
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        socketPath = "/tmp/cmux-debug-\(UUID().uuidString).sock"
+        launchTag = "ui-tests-sizing-\(UUID().uuidString.prefix(8))"
+        tmuxTmpDir = NSTemporaryDirectory() + "cmux-sizing-e2e-\(UUID().uuidString.prefix(8))"
+        shimPath = NSTemporaryDirectory() + "cmux-ssh-shim-\(UUID().uuidString.prefix(8)).sh"
+        tmuxBin = ["/opt/homebrew/bin/tmux", "/usr/local/bin/tmux", "/usr/bin/tmux"]
+            .first { FileManager.default.isExecutableFile(atPath: $0) }
+        try? FileManager.default.createDirectory(atPath: tmuxTmpDir, withIntermediateDirectories: true)
+        writeShim()
+    }
+
+    override func tearDown() {
+        _ = tmux(["kill-server"])
+        try? FileManager.default.removeItem(atPath: shimPath)
+        try? FileManager.default.removeItem(atPath: tmuxTmpDir)
+        try? FileManager.default.removeItem(atPath: socketPath)
+        super.tearDown()
+    }
+
+    // MARK: scenarios
+
+    /// Attach a session holding a 3-pane split window plus a single-pane
+    /// window; the client must settle to one stable, coherent size.
+    func testAttachSettlesStableAndCoherent() throws {
+        try requireTmux()
+        try buildLabSession()
+        let app = launchAppAndAttach()
+        defer { app.terminate() }
+        try assertSettles(within: 15, context: "after attach")
+    }
+
+    /// Resizing the app window (the local trigger) must re-converge at each
+    /// width — the sweep that exposes resize feedback loops.
+    func testWindowResizeSweepConvergesAtEachWidth() throws {
+        try requireTmux()
+        try buildLabSession()
+        let app = launchAppAndAttach()
+        defer { app.terminate() }
+        try assertSettles(within: 15, context: "before sweep")
+
+        let window = app.windows.firstMatch
+        for dx in [-140.0, 60.0, 45.0] {
+            let edge = window.coordinate(withNormalizedOffset: CGVector(dx: 0.999, dy: 0.5))
+            edge.press(forDuration: 0.1, thenDragTo: edge.withOffset(CGVector(dx: dx, dy: 0)))
+            try assertSettles(within: 10, context: "after resize by \(dx)px")
+        }
+    }
+
+    /// A geometry-only layout change NOT caused by the app — a co-attached
+    /// client's `resize-pane` — must heal (bounded correction), not stick
+    /// mismatched and not oscillate.
+    func testForeignResizePaneHealsAndHolds() throws {
+        try requireTmux()
+        try buildLabSession()
+        let app = launchAppAndAttach()
+        defer { app.terminate() }
+        try assertSettles(within: 15, context: "before foreign resize")
+
+        let panes = try splitWindowPaneIds()
+        _ = tmux(["resize-pane", "-t", "\(sessionName):@0.\(panes[0])", "-x", "13"])
+        try assertSettles(within: 10, context: "after foreign resize-pane")
+    }
+
+    // MARK: settle oracle
+
+    /// Polls until STABILITY (8 consecutive identical client samples) and
+    /// COHERENCE (client == windows; split panes + separators == window) hold.
+    private func assertSettles(within timeout: TimeInterval, context: String) throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastFailure = "no samples"
+        while Date() < deadline {
+            if let failure = settleFailure() {
+                lastFailure = failure
+                Thread.sleep(forTimeInterval: 0.5)
+                continue
+            }
+            return
+        }
+        XCTFail("Sizing never settled \(context): \(lastFailure)")
+    }
+
+    private func settleFailure() -> String? {
+        var samples: [String] = []
+        for _ in 0..<8 {
+            guard let width = tmux(["list-clients", "-t", sessionName, "-F", "#{client_width}x#{client_height}"])?
+                .split(separator: "\n").first.map(String.init) else {
+                return "no client attached"
+            }
+            samples.append(width)
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+        guard Set(samples).count == 1 else {
+            return "client size oscillating: \(samples.joined(separator: " "))"
+        }
+        guard let clientCols = Int(samples[0].split(separator: "x")[0]) else {
+            return "unparseable client width \(samples[0])"
+        }
+        guard let windows = tmux(["list-windows", "-t", sessionName, "-F", "#{window_id} #{window_width}"]) else {
+            return "no windows"
+        }
+        for line in windows.split(separator: "\n") {
+            let parts = line.split(separator: " ")
+            guard parts.count == 2, let w = Int(parts[1]) else { continue }
+            if w != clientCols {
+                return "window \(parts[0])=\(w) != client \(clientCols)"
+            }
+        }
+        guard let panes = tmux(["list-panes", "-t", "\(sessionName):@0", "-F", "#{pane_width} #{pane_top}"]) else {
+            return "no panes"
+        }
+        var topRowSum = 0
+        var topRowCount = 0
+        for line in panes.split(separator: "\n") {
+            let parts = line.split(separator: " ")
+            guard parts.count == 2, let w = Int(parts[0]), parts[1] == "0" else { continue }
+            topRowSum += w
+            topRowCount += 1
+        }
+        if topRowCount > 1 {
+            let expected = topRowSum + (topRowCount - 1)
+            guard let winWidth = windows.split(separator: "\n").first.flatMap({ Int($0.split(separator: " ")[1]) }) else {
+                return "no split window width"
+            }
+            if expected != winWidth {
+                return "split panes \(topRowSum)+\(topRowCount - 1)sep=\(expected) != window \(winWidth)"
+            }
+        }
+        return nil
+    }
+
+    // MARK: lab plumbing
+
+    private func requireTmux() throws {
+        try XCTSkipIf(tmuxBin == nil, "tmux binary not found; e2e workflow installs it via brew")
+    }
+
+    private func buildLabSession() throws {
+        _ = tmux(["kill-server"])
+        XCTAssertNotNil(tmux(["new-session", "-d", "-s", sessionName, "-x", "180", "-y", "45"]))
+        _ = tmux(["split-window", "-h", "-t", "\(sessionName):0"])
+        _ = tmux(["split-window", "-h", "-t", "\(sessionName):0"])
+        _ = tmux(["select-layout", "-t", "\(sessionName):0", "even-horizontal"])
+        _ = tmux(["new-window", "-t", sessionName])
+        _ = tmux(["select-window", "-t", "\(sessionName):0"])
+    }
+
+    private func splitWindowPaneIds() throws -> [String] {
+        let out = try XCTUnwrap(tmux(["list-panes", "-t", "\(sessionName):@0", "-F", "#{pane_id}"]))
+        return out.split(separator: "\n").map(String.init)
+    }
+
+    private func launchAppAndAttach() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-socketControlMode", "allowAll",
+            "-remoteTmux.beta.enabled", "YES",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US",
+        ]
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
+        app.launchEnvironment["CMUX_TAG"] = launchTag
+        app.launchEnvironment["CMUX_REMOTE_TMUX_SSH_FOR_TESTING"] = shimPath
+        // The shim needs the same TMUX_TMPDIR to reach the lab server.
+        app.launchEnvironment["TMUX_TMPDIR"] = tmuxTmpDir
+        if let path = ProcessInfo.processInfo.environment["PATH"], !path.isEmpty {
+            app.launchEnvironment["PATH"] = path
+        }
+        app.launch()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15), "app failed to reach foreground")
+        XCTAssertTrue(waitForSocket(timeout: 12), "control socket never answered at \(socketPath)")
+        let response = socketJSON(method: "remote.tmux.attach", params: [
+            "host": "e2e-shim-host",
+            "session": sessionName,
+        ])
+        XCTAssertEqual(response?["ok"] as? Bool, true, "remote.tmux.attach failed: \(response ?? [:])")
+        return app
+    }
+
+    /// The hermetic ssh replacement: drop ssh's option framing and the
+    /// destination, then exec the "remote" command locally. The command cmux
+    /// builds is `/bin/sh -c <script> cmux-remote-tmux -CC attach ...`, so the
+    /// local exec runs the identical tmux control-mode attach against the lab
+    /// server (TMUX_TMPDIR is inherited from the app's environment).
+    private func writeShim() {
+        let shim = """
+        #!/bin/bash
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --) shift; break ;;
+            -o|-p|-i|-l|-F) shift 2 ;;
+            -*) shift ;;
+            *) break ;;
+          esac
+        done
+        shift  # the ssh destination
+        exec "$@"
+        """
+        try? shim.write(toFile: shimPath, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: shimPath)
+    }
+
+    @discardableResult
+    private func tmux(_ args: [String]) -> String? {
+        guard let bin = tmuxBin else { return nil }
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: bin)
+        proc.arguments = args
+        var env = ProcessInfo.processInfo.environment
+        env["TMUX_TMPDIR"] = tmuxTmpDir
+        env.removeValue(forKey: "TMUX")
+        proc.environment = env
+        let out = Pipe()
+        proc.standardOutput = out
+        proc.standardError = FileHandle.nullDevice
+        do { try proc.run() } catch { return nil }
+        proc.waitUntilExit()
+        guard proc.terminationStatus == 0 else { return nil }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: socket plumbing (per-file copy, matching the target's pattern)
+
+    private func waitForSocket(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if socketJSON(method: "system.ping", params: [:])?["ok"] as? Bool == true { return true }
+            Thread.sleep(forTimeInterval: 0.4)
+        }
+        return false
+    }
+
+    private func socketJSON(method: String, params: [String: Any]) -> [String: Any]? {
+        let request: [String: Any] = ["id": UUID().uuidString, "method": method, "params": params]
+        guard JSONSerialization.isValidJSONObject(request),
+              let data = try? JSONSerialization.data(withJSONObject: request),
+              let line = String(data: data, encoding: .utf8),
+              let response = sendLine(line),
+              let responseData = response.data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: responseData)) as? [String: Any]
+    }
+
+    private func sendLine(_ line: String) -> String? {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        defer { close(fd) }
+        var timeout = timeval(tv_sec: 65, tv_usec: 0)
+        withUnsafePointer(to: &timeout) { ptr in
+            _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, ptr, socklen_t(MemoryLayout<timeval>.size))
+            _ = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, ptr, socklen_t(MemoryLayout<timeval>.size))
+        }
+        var addr = sockaddr_un()
+        memset(&addr, 0, MemoryLayout<sockaddr_un>.size)
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(socketPath.utf8CString)
+        guard pathBytes.count <= MemoryLayout.size(ofValue: addr.sun_path) else { return nil }
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+            for index in 0..<pathBytes.count { raw[index] = pathBytes[index] }
+        }
+        let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
+        let addrLen = socklen_t(pathOffset + pathBytes.count)
+        let connected = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { Darwin.connect(fd, $0, addrLen) }
+        }
+        guard connected == 0 else { return nil }
+        let payload = Array((line + "\n").utf8)
+        let wrote = payload.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return false }
+            return Darwin.write(fd, base, raw.count) == raw.count
+        }
+        guard wrote else { return nil }
+        var buffer = [UInt8](repeating: 0, count: 8192)
+        var accumulator = ""
+        let deadline = Date().addingTimeInterval(65)
+        while Date() < deadline {
+            let count = Darwin.read(fd, &buffer, buffer.count)
+            guard count > 0 else { break }
+            if let chunk = String(bytes: buffer[0..<count], encoding: .utf8) {
+                accumulator.append(chunk)
+                if let newline = accumulator.firstIndex(of: "\n") {
+                    return String(accumulator[..<newline])
+                }
+            }
+        }
+        return accumulator.isEmpty ? nil : accumulator.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
Splitting a remote-tmux mirror pane leaves a stray `%` at the top of the pane and puts the cursor one cell off.

Repro: attach a host with the remote-tmux beta, split the mirrored pane (right-split), and look at the new pane's first row — a lone `%` sits above the prompt, and typed characters land one column off until the first full redraw.

### The bug

The mirror sizes the remote tmux client from the tab's **outer content area divided by cell size**. That math counts each local split divider as if it were a terminal column, so tmux ends up laying panes out ~1 column wider than the ghostty surfaces actually render. zsh pads its prompt with the PROMPT_SP filler (`%` + spaces) to the width tmux reported; the surface is narrower, so the filler wraps and strands the `%` — and the cursor lands where tmux thinks column N is, not where the surface renders it.

### The fix

Size the client from the **rendered leaf grids**, folded through the layout tree with tmux's own separator columns/rows (one per split gap). The window size tmux splits back up then yields per-pane widths equal to each surface's rendered width, so live `%output` paints faithfully.

That summed grid is itself downstream of tmux's layout (the split container divides pixels by tmux's cell weights), which shapes the sizing rules:

- **Client sizing re-arms unconditionally only on layout *structure* changes** (pane set / split nesting) and on local triggers (mount, outer resize, tab shown). A geometry-only `%layout-change` is usually the echo of our own `refresh-client -C`, and re-pushing a size recomputed from grids that echo just re-divided has no fixed point at pixel widths where cmux's pixel division and tmux's integer cell division disagree — the client size would alternate ±1 column indefinitely, SIGWINCH-storming every pane in the session (zsh reprints a wrapped prompt on each flip; the app burns ~30% CPU).
- **Geometry-only changes still get a budgeted correction** (at most two re-arms between local/structural triggers): they are also how genuinely foreign changes arrive — a co-attached client's `resize-pane`, or another writer moving the shared client size — and those must re-push or the window sticks with panes rendering a column short of their PTY, wrapping every full-width line. A foreign change heals in one bounded pass; an echo storm burns the budget and goes quiet instead of oscillating.
- **Dedup compares against the connection's last-requested size**, never a mirror-local cache: the client size is shared session state, and a private "what I last pushed" cache would swallow exactly the re-push that reclaims the window after another writer moves it.
- **Each triggered push ends with a short, time-bounded settle-confirm pass** (a push can read grids the layout pass hasn't re-divided yet), and a pane squeezed to a sliver contributes its tmux dims to the fold so one degenerate pane can't stall sizing for its whole window.

### Tests

`RemoteTmuxMirrorSummedGridTests` pins the grid fold (separator/transpose math, nil-until-live). `RemoteTmuxMirrorSizingEchoGateTests` pins the re-arm and recovery contract: the structure signature ignores geometry and sees pane-set/nesting/id changes; the structure version advances monotonically per structural change; geometry-only reflows advance the correction version at most twice per budget (a replay of ten alternating reflow echoes bumps it exactly twice), with the budget refilled by local and structural triggers; dedup is against the connection's shared last-requested size (a foreign push followed by a mirror trigger genuinely re-sends); `reconcile` never pushes a size itself; and a sliver pane falls back to its tmux dims instead of blocking the fold.

### Known limitations (follow-ups)

- A tmux `-CC` client has one size shared by every window in the session, and different tabs can legitimately want values a column apart (a split tab's summed grid vs a single-pane tab's full grid). The budgeted correction keeps every *visible* mirror reconciled, but a hidden tab can render ±1 column off until it is shown or the next event reaches it. The clean fix is per-window sizing (`window-size manual` + `resize-window`), which needs a cmux-owned view session rather than the user's real session — a separate change.
- A pane squeezed to a sliver (≲12 columns) can render one column short of its PTY even when every size agrees: at extreme narrowness the surface's reported grid can exceed its visually usable columns by one (padding rounding inside the terminal surface). Bounded at one column, stable, and independent of the sizing authority — the follow-up is in the surface grid reporting, not here.

### Verified at runtime

Two-host loopback rig, one session holding a 3-pane window plus single-pane windows:

- Swept the app window across 20 pixel widths: the client size settles to a single value at every width and tracks the window as it grows (with sizing driven off the raw layout value instead of the structure version, 3 of the 20 widths oscillate forever — that variant never converges at those widths).
- Parked at the most quantization-hostile width: stable for minutes, app CPU idle (~4%), pane widths sum exactly to the client width.
- Server-side `split-window` / `kill-pane` while parked: the size re-pushes and converges each time.
- A mirror workspace that is not visible never pushes; selecting it sizes the client to its rendered grid.
- A single-pane window split into two while its tab is visible (the mirror is created mid-flight): the size stays consistent through the transition and the panes divide it exactly.
- Fresh session at the hostile width: no stray `%`, no cursor offset, no redraw churn.
- A foreign `resize-pane` against the mirrored window (a geometry-only change not caused by our own push): the client size re-pushes within a second, the panes settle to widths that sum exactly to it, and it holds flat afterwards.
