### PR TITLE
iOS: terminal height/position tracks the real keyboard animation

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -24,7 +24,7 @@
 4487	Sources/Panels/FilePreviewPanel.swift
 4483	Sources/cmuxApp.swift
 4367	cmuxTests/BrowserPanelTests.swift
-4264	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+4347	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 4121	Sources/BrowserWindowPortal.swift
 3934	Sources/Feed/FeedPanelView.swift
 3926	cmuxTests/TabManagerUnitTests.swift
@@ -46,8 +46,8 @@
 2126	cmuxTests/CmuxConfigTests.swift
 2085	cmuxTests/ShortcutAndCommandPaletteTests.swift
 2078	Sources/SessionPersistence.swift
-1966	Sources/RestorableAgentSession.swift
 1952	Sources/KeyboardShortcutSettingsFileStore.swift
+1944	Sources/RestorableAgentSession.swift
 1900	cmuxTests/NotificationAndMenuBarTests.swift
 1866	Sources/Panels/BrowserWebAuthnSupport.swift
 1810	Sources/SessionIndexStore.swift
@@ -128,11 +128,10 @@
 768	cmuxUITests/BrowserFixtureInteractionUITests.swift
 762	Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkByteTransport.swift
 761	Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
-760	Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
 756	Sources/Panels/AgentSessionWebRendererCoordinator.swift
 754	Sources/TerminalController+ControlWorkspaceContext.swift
-752	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
 752	cmuxUITests/CloseWorkspaceCmdDUITests.swift
+750	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
 739	cmuxTests/CLICodexHookTimeoutRegressionTests.swift
 738	Packages/macOS/CMUXProjectModel/Sources/CMUXProjectModel/XcodeProjectAdapter.swift
 718	Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
@@ -163,6 +162,7 @@
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
+644	Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
 642	cmuxTests/RemoteTmuxControlParserTests.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 635	cmuxUITests/RightSidebarChromeHeightUITests.swift
@@ -181,7 +181,7 @@
 604	Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteNucleoFFITests.swift
 602	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
 601	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
-599	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+598	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
 596	cmuxTests/CmuxEventBusTests.swift
 594	cmuxTests/PortalTabDragRoutingTests.swift
 591	Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/DefaultsValueModelLifecycleTests.swift
@@ -217,9 +217,9 @@
 534	Sources/TerminalController+ControlSurfaceContext2.swift
 532	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
 531	Sources/App/WorkspaceRuntimeSettings.swift
-530	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
 530	Sources/BrowserPaneDropTargetView.swift
 530	Sources/TerminalController+ControlSurfaceContext3.swift
+529	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
 528	cmuxUITests/AutomationSocketUITests.swift
 527	CLI/CLISocketPathResolver.swift
 527	cmuxTests/BrowserHTTPBasicAuthPromptTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -23,7 +23,7 @@
 5573	cmuxTests/BrowserConfigTests.swift
 4487	Sources/Panels/FilePreviewPanel.swift
 4483	Sources/cmuxApp.swift
-4380	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+4407	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 4367	cmuxTests/BrowserPanelTests.swift
 4121	Sources/BrowserWindowPortal.swift
 3934	Sources/Feed/FeedPanelView.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -23,8 +23,8 @@
 5573	cmuxTests/BrowserConfigTests.swift
 4487	Sources/Panels/FilePreviewPanel.swift
 4483	Sources/cmuxApp.swift
+4380	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 4367	cmuxTests/BrowserPanelTests.swift
-4347	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 4121	Sources/BrowserWindowPortal.swift
 3934	Sources/Feed/FeedPanelView.swift
 3926	cmuxTests/TabManagerUnitTests.swift

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalLayoutPreviewView.swift
@@ -58,6 +58,9 @@ private struct TerminalLayoutPreviewSurface: UIViewRepresentable {
         if ProcessInfo.processInfo.environment["CMUX_UITEST_SHOW_ZOOM"] == "1" {
             view.debugShowZoomControlOverlayForPreview()
         }
+        if ProcessInfo.processInfo.environment["CMUX_UITEST_KB_EDGE_MARKER"] == "1" {
+            view.debugInstallKeyboardEdgeMarkerForUITest()
+        }
         return view
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -797,6 +797,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             "scrollTotal=\(debugLastScrollbar?.total ?? -1)", "scrollOffset=\(debugLastScrollbar?.offset ?? -1)",
             "scrollLen=\(debugLastScrollbar?.len ?? -1)", "scrollAtBottom=\(debugScrollbarAtBottomForTesting ? 1 : 0)",
             "staleViewportObserved=\(debugBottomViewportMismatchObserved ? 1 : 0)",
+            // Keyboard-guide tracking: the sampled live keyboard top edge, the
+            // dock's actual bottom edge, and whether the per-frame tracker is
+            // active. A UI test polling mid-animation asserts
+            // |toolbarMaxY - guideTop| stays ~0 while kbTracking=1 — the
+            // "terminal edge rides the real keyboard, not a curve replay"
+            // contract. -1 when no sample is available.
+            "kbTracking=\(keyboardDockTracking != nil ? 1 : 0)",
+            "kbGuideTop=\(sampledKeyboardGuideTop().map { Int($0.rounded()) } ?? -1)",
+            "toolbarMaxY=\(dockedToolbar.map { Int($0.frame.maxY.rounded()) } ?? -1)",
             inputProxy.accessoryLayoutDiagnostics,
         ].joined(separator: ";")
     }
@@ -872,8 +881,26 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var lastRenderLayoutViewportHeight: CGFloat?
     private var lastRenderHasSourceLayoutViewport = false
     private var viewportCoordinator = TerminalViewportCoordinator()
-    private var keyboardHeightAnimation: TerminalKeyboardHeightAnimation?
-    private var keyboardHeightAnimationID = 0
+    /// Invisible autolayout child pinned to `keyboardLayoutGuide.topAnchor`.
+    /// UIKit lays it out inside the real keyboard animation transaction, so its
+    /// presentation layer is the keyboard's true animated top edge — the ground
+    /// truth the bottom dock and render layer are frame-set from each display
+    /// link tick (see ``trackKeyboardDockPerFrame()``).
+    private let keyboardGuideAnchor = UIView()
+    /// Non-nil while the dock is following the sampled keyboard guide (a
+    /// notification-driven transition or a self-armed interactive dismissal).
+    private var keyboardDockTracking: KeyboardDockTracking?
+    /// The occupancy sampled on the last applied tracking tick, fed into
+    /// ``viewportSnapshot()`` so every layout consumer sees the same live edge.
+    private var lastSampledBottomOccupancy: CGFloat?
+    /// Debug/preview seams drive `keyboardHeight` synthetically; live guide
+    /// samples would immediately fight them, so they suspend tracking.
+    private var keyboardLiveTrackingSuspended = false
+    #if DEBUG
+    /// Test seam: overrides the keyboard-guide top-edge sample so tests can
+    /// script an exact per-frame keyboard trajectory without a real keyboard.
+    var debugKeyboardGuideTopSamplerForTesting: (() -> CGFloat?)?
+    #endif
 
     #if DEBUG
     struct DebugGeometrySnapshot {
@@ -908,8 +935,46 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         )
     }
 
