### PR TITLE
Design: New Local Workspace in the command palette

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
@@ -44,6 +44,7 @@ extension ShortcutAction {
         case .quit: return ShortcutStroke(key: "q", command: true)
         case .toggleSidebar: return ShortcutStroke(key: "b", command: true)
         case .newTab: return ShortcutStroke(key: "n", command: true)
+        case .newLocalWorkspace: return ShortcutStroke(key: "n", command: true, control: true)
         case .newBrowserWorkspace: return ShortcutStroke(key: "n", command: true, option: true)
         case .saveLayoutTemplate: return ShortcutStroke(key: "s", command: true, control: true)
         case .openFolder: return ShortcutStroke(key: "o", command: true)

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -20,6 +20,7 @@ public enum ShortcutAction: String, CaseIterable, Sendable, Hashable, SettingCod
     // MARK: Workspace
     case toggleSidebar
     case newTab
+    case newLocalWorkspace
     case newBrowserWorkspace
     case saveLayoutTemplate
     case openFolder
@@ -179,7 +180,7 @@ extension ShortcutAction {
         case .openSettings, .reloadConfiguration, .showHideAllWindows, .globalSearch,
              .newWindow, .closeWindow, .toggleFullScreen, .quit:
             return .app
-        case .toggleSidebar, .newTab, .newBrowserWorkspace, .saveLayoutTemplate, .openFolder, .reopenPreviousSession, .goToWorkspace,
+        case .toggleSidebar, .newTab, .newLocalWorkspace, .newBrowserWorkspace, .saveLayoutTemplate, .openFolder, .reopenPreviousSession, .goToWorkspace,
              .commandPalette, .commandPaletteNext, .commandPalettePrevious, .sendFeedback,
              .showNotifications, .jumpToUnread, .toggleUnread, .markOldestUnreadAndJumpNext,
              .focusRightSidebar, .switchRightSidebarToFiles, .switchRightSidebarToFind,
@@ -336,6 +337,8 @@ extension ShortcutAction {
         case .quit: return "Quit cmux"
         case .toggleSidebar: return "Toggle Left Sidebar"
         case .newTab: return "New Workspace"
+        case .newLocalWorkspace:
+            return String(localized: "shortcut.newLocalWorkspace.label", defaultValue: "New Local Workspace")
         case .newBrowserWorkspace:
             return String(localized: "shortcut.newBrowserWorkspace.label", defaultValue: "New Browser Workspace")
         case .saveLayoutTemplate:

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7320,11 +7320,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 let initialWorkspace = context.tabManager.selectedWorkspace
                 switch initialSurface {
                 case .terminal:
-                    _ = executeConfiguredNewWorkspaceActionIfAvailable(
-                        in: context,
-                        debugSource: debugSource,
-                        replacingInitialWorkspace: initialWorkspace
-                    )
+                    // "New Local Workspace" means a PLAIN local terminal
+                    // workspace; the configured override must not substitute
+                    // another action for it.
+                    if !forceLocal {
+                        _ = executeConfiguredNewWorkspaceActionIfAvailable(
+                            in: context,
+                            debugSource: debugSource,
+                            replacingInitialWorkspace: initialWorkspace
+                        )
+                    }
                 case .browser:
                     // The fresh window boots with a terminal workspace; add the
                     // browser workspace and close that initial one so the
@@ -7377,6 +7382,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // plain New Workspace behavior; the browser variant keeps its own
         // fixed semantics and skips it.
         if initialSurface == .terminal,
+           !forceLocal,
            let context,
            executeConfiguredNewWorkspaceActionIfAvailable(
                in: context,
@@ -13430,6 +13436,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             cmuxDebugLog("shortcut.action name=newBrowserWorkspace \(debugShortcutRouteSnapshot(event: event))")
 #endif
             performNewBrowserWorkspaceAction(event: event, debugSource: "shortcut.optCmdN")
+            return true
+        }
+
+        if matchConfiguredShortcut(event: event, action: .newLocalWorkspace) {
+#if DEBUG
+            cmuxDebugLog("shortcut.action name=newLocalWorkspace \(debugShortcutRouteSnapshot(event: event))")
+#endif
+            performNewLocalWorkspaceAction(event: event, debugSource: "shortcut.ctrlCmdN")
             return true
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7174,6 +7174,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    /// Creates a new LOCAL terminal workspace even in a remote-tmux mirror window.
+    /// Plain New Workspace (⌘N) in a mirror window spawns a remote tmux session on
+    /// the active tab's host; this is the explicit escape hatch to open local work
+    /// alongside mirrors — it skips the remote-routing branch and otherwise shares
+    /// the same window routing, placement, and naming.
+    @discardableResult
+    func performNewLocalWorkspaceAction(
+        tabManager preferredTabManager: TabManager? = nil,
+        event: NSEvent? = nil,
+        debugSource: String = "newLocalWorkspace"
+    ) -> Bool {
+        performNewWorkspaceCreationAction(
+            initialSurface: .terminal,
+            preferredTabManager: preferredTabManager,
+            event: event,
+            debugSource: debugSource,
+            forceLocal: true
+        )
+    }
+
     /// Creates a new workspace whose initial surface is a browser pane in its
     /// default new-tab state with the address bar focused. Shares the window
     /// routing, placement, and naming semantics of `performNewWorkspaceAction`.
@@ -7272,7 +7292,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         initialBrowserOmnibarVisible: Bool = true,
         initialBrowserTransparentBackground: Bool = false,
         focusInitialBrowserAddressBarOnCreate: Bool = true,
-        createdWorkspaceHandler: ((Workspace) -> Void)? = nil
+        createdWorkspaceHandler: ((Workspace) -> Void)? = nil,
+        forceLocal: Bool = false
     ) -> Bool {
         let preferredContext = preferredTabManager.flatMap { mainWindowContext(for: $0) }
         let livePreferredContext: MainWindowContext? = {
@@ -7341,8 +7362,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // On a remote-tmux mirror workspace, a new terminal workspace means
         // "create a new tmux session on that workspace's host" — route it to the
         // remote and mirror it back instead of creating a local workspace. The
-        // browser variant always stays local.
+        // browser variant always stays local, and `forceLocal` (the "New Local
+        // Workspace" command) is the explicit escape hatch for opening local
+        // work alongside mirrors.
         if initialSurface == .terminal,
+           !forceLocal,
            let context,
            remoteTmuxController.handleNewWorkspaceRequested(in: context.tabManager) {
             return true

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7338,6 +7338,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let context = livePreferredContext
             ?? preferredMainWindowContextForWorkspaceCreation(event: event, debugSource: debugSource)
 
+        // On a remote-tmux mirror workspace, a new terminal workspace means
+        // "create a new tmux session on that workspace's host" — route it to the
+        // remote and mirror it back instead of creating a local workspace. The
+        // browser variant always stays local.
+        if initialSurface == .terminal,
+           let context,
+           remoteTmuxController.handleNewWorkspaceRequested(in: context.tabManager) {
+            return true
+        }
+
         let workspaceGroupTarget = context.flatMap { workspaceGroupNewWorkspaceTarget(in: $0) }
         // The configured new-workspace action is the user's override for the
         // plain New Workspace behavior; the browser variant keeps its own
@@ -15375,7 +15385,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         case .builtIn(let builtIn):
             switch builtIn {
             case .newWorkspace:
-                context.tabManager.addWorkspace()
+                // Same routing as Cmd+N: on an active mirror workspace the
+                // built-in action creates a session on that mirror's host.
+                if !remoteTmuxController.handleNewWorkspaceRequested(in: context.tabManager) {
+                    context.tabManager.addWorkspace()
+                }
                 onExecuted?()
                 return true
             case .newAgentChat: return performConfiguredNewAgentChatAction(context: context, preferredWindow: preferredWindow, onExecuted: onExecuted)

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -75,6 +75,7 @@ enum KeyboardShortcutSettings {
         // Titlebar / primary UI
         case toggleSidebar
         case newTab
+        case newLocalWorkspace
         case newBrowserWorkspace
         case saveLayoutTemplate
         case openFolder
@@ -208,6 +209,7 @@ enum KeyboardShortcutSettings {
             case .quit: return String(localized: "menu.quitCmux", defaultValue: "Quit cmux")
             case .toggleSidebar: return String(localized: "shortcut.toggleLeftSidebar.label", defaultValue: "Toggle Left Sidebar")
             case .newTab: return String(localized: "shortcut.newWorkspace.label", defaultValue: "New Workspace")
+            case .newLocalWorkspace: return String(localized: "shortcut.newLocalWorkspace.label", defaultValue: "New Local Workspace")
             case .newBrowserWorkspace: return String(localized: "shortcut.newBrowserWorkspace.label", defaultValue: "New Browser Workspace")
             case .saveLayoutTemplate: return String(localized: "shortcut.saveLayoutTemplate.label", defaultValue: "Save Layout as Template…")
             case .openFolder: return String(localized: "shortcut.openFolder.label", defaultValue: "Open Folder")
@@ -355,6 +357,12 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "b", command: true, shift: false, option: false, control: false)
             case .newTab:
                 return StoredShortcut(key: "n", command: true, shift: false, option: false, control: false)
+            case .newLocalWorkspace:
+                // Control+Cmd+N: the local-workspace escape hatch, next to New
+                // Workspace (Cmd+N), New Window (Cmd+Shift+N), and New Browser
+                // Workspace (Option+Cmd+N). Control+Cmd+N is otherwise unused by
+                // cmux defaults and is not an AppKit-reserved keystroke.
+                return StoredShortcut(key: "n", command: true, shift: false, option: false, control: true)
             case .newBrowserWorkspace:
                 // Option+Cmd+N: sits next to New Workspace (Cmd+N) and New Window (Cmd+Shift+N)
                 // without colliding with any cmux default or an AppKit-reserved keystroke.

--- a/Sources/RemoteTmuxController+Decisions.swift
+++ b/Sources/RemoteTmuxController+Decisions.swift
@@ -295,6 +295,24 @@ extension RemoteTmuxController {
         return MirrorTabActivity(hasActiveCommand: hasActive, activeCommandName: name)
     }
 
+    /// The host a New Workspace action should spawn a tmux session on: the host
+    /// of the ACTIVE workspace's live mirror, or nil to create a LOCAL workspace.
+    ///
+    /// Deriving from the active workspace (not the window) is what keeps routing
+    /// correct when one window holds mirrors from several hosts — the default
+    /// placement, since every host mirrors into the current window. A local
+    /// (no-mirror) active workspace, a mirror whose weak workspace is already
+    /// deallocated (`workspaceId` nil, mid-teardown), and no active workspace at
+    /// all each yield nil. Pure over `(activeTabId, entries)` so the whole truth
+    /// table is unit testable without live mirrors.
+    nonisolated static func newSessionHost(
+        activeTabId: UUID?,
+        entries: [(host: RemoteTmuxHost, workspaceId: UUID?)]
+    ) -> RemoteTmuxHost? {
+        guard let activeTabId else { return nil }
+        return entries.first { $0.workspaceId == activeTabId }?.host
+    }
+
     /// The `kill-session` target for a user-initiated mirror-workspace close, or
     /// nil when the control client already ended. Closing a leftover workspace
     /// after deliberate detach must not kill the remote session detach promised to

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -647,6 +647,82 @@ final class RemoteTmuxController {
         }
     }
 
+    /// The pure remote-vs-local decision for a new-workspace request, factored out
+    /// so it can be unit-tested without a live registry/window. `hasManager` false
+    /// (a dedicated window mid-teardown) routes remote to match the handler, which
+    /// returns `true` but no-ops the creation.
+    nonisolated static func newWorkspaceRoutesRemote(
+        hasHost: Bool,
+        hasManager: Bool,
+        activeTabIsMirror: Bool
+    ) -> Bool {
+        guard hasHost else { return false }
+        guard hasManager else { return true }
+        return activeTabIsMirror
+    }
+
+    /// Whether a new-workspace request on `windowId` would spawn a REMOTE tmux
+    /// session (plain New Workspace / ⌘N routes to the window's host) rather than
+    /// creating a local workspace. Non-mutating: the single source of truth shared
+    /// by `handleRemoteWindowNewWorkspaceRequested` and the "New Local Workspace"
+    /// menu item's visibility, so the item appears exactly when plain New Workspace
+    /// would go remote.
+    /// Resolves the host of `windowId`'s ACTIVE mirror workspace, if any. The
+    /// registry no longer maps windows to hosts, so a window "belongs" to a host
+    /// exactly when its active workspace mirrors a session on that host — which
+    /// also keeps a dragged-in local tab local (gate on the ACTIVE workspace,
+    /// not the window).
+    private func activeMirrorHost(windowId: UUID) -> RemoteTmuxHost? {
+        guard let selected = AppDelegate.shared?.tabManagerFor(windowId: windowId)?.selectedTab,
+              selected.isRemoteTmuxMirror else { return nil }
+        return sessionMirrors.values.first(where: { $0.mirroredWorkspaceId == selected.id })?.host
+    }
+
+    func wouldNewWorkspaceSpawnRemote(windowId: UUID) -> Bool {
+        let manager = AppDelegate.shared?.tabManagerFor(windowId: windowId)
+        return Self.newWorkspaceRoutesRemote(
+            hasHost: activeMirrorHost(windowId: windowId) != nil,
+            hasManager: manager != nil,
+            activeTabIsMirror: manager?.selectedTab?.isRemoteTmuxMirror == true
+        )
+    }
+
+    /// Creates a new tmux session on a dedicated remote window's host (and mirrors it
+    /// into that window) when a new workspace is requested while a mirror tab is active.
+    /// The single source of truth for the remote-vs-local decision (via
+    /// `wouldNewWorkspaceSpawnRemote`), so every `performNewWorkspaceAction` entrypoint
+    /// (double-tap, ⌘N, titlebar +, palette) is consistent.
+    ///
+    /// - Returns: `true` only when `windowId` is dedicated AND its active workspace is a
+    ///   mirror (caller suppresses local creation); `false` otherwise — e.g. a dedicated
+    ///   window whose active tab is a dragged-in local one, so the caller goes local.
+    func handleRemoteWindowNewWorkspaceRequested(windowId: UUID) -> Bool {
+        guard wouldNewWorkspaceSpawnRemote(windowId: windowId) else { return false }
+        // The predicate established a host + active mirror exist (or the window is
+        // mid-teardown with no manager). Re-resolve for the creation; a missing
+        // manager means the window is gone, so route remote without creating.
+        // The mirror carries the full host (destination + port + identity), so
+        // the new session reuses the exact connection details of the window's host.
+        guard let host = activeMirrorHost(windowId: windowId),
+              let manager = AppDelegate.shared?.tabManagerFor(windowId: windowId) else { return true }
+        Task { @MainActor in
+            do {
+                // Create a detached session and read back its (auto-assigned) name.
+                let result = try await self.transport(for: host).runTmux(
+                    ["new-session", "-d", "-P", "-F", "#{session_name}"]
+                )
+                let name = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard result.succeeded, !name.isEmpty else { return }
+                _ = try self.mirrorSession(host: host, sessionName: name, into: manager)
+            } catch {
+                #if DEBUG
+                cmuxDebugLog("remote-tmux: new-session on \(host.destination) failed: \(error)")
+                #endif
+            }
+        }
+        return true
+    }
+
     /// The remote tmux session ended FOR GOOD (its last window was killed, it was
     /// killed out-of-band, or a reconnect found it gone) — remove the mirror +
     /// connection and close the now-dead workspace. Never

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import CmuxSettings
 import OSLog
@@ -287,12 +288,15 @@ final class RemoteTmuxController {
 
     /// Mirrors a single tmux session into a new workspace in `tabManager` (idempotent).
     /// `sessionId` seeds discovery's stable id for de-dup before the stream reports it.
+    /// `select` selects the new workspace on creation (a user-initiated New
+    /// Workspace); bulk attach keeps the default so discovery never steals focus.
     @discardableResult
     func mirrorSession(
         host: RemoteTmuxHost,
         sessionName: String,
         sessionId: Int? = nil,
-        into tabManager: TabManager
+        into tabManager: TabManager,
+        select: Bool = false
     ) throws -> Bool {
         let key = Self.connectionKey(host: host, sessionName: sessionName)
         guard sessionMirrors[key] == nil else { return false }
@@ -300,6 +304,8 @@ final class RemoteTmuxController {
         // failed connection doesn't leave an orphaned empty mirror workspace in
         // the sidebar.
         let connection = try attach(host: host, sessionName: sessionName)
+        // Always create unselected: selection fires visibility/sizing observers,
+        // which must see a fully wired mirror, not a half-initialized workspace.
         let workspace = tabManager.addWorkspace(
             title: sessionName,
             select: false,
@@ -324,10 +330,103 @@ final class RemoteTmuxController {
             onControlPaneRemoved: TerminalController.remoteTmuxControlPaneRemovalHandler(),
             onControlSurfaceRemoved: TerminalController.remoteTmuxControlSurfaceRemovalHandler()
         )
+        if select {
+            tabManager.selectWorkspace(workspace)
+        }
         return true
     }
 
     // MARK: - Create / destroy propagation (P5)
+
+    /// New Workspace requested in `manager`: when its ACTIVE workspace is a live
+    /// session mirror, create a new detached tmux session on that mirror's host and
+    /// mirror it into the same manager, returning `true` (the caller suppresses
+    /// local creation). `false` — active workspace isn't a mirror — means the
+    /// caller creates a plain local workspace.
+    ///
+    /// The host comes from the active workspace's own mirror (see
+    /// ``newSessionHost(activeTabId:entries:)``), never from window-level state:
+    /// a window routinely holds mirrors from several hosts plus local workspaces,
+    /// and each must route by what the user is actually sitting on.
+    func handleNewWorkspaceRequested(in manager: TabManager) -> Bool {
+        let entries = sessionMirrors.values.map { (host: $0.host, workspaceId: $0.mirroredWorkspaceId) }
+        guard let activeTabId = manager.selectedTab?.id,
+              let host = Self.newSessionHost(activeTabId: activeTabId, entries: entries) else {
+            return false
+        }
+        newSessionRoutingTask = Task { @MainActor in
+            do {
+                // Create a detached session and read back its (auto-assigned)
+                // name, then attach to it like any discovered session.
+                let result = try await self.transport(for: host).runTmux(
+                    ["new-session", "-d", "-P", "-F", "#{session_name}"]
+                )
+                // Revalidate across the ssh round trip: the manager must still be
+                // a REGISTERED main-window context. `windowId(for:)` would also
+                // answer for a closed window's recoverable route and resurrect a
+                // dead manager, so it is deliberately not used here. On a closed
+                // window, skip — the detached session is picked up on the next
+                // attach.
+                guard AppDelegate.shared?.mainWindowContexts.values
+                    .contains(where: { $0.tabManager === manager }) == true else { return }
+                let name = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard result.succeeded, !name.isEmpty else {
+                    self.reportNewSessionFailure(host, result.stderr, manager)
+                    return
+                }
+                // The user may have moved on to another tab while the round trip
+                // ran (mirror, but don't steal selection).
+                let select = manager.selectedTab?.id == activeTabId
+                // false = an attach for this exact host+name raced us and already
+                // mirrored it (into whichever manager it targeted); nothing to add.
+                _ = try self.mirrorSession(host: host, sessionName: name, into: manager, select: select)
+            } catch {
+                #if DEBUG
+                cmuxDebugLog("remote-tmux: new-session on active mirror's host failed: \(error)")
+                #endif
+                guard AppDelegate.shared?.mainWindowContexts.values
+                    .contains(where: { $0.tabManager === manager }) == true else { return }
+                self.reportNewSessionFailure(host, error.localizedDescription, manager)
+            }
+        }
+        return true
+    }
+
+    /// The in-flight routed New Workspace request, if any. Tests await it so the
+    /// ssh round trip and mirror creation finish inside the test body.
+    private(set) var newSessionRoutingTask: Task<Void, Never>?
+
+    /// How a failed routed New Workspace reaches the user (host, failure detail,
+    /// requesting manager). Local creation stays suppressed either way — a mirror
+    /// workspace's Cmd+N must not quietly fall back to a local workspace — so the
+    /// failure has to be visible. Settable so tests can capture it instead of
+    /// presenting an alert.
+    lazy var reportNewSessionFailure: (RemoteTmuxHost, String, TabManager) -> Void = {
+        [weak self] host, detail, manager in
+        self?.presentNewSessionFailureAlert(host: host, detail: detail, manager: manager)
+    }
+
+    private func presentNewSessionFailureAlert(host: RemoteTmuxHost, detail: String, manager: TabManager) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(
+            localized: "dialog.remoteTmux.newSessionFailed.title",
+            defaultValue: "Couldn't Create a tmux Session on \(host.destination)"
+        )
+        let trimmedDetail = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+        alert.informativeText = trimmedDetail.isEmpty
+            ? String(
+                localized: "dialog.remoteTmux.newSessionFailed.message",
+                defaultValue: "tmux new-session failed on the remote host. No workspace was created."
+            )
+            : trimmedDetail
+        alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
+        if let window = manager.window ?? NSApp.keyWindow ?? NSApp.mainWindow {
+            alert.beginSheetModal(for: window, completionHandler: nil)
+        } else {
+            alert.runModal()
+        }
+    }
 
     /// A mirrored workspace was renamed → `rename-session` on the remote so the
     /// tmux session name tracks the cmux workspace title.

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -338,6 +338,24 @@ final class RemoteTmuxController {
 
     // MARK: - Create / destroy propagation (P5)
 
+    /// The live-mirror host for `activeTabId`, or nil (create locally). See
+    /// ``newSessionHost(activeTabId:entries:)`` for the truth table.
+    private func newSessionHost(activeTabId: UUID?) -> RemoteTmuxHost? {
+        Self.newSessionHost(
+            activeTabId: activeTabId,
+            entries: sessionMirrors.values.map { (host: $0.host, workspaceId: $0.mirroredWorkspaceId) }
+        )
+    }
+
+    /// Whether a New Workspace request in `manager` would spawn a REMOTE tmux
+    /// session rather than a local workspace. Non-mutating twin of
+    /// ``handleNewWorkspaceRequested(in:)`` — the "New Local Workspace" menu
+    /// item's visibility reads it, so the item appears exactly when plain New
+    /// Workspace would go remote.
+    func wouldNewWorkspaceSpawnRemote(in manager: TabManager) -> Bool {
+        newSessionHost(activeTabId: manager.selectedTab?.id) != nil
+    }
+
     /// New Workspace requested in `manager`: when its ACTIVE workspace is a live
     /// session mirror, create a new detached tmux session on that mirror's host and
     /// mirror it into the same manager, returning `true` (the caller suppresses
@@ -349,9 +367,8 @@ final class RemoteTmuxController {
     /// a window routinely holds mirrors from several hosts plus local workspaces,
     /// and each must route by what the user is actually sitting on.
     func handleNewWorkspaceRequested(in manager: TabManager) -> Bool {
-        let entries = sessionMirrors.values.map { (host: $0.host, workspaceId: $0.mirroredWorkspaceId) }
         guard let activeTabId = manager.selectedTab?.id,
-              let host = Self.newSessionHost(activeTabId: activeTabId, entries: entries) else {
+              let host = newSessionHost(activeTabId: activeTabId) else {
             return false
         }
         newSessionRoutingTask = Task { @MainActor in
@@ -645,82 +662,6 @@ final class RemoteTmuxController {
                 completion(self.mirrorTabActivityFromCache(target: target))
             }
         }
-    }
-
-    /// The pure remote-vs-local decision for a new-workspace request, factored out
-    /// so it can be unit-tested without a live registry/window. `hasManager` false
-    /// (a dedicated window mid-teardown) routes remote to match the handler, which
-    /// returns `true` but no-ops the creation.
-    nonisolated static func newWorkspaceRoutesRemote(
-        hasHost: Bool,
-        hasManager: Bool,
-        activeTabIsMirror: Bool
-    ) -> Bool {
-        guard hasHost else { return false }
-        guard hasManager else { return true }
-        return activeTabIsMirror
-    }
-
-    /// Whether a new-workspace request on `windowId` would spawn a REMOTE tmux
-    /// session (plain New Workspace / ⌘N routes to the window's host) rather than
-    /// creating a local workspace. Non-mutating: the single source of truth shared
-    /// by `handleRemoteWindowNewWorkspaceRequested` and the "New Local Workspace"
-    /// menu item's visibility, so the item appears exactly when plain New Workspace
-    /// would go remote.
-    /// Resolves the host of `windowId`'s ACTIVE mirror workspace, if any. The
-    /// registry no longer maps windows to hosts, so a window "belongs" to a host
-    /// exactly when its active workspace mirrors a session on that host — which
-    /// also keeps a dragged-in local tab local (gate on the ACTIVE workspace,
-    /// not the window).
-    private func activeMirrorHost(windowId: UUID) -> RemoteTmuxHost? {
-        guard let selected = AppDelegate.shared?.tabManagerFor(windowId: windowId)?.selectedTab,
-              selected.isRemoteTmuxMirror else { return nil }
-        return sessionMirrors.values.first(where: { $0.mirroredWorkspaceId == selected.id })?.host
-    }
-
-    func wouldNewWorkspaceSpawnRemote(windowId: UUID) -> Bool {
-        let manager = AppDelegate.shared?.tabManagerFor(windowId: windowId)
-        return Self.newWorkspaceRoutesRemote(
-            hasHost: activeMirrorHost(windowId: windowId) != nil,
-            hasManager: manager != nil,
-            activeTabIsMirror: manager?.selectedTab?.isRemoteTmuxMirror == true
-        )
-    }
-
-    /// Creates a new tmux session on a dedicated remote window's host (and mirrors it
-    /// into that window) when a new workspace is requested while a mirror tab is active.
-    /// The single source of truth for the remote-vs-local decision (via
-    /// `wouldNewWorkspaceSpawnRemote`), so every `performNewWorkspaceAction` entrypoint
-    /// (double-tap, ⌘N, titlebar +, palette) is consistent.
-    ///
-    /// - Returns: `true` only when `windowId` is dedicated AND its active workspace is a
-    ///   mirror (caller suppresses local creation); `false` otherwise — e.g. a dedicated
-    ///   window whose active tab is a dragged-in local one, so the caller goes local.
-    func handleRemoteWindowNewWorkspaceRequested(windowId: UUID) -> Bool {
-        guard wouldNewWorkspaceSpawnRemote(windowId: windowId) else { return false }
-        // The predicate established a host + active mirror exist (or the window is
-        // mid-teardown with no manager). Re-resolve for the creation; a missing
-        // manager means the window is gone, so route remote without creating.
-        // The mirror carries the full host (destination + port + identity), so
-        // the new session reuses the exact connection details of the window's host.
-        guard let host = activeMirrorHost(windowId: windowId),
-              let manager = AppDelegate.shared?.tabManagerFor(windowId: windowId) else { return true }
-        Task { @MainActor in
-            do {
-                // Create a detached session and read back its (auto-assigned) name.
-                let result = try await self.transport(for: host).runTmux(
-                    ["new-session", "-d", "-P", "-F", "#{session_name}"]
-                )
-                let name = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard result.succeeded, !name.isEmpty else { return }
-                _ = try self.mirrorSession(host: host, sessionName: name, into: manager)
-            } catch {
-                #if DEBUG
-                cmuxDebugLog("remote-tmux: new-session on \(host.destination) failed: \(error)")
-                #endif
-            }
-        }
-        return true
     }
 
     /// The remote tmux session ended FOR GOOD (its last window was killed, it was

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12471,7 +12471,12 @@ extension Workspace: BonsplitDelegate {
         if let builtInAction = executable.builtInAction {
             switch builtInAction {
             case .newWorkspace:
-                owningTabManager?.addWorkspace()
+                // Same routing as Cmd+N: on an active mirror workspace the
+                // button creates a session on that mirror's host.
+                if let manager = owningTabManager,
+                   AppDelegate.shared?.remoteTmuxController.handleNewWorkspaceRequested(in: manager) != true {
+                    manager.addWorkspace()
+                }
             case .newAgentChat: performSurfaceTabBarNewAgentChatAction(presentingWindow: presentingWindow)
             case .cloudVM:
                 _ = AppDelegate.shared?.performCloudVMAction(tabManager: owningTabManager, preferredWindow: presentingWindow, debugSource: "surfaceTabBar.cloudVM")

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -731,7 +731,7 @@ struct cmuxApp: App {
                 // there. Offer an explicit escape hatch, shown only when New Workspace
                 // would go remote so it never clutters ordinary windows.
                 if newLocalWorkspaceMenuItemVisible {
-                    splitCommandButton(title: String(localized: "menu.file.newLocalWorkspace", defaultValue: "New Local Workspace"), shortcut: .unbound) {
+                    splitCommandButton(title: String(localized: "menu.file.newLocalWorkspace", defaultValue: "New Local Workspace"), shortcut: menuShortcut(for: .newLocalWorkspace)) {
                         AppDelegate.shared?.performNewLocalWorkspaceAction(
                             tabManager: activeTabManager,
                             debugSource: "menu.newLocalWorkspace"
@@ -1182,9 +1182,8 @@ struct cmuxApp: App {
     /// before its menu bar opens, so switching into a mirror window refreshes this).
     private var newLocalWorkspaceMenuItemVisible: Bool {
         let _ = focusHistoryMenuInvalidator.revision
-        guard let appDelegate = AppDelegate.shared,
-              let windowId = appDelegate.windowId(for: activeTabManager) else { return false }
-        return appDelegate.remoteTmuxController.wouldNewWorkspaceSpawnRemote(windowId: windowId)
+        guard let appDelegate = AppDelegate.shared else { return false }
+        return appDelegate.remoteTmuxController.wouldNewWorkspaceSpawnRemote(in: activeTabManager)
     }
 
     private func notificationMenuItemTitle(for notification: TerminalNotification) -> String {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -726,6 +726,19 @@ struct cmuxApp: App {
                     }
                 }
 
+                // In a remote-tmux mirror window, plain New Workspace (above) spawns a
+                // tmux session on the window's host, leaving no way to open LOCAL work
+                // there. Offer an explicit escape hatch, shown only when New Workspace
+                // would go remote so it never clutters ordinary windows.
+                if newLocalWorkspaceMenuItemVisible {
+                    splitCommandButton(title: String(localized: "menu.file.newLocalWorkspace", defaultValue: "New Local Workspace"), shortcut: .unbound) {
+                        AppDelegate.shared?.performNewLocalWorkspaceAction(
+                            tabManager: activeTabManager,
+                            debugSource: "menu.newLocalWorkspace"
+                        )
+                    }
+                }
+
                 splitCommandButton(title: String(localized: "menu.file.newBrowserWorkspace", defaultValue: "New Browser Workspace"), shortcut: menuShortcut(for: .newBrowserWorkspace)) {
                     if let appDelegate = AppDelegate.shared {
                         appDelegate.performNewBrowserWorkspaceAction(
@@ -1160,6 +1173,18 @@ struct cmuxApp: App {
         AppDelegate.shared?.activeTabManagerForCommands(
             preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
         ) ?? tabManager
+    }
+
+    /// Whether the "New Local Workspace" File-menu item should be shown: true only
+    /// when plain New Workspace in the active window would route to a remote tmux
+    /// host. Reads `focusHistoryMenuInvalidator.revision` so the menu re-evaluates
+    /// on window-focus and workspace-selection changes (a window must become key
+    /// before its menu bar opens, so switching into a mirror window refreshes this).
+    private var newLocalWorkspaceMenuItemVisible: Bool {
+        let _ = focusHistoryMenuInvalidator.revision
+        guard let appDelegate = AppDelegate.shared,
+              let windowId = appDelegate.windowId(for: activeTabManager) else { return false }
+        return appDelegate.remoteTmuxController.wouldNewWorkspaceSpawnRemote(windowId: windowId)
     }
 
     private func notificationMenuItemTitle(for notification: TerminalNotification) -> String {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1314,6 +1314,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		7368BEEF7368BEEF7368B002 /* RemoteTmuxMissingTmuxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7368BEEF7368BEEF7368B001 /* RemoteTmuxMissingTmuxTests.swift */; };
 		B8E2A4C1D5F3096871A2B3C3 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E2A4C1D5F3096871A2B3C4 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift */; };
 		0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */; };
+		73620000000000000000000A /* RemoteTmuxNewWorkspaceHostRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736200000000000000000009 /* RemoteTmuxNewWorkspaceHostRoutingTests.swift */; };
 		E9A8CC35D632F14A8669B7D1 /* RemoteTmuxPaneForegroundState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123BF93B1ADC00C5D25EE028 /* RemoteTmuxPaneForegroundState.swift */; };
 		7371A0010000000000000001 /* RemoteTmuxPendingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7371A0010000000000000002 /* RemoteTmuxPendingLayout.swift */; };
 		7371A0020000000000000001 /* RemoteTmuxPipeReadResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7371A0020000000000000002 /* RemoteTmuxPipeReadResult.swift */; };
@@ -3372,6 +3373,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		7368BEEF7368BEEF7368B001 /* RemoteTmuxMissingTmuxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMissingTmuxTests.swift; sourceTree = "<group>"; };
 		B8E2A4C1D5F3096871A2B3C4 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNativeMirrorLayoutFuzzTests.swift; sourceTree = "<group>"; };
 		0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNewWindowCwdTests.swift; sourceTree = "<group>"; };
+		736200000000000000000009 /* RemoteTmuxNewWorkspaceHostRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNewWorkspaceHostRoutingTests.swift; sourceTree = "<group>"; };
 		123BF93B1ADC00C5D25EE028 /* RemoteTmuxPaneForegroundState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPaneForegroundState.swift; sourceTree = "<group>"; };
 		7371A0010000000000000002 /* RemoteTmuxPendingLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPendingLayout.swift; sourceTree = "<group>"; };
 		7371A0020000000000000002 /* RemoteTmuxPipeReadResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPipeReadResult.swift; sourceTree = "<group>"; };
@@ -6146,6 +6148,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					736200000000000000000007 /* RemoteTmuxMirrorTargetingTests.swift */,
 					838000000000000000000001 /* RemoteTmuxMirrorRenameTests.swift */,
 					838000000000000000000003 /* RemoteTmuxMirrorRenameHarness.swift */,
+					736200000000000000000009 /* RemoteTmuxNewWorkspaceHostRoutingTests.swift */,
 					31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */,
 					B8E2A4C1D5F3096871A2B3C4 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift */,
 					B8E2A4C1D5F3096871A2B4A2 /* RemoteTmuxBonsplitImpositionRenderTests.swift */,
@@ -8574,6 +8577,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7368BEEF7368BEEF7368B002 /* RemoteTmuxMissingTmuxTests.swift in Sources */,
 				B8E2A4C1D5F3096871A2B3C3 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift in Sources */,
 				0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */,
+				73620000000000000000000A /* RemoteTmuxNewWorkspaceHostRoutingTests.swift in Sources */,
 				7020C0DE7020C0DE7020A002 /* RemoteTmuxProxyTransportRetryTests.swift in Sources */,
 				6B14EBE2544B2139E2902453 /* RemoteTmuxRectPublicationTests.swift in Sources */,
 				3AC9AB9046E742B93726A405 /* RemoteTmuxSessionListParserTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1315,6 +1315,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B8E2A4C1D5F3096871A2B3C3 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E2A4C1D5F3096871A2B3C4 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift */; };
 		0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */; };
 		73620000000000000000000A /* RemoteTmuxNewWorkspaceHostRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736200000000000000000009 /* RemoteTmuxNewWorkspaceHostRoutingTests.swift */; };
+		C0DEBABE0001F00D0001F00D /* RemoteTmuxNewWorkspaceRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEBABE0002F00D0002F00D /* RemoteTmuxNewWorkspaceRoutingTests.swift */; };
 		E9A8CC35D632F14A8669B7D1 /* RemoteTmuxPaneForegroundState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123BF93B1ADC00C5D25EE028 /* RemoteTmuxPaneForegroundState.swift */; };
 		7371A0010000000000000001 /* RemoteTmuxPendingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7371A0010000000000000002 /* RemoteTmuxPendingLayout.swift */; };
 		7371A0020000000000000001 /* RemoteTmuxPipeReadResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7371A0020000000000000002 /* RemoteTmuxPipeReadResult.swift */; };
@@ -3374,6 +3375,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B8E2A4C1D5F3096871A2B3C4 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNativeMirrorLayoutFuzzTests.swift; sourceTree = "<group>"; };
 		0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNewWindowCwdTests.swift; sourceTree = "<group>"; };
 		736200000000000000000009 /* RemoteTmuxNewWorkspaceHostRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNewWorkspaceHostRoutingTests.swift; sourceTree = "<group>"; };
+		C0DEBABE0002F00D0002F00D /* RemoteTmuxNewWorkspaceRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNewWorkspaceRoutingTests.swift; sourceTree = "<group>"; };
 		123BF93B1ADC00C5D25EE028 /* RemoteTmuxPaneForegroundState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPaneForegroundState.swift; sourceTree = "<group>"; };
 		7371A0010000000000000002 /* RemoteTmuxPendingLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPendingLayout.swift; sourceTree = "<group>"; };
 		7371A0020000000000000002 /* RemoteTmuxPipeReadResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPipeReadResult.swift; sourceTree = "<group>"; };
@@ -6131,6 +6133,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				79380000000000000000000B /* RemoteTmuxLayoutNodePatchingTests.swift */,
 				A7C9D1E3F5B7A9C1D3E5F701 /* RemoteTmuxWindowReorderTests.swift */,
 				F11ED7AB0002000200020002 /* RemoteTmuxMirrorNewTabPlacementTests.swift */,
+				C0DEBABE0002F00D0002F00D /* RemoteTmuxNewWorkspaceRoutingTests.swift */,
 				FA00C0DE0002BEEF0002CAFE /* RemoteTmuxWindowRegistryTests.swift */,
 				0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */,
 				7020C0DE7020C0DE7020A001 /* RemoteTmuxProxyTransportRetryTests.swift */,
@@ -8578,6 +8581,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B8E2A4C1D5F3096871A2B3C3 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift in Sources */,
 				0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */,
 				73620000000000000000000A /* RemoteTmuxNewWorkspaceHostRoutingTests.swift in Sources */,
+				C0DEBABE0001F00D0001F00D /* RemoteTmuxNewWorkspaceRoutingTests.swift in Sources */,
 				7020C0DE7020C0DE7020A002 /* RemoteTmuxProxyTransportRetryTests.swift in Sources */,
 				6B14EBE2544B2139E2902453 /* RemoteTmuxRectPublicationTests.swift in Sources */,
 				3AC9AB9046E742B93726A405 /* RemoteTmuxSessionListParserTests.swift in Sources */,

--- a/cmuxTests/RemoteTmuxNewWorkspaceHostRoutingTests.swift
+++ b/cmuxTests/RemoteTmuxNewWorkspaceHostRoutingTests.swift
@@ -7,20 +7,49 @@ import Testing
 @testable import cmux
 #endif
 
-/// New Workspace routing for remote-tmux mirrors: when the active workspace is
-/// a mirrored tmux session, `performNewWorkspaceAction` must route the request
-/// to the session's host instead of creating a local workspace.
+/// New Workspace routing for remote-tmux mirrors: the pure host-derivation
+/// truth table, the controller seam (`handleNewWorkspaceRequested(in:)`), and
+/// the `performNewWorkspaceAction` hook that suppresses local creation when
+/// the active workspace is a mirror.
+///
+/// SSH never leaves the process: every test pins
+/// `CMUX_REMOTE_TMUX_SSH_FOR_TESTING` to a stub for its WHOLE body — including
+/// the deferred `detach`, whose last-mirror teardown spawns `ssh -O exit` — and
+/// awaits `newSessionRoutingTask` before any teardown can evict the cached stub
+/// transport. Tests that suspend hold `AppContextSerialGate` so another suite's
+/// env/AppDelegate use cannot interleave at an await.
 @MainActor
 @Suite(.serialized)
 struct RemoteTmuxNewWorkspaceHostRoutingTests {
-    private let hostA = RemoteTmuxHost(destination: "user@alpha")
+    private static let sshOverrideKey = "CMUX_REMOTE_TMUX_SSH_FOR_TESTING"
+    private let hostA = RemoteTmuxHost(destination: "user@host-routing-alpha")
+    private let hostB = RemoteTmuxHost(destination: "user@host-routing-beta")
 
-    /// Caches a transport for `host` whose ssh binary is a no-op stub, so any
-    /// async new-session attempt can never spawn a real ssh.
-    private func cacheStubTransport(controller: RemoteTmuxController, host: RemoteTmuxHost) {
-        setenv("CMUX_REMOTE_TMUX_SSH_FOR_TESTING", "/usr/bin/false", 1)
-        defer { unsetenv("CMUX_REMOTE_TMUX_SSH_FOR_TESTING") }
-        _ = controller.transport(for: host)
+    /// Sets the ssh stub for the caller's whole scope; the returned closure
+    /// restores the previous value and is meant for the FIRST `defer`, so it
+    /// runs after every later-registered teardown (detach included).
+    private func pinStubSSH(_ stub: String) -> () -> Void {
+        let prior = ProcessInfo.processInfo.environment[Self.sshOverrideKey]
+        setenv(Self.sshOverrideKey, stub, 1)
+        return {
+            if let prior {
+                setenv(Self.sshOverrideKey, prior, 1)
+            } else {
+                unsetenv(Self.sshOverrideKey)
+            }
+        }
+    }
+
+    /// Writes an executable stub that records its arguments (the ssh framing +
+    /// tmux command) to `argvLog` and reports a created session named
+    /// `sessionName`.
+    private func makeNewSessionSuccessStub(sessionName: String, argvLog: String) throws -> String {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-new-session-stub-\(UUID().uuidString).sh").path
+        try "#!/bin/sh\necho \"$@\" >> \"\(argvLog)\"\necho \(sessionName)\n"
+            .write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+        return path
     }
 
     private func mirrorSelectedSession(
@@ -29,6 +58,7 @@ struct RemoteTmuxNewWorkspaceHostRoutingTests {
         sessionName: String,
         into manager: TabManager
     ) throws -> Workspace {
+        _ = controller.transport(for: host)
         controller.cacheConnection(RemoteTmuxControlConnection(host: host, sessionName: sessionName))
         #expect(try controller.mirrorSession(host: host, sessionName: sessionName, into: manager))
         let workspace = try #require(manager.tabs.first { $0.isRemoteTmuxMirror })
@@ -36,17 +66,12 @@ struct RemoteTmuxNewWorkspaceHostRoutingTests {
         return workspace
     }
 
-    @Test func newWorkspaceOnActiveMirrorSuppressesLocalCreation() throws {
-        _ = NSApplication.shared
-        let appDelegate = try #require(AppDelegate.shared)
-        let controller = appDelegate.remoteTmuxController
-        let manager = TabManager()
-        let localWorkspace = try #require(manager.selectedWorkspace)
-        cacheStubTransport(controller: controller, host: hostA)
-        let mirrorWorkspace = try mirrorSelectedSession(
-            controller: controller, host: hostA, sessionName: "dev", into: manager
-        )
-
+    /// Registers `manager` as a main-window context with a resolvable window
+    /// (the shape `performNewWorkspaceAction`'s preferred-context path needs).
+    private func registerWindowedContext(
+        appDelegate: AppDelegate,
+        manager: TabManager
+    ) -> (windowId: UUID, window: NSWindow) {
         let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
@@ -57,25 +82,249 @@ struct RemoteTmuxNewWorkspaceHostRoutingTests {
         window.isReleasedWhenClosed = false
         window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
         manager.window = window
-        defer {
-            window.close()
-            manager.window = nil
-            if controller.sessionMirror(host: hostA, sessionName: "dev") != nil {
+        return (windowId, window)
+    }
+
+    // MARK: - newSessionHost truth table
+
+    @Test func noActiveTabCreatesLocalWorkspace() {
+        #expect(RemoteTmuxController.newSessionHost(
+            activeTabId: nil,
+            entries: [(host: hostA, workspaceId: UUID())]
+        ) == nil)
+    }
+
+    @Test func localActiveTabCreatesLocalWorkspace() {
+        // The active tab has no mirror entry — e.g. a plain local workspace
+        // sitting next to mirrors in the same window.
+        #expect(RemoteTmuxController.newSessionHost(
+            activeTabId: UUID(),
+            entries: [(host: hostA, workspaceId: UUID())]
+        ) == nil)
+    }
+
+    @Test func activeMirrorTabRoutesToItsHost() {
+        let activeId = UUID()
+        #expect(RemoteTmuxController.newSessionHost(
+            activeTabId: activeId,
+            entries: [(host: hostA, workspaceId: activeId)]
+        ) == hostA)
+    }
+
+    @Test func multiHostWindowRoutesByActiveTabNotNeighbor() {
+        // Mirrors from two hosts share the window (the default placement);
+        // the active tab's own host wins regardless of entry order.
+        let activeId = UUID()
+        let entries = [
+            (host: hostA, workspaceId: Optional(UUID())),
+            (host: hostB, workspaceId: Optional(activeId)),
+        ]
+        #expect(RemoteTmuxController.newSessionHost(activeTabId: activeId, entries: entries) == hostB)
+        #expect(RemoteTmuxController.newSessionHost(activeTabId: activeId, entries: entries.reversed()) == hostB)
+    }
+
+    @Test func deallocatedMirrorWorkspaceNeverMatches() {
+        // A mirror whose weak workspace is gone (mid-teardown) reports a nil
+        // workspaceId; it must not capture any active tab.
+        #expect(RemoteTmuxController.newSessionHost(
+            activeTabId: UUID(),
+            entries: [(host: hostA, workspaceId: nil)]
+        ) == nil)
+    }
+
+    // MARK: - Controller seam
+
+    @Test func handlerClaimsRequestOnlyWhenActiveWorkspaceIsMirror() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let restoreSSH = pinStubSSH("/usr/bin/false")
+            defer { restoreSSH() }
+            let controller = RemoteTmuxController()
+            let manager = TabManager()
+            let localWorkspace = try #require(manager.selectedWorkspace)
+            let mirrorWorkspace = try mirrorSelectedSession(
+                controller: controller, host: hostA, sessionName: "dev", into: manager
+            )
+            defer {
                 controller.detach(host: hostA, sessionName: "dev")
             }
-            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+
+            #expect(manager.selectedTab?.id == mirrorWorkspace.id)
+            #expect(controller.handleNewWorkspaceRequested(in: manager))
+            // Drain the routed request against the cached stub transport before
+            // the deferred detach can evict it.
+            await controller.newSessionRoutingTask?.value
+
+            manager.selectWorkspace(localWorkspace)
+            #expect(!controller.handleNewWorkspaceRequested(in: manager))
         }
+    }
 
-        // Active workspace is the mirror: the action is claimed for the remote
-        // host and no local workspace appears.
-        #expect(manager.selectedTab?.id == mirrorWorkspace.id)
-        let tabsBefore = manager.tabs.map(\.id)
-        #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.remoteMirror"))
-        #expect(manager.tabs.map(\.id) == tabsBefore)
+    /// The full success path: the remote reports the created session's name,
+    /// the handler asked for exactly `new-session -d -P -F #{session_name}`,
+    /// and the result is mirrored into the requesting manager and selected.
+    @Test func routedNewWorkspaceMirrorsAndSelectsTheCreatedSession() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let appDelegate = try #require(AppDelegate.shared)
+            let argvLog = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-new-session-argv-\(UUID().uuidString).log").path
+            let stub = try makeNewSessionSuccessStub(sessionName: "brand-new", argvLog: argvLog)
+            let restoreSSH = pinStubSSH(stub)
+            defer {
+                restoreSSH()
+                try? FileManager.default.removeItem(atPath: stub)
+                try? FileManager.default.removeItem(atPath: argvLog)
+            }
+            let controller = RemoteTmuxController()
+            let manager = TabManager()
+            _ = try mirrorSelectedSession(
+                controller: controller, host: hostA, sessionName: "dev", into: manager
+            )
+            // The mirror the handler creates attaches to the reported name;
+            // cache its connection so no control stream is spawned.
+            controller.cacheConnection(RemoteTmuxControlConnection(host: hostA, sessionName: "brand-new"))
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                for sessionName in ["brand-new", "dev"] {
+                    controller.detach(host: hostA, sessionName: sessionName)
+                }
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            }
 
-        // Active workspace is local: the same action creates a local workspace.
-        manager.selectWorkspace(localWorkspace)
-        #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.localTab"))
-        #expect(manager.tabs.count == tabsBefore.count + 1)
+            #expect(controller.handleNewWorkspaceRequested(in: manager))
+            await controller.newSessionRoutingTask?.value
+
+            let recordedArgv = (try? String(contentsOfFile: argvLog, encoding: .utf8)) ?? ""
+            // RemoteTmuxHost.tmuxRemoteCommand single-quotes every word of the remote
+            // command, so the flags arrive individually quoted, not as one bare run.
+            #expect(recordedArgv.contains("'new-session' '-d' '-P' '-F' '#{session_name}'"))
+            let created = try #require(manager.tabs.first { $0.title == "brand-new" })
+            #expect(created.isRemoteTmuxMirror)
+            #expect(manager.selectedTab?.id == created.id)
+        }
+    }
+
+    /// Moving to another tab during the ssh round trip still mirrors the new
+    /// session, but must not steal the user's selection.
+    @Test func movingOnDuringRoundTripMirrorsWithoutStealingSelection() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let appDelegate = try #require(AppDelegate.shared)
+            let stub = try makeNewSessionSuccessStub(sessionName: "unstolen", argvLog: "/dev/null")
+            let restoreSSH = pinStubSSH(stub)
+            defer {
+                restoreSSH()
+                try? FileManager.default.removeItem(atPath: stub)
+            }
+            let controller = RemoteTmuxController()
+            let manager = TabManager()
+            let localWorkspace = try #require(manager.selectedWorkspace)
+            _ = try mirrorSelectedSession(
+                controller: controller, host: hostA, sessionName: "dev", into: manager
+            )
+            controller.cacheConnection(RemoteTmuxControlConnection(host: hostA, sessionName: "unstolen"))
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                for sessionName in ["unstolen", "dev"] {
+                    controller.detach(host: hostA, sessionName: sessionName)
+                }
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            }
+
+            #expect(controller.handleNewWorkspaceRequested(in: manager))
+            // The user moves on before the round trip completes.
+            manager.selectWorkspace(localWorkspace)
+            await controller.newSessionRoutingTask?.value
+
+            let created = try #require(manager.tabs.first { $0.title == "unstolen" })
+            #expect(created.isRemoteTmuxMirror)
+            #expect(manager.selectedTab?.id == localWorkspace.id)
+        }
+    }
+
+    /// A manager whose window closed (unregistered) during the round trip must
+    /// not receive the mirror — the detached session is picked up on the next
+    /// attach instead of resurrecting a dead manager.
+    @Test func unregisteredManagerDoesNotReceiveTheMirror() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let appDelegate = try #require(AppDelegate.shared)
+            let stub = try makeNewSessionSuccessStub(sessionName: "orphaned", argvLog: "/dev/null")
+            let restoreSSH = pinStubSSH(stub)
+            defer {
+                restoreSSH()
+                try? FileManager.default.removeItem(atPath: stub)
+            }
+            let controller = RemoteTmuxController()
+            let manager = TabManager()
+            _ = try mirrorSelectedSession(
+                controller: controller, host: hostA, sessionName: "dev", into: manager
+            )
+            controller.cacheConnection(RemoteTmuxControlConnection(host: hostA, sessionName: "orphaned"))
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                for sessionName in ["orphaned", "dev"] {
+                    controller.detach(host: hostA, sessionName: sessionName)
+                }
+            }
+
+            #expect(controller.handleNewWorkspaceRequested(in: manager))
+            // The window goes away before the round trip completes.
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            await controller.newSessionRoutingTask?.value
+
+            #expect(!manager.tabs.contains { $0.title == "orphaned" })
+            #expect(controller.sessionMirror(host: hostA, sessionName: "orphaned") == nil)
+        }
+    }
+
+    // MARK: - performNewWorkspaceAction hook
+
+    @Test func newWorkspaceOnActiveMirrorSuppressesLocalCreation() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let appDelegate = try #require(AppDelegate.shared)
+            let controller = appDelegate.remoteTmuxController
+            let restoreSSH = pinStubSSH("/usr/bin/false")
+            defer { restoreSSH() }
+            let manager = TabManager()
+            let localWorkspace = try #require(manager.selectedWorkspace)
+            var reportedFailures: [(host: RemoteTmuxHost, detail: String)] = []
+            let previousReport = controller.reportNewSessionFailure
+            controller.reportNewSessionFailure = { host, detail, _ in
+                reportedFailures.append((host: host, detail: detail))
+            }
+            let mirrorWorkspace = try mirrorSelectedSession(
+                controller: controller, host: hostA, sessionName: "dev", into: manager
+            )
+
+            let (windowId, window) = registerWindowedContext(appDelegate: appDelegate, manager: manager)
+            defer {
+                controller.reportNewSessionFailure = previousReport
+                window.close()
+                manager.window = nil
+                if controller.sessionMirror(host: hostA, sessionName: "dev") != nil {
+                    controller.detach(host: hostA, sessionName: "dev")
+                }
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            }
+
+            // Active workspace is the mirror: the action is claimed for the
+            // remote host and no local workspace appears. The stub ssh fails,
+            // so the suppressed creation must surface as a reported failure,
+            // not silence.
+            #expect(manager.selectedTab?.id == mirrorWorkspace.id)
+            let tabsBefore = manager.tabs.map(\.id)
+            #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.remoteMirror"))
+            await controller.newSessionRoutingTask?.value
+            #expect(manager.tabs.map(\.id) == tabsBefore)
+            #expect(reportedFailures.count == 1)
+            #expect(reportedFailures.first?.host == hostA)
+
+            // Active workspace is local: the same action creates a local workspace.
+            manager.selectWorkspace(localWorkspace)
+            #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.localTab"))
+            #expect(manager.tabs.count == tabsBefore.count + 1)
+        }
     }
 }

