### PR TITLE
New Workspace on a mirrored tmux session creates a local workspace instead of a session on its host

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7338,6 +7338,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let context = livePreferredContext
             ?? preferredMainWindowContextForWorkspaceCreation(event: event, debugSource: debugSource)
 
+        // On a remote-tmux mirror workspace, a new terminal workspace means
+        // "create a new tmux session on that workspace's host" — route it to the
+        // remote and mirror it back instead of creating a local workspace. The
+        // browser variant always stays local.
+        if initialSurface == .terminal,
+           let context,
+           remoteTmuxController.handleNewWorkspaceRequested(in: context.tabManager) {
+            return true
+        }
+
         let workspaceGroupTarget = context.flatMap { workspaceGroupNewWorkspaceTarget(in: $0) }
         // The configured new-workspace action is the user's override for the
         // plain New Workspace behavior; the browser variant keeps its own
@@ -15375,7 +15385,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         case .builtIn(let builtIn):
             switch builtIn {
             case .newWorkspace:
-                context.tabManager.addWorkspace()
+                // Same routing as Cmd+N: on an active mirror workspace the
+                // built-in action creates a session on that mirror's host.
+                if !remoteTmuxController.handleNewWorkspaceRequested(in: context.tabManager) {
+                    context.tabManager.addWorkspace()
+                }
                 onExecuted?()
                 return true
             case .newAgentChat: return performConfiguredNewAgentChatAction(context: context, preferredWindow: preferredWindow, onExecuted: onExecuted)

--- a/Sources/RemoteTmuxController+Decisions.swift
+++ b/Sources/RemoteTmuxController+Decisions.swift
@@ -295,6 +295,24 @@ extension RemoteTmuxController {
         return MirrorTabActivity(hasActiveCommand: hasActive, activeCommandName: name)
     }
 
+    /// The host a New Workspace action should spawn a tmux session on: the host
+    /// of the ACTIVE workspace's live mirror, or nil to create a LOCAL workspace.
+    ///
+    /// Deriving from the active workspace (not the window) is what keeps routing
+    /// correct when one window holds mirrors from several hosts — the default
+    /// placement, since every host mirrors into the current window. A local
+    /// (no-mirror) active workspace, a mirror whose weak workspace is already
+    /// deallocated (`workspaceId` nil, mid-teardown), and no active workspace at
+    /// all each yield nil. Pure over `(activeTabId, entries)` so the whole truth
+    /// table is unit testable without live mirrors.
+    nonisolated static func newSessionHost(
+        activeTabId: UUID?,
+        entries: [(host: RemoteTmuxHost, workspaceId: UUID?)]
+    ) -> RemoteTmuxHost? {
+        guard let activeTabId else { return nil }
+        return entries.first { $0.workspaceId == activeTabId }?.host
+    }
+
     /// The `kill-session` target for a user-initiated mirror-workspace close, or
     /// nil when the control client already ended. Closing a leftover workspace
     /// after deliberate detach must not kill the remote session detach promised to

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import CmuxSettings
 import OSLog
@@ -287,12 +288,15 @@ final class RemoteTmuxController {
 
     /// Mirrors a single tmux session into a new workspace in `tabManager` (idempotent).
     /// `sessionId` seeds discovery's stable id for de-dup before the stream reports it.
+    /// `select` selects the new workspace on creation (a user-initiated New
+    /// Workspace); bulk attach keeps the default so discovery never steals focus.
     @discardableResult
     func mirrorSession(
         host: RemoteTmuxHost,
         sessionName: String,
         sessionId: Int? = nil,
-        into tabManager: TabManager
+        into tabManager: TabManager,
+        select: Bool = false
     ) throws -> Bool {
         let key = Self.connectionKey(host: host, sessionName: sessionName)
         guard sessionMirrors[key] == nil else { return false }
@@ -300,6 +304,8 @@ final class RemoteTmuxController {
         // failed connection doesn't leave an orphaned empty mirror workspace in
         // the sidebar.
         let connection = try attach(host: host, sessionName: sessionName)
+        // Always create unselected: selection fires visibility/sizing observers,
+        // which must see a fully wired mirror, not a half-initialized workspace.
         let workspace = tabManager.addWorkspace(
             title: sessionName,
             select: false,
@@ -324,10 +330,103 @@ final class RemoteTmuxController {
             onControlPaneRemoved: TerminalController.remoteTmuxControlPaneRemovalHandler(),
             onControlSurfaceRemoved: TerminalController.remoteTmuxControlSurfaceRemovalHandler()
         )
+        if select {
+            tabManager.selectWorkspace(workspace)
+        }
         return true
     }
 
     // MARK: - Create / destroy propagation (P5)
+
+    /// New Workspace requested in `manager`: when its ACTIVE workspace is a live
+    /// session mirror, create a new detached tmux session on that mirror's host and
+    /// mirror it into the same manager, returning `true` (the caller suppresses
+    /// local creation). `false` — active workspace isn't a mirror — means the
+    /// caller creates a plain local workspace.
+    ///
+    /// The host comes from the active workspace's own mirror (see
+    /// ``newSessionHost(activeTabId:entries:)``), never from window-level state:
+    /// a window routinely holds mirrors from several hosts plus local workspaces,
+    /// and each must route by what the user is actually sitting on.
+    func handleNewWorkspaceRequested(in manager: TabManager) -> Bool {
+        let entries = sessionMirrors.values.map { (host: $0.host, workspaceId: $0.mirroredWorkspaceId) }
+        guard let activeTabId = manager.selectedTab?.id,
+              let host = Self.newSessionHost(activeTabId: activeTabId, entries: entries) else {
+            return false
+        }
+        newSessionRoutingTask = Task { @MainActor in
+            do {
+                // Create a detached session and read back its (auto-assigned)
+                // name, then attach to it like any discovered session.
+                let result = try await self.transport(for: host).runTmux(
+                    ["new-session", "-d", "-P", "-F", "#{session_name}"]
+                )
+                // Revalidate across the ssh round trip: the manager must still be
+                // a REGISTERED main-window context. `windowId(for:)` would also
+                // answer for a closed window's recoverable route and resurrect a
+                // dead manager, so it is deliberately not used here. On a closed
+                // window, skip — the detached session is picked up on the next
+                // attach.
+                guard AppDelegate.shared?.mainWindowContexts.values
+                    .contains(where: { $0.tabManager === manager }) == true else { return }
+                let name = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard result.succeeded, !name.isEmpty else {
+                    self.reportNewSessionFailure(host, result.stderr, manager)
+                    return
+                }
+                // The user may have moved on to another tab while the round trip
+                // ran (mirror, but don't steal selection).
+                let select = manager.selectedTab?.id == activeTabId
+                // false = an attach for this exact host+name raced us and already
+                // mirrored it (into whichever manager it targeted); nothing to add.
+                _ = try self.mirrorSession(host: host, sessionName: name, into: manager, select: select)
+            } catch {
+                #if DEBUG
+                cmuxDebugLog("remote-tmux: new-session on active mirror's host failed: \(error)")
+                #endif
+                guard AppDelegate.shared?.mainWindowContexts.values
+                    .contains(where: { $0.tabManager === manager }) == true else { return }
+                self.reportNewSessionFailure(host, error.localizedDescription, manager)
+            }
+        }
+        return true
+    }
+
+    /// The in-flight routed New Workspace request, if any. Tests await it so the
+    /// ssh round trip and mirror creation finish inside the test body.
+    private(set) var newSessionRoutingTask: Task<Void, Never>?
+
+    /// How a failed routed New Workspace reaches the user (host, failure detail,
+    /// requesting manager). Local creation stays suppressed either way — a mirror
+    /// workspace's Cmd+N must not quietly fall back to a local workspace — so the
+    /// failure has to be visible. Settable so tests can capture it instead of
+    /// presenting an alert.
+    lazy var reportNewSessionFailure: (RemoteTmuxHost, String, TabManager) -> Void = {
+        [weak self] host, detail, manager in
+        self?.presentNewSessionFailureAlert(host: host, detail: detail, manager: manager)
+    }
+
+    private func presentNewSessionFailureAlert(host: RemoteTmuxHost, detail: String, manager: TabManager) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(
+            localized: "dialog.remoteTmux.newSessionFailed.title",
+            defaultValue: "Couldn't Create a tmux Session on \(host.destination)"
+        )
+        let trimmedDetail = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+        alert.informativeText = trimmedDetail.isEmpty
+            ? String(
+                localized: "dialog.remoteTmux.newSessionFailed.message",
+                defaultValue: "tmux new-session failed on the remote host. No workspace was created."
+            )
+            : trimmedDetail
+        alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
+        if let window = manager.window ?? NSApp.keyWindow ?? NSApp.mainWindow {
+            alert.beginSheetModal(for: window, completionHandler: nil)
+        } else {
+            alert.runModal()
+        }
+    }
 
     /// A mirrored workspace was renamed → `rename-session` on the remote so the
     /// tmux session name tracks the cmux workspace title.

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12471,7 +12471,12 @@ extension Workspace: BonsplitDelegate {
         if let builtInAction = executable.builtInAction {
             switch builtInAction {
             case .newWorkspace:
-                owningTabManager?.addWorkspace()
+                // Same routing as Cmd+N: on an active mirror workspace the
+                // button creates a session on that mirror's host.
+                if let manager = owningTabManager,
+                   AppDelegate.shared?.remoteTmuxController.handleNewWorkspaceRequested(in: manager) != true {
+                    manager.addWorkspace()
+                }
             case .newAgentChat: performSurfaceTabBarNewAgentChatAction(presentingWindow: presentingWindow)
             case .cloudVM:
                 _ = AppDelegate.shared?.performCloudVMAction(tabManager: owningTabManager, preferredWindow: presentingWindow, debugSource: "surfaceTabBar.cloudVM")

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1314,6 +1314,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		7368BEEF7368BEEF7368B002 /* RemoteTmuxMissingTmuxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7368BEEF7368BEEF7368B001 /* RemoteTmuxMissingTmuxTests.swift */; };
 		B8E2A4C1D5F3096871A2B3C3 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E2A4C1D5F3096871A2B3C4 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift */; };
 		0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */; };
+		73620000000000000000000A /* RemoteTmuxNewWorkspaceHostRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736200000000000000000009 /* RemoteTmuxNewWorkspaceHostRoutingTests.swift */; };
 		E9A8CC35D632F14A8669B7D1 /* RemoteTmuxPaneForegroundState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123BF93B1ADC00C5D25EE028 /* RemoteTmuxPaneForegroundState.swift */; };
 		7371A0010000000000000001 /* RemoteTmuxPendingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7371A0010000000000000002 /* RemoteTmuxPendingLayout.swift */; };
 		7371A0020000000000000001 /* RemoteTmuxPipeReadResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7371A0020000000000000002 /* RemoteTmuxPipeReadResult.swift */; };
