### PR TITLE
Send Pi prompt-submit hook without blocking Pi's event loop

### DIFF
--- a/CLI/CMUXCLI+PiExtensionSourcePart1.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart1.swift
@@ -1,6 +1,6 @@
 extension CMUXCLI {
     static let piExtensionSourcePart1 = #"""
-// cmux-pi-session-extension-marker v2
+// cmux-pi-session-extension-marker v3
 // Bridges Pi session lifecycle, tool telemetry, notifications, and resume bindings into cmux.
 // Installed by `cmux hooks pi install` or `cmux hooks setup`.
 // DO NOT EDIT MANUALLY. cmux upgrades this file in place.

--- a/CLI/CMUXCLI+PiExtensionSourcePart2.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart2.swift
@@ -29,6 +29,37 @@ function sendHook(subcommand: string, ctx: ExtensionContext, extra: HookExtra = 
   return result.ok;
 }
 
+// Fire-and-forget variant for latency-sensitive paths whose result is unused.
+// sendHook blocks Pi's event loop on a full cmux CLI process launch (hundreds
+// of ms), which made every prompt submission visibly lag before the fix.
+function sendHookFireAndForget(subcommand: string, ctx: ExtensionContext, extra: HookExtra = {}): void {
+  if (process.env.CMUX_PI_HOOKS_DISABLED === "1") return;
+  if (!process.env.CMUX_SURFACE_ID) return;
+
+  const sessionId = sessionIdFrom(ctx);
+  if (!sessionId) return;
+
+  const cwd = cwdFrom(ctx);
+  const payload: HookExtra = {
+    session_id: sessionId,
+    cwd,
+    hook_event_name: eventName(subcommand),
+    event: eventName(subcommand),
+    ...extra,
+  };
+  try {
+    const child = spawn(cmuxExecutable(), ["hooks", "pi", subcommand], {
+      env: hookEnvironment(cwd, true),
+      stdio: ["pipe", "ignore", "ignore"],
+      detached: true,
+    });
+    child.on("error", () => {});
+    child.stdin.on("error", () => {});
+    child.stdin.end(JSON.stringify(payload));
+    child.unref();
+  } catch (_) {}
+}
+
 function surfaceTargetArgs(): string[] | null {
   const surfaceId = firstString(process.env.CMUX_SURFACE_ID);
   if (!surfaceId) return null;
@@ -236,7 +267,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
   pi.on("before_agent_start", async (event, ctx) => {
     const sessionId = sessionIdFrom(ctx);
     const turnId = sessionId ? beginTurn(sessionId, event) : undefined;
-    sendHook("prompt-submit", ctx, { prompt: event.prompt, turn_id: turnId });
+    // Fire-and-forget: this runs between the user's Enter keypress and the
+    // prompt registering. Blocking here (spawnSync) added the full cmux CLI
+    // startup cost (~300ms+) to every submission, and the result is unused.
+    sendHookFireAndForget("prompt-submit", ctx, { prompt: event.prompt, turn_id: turnId });
   });
 
   pi.on("tool_execution_start", async (event, ctx) => {


### PR DESCRIPTION
## Problem

Every Enter in a Pi surface visibly lagged before the prompt registered. The cmux Pi extension runs the `prompt-submit` hook via `spawnSync`, which blocks Pi's (single-threaded) event loop until a full cmux CLI process starts, delivers the payload, and exits. Measured on an M-series machine: ~280ms for CLI startup alone (the CLI links AppKit/SwiftUI), ~560ms for the full hook invocation — paid synchronously on every submission.

## Fix

Add `sendHookFireAndForget` — the same detached `spawn` + `unref()` pattern the extension already uses for `hooks feed` — and use it for `prompt-submit`, whose return value is unused. `session-start` and `notification` keep the synchronous `sendHook` because their results drive resume binding and notification routing. Marker bumped to v3 so installed extensions upgrade in place.

`stop` (also result-ignored) is left synchronous to keep this change minimal; it could get the same treatment as a follow-up, as could the OpenCode plugin template which has the same blocking pattern.

## Validation

- Applied the equivalent change to a live `~/.pi/agent/extensions/cmux-session.ts` and restarted Pi: Enter registers immediately; the prompt-submit hook still lands in cmux (session store updated).
- Localization audit: no user-facing strings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785608114&installation_id=133855650&pr_number=7211&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7211&signature=583a7e8f44f7e8f89133a31d6fe64e3cb7a4cc38b3a82128cd33307c56f848d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the `prompt-submit` hook asynchronously so Pi’s event loop isn’t blocked by a `cmux` CLI launch. This removes the visible lag on Enter (~300ms+ per submission).

- **Bug Fixes**
  - Added `sendHookFireAndForget` (detached `spawn` + `unref()`) and used it for `prompt-submit` where the result is unused.
  - Kept synchronous `sendHook` for `session-start` and `notification` because their results drive resume binding and routing; `stop` unchanged.
  - Bumped the session extension marker to v3 for in-place upgrade.

<sup>Written for commit 5687043f0ffbd32eacf57d09de785d530b557817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt-submit hook handling is now asynchronous, reducing waiting time in latency-sensitive flows.
  * Added a non-blocking hook dispatch path that runs in the background without delaying the main session.

* **Chores**
  * Updated the embedded session extension marker to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->