--- a/cmuxTests/RemoteTmuxNewWorkspaceHostRoutingTests.swift
+++ b/cmuxTests/RemoteTmuxNewWorkspaceHostRoutingTests.swift
@@ -1,0 +1,81 @@
+import AppKit
+import Foundation
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// New Workspace routing for remote-tmux mirrors: when the active workspace is
+/// a mirrored tmux session, `performNewWorkspaceAction` must route the request
+/// to the session's host instead of creating a local workspace.
+@MainActor
+@Suite(.serialized)
+struct RemoteTmuxNewWorkspaceHostRoutingTests {
+    private let hostA = RemoteTmuxHost(destination: "user@alpha")
+
+    /// Caches a transport for `host` whose ssh binary is a no-op stub, so any
+    /// async new-session attempt can never spawn a real ssh.
+    private func cacheStubTransport(controller: RemoteTmuxController, host: RemoteTmuxHost) {
+        setenv("CMUX_REMOTE_TMUX_SSH_FOR_TESTING", "/usr/bin/false", 1)
+        defer { unsetenv("CMUX_REMOTE_TMUX_SSH_FOR_TESTING") }
+        _ = controller.transport(for: host)
+    }
+
+    private func mirrorSelectedSession(
+        controller: RemoteTmuxController,
+        host: RemoteTmuxHost,
+        sessionName: String,
+        into manager: TabManager
+    ) throws -> Workspace {
+        controller.cacheConnection(RemoteTmuxControlConnection(host: host, sessionName: sessionName))
+        #expect(try controller.mirrorSession(host: host, sessionName: sessionName, into: manager))
+        let workspace = try #require(manager.tabs.first { $0.isRemoteTmuxMirror })
+        manager.selectWorkspace(workspace)
+        return workspace
+    }
+
+    @Test func newWorkspaceOnActiveMirrorSuppressesLocalCreation() throws {
+        _ = NSApplication.shared
+        let appDelegate = try #require(AppDelegate.shared)
+        let controller = appDelegate.remoteTmuxController
+        let manager = TabManager()
+        let localWorkspace = try #require(manager.selectedWorkspace)
+        cacheStubTransport(controller: controller, host: hostA)
+        let mirrorWorkspace = try mirrorSelectedSession(
+            controller: controller, host: hostA, sessionName: "dev", into: manager
+        )
+
+        let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
+        manager.window = window
+        defer {
+            window.close()
+            manager.window = nil
+            if controller.sessionMirror(host: hostA, sessionName: "dev") != nil {
+                controller.detach(host: hostA, sessionName: "dev")
+            }
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+        }
+
+        // Active workspace is the mirror: the action is claimed for the remote
+        // host and no local workspace appears.
+        #expect(manager.selectedTab?.id == mirrorWorkspace.id)
+        let tabsBefore = manager.tabs.map(\.id)
+        #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.remoteMirror"))
+        #expect(manager.tabs.map(\.id) == tabsBefore)
+
+        // Active workspace is local: the same action creates a local workspace.
+        manager.selectWorkspace(localWorkspace)
+        #expect(appDelegate.performNewWorkspaceAction(tabManager: manager, debugSource: "test.localTab"))
+        #expect(manager.tabs.count == tabsBefore.count + 1)
+    }
+}