@@ -3372,6 +3373,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		7368BEEF7368BEEF7368B001 /* RemoteTmuxMissingTmuxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMissingTmuxTests.swift; sourceTree = "<group>"; };
 		B8E2A4C1D5F3096871A2B3C4 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNativeMirrorLayoutFuzzTests.swift; sourceTree = "<group>"; };
 		0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNewWindowCwdTests.swift; sourceTree = "<group>"; };
+		736200000000000000000009 /* RemoteTmuxNewWorkspaceHostRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNewWorkspaceHostRoutingTests.swift; sourceTree = "<group>"; };
 		123BF93B1ADC00C5D25EE028 /* RemoteTmuxPaneForegroundState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPaneForegroundState.swift; sourceTree = "<group>"; };
 		7371A0010000000000000002 /* RemoteTmuxPendingLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPendingLayout.swift; sourceTree = "<group>"; };
 		7371A0020000000000000002 /* RemoteTmuxPipeReadResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPipeReadResult.swift; sourceTree = "<group>"; };
@@ -6146,6 +6148,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					736200000000000000000007 /* RemoteTmuxMirrorTargetingTests.swift */,
 					838000000000000000000001 /* RemoteTmuxMirrorRenameTests.swift */,
 					838000000000000000000003 /* RemoteTmuxMirrorRenameHarness.swift */,
