### PR TITLE
Add Find Restores Last Search setting for find-bar recovery

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
@@ -159,6 +159,12 @@ public struct AppCatalogSection: SettingCatalogSection {
         userDefaultsKey: "commandPalette.switcherSearchAllSurfaces"
     )
 
+    public let findRestoresLastSearch = DefaultsKey<Bool>(
+        id: "app.findRestoresLastSearch",
+        defaultValue: true,
+        userDefaultsKey: "find.restoresLastSearch"
+    )
+
     public let fileDropDefaultBehavior = DefaultsKey<FileDropDefaultBehavior>(
         id: "app.fileDropDefaultBehavior",
         defaultValue: .text,

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -55,6 +55,13 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .app, id: "palette-search-all", title: "Command Palette Searches All Surfaces", synonyms: "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown"),
             .init(
                 section: .app,
+                id: "find-restores-last-search",
+                title: String(localized: "settings.app.findRestoresLastSearch", defaultValue: "Find Restores Last Search"),
+                paths: ["app.findRestoresLastSearch"],
+                synonyms: "app.findRestoresLastSearch find restore last search previous cmd-f clear empty needle terminal browser"
+            ),
+            .init(
+                section: .app,
                 id: "canvas-pane-gap",
                 title: String(localized: "settings.app.canvasPaneGap", defaultValue: "Canvas Pane Gap"),
                 paths: ["canvas.paneGap"],

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -62,6 +62,7 @@ public struct AppSection: View {
     @State private var hideCloseButton: DefaultsValueModel<Bool>
     @State private var renameSelects: DefaultsValueModel<Bool>
     @State private var paletteAllSurfaces: DefaultsValueModel<Bool>
+    @State private var findRestoresLastSearch: DefaultsValueModel<Bool>
 
     @State private var languageAtAppear: AppLanguage?
     @State private var telemetryAtAppear: Bool?
@@ -112,6 +113,7 @@ public struct AppSection: View {
         _hideCloseButton = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.hideTabCloseButton))
         _renameSelects = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.renameSelectsExistingName))
         _paletteAllSurfaces = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.commandPaletteSearchesAllSurfaces))
+        _findRestoresLastSearch = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.findRestoresLastSearch))
     }
 
     private static let columnWidth: CGFloat = 196
@@ -134,7 +136,7 @@ public struct AppSection: View {
             mainCard
         }
         .task {
-            startSettingsObservation([language, appearance, appIcon, placement, inheritDir, minimalMode, keepWorkspaceOpen, firstClick, fileDrop, preferredEditor, openSupported, openMarkdown, globalFontMagnification, markdownFontSize, markdownFontFamily, markdownMaxWidth, canvasPaneGap, canvasSnapping, fileEditorWordWrap, iMessage, reorder, dockBadge, menuBarOnly, showInMenuBar, paneRing, paneFlash, agentPermissionPrompt, agentTurnComplete, agentIdleReminder, soundName, soundCommand, customSoundFile, telemetry, confirmQuit, warnCloseTab, warnCloseX, hideCloseButton, renameSelects, paletteAllSurfaces])
+            startSettingsObservation([language, appearance, appIcon, placement, inheritDir, minimalMode, keepWorkspaceOpen, firstClick, fileDrop, preferredEditor, openSupported, openMarkdown, globalFontMagnification, markdownFontSize, markdownFontFamily, markdownMaxWidth, canvasPaneGap, canvasSnapping, fileEditorWordWrap, iMessage, reorder, dockBadge, menuBarOnly, showInMenuBar, paneRing, paneFlash, agentPermissionPrompt, agentTurnComplete, agentIdleReminder, soundName, soundCommand, customSoundFile, telemetry, confirmQuit, warnCloseTab, warnCloseX, hideCloseButton, renameSelects, paletteAllSurfaces, findRestoresLastSearch])
             if languageAtAppear == nil { languageAtAppear = language.current }; if telemetryAtAppear == nil { telemetryAtAppear = telemetry.current }
         }
     }