--- a/cmuxTests/RemoteTmuxNewWorkspaceRoutingTests.swift
+++ b/cmuxTests/RemoteTmuxNewWorkspaceRoutingTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import CmuxSettings
 import Foundation
 import Testing
 
@@ -7,42 +9,132 @@ import Testing
 @testable import cmux
 #endif
 
-/// Truth-table coverage for `RemoteTmuxController.newWorkspaceRoutesRemote`, the
-/// pure remote-vs-local decision behind both `handleRemoteWindowNewWorkspaceRequested`
-/// (does plain New Workspace / ⌘N spawn a tmux session on the window's host?) and the
-/// "New Local Workspace" File-menu item's visibility (shown exactly when that answer
-/// is `true`). Sharing one decision keeps the menu's shown-state and the action in
-/// lockstep. The factored-out form takes booleans so the edges are testable without a
-/// live registry, window, or tab manager.
-@Suite struct RemoteTmuxNewWorkspaceRoutingTests {
-    /// No host bound to the window → plain New Workspace stays local, so the item hides.
-    /// The manager/mirror flags are irrelevant once there is no host.
-    @Test func noHostRoutesLocal() {
-        #expect(RemoteTmuxController.newWorkspaceRoutesRemote(
-            hasHost: false, hasManager: false, activeTabIsMirror: false) == false)
-        #expect(RemoteTmuxController.newWorkspaceRoutesRemote(
-            hasHost: false, hasManager: true, activeTabIsMirror: true) == false)
+/// The "New Local Workspace" escape hatch: `wouldNewWorkspaceSpawnRemote(in:)`
+/// (the File-menu item's visibility, shown exactly when plain New Workspace
+/// would go remote), `performNewLocalWorkspaceAction` (forced-local creation
+/// that must produce a plain local workspace even on an active mirror), and
+/// the ⌃⌘N default's alignment across both shortcut catalogs.
+///
+/// SSH never leaves the process: env-pinned stub for the whole test body
+/// (including deferred `detach`, whose last-mirror teardown spawns
+/// `ssh -O exit`), and `AppContextSerialGate` around bodies that suspend so
+/// another suite's env/AppDelegate use cannot interleave.
+@MainActor
+@Suite(.serialized)
+struct RemoteTmuxNewWorkspaceRoutingTests {
+    private static let sshOverrideKey = "CMUX_REMOTE_TMUX_SSH_FOR_TESTING"
+    private let host = RemoteTmuxHost(destination: "user@local-escape-hatch")
+
+    /// Sets the ssh stub for the caller's whole scope; the returned closure
+    /// restores the previous value and belongs in the FIRST `defer`, so it
+    /// runs after every later-registered teardown (detach included).
+    private func pinStubSSH(_ stub: String) -> () -> Void {
+        let prior = ProcessInfo.processInfo.environment[Self.sshOverrideKey]
+        setenv(Self.sshOverrideKey, stub, 1)
+        return {
+            if let prior {
+                setenv(Self.sshOverrideKey, prior, 1)
+            } else {
+                unsetenv(Self.sshOverrideKey)
+            }
+        }
     }
 
-    /// A host is bound but the tab manager isn't resolvable (the window is mid-teardown):
-    /// route remote to match the handler, which returns `true` and no-ops the creation.
-    @Test func hostWithoutManagerRoutesRemote() {
-        #expect(RemoteTmuxController.newWorkspaceRoutesRemote(
-            hasHost: true, hasManager: false, activeTabIsMirror: false) == true)
+    private func mirrorSelectedSession(
+        controller: RemoteTmuxController,
+        into manager: TabManager
+    ) throws -> Workspace {
+        _ = controller.transport(for: host)
+        controller.cacheConnection(RemoteTmuxControlConnection(host: host, sessionName: "esc"))
+        #expect(try controller.mirrorSession(host: host, sessionName: "esc", into: manager))
+        let workspace = try #require(manager.tabs.first { $0.isRemoteTmuxMirror })
+        manager.selectWorkspace(workspace)
+        return workspace
     }
 