+					736200000000000000000009 /* RemoteTmuxNewWorkspaceHostRoutingTests.swift */,
 					31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */,
 					B8E2A4C1D5F3096871A2B3C4 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift */,
 					B8E2A4C1D5F3096871A2B4A2 /* RemoteTmuxBonsplitImpositionRenderTests.swift */,
@@ -8574,6 +8577,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7368BEEF7368BEEF7368B002 /* RemoteTmuxMissingTmuxTests.swift in Sources */,
 				B8E2A4C1D5F3096871A2B3C3 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift in Sources */,
 				0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */,
+				73620000000000000000000A /* RemoteTmuxNewWorkspaceHostRoutingTests.swift in Sources */,
 				7020C0DE7020C0DE7020A002 /* RemoteTmuxProxyTransportRetryTests.swift in Sources */,
 				6B14EBE2544B2139E2902453 /* RemoteTmuxRectPublicationTests.swift in Sources */,
 				3AC9AB9046E742B93726A405 /* RemoteTmuxSessionListParserTests.swift in Sources */,

--- a/cmuxTests/RemoteTmuxNewWorkspaceHostRoutingTests.swift
+++ b/cmuxTests/RemoteTmuxNewWorkspaceHostRoutingTests.swift
@@ -7,20 +7,49 @@ import Testing
 @testable import cmux
 #endif
 
