### PR TITLE
Make iOS terminal scrolling phone-owned (fix optimistic scroll jumps)

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
@@ -113,7 +113,8 @@ extension MobileShellComposite {
                 MobileTerminalOutputChunk(
                     data: immediate.bytes,
                     streamToken: streamToken,
-                    viewportPolicy: immediate.viewportPolicy
+                    viewportPolicy: immediate.viewportPolicy,
+                    isFullReplacement: immediate.isFullReplacement
                 )
             )
         }
@@ -159,7 +160,8 @@ extension MobileShellComposite {
         continuation.yield(MobileTerminalOutputChunk(
             data: next.bytes,
             streamToken: streamToken,
-            viewportPolicy: next.viewportPolicy
+            viewportPolicy: next.viewportPolicy,
+            isFullReplacement: next.isFullReplacement
         ))
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalScrollDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalScrollDelivery.swift
@@ -33,7 +33,7 @@ extension MobileShellComposite {
             ?? TerminalScrollbackPrefetchState()
         let delivery = TerminalScrollDelivery.forScrollGesture(
             surfaceID: surfaceID,
-            activeScreen: terminalActiveScreenBySurfaceID[surfaceID] ?? .primary,
+            activeScreen: terminalActiveScreenBySurfaceID[surfaceID],
             lines: lines,
             col: col,
             row: row,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalScrollDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalScrollDelivery.swift
@@ -8,11 +8,21 @@ private let terminalScrollDeliveryLog = Logger(
 )
 
 extension MobileShellComposite {
-    /// Forward a scroll gesture to the Mac's real surface. libghostty does the
-    /// mode-correct thing: normal screen moves the viewport into scrollback;
-    /// alt screen + mouse reporting encodes mouse-wheel to the PTY for the
-    /// program. The render-grid mirrors the result (it exports the live
-    /// `vp_top`).
+    /// Route a scroll gesture by active screen.
+    ///
+    /// Primary screen: the phone's local Ghostty mirror owns the viewport. The
+    /// Mac's real viewport is never scrolled from here; render-grid exports
+    /// follow the Mac's live `vp_top`, so scrolling it would repaint the
+    /// phone's grid with the Mac's scrolled viewport while the mirror is also
+    /// scrolled locally (the same gesture applied twice, drifting apart). The
+    /// RPC is used only to fetch scrollback history windows (`delta_lines = 0`,
+    /// which the Mac treats as a no-op scroll), and the mirror rebuilds from
+    /// the response while preserving its own scroll position.
+    ///
+    /// Alternate screen: libghostty needs the wheel on the real PTY
+    /// (vim/less/htop mouse reporting), so deltas are forwarded; the
+    /// display-only mirror drops its own wheel bytes and the Mac's render-grid
+    /// response is the visible update.
     ///
     /// Fire-and-forget and single-flight per surface. Native iOS scrolling can
     /// continue through deceleration after the finger lifts; while one RPC is
@@ -21,19 +31,21 @@ extension MobileShellComposite {
     public func scrollTerminal(surfaceID: String, lines: Double, col: Int, row: Int) async {
         var prefetchState = terminalScrollbackPrefetchStatesBySurfaceID[surfaceID]
             ?? TerminalScrollbackPrefetchState()
-        let maxScrollbackRows = prefetchState.rowsToPrefetch(forScrollLines: lines)
-        terminalScrollbackPrefetchStatesBySurfaceID[surfaceID] = prefetchState
-        enqueueTerminalScroll(TerminalScrollDelivery(
+        let delivery = TerminalScrollDelivery.forScrollGesture(
             surfaceID: surfaceID,
+            activeScreen: terminalActiveScreenBySurfaceID[surfaceID] ?? .primary,
             lines: lines,
             col: col,
             row: row,
-            maxScrollbackRows: maxScrollbackRows
-        ))
+            prefetchState: &prefetchState
+        )
+        terminalScrollbackPrefetchStatesBySurfaceID[surfaceID] = prefetchState
+        guard let delivery else { return }
+        enqueueTerminalScroll(delivery)
     }
 
     private func enqueueTerminalScroll(_ delivery: TerminalScrollDelivery) {
-        guard delivery.lines != 0 else { return }
+        guard delivery.lines != 0 || delivery.maxScrollbackRows != nil else { return }
         let queueToken = terminalScrollQueueTokensBySurfaceID[delivery.surfaceID] ?? UUID()
         terminalScrollQueueTokensBySurfaceID[delivery.surfaceID] = queueToken
         var queue = terminalScrollQueuesBySurfaceID[delivery.surfaceID] ?? TerminalScrollDeliveryQueue()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -720,7 +720,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var reportedViewportSizesByTerminalKey: [MobileTerminalViewportKey: MobileTerminalViewportSize]
     var deliveredTerminalByteEndSeqBySurfaceID: [String: UInt64]
     var pendingTerminalByteEndSeqBySurfaceID: [String: UInt64]
-    private var terminalActiveScreenBySurfaceID: [String: MobileTerminalRenderGridFrame.Screen]
+    var terminalActiveScreenBySurfaceID: [String: MobileTerminalRenderGridFrame.Screen]
     var terminalReplaySurfaceIDsInFlight: Set<String>
     private var terminalReplayRequestIDsInFlightBySurfaceID: [String: UUID]
     private var terminalReplayTasksBySurfaceID: [String: Task<Void, Never>]

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
@@ -53,6 +53,18 @@ struct TerminalOutputDelivery: Equatable, Sendable {
             frame.vtPatchBytes()
         }
     }
+
+    /// True when the payload replays a full render-grid snapshot, whose bytes
+    /// begin with an `ESC c` terminal reset. The apply side preserves the local
+    /// viewport scroll position across these.
+    var isFullReplacement: Bool {
+        switch payload {
+        case .bytes:
+            false
+        case .renderGrid(let frame):
+            frame.full
+        }
+    }
 }
 
 /// Backpressure queue for one mounted mobile terminal output stream.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalScrollDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalScrollDelivery.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import Foundation
 
 struct TerminalScrollDelivery: Equatable, Sendable {
@@ -25,18 +26,22 @@ struct TerminalScrollDelivery: Equatable, Sendable {
 struct TerminalScrollbackPrefetchState: Equatable, Sendable {
     static let defaultWindowRows = 600
     static let defaultRefreshDistanceRows = 120.0
+    static let defaultMaxWindowRows = 4800
 
     var windowRows: Int
     var refreshDistanceRows: Double
+    var maxWindowRows: Int
     private var hasPrimedWindow = false
     private var accumulatedRowsSincePrefetch = 0.0
 
     init(
         windowRows: Int = Self.defaultWindowRows,
-        refreshDistanceRows: Double = Self.defaultRefreshDistanceRows
+        refreshDistanceRows: Double = Self.defaultRefreshDistanceRows,
+        maxWindowRows: Int = Self.defaultMaxWindowRows
     ) {
         self.windowRows = max(0, windowRows)
         self.refreshDistanceRows = max(1, refreshDistanceRows)
+        self.maxWindowRows = max(self.windowRows, maxWindowRows)
     }
 
     mutating func rowsToPrefetch(forScrollLines lines: Double) -> Int? {
@@ -45,9 +50,48 @@ struct TerminalScrollbackPrefetchState: Equatable, Sendable {
         guard !hasPrimedWindow || accumulatedRowsSincePrefetch >= refreshDistanceRows else {
             return nil
         }
+        // Sustained scrolling into history pages the window deeper so the
+        // local mirror can keep going past the initial window; scrolling back
+        // toward the bottom refreshes at the current depth instead.
+        if hasPrimedWindow, lines > 0 {
+            windowRows = min(windowRows + Self.defaultWindowRows, maxWindowRows)
+        }
         hasPrimedWindow = true
         accumulatedRowsSincePrefetch = 0
         return windowRows
+    }
+}
+
+extension TerminalScrollDelivery {
+    /// Pure routing decision for a phone scroll gesture; nil means nothing is
+    /// sent to the Mac.
+    ///
+    /// Primary screen: the phone's local Ghostty mirror owns the viewport, so
+    /// no scroll delta is ever sent to the Mac; the only RPC is a
+    /// `delta_lines = 0` scrollback-window fetch when the prefetch state says
+    /// the local history needs (re)priming or deepening. Alternate screen: the
+    /// wheel must reach the real PTY, so the delta is forwarded unchanged.
+    static func forScrollGesture(
+        surfaceID: String,
+        activeScreen: MobileTerminalRenderGridFrame.Screen,
+        lines: Double,
+        col: Int,
+        row: Int,
+        prefetchState: inout TerminalScrollbackPrefetchState
+    ) -> TerminalScrollDelivery? {
+        guard activeScreen == .primary else {
+            return TerminalScrollDelivery(surfaceID: surfaceID, lines: lines, col: col, row: row)
+        }
+        guard let maxScrollbackRows = prefetchState.rowsToPrefetch(forScrollLines: lines) else {
+            return nil
+        }
+        return TerminalScrollDelivery(
+            surfaceID: surfaceID,
+            lines: 0,
+            col: col,
+            row: row,
+            maxScrollbackRows: maxScrollbackRows
+        )
     }
 }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalScrollDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalScrollDelivery.swift
@@ -71,27 +71,44 @@ extension TerminalScrollDelivery {
     /// `delta_lines = 0` scrollback-window fetch when the prefetch state says
     /// the local history needs (re)priming or deepening. Alternate screen: the
     /// wheel must reach the real PTY, so the delta is forwarded unchanged.
+    ///
+    /// Unknown screen (`nil`): no render grid has reported the mode yet, which
+    /// covers the first moments after attach and, permanently, legacy raw-byte
+    /// hosts that never send render grids. Route the legacy way (forward the
+    /// delta AND request prefetch) so an alternate-screen TUI never loses the
+    /// wheel; once a grid arrives the mode is known and phone-owned routing
+    /// takes over.
     static func forScrollGesture(
         surfaceID: String,
-        activeScreen: MobileTerminalRenderGridFrame.Screen,
+        activeScreen: MobileTerminalRenderGridFrame.Screen?,
         lines: Double,
         col: Int,
         row: Int,
         prefetchState: inout TerminalScrollbackPrefetchState
     ) -> TerminalScrollDelivery? {
-        guard activeScreen == .primary else {
+        switch activeScreen {
+        case .alternate:
             return TerminalScrollDelivery(surfaceID: surfaceID, lines: lines, col: col, row: row)
+        case nil:
+            return TerminalScrollDelivery(
+                surfaceID: surfaceID,
+                lines: lines,
+                col: col,
+                row: row,
+                maxScrollbackRows: prefetchState.rowsToPrefetch(forScrollLines: lines)
+            )
+        case .primary:
+            guard let maxScrollbackRows = prefetchState.rowsToPrefetch(forScrollLines: lines) else {
+                return nil
+            }
+            return TerminalScrollDelivery(
+                surfaceID: surfaceID,
+                lines: 0,
+                col: col,
+                row: row,
+                maxScrollbackRows: maxScrollbackRows
+            )
         }
-        guard let maxScrollbackRows = prefetchState.rowsToPrefetch(forScrollLines: lines) else {
-            return nil
-        }
-        return TerminalScrollDelivery(
-            surfaceID: surfaceID,
-            lines: 0,
-            col: col,
-            row: row,
-            maxScrollbackRows: maxScrollbackRows
-        )
     }
 }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalScrollDeliveryQueueTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalScrollDeliveryQueueTests.swift
@@ -109,6 +109,25 @@ import Testing
     #expect(prefetchState.rowsToPrefetch(forScrollLines: 1) == 600)
 }
 
+@Test func terminalScrollGestureRoutingKeepsLegacyForwardingWhileScreenUnknown() {
+    var prefetchState = TerminalScrollbackPrefetchState(windowRows: 600, refreshDistanceRows: 10)
+
+    let delivery = TerminalScrollDelivery.forScrollGesture(
+        surfaceID: "surface",
+        activeScreen: nil,
+        lines: 2,
+        col: 1,
+        row: 1,
+        prefetchState: &prefetchState
+    )
+
+    // No render grid has reported the screen mode (cold attach, or a legacy
+    // raw-bytes host that never sends one): forward the delta so alt-screen
+    // TUIs never lose the wheel, and still prime the local window.
+    #expect(delivery?.lines == 2)
+    #expect(delivery?.maxScrollbackRows == 600)
+}
+
 @Test func terminalScrollGestureRoutingKeepsPrimaryScreenDeltasLocal() {
     var prefetchState = TerminalScrollbackPrefetchState(windowRows: 600, refreshDistanceRows: 10)
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalScrollDeliveryQueueTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalScrollDeliveryQueueTests.swift
@@ -74,7 +74,67 @@ import Testing
     #expect(state.rowsToPrefetch(forScrollLines: 1) == 600)
     #expect(state.rowsToPrefetch(forScrollLines: 4) == nil)
     #expect(state.rowsToPrefetch(forScrollLines: -5.5) == nil)
-    #expect(state.rowsToPrefetch(forScrollLines: 0.5) == 600)
+    // Downward refresh keeps the current depth instead of paging deeper.
+    #expect(state.rowsToPrefetch(forScrollLines: -0.5) == 600)
+}
+
+@Test func terminalScrollbackPrefetchStatePagesDeeperOnSustainedUpwardScroll() {
+    var state = TerminalScrollbackPrefetchState(
+        windowRows: 600,
+        refreshDistanceRows: 10,
+        maxWindowRows: 1800
+    )
+
+    #expect(state.rowsToPrefetch(forScrollLines: 1) == 600)
+    #expect(state.rowsToPrefetch(forScrollLines: 10) == 1200)
+    #expect(state.rowsToPrefetch(forScrollLines: 10) == 1800)
+    // Capped at maxWindowRows.
+    #expect(state.rowsToPrefetch(forScrollLines: 10) == 1800)
+}
+
+@Test func terminalScrollGestureRoutingForwardsAlternateScreenDeltasUnchanged() {
+    var prefetchState = TerminalScrollbackPrefetchState(windowRows: 600, refreshDistanceRows: 10)
+
+    let delivery = TerminalScrollDelivery.forScrollGesture(
+        surfaceID: "surface",
+        activeScreen: .alternate,
+        lines: -3.5,
+        col: 7,
+        row: 9,
+        prefetchState: &prefetchState
+    )
+
+    #expect(delivery == TerminalScrollDelivery(surfaceID: "surface", lines: -3.5, col: 7, row: 9))
+    // Alternate screen never touches the primary-screen prefetch pacing.
+    #expect(prefetchState.rowsToPrefetch(forScrollLines: 1) == 600)
+}
+
+@Test func terminalScrollGestureRoutingKeepsPrimaryScreenDeltasLocal() {
+    var prefetchState = TerminalScrollbackPrefetchState(windowRows: 600, refreshDistanceRows: 10)
+
+    let primed = TerminalScrollDelivery.forScrollGesture(
+        surfaceID: "surface",
+        activeScreen: .primary,
+        lines: 2,
+        col: 1,
+        row: 1,
+        prefetchState: &prefetchState
+    )
+    // The first scroll primes the local scrollback window but sends no delta:
+    // the Mac's viewport must not move for a phone-local scroll.
+    #expect(primed?.lines == 0)
+    #expect(primed?.maxScrollbackRows == 600)
+
+    let followUp = TerminalScrollDelivery.forScrollGesture(
+        surfaceID: "surface",
+        activeScreen: .primary,
+        lines: 3,
+        col: 1,
+        row: 1,
+        prefetchState: &prefetchState
+    )
+    // Below the refresh distance there is nothing to send at all.
+    #expect(followUp == nil)
 }
 
 @Test func terminalScrollQueueResetDropsPendingWork() {

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalOutputSinking.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalOutputSinking.swift
@@ -24,15 +24,22 @@ public struct MobileTerminalOutputChunk: Sendable {
     public let data: Data
     public let streamToken: UUID
     public let viewportPolicy: MobileTerminalOutputViewportPolicy?
+    /// True when `data` replays a full render-grid snapshot (`ESC c` reset +
+    /// scrollback + viewport repaint). The consuming surface must preserve its
+    /// local scrollback scroll position across the apply so an authoritative
+    /// rebuild never moves the viewport the user is holding.
+    public let isFullReplacement: Bool
 
     public init(
         data: Data,
         streamToken: UUID,
-        viewportPolicy: MobileTerminalOutputViewportPolicy? = nil
+        viewportPolicy: MobileTerminalOutputViewportPolicy? = nil,
+        isFullReplacement: Bool = false
     ) {
         self.data = data
         self.streamToken = streamToken
         self.viewportPolicy = viewportPolicy
+        self.isFullReplacement = isFullReplacement
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -176,7 +176,9 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                         break
                     }
                     if !chunk.data.isEmpty {
-                        let applied = await surfaceView.processOutputAndWait(chunk.data)
+                        let applied = chunk.isFullReplacement
+                            ? await surfaceView.processFullReplacementOutputAndWait(chunk.data)
+                            : await surfaceView.processOutputAndWait(chunk.data)
                         guard applied else {
                             store.terminalOutputDidReset(
                                 surfaceID: surfaceID,

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/Debug/GhosttySurfaceView+BottomScrollStressDebug.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/Debug/GhosttySurfaceView+BottomScrollStressDebug.swift
@@ -25,13 +25,8 @@ extension GhosttySurfaceView {
         }
     }
 
-    @MainActor
-    func recordBottomScrollStressScrollbar(total: Int, offset: Int, len: Int) {
-        debugLastScrollbar = (total: total, offset: offset, len: len)
-    }
-
     var bottomScrollDebugScrollbarAtBottom: Bool {
-        guard let snapshot = debugLastScrollbar else { return false }
+        guard let snapshot = lastScrollbarSnapshot else { return false }
         return snapshot.total > snapshot.len && snapshot.offset >= max(0, snapshot.total - snapshot.len - 1)
     }
 }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
@@ -383,18 +383,18 @@ public final class GhosttyRuntime {
             return true
         }
 
-        #if DEBUG
         if action.tag == GHOSTTY_ACTION_SCROLLBAR {
             let sb = action.action.scrollbar
+            #if DEBUG
             MobileDebugLog.anchormux("scroll.bar total=\(sb.total) offset=\(sb.offset) len=\(sb.len)")
+            #endif
             if target.tag == GHOSTTY_TARGET_SURFACE, let surface = target.target.surface {
                 Task { @MainActor in
-                    GhosttySurfaceView.view(for: surface)?.recordBottomScrollStressScrollbar(total: Int(sb.total), offset: Int(sb.offset), len: Int(sb.len))
+                    GhosttySurfaceView.view(for: surface)?.recordScrollbarSnapshot(total: Int(sb.total), offset: Int(sb.offset), len: Int(sb.len))
                 }
             }
             return true
         }
-        #endif
 
         return false
     }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalScrollbackScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalScrollbackScroll.swift
@@ -22,5 +22,21 @@ extension GhosttySurfaceView {
         ghostty_surface_mouse_scroll(surface, 0, lines, 0)
         drawForWakeup()
     }
+
+    /// Row-exact viewport scroll on the local mirror via ghostty's
+    /// `scroll_page_lines` binding action. Unlike the wheel path above, this is
+    /// not subject to the discrete `mouse-scroll-multiplier` (3x by default),
+    /// so callers restoring a measured scrollbar offset get exactly that many
+    /// rows. Negative `lines` scroll upwards, into history.
+    func scrollLocalViewportRows(_ lines: Int) {
+        guard lines != 0, let surface else { return }
+        let action = "scroll_page_lines:\(lines)"
+        outputQueue.async {
+            action.withCString { pointer in
+                _ = ghostty_surface_binding_action(surface, pointer, UInt(action.utf8.count))
+            }
+        }
+        drawForWakeup()
+    }
 }
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalScrollbackScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalScrollbackScroll.swift
@@ -38,5 +38,50 @@ extension GhosttySurfaceView {
         }
         drawForWakeup()
     }
+
+    /// Record the mirror's Ghostty scrollbar geometry (`total` rows of
+    /// scrollback + screen, viewport `offset` from the top, viewport `len`),
+    /// fed by the runtime's `GHOSTTY_ACTION_SCROLLBAR` callback. The snapshot
+    /// is nil until the mirror first reports one, which only happens once
+    /// there is scrollback to scroll, so nil means "at bottom". The monotonic
+    /// update count lets a caller that just mutated the terminal distinguish a
+    /// fresh snapshot from the stale pre-mutation one.
+    @MainActor
+    func recordScrollbarSnapshot(total: Int, offset: Int, len: Int) {
+        lastScrollbarSnapshot = (total: total, offset: offset, len: len)
+        scrollbarUpdateCount += 1
+    }
+
+    /// How many rows the local mirror's viewport currently sits above the
+    /// scrollback bottom. 0 when pinned to the live bottom.
+    var scrollbackOffsetFromBottom: Int {
+        guard let snapshot = lastScrollbarSnapshot else { return 0 }
+        return max(0, snapshot.total - snapshot.len - snapshot.offset)
+    }
+
+    /// Apply a full render-grid replacement (bytes begin with an `ESC c`
+    /// terminal reset) while preserving the local viewport scroll position.
+    ///
+    /// Invariant: authoritative content rebuilds never move the phone-owned
+    /// viewport. The reset leaves the rebuilt mirror pinned to the bottom, so
+    /// when the viewport was scrolled into scrollback the same offset-from-
+    /// bottom is re-applied after the rebuild. At the bottom (offset 0, the
+    /// cold-attach case) this is a no-op and the surface stays pinned to live
+    /// output. The rebuilt scrollback carries the same trailing history, so
+    /// offset-from-bottom maps to the same content modulo output that arrived
+    /// since the snapshot was taken.
+    /// - Parameter data: Full-snapshot VT bytes to feed into the surface.
+    /// - Returns: `true` when the bytes reached the current surface generation,
+    ///   or `false` when the caller should reset its delivery queue and replay.
+    @discardableResult
+    public func processFullReplacementOutputAndWait(_ data: Data) async -> Bool {
+        let offsetFromBottom = scrollbackOffsetFromBottom
+        let applied = await processOutputAndWait(data)
+        guard applied else { return false }
+        if offsetFromBottom > 0 {
+            scrollLocalViewportRows(-offsetFromBottom)
+        }
+        return true
+    }
 }
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -747,7 +747,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// compose-button tap.
     fileprivate var lastComposerDockIntent: ComposerDockIntent?
 
-    var debugLastScrollbar: (total: Int, offset: Int, len: Int)?
     var debugBottomScrollStressPhase = "idle"
     var debugBottomViewportMismatchObserved = false
 
@@ -794,18 +793,43 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             // full height; the test compares the gap, not equality.
             "renderHeight=\(Int(lastRenderRect.height))",
             "boundsHeight=\(Int(bounds.height))",
-            "scrollTotal=\(debugLastScrollbar?.total ?? -1)", "scrollOffset=\(debugLastScrollbar?.offset ?? -1)",
-            "scrollLen=\(debugLastScrollbar?.len ?? -1)", "scrollAtBottom=\(debugScrollbarAtBottomForTesting ? 1 : 0)",
+            "scrollTotal=\(lastScrollbarSnapshot?.total ?? -1)", "scrollOffset=\(lastScrollbarSnapshot?.offset ?? -1)",
+            "scrollLen=\(lastScrollbarSnapshot?.len ?? -1)", "scrollAtBottom=\(debugScrollbarAtBottomForTesting ? 1 : 0)",
             "staleViewportObserved=\(debugBottomViewportMismatchObserved ? 1 : 0)",
             inputProxy.accessoryLayoutDiagnostics,
         ].joined(separator: ";")
     }
 
     private var debugScrollbarAtBottomForTesting: Bool {
-        guard let snapshot = debugLastScrollbar else { return false }
+        guard let snapshot = lastScrollbarSnapshot else { return false }
         return snapshot.total > snapshot.len && snapshot.offset >= max(0, snapshot.total - snapshot.len - 1)
     }
     #endif
+
+    /// Latest Ghostty scrollbar geometry for the local mirror: `total` rows of
+    /// scrollback + screen, the viewport's `offset` from the top, and the
+    /// viewport `len`. Fed by the runtime's `GHOSTTY_ACTION_SCROLLBAR` callback;
+    /// nil until the mirror first reports one (which only happens once there is
+    /// scrollback to scroll, so nil means "at bottom").
+    private(set) var lastScrollbarSnapshot: (total: Int, offset: Int, len: Int)?
+
+    /// Monotonic count of scrollbar callbacks, so a caller that just mutated
+    /// the terminal can distinguish a fresh ``lastScrollbarSnapshot`` from the
+    /// stale pre-mutation one.
+    private(set) var scrollbarUpdateCount = 0
+
+    @MainActor
+    func recordScrollbarSnapshot(total: Int, offset: Int, len: Int) {
+        lastScrollbarSnapshot = (total: total, offset: offset, len: len)
+        scrollbarUpdateCount += 1
+    }
+
+    /// How many rows the local mirror's viewport currently sits above the
+    /// scrollback bottom. 0 when pinned to the live bottom.
+    var scrollbackOffsetFromBottom: Int {
+        guard let snapshot = lastScrollbarSnapshot else { return 0 }
+        return max(0, snapshot.total - snapshot.len - snapshot.offset)
+    }
     private let snapshotFallbackView: UITextView = {
         let view = UITextView()
         view.backgroundColor = UIColor(red: 0x27/255.0, green: 0x28/255.0, blue: 0x22/255.0, alpha: 1)
@@ -2283,6 +2307,25 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 self?.completePendingOutputApply(id: operationID, returning: applied)
             }
         }
+    }
+
+    /// Apply a full render-grid replacement (bytes begin with an `ESC c`
+    /// terminal reset) while preserving the local viewport scroll position.
+    ///
+    /// Invariant: authoritative content rebuilds never move the phone-owned
+    /// viewport. The reset leaves the rebuilt mirror pinned to the bottom, so
+    /// when the viewport was scrolled into scrollback the same offset-from-
+    /// bottom is re-applied after the rebuild. At the bottom (offset 0, the
+    /// cold-attach case) this is a no-op and the surface stays pinned to live
+    /// output. The rebuilt scrollback carries the same trailing history, so
+    /// offset-from-bottom maps to the same content modulo output that arrived
+    /// since the snapshot was taken.
+    /// - Parameter data: Full-snapshot VT bytes to feed into the surface.
+    /// - Returns: `true` when the bytes reached the current surface generation,
+    ///   or `false` when the caller should reset its delivery queue and replay.
+    @discardableResult
+    public func processFullReplacementOutputAndWait(_ data: Data) async -> Bool {
+        await processOutputAndWait(data)
     }
 
     private func makeSurfaceOperationID() -> UInt64 {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -806,30 +806,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
     #endif
 
-    /// Latest Ghostty scrollbar geometry for the local mirror: `total` rows of
-    /// scrollback + screen, the viewport's `offset` from the top, and the
-    /// viewport `len`. Fed by the runtime's `GHOSTTY_ACTION_SCROLLBAR` callback;
-    /// nil until the mirror first reports one (which only happens once there is
-    /// scrollback to scroll, so nil means "at bottom").
-    private(set) var lastScrollbarSnapshot: (total: Int, offset: Int, len: Int)?
-
-    /// Monotonic count of scrollbar callbacks, so a caller that just mutated
-    /// the terminal can distinguish a fresh ``lastScrollbarSnapshot`` from the
-    /// stale pre-mutation one.
-    private(set) var scrollbarUpdateCount = 0
-
-    @MainActor
-    func recordScrollbarSnapshot(total: Int, offset: Int, len: Int) {
-        lastScrollbarSnapshot = (total: total, offset: offset, len: len)
-        scrollbarUpdateCount += 1
-    }
-
-    /// How many rows the local mirror's viewport currently sits above the
-    /// scrollback bottom. 0 when pinned to the live bottom.
-    var scrollbackOffsetFromBottom: Int {
-        guard let snapshot = lastScrollbarSnapshot else { return 0 }
-        return max(0, snapshot.total - snapshot.len - snapshot.offset)
-    }
+    /// Latest Ghostty scrollbar geometry plus a monotonic callback count for
+    /// the local mirror; owned here because extensions cannot store state. All
+    /// behavior lives in `GhosttySurfaceView+LocalScrollbackScroll.swift`.
+    var lastScrollbarSnapshot: (total: Int, offset: Int, len: Int)?
+    var scrollbarUpdateCount = 0
     private let snapshotFallbackView: UITextView = {
         let view = UITextView()
         view.backgroundColor = UIColor(red: 0x27/255.0, green: 0x28/255.0, blue: 0x22/255.0, alpha: 1)
@@ -2307,31 +2288,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 self?.completePendingOutputApply(id: operationID, returning: applied)
             }
         }
-    }
-
-    /// Apply a full render-grid replacement (bytes begin with an `ESC c`
-    /// terminal reset) while preserving the local viewport scroll position.
-    ///
-    /// Invariant: authoritative content rebuilds never move the phone-owned
-    /// viewport. The reset leaves the rebuilt mirror pinned to the bottom, so
-    /// when the viewport was scrolled into scrollback the same offset-from-
-    /// bottom is re-applied after the rebuild. At the bottom (offset 0, the
-    /// cold-attach case) this is a no-op and the surface stays pinned to live
-    /// output. The rebuilt scrollback carries the same trailing history, so
-    /// offset-from-bottom maps to the same content modulo output that arrived
-    /// since the snapshot was taken.
-    /// - Parameter data: Full-snapshot VT bytes to feed into the surface.
-    /// - Returns: `true` when the bytes reached the current surface generation,
-    ///   or `false` when the caller should reset its delivery queue and replay.
-    @discardableResult
-    public func processFullReplacementOutputAndWait(_ data: Data) async -> Bool {
-        let offsetFromBottom = scrollbackOffsetFromBottom
-        let applied = await processOutputAndWait(data)
-        guard applied else { return false }
-        if offsetFromBottom > 0 {
-            scrollLocalViewportRows(-offsetFromBottom)
-        }
-        return true
     }
 
     private func makeSurfaceOperationID() -> UInt64 {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2325,7 +2325,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     ///   or `false` when the caller should reset its delivery queue and replay.
     @discardableResult
     public func processFullReplacementOutputAndWait(_ data: Data) async -> Bool {
-        await processOutputAndWait(data)
+        let offsetFromBottom = scrollbackOffsetFromBottom
+        let applied = await processOutputAndWait(data)
+        guard applied else { return false }
+        if offsetFromBottom > 0 {
+            scrollLocalViewportRows(-offsetFromBottom)
+        }
+        return true
     }
 
     private func makeSurfaceOperationID() -> UInt64 {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileBottomScrollStressCoordinator.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileBottomScrollStressCoordinator.swift
@@ -7,7 +7,13 @@ import UIKit
 @MainActor
 final class MobileBottomScrollStressCoordinator: NSObject, GhosttySurfaceViewDelegate {
     weak var surfaceView: GhosttySurfaceView?
+    private let scenario: MobileBottomScrollStressScenario
     private var task: Task<Void, Never>?
+
+    init(scenario: MobileBottomScrollStressScenario = .composerShrink) {
+        self.scenario = scenario
+        super.init()
+    }
 
     deinit {
         task?.cancel()
@@ -16,8 +22,82 @@ final class MobileBottomScrollStressCoordinator: NSObject, GhosttySurfaceViewDel
     func start() {
         task = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.runScenario()
+            switch self.scenario {
+            case .composerShrink:
+                await self.runScenario()
+            case .fullReplayOffset:
+                await self.runFullReplayOffsetScenario()
+            }
         }
+    }
+
+    /// Repro for the "authoritative rebuild snaps the viewport to bottom" bug:
+    /// seed scrollback, scroll the local mirror up into it, then apply a full
+    /// `ESC c` snapshot the way an authoritative render-grid replay does. The
+    /// phone-owned scroll position must survive the rebuild; ending phase is
+    /// `done` when the offset is preserved and `regressed` when the rebuild
+    /// moved the viewport.
+    private func runFullReplayOffsetScenario() async {
+        guard let view = surfaceView else { return }
+        view.setBottomScrollStressPhase("mount")
+        guard await waitForMountedSurface(view) else { return }
+
+        view.setBottomScrollStressPhase("seed")
+        _ = await view.processOutputAndWait(Data(Self.fullReplaySeedText(terminated: true).utf8))
+
+        view.setBottomScrollStressPhase("bottom")
+        view.scrollToBottomForBottomScrollStress()
+        guard await waitUntil(timeoutNanoseconds: 2_000_000_000, {
+            view.isBottomScrollStressAtBottom
+        }) else {
+            view.setBottomScrollStressPhase("timeout")
+            return
+        }
+
+        view.setBottomScrollStressPhase("scrollback")
+        view.applyLocalScrollbackScroll(lines: 60, col: 0, row: 0)
+        guard await waitUntil(timeoutNanoseconds: 2_000_000_000, {
+            view.scrollbackOffsetFromBottom >= 40
+        }) else {
+            view.setBottomScrollStressPhase("timeout")
+            return
+        }
+        let preOffset = view.scrollbackOffsetFromBottom
+        let scrollbarUpdatesBeforeReplay = view.scrollbarUpdateCount
+
+        view.setBottomScrollStressPhase("replay")
+        var replay = "\u{1B}c"
+        replay += Self.fullReplaySeedText(terminated: false)
+        _ = await view.processFullReplacementOutputAndWait(Data(replay.utf8))
+
+        // The cached scrollbar still reports the pre-replay geometry until the
+        // rebuilt terminal renders, so judging the offset immediately would
+        // trivially pass. Require at least one post-replay scrollbar callback
+        // before trusting the reading.
+        guard await waitUntil(timeoutNanoseconds: 4_000_000_000, {
+            view.scrollbarUpdateCount > scrollbarUpdatesBeforeReplay
+        }) else {
+            view.setBottomScrollStressPhase("timeout")
+            return
+        }
+        let preserved = await waitUntil(timeoutNanoseconds: 2_000_000_000) {
+            let offset = view.scrollbackOffsetFromBottom
+            return view.scrollbarUpdateCount > scrollbarUpdatesBeforeReplay
+                && offset > 0
+                && abs(offset - preOffset) <= 5
+        }
+        view.setBottomScrollStressPhase(preserved ? "done" : "regressed")
+    }
+
+    private static func fullReplaySeedText(terminated: Bool) -> String {
+        var text = ""
+        for i in 1...260 {
+            text += String(format: "full-replay-repro line %03d", i)
+            if i < 260 || terminated {
+                text += "\r\n"
+            }
+        }
+        return text
     }
 
     func stop() {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileBottomScrollStressRepresentable.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileBottomScrollStressRepresentable.swift
@@ -3,8 +3,10 @@ import SwiftUI
 import UIKit
 
 struct MobileBottomScrollStressRepresentable: UIViewRepresentable {
+    let scenario: MobileBottomScrollStressScenario
+
     func makeCoordinator() -> MobileBottomScrollStressCoordinator {
-        MobileBottomScrollStressCoordinator()
+        MobileBottomScrollStressCoordinator(scenario: scenario)
     }
 
     func makeUIView(context: Context) -> UIView {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileBottomScrollStressView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileBottomScrollStressView.swift
@@ -1,14 +1,27 @@
 #if canImport(UIKit) && DEBUG
 import SwiftUI
 
-/// DEBUG repro harness for the bottom-scroll viewport-shrink bug.
+/// Which bottom-scroll stress scenario the harness drives.
+public enum MobileBottomScrollStressScenario: Sendable {
+    /// Composer/keyboard viewport shrink while pinned to scrollback bottom.
+    case composerShrink
+    /// Authoritative full-replay (`ESC c` snapshot) applied while the viewport
+    /// is scrolled into scrollback; the scroll position must survive.
+    case fullReplayOffset
+}
+
+/// DEBUG repro harness for bottom-scroll viewport bugs.
 public struct MobileBottomScrollStressView: View {
+    private let scenario: MobileBottomScrollStressScenario
+
     /// Creates the bottom-scroll stress harness view.
-    public init() {}
+    public init(scenario: MobileBottomScrollStressScenario = .composerShrink) {
+        self.scenario = scenario
+    }
 
     /// The mounted stress harness.
     public var body: some View {
-        MobileBottomScrollStressRepresentable()
+        MobileBottomScrollStressRepresentable(scenario: scenario)
             .ignoresSafeArea()
             .background(Color.black)
     }

--- a/Sources/TerminalController+MobileScrollPrefetch.swift
+++ b/Sources/TerminalController+MobileScrollPrefetch.swift
@@ -8,9 +8,12 @@ extension TerminalController {
     /// the Mac remains authoritative.
     nonisolated static let mobileReplayScrollbackLineBudget = 240
 
-    /// Larger history window returned only on explicit mobile scroll prefetch
-    /// requests, keeping ordinary scroll RPCs small.
-    nonisolated static let mobileScrollPrefetchScrollbackLineBudget = 600
+    /// Cap on the history window returned for explicit mobile scroll prefetch
+    /// requests. The phone starts at a small window and pages deeper as the
+    /// user keeps scrolling into history (`TerminalScrollbackPrefetchState`),
+    /// so ordinary scrolls stay small and only sustained deep scrolls approach
+    /// this cap.
+    nonisolated static let mobileScrollPrefetchScrollbackLineBudget = 4800
 
     func mobileTerminalRenderGridFrame(
         terminalPanel: TerminalPanel,

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -53,7 +53,8 @@ The top entry's version MUST equal the checked-in `MARKETING_VERSION` in
 - Sign-out is local-first and works offline; revocation is best-effort and bounded (#5776).
 - Workspace list: groups, unread dots, last-activity previews, shared Unread filter (#5726).
 - Watchdog fix: render-grid liveness probes before teardown, fixing a false-fire replay loop (#5869).
-- Dogfood focus: hit the composer (send + drafts), View as Text, pair a Mac via the new QR, lock the phone and confirm a forwarded notification taps through to the right workspace, sign out with airplane mode on.
+- Terminal scroll rework: the phone now owns the primary-screen viewport. Scrolling no longer moves the Mac's viewport, scrollback prefetch rebuilds keep your scroll position instead of snapping to the bottom, and sustained scrolling pages deeper history (up to 4800 rows). Alt-screen TUIs (vim/less/htop) still forward the wheel to the Mac.
+- Dogfood focus: hit the composer (send + drafts), View as Text, pair a Mac via the new QR, lock the phone and confirm a forwarded notification taps through to the right workspace, sign out with airplane mode on. For scrolling: flick up hard mid-output and confirm no snap-to-bottom jumps, no duplicated rows, and the Mac's own terminal view does not scroll while you scroll on the phone.
 
 ### External
 

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -239,6 +239,8 @@ public struct CMUXMobileRootScene: View {
             MobileZoomStressView()
         } else if ProcessInfo.processInfo.environment["CMUX_BOTTOM_SCROLL_STRESS"] == "1" {
             MobileBottomScrollStressView()
+        } else if ProcessInfo.processInfo.environment["CMUX_FULL_REPLAY_SCROLL_STRESS"] == "1" {
+            MobileBottomScrollStressView(scenario: .fullReplayOffset)
         } else {
             CMUXMobileAppView(store: makeStore(), onboardingStore: onboardingStore)
         }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -324,6 +324,23 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
+    func testScrollbackPositionSurvivesAuthoritativeFullReplay() throws {
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_FULL_REPLAY_SCROLL_STRESS": "1",
+        ])
+        XCTAssertTrue(app.otherElements["MobileTerminalSurface"].waitForExistence(timeout: 8))
+
+        let dock = waitForDock(in: app, timeout: 12, describe: "full-replay scroll stress completed") {
+            $0["bottomStressPhase"] == "done" || $0["bottomStressPhase"] == "regressed"
+        }
+        XCTAssertEqual(
+            dock["bottomStressPhase"],
+            "done",
+            "Authoritative full replay must not move the phone-owned scrollback viewport. dock=\(dock)"
+        )
+    }
+
+    @MainActor
     func testWorkspaceToolbarCreatesWorkspaceAndTerminal() async throws {
         let server = try MobileSyncMockHostServer()
         let port = try await server.start()


### PR DESCRIPTION
## Summary

iOS optimistic scroll (https://github.com/manaflow-ai/cmux/pull/6067) had three unreconciled viewport owners: the phone's UIScrollView delta stream, the phone's local Ghostty mirror, and the Mac's real viewport (which the scroll RPC also moved). Render-grid exports follow the Mac's live `vp_top` (`ghostty/src/apprt/embedded.zig`), so every phone gesture was applied twice: the mirror scrolled locally over stale prefetched history while the Mac's scrolled viewport repainted the mirror's hidden screen rows, and the two offsets drifted apart on clamping and coalescing. On top of that, scrollback prefetch responses arrive as full `ESC c` snapshots that reset the mirror and snapped the viewport to the bottom mid-drag.

This makes the phone the single owner of the primary-screen viewport and the Mac the single owner of content:

- `TerminalScrollRouting` (new, pure): primary-screen gestures send NO scroll delta to the Mac; the RPC is only used to fetch history windows (`delta_lines=0`, already a no-op scroll on the Mac, so old hosts are compatible). Alternate screen still forwards wheel deltas to the real PTY for TUIs.
- Full render-grid replays now go through `GhosttySurfaceView.processFullReplacementOutputAndWait`, which captures the mirror's scrollback offset-from-bottom before the `ESC c` rebuild and re-applies it after via the row-exact `scroll_page_lines` binding action (the wheel path is subject to the 3x discrete `mouse-scroll-multiplier` and would overshoot). Invariant: an authoritative content rebuild never moves the phone-owned viewport. At the bottom (cold attach) it is a no-op.
- Sustained scrolling into history pages the prefetch window deeper (600 rows per refresh); the Mac-side prefetch cap rises from 600 to 4800 rows.
- The mirror's Ghostty scrollbar geometry (`GHOSTTY_ACTION_SCROLLBAR`) plus a monotonic update counter are now recorded in all builds (was DEBUG-only) to drive the offset restore.

## Red/green (simulator-verified locally)

- Red `1455fe519d`: `CMUX_FULL_REPLAY_SCROLL_STRESS` harness + `cmuxUITests/testScrollbackPositionSurvivesAuthoritativeFullReplay`. The harness requires a post-replay scrollbar callback before judging, so the stale cached geometry cannot produce a false pass. Verified failing on iPhone 17 Pro sim: dock shows `scrollAtBottom=1`, `bottomStressPhase=regressed` (replay snapped the viewport to the bottom).
- Green `75acd90510`: offset capture/restore. Verified passing on the same sim.

## Testing

- `swift test --package-path Packages/iOS/CmuxMobileShell` passed (incl. new `TerminalScrollRouting` + prefetch paging tests)
- iOS sim compile checks: `CmuxMobileTerminal`, `CmuxMobileShellUI`, `ios/cmuxPackage` build for `arm64-apple-ios26.0-simulator`
- New XCUITest run locally red→green as above (`CMUX_ALLOW_LOCAL_TEST=1`, isolated derived data)

## Localization

No user-facing strings changed (debug harness phases and test identifiers only); no localization updates needed.

## Related

- https://github.com/manaflow-ai/cmux/pull/6067 (optimistic scroll feature)
- https://github.com/manaflow-ai/cmux/pull/7153 (bottom-scroll anchoring, scrollbar bridge this reuses)
- https://github.com/manaflow-ai/cmux/issues/7160 (same family: viewport-relative repaints compositing rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core mobile terminal scroll routing, Mac RPC semantics, and viewport apply path for full snapshots—high interaction surface but well-tested and scoped to iOS shell/terminal layers.
> 
> **Overview**
> **Primary-screen scrolling** no longer forwards wheel deltas to the Mac. `TerminalScrollDelivery.forScrollGesture` routes by `activeScreen`: primary sends `delta_lines = 0` RPCs only when scrollback prefetch needs priming or deepening; alternate still forwards deltas for TUI mouse reporting; unknown screen keeps legacy forward+delta behavior until a render grid reports the mode. Prefetch windows **page deeper** on sustained upward scroll (capped at 4800 rows on Mac and phone).
> 
> **Full render-grid snapshots** (`ESC c`) are flagged with `isFullReplacement` on `MobileTerminalOutputChunk` and applied via `processFullReplacementOutputAndWait`, which saves scrollback offset-from-bottom from Ghostty scrollbar callbacks and restores it with row-exact `scroll_page_lines` after the rebuild so authoritative prefetch/replay does not snap the viewport to the bottom mid-gesture.
> 
> Scrollbar geometry is recorded in all builds (not DEBUG-only) to drive that restore. New unit tests cover routing and prefetch paging; a DEBUG/UI test harness covers full-replay offset preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 142dc3dededb605e094259ae376bd64b3359c2ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal output handling so full refreshes preserve your current scroll position instead of snapping.
  * Deeper scrollback prefetching (up to 4800 rows) for smoother long scrolling.
  * Improved scroll routing across primary vs alternate terminal screens, including proper wheel behavior.

* **Bug Fixes**
  * Fixed scrollback viewport regressions during authoritative full replay.
  * Ensured scrollback-prefetch-only operations still run when needed.

* **Tests**
  * Added UI and unit coverage for scrollback preservation, prefetch pacing, and full-replay correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->