-    /// Host + manager + the active workspace is a mirror → New Workspace spawns a remote
-    /// session, so "New Local Workspace" is shown as the local escape hatch.
-    @Test func hostWithActiveMirrorRoutesRemote() {
-        #expect(RemoteTmuxController.newWorkspaceRoutesRemote(
-            hasHost: true, hasManager: true, activeTabIsMirror: true) == true)
+    /// The visibility predicate flips with the ACTIVE workspace, not the window:
+    /// a mirror tab shows the item, a local tab in the same manager hides it.
+    @Test func menuVisibilityFollowsTheActiveWorkspace() throws {
+        let restoreSSH = pinStubSSH("/usr/bin/false")
+        defer { restoreSSH() }
+        let controller = RemoteTmuxController()
+        let manager = TabManager()
+        let localWorkspace = try #require(manager.selectedWorkspace)
+        #expect(!controller.wouldNewWorkspaceSpawnRemote(in: manager))
+
+        let mirrorWorkspace = try mirrorSelectedSession(controller: controller, into: manager)
+        defer { controller.detach(host: host, sessionName: "esc") }
+        #expect(manager.selectedTab?.id == mirrorWorkspace.id)
+        #expect(controller.wouldNewWorkspaceSpawnRemote(in: manager))
+
+        manager.selectWorkspace(localWorkspace)
+        #expect(!controller.wouldNewWorkspaceSpawnRemote(in: manager))
     }
 