+    struct DebugKeyboardDockState {
+        let isTracking: Bool
+        let liveOccupancy: CGFloat?
+        let sampledGuideTop: CGFloat?
+        let toolbarFrame: CGRect?
+        let composerFrame: CGRect
+        let fallbackFrame: CGRect
+        let targetViewportHeight: CGFloat
+        let liveViewportHeight: CGFloat
+        let keyboardHeight: CGFloat
+    }
+
+    /// Test seam: the current keyboard-dock tracking state plus the frames the
+    /// tracking loop owns, so tests can assert the dock and viewport sit exactly
+    /// on a scripted keyboard sample.
+    func debugKeyboardDockStateForTesting() -> DebugKeyboardDockState {
+        DebugKeyboardDockState(
+            isTracking: keyboardDockTracking != nil,
+            liveOccupancy: lastSampledBottomOccupancy,
+            sampledGuideTop: sampledKeyboardGuideTop(),
+            toolbarFrame: dockedToolbar?.frame,
+            composerFrame: composerContainer.frame,
+            fallbackFrame: snapshotFallbackView.frame,
+            targetViewportHeight: targetTerminalViewportHeight,
+            liveViewportHeight: viewportSnapshot().liveViewportRect.height,
+            keyboardHeight: keyboardHeight
+        )
+    }
+
+    /// Test seam: run exactly one keyboard-dock tracking tick (what the display
+    /// link does each frame), so tests can step a scripted keyboard trajectory
+    /// deterministically.
+    func debugAdvanceKeyboardDockTrackingForTesting() {
+        trackKeyboardDockPerFrame()
+    }
+
     func setKeyboardHeightForTesting(_ height: CGFloat) {
-        stopKeyboardHeightAnimation()
+        keyboardLiveTrackingSuspended = true
+        keyboardDockTracking = nil
+        lastSampledBottomOccupancy = nil
         keyboardHeight = max(0, height)
         layoutRenderedTerminalForCurrentViewport()
         layoutBottomDock()
@@ -1057,6 +1122,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         #endif
         installPersistentToolbar()
         installComposerContainer()
+        installKeyboardGuideAnchor()
         initializeSurface()
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
@@ -1136,6 +1202,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// `willResignActive` and `didEnterBackground`.
     private func suspendRendering() {
         renderingSuspended = true
+        // The display link is about to stop, so an in-flight keyboard tracking
+        // window would never tick again; snap it to the target layout now.
+        if keyboardDockTracking != nil {
+            finishKeyboardDockTracking()
+        }
         skipPendingVisibleSnapshot()
         skipPendingCopyableTextRead()
         stopDisplayLink()
@@ -1269,52 +1340,136 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // reclaims the keyboard's space (minus the now-reserved safe area + toolbar +
         // composer band).
         updateDockedToolbarVisibility()
-        startKeyboardHeightAnimation(to: overlap, transition: transition)
-    }
-
-    private func startKeyboardHeightAnimation(
-        to targetHeight: CGFloat,
-        transition: MobileKeyboardTransition
-    ) {
-        stopKeyboardHeightAnimation()
-        let clampedTarget = max(0, targetHeight)
-        guard transition.duration > 0, abs(clampedTarget - keyboardHeight) > 0.5 else {
-            applyKeyboardHeight(clampedTarget)
-            if clampedTarget == 0 {
-                scheduleKeyboardHideHeightResync()
-            }
-            return
-        }
-
-        keyboardHeightAnimationID &+= 1
-        let animationID = keyboardHeightAnimationID
-        keyboardHeightAnimation = TerminalKeyboardHeightAnimation(id: animationID)
-        startDisplayLink()
-        transition.animate {
-            self.applyKeyboardHeight(clampedTarget)
-            self.layoutIfNeeded()
-        } completion: { _ in
-            guard self.keyboardHeightAnimationID == animationID else { return }
-            self.finishKeyboardHeightAnimation(targetHeight: clampedTarget)
-        }
-    }
-
-    private func stopKeyboardHeightAnimation() {
-        keyboardHeightAnimationID &+= 1
-        keyboardHeightAnimation = nil
-    }
-
-    private func finishKeyboardHeightAnimation(targetHeight: CGFloat) {
-        stopKeyboardHeightAnimation()
-        applyKeyboardHeight(targetHeight)
-        if targetHeight == 0 {
+        // Begin ground-truth tracking BEFORE applying the target height: seeding
+        // the live sample with the keyboard's current (pre-animation) guide
+        // position keeps the dock exactly where it is this frame; the display
+        // link then walks it along UIKit's real keyboard animation.
+        beginKeyboardDockTracking(expectedDuration: transition.duration)
+        applyKeyboardHeight(max(0, overlap))
+        if keyboardDockTracking == nil, keyboardHeight == 0 {
+            // No live tracking possible (off-window / suppressed): the height
+            // applied instantly, so run the hide resync now, as before.
             scheduleKeyboardHideHeightResync()
         }
     }
 
-    private func advanceKeyboardHeightAnimation() {
-        guard keyboardHeightAnimation != nil else { return }
-        layoutRenderedTerminalForCurrentViewport()
+    /// Ground-truth keyboard tracking (replaces the old duration/curve replay).
+    ///
+    /// `keyboardGuideAnchor` is constrained to `keyboardLayoutGuide.topAnchor`,
+    /// so UIKit moves it inside the actual keyboard animation transaction — the
+    /// same private spring the keyboard itself runs, including interactive
+    /// dismiss, which posts no notifications while the finger drags. Every
+    /// display-link frame while a transition is live, ``trackKeyboardDockPerFrame()``
+    /// samples the anchor's presentation layer and frame-sets the whole bottom
+    /// dock (toolbar + composer band) and the render layer from that one sample,
+    /// so the terminal edge cannot diverge from the keyboard by construction.
+    /// The old path animated the dock with `UIView.animate` using the
+    /// notification's duration + curve — a REPLAY that drifted from UIKit's
+    /// keyboard spring mid-flight and missed interactive dismissal entirely.
+    private struct KeyboardDockTracking {
+        /// Hard stop for the tracking window. Normally tracking ends when the
+        /// sampled occupancy converges on the target; the deadline covers a
+        /// guide that never converges (e.g. a floating-keyboard frame the
+        /// notification math resolved differently), snapping to target math.
+        let deadline: CFTimeInterval
+    }
+
+    private func beginKeyboardDockTracking(expectedDuration: TimeInterval) {
+        guard !keyboardLiveTrackingSuspended,
+              window != nil,
+              !renderingSuspended,
+              sampledKeyboardGuideTop() != nil else {
+            // No trustworthy live signal (off-window, suspended, pre-layout,
+            // or a debug seam owns the height): fall back to the instant
+            // apply, exactly like the old zero-duration path.
+            keyboardDockTracking = nil
+            lastSampledBottomOccupancy = nil
+            return
+        }
+        keyboardDockTracking = KeyboardDockTracking(
+            deadline: CACurrentMediaTime() + max(expectedDuration, 0.25) + 0.75
+        )
+        lastSampledBottomOccupancy = currentSampledBottomOccupancy()
+        startDisplayLink()
+    }
+
+    /// The keyboard guide anchor's live top edge in this view's bounds, from its
+    /// presentation layer while UIKit animates it (nil when it can't be trusted:
+    /// off-window, pre-layout, or a debug override says so).
+    private func sampledKeyboardGuideTop() -> CGFloat? {
+        #if DEBUG
+        if let sampler = debugKeyboardGuideTopSamplerForTesting {
+            return sampler()
+        }
+        #endif
+        guard window != nil, bounds.height > 1 else { return nil }
+        let anchorLayer = keyboardGuideAnchor.layer
+        let frame = (anchorLayer.presentation() ?? anchorLayer).frame
+        // Zero/near-zero minY means the guide has not produced a real layout
+        // yet (the guide top can never legitimately reach the view top: it
+        // bottoms out at the keyboard's tallest, well below y=0).
+        guard frame.minY > 0.5 else { return nil }
+        return frame.minY
+    }
+
+    private func currentSampledBottomOccupancy() -> CGFloat? {
+        guard let top = sampledKeyboardGuideTop() else { return nil }
+        return TerminalLetterboxGeometry.sampledBottomOccupancy(
+            keyboardGuideTopY: top,
+            boundsHeight: bounds.height
+        )
+    }
+
+    /// One tracking step per display-link frame: sample the guide, re-seat the
+    /// dock + render layer at the sampled position, and settle when the sample
+    /// converges on the target occupancy. Also SELF-ARMS when the guide moves
+    /// with no notification-driven window active — that is interactive keyboard
+    /// dismissal, which only reports a frame change when the drag ends.
+    private func trackKeyboardDockPerFrame() {
+        guard !keyboardLiveTrackingSuspended, !chromeHidden,
+              let liveOccupancy = currentSampledBottomOccupancy() else { return }
+        let targetOccupancy = keyboardOccupancyInBounds
+        let converged = abs(liveOccupancy - targetOccupancy) <= 0.25
+        if keyboardDockTracking == nil {
+            guard !converged else { return }
+            // Guide moved without a notification window (interactive dismiss).
+            keyboardDockTracking = KeyboardDockTracking(
+                deadline: CACurrentMediaTime() + 2.0
+            )
+        }
+        let now = CACurrentMediaTime()
+        if converged || now > keyboardDockTracking!.deadline {
+            finishKeyboardDockTracking()
+            return
+        }
+        if lastSampledBottomOccupancy.map({ abs($0 - liveOccupancy) > 0.05 }) ?? true {
+            lastSampledBottomOccupancy = liveOccupancy
+            applyDockLayoutForCurrentViewport()
+            // A moving sample means UIKit is still driving the guide (a long
+            // interactive drag outlives any fixed deadline), so keep the window
+            // open. A STALLED unconverged sample stops extending and expires,
+            // snapping the dock to target math.
+            if keyboardDockTracking!.deadline < now + 1.0 {
+                keyboardDockTracking = KeyboardDockTracking(deadline: now + 1.0)
+            }
+        }
+    }
+
+    private func finishKeyboardDockTracking() {
+        keyboardDockTracking = nil
+        lastSampledBottomOccupancy = nil
+        applyDockLayoutForCurrentViewport()
+        if keyboardHeight == 0 {
+            scheduleKeyboardHideHeightResync()
+        }
+    }
+
+    /// Re-seat everything that rides the keyboard edge from one snapshot (which
+    /// carries the live sampled occupancy while tracking is active).
+    private func applyDockLayoutForCurrentViewport() {
+        let snapshot = viewportSnapshot()
+        layoutBottomDock(using: snapshot)
+        layoutRenderedTerminalForCurrentViewport(using: snapshot)
         layoutZoomOverlay()
     }
 
@@ -1352,7 +1507,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// the software keyboard. Drives the exact same geometry path as a real
     /// keyboard. Used only by the terminal-layout preview harness.
     public func debugSetKeyboardHeightForLayoutPreview(_ height: CGFloat) {
-        stopKeyboardHeightAnimation()
+        // Live guide samples would immediately fight a synthetic keyboard
+        // height (the real guide rests on the safe area), so suspend tracking
+        // while one is active. Clearing the synthetic height (0) re-enables
+        // ground-truth tracking so the preview harness can also exercise a REAL
+        // simulator keyboard.
+        keyboardLiveTrackingSuspended = height > 0
+        keyboardDockTracking = nil
+        lastSampledBottomOccupancy = nil
         keyboardVisible = height > 0
         inputProxy.setKeyboardShown(keyboardVisible)
         keyboardHeight = max(0, height)
@@ -1373,6 +1535,28 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         zoomOverlayLastInteraction = CACurrentMediaTime() + 3600
     }
     #endif
+
+    /// Pin the invisible keyboard anchor to `keyboardLayoutGuide.topAnchor`.
+    ///
+    /// The guide's top edge rests on the bottom safe-area edge while the
+    /// keyboard is down and rides the keyboard's real top while it moves, and
+    /// UIKit lays out guide-constrained views inside the keyboard's own
+    /// animation transaction. The anchor's presentation layer is therefore the
+    /// keyboard's true animated position — what ``trackKeyboardDockPerFrame()``
+    /// samples. The anchor renders nothing (clear, non-interactive) and the
+    /// rest of the view stays manually frame-laid-out.
+    private func installKeyboardGuideAnchor() {
+        keyboardGuideAnchor.isUserInteractionEnabled = false
+        keyboardGuideAnchor.backgroundColor = .clear
+        keyboardGuideAnchor.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(keyboardGuideAnchor)
+        NSLayoutConstraint.activate([
+            keyboardGuideAnchor.topAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor),
+            keyboardGuideAnchor.leadingAnchor.constraint(equalTo: leadingAnchor),
+            keyboardGuideAnchor.trailingAnchor.constraint(equalTo: trailingAnchor),
+            keyboardGuideAnchor.heightAnchor.constraint(equalToConstant: 1),
+        ])
+    }
 
     /// Dock the accessory bar as a persistent bottom toolbar. Frame-positioned
     /// (not `keyboardLayoutGuide`-pinned) so it uses the exact same bottom
@@ -1466,7 +1650,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             chromeHidden: chromeHidden,
             chromeVisible: dockedToolbarShouldBeVisible && dockedToolbar?.isHidden == false,
             toolbarFrame: dockedToolbar?.frame,
-            toolbarPresentationFrame: dockedToolbar?.layer.presentation()?.frame
+            toolbarPresentationFrame: dockedToolbar?.layer.presentation()?.frame,
+            liveBottomOccupancy: keyboardDockTracking != nil ? lastSampledBottomOccupancy : nil
         ))
     }
 
@@ -2192,7 +2377,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     deinit {
-        stopKeyboardHeightAnimation()
         disposeSurface()
     }
 
@@ -2635,7 +2819,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         renderInFlightSince = nil
         needsAnotherRender = false
         resignInput()
-        stopKeyboardHeightAnimation()
+        // Detached views get no more display-link ticks; drop any live tracking
+        // window so re-attach starts from clean target-math layout.
+        keyboardDockTracking = nil
+        lastSampledBottomOccupancy = nil
         stopDisplayLink()
         setFocus(false)
         #if DEBUG
@@ -3084,7 +3271,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 zoomSettleFrames = frames
             }
         }
-        advanceKeyboardHeightAnimation()
+        trackKeyboardDockPerFrame()
         // Apply geometry at most once per frame. Every trigger (resize, zoom,
         // keyboard, effective-grid pin) only marks `needsGeometrySync`, so a
         // fast pinch can no longer drive a synchronous per-event storm of

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1948,7 +1948,40 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private func layoutBottomDock(using snapshot: TerminalViewportSnapshot) {
         composerContainer.frame = snapshot.composerFrame
         dockedToolbar?.frame = snapshot.toolbarFrame
+        #if DEBUG
+        // The marker's BOTTOM edge = the dock's keyboard edge, positioned by the
+        // exact math under test (never by the keyboard guide), so a UI test can
+        // measure our dock against the real keyboard's on-screen frame.
+        kbEdgeMarkerView?.frame = CGRect(
+            x: 0,
+            y: snapshot.composerFrame.maxY - 2,
+            width: snapshot.bounds.width,
+            height: 2
+        )
+        #endif
     }
+
+    #if DEBUG
+    private var kbEdgeMarkerView: UIView?
+
+    /// UI-test seam: a red bar whose bottom edge is the dock's keyboard edge,
+    /// frame-set by ``layoutBottomDock(using:)`` on every layout/tracking tick.
+    /// The pixel-alignment UI test reads its accessibility frame against the
+    /// real keyboard's frame to verify the dock rides the ACTUAL keyboard, not
+    /// merely the layout guide.
+    public func debugInstallKeyboardEdgeMarkerForUITest() {
+        guard kbEdgeMarkerView == nil else { return }
+        let marker = UIView()
+        marker.backgroundColor = .systemRed
+        marker.isUserInteractionEnabled = false
+        marker.isAccessibilityElement = true
+        marker.accessibilityIdentifier = "MobileKbEdgeMarker"
+        marker.layer.zPosition = Self.bottomChromeZPosition + 50
+        addSubview(marker)
+        kbEdgeMarkerView = marker
+        layoutBottomDock()
+    }
+    #endif
 
     /// Animate the whole bottom dock (composer band + toolbar) to its current target
     /// frames over the given duration/curve. Used by the HIDE/show and composer close

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -805,6 +805,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             "toolbarMaxY=\(dockedToolbar.map { Int($0.frame.maxY.rounded()) } ?? -1)",
             "kbApplyTicks=\(keyboardDockTracker.debugApplyTickCount)",
             "kbMaxDivergencePt=\(Int(debugKbMaxDivergence.rounded(.up)))",
+            "kbMidTrackResizes=\(debugKbMidTrackResizeCount)",
             inputProxy.accessoryLayoutDiagnostics,
         ].joined(separator: ";")
     }
@@ -1390,6 +1391,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             // band height; the toolbar rides its top).
             let dockBottom = composerContainer.frame.maxY
             debugKbMaxDivergence = max(debugKbMaxDivergence, abs(dockBottom - guideTop))
+            // A render-layer size change while the dock is mid-flight is the
+            // "content shoots off-screen and slides back" bug: the geometry
+            // sync must stay deferred until the dock settles.
+            if let tracked = debugKbTrackedRenderHeight,
+               abs(tracked - lastRenderRect.height) > 0.5 {
+                debugKbMidTrackResizeCount += 1
+            }
+            debugKbTrackedRenderHeight = lastRenderRect.height
+        } else {
+            debugKbTrackedRenderHeight = nil
         }
         #endif
     }
@@ -1398,6 +1409,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Max |dock bottom - sampled keyboard edge| observed across all tracking
     /// applies since launch, in points. See ``applyDockLayoutForCurrentViewport()``.
     private var debugKbMaxDivergence: CGFloat = 0