-/// New Workspace routing for remote-tmux mirrors: when the active workspace is
-/// a mirrored tmux session, `performNewWorkspaceAction` must route the request
-/// to the session's host instead of creating a local workspace.
+/// New Workspace routing for remote-tmux mirrors: the pure host-derivation
+/// truth table, the controller seam (`handleNewWorkspaceRequested(in:)`), and
+/// the `performNewWorkspaceAction` hook that suppresses local creation when
+/// the active workspace is a mirror.
+///
+/// SSH never leaves the process: every test pins
+/// `CMUX_REMOTE_TMUX_SSH_FOR_TESTING` to a stub for its WHOLE body — including
+/// the deferred `detach`, whose last-mirror teardown spawns `ssh -O exit` — and
+/// awaits `newSessionRoutingTask` before any teardown can evict the cached stub
+/// transport. Tests that suspend hold `AppContextSerialGate` so another suite's
+/// env/AppDelegate use cannot interleave at an await.
 @MainActor
 @Suite(.serialized)
 struct RemoteTmuxNewWorkspaceHostRoutingTests {
-    private let hostA = RemoteTmuxHost(destination: "user@alpha")
+    private static let sshOverrideKey = "CMUX_REMOTE_TMUX_SSH_FOR_TESTING"
+    private let hostA = RemoteTmuxHost(destination: "user@host-routing-alpha")
+    private let hostB = RemoteTmuxHost(destination: "user@host-routing-beta")
 
-    /// Caches a transport for `host` whose ssh binary is a no-op stub, so any
-    /// async new-session attempt can never spawn a real ssh.
-    private func cacheStubTransport(controller: RemoteTmuxController, host: RemoteTmuxHost) {
-        setenv("CMUX_REMOTE_TMUX_SSH_FOR_TESTING", "/usr/bin/false", 1)
-        defer { unsetenv("CMUX_REMOTE_TMUX_SSH_FOR_TESTING") }
-        _ = controller.transport(for: host)
+    /// Sets the ssh stub for the caller's whole scope; the returned closure
+    /// restores the previous value and is meant for the FIRST `defer`, so it
+    /// runs after every later-registered teardown (detach included).
+    private func pinStubSSH(_ stub: String) -> () -> Void {
+        let prior = ProcessInfo.processInfo.environment[Self.sshOverrideKey]
+        setenv(Self.sshOverrideKey, stub, 1)
+        return {
+            if let prior {
+                setenv(Self.sshOverrideKey, prior, 1)
+            } else {
+                unsetenv(Self.sshOverrideKey)
+            }
+        }
+    }
+
+    /// Writes an executable stub that records its arguments (the ssh framing +
+    /// tmux command) to `argvLog` and reports a created session named
+    /// `sessionName`.
+    private func makeNewSessionSuccessStub(sessionName: String, argvLog: String) throws -> String {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-new-session-stub-\(UUID().uuidString).sh").path
+        try "#!/bin/sh\necho \"$@\" >> \"\(argvLog)\"\necho \(sessionName)\n"
+            .write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+        return path
     }
 
     private func mirrorSelectedSession(
@@ -29,6 +58,7 @@ struct RemoteTmuxNewWorkspaceHostRoutingTests {
         sessionName: String,
         into manager: TabManager
     ) throws -> Workspace {
+        _ = controller.transport(for: host)
         controller.cacheConnection(RemoteTmuxControlConnection(host: host, sessionName: sessionName))
         #expect(try controller.mirrorSession(host: host, sessionName: sessionName, into: manager))
         let workspace = try #require(manager.tabs.first { $0.isRemoteTmuxMirror })
@@ -36,17 +66,12 @@ struct RemoteTmuxNewWorkspaceHostRoutingTests {
         return workspace
     }
 
-    @Test func newWorkspaceOnActiveMirrorSuppressesLocalCreation() throws {
-        _ = NSApplication.shared
-        let appDelegate = try #require(AppDelegate.shared)
-        let controller = appDelegate.remoteTmuxController
-        let manager = TabManager()
-        let localWorkspace = try #require(manager.selectedWorkspace)
-        cacheStubTransport(controller: controller, host: hostA)
-        let mirrorWorkspace = try mirrorSelectedSession(
-            controller: controller, host: hostA, sessionName: "dev", into: manager
-        )
-
+    /// Registers `manager` as a main-window context with a resolvable window
+    /// (the shape `performNewWorkspaceAction`'s preferred-context path needs).
+    private func registerWindowedContext(
+        appDelegate: AppDelegate,
+        manager: TabManager
+    ) -> (windowId: UUID, window: NSWindow) {
         let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
@@ -57,25 +82,249 @@ struct RemoteTmuxNewWorkspaceHostRoutingTests {
         window.isReleasedWhenClosed = false
         window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
         manager.window = window
-        defer {
-            window.close()
-            manager.window = nil
-            if controller.sessionMirror(host: hostA, sessionName: "dev") != nil {
+        return (windowId, window)
+    }
+
+    // MARK: - newSessionHost truth table
+
+    @Test func noActiveTabCreatesLocalWorkspace() {
+        #expect(RemoteTmuxController.newSessionHost(
+            activeTabId: nil,
+            entries: [(host: hostA, workspaceId: UUID())]
+        ) == nil)
+    }
+
+    @Test func localActiveTabCreatesLocalWorkspace() {
+        // The active tab has no mirror entry — e.g. a plain local workspace
+        // sitting next to mirrors in the same window.
+        #expect(RemoteTmuxController.newSessionHost(
+            activeTabId: UUID(),
+            entries: [(host: hostA, workspaceId: UUID())]
+        ) == nil)
+    }
+
+    @Test func activeMirrorTabRoutesToItsHost() {
+        let activeId = UUID()
+        #expect(RemoteTmuxController.newSessionHost(
+            activeTabId: activeId,
+            entries: [(host: hostA, workspaceId: activeId)]
+        ) == hostA)
+    }
+
+    @Test func multiHostWindowRoutesByActiveTabNotNeighbor() {
+        // Mirrors from two hosts share the window (the default placement);
+        // the active tab's own host wins regardless of entry order.
+        let activeId = UUID()
+        let entries = [
+            (host: hostA, workspaceId: Optional(UUID())),
+            (host: hostB, workspaceId: Optional(activeId)),
+        ]
+        #expect(RemoteTmuxController.newSessionHost(activeTabId: activeId, entries: entries) == hostB)
+        #expect(RemoteTmuxController.newSessionHost(activeTabId: activeId, entries: entries.reversed()) == hostB)
+    }
+
+    @Test func deallocatedMirrorWorkspaceNeverMatches() {
+        // A mirror whose weak workspace is gone (mid-teardown) reports a nil
+        // workspaceId; it must not capture any active tab.
+        #expect(RemoteTmuxController.newSessionHost(
+            activeTabId: UUID(),
+            entries: [(host: hostA, workspaceId: nil)]
+        ) == nil)
+    }
+
+    // MARK: - Controller seam
+
+    @Test func handlerClaimsRequestOnlyWhenActiveWorkspaceIsMirror() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let restoreSSH = pinStubSSH("/usr/bin/false")
+            defer { restoreSSH() }
+            let controller = RemoteTmuxController()
+            let manager = TabManager()
+            let localWorkspace = try #require(manager.selectedWorkspace)
+            let mirrorWorkspace = try mirrorSelectedSession(
+                controller: controller, host: hostA, sessionName: "dev", into: manager
+            )
+            defer {
                 controller.detach(host: hostA, sessionName: "dev")
             }