-    /// Host + manager but the active workspace is a dragged-in LOCAL tab → New Workspace
-    /// stays local (no unwanted tmux session), and the item stays hidden because plain
-    /// New Workspace already does the right thing.
-    @Test func hostWithActiveLocalTabRoutesLocal() {
-        #expect(RemoteTmuxController.newWorkspaceRoutesRemote(
-            hasHost: true, hasManager: true, activeTabIsMirror: false) == false)
+    /// New Local Workspace on an ACTIVE MIRROR creates a plain local workspace —
+    /// it must not route to the remote (that is plain New Workspace's job).
+    /// (The `forceLocal` skip of a CONFIGURED new-workspace override is enforced
+    /// by the `!forceLocal` guards in `performNewWorkspaceCreationAction`; no
+    /// override is installed here.)
+    @Test func newLocalWorkspaceOnActiveMirrorCreatesLocalWorkspace() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let appDelegate = try #require(AppDelegate.shared)
+            let controller = appDelegate.remoteTmuxController
+            let restoreSSH = pinStubSSH("/usr/bin/false")
+            defer { restoreSSH() }
+            let manager = TabManager()
+            let mirrorWorkspace = try mirrorSelectedSession(controller: controller, into: manager)
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            window.isReleasedWhenClosed = false
+            window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
+            manager.window = window
+            defer {
+                window.close()
+                manager.window = nil
+                if controller.sessionMirror(host: host, sessionName: "esc") != nil {
+                    controller.detach(host: host, sessionName: "esc")
+                }
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            }
+
+            #expect(manager.selectedTab?.id == mirrorWorkspace.id)
+            let tabsBefore = Set(manager.tabs.map(\.id))
+            #expect(appDelegate.performNewLocalWorkspaceAction(
+                tabManager: manager, debugSource: "test.newLocalWorkspace"
+            ))
+            // Creation happened synchronously and locally: a routed request
+            // would have added NO tab here (the mirror lands only after the ssh
+            // round trip), so exactly one immediate non-mirror tab proves
+            // forced-local.
+            let createdIds = Set(manager.tabs.map(\.id)).subtracting(tabsBefore)
+            #expect(createdIds.count == 1)
+            let created = try #require(manager.tabs.first { createdIds.contains($0.id) })
+            #expect(!created.isRemoteTmuxMirror)
+        }
+    }
+
+    /// The ⌃⌘N default must agree between the app catalog (dispatch) and the
+    /// CmuxSettings catalog (settings UI, conflict detection, config bindings).
+    @Test func defaultShortcutAlignsAcrossCatalogs() {
+        let appDefault = KeyboardShortcutSettings.Action.newLocalWorkspace.defaultShortcut
+        #expect(appDefault.key == "n")
+        #expect(appDefault.command)
+        #expect(appDefault.control)
+        #expect(!appDefault.option)
+        #expect(!appDefault.shift)
+
+        let settingsDefault = ShortcutAction.newLocalWorkspace.defaultStroke
+        #expect(settingsDefault?.key == "n")
+        #expect(settingsDefault?.command == true)
+        #expect(settingsDefault?.control == true)
+        #expect(settingsDefault?.option != true)
+        #expect(settingsDefault?.shift != true)
     }
 }