+    /// Render height on the previous tracking tick, and how many times it
+    /// changed mid-tracking (must stay 0; see the geometry-sync hold).
+    private var debugKbTrackedRenderHeight: CGFloat?
+    private var debugKbMidTrackResizeCount = 0
     #endif
 
     private func applyKeyboardHeight(_ height: CGFloat) {
@@ -3212,7 +3227,17 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // keyboard, effective-grid pin) only marks `needsGeometrySync`, so a
         // fast pinch can no longer drive a synchronous per-event storm of
         // set_size calls (the source of the jumbled grid + renderer overload).
-        if needsGeometrySync {
+        //
+        // HOLD the sync entirely while keyboard tracking is live: resizing the
+        // local grid mid-animation swaps the render layer to the FINAL size
+        // while the live viewport is still mid-flight, so on keyboard-hide the
+        // now-full-height layer bottom-anchors with its top far off-screen
+        // (old contents stretched into it) and visibly slides back down — the
+        // "content shoots up out of the screen then animates back" jank. The
+        // flag stays set, so the resize lands on the first frame after the
+        // dock settles; the current-size render stays glued to the dock
+        // throughout the animation.
+        if needsGeometrySync, !keyboardDockTracker.isTracking {
             needsGeometrySync = false
             let reassert = pendingGeometryReassert
             pendingGeometryReassert = false
@@ -3343,9 +3368,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         needsDraw = true
         // A geometry sync (for any reason) satisfies a pending post-zoom resync.
         zoomSettleFrames = nil
-        if displayLink == nil, window != nil {
+        if displayLink == nil, window != nil, !keyboardDockTracker.isTracking {
             // No frame pump while detached/backgrounded; apply directly so the
             // surface still gets sized before the next render path resumes.
+            // (Tracking always runs with a live display link, so the tracking
+            // guard here is belt-and-braces against a mid-animation resize.)
             needsGeometrySync = false
             let reassert = pendingGeometryReassert
             pendingGeometryReassert = false

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -797,15 +797,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             "scrollTotal=\(debugLastScrollbar?.total ?? -1)", "scrollOffset=\(debugLastScrollbar?.offset ?? -1)",
             "scrollLen=\(debugLastScrollbar?.len ?? -1)", "scrollAtBottom=\(debugScrollbarAtBottomForTesting ? 1 : 0)",
             "staleViewportObserved=\(debugBottomViewportMismatchObserved ? 1 : 0)",
-            // Keyboard-guide tracking: the sampled live keyboard top edge, the
-            // dock's actual bottom edge, and whether the per-frame tracker is
-            // active. A UI test polling mid-animation asserts
-            // |toolbarMaxY - guideTop| stays ~0 while kbTracking=1 — the
-            // "terminal edge rides the real keyboard, not a curve replay"
-            // contract. -1 when no sample is available.
-            "kbTracking=\(keyboardDockTracking != nil ? 1 : 0)",
-            "kbGuideTop=\(sampledKeyboardGuideTop().map { Int($0.rounded()) } ?? -1)",
+            // Keyboard-guide tracking: UI tests assert |toolbarMaxY - kbGuideTop|
+            // stays ~0 while kbTracking=1 — the "terminal edge rides the real
+            // keyboard, not a curve replay" contract. -1 = no sample.
+            "kbTracking=\(keyboardDockTracker.isTracking ? 1 : 0)",
+            "kbGuideTop=\(keyboardDockTracker.sampledGuideTop().map { Int($0.rounded()) } ?? -1)",
             "toolbarMaxY=\(dockedToolbar.map { Int($0.frame.maxY.rounded()) } ?? -1)",
+            "kbApplyTicks=\(keyboardDockTracker.debugApplyTickCount)",
+            "kbMaxDivergencePt=\(Int(debugKbMaxDivergence.rounded(.up)))",
             inputProxy.accessoryLayoutDiagnostics,
         ].joined(separator: ";")
     }
@@ -881,25 +880,18 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var lastRenderLayoutViewportHeight: CGFloat?
     private var lastRenderHasSourceLayoutViewport = false
     private var viewportCoordinator = TerminalViewportCoordinator()
-    /// Invisible autolayout child pinned to `keyboardLayoutGuide.topAnchor`.
-    /// UIKit lays it out inside the real keyboard animation transaction, so its
-    /// presentation layer is the keyboard's true animated top edge — the ground
-    /// truth the bottom dock and render layer are frame-set from each display
-    /// link tick (see ``trackKeyboardDockPerFrame()``).
-    private let keyboardGuideAnchor = UIView()
-    /// Non-nil while the dock is following the sampled keyboard guide (a
-    /// notification-driven transition or a self-armed interactive dismissal).
-    private var keyboardDockTracking: KeyboardDockTracking?
-    /// The occupancy sampled on the last applied tracking tick, fed into
-    /// ``viewportSnapshot()`` so every layout consumer sees the same live edge.
-    private var lastSampledBottomOccupancy: CGFloat?
-    /// Debug/preview seams drive `keyboardHeight` synthetically; live guide
-    /// samples would immediately fight them, so they suspend tracking.
-    private var keyboardLiveTrackingSuspended = false
+    /// Ground-truth keyboard tracking: an invisible anchor pinned to
+    /// `keyboardLayoutGuide.topAnchor`, sampled each display-link tick so the
+    /// bottom dock and render layer ride the keyboard's REAL animated edge
+    /// (see `TerminalKeyboardDockTracker`).
+    private lazy var keyboardDockTracker = TerminalKeyboardDockTracker(host: self)
     #if DEBUG
     /// Test seam: overrides the keyboard-guide top-edge sample so tests can
     /// script an exact per-frame keyboard trajectory without a real keyboard.
-    var debugKeyboardGuideTopSamplerForTesting: (() -> CGFloat?)?
+    var debugKeyboardGuideTopSamplerForTesting: (() -> CGFloat?)? {
+        get { keyboardDockTracker.debugGuideTopSampler }
+        set { keyboardDockTracker.debugGuideTopSampler = newValue }
+    }
     #endif
 
     #if DEBUG
@@ -947,14 +939,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let keyboardHeight: CGFloat
     }
 
-    /// Test seam: the current keyboard-dock tracking state plus the frames the
-    /// tracking loop owns, so tests can assert the dock and viewport sit exactly
-    /// on a scripted keyboard sample.
+    /// Test seam: tracking state + the frames the tracking loop owns, so tests
+    /// can assert the dock and viewport sit exactly on a scripted sample.
     func debugKeyboardDockStateForTesting() -> DebugKeyboardDockState {
         DebugKeyboardDockState(
-            isTracking: keyboardDockTracking != nil,
-            liveOccupancy: lastSampledBottomOccupancy,
-            sampledGuideTop: sampledKeyboardGuideTop(),
+            isTracking: keyboardDockTracker.isTracking,
+            liveOccupancy: keyboardDockTracker.lastSampledBottomOccupancy,
+            sampledGuideTop: keyboardDockTracker.sampledGuideTop(),
             toolbarFrame: dockedToolbar?.frame,
             composerFrame: composerContainer.frame,
             fallbackFrame: snapshotFallbackView.frame,
@@ -964,17 +955,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         )
     }
 
-    /// Test seam: run exactly one keyboard-dock tracking tick (what the display
-    /// link does each frame), so tests can step a scripted keyboard trajectory
-    /// deterministically.
+    /// Test seam: one keyboard-dock tracking tick (what the display link does
+    /// each frame), so tests step a scripted trajectory deterministically.
     func debugAdvanceKeyboardDockTrackingForTesting() {
         trackKeyboardDockPerFrame()
     }
 
     func setKeyboardHeightForTesting(_ height: CGFloat) {
-        keyboardLiveTrackingSuspended = true
-        keyboardDockTracking = nil
-        lastSampledBottomOccupancy = nil
+        keyboardDockTracker.suspended = true
+        keyboardDockTracker.cancel()
         keyboardHeight = max(0, height)
         layoutRenderedTerminalForCurrentViewport()
         layoutBottomDock()
@@ -1122,7 +1111,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         #endif
         installPersistentToolbar()
         installComposerContainer()
-        installKeyboardGuideAnchor()
+        keyboardDockTracker.install()
         initializeSurface()
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
@@ -1204,7 +1193,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         renderingSuspended = true
         // The display link is about to stop, so an in-flight keyboard tracking
         // window would never tick again; snap it to the target layout now.
-        if keyboardDockTracking != nil {
+        if keyboardDockTracker.isTracking {
             finishKeyboardDockTracking()
         }
         skipPendingVisibleSnapshot()
@@ -1340,124 +1329,42 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // reclaims the keyboard's space (minus the now-reserved safe area + toolbar +
         // composer band).
         updateDockedToolbarVisibility()
-        // Begin ground-truth tracking BEFORE applying the target height: seeding
-        // the live sample with the keyboard's current (pre-animation) guide
-        // position keeps the dock exactly where it is this frame; the display
-        // link then walks it along UIKit's real keyboard animation.
-        beginKeyboardDockTracking(expectedDuration: transition.duration)
+        // Begin ground-truth tracking BEFORE applying the target height, so the
+        // dock stays at the keyboard's current (pre-animation) guide position
+        // this frame and the display link walks it along UIKit's real keyboard
+        // animation. Off-window or suspended, the tracker declines and the
+        // height applies instantly (the old zero-duration path).
+        if window != nil, !renderingSuspended {
+            keyboardDockTracker.begin(expectedDuration: transition.duration)
+        } else {
+            keyboardDockTracker.cancel()
+        }
+        if keyboardDockTracker.isTracking {
+            startDisplayLink()
+        }
         applyKeyboardHeight(max(0, overlap))
-        if keyboardDockTracking == nil, keyboardHeight == 0 {
-            // No live tracking possible (off-window / suppressed): the height
-            // applied instantly, so run the hide resync now, as before.
+        if !keyboardDockTracker.isTracking, keyboardHeight == 0 {
             scheduleKeyboardHideHeightResync()
         }
     }
 
-    /// Ground-truth keyboard tracking (replaces the old duration/curve replay).
-    ///
-    /// `keyboardGuideAnchor` is constrained to `keyboardLayoutGuide.topAnchor`,
-    /// so UIKit moves it inside the actual keyboard animation transaction — the
-    /// same private spring the keyboard itself runs, including interactive
-    /// dismiss, which posts no notifications while the finger drags. Every
-    /// display-link frame while a transition is live, ``trackKeyboardDockPerFrame()``
-    /// samples the anchor's presentation layer and frame-sets the whole bottom
-    /// dock (toolbar + composer band) and the render layer from that one sample,
-    /// so the terminal edge cannot diverge from the keyboard by construction.
-    /// The old path animated the dock with `UIView.animate` using the
-    /// notification's duration + curve — a REPLAY that drifted from UIKit's
-    /// keyboard spring mid-flight and missed interactive dismissal entirely.
-    private struct KeyboardDockTracking {
-        /// Hard stop for the tracking window. Normally tracking ends when the
-        /// sampled occupancy converges on the target; the deadline covers a
-        /// guide that never converges (e.g. a floating-keyboard frame the
-        /// notification math resolved differently), snapping to target math.
-        let deadline: CFTimeInterval
-    }
-
-    private func beginKeyboardDockTracking(expectedDuration: TimeInterval) {
-        guard !keyboardLiveTrackingSuspended,
-              window != nil,
-              !renderingSuspended,
-              sampledKeyboardGuideTop() != nil else {
-            // No trustworthy live signal (off-window, suspended, pre-layout,
-            // or a debug seam owns the height): fall back to the instant
-            // apply, exactly like the old zero-duration path.
-            keyboardDockTracking = nil
-            lastSampledBottomOccupancy = nil
-            return
-        }
-        keyboardDockTracking = KeyboardDockTracking(
-            deadline: CACurrentMediaTime() + max(expectedDuration, 0.25) + 0.75
-        )
-        lastSampledBottomOccupancy = currentSampledBottomOccupancy()
-        startDisplayLink()
-    }
-
-    /// The keyboard guide anchor's live top edge in this view's bounds, from its
-    /// presentation layer while UIKit animates it (nil when it can't be trusted:
-    /// off-window, pre-layout, or a debug override says so).
-    private func sampledKeyboardGuideTop() -> CGFloat? {
-        #if DEBUG
-        if let sampler = debugKeyboardGuideTopSamplerForTesting {
-            return sampler()
-        }
-        #endif
-        guard window != nil, bounds.height > 1 else { return nil }
-        let anchorLayer = keyboardGuideAnchor.layer
-        let frame = (anchorLayer.presentation() ?? anchorLayer).frame
-        // Zero/near-zero minY means the guide has not produced a real layout
-        // yet (the guide top can never legitimately reach the view top: it
-        // bottoms out at the keyboard's tallest, well below y=0).
-        guard frame.minY > 0.5 else { return nil }
-        return frame.minY
-    }
-
-    private func currentSampledBottomOccupancy() -> CGFloat? {
-        guard let top = sampledKeyboardGuideTop() else { return nil }
-        return TerminalLetterboxGeometry.sampledBottomOccupancy(
-            keyboardGuideTopY: top,
-            boundsHeight: bounds.height
-        )
-    }
-
-    /// One tracking step per display-link frame: sample the guide, re-seat the
-    /// dock + render layer at the sampled position, and settle when the sample
-    /// converges on the target occupancy. Also SELF-ARMS when the guide moves
-    /// with no notification-driven window active — that is interactive keyboard
-    /// dismissal, which only reports a frame change when the drag ends.
+    /// One `TerminalKeyboardDockTracker` step per display-link frame: sample
+    /// the keyboard guide and re-seat the dock + render layer at the sampled
+    /// position; on convergence snap to exact target math.
     private func trackKeyboardDockPerFrame() {
-        guard !keyboardLiveTrackingSuspended, !chromeHidden,
-              let liveOccupancy = currentSampledBottomOccupancy() else { return }
-        let targetOccupancy = keyboardOccupancyInBounds
-        let converged = abs(liveOccupancy - targetOccupancy) <= 0.25
-        if keyboardDockTracking == nil {
-            guard !converged else { return }
-            // Guide moved without a notification window (interactive dismiss).
-            keyboardDockTracking = KeyboardDockTracking(
-                deadline: CACurrentMediaTime() + 2.0
-            )
-        }
-        let now = CACurrentMediaTime()
-        if converged || now > keyboardDockTracking!.deadline {
-            finishKeyboardDockTracking()
-            return
-        }
-        if lastSampledBottomOccupancy.map({ abs($0 - liveOccupancy) > 0.05 }) ?? true {
-            lastSampledBottomOccupancy = liveOccupancy
+        guard !chromeHidden else { return }
+        switch keyboardDockTracker.tick(targetOccupancy: keyboardOccupancyInBounds) {
+        case .idle:
+            break
+        case .apply:
             applyDockLayoutForCurrentViewport()
-            // A moving sample means UIKit is still driving the guide (a long
-            // interactive drag outlives any fixed deadline), so keep the window
-            // open. A STALLED unconverged sample stops extending and expires,
-            // snapping the dock to target math.
-            if keyboardDockTracking!.deadline < now + 1.0 {
-                keyboardDockTracking = KeyboardDockTracking(deadline: now + 1.0)
-            }
+        case .settle:
+            finishKeyboardDockTracking()
         }
     }
 
     private func finishKeyboardDockTracking() {
-        keyboardDockTracking = nil
-        lastSampledBottomOccupancy = nil
+        keyboardDockTracker.cancel()
         applyDockLayoutForCurrentViewport()
         if keyboardHeight == 0 {
             scheduleKeyboardHideHeightResync()
@@ -1471,7 +1378,27 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         layoutBottomDock(using: snapshot)
         layoutRenderedTerminalForCurrentViewport(using: snapshot)
         layoutZoomOverlay()
+        #if DEBUG
+        // Record the dock's actual frame vs the anchor's live presentation —
+        // the per-frame "terminal rides the keyboard" evidence UI tests read
+        // through the probe (kbMaxDivergencePt), since accessibility polls are
+        // too slow to reliably sample mid-animation themselves.
+        if keyboardDockTracker.isTracking,
+           let guideTop = keyboardDockTracker.sampledGuideTop() {
+            // The composer container's bottom edge IS the dock's keyboard edge
+            // in every mode (its frame bottom rests on bottomEdge even at zero
+            // band height; the toolbar rides its top).
+            let dockBottom = composerContainer.frame.maxY
+            debugKbMaxDivergence = max(debugKbMaxDivergence, abs(dockBottom - guideTop))
+        }
+        #endif
     }
+
+    #if DEBUG
+    /// Max |dock bottom - sampled keyboard edge| observed across all tracking
+    /// applies since launch, in points. See ``applyDockLayoutForCurrentViewport()``.
+    private var debugKbMaxDivergence: CGFloat = 0
+    #endif
 
     private func applyKeyboardHeight(_ height: CGFloat) {
         let clamped = max(0, height)
@@ -1512,9 +1439,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // while one is active. Clearing the synthetic height (0) re-enables
         // ground-truth tracking so the preview harness can also exercise a REAL
         // simulator keyboard.
-        keyboardLiveTrackingSuspended = height > 0
-        keyboardDockTracking = nil
-        lastSampledBottomOccupancy = nil
+        keyboardDockTracker.suspended = height > 0
+        keyboardDockTracker.cancel()
         keyboardVisible = height > 0
         inputProxy.setKeyboardShown(keyboardVisible)
         keyboardHeight = max(0, height)
@@ -1535,28 +1461,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         zoomOverlayLastInteraction = CACurrentMediaTime() + 3600
     }
     #endif
-
-    /// Pin the invisible keyboard anchor to `keyboardLayoutGuide.topAnchor`.
-    ///
-    /// The guide's top edge rests on the bottom safe-area edge while the
-    /// keyboard is down and rides the keyboard's real top while it moves, and
-    /// UIKit lays out guide-constrained views inside the keyboard's own
-    /// animation transaction. The anchor's presentation layer is therefore the
-    /// keyboard's true animated position — what ``trackKeyboardDockPerFrame()``
-    /// samples. The anchor renders nothing (clear, non-interactive) and the
-    /// rest of the view stays manually frame-laid-out.
-    private func installKeyboardGuideAnchor() {
-        keyboardGuideAnchor.isUserInteractionEnabled = false
-        keyboardGuideAnchor.backgroundColor = .clear
-        keyboardGuideAnchor.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(keyboardGuideAnchor)
-        NSLayoutConstraint.activate([
-            keyboardGuideAnchor.topAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor),
-            keyboardGuideAnchor.leadingAnchor.constraint(equalTo: leadingAnchor),
-            keyboardGuideAnchor.trailingAnchor.constraint(equalTo: trailingAnchor),
-            keyboardGuideAnchor.heightAnchor.constraint(equalToConstant: 1),
-        ])
-    }
 
     /// Dock the accessory bar as a persistent bottom toolbar. Frame-positioned
     /// (not `keyboardLayoutGuide`-pinned) so it uses the exact same bottom
@@ -1651,7 +1555,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             chromeVisible: dockedToolbarShouldBeVisible && dockedToolbar?.isHidden == false,
             toolbarFrame: dockedToolbar?.frame,
             toolbarPresentationFrame: dockedToolbar?.layer.presentation()?.frame,
-            liveBottomOccupancy: keyboardDockTracking != nil ? lastSampledBottomOccupancy : nil
+            liveBottomOccupancy: keyboardDockTracker.liveBottomOccupancy
         ))
     }
 
@@ -2821,8 +2725,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         resignInput()
         // Detached views get no more display-link ticks; drop any live tracking
         // window so re-attach starts from clean target-math layout.
-        keyboardDockTracking = nil
-        lastSampledBottomOccupancy = nil
+        keyboardDockTracker.cancel()
         stopDisplayLink()
         setFocus(false)
         #if DEBUG

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalKeyboardDockTracker.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalKeyboardDockTracker.swift
@@ -1,0 +1,178 @@
+#if canImport(UIKit)
+import CmuxMobileTerminalKit
+import UIKit
+
+/// Ground-truth keyboard tracking for the terminal's bottom dock (replaces the
+/// old duration/curve replay).
+///
+/// An invisible anchor view is pinned to the host's
+/// `keyboardLayoutGuide.topAnchor`, so UIKit moves it inside the actual
+/// keyboard animation transaction — the same private spring the keyboard
+/// itself runs, including interactive dismiss, which posts no notifications
+/// while the finger drags. Every display-link frame while a transition is
+/// live, the host calls ``tick(targetOccupancy:)``, which samples the anchor's
+/// presentation layer; the host then frame-sets the whole bottom dock
+/// (toolbar + composer band) and the render layer from that one sample, so the
+/// terminal edge cannot diverge from the keyboard by construction. The old
+/// path animated the dock with `UIView.animate` using the notification's
+/// duration + curve — a REPLAY that drifted from UIKit's keyboard spring
+/// mid-flight and missed interactive dismissal entirely.
+///
+/// When the keyboard is down the guide rests on the bottom safe-area edge,
+/// which is the identical quantity
+/// `TerminalLetterboxGeometry.keyboardOccupancy` reserves — so one sampled
+/// value drives both steady states and every frame of the transition between
+/// them.
+@MainActor
+final class TerminalKeyboardDockTracker {
+    /// What the host should do after a tracking tick.
+    enum TickOutcome {
+        /// Nothing changed (steady state, no sample, or an unchanged sample).
+        case idle
+        /// The sample moved: re-seat the dock and render layer from it.
+        case apply
+        /// The sample converged on the target (or the window expired): snap to
+        /// exact target math and run any settle work.
+        case settle
+    }
+
+    private struct Window {
+        /// Hard stop for the tracking window. Normally tracking ends when the
+        /// sampled occupancy converges on the target; the deadline covers a
+        /// guide that never converges (e.g. a floating-keyboard frame the
+        /// notification math resolved differently), snapping to target math.
+        let deadline: CFTimeInterval
+    }
+
+    private unowned let host: UIView
+    private let anchor = UIView()
+    private var window: Window?
+    /// The occupancy sampled on the last applied tracking tick, so every
+    /// layout consumer within a frame sees the same live edge.
+    private(set) var lastSampledBottomOccupancy: CGFloat?
+    /// Debug/preview seams drive the keyboard height synthetically; live guide
+    /// samples would immediately fight them, so they suspend tracking.
+    var suspended = false
+    #if DEBUG
+    /// Test seam: overrides the keyboard-guide top-edge sample so tests can
+    /// script an exact per-frame keyboard trajectory without a real keyboard.
+    var debugGuideTopSampler: (() -> CGFloat?)?
+    /// Cumulative count of `.apply` ticks since creation. UI tests read this
+    /// through the dock probe to prove per-frame tracking actually engaged
+    /// during a real keyboard animation (an accessibility poll is too slow to
+    /// reliably land inside the ~0.4s animation window).
+    private(set) var debugApplyTickCount = 0
+    #endif
+
+    init(host: UIView) {
+        self.host = host
+    }
+
+    /// Whether a live tracking window (notification-driven transition or a
+    /// self-armed interactive dismissal) is active.
+    var isTracking: Bool { window != nil }
+
+    /// The live occupancy the viewport snapshot should use, or nil at steady
+    /// state (target math applies).
+    var liveBottomOccupancy: CGFloat? { window != nil ? lastSampledBottomOccupancy : nil }
+
+    /// Pin the invisible anchor to the host's `keyboardLayoutGuide.topAnchor`.
+    /// The anchor renders nothing (clear, non-interactive) and the rest of the
+    /// host stays manually frame-laid-out.
+    func install() {
+        anchor.isUserInteractionEnabled = false
+        anchor.backgroundColor = .clear
+        anchor.translatesAutoresizingMaskIntoConstraints = false
+        host.addSubview(anchor)
+        NSLayoutConstraint.activate([
+            anchor.topAnchor.constraint(equalTo: host.keyboardLayoutGuide.topAnchor),
+            anchor.leadingAnchor.constraint(equalTo: host.leadingAnchor),
+            anchor.trailingAnchor.constraint(equalTo: host.trailingAnchor),
+            anchor.heightAnchor.constraint(equalToConstant: 1),
+        ])
+    }
+
+    /// The keyboard guide anchor's live top edge in the host's bounds, from
+    /// its presentation layer while UIKit animates it (nil when it can't be
+    /// trusted: off-window, pre-layout, or a debug override says so).
+    func sampledGuideTop() -> CGFloat? {
+        #if DEBUG
+        if let sampler = debugGuideTopSampler {
+            return sampler()
+        }
+        #endif
+        guard host.window != nil, host.bounds.height > 1 else { return nil }
+        let anchorLayer = anchor.layer
+        let frame = (anchorLayer.presentation() ?? anchorLayer).frame
+        // Zero/near-zero minY means the guide has not produced a real layout
+        // yet (the guide top can never legitimately reach the view top: it
+        // bottoms out at the keyboard's tallest, well below y=0).
+        guard frame.minY > 0.5 else { return nil }
+        return frame.minY
+    }
+
+    private func sampledBottomOccupancy() -> CGFloat? {
+        guard let top = sampledGuideTop() else { return nil }
+        return TerminalLetterboxGeometry.sampledBottomOccupancy(
+            keyboardGuideTopY: top,
+            boundsHeight: host.bounds.height
+        )
+    }
+
+    /// Open a tracking window for a notification-driven keyboard transition.
+    /// Seeding the live sample with the keyboard's current (pre-animation)
+    /// guide position keeps the dock exactly where it is this frame; ticks
+    /// then walk it along UIKit's real keyboard animation. Declines (leaving
+    /// the host on the instant-apply path, exactly like the old zero-duration
+    /// case) when suspended, off-window, or no trustworthy sample exists yet.
+    func begin(expectedDuration: TimeInterval) {
+        guard !suspended, host.window != nil, let seed = sampledBottomOccupancy() else {
+            cancel()
+            return
+        }
+        window = Window(deadline: CACurrentMediaTime() + max(expectedDuration, 0.25) + 0.75)
+        lastSampledBottomOccupancy = seed
+    }
+
+    /// Drop any live tracking window without settle work (detach, suspend,
+    /// synthetic-height seams).
+    func cancel() {
+        window = nil
+        lastSampledBottomOccupancy = nil
+    }
+
+    /// One tracking step per display-link frame. Also SELF-ARMS when the guide
+    /// moves with no notification-driven window active — that is interactive
+    /// keyboard dismissal, which only reports a frame change when the drag
+    /// ends.
+    func tick(targetOccupancy: CGFloat) -> TickOutcome {
+        guard !suspended, let liveOccupancy = sampledBottomOccupancy() else { return .idle }
+        let converged = abs(liveOccupancy - targetOccupancy) <= 0.25
+        if window == nil {
+            guard !converged else { return .idle }
+            // Guide moved without a notification window (interactive dismiss).
+            window = Window(deadline: CACurrentMediaTime() + 2.0)
+        }
+        let now = CACurrentMediaTime()
+        if converged || now > window!.deadline {
+            cancel()
+            return .settle
+        }
+        guard lastSampledBottomOccupancy.map({ abs($0 - liveOccupancy) > 0.05 }) ?? true else {
+            return .idle
+        }
+        lastSampledBottomOccupancy = liveOccupancy
+        // A moving sample means UIKit is still driving the guide (a long
+        // interactive drag outlives any fixed deadline), so keep the window
+        // open. A STALLED unconverged sample stops extending and expires,
+        // snapping the dock to target math.
+        if window!.deadline < now + 1.0 {
+            window = Window(deadline: now + 1.0)
+        }
+        #if DEBUG
+        debugApplyTickCount += 1
+        #endif
+        return .apply
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalKeyboardHeightAnimation.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalKeyboardHeightAnimation.swift
@@ -1,3 +1,0 @@
-struct TerminalKeyboardHeightAnimation {
-    let id: Int
-}

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportCoordinator.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportCoordinator.swift
@@ -28,7 +28,12 @@ struct TerminalViewportCoordinator {
             chromeHidden: inputs.chromeHidden
         )
 
-        let bottomEdge = max(0, inputs.chromeHidden ? bounds.height : bounds.height - occupancy)
+        // Dock frames follow the LIVE keyboard edge while it moves (the sampled
+        // guide position), and the target occupancy at steady state. The grid
+        // reservation below stays on the target so the PTY resizes exactly once
+        // per keyboard change while the chrome glides.
+        let dockOccupancy = inputs.chromeHidden ? 0 : (inputs.liveBottomOccupancy ?? occupancy)
+        let bottomEdge = max(0, inputs.chromeHidden ? bounds.height : bounds.height - dockOccupancy)
         let effectiveComposerHeight = inputs.chromeHidden ? 0 : inputs.composerBandHeight
         let composerTop = bottomEdge - effectiveComposerHeight
         let composerY = max(0, composerTop)
@@ -57,7 +62,8 @@ struct TerminalViewportCoordinator {
         let liveViewportHeight = liveViewportHeight(
             inputs: inputs,
             boundsHeight: bounds.height,
-            fallbackHeight: layoutViewport.height
+            fallbackHeight: layoutViewport.height,
+            liveToolbarTop: inputs.liveBottomOccupancy != nil ? toolbarFrame.minY : nil
         )
         return TerminalViewportSnapshot(
             bounds: bounds,
@@ -78,10 +84,19 @@ struct TerminalViewportCoordinator {
     private func liveViewportHeight(
         inputs: TerminalViewportInputs,
         boundsHeight: CGFloat,
-        fallbackHeight: CGFloat
+        fallbackHeight: CGFloat,
+        liveToolbarTop: CGFloat?
     ) -> CGFloat {
-        guard inputs.chromeVisible,
-              let frame = inputs.toolbarPresentationFrame ?? inputs.toolbarFrame,
+        guard inputs.chromeVisible else { return fallbackHeight }
+        // Keyboard in motion: the toolbar frame just computed from the sampled
+        // guide occupancy IS the live dock position (the dock is frame-set from
+        // it this same tick), so the render viewport bottom sits exactly on it.
+        if let liveToolbarTop {
+            return min(max(1, liveToolbarTop), max(1, boundsHeight))
+        }
+        // Non-keyboard dock animations (HIDE/show, composer close) still move
+        // the toolbar with UIView.animate, so follow its presentation frame.
+        guard let frame = inputs.toolbarPresentationFrame ?? inputs.toolbarFrame,
               !frame.isNull,
               !frame.isEmpty else {
             return fallbackHeight

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportInputs.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportInputs.swift
@@ -12,6 +12,12 @@ struct TerminalViewportInputs {
     let chromeVisible: Bool
     let toolbarFrame: CGRect?
     let toolbarPresentationFrame: CGRect?
+    /// The bottom occupancy sampled from the keyboard-layout-guide anchor's
+    /// presentation layer THIS frame, or nil at steady state. When set, the
+    /// dock frames and live viewport are placed at this ground-truth keyboard
+    /// position; the grid reservation (`layoutViewportRect`) still uses the
+    /// target `keyboardHeight` so the PTY resizes once, not per frame.
+    let liveBottomOccupancy: CGFloat?
 }
 #endif
 

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
@@ -118,6 +118,35 @@ public struct TerminalLetterboxGeometry {
         viewInset > 0 ? viewInset : max(0, windowInset)
     }
 
+    /// The bottom occupancy implied by a SAMPLED keyboard-layout-guide top edge,
+    /// in the host view's coordinate space.
+    ///
+    /// This is the live counterpart of ``keyboardOccupancy(keyboardHeight:bottomSafeAreaInset:)``:
+    /// `UIKeyboardLayoutGuide`'s top edge rests on the bottom safe-area edge while
+    /// the keyboard is down and rides the keyboard's real animated top while it
+    /// moves, so `bounds.height - guideTop` IS the current bottom occupancy at any
+    /// instant of the system keyboard animation (including interactive dismiss).
+    /// Sampling the guide-pinned anchor's presentation layer and feeding this
+    /// value into the dock/viewport math is what keeps the terminal edge glued to
+    /// the keyboard, instead of replaying the notification's duration/curve and
+    /// hoping it matches UIKit's private spring.
+    ///
+    /// Clamped to `[0, boundsHeight]` so a transient out-of-bounds sample (mid
+    /// rotation, detached guide) cannot produce a negative or over-full
+    /// reservation.
+    ///
+    /// - Parameters:
+    ///   - keyboardGuideTopY: The sampled guide top edge (min-Y) in view points.
+    ///   - boundsHeight: The host view bounds height in points.
+    /// - Returns: The live bottom occupancy in points.
+    public static func sampledBottomOccupancy(
+        keyboardGuideTopY: CGFloat,
+        boundsHeight: CGFloat
+    ) -> CGFloat {
+        guard boundsHeight > 0 else { return 0 }
+        return min(max(0, boundsHeight - keyboardGuideTopY), boundsHeight)
+    }
+
     /// The container size in device pixels for libghostty's `set_size`.
     ///
     /// Floors `container * scale` and clamps each axis to at least 1 pixel,

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
@@ -289,4 +289,31 @@ struct TerminalLetterboxGeometryTests {
         )
         #expect(clamped == CGSize(width: 402, height: 700))
     }
+
+    @Test("sampled occupancy converts a live guide top edge into bottom occupancy")
+    func sampledOccupancyContract() {
+        // Keyboard resting DOWN: the guide top sits on the bottom safe-area
+        // edge, so the sampled occupancy equals the safe-area reservation —
+        // the same value keyboardOccupancy(0, inset) produces. This identity is
+        // what lets one sampled value drive both steady states and every frame
+        // of the transition between them.
+        #expect(
+            TerminalLetterboxGeometry.sampledBottomOccupancy(keyboardGuideTopY: 810, boundsHeight: 844)
+                == TerminalLetterboxGeometry.keyboardOccupancy(keyboardHeight: 0, bottomSafeAreaInset: 34)
+        )
+        // Keyboard fully UP: guide top = keyboard top.
+        #expect(TerminalLetterboxGeometry.sampledBottomOccupancy(keyboardGuideTopY: 508, boundsHeight: 844) == 336)
+        // Mid-animation sample.
+        #expect(TerminalLetterboxGeometry.sampledBottomOccupancy(keyboardGuideTopY: 700, boundsHeight: 844) == 144)
+    }
+
+    @Test("sampled occupancy clamps out-of-bounds guide samples")
+    func sampledOccupancyClamps() {
+        // Guide below the view (detached / mid-rotation): never negative.
+        #expect(TerminalLetterboxGeometry.sampledBottomOccupancy(keyboardGuideTopY: 900, boundsHeight: 844) == 0)
+        // Guide above the view top: never more than the full bounds.
+        #expect(TerminalLetterboxGeometry.sampledBottomOccupancy(keyboardGuideTopY: -50, boundsHeight: 844) == 844)
+        // Degenerate bounds cannot produce a reservation.
+        #expect(TerminalLetterboxGeometry.sampledBottomOccupancy(keyboardGuideTopY: 100, boundsHeight: 0) == 0)
+    }
 }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalKeyboardDockTrackingTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalKeyboardDockTrackingTests.swift
@@ -1,0 +1,273 @@
+#if canImport(UIKit)
+import CMUXMobileCore
+import Foundation
+import Testing
+import UIKit
+
+@testable import CmuxMobileTerminal
+
+/// Behavioral tests for keyboard-synchronized terminal layout.
+///
+/// The terminal's bottom dock (toolbar + composer band) and render viewport must
+/// sit EXACTLY on the keyboard's live animated edge every frame, not on a replay
+/// of the notification's duration/curve. The surface samples an anchor pinned to
+/// `keyboardLayoutGuide` each display-link tick and frame-sets the dock from that
+/// sample; these tests script the sample (via `debugKeyboardGuideTopSamplerForTesting`)
+/// and step ticks (via `debugAdvanceKeyboardDockTrackingForTesting`) so the whole
+/// trajectory is deterministic — no real keyboard, no timing flake.
+@MainActor
+@Suite("Terminal keyboard dock tracking")
+struct TerminalKeyboardDockTrackingTests {
+    private final class StubDelegate: GhosttySurfaceViewDelegate {
+        func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {}
+        func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize) {}
+    }
+
+    /// A scripted keyboard-guide sample the tests move frame by frame.
+    private final class ScriptedGuide {
+        var top: CGFloat
+
+        init(top: CGFloat) {
+            self.top = top
+        }
+    }
+
+    private struct Harness {
+        let window: UIWindow
+        let view: GhosttySurfaceView
+        let delegate: StubDelegate
+        let guide: ScriptedGuide
+
+        var boundsHeight: CGFloat { view.bounds.height }
+
+        func setSample(_ top: CGFloat) {
+            guide.top = top
+        }
+
+        func tick() {
+            view.debugAdvanceKeyboardDockTrackingForTesting()
+        }
+
+        var state: GhosttySurfaceView.DebugKeyboardDockState {
+            view.debugKeyboardDockStateForTesting()
+        }
+
+        /// Post a real `keyboardWillChangeFrame` through NotificationCenter so
+        /// the production observer path runs, with `endFrame` in screen space.
+        func postKeyboardFrameChange(overlap: CGFloat, duration: TimeInterval = 0.25) {
+            let screenBounds = window.screen.bounds
+            let endFrame = CGRect(
+                x: 0,
+                y: screenBounds.height - overlap,
+                width: screenBounds.width,
+                height: max(overlap, 336)
+            )
+            NotificationCenter.default.post(
+                name: UIResponder.keyboardWillChangeFrameNotification,
+                object: nil,
+                userInfo: [
+                    UIResponder.keyboardFrameEndUserInfoKey: endFrame,
+                    UIResponder.keyboardAnimationDurationUserInfoKey: duration,
+                    UIResponder.keyboardAnimationCurveUserInfoKey: 7,
+                ]
+            )
+        }
+    }
+
+    private func makeHarness() throws -> Harness {
+        let runtime = try GhosttyRuntime.shared()
+        let delegate = StubDelegate()
+        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
+        view.autoFocusOnWindowAttach = false
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.isHidden = false
+        view.frame = window.bounds
+        window.addSubview(view)
+        window.layoutIfNeeded()
+        view.layoutIfNeeded()
+        // Rest state: guide top on the bottom occupancy edge, so the sample
+        // matches the target exactly and no tracking is armed.
+        let guide = ScriptedGuide(top: view.bounds.height)
+        let harness = Harness(window: window, view: view, delegate: delegate, guide: guide)
+        view.debugKeyboardGuideTopSamplerForTesting = { [guide] in guide.top }
+        // Rest the scripted guide on the real resting occupancy (bottom safe
+        // area, or the view bottom when the test window has no inset).
+        let restingOccupancy = harness.state.keyboardHeight > 0
+            ? harness.state.keyboardHeight
+            : max(0, window.safeAreaInsets.bottom)
+        guide.top = view.bounds.height - restingOccupancy
+        return harness
+    }
+
+    @Test("keyboard show: dock and live viewport ride the sampled guide frame by frame")
+    func showTracksScriptedGuide() throws {
+        let h = try makeHarness()
+        let height = h.boundsHeight
+        let keyboard: CGFloat = 336
+        let restingTop = h.guide.top
+
+        h.postKeyboardFrameChange(overlap: keyboard)
+
+        let afterNotification = h.state
+        // The target (grid reservation) jumps to the final height immediately…
+        #expect(abs(afterNotification.keyboardHeight - keyboard) <= 0.5)
+        #expect(afterNotification.isTracking)
+        // …but the dock has NOT snapped: it still sits at the pre-animation
+        // sample (the resting guide position).
+        if let toolbar = afterNotification.toolbarFrame {
+            #expect(abs(toolbar.maxY - restingTop) <= 0.5)
+        }
+
+        let finalTop = height - keyboard
+        let targetViewportDuringAnimation = afterNotification.targetViewportHeight
+        // Walk the guide along an arbitrary trajectory (the real one is UIKit's
+        // private spring — the contract is "wherever the guide is, the dock is").
+        for top in [restingTop - 40, restingTop - 120, finalTop + 90, finalTop + 12] {
+            h.setSample(top)
+            h.tick()
+            let state = h.state
+            #expect(state.isTracking)
+            let toolbar = try #require(state.toolbarFrame)
+            // The dock bottom sits exactly on the sampled keyboard edge.
+            #expect(abs(toolbar.maxY - top) <= 0.5)
+            // The live render viewport bottom sits exactly on the dock top.
+            #expect(abs(state.liveViewportHeight - toolbar.minY) <= 0.5)
+            // The grid reservation does not thrash per frame.
+            #expect(abs(state.targetViewportHeight - targetViewportDuringAnimation) <= 0.5)
+        }
+
+        // Converge: the sample reaches the target occupancy and tracking settles
+        // on exact target math.
+        h.setSample(finalTop)
+        h.tick()
+        let settled = h.state
+        #expect(!settled.isTracking)
+        let settledToolbar = try #require(settled.toolbarFrame)
+        #expect(abs(settledToolbar.maxY - finalTop) <= 0.5)
+    }
+
+    @Test("keyboard hide: tracking walks the dock down and settles at the resting edge")
+    func hideTracksScriptedGuide() throws {
+        let h = try makeHarness()
+        let height = h.boundsHeight
+        let keyboard: CGFloat = 336
+        let upTop = height - keyboard
+
+        // Raise the keyboard and settle.
+        h.postKeyboardFrameChange(overlap: keyboard)
+        h.setSample(upTop)
+        h.tick()
+        #expect(!h.state.isTracking)
+
+        // Hide. The dock must stay at the keyboard's current edge, then follow
+        // the samples down.
+        let restingOccupancy = max(0, h.window.safeAreaInsets.bottom)
+        let restingTop = height - restingOccupancy
+        h.postKeyboardFrameChange(overlap: 0)
+        let afterHide = h.state
+        #expect(afterHide.keyboardHeight == 0)
+        #expect(afterHide.isTracking)
+        if let toolbar = afterHide.toolbarFrame {
+            #expect(abs(toolbar.maxY - upTop) <= 0.5)
+        }
+
+        for top in [upTop + 60, upTop + 180, restingTop - 20] {
+            h.setSample(top)
+            h.tick()
+            let toolbar = try #require(h.state.toolbarFrame)
+            #expect(abs(toolbar.maxY - top) <= 0.5)
+            #expect(h.state.isTracking)
+        }
+
+        h.setSample(restingTop)
+        h.tick()
+        let settled = h.state
+        #expect(!settled.isTracking)
+        let settledToolbar = try #require(settled.toolbarFrame)
+        #expect(abs(settledToolbar.maxY - restingTop) <= 0.5)
+    }
+
+    @Test("interactive dismissal: a moving guide with no notification self-arms tracking")
+    func interactiveDismissSelfArms() throws {
+        let h = try makeHarness()
+        let height = h.boundsHeight
+        let keyboard: CGFloat = 336
+        let upTop = height - keyboard
+
+        h.postKeyboardFrameChange(overlap: keyboard)
+        h.setSample(upTop)
+        h.tick()
+        #expect(!h.state.isTracking)
+
+        // The finger drags the keyboard down: the guide moves but UIKit posts
+        // no willChangeFrame until the drag ends.
+        h.setSample(upTop + 120)
+        h.tick()
+        let dragging = h.state
+        #expect(dragging.isTracking)
+        let draggingToolbar = try #require(dragging.toolbarFrame)
+        #expect(abs(draggingToolbar.maxY - (upTop + 120)) <= 0.5)
+        // The grid reservation still reflects the last committed keyboard state.
+        #expect(abs(dragging.keyboardHeight - keyboard) <= 0.5)
+
+        // Drag ends: UIKit posts the hide notification and the guide finishes
+        // its run to the resting edge.
+        let restingTop = height - max(0, h.window.safeAreaInsets.bottom)
+        h.postKeyboardFrameChange(overlap: 0)
+        h.setSample(restingTop)
+        h.tick()
+        let settled = h.state
+        #expect(!settled.isTracking)
+        #expect(settled.keyboardHeight == 0)
+        let settledToolbar = try #require(settled.toolbarFrame)
+        #expect(abs(settledToolbar.maxY - restingTop) <= 0.5)
+    }
+
+    @Test("real keyboard: the guide anchor is live and the dock converges onto it")
+    func realKeyboardGuideAnchorDrivesDock() async throws {
+        let h = try makeHarness()
+        // Use the REAL guide (no scripted sampler) and a real first responder.
+        h.view.debugKeyboardGuideTopSamplerForTesting = nil
+
+        var sawKeyboard = false
+        let token = NotificationCenter.default.addObserver(
+            forName: UIResponder.keyboardWillShowNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated { sawKeyboard = true }
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        h.view.focusInput()
+        // Async-poll for the software keyboard; a simulator with a connected
+        // hardware keyboard never shows one, in which case this test cannot
+        // exercise the real guide and passes vacuously.
+        for _ in 0..<60 {
+            if sawKeyboard { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        guard sawKeyboard else { return }
+
+        // Let the animation run; every observed frame with tracking active must
+        // have the dock exactly on the sampled guide edge.
+        for _ in 0..<40 {
+            let state = h.state
+            if state.isTracking,
+               let toolbar = state.toolbarFrame,
+               let guideTop = state.sampledGuideTop {
+                #expect(abs(toolbar.maxY - guideTop) <= 1.5)
+            }
+            try await Task.sleep(nanoseconds: 16_000_000)
+        }
+
+        // After the animation the dock must have converged to the target math.
+        let settled = h.state
+        #expect(!settled.isTracking)
+        #expect(settled.keyboardHeight > 0)
+        if let toolbar = settled.toolbarFrame {
+            #expect(abs(toolbar.maxY - (h.boundsHeight - settled.keyboardHeight)) <= 1.0)
+        }
+    }
+}
+#endif

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -326,7 +326,6 @@ final class cmuxUITests: XCTestCase {
 
         let probe = app.descendants(matching: .any)[Composer.surfaceProbe]
         let hideKeyboard = app.buttons["terminal.inputAccessory.hideKeyboard"]
-        var trackedSamples = 0
 
         func pollTransition(until settled: @escaping ([String: String]) -> Bool, context: String) {
             let deadline = Date().addingTimeInterval(4)
@@ -334,10 +333,14 @@ final class cmuxUITests: XCTestCase {
             while Date() < deadline {
                 let dock = parseProbe(probe.value as? String ?? "")
                 last = dock
+                // Opportunistic mid-animation check; an accessibility read is
+                // slow (~100s of ms) so landing inside the window is not
+                // guaranteed — the authoritative per-frame evidence is the
+                // surface-recorded kbApplyTicks/kbMaxDivergencePt asserted at
+                // the end.
                 if dock["kbTracking"] == "1",
                    let guideTop = Int(dock["kbGuideTop"] ?? ""), guideTop > 0,
                    let toolbarMaxY = Int(dock["toolbarMaxY"] ?? ""), toolbarMaxY > 0 {
-                    trackedSamples += 1
                     XCTAssertLessThanOrEqual(
                         abs(toolbarMaxY - guideTop), 2,
                         "\(context): mid-animation dock bottom diverged from the live keyboard edge. dock=\(dock)"
@@ -369,11 +372,22 @@ final class cmuxUITests: XCTestCase {
             pollTransition(until: { $0["keyboardUp"] == "1" }, context: "keyboard show cycle \(cycle + 1)")
         }
 
-        // The accessibility poll is coarse relative to a ~0.4s animation, but
-        // across five transitions it must land inside at least one of them —
-        // otherwise the tracker never engaged and the per-frame contract went
-        // completely unexercised.
-        XCTAssertGreaterThan(trackedSamples, 0, "no mid-animation tracking sample was ever observed")
+        // Surface-recorded per-frame evidence across all five real keyboard
+        // transitions: tracking must have applied on many display-link frames
+        // (an animation is dozens of frames; 5 is a loose floor covering slow
+        // CI), and on every one of those frames the dock's actual bottom edge
+        // stayed within 2pt of the anchor's live presentation frame.
+        let final = parseProbe(probe.value as? String ?? "")
+        let applyTicks = Int(final["kbApplyTicks"] ?? "") ?? 0
+        XCTAssertGreaterThanOrEqual(
+            applyTicks, 5,
+            "per-frame keyboard tracking never engaged across five real keyboard transitions. dock=\(final)"
+        )
+        let maxDivergence = Int(final["kbMaxDivergencePt"] ?? "") ?? .max
+        XCTAssertLessThanOrEqual(
+            maxDivergence, 2,
+            "dock bottom diverged from the live keyboard edge mid-animation. dock=\(final)"
+        )
     }
 
     @MainActor

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -388,6 +388,14 @@ final class cmuxUITests: XCTestCase {
             maxDivergence, 2,
             "dock bottom diverged from the live keyboard edge mid-animation. dock=\(final)"
         )
+        // A render-layer resize while the dock is mid-flight bottom-anchors the
+        // final-size layer to a mid-animation viewport (content shoots
+        // off-screen then slides back). The geometry sync must hold until the
+        // dock settles, so this counter must never move.
+        XCTAssertEqual(
+            Int(final["kbMidTrackResizes"] ?? "") ?? -1, 0,
+            "render layer was resized mid keyboard animation. dock=\(final)"
+        )
     }
 
     /// Pixel-level alignment of the dock against the REAL keyboard (not the

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -390,6 +390,89 @@ final class cmuxUITests: XCTestCase {
         )
     }
 
+    /// Pixel-level alignment of the dock against the REAL keyboard (not the
+    /// layout guide): a red marker bar whose bottom edge is positioned by the
+    /// dock-layout math under test is measured against the keyboard element's
+    /// on-screen frame. Mid-animation the two frame reads are ~100ms apart, so
+    /// each sample brackets the marker read with two keyboard reads and only
+    /// counts when the keyboard barely moved between them (coherent sample).
+    /// Every sample is printed (`KBEDGE ...`) so the run log doubles as the
+    /// measurement record.
+    @MainActor
+    func testTerminalKeyboardEdgePixelAlignment() throws {
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_TERMINAL_PREVIEW": "1",
+            "CMUX_UITEST_KB_EDGE_MARKER": "1",
+        ])
+        let surface = app.otherElements["MobileTerminalSurface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 8))
+        let marker = app.otherElements["MobileKbEdgeMarker"]
+        XCTAssertTrue(marker.waitForExistence(timeout: 4), "keyboard-edge marker missing")
+        let hideKeyboard = app.buttons["terminal.inputAccessory.hideKeyboard"]
+
+        surface.tap()
+        guard app.keyboards.firstMatch.waitForExistence(timeout: 4) else {
+            throw XCTSkip("Simulator presented no software keyboard; pixel alignment needs one.")
+        }
+
+        var settledDeltas: [CGFloat] = []
+        var midFlightDeltas: [CGFloat] = []
+
+        func sampleThroughTransition(context: String) {
+            let deadline = Date().addingTimeInterval(3.5)
+            var stableReads = 0
+            var lastKbTop: CGFloat?
+            while Date() < deadline, stableReads < 3 {
+                let kb = app.keyboards.firstMatch
+                guard kb.exists else { continue }
+                let kbTopBefore = kb.frame.minY
+                let markerBottom = marker.frame.maxY
+                let kbTopAfter = kb.frame.minY
+                guard kbTopBefore > 1, markerBottom > 1 else { continue }
+                let coherent = abs(kbTopBefore - kbTopAfter) <= 2
+                let kbTop = (kbTopBefore + kbTopAfter) / 2
+                let delta = markerBottom - kbTop
+                let settled = coherent && lastKbTop.map { abs($0 - kbTop) <= 0.5 } ?? false
+                print("KBEDGE context=\(context) kbTop=\(kbTop) markerBottom=\(markerBottom) delta=\(delta) coherent=\(coherent) settled=\(settled)")
+                if coherent {
+                    if settled {
+                        stableReads += 1
+                        settledDeltas.append(delta)
+                    } else {
+                        stableReads = 0
+                        midFlightDeltas.append(delta)
+                    }
+                }
+                if coherent { lastKbTop = kbTop }
+            }
+        }
+
+        sampleThroughTransition(context: "show1")
+        for cycle in 1...2 {
+            XCTAssertTrue(hideKeyboard.waitForExistence(timeout: 4))
+            hideKeyboard.tap()
+            _ = app.keyboards.firstMatch.waitForNonExistence(withTimeout: 4)
+            surface.tap()
+            XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 4))
+            sampleThroughTransition(context: "show\(cycle + 1)")
+        }
+
+        print("KBEDGE summary settled=\(settledDeltas) midFlight=\(midFlightDeltas)")
+        XCTAssertGreaterThanOrEqual(settledDeltas.count, 3, "never observed a settled keyboard-up state")
+        for delta in settledDeltas {
+            XCTAssertLessThanOrEqual(
+                abs(delta), 1.5,
+                "settled dock edge is not pixel-aligned with the real keyboard top (delta=\(delta))"
+            )
+        }
+        for delta in midFlightDeltas {
+            XCTAssertLessThanOrEqual(
+                abs(delta), 3.0,
+                "mid-animation dock edge diverged from the real keyboard top (delta=\(delta))"
+            )
+        }
+    }
+
     @MainActor
     func testBottomScrollStaysPinnedAcrossComposerViewportShrink() throws {
         let app = launchApp(mockData: false, environment: [

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -456,6 +456,37 @@ final class cmuxUITests: XCTestCase {
         }
 
         sampleThroughTransition(context: "show1")
+        // Pixel scan of the settled state: log row colors from above the red
+        // marker down into the keyboard, so the run log shows WHAT fills the
+        // band between the dock edge (avoidance rect) and the keyboard's a11y
+        // frame — keyboard glass (no visual gap) vs exposed background (real
+        // gap). Screen coords are mapped to image pixels via the app frame.
+        do {
+            let markerBottom = marker.frame.maxY
+            let kbTop = app.keyboards.firstMatch.frame.minY
+            let shot = XCUIScreen.main.screenshot().image
+            if let cg = shot.cgImage, let data = cg.dataProvider?.data, let base = CFDataGetBytePtr(data) {
+                let appHeight = app.windows.firstMatch.frame.height
+                let pxPerPt = CGFloat(cg.height) / max(appHeight, 1)
+                let bytesPerRow = cg.bytesPerRow
+                let bpp = cg.bitsPerPixel / 8
+                print("KBPIX meta markerBottom=\(markerBottom) kbTop=\(kbTop) imgH=\(cg.height) pxPerPt=\(pxPerPt) bpp=\(bpp)")
+                let startPt = Int(markerBottom) - 8
+                let endPt = Int(kbTop) + 16
+                for yPt in stride(from: startPt, through: endPt, by: 2) {
+                    let yPx = min(max(Int(CGFloat(yPt) * pxPerPt), 0), cg.height - 1)
+                    var rgbs: [String] = []
+                    for xFrac in [0.3, 0.5, 0.7] {
+                        let xPx = min(Int(CGFloat(cg.width) * xFrac), cg.width - 1)
+                        let p = base + yPx * bytesPerRow + xPx * bpp
+                        rgbs.append("(\(p[0]),\(p[1]),\(p[2]))")
+                    }
+                    print("KBPIX y=\(yPt) \(rgbs.joined(separator: " "))")
+                }
+            } else {
+                print("KBPIX unavailable")
+            }
+        }
         for cycle in 1...2 {
             XCTAssertTrue(hideKeyboard.waitForExistence(timeout: 4))
             hideKeyboard.tap()

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -301,6 +301,81 @@ final class cmuxUITests: XCTestCase {
         assertTerminalRenderBottomAttachedToViewport(dock, context: "synthetic keyboard preview")
     }
 
+    /// The terminal's bottom dock must ride the REAL keyboard's animated edge —
+    /// the keyboard-layout-guide sample — not a replay of the notification's
+    /// duration/curve. Cycles the real simulator keyboard up and down and polls
+    /// the dock probe: every mid-animation sample (`kbTracking=1`) must have the
+    /// dock bottom on the sampled guide edge, and each settle must land exactly
+    /// on it. Also serves as the interaction driver for the keyboard-animation
+    /// evidence video (record-ios-video-cloud.sh --test-filter this test).
+    @MainActor
+    func testTerminalDockRidesRealKeyboardAnimation() throws {
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_TERMINAL_PREVIEW": "1",
+        ])
+        let surface = app.otherElements["MobileTerminalSurface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 8))
+        _ = waitForDock(in: app, timeout: 8, describe: "preview settled with keyboard down") {
+            $0["toolbarVisible"] == "1" && $0["kbTracking"] == "0"
+        }
+
+        surface.tap()
+        guard app.keyboards.firstMatch.waitForExistence(timeout: 4) else {
+            throw XCTSkip("Simulator presented no software keyboard (hardware keyboard connected); real-guide tracking needs one.")
+        }
+
+        let probe = app.descendants(matching: .any)[Composer.surfaceProbe]
+        let hideKeyboard = app.buttons["terminal.inputAccessory.hideKeyboard"]
+        var trackedSamples = 0
+
+        func pollTransition(until settled: @escaping ([String: String]) -> Bool, context: String) {
+            let deadline = Date().addingTimeInterval(4)
+            var last: [String: String] = [:]
+            while Date() < deadline {
+                let dock = parseProbe(probe.value as? String ?? "")
+                last = dock
+                if dock["kbTracking"] == "1",
+                   let guideTop = Int(dock["kbGuideTop"] ?? ""), guideTop > 0,
+                   let toolbarMaxY = Int(dock["toolbarMaxY"] ?? ""), toolbarMaxY > 0 {
+                    trackedSamples += 1
+                    XCTAssertLessThanOrEqual(
+                        abs(toolbarMaxY - guideTop), 2,
+                        "\(context): mid-animation dock bottom diverged from the live keyboard edge. dock=\(dock)"
+                    )
+                }
+                if dock["kbTracking"] == "0", settled(dock) { break }
+            }
+            XCTAssertTrue(settled(last), "\(context): did not settle. last=\(last)")
+            // Settled: the dock bottom rests exactly on the guide's resting edge.
+            if let guideTop = Int(last["kbGuideTop"] ?? ""), guideTop > 0,
+               let toolbarMaxY = Int(last["toolbarMaxY"] ?? "") {
+                XCTAssertLessThanOrEqual(
+                    abs(toolbarMaxY - guideTop), 2,
+                    "\(context): settled dock bottom must rest on the keyboard/safe-area edge. dock=\(last)"
+                )
+            }
+            assertTerminalRenderBottomAttachedToViewport(last, context: context)
+        }
+
+        pollTransition(until: { $0["keyboardUp"] == "1" }, context: "keyboard show cycle 1")
+
+        for cycle in 1...2 {
+            XCTAssertTrue(hideKeyboard.waitForExistence(timeout: 4), "hide-keyboard accessory missing")
+            hideKeyboard.tap()
+            pollTransition(until: { $0["keyboardUp"] == "0" }, context: "keyboard hide cycle \(cycle)")
+
+            surface.tap()
+            XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 4))
+            pollTransition(until: { $0["keyboardUp"] == "1" }, context: "keyboard show cycle \(cycle + 1)")
+        }
+
+        // The accessibility poll is coarse relative to a ~0.4s animation, but
+        // across five transitions it must land inside at least one of them —
+        // otherwise the tracker never engaged and the per-frame contract went
+        // completely unexercised.
+        XCTAssertGreaterThan(trackedSamples, 0, "no mid-animation tracking sample was ever observed")
+    }
+
     @MainActor
     func testBottomScrollStaysPinnedAcrossComposerViewportShrink() throws {
         let app = launchApp(mockData: false, environment: [

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -451,7 +451,7 @@ final class cmuxUITests: XCTestCase {
         for cycle in 1...2 {
             XCTAssertTrue(hideKeyboard.waitForExistence(timeout: 4))
             hideKeyboard.tap()
-            _ = app.keyboards.firstMatch.waitForNonExistence(withTimeout: 4)
+            _ = app.keyboards.firstMatch.waitForNonExistence(timeout: 4)
             surface.tap()
             XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 4))
             sampleThroughTransition(context: "show\(cycle + 1)")

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -398,14 +398,15 @@ final class cmuxUITests: XCTestCase {
         )
     }
 
-    /// Pixel-level alignment of the dock against the REAL keyboard (not the
-    /// layout guide): a red marker bar whose bottom edge is positioned by the
-    /// dock-layout math under test is measured against the keyboard element's
-    /// on-screen frame. Mid-animation the two frame reads are ~100ms apart, so
-    /// each sample brackets the marker read with two keyboard reads and only
-    /// counts when the keyboard barely moved between them (coherent sample).
-    /// Every sample is printed (`KBEDGE ...`) so the run log doubles as the
-    /// measurement record.
+    /// Pixel-level alignment of the dock against the REAL keyboard visual
+    /// panel: a red marker bar whose bottom edge is positioned by the
+    /// dock-layout math under test is measured against the screenshot luma
+    /// edge of the keyboard surface. The keyboard element's a11y frame is only
+    /// used as a rigidity ruler: mid-animation the two frame reads are ~100ms
+    /// apart, so each sample brackets the marker read with two keyboard reads
+    /// and only counts when the keyboard barely moved between them (coherent
+    /// sample). Every sample is printed (`KBEDGE ...`) so the run log doubles
+    /// as the measurement record.
     @MainActor
     func testTerminalKeyboardEdgePixelAlignment() throws {
         let app = launchApp(mockData: false, environment: [
@@ -425,6 +426,16 @@ final class cmuxUITests: XCTestCase {
 
         var settledDeltas: [CGFloat] = []
         var midFlightDeltas: [CGFloat] = []
+
+        func median(_ values: [CGFloat]) -> CGFloat? {
+            guard !values.isEmpty else { return nil }
+            let sorted = values.sorted()
+            let midpoint = sorted.count / 2
+            if sorted.count.isMultiple(of: 2) {
+                return (sorted[midpoint - 1] + sorted[midpoint]) / 2
+            }
+            return sorted[midpoint]
+        }
 
         func sampleThroughTransition(context: String) {
             let deadline = Date().addingTimeInterval(3.5)
@@ -483,6 +494,114 @@ final class cmuxUITests: XCTestCase {
                     }
                     print("KBPIX y=\(yPt) \(rgbs.joined(separator: " "))")
                 }
+
+                func pixel(x: Int, y: Int) -> (r: UInt8, g: UInt8, b: UInt8) {
+                    let p = base + y * bytesPerRow + x * bpp
+                    return (p[0], p[1], p[2])
+                }
+
+                func isRed(_ rgb: (r: UInt8, g: UInt8, b: UInt8)) -> Bool {
+                    rgb.r > 200 && rgb.g < 120 && rgb.b < 120
+                }
+
+                func luma(_ rgb: (r: UInt8, g: UInt8, b: UInt8)) -> CGFloat {
+                    0.299 * CGFloat(rgb.r) + 0.587 * CGFloat(rgb.g) + 0.114 * CGFloat(rgb.b)
+                }
+
+                func lumas(x: Int, from startY: Int, through endY: Int) -> [CGFloat] {
+                    guard startY <= endY else { return [] }
+                    return (startY...endY).compactMap { y -> CGFloat? in
+                        let rgb = pixel(x: x, y: y)
+                        return isRed(rgb) ? nil : luma(rgb)
+                    }
+                }
+
+                if bpp >= 3 {
+                    let sampleFractions = [CGFloat(0.3), CGFloat(0.5), CGFloat(0.7)]
+                    let markerSearchStartPx = max(Int((marker.frame.minY - 24) * pxPerPt), 0)
+                    let markerSearchEndPx = min(Int((marker.frame.maxY + 24) * pxPerPt), cg.height - 1)
+                    let twelvePtPx = max(Int((12 * pxPerPt).rounded(.up)), 1)
+                    let fourPtPx = max(Int((4 * pxPerPt).rounded(.up)), 1)
+                    let sixteenPtPx = max(Int((16 * pxPerPt).rounded(.up)), 1)
+                    let twentyPtPx = max(Int((20 * pxPerPt).rounded(.up)), 1)
+                    let stepPx = max(Int(pxPerPt.rounded()), 1)
+                    var edgePositionsPx: [CGFloat] = []
+                    var markerBottomsPx: [CGFloat] = []
+                    var pixelEdgeSkipNote: String?
+                    var pixelEdgeFailure: String?
+
+                    for xFrac in sampleFractions {
+                        let xPx = min(Int(CGFloat(cg.width) * xFrac), cg.width - 1)
+                        let redRows = (markerSearchStartPx...markerSearchEndPx).filter { y in
+                            isRed(pixel(x: xPx, y: y))
+                        }
+                        guard let markerTopPx = redRows.first, let lastRedPx = redRows.last else {
+                            pixelEdgeFailure = "no red marker rows found at xFrac=\(xFrac)"
+                            break
+                        }
+
+                        let markerBottomPx = min(lastRedPx + 1, cg.height - 1)
+                        guard let lumaAbove = median(lumas(
+                            x: xPx,
+                            from: max(markerBottomPx - twelvePtPx, 0),
+                            through: max(markerTopPx - 1, 0)
+                        )),
+                              let lumaBelow = median(lumas(
+                                  x: xPx,
+                                  from: min(markerBottomPx + fourPtPx, cg.height - 1),
+                                  through: min(markerBottomPx + sixteenPtPx, cg.height - 1)
+                              )) else {
+                            pixelEdgeFailure = "insufficient non-red luma samples at xFrac=\(xFrac)"
+                            break
+                        }
+
+                        let contrast = abs(lumaAbove - lumaBelow)
+                        guard contrast >= 25 else {
+                            pixelEdgeSkipNote = "low luma contrast at xFrac=\(xFrac) contrast=\(contrast) above=\(lumaAbove) below=\(lumaBelow)"
+                            break
+                        }
+
+                        let midpointLuma = (lumaAbove + lumaBelow) / 2
+                        let scanStartPx = max(markerBottomPx - twelvePtPx, 0)
+                        let scanEndPx = min(markerBottomPx + twentyPtPx, cg.height - 1)
+                        let edgePx = stride(from: scanStartPx, through: scanEndPx, by: stepPx).first { y in
+                            let rgb = pixel(x: xPx, y: y)
+                            guard !isRed(rgb) else { return false }
+                            let rowLuma = luma(rgb)
+                            if lumaBelow >= lumaAbove {
+                                return rowLuma >= midpointLuma
+                            }
+                            return rowLuma <= midpointLuma
+                        }
+
+                        guard let edgePx else {
+                            pixelEdgeFailure = "no luma edge found at xFrac=\(xFrac) contrast=\(contrast) above=\(lumaAbove) below=\(lumaBelow)"
+                            break
+                        }
+
+                        edgePositionsPx.append(CGFloat(edgePx))
+                        markerBottomsPx.append(CGFloat(markerBottomPx))
+                        print("KBPIX-edge xFrac=\(xFrac) markerBottomPx=\(markerBottomPx) edgePx=\(edgePx) deltaPt=\((CGFloat(edgePx) - CGFloat(markerBottomPx)) / pxPerPt) lumaAbove=\(lumaAbove) lumaBelow=\(lumaBelow)")
+                    }
+
+                    if let pixelEdgeSkipNote {
+                        print("KBPIX-note skipping pixel-edge assertion: \(pixelEdgeSkipNote)")
+                    } else if let pixelEdgeFailure {
+                        XCTFail("settled pixel-edge measurement failed: \(pixelEdgeFailure)")
+                    } else if let medianEdgePx = median(edgePositionsPx),
+                              let medianMarkerBottomPx = median(markerBottomsPx) {
+                        let deltaPx = medianEdgePx - medianMarkerBottomPx
+                        XCTAssertLessThanOrEqual(
+                            abs(deltaPx),
+                            1.5 * pxPerPt,
+                            "settled visual keyboard edge is not flush with marker bottom (deltaPt=\(deltaPx / pxPerPt), edgePx=\(medianEdgePx), markerBottomPx=\(medianMarkerBottomPx))"
+                        )
+                    } else {
+                        XCTFail("settled pixel-edge measurement failed: incomplete edge samples")
+                    }
+                } else {
+                    XCTFail("settled pixel-edge measurement failed: unsupported screenshot bpp=\(bpp)")
+                }
             } else {
                 print("KBPIX unavailable")
             }
@@ -498,17 +617,15 @@ final class cmuxUITests: XCTestCase {
 
         print("KBEDGE summary settled=\(settledDeltas) midFlight=\(midFlightDeltas)")
         XCTAssertGreaterThanOrEqual(settledDeltas.count, 3, "never observed a settled keyboard-up state")
-        for delta in settledDeltas {
+        let allDeltas = settledDeltas + midFlightDeltas
+        if let minDelta = allDeltas.min(), let maxDelta = allDeltas.max() {
             XCTAssertLessThanOrEqual(
-                abs(delta), 1.5,
-                "settled dock edge is not pixel-aligned with the real keyboard top (delta=\(delta))"
+                maxDelta - minDelta,
+                1.5,
+                "dock edge is not rigidly attached to the keyboard visual panel (spread=\(maxDelta - minDelta), settled=\(settledDeltas), midFlight=\(midFlightDeltas))"
             )
-        }
-        for delta in midFlightDeltas {
-            XCTAssertLessThanOrEqual(
-                abs(delta), 3.0,
-                "mid-animation dock edge diverged from the real keyboard top (delta=\(delta))"
-            )
+        } else {
+            XCTFail("no coherent keyboard-edge samples were collected")
         }
     }
 


### PR DESCRIPTION
The iOS terminal's bottom dock (accessory toolbar + composer band) and render viewport animated on a replay of the keyboard notification's duration/curve (`UIView.animate` + presentation-frame sampling of the replayed toolbar animation). UIKit's keyboard runs on a private spring, so the replay drifts mid-flight (terminal edge visibly leads/lags the keyboard, worse when a show reverses into a hide), and interactive drag-dismiss was never tracked at all because it posts no frame-change notifications during the drag.

This PR switches to ground truth. An invisible anchor view is pinned to `keyboardLayoutGuide.topAnchor`; UIKit lays it out inside the actual keyboard animation transaction, so its presentation layer is the keyboard's true animated top edge at every instant, including interactive dismissal. Each display-link frame, `trackKeyboardDockPerFrame()` samples the anchor and frame-sets the toolbar, composer band, and render layer from that one sample (`TerminalViewportInputs.liveBottomOccupancy`), so the terminal edge matches the keyboard by construction. Tracking self-arms when the guide moves with no notification window (interactive dismiss), settles onto exact target math on convergence, and has a deadline fallback for a guide that never converges. The grid reservation (`layoutViewportRect`) still jumps once to the target height so the PTY resizes once per keyboard change, not per frame. When the keyboard is down the guide rests on the bottom safe-area edge, which is the identical quantity `keyboardOccupancy` already reserves, so one sampled value drives both steady states and every frame between them.

Tests:
- `TerminalLetterboxGeometryTests`: pure `sampledBottomOccupancy` contract + clamping (runs with `swift test`, passing locally).
- `TerminalKeyboardDockTrackingTests` (cmuxFeatureTests): scripted per-frame guide trajectories through the production notification observer and tick path, asserting the dock bottom and live viewport sit exactly on every sample while the grid target stays fixed, for show, hide, and notification-less interactive dismissal; plus a real-keyboard convergence test that skips when the simulator has a hardware keyboard connected.
- `cmuxUITests/testTerminalDockRidesRealKeyboardAnimation`: cycles the real simulator keyboard in the terminal layout preview and polls the dock probe (`kbTracking`/`kbGuideTop`/`toolbarMaxY`) mid-animation, asserting the dock never diverges from the sampled keyboard edge by more than 2pt across five transitions. Also serves as the interaction driver for the evidence video.

A two-commit red/green structure is not applicable: the old code has no per-frame keyboard ground truth to assert against (the probe fields and test seams only exist with the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785570377&installation_id=133855650&pr_number=7194&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7194&signature=815e0368b01dea7c3bf4deb844095cd6c5335071185cba83df4110c1ec669089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core iOS terminal layout, display-link geometry, and keyboard lifecycle; regressions would show as dock/keyboard misalignment or viewport jank, but behavior is heavily covered by new unit, feature, and UI tests.
> 
> **Overview**
> Replaces **keyboard height replay** (`UIView.animate` on notification duration/curve) with **per-frame sampling** of an anchor pinned to `keyboardLayoutGuide`. Each display-link tick, `TerminalKeyboardDockTracker` drives dock and live viewport from `liveBottomOccupancy` while the **grid reservation** still jumps once to the target height (single PTY resize).
> 
> **Geometry sync is deferred** while tracking is active so the render layer does not resize mid-animation (fixes content shooting off-screen). Interactive dismiss is covered by self-arming when the guide moves without a notification.
> 
> Removes `TerminalKeyboardHeightAnimation`; adds `sampledBottomOccupancy` in `TerminalLetterboxGeometry`, probe fields for UI tests, scripted feature tests, and UI tests for real-keyboard dock alignment plus an optional keyboard-edge marker for pixel checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb748e39ebe5b8c88488e7d09520eeed2a4ef964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tracks the real iOS keyboard animation with a `keyboardLayoutGuide`-pinned anchor so the dock and live viewport follow the keyboard every frame, including interactive dismiss. Holds geometry resizes until the dock settles to eliminate the “content shoots off-screen” jank.

- New Features
  - Per-frame sampling drives `liveBottomOccupancy`; the dock and live viewport ride the real keyboard while the grid target stays fixed (single PTY resize per change). Geometry sync is held while tracking; recorded via `kbMidTrackResizes` and asserted as zero in UI tests. Tracking self-arms on interactive dismiss, suspends in preview when a synthetic height is set, and snaps/cleans up on background or detach.
  - Probe fields/tests: `kbTracking`, `kbGuideTop`, `toolbarMaxY`, `kbApplyTicks`, `kbMaxDivergencePt`, `kbMidTrackResizes`; occupancy math tests; scripted show/hide/interactive dismiss; real-keyboard convergence; env-gated red keyboard-edge marker + pixel-alignment UI test that measures against the keyboard’s visual panel edge (luma), not the a11y frame, asserting mid-flight rigid attachment (spread ≤ 1.5pt) and settled alignment (≤ 1.5pt). Also logs a pixel scan of the dock-to-keyboard band to confirm no visual gap.

- Refactors
  - Extracts `TerminalKeyboardDockTracker`; removes `TerminalKeyboardHeightAnimation`. `GhosttySurfaceView` installs/ticks the tracker and settles/cancels on lifecycle events.
  - `TerminalViewportCoordinator` uses `liveBottomOccupancy` for dock placement and live viewport height during motion; falls back to target math at rest.

<sup>Written for commit fb748e39ebe5b8c88488e7d09520eeed2a4ef964. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal bottom-dock keyboard tracking using per-frame keyboard-edge measurement, improving alignment during keyboard show/hide and interactive dismissal.
  * Added “live bottom occupancy” support so the layout follows the keyboard’s moving edge in real time.

* **Bug Fixes**
  * Improved keyboard occupancy sampling and viewport/dock synchronization to prevent mid-transition layout jumps and reduce divergence.

* **Tests**
  * Added deterministic dock-tracking test coverage plus new UI/regression pixel-alignment checks; expanded unit tests for occupancy clamping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->