-            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+
+            #expect(manager.selectedTab?.id == mirrorWorkspace.id)
+            #expect(controller.handleNewWorkspaceRequested(in: manager))
+            // Drain the routed request against the cached stub transport before
+            // the deferred detach can evict it.
+            await controller.newSessionRoutingTask?.value
+
+            manager.selectWorkspace(localWorkspace)
+            #expect(!controller.handleNewWorkspaceRequested(in: manager))
         }
+    }
 
-        // Active workspace is the mirror: the action is claimed for the remote
-        // host and no local workspace appears.
-        #expect(manager.selectedTab?.id == mirrorWorkspace.id)
-        let tabsBefore = manager.tabs.map(\.id)
-        #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.remoteMirror"))
-        #expect(manager.tabs.map(\.id) == tabsBefore)
+    /// The full success path: the remote reports the created session's name,
+    /// the handler asked for exactly `new-session -d -P -F #{session_name}`,
+    /// and the result is mirrored into the requesting manager and selected.
+    @Test func routedNewWorkspaceMirrorsAndSelectsTheCreatedSession() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let appDelegate = try #require(AppDelegate.shared)
+            let argvLog = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-new-session-argv-\(UUID().uuidString).log").path
+            let stub = try makeNewSessionSuccessStub(sessionName: "brand-new", argvLog: argvLog)
+            let restoreSSH = pinStubSSH(stub)
+            defer {
+                restoreSSH()
+                try? FileManager.default.removeItem(atPath: stub)
+                try? FileManager.default.removeItem(atPath: argvLog)
+            }
+            let controller = RemoteTmuxController()
+            let manager = TabManager()
+            _ = try mirrorSelectedSession(
+                controller: controller, host: hostA, sessionName: "dev", into: manager
+            )
+            // The mirror the handler creates attaches to the reported name;
+            // cache its connection so no control stream is spawned.
+            controller.cacheConnection(RemoteTmuxControlConnection(host: hostA, sessionName: "brand-new"))
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                for sessionName in ["brand-new", "dev"] {
+                    controller.detach(host: hostA, sessionName: sessionName)
+                }
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            }
 
