### PR TITLE
Stop forcing layout from viewDidMoveToWindow during workspace switches

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3857,10 +3857,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             ghostty_surface_set_display_id(surface, displayID)
         }
 
-        // Recompute from current bounds after layout. Pending size is only a fallback
-        // when we don't have usable bounds (e.g. detached/off-window transitions).
-        superview?.layoutSubtreeIfNeeded()
-        layoutSubtreeIfNeeded()
+        // Recompute from current bounds now and let the pending layout pass refine it
+        // (layout() calls updateSurfaceSize()). Do NOT force layoutSubtreeIfNeeded here:
+        // viewDidMoveToWindow fires inside AppKit's _setWindow: constraint pass during
+        // workspace-switch reparenting, and forcing layout there reenters NSHostingView
+        // layout ("laid out reentrantly" faults; SwiftUI skips the pass).
+        needsLayout = true
         updateSurfaceSize()
         applySurfaceBackground()
         applySurfaceColorScheme(force: true)
@@ -11806,7 +11808,14 @@ struct GhosttyTerminalView: NSViewRepresentable {
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
             onDidMoveToWindow?()
-            notifyGeometryChangedIfNeeded()
+            // Defer the geometry notification: it fires inside AppKit's _setWindow:
+            // constraint pass during workspace-switch reparenting, and the portal
+            // reconcile it triggers forces layout, reentering NSHostingView layout.
+            // The next layout() invokes notifyGeometryChangedIfNeeded() anyway; this
+            // async pass covers moves that do not dirty layout.
+            DispatchQueue.main.async { [weak self] in
+                self?.notifyGeometryChangedIfNeeded()
+            }
         }
 
         override func viewDidMoveToSuperview() {


### PR DESCRIPTION
## Problem

Workspace switching intermittently feels sluggish. During the lag, the unified log emits bursts of:

```
[com.apple.SwiftUI:Invalid Configuration] NSHostingView is being laid out reentrantly
while rendering its SwiftUI content. This is not supported and the current layout pass
will be skipped.
```

~4+ faults on **every** workspace switch, with the main thread stuck in AppKit/SwiftUI layout/AttributeGraph churn (`sample` confirmed).

## Root cause

Workspace switches reparent terminal views. Backtraces captured via an lldb breakpoint on the fault-logging path (25 stacks, all identical in shape) show two paths forcing synchronous layout from inside AppKit's `_setWindow:` constraint pass, while SwiftUI is still rendering the hosting view:

1. `GhosttyNSView.viewDidMoveToWindow()` called `layoutSubtreeIfNeeded()` on itself and its superview to recompute the surface size.
2. `HostContainerView.viewDidMoveToWindow()` fired `notifyGeometryChangedIfNeeded()` synchronously → portal `anchorGeometrySync` → `reconcileVisibleHostedViewsAfterGeometrySync()` → `reconcileGeometryNow()` → forced layout.

SwiftUI skips each reentrant pass and the portal layer schedules retries on top — wasted main-thread work multiplied by the number of terminal surfaces being re-hosted.

## Fix

- `GhosttyNSView.viewDidMoveToWindow()`: mark `needsLayout` and do an immediate best-effort `updateSurfaceSize()` from current bounds; the pending layout pass refines it (`layout()` already calls `updateSurfaceSize()`, and `resolvedSurfaceSize` has fallbacks for not-yet-laid-out bounds).
- `HostContainerView.viewDidMoveToWindow()`: defer the geometry notification one runloop tick. The next `layout()` also invokes it, so the async pass only covers moves that don't dirty layout.

Reparenting is not a per-frame path, so neither change touches typing-latency-sensitive code paths.

## Validation

Scripted A/B with `cmux workspace select` loops against a tagged debug build, watching `log stream` and an lldb breakpoint on the fault path:

- **Before**: ~4 reentrancy faults per switch, every switch.
- **After**: zero faults across 46 switches; the lldb breakpoint never fired.

Manual checks on the fixed build: workspace switching, no stale/stretched terminal content on switch.

Note on regression-test policy: this is UI layout-timing behavior driven by AppKit reparenting; I don't have an automated red/green harness for it. Suggestions welcome — a debug-only fault counter assertion around workspace switching could work if there's an existing UI-test seam for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785608186&installation_id=133855650&pr_number=7212&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7212&signature=c501982c2b785ddb78d59dce95cc9ba431e2758296c5c1e46f773bd267e99f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix sluggish workspace switching by removing forced layout during viewDidMoveToWindow. Eliminates SwiftUI reentrant layout faults and avoids main-thread churn.

- **Bug Fixes**
  - `GhosttyNSView.viewDidMoveToWindow`: stop calling `layoutSubtreeIfNeeded`; set `needsLayout = true` and call `updateSurfaceSize()`.
  - `HostContainerView.viewDidMoveToWindow`: defer `notifyGeometryChangedIfNeeded()` one runloop tick via `DispatchQueue.main.async`.

- **Performance**
  - Removed 4+ reentrancy faults per switch; measured zero across 46 switches.
  - Smoother workspace switches with no visual stretching or stale content.

<sup>Written for commit 48f520b454bb476d22e30ae500eef7eb81da6e3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window attachment behavior to reduce layout and sizing glitches when the terminal view is moved between windows or workspaces.
  * Made geometry updates happen at a safer time, helping avoid display refresh issues during reparenting.
  * Switched to a smoother layout update flow so the terminal surface is refreshed correctly without forcing immediate layout work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->