--- a/cmuxTests/RemoteTmuxNewWorkspaceRoutingTests.swift
+++ b/cmuxTests/RemoteTmuxNewWorkspaceRoutingTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Truth-table coverage for `RemoteTmuxController.newWorkspaceRoutesRemote`, the
+/// pure remote-vs-local decision behind both `handleRemoteWindowNewWorkspaceRequested`
+/// (does plain New Workspace / ⌘N spawn a tmux session on the window's host?) and the
+/// "New Local Workspace" File-menu item's visibility (shown exactly when that answer
+/// is `true`). Sharing one decision keeps the menu's shown-state and the action in
+/// lockstep. The factored-out form takes booleans so the edges are testable without a
+/// live registry, window, or tab manager.
+@Suite struct RemoteTmuxNewWorkspaceRoutingTests {
+    /// No host bound to the window → plain New Workspace stays local, so the item hides.
+    /// The manager/mirror flags are irrelevant once there is no host.
+    @Test func noHostRoutesLocal() {
+        #expect(RemoteTmuxController.newWorkspaceRoutesRemote(
+            hasHost: false, hasManager: false, activeTabIsMirror: false) == false)
+        #expect(RemoteTmuxController.newWorkspaceRoutesRemote(
+            hasHost: false, hasManager: true, activeTabIsMirror: true) == false)
+    }
+
+    /// A host is bound but the tab manager isn't resolvable (the window is mid-teardown):
+    /// route remote to match the handler, which returns `true` and no-ops the creation.
+    @Test func hostWithoutManagerRoutesRemote() {
+        #expect(RemoteTmuxController.newWorkspaceRoutesRemote(
+            hasHost: true, hasManager: false, activeTabIsMirror: false) == true)
+    }
+
+    /// Host + manager + the active workspace is a mirror → New Workspace spawns a remote
+    /// session, so "New Local Workspace" is shown as the local escape hatch.
+    @Test func hostWithActiveMirrorRoutesRemote() {
+        #expect(RemoteTmuxController.newWorkspaceRoutesRemote(
+            hasHost: true, hasManager: true, activeTabIsMirror: true) == true)
+    }
+
+    /// Host + manager but the active workspace is a dragged-in LOCAL tab → New Workspace
+    /// stays local (no unwanted tmux session), and the item stays hidden because plain
+    /// New Workspace already does the right thing.
+    @Test func hostWithActiveLocalTabRoutesLocal() {
+        #expect(RemoteTmuxController.newWorkspaceRoutesRemote(
+            hasHost: true, hasManager: true, activeTabIsMirror: false) == false)
+    }
+}

--- a/docs/remote-tmux-new-local-workspace-command-palette.md
+++ b/docs/remote-tmux-new-local-workspace-command-palette.md
@@ -5,15 +5,16 @@ Local Workspace* File-menu item). No code yet — this doc is the spec for a
 separate implementation PR.
 
 This document specifies adding a **New Local Workspace** entry to the command
-palette, gated so it only appears when plain New Workspace in the active window
-would spawn a remote tmux session. It is a companion to the menu-item change,
+palette, gated so it only appears when plain New Workspace on the active
+workspace would spawn a remote tmux session. It is a companion to the menu-item change,
 which is the load-bearing piece; this palette entry is pure surface parity and is
 split out to keep that change focused.
 
 ## Background
 
 In a remote-tmux mirror window, plain **New Workspace** (⌘N / File → New
-Workspace) spawns a new tmux session on the window's host and mirrors it in,
+Workspace) spawns a new tmux session on the active workspace's host and
+mirrors it in,
 rather than creating a local workspace. The menu-item change adds a **New Local
 Workspace** command that forces local creation, shown only when New Workspace
 would otherwise go remote.
@@ -22,10 +23,10 @@ That change already provides the two pieces this work builds on:
 
 - `AppDelegate.performNewLocalWorkspaceAction(tabManager:event:debugSource:)` —
   the shared action; routes through `performNewWorkspaceCreationAction(..., forceLocal: true)`.
-- `RemoteTmuxController.wouldNewWorkspaceSpawnRemote(windowId:)` — the
-  non-mutating decision ("would New Workspace in this window route remote?"),
-  already the single source of truth behind the menu item's visibility and the
-  ⌘N routing handler.
+- `RemoteTmuxController.wouldNewWorkspaceSpawnRemote(in:)` — the non-mutating
+  decision ("would New Workspace in this tab manager route remote?", i.e. is its
+  active workspace a live mirror), already the single source of truth behind the
+  menu item's visibility and the ⌘N routing handler.
 
 The command palette is the other primary way users create workspaces
 (`palette.newWorkspace`, `palette.newBrowserWorkspace`), so New Local Workspace
@@ -34,8 +35,11 @@ should be reachable there too.
 ## Goal
 
 Add `palette.newLocalWorkspace`, visible **only** when