-        // Active workspace is local: the same action creates a local workspace.
-        manager.selectWorkspace(localWorkspace)
-        #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.localTab"))
-        #expect(manager.tabs.count == tabsBefore.count + 1)
+            #expect(controller.handleNewWorkspaceRequested(in: manager))
+            await controller.newSessionRoutingTask?.value
+
+            let recordedArgv = (try? String(contentsOfFile: argvLog, encoding: .utf8)) ?? ""
+            // RemoteTmuxHost.tmuxRemoteCommand single-quotes every word of the remote
+            // command, so the flags arrive individually quoted, not as one bare run.
+            #expect(recordedArgv.contains("'new-session' '-d' '-P' '-F' '#{session_name}'"))
+            let created = try #require(manager.tabs.first { $0.title == "brand-new" })
+            #expect(created.isRemoteTmuxMirror)
+            #expect(manager.selectedTab?.id == created.id)
+        }
+    }
+
+    /// Moving to another tab during the ssh round trip still mirrors the new
+    /// session, but must not steal the user's selection.
+    @Test func movingOnDuringRoundTripMirrorsWithoutStealingSelection() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let appDelegate = try #require(AppDelegate.shared)
+            let stub = try makeNewSessionSuccessStub(sessionName: "unstolen", argvLog: "/dev/null")
+            let restoreSSH = pinStubSSH(stub)
+            defer {
+                restoreSSH()
+                try? FileManager.default.removeItem(atPath: stub)
+            }
+            let controller = RemoteTmuxController()
+            let manager = TabManager()
+            let localWorkspace = try #require(manager.selectedWorkspace)
+            _ = try mirrorSelectedSession(
+                controller: controller, host: hostA, sessionName: "dev", into: manager
+            )
+            controller.cacheConnection(RemoteTmuxControlConnection(host: hostA, sessionName: "unstolen"))
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                for sessionName in ["unstolen", "dev"] {
+                    controller.detach(host: hostA, sessionName: sessionName)
+                }
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            }
+
+            #expect(controller.handleNewWorkspaceRequested(in: manager))
+            // The user moves on before the round trip completes.
+            manager.selectWorkspace(localWorkspace)
+            await controller.newSessionRoutingTask?.value
+
+            let created = try #require(manager.tabs.first { $0.title == "unstolen" })
+            #expect(created.isRemoteTmuxMirror)
+            #expect(manager.selectedTab?.id == localWorkspace.id)
+        }
+    }
+
+    /// A manager whose window closed (unregistered) during the round trip must
+    /// not receive the mirror — the detached session is picked up on the next
+    /// attach instead of resurrecting a dead manager.
+    @Test func unregisteredManagerDoesNotReceiveTheMirror() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let appDelegate = try #require(AppDelegate.shared)
+            let stub = try makeNewSessionSuccessStub(sessionName: "orphaned", argvLog: "/dev/null")
+            let restoreSSH = pinStubSSH(stub)
+            defer {
+                restoreSSH()
+                try? FileManager.default.removeItem(atPath: stub)
+            }
+            let controller = RemoteTmuxController()
+            let manager = TabManager()
+            _ = try mirrorSelectedSession(
+                controller: controller, host: hostA, sessionName: "dev", into: manager
+            )
+            controller.cacheConnection(RemoteTmuxControlConnection(host: hostA, sessionName: "orphaned"))
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                for sessionName in ["orphaned", "dev"] {
+                    controller.detach(host: hostA, sessionName: sessionName)
+                }
+            }
+
+            #expect(controller.handleNewWorkspaceRequested(in: manager))
+            // The window goes away before the round trip completes.
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            await controller.newSessionRoutingTask?.value
+
+            #expect(!manager.tabs.contains { $0.title == "orphaned" })
+            #expect(controller.sessionMirror(host: hostA, sessionName: "orphaned") == nil)
+        }
+    }
+
+    // MARK: - performNewWorkspaceAction hook
+
+    @Test func newWorkspaceOnActiveMirrorSuppressesLocalCreation() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let appDelegate = try #require(AppDelegate.shared)
+            let controller = appDelegate.remoteTmuxController
+            let restoreSSH = pinStubSSH("/usr/bin/false")
+            defer { restoreSSH() }
+            let manager = TabManager()
+            let localWorkspace = try #require(manager.selectedWorkspace)
+            var reportedFailures: [(host: RemoteTmuxHost, detail: String)] = []
+            let previousReport = controller.reportNewSessionFailure
+            controller.reportNewSessionFailure = { host, detail, _ in
+                reportedFailures.append((host: host, detail: detail))
+            }
+            let mirrorWorkspace = try mirrorSelectedSession(
+                controller: controller, host: hostA, sessionName: "dev", into: manager
+            )
+
+            let (windowId, window) = registerWindowedContext(appDelegate: appDelegate, manager: manager)
+            defer {
+                controller.reportNewSessionFailure = previousReport
+                window.close()
+                manager.window = nil
+                if controller.sessionMirror(host: hostA, sessionName: "dev") != nil {
+                    controller.detach(host: hostA, sessionName: "dev")
+                }
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            }
+
+            // Active workspace is the mirror: the action is claimed for the
+            // remote host and no local workspace appears. The stub ssh fails,
+            // so the suppressed creation must surface as a reported failure,
+            // not silence.
+            #expect(manager.selectedTab?.id == mirrorWorkspace.id)
+            let tabsBefore = manager.tabs.map(\.id)
+            #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.remoteMirror"))
+            await controller.newSessionRoutingTask?.value
+            #expect(manager.tabs.map(\.id) == tabsBefore)
+            #expect(reportedFailures.count == 1)
+            #expect(reportedFailures.first?.host == hostA)
+
+            // Active workspace is local: the same action creates a local workspace.
+            manager.selectWorkspace(localWorkspace)
+            #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.localTab"))
+            #expect(manager.tabs.count == tabsBefore.count + 1)
+        }
     }
 }