@@ -757,6 +759,21 @@ public struct AppSection: View {
                     .labelsHidden()
                     .controlSize(.small)
                     .accessibilityIdentifier("CommandPaletteSearchAllSurfacesToggle")
+            }
+            SettingsCardDivider()
+
+            // Find Restores Last Search
+            SettingsCardRow(
+                configurationReview: .json("app.findRestoresLastSearch"),
+                String(localized: "settings.app.findRestoresLastSearch", defaultValue: "Find Restores Last Search"),
+                subtitle: findRestoresLastSearch.current
+                    ? String(localized: "settings.app.findRestoresLastSearch.subtitleOn", defaultValue: "Find reopens with the previous search text selected.")
+                    : String(localized: "settings.app.findRestoresLastSearch.subtitleOff", defaultValue: "Find always opens with an empty search field.")
+            ) {
+                Toggle("", isOn: Binding(get: { findRestoresLastSearch.current }, set: { findRestoresLastSearch.set($0) }))
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .accessibilityIdentifier("FindRestoresLastSearchToggle")
             }
         }
     }

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -38,6 +38,7 @@ struct SettingsRowAnchorResolutionTests {
     static let rowConfigPaths: [String] = [
         "app.commandPaletteSearchesAllSurfaces",
         "app.confirmQuit",
+        "app.findRestoresLastSearch",
         "app.focusPaneOnFirstClick",
         "app.globalFontMagnification",
         "app.hideTabCloseButton",

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Bonsplit
 import CmuxCommandPalette
+import CmuxSettings
 import Foundation
 import CmuxTerminal
 
@@ -524,6 +525,27 @@ func shouldRouteTerminalFontZoomShortcutToGhostty(
         literalChars: literalChars
     ) != nil
 }
+/// What a newly opened find bar starts with. Shared by the terminal and
+/// browser find entrypoints so Cmd+F recovery stays consistent across
+/// surfaces and honors `app.findRestoresLastSearch`.
+struct FindSearchRecovery: Equatable {
+    var needle: String
+    var selectAll: Bool
+}
+
+func recoveredFindSearch(
+    startsNewSearchSession: Bool,
+    lastNeedle: String,
+    defaults: UserDefaults = .standard
+) -> FindSearchRecovery {
+    let key = AppCatalogSection().findRestoresLastSearch
+    let restoresLastSearch = defaults.object(forKey: key.userDefaultsKey) as? Bool ?? key.defaultValue
+    guard startsNewSearchSession, restoresLastSearch, !lastNeedle.isEmpty else {
+        return FindSearchRecovery(needle: "", selectAll: false)
+    }
+    return FindSearchRecovery(needle: lastNeedle, selectAll: true)
+}
+
 // Main-actor isolated: TerminalSurface.searchState carries the legacy
 // main-thread-only contract as compiler-enforced isolation after the
 // CmuxTerminal lift; both callers (TabManager, overlay tests) are @MainActor.

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -531,19 +531,19 @@ func shouldRouteTerminalFontZoomShortcutToGhostty(
 struct FindSearchRecovery: Equatable {
     var needle: String
     var selectAll: Bool
-}
 
-func recoveredFindSearch(
-    startsNewSearchSession: Bool,
-    lastNeedle: String,
-    defaults: UserDefaults = .standard
-) -> FindSearchRecovery {
-    let key = AppCatalogSection().findRestoresLastSearch
-    let restoresLastSearch = defaults.object(forKey: key.userDefaultsKey) as? Bool ?? key.defaultValue
-    guard startsNewSearchSession, restoresLastSearch, !lastNeedle.isEmpty else {
-        return FindSearchRecovery(needle: "", selectAll: false)
+    static func resolve(
+        startsNewSearchSession: Bool,
+        lastNeedle: String,
+        defaults: UserDefaults = .standard
+    ) -> FindSearchRecovery {
+        let key = AppCatalogSection().findRestoresLastSearch
+        let restoresLastSearch = defaults.object(forKey: key.userDefaultsKey) as? Bool ?? key.defaultValue
+        guard startsNewSearchSession, restoresLastSearch, !lastNeedle.isEmpty else {
+            return FindSearchRecovery(needle: "", selectAll: false)
+        }
+        return FindSearchRecovery(needle: lastNeedle, selectAll: true)
     }
-    return FindSearchRecovery(needle: lastNeedle, selectAll: true)
 }
 
 // Main-actor isolated: TerminalSurface.searchState carries the legacy

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -131,6 +131,10 @@ enum AppSettingsFileMapping {
             jsonKey: "commandPaletteSearchesAllSurfaces",
             defaultsKey: app.commandPaletteSearchesAllSurfaces.userDefaultsKey
         ),
+        .init(
+            jsonKey: "findRestoresLastSearch",
+            defaultsKey: app.findRestoresLastSearch.userDefaultsKey
+        ),
     ]
 
     static let stringSettings: [SettingsFileStringMapping] = [
@@ -362,6 +366,7 @@ extension CmuxSettingsFileStore {
         "app.hideTabCloseButton",
         "app.renameSelectsExistingName",
         "app.commandPaletteSearchesAllSurfaces",
+        "app.findRestoresLastSearch",
         "workspaceGroups.newWorkspacePlacement",
         "terminal.showScrollBar",
         "terminal.scrollSpeed",

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -80,6 +80,7 @@ extension CmuxSettingsFileStore {
                     "hideTabCloseButton": AppCatalogSection().hideTabCloseButton.defaultValue,
                     "renameSelectsExistingName": AppCatalogSection().renameSelectsExistingName.defaultValue,
                     "commandPaletteSearchesAllSurfaces": AppCatalogSection().commandPaletteSearchesAllSurfaces.defaultValue,
+                    "findRestoresLastSearch": AppCatalogSection().findRestoresLastSearch.defaultValue,
                 ],
             ],
             [

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -7417,9 +7417,9 @@ extension BrowserPanel {
         clearBrowserFocusMode(reason: "startFind")
         preferredFocusIntent = .findField
         let created = searchState == nil
-        let recoveredNeedle = created ? lastSearchNeedle : ""
-        if created { searchState = BrowserSearchState(needle: recoveredNeedle) }
-        let shouldSelectAll = created && !recoveredNeedle.isEmpty
+        let recovery = recoveredFindSearch(startsNewSearchSession: created, lastNeedle: lastSearchNeedle)
+        if created { searchState = BrowserSearchState(needle: recovery.needle) }
+        let shouldSelectAll = recovery.selectAll
         pendingAddressBarFocusRequestId = nil
         pendingAddressBarFocusSelectionIntent = .preserveFieldEditorSelection
         NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: id)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -7417,7 +7417,7 @@ extension BrowserPanel {
         clearBrowserFocusMode(reason: "startFind")
         preferredFocusIntent = .findField
         let created = searchState == nil
-        let recovery = recoveredFindSearch(startsNewSearchSession: created, lastNeedle: lastSearchNeedle)
+        let recovery = FindSearchRecovery.resolve(startsNewSearchSession: created, lastNeedle: lastSearchNeedle)
         if created { searchState = BrowserSearchState(needle: recovery.needle) }
         let shouldSelectAll = recovery.selectAll
         pendingAddressBarFocusRequestId = nil

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -369,6 +369,7 @@ enum SettingsSearchIndex {
         ),
         setting(.app, "rename-selects-name", String(localized: "settings.app.renameSelectsName", defaultValue: "Rename Selects Existing Name"), "command palette rename text selection"),
         setting(.app, "palette-search-all", String(localized: "settings.app.commandPaletteSearchAllSurfaces", defaultValue: "Command Palette Searches All Surfaces"), "cmd p search terminal browser markdown"),
+        setting(.app, "find-restores-last-search", String(localized: "settings.app.findRestoresLastSearch", defaultValue: "Find Restores Last Search"), "cmd f find search restore previous clear empty terminal browser"),
         setting(.app, "canvas-pane-gap", String(localized: "settings.app.canvasPaneGap", defaultValue: "Canvas Pane Gap"), "canvas.paneGap canvas pane gap spacing freeform layout panes snapping tidy distribute align"),
         setting(.app, "canvas-snapping", String(localized: "settings.app.canvasSnapping", defaultValue: "Canvas Snapping"), "canvas.snappingEnabled canvas snap snapping enabled edges drag resize align panes freeform layout"),
         setting(.terminal, "scrollbar", String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar"), "terminal shell scrollback"),

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -510,6 +510,7 @@ enum SettingsSearchIndex {
         "app.hideTabCloseButton": settingID(for: .app, idSuffix: "hide-tab-close-button"),
         "app.renameSelectsExistingName": settingID(for: .app, idSuffix: "rename-selects-name"),
         "app.commandPaletteSearchesAllSurfaces": settingID(for: .app, idSuffix: "palette-search-all"),
+        "app.findRestoresLastSearch": settingID(for: .app, idSuffix: "find-restores-last-search"),
         "canvas.paneGap": settingID(for: .app, idSuffix: "canvas-pane-gap"),
         "canvas.snappingEnabled": settingID(for: .app, idSuffix: "canvas-snapping"),
         "sidebar.hideAllDetails": settingID(for: .sidebarAppearance, idSuffix: "hide-sidebar-details"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -92,6 +92,7 @@ enum SettingsSearchAliasIndex {
         ),
         "app:rename-selects-name": localized("settings.search.alias.setting.app.rename-selects-name", defaultValue: "app.renameSelectsExistingName rename select all existing title command palette workspace name"),
         "app:palette-search-all": localized("settings.search.alias.setting.app.palette-search-all", defaultValue: "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown"),
+        "app:find-restores-last-search": localized("settings.search.alias.setting.app.find-restores-last-search", defaultValue: "app.findRestoresLastSearch find restore last search previous cmd-f clear empty needle terminal browser"),
         "app:canvas-pane-gap": localized("settings.search.alias.setting.app.canvas-pane-gap", defaultValue: "canvas.paneGap canvas pane gap spacing freeform layout panes snapping tidy distribute align"),
         "app:canvas-snapping": localized("settings.search.alias.setting.app.canvas-snapping", defaultValue: "canvas.snappingEnabled canvas snap snapping enabled edges drag resize align panes freeform layout"),
         "terminal:scrollbar": localized("settings.search.alias.setting.terminal.scrollbar", defaultValue: "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui"),

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -770,12 +770,15 @@ class TabManager: ObservableObject {
         if let panel = selectedTerminalPanel {
             let hadExistingSearch = panel.searchState != nil
             panel.hostedView.preparePanelFocusIntentForActivation(.findField)
-            let recoveredNeedle = hadExistingSearch ? "" : panel.surface.lastSearchNeedle
-            let handled = startOrFocusTerminalSearch(panel.surface, initialNeedle: recoveredNeedle) { surface in
+            let recovery = recoveredFindSearch(
+                startsNewSearchSession: !hadExistingSearch,
+                lastNeedle: panel.surface.lastSearchNeedle
+            )
+            let handled = startOrFocusTerminalSearch(panel.surface, initialNeedle: recovery.needle) { surface in
                 NotificationCenter.default.post(
                     name: .ghosttySearchFocus,
                     object: surface,
-                    userInfo: [FindFocusNotificationKey.selectAll: !hadExistingSearch && !recoveredNeedle.isEmpty]
+                    userInfo: [FindFocusNotificationKey.selectAll: recovery.selectAll]
                 )
             }
 #if DEBUG

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -770,7 +770,7 @@ class TabManager: ObservableObject {
         if let panel = selectedTerminalPanel {
             let hadExistingSearch = panel.searchState != nil
             panel.hostedView.preparePanelFocusIntentForActivation(.findField)
-            let recovery = recoveredFindSearch(
+            let recovery = FindSearchRecovery.resolve(
                 startsNewSearchSession: !hadExistingSearch,
                 lastNeedle: panel.surface.lastSearchNeedle
             )

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -562,6 +562,7 @@
 		A5001445A5001445A5001445 /* FilePreviewWorkspaceOpenSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001444A5001444A5001444 /* FilePreviewWorkspaceOpenSupport.swift */; };
 		FE002103 /* FileSearchRipgrepParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002003 /* FileSearchRipgrepParserTests.swift */; };
 		C35610000000000000000001 /* FinderFileDropRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35610000000000000000002 /* FinderFileDropRegressionTests.swift */; };
+		52FD93EC6C2847E39EE33FD5 /* FindSearchRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA65C0E29B4407588F28041 /* FindSearchRecoveryTests.swift */; };
 		D0E0F0B4A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B5A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift */; };
 		F1A0C0DE0000000000000002 /* FindTextFieldSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A0C0DE0000000000000001 /* FindTextFieldSupport.swift */; };
 		C0F15A000000000000000001 /* FishShellIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F15A000000000000000002 /* FishShellIntegrationTests.swift */; };
@@ -1844,6 +1845,7 @@
 		A5001444A5001444A5001444 /* FilePreviewWorkspaceOpenSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewWorkspaceOpenSupport.swift; sourceTree = "<group>"; };
 		FE002003 /* FileSearchRipgrepParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchRipgrepParserTests.swift; sourceTree = "<group>"; };
 		C35610000000000000000002 /* FinderFileDropRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderFileDropRegressionTests.swift; sourceTree = "<group>"; };
+		4DA65C0E29B4407588F28041 /* FindSearchRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindSearchRecoveryTests.swift; sourceTree = "<group>"; };
 		D0E0F0B5A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindSelectionShortcutUITests.swift; sourceTree = "<group>"; };
 		F1A0C0DE0000000000000001 /* FindTextFieldSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/FindTextFieldSupport.swift; sourceTree = "<group>"; };
 		C0F15A000000000000000002 /* FishShellIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FishShellIntegrationTests.swift; sourceTree = "<group>"; };
@@ -3831,6 +3833,7 @@
 				C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */,
 				C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
+				4DA65C0E29B4407588F28041 /* FindSearchRecoveryTests.swift */,
 				5830CA11BAC0000000000001 /* SocketCallbackAwaiterMainThreadTests.swift */,
 				5C0011AA0000000000000002 /* GhosttyScrollPreciseBoostTests.swift */,
 				C0793DC7D7B61CF54886EC36 /* RemoteTmuxControlParserTests.swift */,
@@ -5376,6 +5379,7 @@
 				C0DEFC100000000000000001 /* FilePreviewTextEditorTextKitTests.swift in Sources */,
 				FE002103 /* FileSearchRipgrepParserTests.swift in Sources */,
 				C35610000000000000000001 /* FinderFileDropRegressionTests.swift in Sources */,
+				52FD93EC6C2847E39EE33FD5 /* FindSearchRecoveryTests.swift in Sources */,
 				C0F15A000000000000000001 /* FishShellIntegrationTests.swift in Sources */,
 				C0DEFB300000000000000001 /* FocusSurfaceBroadcasterTests.swift in Sources */,
 				AA5269A0C0DE0004FACE0004 /* ForeignFirstResponderPolicyTests.swift in Sources */,

--- a/cmuxTests/FindSearchRecoveryTests.swift
+++ b/cmuxTests/FindSearchRecoveryTests.swift
@@ -22,7 +22,7 @@ struct FindSearchRecoveryTests {
     @Test("New find session restores the last needle by default")
     func newSessionRestoresLastNeedleByDefault() throws {
         try withIsolatedDefaults { defaults in
-            let recovery = recoveredFindSearch(
+            let recovery = FindSearchRecovery.resolve(
                 startsNewSearchSession: true,
                 lastNeedle: "needle",
                 defaults: defaults
@@ -35,7 +35,7 @@ struct FindSearchRecoveryTests {
     func newSessionOpensEmptyWhenRestoreDisabled() throws {
         try withIsolatedDefaults { defaults in
             defaults.set(false, forKey: Self.settingKey.userDefaultsKey)
-            let recovery = recoveredFindSearch(
+            let recovery = FindSearchRecovery.resolve(
                 startsNewSearchSession: true,
                 lastNeedle: "needle",
                 defaults: defaults
@@ -48,7 +48,7 @@ struct FindSearchRecoveryTests {
     func explicitlyEnabledRestoreRecoversLastNeedle() throws {
         try withIsolatedDefaults { defaults in
             defaults.set(true, forKey: Self.settingKey.userDefaultsKey)
-            let recovery = recoveredFindSearch(
+            let recovery = FindSearchRecovery.resolve(
                 startsNewSearchSession: true,
                 lastNeedle: "needle",
                 defaults: defaults
@@ -61,7 +61,7 @@ struct FindSearchRecoveryTests {
     func refocusNeverInjectsRecoveredNeedle(restoreEnabled: Bool) throws {
         try withIsolatedDefaults { defaults in
             defaults.set(restoreEnabled, forKey: Self.settingKey.userDefaultsKey)
-            let recovery = recoveredFindSearch(
+            let recovery = FindSearchRecovery.resolve(
                 startsNewSearchSession: false,
                 lastNeedle: "needle",
                 defaults: defaults
@@ -73,7 +73,7 @@ struct FindSearchRecoveryTests {
     @Test("An empty last needle never requests select-all")
     func emptyLastNeedleNeverRequestsSelectAll() throws {
         try withIsolatedDefaults { defaults in
-            let recovery = recoveredFindSearch(
+            let recovery = FindSearchRecovery.resolve(
                 startsNewSearchSession: true,
                 lastNeedle: "",
                 defaults: defaults

--- a/cmuxTests/FindSearchRecoveryTests.swift
+++ b/cmuxTests/FindSearchRecoveryTests.swift
@@ -1,0 +1,84 @@
+import CmuxSettings
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Find search recovery")
+struct FindSearchRecoveryTests {
+    private static let settingKey = AppCatalogSection().findRestoresLastSearch
+
+    private func withIsolatedDefaults(_ body: (UserDefaults) throws -> Void) throws {
+        let suiteName = "FindSearchRecoveryTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        try body(defaults)
+    }
+
+    @Test("New find session restores the last needle by default")
+    func newSessionRestoresLastNeedleByDefault() throws {
+        try withIsolatedDefaults { defaults in
+            let recovery = recoveredFindSearch(
+                startsNewSearchSession: true,
+                lastNeedle: "needle",
+                defaults: defaults
+            )
+            #expect(recovery == FindSearchRecovery(needle: "needle", selectAll: true))
+        }
+    }
+
+    @Test("New find session opens empty when restore is disabled")
+    func newSessionOpensEmptyWhenRestoreDisabled() throws {
+        try withIsolatedDefaults { defaults in
+            defaults.set(false, forKey: Self.settingKey.userDefaultsKey)
+            let recovery = recoveredFindSearch(
+                startsNewSearchSession: true,
+                lastNeedle: "needle",
+                defaults: defaults
+            )
+            #expect(recovery == FindSearchRecovery(needle: "", selectAll: false))
+        }
+    }
+
+    @Test("Explicitly enabled restore keeps recovering the last needle")
+    func explicitlyEnabledRestoreRecoversLastNeedle() throws {
+        try withIsolatedDefaults { defaults in
+            defaults.set(true, forKey: Self.settingKey.userDefaultsKey)
+            let recovery = recoveredFindSearch(
+                startsNewSearchSession: true,
+                lastNeedle: "needle",
+                defaults: defaults
+            )
+            #expect(recovery == FindSearchRecovery(needle: "needle", selectAll: true))
+        }
+    }
+
+    @Test("Refocusing an open find bar never injects a recovered needle", arguments: [true, false])
+    func refocusNeverInjectsRecoveredNeedle(restoreEnabled: Bool) throws {
+        try withIsolatedDefaults { defaults in
+            defaults.set(restoreEnabled, forKey: Self.settingKey.userDefaultsKey)
+            let recovery = recoveredFindSearch(
+                startsNewSearchSession: false,
+                lastNeedle: "needle",
+                defaults: defaults
+            )
+            #expect(recovery == FindSearchRecovery(needle: "", selectAll: false))
+        }
+    }
+
+    @Test("An empty last needle never requests select-all")
+    func emptyLastNeedleNeverRequestsSelectAll() throws {
+        try withIsolatedDefaults { defaults in
+            let recovery = recoveredFindSearch(
+                startsNewSearchSession: true,
+                lastNeedle: "",
+                defaults: defaults
+            )
+            #expect(recovery == FindSearchRecovery(needle: "", selectAll: false))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Reopening find (Cmd+F) in a terminal or browser panel always restores the previous search text. This PR adds an **App** setting, `app.findRestoresLastSearch` (default **on**, preserving current behavior). When disabled, find always opens with an empty search field.

## Behavior

| Scenario | Setting on (default) | Setting off |
|---|---|---|
| Cmd+F after closing a previous search | Previous text restored, fully selected | Empty field |
| Cmd+F while the find bar is already open | Unchanged (refocus, cursor preserved) | Unchanged |
| No previous search | Empty field | Empty field |

## Implementation

- The recovery decision is a single shared helper, `recoveredFindSearch()` in `Sources/App/ShortcutRoutingSupport.swift`, used by both `TabManager.startSearch()` (terminal) and `BrowserPanel.startFind()` (browser), per the shared-behavior policy. It also owns the existing select-all-on-restore rule, so the two entrypoints can't drift.
- Setting wired through: `AppCatalogSection` (`DefaultsKey`, default `true`), Settings > App row with on/off subtitles, settings sidebar navigation + search aliases + curated entry, `cmux.json` (`app.findRestoresLastSearch`: file mapping, template, supported JSON paths), and the `SettingsRowAnchorResolutionTests` contract list.

## Localization audit

New user-facing surfaces: the Settings row title and two subtitles, plus the settings-search alias. All four keys are in `Resources/Localizable.xcstrings` with `en` and `ja` entries (`settings.app.findRestoresLastSearch`, `.subtitleOn`, `.subtitleOff`, `settings.search.alias.setting.app.find-restores-last-search`). The curated search entry title uses `String(localized:)` with the same key. No web/docs message catalogs reference sibling app-behavior settings, so none needed updating.

## Testing

- New `cmuxTests/FindSearchRecoveryTests.swift` (Swift Testing, wired into `project.pbxproj`; `lint-pbxproj-test-wiring.sh` passes) covering: default restore, restore disabled, explicit enable, refocus-never-injects (both setting states), and empty-last-needle never selecting all.
- `CmuxSettings` package: 230 tests pass locally. `CmuxSettingsUI` package: 78 tests pass locally, including the updated `SettingsRowAnchorResolution` contract (94 row paths).
- App-target compile + `cmuxTests` run on CI: this machine has no zig toolchain to build GhosttyKit, so the full app build could not be validated locally. All edited app-target files pass `swiftc -parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785594964&installation_id=133855650&pr_number=7207&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7207&signature=329c0b61f2f3fb3e46a8f87dbf9a10ca48f404ce01b57e349aeae0c22f611d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new setting to control whether Cmd+F restores the last search text. Default stays the same (restore and select-all); turning it off opens find with an empty field.

- **New Features**
  - Added `app.findRestoresLastSearch` (default true) in Settings > App; added to settings search, curated entry, path-to-anchor map, and `cmux.json`.
  - Centralized recovery logic in `FindSearchRecovery.resolve()` to keep terminal and browser behavior consistent, including select-all on restore.
  - Localized new strings and settings-search aliases across all supported locales.
  - Added `FindSearchRecoveryTests` to cover default, disabled, refocus, and empty-needle cases.

<sup>Written for commit 74a60063afa9f6751663189f1c155c6a2863c764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Find Restores Last Search” setting to let you choose whether reopening the Find bar restores your previous query.
  * Updated Find-in-page and terminal search to follow this setting consistently.
* **Bug Fixes**
  * If restoration is disabled, reopening Find now reliably starts with an empty query.
* **Tests**
  * Added unit tests covering recovery behavior for new sessions vs refocusing the existing Find bar, including edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->