-`wouldNewWorkspaceSpawnRemote(windowId:)` is true for the palette's window, and
-executing the same `performNewLocalWorkspaceAction`. No new keyboard shortcut.
+`wouldNewWorkspaceSpawnRemote(in:)` is true for the palette window's tab
+manager, and
+executing the same `performNewLocalWorkspaceAction`. The command already has a
+keyboard shortcut (⌃⌘N, added with the menu item), so the palette row should
+surface that glyph — see §5.
 
 ## Design
 
@@ -55,7 +59,7 @@ enforces the pairing.
 — add alongside the other boolean keys (e.g. after `authWorking`):
 
 ```swift
-/// Whether a plain New Workspace in this window would spawn a remote tmux session.
+/// Whether a plain New Workspace on this window's active workspace would spawn a remote tmux session.
 public static let newWorkspaceRoutesRemote = CommandPaletteContextKeys(rawValue: "newWorkspace.routesRemote")
 ```
 
@@ -67,37 +71,35 @@ this is the only declaration needed.
 
 `Sources/ContentView.swift`, in `commandPaletteContextSnapshot(terminalOpenTargets:)`
 — add at the top level (always emitted, next to the `browserDisabled` `setBool`).
-`ContentView` has a stored `let windowId: UUID`, so it reuses the exact same
-source of truth the menu item uses:
+Use the view's own captured `tabManager` — the same object the handler targets —
+NOT a re-resolution through `tabManagerFor(windowId:)`, which can answer from a
+recoverable (closed-window) route during teardown and let visibility and the
+handler disagree about the target:
 
 ```swift
-if let remoteTmux = AppDelegate.shared?.remoteTmuxController {
+if let appDelegate = AppDelegate.shared {
     snapshot.setBool(
         CommandPaletteContextKeys.newWorkspaceRoutesRemote,
-        remoteTmux.wouldNewWorkspaceSpawnRemote(windowId: windowId)
+        appDelegate.remoteTmuxController.wouldNewWorkspaceSpawnRemote(in: tabManager)
     )
 }
 ```
 
-`remoteTmuxController` is a non-optional `let`, so the `if let` only guards
-`AppDelegate.shared == nil`; when it is nil (or the beta flag is off, so no
-window has a host and `wouldNewWorkspaceSpawnRemote` returns false) the key is
-never set and `snapshot.bool(...)` defaults to false — the command hides. That is
-the intended fail-safe and matches how the `authSignedIn` key is set
-conditionally.
+When `AppDelegate.shared` is nil or no workspace in this manager mirrors a
+remote session (e.g. the beta flag is off), the key is never set or set false,
+and `snapshot.bool(...)` defaults to false — the command hides. That is the
+intended fail-safe and matches how the `authSignedIn` key is set conditionally.
 
 The snapshot is rebuilt fresh whenever palette results recompute, and the value
 feeds the results fingerprint, so the gate is correct every time the palette
-opens. **Reactivity caveat (see Consistency below):** the menu item re-evaluates
-its visibility on every focus/selection change (it reads
-`focusHistoryMenuInvalidator.revision`); the palette has no equivalent hook, so a
-tab/window switch *while the palette stays open* is not guaranteed to re-derive
-the gate. To keep the two surfaces in lockstep even in that case, add an
-invalidation hook mirroring `refreshCachedDefaultTerminalStatus` — clear
-`cachedCommandPaletteFingerprint`, and if presented call
-`scheduleCommandPaletteResultsRefresh(forceSearchCorpusRefresh: true, ...)` — on
-the same signals the menu invalidator listens to
-(`.tabManagerFocusHistoryRevisionDidChange` and `NSWindow.didBecomeKeyNotification`).
+opens, and a selection change while the palette is open already lands through
+the existing fingerprint-recompute path. The one gap is a change to the MIRROR
+SET itself with the selection unchanged (attach, or a detach that keeps the
+workspace open locally): nothing recomputes the snapshot. Close it narrowly —
+publish a mirror-routing revision from `RemoteTmuxController` when
+`sessionMirrors` changes and observe it where the palette schedules refreshes —
+rather than re-listening to the menu invalidator's focus/key signals, which the
+fingerprint path already covers.
 
 ### 3. Contribution (with visibility gate)
 