--- a/cmuxTests/RemoteTmuxNewWorkspaceHostRoutingTests.swift
+++ b/cmuxTests/RemoteTmuxNewWorkspaceHostRoutingTests.swift
@@ -1,0 +1,81 @@
+import AppKit
+import Foundation
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// New Workspace routing for remote-tmux mirrors: when the active workspace is
+/// a mirrored tmux session, `performNewWorkspaceAction` must route the request
+/// to the session's host instead of creating a local workspace.
+@MainActor
+@Suite(.serialized)
+struct RemoteTmuxNewWorkspaceHostRoutingTests {
+    private let hostA = RemoteTmuxHost(destination: "user@alpha")
+
+    /// Caches a transport for `host` whose ssh binary is a no-op stub, so any
+    /// async new-session attempt can never spawn a real ssh.
+    private func cacheStubTransport(controller: RemoteTmuxController, host: RemoteTmuxHost) {
+        setenv("CMUX_REMOTE_TMUX_SSH_FOR_TESTING", "/usr/bin/false", 1)
+        defer { unsetenv("CMUX_REMOTE_TMUX_SSH_FOR_TESTING") }
+        _ = controller.transport(for: host)
+    }
+
+    private func mirrorSelectedSession(
+        controller: RemoteTmuxController,
+        host: RemoteTmuxHost,
+        sessionName: String,
+        into manager: TabManager
+    ) throws -> Workspace {
+        controller.cacheConnection(RemoteTmuxControlConnection(host: host, sessionName: sessionName))
+        #expect(try controller.mirrorSession(host: host, sessionName: sessionName, into: manager))
+        let workspace = try #require(manager.tabs.first { $0.isRemoteTmuxMirror })
+        manager.selectWorkspace(workspace)
+        return workspace
+    }
+
+    @Test func newWorkspaceOnActiveMirrorSuppressesLocalCreation() throws {
+        _ = NSApplication.shared
+        let appDelegate = try #require(AppDelegate.shared)
+        let controller = appDelegate.remoteTmuxController
+        let manager = TabManager()
+        let localWorkspace = try #require(manager.selectedWorkspace)
+        cacheStubTransport(controller: controller, host: hostA)
+        let mirrorWorkspace = try mirrorSelectedSession(
+            controller: controller, host: hostA, sessionName: "dev", into: manager
+        )
+
+        let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
+        manager.window = window
+        defer {
+            window.close()
+            manager.window = nil
+            if controller.sessionMirror(host: hostA, sessionName: "dev") != nil {
+                controller.detach(host: hostA, sessionName: "dev")
+            }
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+        }
+
+        // Active workspace is the mirror: the action is claimed for the remote
+        // host and no local workspace appears.
+        #expect(manager.selectedTab?.id == mirrorWorkspace.id)
+        let tabsBefore = manager.tabs.map(\.id)
+        #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.remoteMirror"))
+        #expect(manager.tabs.map(\.id) == tabsBefore)
+
+        // Active workspace is local: the same action creates a local workspace.
+        manager.selectWorkspace(localWorkspace)
+        #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.localTab"))
+        #expect(manager.tabs.count == tabsBefore.count + 1)
+    }
+}