@@ -117,9 +119,10 @@ contributions.append(
 ```
 
 `CommandPaletteCommandContribution` supports both `when:` (visibility) and
-`enablement:` (grey-out). Use `when:` — the item should be **hidden**, not
-disabled, when it doesn't apply, matching the menu item (which is conditionally
-shown) and sibling contextual commands like `palette.installCLI`.
+`enablement:` (a failed `enablement` currently filters the row out of results as
+well). Use `when:` — the item should be **hidden**, not present-but-inert, when
+it doesn't apply, matching the menu item (which is conditionally shown) and
+sibling contextual commands like `palette.installCLI`.
 
 **Testability seam.** The New Workspace / New Browser Workspace contributions are
 appended inline inside the *private instance* method
@@ -149,16 +152,23 @@ registry.register(commandId: "palette.newLocalWorkspace") {
 Synchronous, like `newWorkspace` (the `newBrowserWorkspace` handler only wraps in
 `DispatchQueue.main.async` because it focuses the omnibar afterward).
 
-### 5. Right-sidebar shortcut-hint switch — no change
+### 5. Right-sidebar shortcut-hint switch — add the case
 
 `Sources/ContentView+RightSidebarCommandPalette.swift`'s
-`commandPaletteShortcutAction(forCommandID:)` maps a command ID to a bindable
+`commandPaletteShortcutAction(forCommandID:)` maps a command ID to a
 `KeyboardShortcutSettings.Action` purely to render a shortcut glyph on the row.
-It has a total `default: return nil`, so omitting a case yields "no glyph" — the
-correct behavior, since New Local Workspace has no bound shortcut. **Do not** add
-a case here unless a bindable `.newLocalWorkspace` action is introduced (which
-would pull in the full shortcut policy: enum case, Settings visibility,
-`cmux.json` support, and docs).
+The menu-item change added a bindable `.newLocalWorkspace` action (default ⌃⌘N),
+so add the matching case here (mirroring `palette.newWorkspace`) so the palette
+row shows ⌃⌘N:
+
+```swift
+case "palette.newLocalWorkspace":
+    return .newLocalWorkspace
+```
+
+The switch has a total `default: return nil`; without this case the command still
+appears and runs, it just wouldn't show its shortcut glyph. Since the action now
+exists, add the case.
 
 ### 6. Localization
 
@@ -172,22 +182,13 @@ the subtitle, so the palette and menu strings stay identical per locale.
 ## Consistency
 
 Visibility and behavior both derive from the same primitives as the menu item:
-`wouldNewWorkspaceSpawnRemote(windowId:)` for the gate and
+`wouldNewWorkspaceSpawnRemote(in:)` for the gate and
 `performNewLocalWorkspaceAction` for the action — one decision, one action. On
-every palette open the gate re-derives the current window's state, so it agrees
-with the menu item at open time. The one way they can diverge is timing: the menu
-re-evaluates on every focus/selection change, the palette only on results
-recompute. Adding the invalidation hook above closes that gap; without it, the
-palette gate is still correct per-open, just not live while the palette stays
-open across a tab/window switch.
-
-Note the gate's `hasManager == false` branch (a window with a host but no
-resolvable tab manager, mid-teardown) returns true, so the command could show
-while the action — which always forces local — creates a local workspace. This is
-benign (New Local Workspace's whole job is to create local) and vanishingly rare
-(the palette is hosted by the same view that owns the tab manager), but it means
-the gate is "would New Workspace route remote" in the normal case, not a
-hard guarantee in that teardown sliver.
+every palette open the gate re-derives the active workspace's state, so it
+agrees with the menu item at open time, and selection changes while the palette
+is open flow through the existing fingerprint recompute. The residual gap is a
+mirror-set change with the selection unchanged; the narrow mirror-routing
+revision described in §2 closes it for both surfaces.
 
 ## Testing
 
@@ -202,6 +203,17 @@ hard guarantee in that teardown sliver.
   take the contribution from the static factory above, and assert `when(snapshot)` is
   true / false / false respectively. This is why the contribution must be reachable
   from a static seam.
+- **A predicate-only test is not wiring coverage.** The gate test above still
+  passes if the snapshot population, the contribution insertion, the handler
+  registration, or the shortcut-glyph mapping is simply omitted — four
+  connections, each a one-liner someone can drop in a refactor. Declare the
+  command ID once (`static let newLocalWorkspaceCommandId = "palette.newLocalWorkspace"`)
+  and use it at all four sites, then add connection assertions: the resolved
+  command list from `ContentView.commandPaletteCommands(...)` contains the ID
+  when the context key is set (proves population + insertion), the handler
+  registry resolves the ID (proves registration), and
+  `commandPaletteShortcutAction(forCommandID:)` maps it to `.newLocalWorkspace`
+  (proves the glyph mapping).
 - **Where the test goes.** The gate/snapshot wiring lives in the app target, so the
   behavior-level test belongs in the `cmuxTests` XCTest suite (which can
   `@testable import cmux_DEV`), not the `CmuxCommandPalette` package Tests suite
@@ -219,7 +231,5 @@ hard guarantee in that teardown sliver.
 
 ## Out of scope
 
-- A bindable keyboard shortcut for New Local Workspace (would trigger the shortcut
-  policy end-to-end).
 - Any change to how New Workspace / ⌘N routes; this only adds a palette surface for
   the already-defined local action.

--- a/docs/remote-tmux-new-local-workspace-command-palette.md
+++ b/docs/remote-tmux-new-local-workspace-command-palette.md
@@ -1,0 +1,225 @@
+# Design: "New Local Workspace" in the command palette
+
+**Status:** Design placeholder, adversarially reviewed (follow-up to the *New
+Local Workspace* File-menu item). No code yet — this doc is the spec for a
+separate implementation PR.
+
+This document specifies adding a **New Local Workspace** entry to the command
+palette, gated so it only appears when plain New Workspace in the active window
+would spawn a remote tmux session. It is a companion to the menu-item change,
+which is the load-bearing piece; this palette entry is pure surface parity and is
+split out to keep that change focused.
+
+## Background
+
+In a remote-tmux mirror window, plain **New Workspace** (⌘N / File → New
+Workspace) spawns a new tmux session on the window's host and mirrors it in,
+rather than creating a local workspace. The menu-item change adds a **New Local
+Workspace** command that forces local creation, shown only when New Workspace
+would otherwise go remote.
+
+That change already provides the two pieces this work builds on:
+
+- `AppDelegate.performNewLocalWorkspaceAction(tabManager:event:debugSource:)` —
+  the shared action; routes through `performNewWorkspaceCreationAction(..., forceLocal: true)`.
+- `RemoteTmuxController.wouldNewWorkspaceSpawnRemote(windowId:)` — the
+  non-mutating decision ("would New Workspace in this window route remote?"),
+  already the single source of truth behind the menu item's visibility and the
+  ⌘N routing handler.
+
+The command palette is the other primary way users create workspaces
+(`palette.newWorkspace`, `palette.newBrowserWorkspace`), so New Local Workspace
+should be reachable there too.
+
+## Goal
+
+Add `palette.newLocalWorkspace`, visible **only** when
+`wouldNewWorkspaceSpawnRemote(windowId:)` is true for the palette's window, and
+executing the same `performNewLocalWorkspaceAction`. No new keyboard shortcut.
+
+## Design
+
+The palette wires a command through: a **context key** (per-window boolean), a
+**snapshot population** that sets it, a **contribution** (title/subtitle/keywords
++ a `when:` visibility gate), and a **handler** (the action to run). Command IDs
+are plain strings — there is no central registry enum — so the load-bearing pair
+is *contribution + handler*. A contribution without a matching handler is
+asserted-then-dropped by the app-side resolution loop
+`ContentView.commandPaletteCommands(...)` (`assertionFailure` in Debug, silently
+`continue`d in Release) — it is that loop, not the handler registry type, that
+enforces the pairing.
+
+### 1. Context key
+
+`Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift`
+— add alongside the other boolean keys (e.g. after `authWorking`):
+
+```swift
+/// Whether a plain New Workspace in this window would spawn a remote tmux session.
+public static let newWorkspaceRoutesRemote = CommandPaletteContextKeys(rawValue: "newWorkspace.routesRemote")
+```
+
+`CommandPaletteContextKeys` is a plain `Hashable, Sendable` wrapper over a
+`rawValue: String`; it is not `CaseIterable` and nothing enumerates every key, so
+this is the only declaration needed.
+
+### 2. Populate the context snapshot
+
+`Sources/ContentView.swift`, in `commandPaletteContextSnapshot(terminalOpenTargets:)`
+— add at the top level (always emitted, next to the `browserDisabled` `setBool`).
+`ContentView` has a stored `let windowId: UUID`, so it reuses the exact same
+source of truth the menu item uses:
+
+```swift
+if let remoteTmux = AppDelegate.shared?.remoteTmuxController {
+    snapshot.setBool(
+        CommandPaletteContextKeys.newWorkspaceRoutesRemote,
+        remoteTmux.wouldNewWorkspaceSpawnRemote(windowId: windowId)
+    )
+}
+```
+
+`remoteTmuxController` is a non-optional `let`, so the `if let` only guards
+`AppDelegate.shared == nil`; when it is nil (or the beta flag is off, so no
+window has a host and `wouldNewWorkspaceSpawnRemote` returns false) the key is
+never set and `snapshot.bool(...)` defaults to false — the command hides. That is
+the intended fail-safe and matches how the `authSignedIn` key is set
+conditionally.
+
+The snapshot is rebuilt fresh whenever palette results recompute, and the value
+feeds the results fingerprint, so the gate is correct every time the palette
+opens. **Reactivity caveat (see Consistency below):** the menu item re-evaluates
+its visibility on every focus/selection change (it reads
+`focusHistoryMenuInvalidator.revision`); the palette has no equivalent hook, so a
+tab/window switch *while the palette stays open* is not guaranteed to re-derive
+the gate. To keep the two surfaces in lockstep even in that case, add an
+invalidation hook mirroring `refreshCachedDefaultTerminalStatus` — clear
+`cachedCommandPaletteFingerprint`, and if presented call
+`scheduleCommandPaletteResultsRefresh(forceSearchCorpusRefresh: true, ...)` — on
+the same signals the menu invalidator listens to
+(`.tabManagerFocusHistoryRevisionDidChange` and `NSWindow.didBecomeKeyNotification`).
+
+### 3. Contribution (with visibility gate)
+
+`Sources/ContentView.swift`, in the contributions builder — add after the
+`palette.newBrowserWorkspace` contribution:
+
+```swift
+contributions.append(
+    CommandPaletteCommandContribution(
+        commandId: "palette.newLocalWorkspace",
+        title: constant(String(localized: "command.newLocalWorkspace.title", defaultValue: "New Local Workspace")),
+        subtitle: constant(String(localized: "command.newLocalWorkspace.subtitle", defaultValue: "Workspace")),
+        keywords: ["create", "new", "local", "workspace"],
+        when: { $0.bool(CommandPaletteContextKeys.newWorkspaceRoutesRemote) }
+    )
+)
+```
+
+`CommandPaletteCommandContribution` supports both `when:` (visibility) and
+`enablement:` (grey-out). Use `when:` — the item should be **hidden**, not
+disabled, when it doesn't apply, matching the menu item (which is conditionally
+shown) and sibling contextual commands like `palette.installCLI`.
+
+**Testability seam.** The New Workspace / New Browser Workspace contributions are
+appended inline inside the *private instance* method
+`commandPaletteCommandContributions()`, which no unit test can invoke. To make
+the gate unit-testable (see Testing), expose the new contribution through a
+`static` factory the way `commandPaletteAuthCommandContributions()` and
+`commandPaletteRightSidebarModeCommandContributions()` already do — e.g. a small
+`static func commandPaletteNewLocalWorkspaceCommandContribution()` that the
+instance builder appends — so a test can construct it, run its `when:` against a
+hand-built snapshot, and assert presence/absence.
+
+### 4. Handler
+
+`Sources/ContentView.swift`, in `registerCommandPaletteHandlers(...)` — add after
+the `palette.newWorkspace` handler, passing the palette view's own `tabManager`
+so the local workspace lands in the palette's window (mirrors `newWorkspace`):
+
+```swift
+registry.register(commandId: "palette.newLocalWorkspace") {
+    AppDelegate.shared?.performNewLocalWorkspaceAction(
+        tabManager: tabManager,
+        debugSource: "palette.newLocalWorkspace"
+    )
+}
+```
+
+Synchronous, like `newWorkspace` (the `newBrowserWorkspace` handler only wraps in
+`DispatchQueue.main.async` because it focuses the omnibar afterward).
+
+### 5. Right-sidebar shortcut-hint switch — no change
+
+`Sources/ContentView+RightSidebarCommandPalette.swift`'s
+`commandPaletteShortcutAction(forCommandID:)` maps a command ID to a bindable
+`KeyboardShortcutSettings.Action` purely to render a shortcut glyph on the row.
+It has a total `default: return nil`, so omitting a case yields "no glyph" — the
+correct behavior, since New Local Workspace has no bound shortcut. **Do not** add
+a case here unless a bindable `.newLocalWorkspace` action is introduced (which
+would pull in the full shortcut policy: enum case, Settings visibility,
+`cmux.json` support, and docs).
+
+### 6. Localization
+
+`Resources/Localizable.xcstrings` — add `command.newLocalWorkspace.title` and
+`command.newLocalWorkspace.subtitle` across all locales the sibling
+`command.newWorkspace.*` keys carry (currently 19). Reuse the existing
+`menu.file.newLocalWorkspace` translations verbatim for the title and the
+existing `command.newWorkspace.subtitle` ("Workspace") translations verbatim for
+the subtitle, so the palette and menu strings stay identical per locale.
+
+## Consistency
+
+Visibility and behavior both derive from the same primitives as the menu item:
+`wouldNewWorkspaceSpawnRemote(windowId:)` for the gate and
+`performNewLocalWorkspaceAction` for the action — one decision, one action. On
+every palette open the gate re-derives the current window's state, so it agrees
+with the menu item at open time. The one way they can diverge is timing: the menu
+re-evaluates on every focus/selection change, the palette only on results
+recompute. Adding the invalidation hook above closes that gap; without it, the
+palette gate is still correct per-open, just not live while the palette stays
+open across a tab/window switch.
+
+Note the gate's `hasManager == false` branch (a window with a host but no
+resolvable tab manager, mid-teardown) returns true, so the command could show
+while the action — which always forces local — creates a local workspace. This is
+benign (New Local Workspace's whole job is to create local) and vanishingly rare
+(the palette is hosted by the same view that owns the tab manager), but it means
+the gate is "would New Workspace route remote" in the normal case, not a
+hard guarantee in that teardown sliver.
+
+## Testing
+
+- **Gate test (the important one), auth-command style — not search-engine style.**
+  The search-engine suites (`CommandPaletteSearchEngineTests`) only feed hand-built
+  fixture corpora into the fuzzy matcher; they never build a
+  `CommandPaletteContextSnapshot` or evaluate a contribution's `when:`, so they
+  cannot prove "shown when true / hidden when false." The gate lives in
+  `ContentView.commandPaletteCommands` via `contribution.when(context)`. Test it the
+  way `CommandPaletteAuthCommandTests` does: build a `CommandPaletteContextSnapshot`,
+  `setBool(CommandPaletteContextKeys.newWorkspaceRoutesRemote, true/false/unset)`,
+  take the contribution from the static factory above, and assert `when(snapshot)` is
+  true / false / false respectively. This is why the contribution must be reachable
+  from a static seam.
+- **Where the test goes.** The gate/snapshot wiring lives in the app target, so the
+  behavior-level test belongs in the `cmuxTests` XCTest suite (which can
+  `@testable import cmux_DEV`), not the `CmuxCommandPalette` package Tests suite
+  (which can only reach pure search ranking). Note the command-palette search tests
+  are duplicated across both locations; if a ranking fixture is ever added, update
+  both to avoid drift.
+- **Wiring.** Prefer appending to an already-wired suite
+  (`cmuxTests/ShortcutAndCommandPaletteTests.swift` already exercises these context
+  keys). If a new test file is added instead, wire it into
+  `cmux.xcodeproj/project.pbxproj` and run `scripts/lint-pbxproj-test-wiring.sh`,
+  or Xcode silently ignores it ("Executed 0 tests").
+- The remote-vs-local decision itself is already covered by
+  `RemoteTmuxNewWorkspaceRoutingTests` (from the menu-item change); no duplication
+  needed.
+
+## Out of scope
+
+- A bindable keyboard shortcut for New Local Workspace (would trigger the shortcut
+  policy end-to-end).
+- Any change to how New Workspace / ⌘N routes; this only adds a palette surface for
+  the already-defined local action.

--- a/skills/cmux-settings/references/shortcut-actions.md
+++ b/skills/cmux-settings/references/shortcut-actions.md
@@ -24,6 +24,7 @@ Values for `shortcuts.bindings.<action>`:
 ## Tabs
 
 - `shortcuts.bindings.newTab`
+- `shortcuts.bindings.newLocalWorkspace`
 - `shortcuts.bindings.newBrowserWorkspace`
 - `shortcuts.bindings.reopenPreviousSession`
 - `shortcuts.bindings.renameTab`

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -83,6 +83,15 @@ export const shortcutCategories: ShortcutCategory[] = [
       { id: "toggleFileExplorer", combos: [["⌘", "⌥", "B"]], description: { en: "Toggle right sidebar", ja: "右サイドバーを切り替え" } },
       { id: "newTab", combos: [["⌘", "N"]], description: { en: "New workspace", ja: "新規ワークスペース" } },
       {
+        id: "newLocalWorkspace",
+        combos: [["⌃", "⌘", "N"]],
+        description: { en: "New local workspace", ja: "新規ローカルワークスペース" },
+        note: {
+          en: "opens a local workspace while a remote tmux mirror workspace is active, where New Workspace would start a session on that workspace's host instead",
+          ja: "リモート tmux ミラーワークスペースがアクティブなときでも、ローカルワークスペースを開きます（通常の新規ワークスペースはそのワークスペースのホスト上でセッションを開始します）",
+        },
+      },
+      {
         id: "newBrowserWorkspace",
         combos: [["⌥", "⌘", "N"]],
         description: { en: "New browser workspace", ja: "新規ブラウザワークスペース" },

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1587,6 +1587,7 @@
               "quit",
               "toggleSidebar",
               "newTab",
+              "newLocalWorkspace",
               "newBrowserWorkspace",
               "openFolder",
               "reopenPreviousSession",


### PR DESCRIPTION
Design placeholder for a follow-up that adds a **New Local Workspace** entry to the command palette — the palette companion to the New Local Workspace File-menu item.

In a remote-tmux mirror window, plain New Workspace (⌘N) spawns a tmux session on the window's host instead of a local workspace. The menu-item change adds a "New Local Workspace" action that forces local creation, shown only when New Workspace would otherwise go remote. This specs the same thing for the command palette, gated the same way and running the same action.

**No code — this PR is just the design doc**, opened as a draft so the implementation can be reviewed against a written plan (and referenced from the menu-item PR). The doc was adversarially reviewed; it calls out:

- the testability seam — expose the contribution via a `static` factory (like the auth commands) so the `when:` gate is unit-testable;
- the menu/palette reactivity gap and the invalidation hook that keeps the two surfaces in lockstep while the palette stays open across a tab/window switch;
- the fail-safe when there is no host / the beta is off (gate reads false → hidden);
- an auth-command-style gate test in the app-target test suite (not the search-engine suites, which don't evaluate `when:`).

Depends on the New Local Workspace menu-item PR #7214, which adds `performNewLocalWorkspaceAction` and `wouldNewWorkspaceSpawnRemote` (the shared action and the gate this design reuses).