### PR DESCRIPTION
Press ⌘N while sitting on a mirrored tmux session and cmux creates a plain local workspace. It used to create a new tmux session on that workspace's host and mirror it back as a new workspace.

Repro: `cmux ssh-tmux <host>`, select one of the mirrored session workspaces, press ⌘N (or double-click the sidebar's empty area, whose code still documents "a new workspace becomes a new tmux session"). A local workspace appears; nothing happens on the host.

The remote routing hook disappeared in #7406: when mirror placement moved from dedicated windows into the current window, `performNewWorkspaceCreationAction` lost its remote-tmux branch, so every entry point that funnels through it (⌘N, the titlebar plus button, the sidebar double-click) falls through to local creation.

The old hook can't return as it was, because it looked up the window's one registered host and that concept is gone — mirrors from several hosts share one window by default now. Instead the host comes from the workspace the user is actually sitting on:

- `newSessionHost(activeTabId:entries:)` is the pure core: the host of the active workspace's live mirror, or nil to create a local workspace. A local workspace next to mirrors, a mirror mid-teardown (weak workspace gone), or no selection at all each fall through to local creation.
- `handleNewWorkspaceRequested(in:)` claims the action synchronously, then runs `new-session -d -P -F '#{session_name}'` on the host and mirrors the session back into the same window. After the ssh round trip it revalidates: a closed window skips the mirror (the detached session is picked up on the next attach), and if the user switched tabs meanwhile the new workspace is added without stealing selection.
- `mirrorSession` gains a `select:` parameter so a user-initiated create selects its workspace through the normal path, while bulk attach keeps `select: false` and never steals focus.
- The hook sits before the configured new-workspace action and only for terminal workspaces — a new browser workspace never spawns a tmux session.

Out of scope, deliberately: workspace-group placement and cwd inheritance don't apply to the remote path (a new remote session starts in tmux's default cwd).

The first commit adds only the regression test so CI shows it failing without the fix: New Workspace on a selected mirror must not add a local workspace, and must still add one when a local workspace is selected. The second commit adds the fix plus unit tests for the host-derivation truth table (including two hosts' mirrors sharing a window) and the controller seam.
