### PR TITLE
Stabilize iOS workspace toolbar after terminal attach

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+UITestWorkspaceCreation.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+UITestWorkspaceCreation.swift
@@ -1,0 +1,24 @@
+internal import CmuxMobileSupport
+internal import CmuxMobileShellModel
+
+extension MobileShellComposite {
+    func createLocalWorkspaceWithoutTerminalForDelayedUITestIfNeeded() -> Bool {
+        #if DEBUG
+        guard UITestConfig.workspaceDetailCreateDelayedTerminalPreviewEnabled else {
+            return false
+        }
+        let nextIndex = workspaces.count + 1
+        let workspace = MobileWorkspacePreview(
+            id: .init(rawValue: "workspace-\(nextIndex)"),
+            name: L10n.workspaceName(index: nextIndex),
+            terminals: []
+        )
+        mutateForegroundWorkspaces { $0.append(workspace) }
+        selectedWorkspaceID = workspace.id
+        selectedTerminalID = nil
+        return true
+        #else
+        return false
+        #endif
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3936,7 +3936,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Test seam: seed the foreground Mac's workspaces/groups (the per-Mac source
     /// of truth) so the derived ``workspaces``/``workspaceGroups`` reflect them,
     /// for tests downstream of the list that do not run a live connection.
-    func setWorkspacesForTesting(
+    public func setWorkspacesForTesting(
         _ workspaces: [MobileWorkspacePreview],
         groups: [MobileWorkspaceGroupPreview] = []
     ) {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3933,10 +3933,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     #if DEBUG
-    /// Test seam: seed the foreground Mac's workspaces/groups (the per-Mac source
-    /// of truth) so the derived ``workspaces``/``workspaceGroups`` reflect them,
-    /// for tests downstream of the list that do not run a live connection.
-    public func setWorkspacesForTesting(
+    /// Replace the foreground Mac's workspaces/groups for DEBUG-only preview
+    /// harnesses that exercise shell state without opening a live connection.
+    public func replaceForegroundWorkspaceState(
         _ workspaces: [MobileWorkspacePreview],
         groups: [MobileWorkspaceGroupPreview] = []
     ) {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -4028,7 +4028,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Apply an optimistic mutation to the foreground Mac's workspace list (e.g. a
     /// just-created workspace or terminal) directly on the per-Mac source of
     /// truth, so the derived list reflects it immediately.
-    private func mutateForegroundWorkspaces(_ body: (inout [MobileWorkspacePreview]) -> Void) {
+    func mutateForegroundWorkspaces(_ body: (inout [MobileWorkspacePreview]) -> Void) {
         let key = foregroundMacKey
         var state = workspacesByMac[key] ?? MacWorkspaceState(macDeviceID: key)
         body(&state.workspaces)
@@ -4048,6 +4048,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             }
             return
         }
+        if createLocalWorkspaceWithoutTerminalForDelayedUITestIfNeeded() { return }
         let nextIndex = workspaces.count + 1
         let workspace = MobileWorkspacePreview(
             id: .init(rawValue: "workspace-\(nextIndex)"),
@@ -4064,7 +4065,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         selectedTerminalID = workspace.terminals.first?.id
         suppressTerminalAutoFocusOnNextAttach(for: selectedTerminalID)
     }
-
     /// Creates a terminal in `workspaceID`, or the selected workspace when nil.
     ///
     /// Callers that act on a specific workspace (e.g. the "+" button on a

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerPendingAttachmentTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerPendingAttachmentTests.swift
@@ -202,7 +202,7 @@ import Testing
         // A workspace sync now reports only term-a (term-b was closed). Setting
         // `workspaces` is the single topology funnel; its `didSet` must prune the
         // staged bytes for the terminal that disappeared.
-        composite.setWorkspacesForTesting([
+        composite.replaceForegroundWorkspaceState([
             MobileWorkspacePreview(id: "ws-1", name: "ws", terminals: [Self.terminalA]),
         ])
 
@@ -219,7 +219,7 @@ import Testing
 
         // term-b moves to a second workspace; it is still in topology, so its
         // attachments survive.
-        composite.setWorkspacesForTesting([
+        composite.replaceForegroundWorkspaceState([
             MobileWorkspacePreview(id: "ws-1", name: "ws", terminals: [Self.terminalA]),
             MobileWorkspacePreview(id: "ws-2", name: "ws2", terminals: [Self.terminalB]),
         ])

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeAgentChatCacheTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeAgentChatCacheTests.swift
@@ -25,12 +25,12 @@ import Testing
             terminalID: "terminal-removed"
         )
 
-        store.setWorkspacesForTesting([keptWorkspace, removedWorkspace])
+        store.replaceForegroundWorkspaceState([keptWorkspace, removedWorkspace])
         store.rememberChatSessions([session], workspaceID: keptWorkspace.id.rawValue)
         store.rememberChatSessions([session], workspaceID: removedWorkspace.id.rawValue)
         #expect(store.cachedChatSessions(workspaceID: removedWorkspace.id.rawValue).isEmpty == false)
 
-        store.setWorkspacesForTesting([keptWorkspace])
+        store.replaceForegroundWorkspaceState([keptWorkspace])
 
         #expect(store.cachedChatSessions(workspaceID: keptWorkspace.id.rawValue).isEmpty == false)
         #expect(store.cachedChatSessions(workspaceID: removedWorkspace.id.rawValue).isEmpty)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
@@ -46,7 +46,7 @@ import Testing
         store.connectPreviewHost()
         // Group sections are account-scoped: the previous account's group
         // names must not survive sign-out into the next session.
-        store.setWorkspacesForTesting(store.workspaces, groups: [
+        store.replaceForegroundWorkspaceState(store.workspaces, groups: [
             MobileWorkspaceGroupPreview(
                 id: "group-1",
                 name: "previous account group",
@@ -70,7 +70,7 @@ import Testing
         store.signIn()
         store.pairingCode = "debug"
         store.connectPreviewHost()
-        store.setWorkspacesForTesting([
+        store.replaceForegroundWorkspaceState([
             MobileWorkspacePreview(id: "ws-foreground", name: "Live", terminals: []),
         ])
         #expect(store.workspaces.map(\.id.rawValue) == ["ws-foreground"])

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -16,6 +16,7 @@ struct MobileLeadingToolbarTitleWidth {
     static let chatToggleReserve: CGFloat = 56
     static let barMarginsAndSpacing: CGFloat = 44
     static let unmeasuredFallback: CGFloat = 180
+    static let maximumMeasuredCap: CGFloat = unmeasuredFallback
     static let floor: CGFloat = 96
 
     var cap: CGFloat {
@@ -24,6 +25,7 @@ struct MobileLeadingToolbarTitleWidth {
         let trailing = hasTrailingCluster
             ? Self.trailingReserveBase + (hasChatToggle ? Self.chatToggleReserve : 0)
             : 0
-        return max(0, contentWidth - leading - trailing - Self.barMarginsAndSpacing)
+        let measuredCap = max(0, contentWidth - leading - trailing - Self.barMarginsAndSpacing)
+        return min(Self.maximumMeasuredCap, measuredCap)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileLeadingToolbarTitleWidth.swift
@@ -12,10 +12,10 @@ struct MobileLeadingToolbarTitleWidth {
     let hasChatToggle: Bool
 
     static let backButtonReserve: CGFloat = 44
-    static let trailingReserveBase: CGFloat = 60
-    static let chatToggleReserve: CGFloat = 56
-    static let barMarginsAndSpacing: CGFloat = 44
-    static let unmeasuredFallback: CGFloat = 180
+    static let trailingReserveBase: CGFloat = 64
+    static let chatToggleReserve: CGFloat = 60
+    static let barMarginsAndSpacing: CGFloat = 84
+    static let unmeasuredFallback: CGFloat = 140
     static let maximumMeasuredCap: CGFloat = unmeasuredFallback
     static let floor: CGFloat = 96
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailContainer.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailContainer.swift
@@ -1,4 +1,3 @@
-import CmuxMobileDiagnostics
 import CmuxMobileShell
 import CmuxMobileShellModel
 import CmuxMobileSupport
@@ -56,22 +55,10 @@ struct WorkspaceDetailContainer: View {
                     signOut: signOut
                 )
                 .onAppear {
-                    #if DEBUG
-                    MobileDebugLog.anchormux(
-                        "toolbar.container.detailAppear requested=\(workspaceID?.rawValue ?? "nil") resolved=\(workspace.id.rawValue) selected=\(store.selectedWorkspaceID?.rawValue ?? "nil") terminals=\(workspace.terminals.count) back=\(backButtonConfiguration != nil)"
-                    )
-                    #endif
                     if store.selectedWorkspaceID != workspace.id {
                         store.selectedWorkspaceID = workspace.id
                     }
                 }
-                #if DEBUG
-                .onDisappear {
-                    MobileDebugLog.anchormux(
-                        "toolbar.container.detailDisappear requested=\(workspaceID?.rawValue ?? "nil") resolved=\(workspace.id.rawValue) selected=\(store.selectedWorkspaceID?.rawValue ?? "nil")"
-                    )
-                }
-                #endif
                 .task(id: workspace.id) {
                     await store.openWorkspace(workspace.id)
                 }
@@ -82,26 +69,5 @@ struct WorkspaceDetailContainer: View {
                 )
             }
         }
-        #if DEBUG
-        .onAppear {
-            MobileDebugLog.anchormux("toolbar.container.appear \(debugSignature)")
-        }
-        .onChange(of: debugSignature) { _, signature in
-            MobileDebugLog.anchormux("toolbar.container.change \(signature)")
-        }
-        #endif
     }
-
-    #if DEBUG
-    private var debugSignature: String {
-        [
-            "requested=\(workspaceID?.rawValue ?? "nil")",
-            "resolved=\(workspace?.id.rawValue ?? "nil")",
-            "selected=\(store.selectedWorkspaceID?.rawValue ?? "nil")",
-            "selectedTerminal=\(store.selectedTerminalID?.rawValue ?? "nil")",
-            "workspaces=\(store.workspaces.map(\.id.rawValue).joined(separator: ","))",
-            "back=\(backButtonConfiguration != nil)",
-        ].joined(separator: " ")
-    }
-    #endif
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailContainer.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailContainer.swift
@@ -17,10 +17,17 @@ struct WorkspaceDetailContainer: View {
     let safeAreaContext: MobileTerminalSafeAreaContext
     let backButtonConfiguration: WorkspaceBackButtonConfiguration?
     let signOut: (() -> Void)?
+    @State private var routeWorkspaceSnapshot: MobileWorkspacePreview?
 
     private var workspace: MobileWorkspacePreview? {
         if let workspaceID {
-            return store.workspaces.first { $0.id == workspaceID } ?? store.selectedWorkspace
+            if let liveWorkspace = store.workspaces.first(where: { $0.id == workspaceID }) {
+                return liveWorkspace
+            }
+            if routeWorkspaceSnapshot?.id == workspaceID {
+                return routeWorkspaceSnapshot
+            }
+            return nil
         }
         return store.selectedWorkspace
     }
@@ -55,9 +62,13 @@ struct WorkspaceDetailContainer: View {
                     signOut: signOut
                 )
                 .onAppear {
+                    rememberRouteWorkspace(workspace)
                     if store.selectedWorkspaceID != workspace.id {
                         store.selectedWorkspaceID = workspace.id
                     }
+                }
+                .onChange(of: workspace) { _, workspace in
+                    rememberRouteWorkspace(workspace)
                 }
                 .task(id: workspace.id) {
                     await store.openWorkspace(workspace.id)
@@ -69,5 +80,10 @@ struct WorkspaceDetailContainer: View {
                 )
             }
         }
+    }
+
+    private func rememberRouteWorkspace(_ workspace: MobileWorkspacePreview) {
+        guard workspaceID == workspace.id else { return }
+        routeWorkspaceSnapshot = workspace
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailCreateDelayedTerminalPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailCreateDelayedTerminalPreviewView.swift
@@ -60,7 +60,7 @@ struct WorkspaceDetailCreateDelayedTerminalPreviewView: View {
             return
         }
         delayedTerminalTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            try? await ContinuousClock().sleep(for: .milliseconds(1_500))
             guard !Task.isCancelled else { return }
             let terminalID = MobileTerminalPreview.ID(rawValue: "\(workspaceID.rawValue)-terminal-1")
             let updatedWorkspace = MobileWorkspacePreview(
@@ -82,7 +82,7 @@ struct WorkspaceDetailCreateDelayedTerminalPreviewView: View {
             let workspaces = store.workspaces.map { existing in
                 existing.id == workspaceID ? updatedWorkspace : existing
             }
-            store.setWorkspacesForTesting(workspaces)
+            store.replaceForegroundWorkspaceState(workspaces)
             store.selectedWorkspaceID = workspaceID
             store.selectedTerminalID = terminalID
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailCreateDelayedTerminalPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailCreateDelayedTerminalPreviewView.swift
@@ -1,0 +1,91 @@
+import CmuxMobileBrowser
+import CmuxMobileShell
+import CmuxMobileShellModel
+import SwiftUI
+
+#if os(iOS) && DEBUG
+struct WorkspaceDetailCreateDelayedTerminalPreviewView: View {
+    private static let initialWorkspaceID = MobileWorkspacePreview.ID(rawValue: "workspace-main")
+    private static let initialTerminalID = MobileTerminalPreview.ID(rawValue: "terminal-build")
+
+    @State private var store = MobileShellComposite(
+        isSignedIn: true,
+        connectionState: .connected,
+        connectedHostName: "UI Test Mac",
+        workspaces: [
+            MobileWorkspacePreview(
+                id: initialWorkspaceID,
+                name: "cmux",
+                terminals: [
+                    MobileTerminalPreview(id: initialTerminalID, name: "Build"),
+                ]
+            ),
+            MobileWorkspacePreview(
+                id: "workspace-docs",
+                name: "Docs",
+                terminals: [
+                    MobileTerminalPreview(id: "terminal-notes", name: "Notes"),
+                ]
+            ),
+        ]
+    )
+    @State private var browserStore = BrowserSurfaceStore()
+    @State private var delayedTerminalTask: Task<Void, Never>?
+
+    var body: some View {
+        WorkspaceShellView(
+            store: store,
+            signOut: {},
+            showAddDevice: nil
+        )
+        .environment(browserStore)
+        .task {
+            store.selectedWorkspaceID = Self.initialWorkspaceID
+            store.selectedTerminalID = Self.initialTerminalID
+        }
+        .onChange(of: store.selectedWorkspaceID) { _, workspaceID in
+            scheduleDelayedTerminalInjection(for: workspaceID)
+        }
+        .onDisappear {
+            delayedTerminalTask?.cancel()
+        }
+    }
+
+    private func scheduleDelayedTerminalInjection(for workspaceID: MobileWorkspacePreview.ID?) {
+        delayedTerminalTask?.cancel()
+        guard let workspaceID,
+              workspaceID != Self.initialWorkspaceID,
+              let workspace = store.workspaces.first(where: { $0.id == workspaceID }),
+              workspace.terminals.isEmpty else {
+            return
+        }
+        delayedTerminalTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
+            let terminalID = MobileTerminalPreview.ID(rawValue: "\(workspaceID.rawValue)-terminal-1")
+            let updatedWorkspace = MobileWorkspacePreview(
+                id: workspace.id,
+                macDeviceID: workspace.macDeviceID,
+                macDisplayName: workspace.macDisplayName,
+                windowID: workspace.windowID,
+                name: workspace.name,
+                isPinned: workspace.isPinned,
+                groupID: workspace.groupID,
+                previewText: workspace.previewText,
+                previewAt: workspace.previewAt,
+                lastActivityAt: workspace.lastActivityAt,
+                hasUnread: workspace.hasUnread,
+                terminals: [
+                    MobileTerminalPreview(id: terminalID, name: "Terminal 1"),
+                ]
+            )
+            let workspaces = store.workspaces.map { existing in
+                existing.id == workspaceID ? updatedWorkspace : existing
+            }
+            store.setWorkspacesForTesting(workspaces)
+            store.selectedWorkspaceID = workspaceID
+            store.selectedTerminalID = terminalID
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailDelayedTerminalPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailDelayedTerminalPreviewView.swift
@@ -1,0 +1,52 @@
+import CmuxMobileBrowser
+import CmuxMobileShell
+import CmuxMobileShellModel
+import SwiftUI
+
+#if os(iOS) && DEBUG
+struct WorkspaceDetailDelayedTerminalPreviewView: View {
+    private static let workspaceID = MobileWorkspacePreview.ID(rawValue: "workspace-delayed-terminal")
+    private static let terminalID = MobileTerminalPreview.ID(rawValue: "terminal-delayed")
+
+    @State private var store = MobileShellComposite(
+        isSignedIn: true,
+        connectionState: .connected,
+        connectedHostName: "UI Test Mac",
+        workspaces: [
+            MobileWorkspacePreview(
+                id: workspaceID,
+                name: "New Workspace",
+                terminals: []
+            ),
+        ]
+    )
+    @State private var browserStore = BrowserSurfaceStore()
+    @State private var didInjectTerminal = false
+
+    var body: some View {
+        WorkspaceShellView(
+            store: store,
+            signOut: {},
+            showAddDevice: nil
+        )
+        .environment(browserStore)
+        .task {
+            guard !didInjectTerminal else { return }
+            didInjectTerminal = true
+            store.selectedWorkspaceID = Self.workspaceID
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
+            let workspace = MobileWorkspacePreview(
+                id: Self.workspaceID,
+                name: "New Workspace",
+                terminals: [
+                    MobileTerminalPreview(id: Self.terminalID, name: "Terminal 1"),
+                ]
+            )
+            store.setWorkspacesForTesting([workspace])
+            store.selectedWorkspaceID = Self.workspaceID
+            store.selectedTerminalID = Self.terminalID
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailDelayedTerminalPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailDelayedTerminalPreviewView.swift
@@ -1,3 +1,4 @@
+import CmuxAgentChat
 import CmuxMobileBrowser
 import CmuxMobileShell
 import CmuxMobileShellModel
@@ -7,6 +8,8 @@ import SwiftUI
 struct WorkspaceDetailDelayedTerminalPreviewView: View {
     private static let workspaceID = MobileWorkspacePreview.ID(rawValue: "workspace-delayed-terminal")
     private static let terminalID = MobileTerminalPreview.ID(rawValue: "terminal-delayed")
+    private static let longWorkspaceTitle = "Extremely Long Workspace Title That Should Truncate Before Toolbar Buttons Overflow"
+    private static let longTerminalTitle = "Long Agent Session Subtitle That Should Also Truncate First"
 
     @State private var store = MobileShellComposite(
         isSignedIn: true,
@@ -15,7 +18,7 @@ struct WorkspaceDetailDelayedTerminalPreviewView: View {
         workspaces: [
             MobileWorkspacePreview(
                 id: workspaceID,
-                name: "New Workspace",
+                name: workspaceTitle,
                 terminals: []
             ),
         ]
@@ -38,15 +41,47 @@ struct WorkspaceDetailDelayedTerminalPreviewView: View {
             guard !Task.isCancelled else { return }
             let workspace = MobileWorkspacePreview(
                 id: Self.workspaceID,
-                name: "New Workspace",
+                name: Self.workspaceTitle,
                 terminals: [
-                    MobileTerminalPreview(id: Self.terminalID, name: "Terminal 1"),
+                    MobileTerminalPreview(id: Self.terminalID, name: Self.terminalTitle),
                 ]
             )
             store.setWorkspacesForTesting([workspace])
             store.selectedWorkspaceID = Self.workspaceID
             store.selectedTerminalID = Self.terminalID
+            if Self.showsChatToggle {
+                store.rememberChatSessions(
+                    [
+                        ChatSessionDescriptor(
+                            id: "preview-chat-session",
+                            agentKind: .claude,
+                            title: "Preview Agent",
+                            workspaceID: Self.workspaceID.rawValue,
+                            terminalID: Self.terminalID.rawValue,
+                            state: .working(since: Date()),
+                            lastActivityAt: Date()
+                        ),
+                    ],
+                    workspaceID: Self.workspaceID.rawValue
+                )
+            }
         }
+    }
+
+    private static var usesLongTitle: Bool {
+        ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_DETAIL_LONG_TITLE"] == "1"
+    }
+
+    private static var showsChatToggle: Bool {
+        ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_DETAIL_CHAT_TOGGLE"] == "1"
+    }
+
+    private static var workspaceTitle: String {
+        usesLongTitle ? longWorkspaceTitle : "New Workspace"
+    }
+
+    private static var terminalTitle: String {
+        usesLongTitle ? longTerminalTitle : "Terminal 1"
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailDelayedTerminalPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailDelayedTerminalPreviewView.swift
@@ -37,7 +37,7 @@ struct WorkspaceDetailDelayedTerminalPreviewView: View {
             guard !didInjectTerminal else { return }
             didInjectTerminal = true
             store.selectedWorkspaceID = Self.workspaceID
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            try? await ContinuousClock().sleep(for: .milliseconds(1_500))
             guard !Task.isCancelled else { return }
             let workspace = MobileWorkspacePreview(
                 id: Self.workspaceID,
@@ -46,7 +46,7 @@ struct WorkspaceDetailDelayedTerminalPreviewView: View {
                     MobileTerminalPreview(id: Self.terminalID, name: Self.terminalTitle),
                 ]
             )
-            store.setWorkspacesForTesting([workspace])
+            store.replaceForegroundWorkspaceState([workspace])
             store.selectedWorkspaceID = Self.workspaceID
             store.selectedTerminalID = Self.terminalID
             if Self.showsChatToggle {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -89,22 +89,8 @@ struct WorkspaceDetailView: View {
                 await runWarmChatConversation()
             }
             .onChange(of: selectedTerminalID) { _, _ in
-                #if DEBUG
-                MobileDebugLog.anchormux("toolbar.detail.selectedTerminal \(debugToolbarSignature)")
-                #endif
                 refreshCachedChatToggleAnchor()
             }
-            #if DEBUG
-            .onChange(of: debugToolbarSignature) { _, signature in
-                MobileDebugLog.anchormux("toolbar.detail.change \(signature)")
-            }
-            .onAppear {
-                MobileDebugLog.anchormux("toolbar.detail.appear \(debugToolbarSignature)")
-            }
-            .onDisappear {
-                MobileDebugLog.anchormux("toolbar.detail.disappear \(debugToolbarSignature)")
-            }
-            #endif
             .closeWorkspaceConfirmation(
                 isPresented: $isConfirmingClose,
                 confirm: confirmCloseWorkspaceFromMenu
@@ -135,17 +121,17 @@ struct WorkspaceDetailView: View {
     @ToolbarContentBuilder
     private var workspaceDetailToolbar: some ToolbarContent {
         if backButtonConfiguration != nil {
-            ToolbarItem(placement: .topBarLeading) {
+            ToolbarItem(id: "workspace-back", placement: .topBarLeading) {
                 workspaceBackToolbarButton
             }
             if #available(iOS 26.0, *) {
                 ToolbarSpacer(.fixed, placement: .topBarLeading)
             }
         }
-        ToolbarItem(placement: .topBarLeading) {
+        ToolbarItem(id: "workspace-title", placement: .topBarLeading) {
             workspaceTitleToolbarMenu
         }
-        ToolbarItem(placement: .topBarTrailing) {
+        ToolbarItem(id: "workspace-trailing", placement: .topBarTrailing) {
             toolbarTrailingCluster
         }
     }
@@ -162,22 +148,6 @@ struct WorkspaceDetailView: View {
             toolbarTitleLabel
         }
     }
-
-    #if DEBUG
-    private var debugToolbarSignature: String {
-        [
-            "workspace=\(workspace.id.rawValue)",
-            "selected=\(store.selectedWorkspaceID?.rawValue ?? "nil")",
-            "selectedTerminal=\(selectedTerminalID ?? "nil")",
-            "terminals=\(workspace.terminals.map(\.id.rawValue).joined(separator: ","))",
-            "back=\(backButtonConfiguration != nil)",
-            "titleActions=\(hasTitleMenuActions)",
-            "chatToggle=\(shouldShowChatToggle)",
-            "browser=\(activeBrowser?.id.rawValue ?? "nil")",
-            "width=\(Int(contentWidth))",
-        ].joined(separator: " ")
-    }
-    #endif
 
     @ViewBuilder
     private var toolbarTitleLabel: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -49,7 +49,9 @@ public struct WorkspaceListLayoutPreviewView: View {
     ]
 
     public var body: some View {
-        if UITestConfig.workspaceDetailDelayedTerminalPreviewEnabled {
+        if UITestConfig.workspaceDetailCreateDelayedTerminalPreviewEnabled {
+            WorkspaceDetailCreateDelayedTerminalPreviewView()
+        } else if UITestConfig.workspaceDetailDelayedTerminalPreviewEnabled {
             WorkspaceDetailDelayedTerminalPreviewView()
         } else {
             NavigationStack {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -1,6 +1,7 @@
 #if canImport(UIKit) && DEBUG
 import CmuxMobileShell
 import CmuxMobileShellModel
+import CmuxMobileSupport
 import SwiftUI
 
 /// DEBUG-only workspace list fixture for simulator layout screenshots.
@@ -48,22 +49,26 @@ public struct WorkspaceListLayoutPreviewView: View {
     ]
 
     public var body: some View {
-        NavigationStack {
-            WorkspaceListView(
-                workspaces: workspaces,
-                selectedWorkspaceID: selectedWorkspaceID,
-                host: "Visual Mock Mac",
-                connectionStatus: .connected,
-                navigationStyle: .push,
-                wrapWorkspaceTitles: false,
-                previewLineLimit: MobileDisplaySettings.defaultWorkspacePreviewLineCount,
-                unreadIndicatorLeftShift: MobileDisplaySettings.defaultUnreadIndicatorLeftShift,
-                profilePictureLeftShift: MobileDisplaySettings.defaultProfilePictureLeftShift,
-                profilePictureSize: MobileDisplaySettings.defaultProfilePictureSize,
-                selectWorkspace: { selectedWorkspaceID = $0 },
-                createWorkspace: {},
-                macSelection: $macSelection
-            )
+        if UITestConfig.workspaceDetailDelayedTerminalPreviewEnabled {
+            WorkspaceDetailDelayedTerminalPreviewView()
+        } else {
+            NavigationStack {
+                WorkspaceListView(
+                    workspaces: workspaces,
+                    selectedWorkspaceID: selectedWorkspaceID,
+                    host: "Visual Mock Mac",
+                    connectionStatus: .connected,
+                    navigationStyle: .push,
+                    wrapWorkspaceTitles: false,
+                    previewLineLimit: MobileDisplaySettings.defaultWorkspacePreviewLineCount,
+                    unreadIndicatorLeftShift: MobileDisplaySettings.defaultUnreadIndicatorLeftShift,
+                    profilePictureLeftShift: MobileDisplaySettings.defaultProfilePictureLeftShift,
+                    profilePictureSize: MobileDisplaySettings.defaultProfilePictureSize,
+                    selectWorkspace: { selectedWorkspaceID = $0 },
+                    createWorkspace: {},
+                    macSelection: $macSelection
+                )
+            }
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+extension WorkspaceListView {
+    @ViewBuilder
+    func workspaceListWithToolbar<Content: View>(
+        _ content: Content,
+        machineSnapshots: WorkspaceMachineSnapshots,
+        filterMachines: [WorkspaceFilterMachine]
+    ) -> some View {
+        #if os(iOS)
+            if showsNavigationToolbar {
+                content
+                    .toolbar {
+                        ToolbarItem(id: "workspace-list-settings", placement: .topBarLeading) {
+                            settingsMenu
+                        }
+                        ToolbarItem(id: "workspace-list-title", placement: .principal) {
+                            macTitlePicker(machineSnapshots: machineSnapshots)
+                        }
+                        if showsDevicesButton {
+                            ToolbarItem(id: "workspace-list-devices", placement: .topBarLeading) {
+                                devicesButton
+                            }
+                        }
+                        ToolbarItemGroup(placement: .topBarTrailing) {
+                            WorkspaceListFilterMenu(filter: $filter, machines: filterMachines)
+                            if canCreateWorkspace {
+                                newWorkspaceButton
+                            }
+                        }
+                    }
+            } else {
+                content
+            }
+        #else
+            content
+                .toolbar {
+                    ToolbarItemGroup {
+                        WorkspaceListFilterMenu(filter: $filter, machines: filterMachines)
+                        if canCreateWorkspace {
+                            newWorkspaceButton
+                        }
+                    }
+                }
+        #endif
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -268,19 +268,23 @@ struct WorkspaceListView: View {
         .searchable(text: $searchText)
         .toolbar {
             #if os(iOS)
-            if showsNavigationToolbar {
-                ToolbarItem(placement: .topBarLeading) {
+            ToolbarItem(id: "workspace-list-settings", placement: .topBarLeading) {
+                if showsNavigationToolbar {
                     settingsMenu
                 }
-                ToolbarItem(placement: .principal) {
+            }
+            ToolbarItem(id: "workspace-list-title", placement: .principal) {
+                if showsNavigationToolbar {
                     macTitlePicker(machineSnapshots: displayedMachineSnapshots)
                 }
-                if showsDevicesButton {
-                    ToolbarItem(placement: .topBarLeading) {
-                        devicesButton
-                    }
+            }
+            ToolbarItem(id: "workspace-list-devices", placement: .topBarLeading) {
+                if showsNavigationToolbar && showsDevicesButton {
+                    devicesButton
                 }
-                ToolbarItemGroup(placement: .topBarTrailing) {
+            }
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                if showsNavigationToolbar {
                     WorkspaceListFilterMenu(filter: $filter, machines: displayedFilterMachines)
                     if canCreateWorkspace {
                         newWorkspaceButton

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -268,23 +268,15 @@ struct WorkspaceListView: View {
         .searchable(text: $searchText)
         .toolbar {
             #if os(iOS)
-            ToolbarItem(id: "workspace-list-settings", placement: .topBarLeading) {
-                if showsNavigationToolbar {
+            if showsNavigationToolbar {
+                ToolbarItem(id: "workspace-list-settings", placement: .topBarLeading) {
                     settingsMenu
                 }
-            }
-            ToolbarItem(id: "workspace-list-title", placement: .principal) {
-                if showsNavigationToolbar {
-                    macTitlePicker(machineSnapshots: displayedMachineSnapshots)
+                ToolbarItem(id: "workspace-list-title", placement: .principal) { macTitlePicker(machineSnapshots: displayedMachineSnapshots) }
+                if showsDevicesButton {
+                    ToolbarItem(id: "workspace-list-devices", placement: .topBarLeading) { devicesButton }
                 }
-            }
-            ToolbarItem(id: "workspace-list-devices", placement: .topBarLeading) {
-                if showsNavigationToolbar && showsDevicesButton {
-                    devicesButton
-                }
-            }
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                if showsNavigationToolbar {
+                ToolbarItemGroup(placement: .topBarTrailing) {
                     WorkspaceListFilterMenu(filter: $filter, machines: displayedFilterMachines)
                     if canCreateWorkspace {
                         newWorkspaceButton

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -17,6 +17,7 @@ struct WorkspaceListView: View {
     let host: String
     let connectionStatus: MobileMacConnectionStatus
     let navigationStyle: WorkspaceNavigationStyle
+    var showsNavigationToolbar = true
     /// Whether workspace-row titles wrap (multi-line) instead of truncating to a
     /// single line. Passed in as a value snapshot so no `@Observable` store
     /// crosses the `List` boundary.
@@ -267,21 +268,23 @@ struct WorkspaceListView: View {
         .searchable(text: $searchText)
         .toolbar {
             #if os(iOS)
-            ToolbarItem(placement: .topBarLeading) {
-                settingsMenu
-            }
-            ToolbarItem(placement: .principal) {
-                macTitlePicker(machineSnapshots: displayedMachineSnapshots)
-            }
-            if showsDevicesButton {
+            if showsNavigationToolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    devicesButton
+                    settingsMenu
                 }
-            }
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                WorkspaceListFilterMenu(filter: $filter, machines: displayedFilterMachines)
-                if canCreateWorkspace {
-                    newWorkspaceButton
+                ToolbarItem(placement: .principal) {
+                    macTitlePicker(machineSnapshots: displayedMachineSnapshots)
+                }
+                if showsDevicesButton {
+                    ToolbarItem(placement: .topBarLeading) {
+                        devicesButton
+                    }
+                }
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    WorkspaceListFilterMenu(filter: $filter, machines: displayedFilterMachines)
+                    if canCreateWorkspace {
+                        newWorkspaceButton
+                    }
                 }
             }
             #else

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -196,7 +196,7 @@ struct WorkspaceListView: View {
             machineSnapshots: displayedMachineSnapshots,
             visibleSelection: currentVisibleMacSelection
         )
-        List {
+        let list = List {
             if let store, showsConnectionRecoveryRow {
                 Section {
                     MobileConnectionRecoveryBanner(
@@ -266,32 +266,12 @@ struct WorkspaceListView: View {
         .navigationTitle(L10n.string("mobile.workspaces.title", defaultValue: "Workspaces"))
         .mobileInlineNavigationTitle()
         .searchable(text: $searchText)
-        .toolbar {
-            #if os(iOS)
-            if showsNavigationToolbar {
-                ToolbarItem(id: "workspace-list-settings", placement: .topBarLeading) {
-                    settingsMenu
-                }
-                ToolbarItem(id: "workspace-list-title", placement: .principal) { macTitlePicker(machineSnapshots: displayedMachineSnapshots) }
-                if showsDevicesButton {
-                    ToolbarItem(id: "workspace-list-devices", placement: .topBarLeading) { devicesButton }
-                }
-                ToolbarItemGroup(placement: .topBarTrailing) {
-                    WorkspaceListFilterMenu(filter: $filter, machines: displayedFilterMachines)
-                    if canCreateWorkspace {
-                        newWorkspaceButton
-                    }
-                }
-            }
-            #else
-            ToolbarItemGroup {
-                WorkspaceListFilterMenu(filter: $filter, machines: displayedFilterMachines)
-                if canCreateWorkspace {
-                    newWorkspaceButton
-                }
-            }
-            #endif
-        }
+
+        workspaceListWithToolbar(
+            list,
+            machineSnapshots: displayedMachineSnapshots,
+            filterMachines: displayedFilterMachines
+        )
         .accessibilityIdentifier("MobileWorkspaceList")
         .onDisappear {
             invalidateDeferredWorkspaceSelection()
@@ -468,7 +448,7 @@ struct WorkspaceListView: View {
     }
 
     #if os(iOS)
-    private var devicesButton: some View {
+    var devicesButton: some View {
         Button {
             showingDeviceTree = true
         } label: {
@@ -540,7 +520,7 @@ struct WorkspaceListView: View {
         .listRowSeparator(.hidden)
     }
 
-    private var newWorkspaceButton: some View {
+    var newWorkspaceButton: some View {
         Button {
             guard canCreateWorkspaceForMacSelection else { return }
             createWorkspace()
@@ -582,7 +562,7 @@ struct WorkspaceListView: View {
         deferredWorkspaceSelectionGeneration &+= 1
     }
 
-    private var settingsMenu: some View {
+    var settingsMenu: some View {
         #if os(iOS)
         // Open the full Settings page (account, terminal shortcuts,
         // notifications, paired Mac) rather than a transient menu.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CmuxMobileDiagnostics
 import CmuxMobileShell
 import CmuxMobileShellModel
 import CmuxMobileWorkspace
@@ -145,9 +144,6 @@ struct WorkspaceShellView: View {
             }
         }
         .onChange(of: store.selectedWorkspaceID) { _, selectedWorkspaceID in
-            MobileDebugLog.anchormux(
-                "toolbar.shell.selected workspace=\(selectedWorkspaceID?.rawValue ?? "nil") path=\(debugCompactNavigationPath) pendingCreate=\(pendingCompactCreateNavigationWorkspaceIDs != nil)"
-            )
             if let createdPath = WorkspaceShellCompactNavigationPolicy.pathForCreatedWorkspaceSelection(
                 currentPath: compactNavigationPath,
                 selectedWorkspaceID: selectedWorkspaceID,
@@ -165,9 +161,6 @@ struct WorkspaceShellView: View {
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }
         .onChange(of: compactNavigationPath) { _, path in
-            MobileDebugLog.anchormux(
-                "toolbar.shell.path path=\(path.map(\.rawValue).joined(separator: ",")) selected=\(store.selectedWorkspaceID?.rawValue ?? "nil")"
-            )
             guard let selectedWorkspaceID = path.last else {
                 return
             }
@@ -178,11 +171,7 @@ struct WorkspaceShellView: View {
             store.selectedWorkspaceID = selectedWorkspaceID
         }
         .onChange(of: store.workspaces.map(\.id)) { _, workspaceIDs in
-            MobileDebugLog.anchormux(
-                "toolbar.shell.workspaceIDs ids=\(workspaceIDs.map(\.rawValue).joined(separator: ",")) pathBefore=\(debugCompactNavigationPath)"
-            )
             compactNavigationPath.removeAll { !workspaceIDs.contains($0) }
-            MobileDebugLog.anchormux("toolbar.shell.workspaceIDs pathAfter=\(debugCompactNavigationPath)")
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }
         .onAppear {
@@ -239,10 +228,6 @@ struct WorkspaceShellView: View {
         .onAppear {
             hasPresentedSplitDetail = true
         }
-    }
-
-    private var debugCompactNavigationPath: String {
-        compactNavigationPath.map(\.rawValue).joined(separator: ",")
     }
 
     /// Apply (and clear) a pending deep-link navigation intent. On the compact

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -157,7 +157,8 @@ struct WorkspaceShellView: View {
             }
             compactNavigationPath = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
                 currentPath: compactNavigationPath,
-                selectedWorkspaceID: selectedWorkspaceID
+                selectedWorkspaceID: selectedWorkspaceID,
+                visibleWorkspaceIDs: Set(store.workspaces.map(\.id))
             )
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -96,6 +96,7 @@ struct WorkspaceShellView: View {
                 host: store.connectedHostName,
                 connectionStatus: listConnectionStatus,
                 navigationStyle: .push,
+                showsNavigationToolbar: compactNavigationPath.isEmpty,
                 wrapWorkspaceTitles: displaySettings.wrapWorkspaceTitles,
                 previewLineLimit: displaySettings.workspacePreviewLineCount,
                 unreadIndicatorLeftShift: displaySettings.unreadIndicatorLeftShift,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -18,6 +18,7 @@ struct WorkspaceShellView: View {
     /// Present the add-device (pairing) flow from the Computers screen. `nil`
     /// hides the add affordance.
     var showAddDevice: (() -> Void)?
+    private let compactNavigationPolicy = WorkspaceShellCompactNavigationPolicy()
     @Environment(MobileDisplaySettings.self) private var displaySettings
     @State private var compactNavigationPath: [MobileWorkspacePreview.ID] = []
     @State private var pendingCompactCreateNavigationWorkspaceIDs: Set<MobileWorkspacePreview.ID>?
@@ -145,7 +146,7 @@ struct WorkspaceShellView: View {
             }
         }
         .onChange(of: store.selectedWorkspaceID) { _, selectedWorkspaceID in
-            if let createdPath = WorkspaceShellCompactNavigationPolicy.pathForCreatedWorkspaceSelection(
+            if let createdPath = compactNavigationPolicy.pathForCreatedWorkspaceSelection(
                 currentPath: compactNavigationPath,
                 selectedWorkspaceID: selectedWorkspaceID,
                 existingWorkspaceIDs: pendingCompactCreateNavigationWorkspaceIDs
@@ -155,7 +156,7 @@ struct WorkspaceShellView: View {
                 autoOpenSelectedWorkspaceForSoakIfNeeded()
                 return
             }
-            compactNavigationPath = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
+            compactNavigationPath = compactNavigationPolicy.pathForSelectionChange(
                 currentPath: compactNavigationPath,
                 selectedWorkspaceID: selectedWorkspaceID,
                 visibleWorkspaceIDs: Set(store.workspaces.map(\.id))
@@ -173,7 +174,7 @@ struct WorkspaceShellView: View {
             store.selectedWorkspaceID = selectedWorkspaceID
         }
         .onChange(of: store.workspaces.map(\.id)) { _, workspaceIDs in
-            compactNavigationPath = WorkspaceShellCompactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
+            compactNavigationPath = compactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
                 currentPath: compactNavigationPath,
                 visibleWorkspaceIDs: Set(workspaceIDs),
                 selectedWorkspaceID: store.selectedWorkspaceID
@@ -366,7 +367,7 @@ struct WorkspaceShellView: View {
         let existingWorkspaceIDs = Set(store.workspaces.map(\.id))
         pendingCompactCreateNavigationWorkspaceIDs = existingWorkspaceIDs
         store.createWorkspace()
-        if let createdPath = WorkspaceShellCompactNavigationPolicy.pathForCreatedWorkspaceSelection(
+        if let createdPath = compactNavigationPolicy.pathForCreatedWorkspaceSelection(
             currentPath: compactNavigationPath,
             selectedWorkspaceID: store.selectedWorkspaceID,
             existingWorkspaceIDs: existingWorkspaceIDs

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -172,7 +172,11 @@ struct WorkspaceShellView: View {
             store.selectedWorkspaceID = selectedWorkspaceID
         }
         .onChange(of: store.workspaces.map(\.id)) { _, workspaceIDs in
-            compactNavigationPath.removeAll { !workspaceIDs.contains($0) }
+            compactNavigationPath = WorkspaceShellCompactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
+                currentPath: compactNavigationPath,
+                visibleWorkspaceIDs: Set(workspaceIDs),
+                selectedWorkspaceID: store.selectedWorkspaceID
+            )
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }
         .onAppear {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -9,23 +9,16 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View {
     @ViewBuilder let menuContent: () -> MenuContent
     @ViewBuilder let label: () -> Label
 
-    @ViewBuilder
     var body: some View {
-        if isEnabled {
-            Menu {
+        Menu {
+            if isEnabled {
                 menuContent()
-            } label: {
-                fittedLabel
             }
-            .accessibilityIdentifier("MobileWorkspaceTitleMenu")
-        } else {
-            Button {} label: {
-                fittedLabel
-            }
-                .allowsHitTesting(false)
-                .accessibilityRemoveTraits(.isButton)
-                .accessibilityIdentifier("MobileWorkspaceTitleMenu")
+        } label: {
+            fittedLabel
         }
+        .allowsHitTesting(isEnabled)
+        .accessibilityIdentifier("MobileWorkspaceTitleMenu")
     }
 
     private var fittedLabel: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -35,6 +35,5 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View {
                 maxWidth: cap,
                 alignment: .leading
             )
-            .layoutPriority(1)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -9,17 +9,23 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View {
     @ViewBuilder let menuContent: () -> MenuContent
     @ViewBuilder let label: () -> Label
 
+    @ViewBuilder
     var body: some View {
-        Menu {
-            if isEnabled {
+        if isEnabled {
+            Menu {
                 menuContent()
+            } label: {
+                fittedLabel
             }
-        } label: {
-            fittedLabel
+            .accessibilityIdentifier("MobileWorkspaceTitleMenu")
+        } else {
+            Button {} label: {
+                fittedLabel
+            }
+            .allowsHitTesting(false)
+            .accessibilityRemoveTraits(.isButton)
+            .accessibilityIdentifier("MobileWorkspaceTitleMenu")
         }
-        .allowsHitTesting(isEnabled)
-        .disabled(!isEnabled)
-        .accessibilityIdentifier("MobileWorkspaceTitleMenu")
     }
 
     private var fittedLabel: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -18,6 +18,7 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View {
             fittedLabel
         }
         .allowsHitTesting(isEnabled)
+        .disabled(!isEnabled)
         .accessibilityIdentifier("MobileWorkspaceTitleMenu")
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -40,7 +40,7 @@ import Testing
 
     @Test func iPhoneWidthCapsTitleBeforeTrailingControlsOverflow() {
         #expect(cap(393, hasChatToggle: true) <= 140)
-        #expect(cap(393, hasChatToggle: false) <= MobileLeadingToolbarTitleWidth.maximumMeasuredCap)
+        #expect(cap(393, hasChatToggle: false) == 140)
     }
 
     @Test func titleGainsRoomWithoutBackButton() {
@@ -48,10 +48,11 @@ import Testing
     }
 
     @Test func noTrailingClusterDoesNotReserveChatToggle() {
-        let withoutTrailing = cap(393, hasTrailingCluster: false)
+        let contentWidth: CGFloat = 220
+        let withoutTrailing = cap(contentWidth, hasTrailingCluster: false)
         let expected = min(
             MobileLeadingToolbarTitleWidth.maximumMeasuredCap,
-            393
+            contentWidth
             - MobileLeadingToolbarTitleWidth.backButtonReserve
             - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
         )

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -38,6 +38,11 @@ import Testing
         #expect(cap(260, hasChatToggle: false) > cap(260, hasChatToggle: true))
     }
 
+    @Test func iPhoneWidthCapsTitleBeforeTrailingControlsOverflow() {
+        #expect(cap(393, hasChatToggle: true) <= 140)
+        #expect(cap(393, hasChatToggle: false) <= MobileLeadingToolbarTitleWidth.maximumMeasuredCap)
+    }
+
     @Test func titleGainsRoomWithoutBackButton() {
         #expect(cap(260, hasBackButton: false) > cap(260, hasBackButton: true))
     }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileLeadingToolbarTitleWidthTests.swift
@@ -22,29 +22,39 @@ import Testing
     }
 
     @Test func leadingTitleReservesBackAndTrailingControls() {
-        let expected = 393
+        let expected = min(
+            MobileLeadingToolbarTitleWidth.maximumMeasuredCap,
+            393
             - MobileLeadingToolbarTitleWidth.backButtonReserve
             - MobileLeadingToolbarTitleWidth.trailingReserveBase
             - MobileLeadingToolbarTitleWidth.chatToggleReserve
             - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
+        )
 
         #expect(cap(393) == expected)
     }
 
     @Test func titleGainsRoomWithoutChatToggle() {
-        #expect(cap(393, hasChatToggle: false) > cap(393, hasChatToggle: true))
+        #expect(cap(260, hasChatToggle: false) > cap(260, hasChatToggle: true))
     }
 
     @Test func titleGainsRoomWithoutBackButton() {
-        #expect(cap(393, hasBackButton: false) > cap(393, hasBackButton: true))
+        #expect(cap(260, hasBackButton: false) > cap(260, hasBackButton: true))
     }
 
     @Test func noTrailingClusterDoesNotReserveChatToggle() {
         let withoutTrailing = cap(393, hasTrailingCluster: false)
-        let expected = 393
+        let expected = min(
+            MobileLeadingToolbarTitleWidth.maximumMeasuredCap,
+            393
             - MobileLeadingToolbarTitleWidth.backButtonReserve
             - MobileLeadingToolbarTitleWidth.barMarginsAndSpacing
+        )
 
         #expect(withoutTrailing == expected)
+    }
+
+    @Test func measuredWidthDoesNotExpandPastInitialFallback() {
+        #expect(cap(800, hasChatToggle: false) == MobileLeadingToolbarTitleWidth.unmeasuredFallback)
     }
 }

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -88,7 +88,21 @@ public struct UITestConfig {
     public static var workspaceListLayoutPreviewEnabled: Bool {
         #if DEBUG
         return ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW"] == "1"
+            || workspaceDetailDelayedTerminalPreviewEnabled
             || ProcessInfo.processInfo.arguments.contains("CMUX_UITEST_WORKSPACE_LIST_PREVIEW=1")
+        #else
+        return false
+        #endif
+    }
+
+    /// Whether the workspace detail delayed-terminal lifecycle preview is enabled.
+    ///
+    /// When `CMUX_UITEST_WORKSPACE_DETAIL_DELAYED_TERMINAL=1`, the root view renders
+    /// a connected workspace shell already opened to a fresh workspace with no
+    /// terminal, then updates that same workspace with a terminal. DEBUG-only.
+    public static var workspaceDetailDelayedTerminalPreviewEnabled: Bool {
+        #if DEBUG
+        return ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_DETAIL_DELAYED_TERMINAL"] == "1"
         #else
         return false
         #endif

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -89,6 +89,7 @@ public struct UITestConfig {
         #if DEBUG
         return ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW"] == "1"
             || workspaceDetailDelayedTerminalPreviewEnabled
+            || workspaceDetailCreateDelayedTerminalPreviewEnabled
             || ProcessInfo.processInfo.arguments.contains("CMUX_UITEST_WORKSPACE_LIST_PREVIEW=1")
         #else
         return false
@@ -103,6 +104,21 @@ public struct UITestConfig {
     public static var workspaceDetailDelayedTerminalPreviewEnabled: Bool {
         #if DEBUG
         return ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_DETAIL_DELAYED_TERMINAL"] == "1"
+        #else
+        return false
+        #endif
+    }
+
+    /// Whether the workspace detail create-workspace delayed-terminal lifecycle
+    /// preview is enabled.
+    ///
+    /// When `CMUX_UITEST_WORKSPACE_DETAIL_CREATE_DELAYED_TERMINAL=1`, the root
+    /// view renders a connected workspace shell opened to an existing workspace.
+    /// The actual new-workspace toolbar button creates a fresh workspace without
+    /// a terminal, then the preview injects that terminal after a delay. DEBUG-only.
+    public static var workspaceDetailCreateDelayedTerminalPreviewEnabled: Bool {
+        #if DEBUG
+        return ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_DETAIL_CREATE_DELAYED_TERMINAL"] == "1"
         #else
         return false
         #endif

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
@@ -13,9 +13,10 @@ public struct WorkspaceShellCompactNavigationPolicy {
     /// - Parameters:
     ///   - currentPath: The current navigation path.
     ///   - selectedWorkspaceID: The newly selected workspace, or `nil` to clear.
-    /// - Returns: The path to apply. Stays empty when the user is at the root,
-    ///   keeps an existing visible detail route through transient selection
-    ///   clears, and otherwise pushes the selected workspace.
+    /// - Returns: The path to apply. Stays empty when the user is at the root and
+    ///   keeps an existing detail route mounted through store-driven selection
+    ///   refreshes. Compact navigation is owned by explicit pushes and pops; a
+    ///   workspace-list refresh must not hand toolbar ownership back to the list.
     public static func pathForSelectionChange<ID: Hashable>(
         currentPath: [ID],
         selectedWorkspaceID: ID?,
@@ -24,17 +25,7 @@ public struct WorkspaceShellCompactNavigationPolicy {
         guard !currentPath.isEmpty else {
             return currentPath
         }
-        guard let selectedWorkspaceID else {
-            if let currentDetailID = currentPath.last,
-               visibleWorkspaceIDs.contains(currentDetailID) {
-                return currentPath
-            }
-            return []
-        }
-        guard currentPath.last != selectedWorkspaceID else {
-            return currentPath
-        }
-        return [selectedWorkspaceID]
+        return currentPath
     }
 
     /// Computes the navigation path when a workspace was just created, pushing it
@@ -61,23 +52,15 @@ public struct WorkspaceShellCompactNavigationPolicy {
     }
 
     /// Computes the navigation path after the workspace list's visible IDs
-    /// change. Keep the current detail route mounted while it is still the
-    /// selected workspace, even if a transient list refresh omits it; the store's
-    /// selection change is the authoritative signal to pop or retarget.
+    /// change. The compact route is not derived from list visibility: a fresh
+    /// no-agent workspace can temporarily disappear from a list response while the
+    /// terminal arrives, and clearing the path there makes the list toolbar replace
+    /// the detail toolbar. Explicit pushes and pops own route changes instead.
     public static func pathForVisibleWorkspaceIDsChange<ID: Hashable>(
         currentPath: [ID],
         visibleWorkspaceIDs: Set<ID>,
         selectedWorkspaceID: ID?
     ) -> [ID] {
-        guard let currentDetailID = currentPath.last else {
-            return currentPath
-        }
-        guard !visibleWorkspaceIDs.contains(currentDetailID) else {
-            return currentPath
-        }
-        guard selectedWorkspaceID != currentDetailID else {
-            return currentPath
-        }
-        return currentPath.filter { visibleWorkspaceIDs.contains($0) }
+        return currentPath
     }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
@@ -13,10 +13,10 @@ public struct WorkspaceShellCompactNavigationPolicy {
     /// - Parameters:
     ///   - currentPath: The current navigation path.
     ///   - selectedWorkspaceID: The newly selected workspace, or `nil` to clear.
-    /// - Returns: The path to apply. Stays empty when the user is at the root and
-    ///   keeps an existing detail route mounted through store-driven selection
-    ///   refreshes. Compact navigation is owned by explicit pushes and pops; a
-    ///   workspace-list refresh must not hand toolbar ownership back to the list.
+    /// - Returns: The path to apply. Stays empty when the user is at the root,
+    ///   clears when the authoritative selection clears, and retargets when the
+    ///   store selects a different workspace. Transient workspace-list omissions
+    ///   are handled by ``pathForVisibleWorkspaceIDsChange``.
     public static func pathForSelectionChange<ID: Hashable>(
         currentPath: [ID],
         selectedWorkspaceID: ID?,
@@ -25,7 +25,13 @@ public struct WorkspaceShellCompactNavigationPolicy {
         guard !currentPath.isEmpty else {
             return currentPath
         }
-        return currentPath
+        guard let selectedWorkspaceID else {
+            return []
+        }
+        guard currentPath.last != selectedWorkspaceID else {
+            return currentPath
+        }
+        return [selectedWorkspaceID]
     }
 
     /// Computes the navigation path when a workspace was just created, pushing it

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
@@ -52,15 +52,29 @@ public struct WorkspaceShellCompactNavigationPolicy {
     }
 
     /// Computes the navigation path after the workspace list's visible IDs
-    /// change. The compact route is not derived from list visibility: a fresh
-    /// no-agent workspace can temporarily disappear from a list response while the
-    /// terminal arrives, and clearing the path there makes the list toolbar replace
-    /// the detail toolbar. Explicit pushes and pops own route changes instead.
+    /// change. Keep the current detail route mounted while the routed workspace
+    /// is still selected, even if a transient list refresh omits it while the
+    /// terminal arrives. If the authoritative selection has moved away, pop or
+    /// remap to the selected visible workspace so deleted workspaces do not stay
+    /// mounted from a stale route snapshot.
     public static func pathForVisibleWorkspaceIDsChange<ID: Hashable>(
         currentPath: [ID],
         visibleWorkspaceIDs: Set<ID>,
         selectedWorkspaceID: ID?
     ) -> [ID] {
-        return currentPath
+        guard let currentDetailID = currentPath.last else {
+            return currentPath
+        }
+        guard !visibleWorkspaceIDs.contains(currentDetailID) else {
+            return currentPath
+        }
+        guard selectedWorkspaceID != currentDetailID else {
+            return currentPath
+        }
+        if let selectedWorkspaceID,
+           visibleWorkspaceIDs.contains(selectedWorkspaceID) {
+            return [selectedWorkspaceID]
+        }
+        return currentPath.filter { visibleWorkspaceIDs.contains($0) }
     }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
@@ -7,6 +7,7 @@ import Foundation
 /// or store. Generic over the workspace identifier so it can be tested with any
 /// `Hashable` ID type.
 public struct WorkspaceShellCompactNavigationPolicy {
+    /// Creates a compact workspace navigation policy.
     public init() {}
 
     /// Computes the navigation path after the selected workspace changes.

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
@@ -52,4 +52,25 @@ public struct WorkspaceShellCompactNavigationPolicy {
         }
         return [selectedWorkspaceID]
     }
+
+    /// Computes the navigation path after the workspace list's visible IDs
+    /// change. Keep the current detail route mounted while it is still the
+    /// selected workspace, even if a transient list refresh omits it; the store's
+    /// selection change is the authoritative signal to pop or retarget.
+    public static func pathForVisibleWorkspaceIDsChange<ID: Hashable>(
+        currentPath: [ID],
+        visibleWorkspaceIDs: Set<ID>,
+        selectedWorkspaceID: ID?
+    ) -> [ID] {
+        guard let currentDetailID = currentPath.last else {
+            return currentPath
+        }
+        guard !visibleWorkspaceIDs.contains(currentDetailID) else {
+            return currentPath
+        }
+        guard selectedWorkspaceID != currentDetailID else {
+            return currentPath
+        }
+        return currentPath.filter { visibleWorkspaceIDs.contains($0) }
+    }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
@@ -13,15 +13,22 @@ public struct WorkspaceShellCompactNavigationPolicy {
     /// - Parameters:
     ///   - currentPath: The current navigation path.
     ///   - selectedWorkspaceID: The newly selected workspace, or `nil` to clear.
-    /// - Returns: The path to apply. Stays empty when the user is at the root, clears when selection is removed, and otherwise pushes the selected workspace.
+    /// - Returns: The path to apply. Stays empty when the user is at the root,
+    ///   keeps an existing visible detail route through transient selection
+    ///   clears, and otherwise pushes the selected workspace.
     public static func pathForSelectionChange<ID: Hashable>(
         currentPath: [ID],
-        selectedWorkspaceID: ID?
+        selectedWorkspaceID: ID?,
+        visibleWorkspaceIDs: Set<ID> = []
     ) -> [ID] {
         guard !currentPath.isEmpty else {
             return currentPath
         }
         guard let selectedWorkspaceID else {
+            if let currentDetailID = currentPath.last,
+               visibleWorkspaceIDs.contains(currentDetailID) {
+                return currentPath
+            }
             return []
         }
         guard currentPath.last != selectedWorkspaceID else {

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
@@ -7,7 +7,7 @@ import Foundation
 /// or store. Generic over the workspace identifier so it can be tested with any
 /// `Hashable` ID type.
 public struct WorkspaceShellCompactNavigationPolicy {
-    private init() {}
+    public init() {}
 
     /// Computes the navigation path after the selected workspace changes.
     /// - Parameters:
@@ -17,7 +17,7 @@ public struct WorkspaceShellCompactNavigationPolicy {
     ///   clears when the authoritative selection clears, and retargets when the
     ///   store selects a different workspace. Transient workspace-list omissions
     ///   are handled by ``pathForVisibleWorkspaceIDsChange``.
-    public static func pathForSelectionChange<ID: Hashable>(
+    public func pathForSelectionChange<ID: Hashable>(
         currentPath: [ID],
         selectedWorkspaceID: ID?,
         visibleWorkspaceIDs: Set<ID> = []
@@ -41,7 +41,7 @@ public struct WorkspaceShellCompactNavigationPolicy {
     ///   - selectedWorkspaceID: The selected workspace, expected to be the created one.
     ///   - existingWorkspaceIDs: The workspaces that existed before creation, or `nil` when no create is pending.
     /// - Returns: The path to push for a newly created workspace, or `nil` when there is nothing to push.
-    public static func pathForCreatedWorkspaceSelection<ID: Hashable>(
+    public func pathForCreatedWorkspaceSelection<ID: Hashable>(
         currentPath: [ID],
         selectedWorkspaceID: ID?,
         existingWorkspaceIDs: Set<ID>?
@@ -63,7 +63,7 @@ public struct WorkspaceShellCompactNavigationPolicy {
     /// terminal arrives. If the authoritative selection has moved away, pop or
     /// remap to the selected visible workspace so deleted workspaces do not stay
     /// mounted from a stale route snapshot.
-    public static func pathForVisibleWorkspaceIDsChange<ID: Hashable>(
+    public func pathForVisibleWorkspaceIDsChange<ID: Hashable>(
         currentPath: [ID],
         visibleWorkspaceIDs: Set<ID>,
         selectedWorkspaceID: ID?

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
@@ -61,10 +61,22 @@ import Testing
     @Test func clearsWhenSelectedWorkspaceDisappears() {
         let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
-            selectedWorkspaceID: nil
+            selectedWorkspaceID: nil,
+            visibleWorkspaceIDs: [MobileWorkspacePreview.ID(rawValue: "workspace-b")]
         )
 
         #expect(path.isEmpty)
+    }
+
+    @Test func keepsVisibleDetailRouteWhenSelectionClearsTransiently() {
+        let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
+        let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
+            currentPath: [selectedID],
+            selectedWorkspaceID: nil,
+            visibleWorkspaceIDs: [selectedID, MobileWorkspacePreview.ID(rawValue: "workspace-b")]
+        )
+
+        #expect(path == [selectedID])
     }
 
     @Test func keepsSelectedDetailRouteWhenVisibleWorkspaceIDsTemporarilyOmitIt() {

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
@@ -49,26 +49,26 @@ import Testing
         #expect(path == nil)
     }
 
-    @Test func keepsExplicitRouteWhenStoreSelectionRetargets() {
+    @Test func tracksSelectionAfterUserOpenedWorkspace() {
         let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
             selectedWorkspaceID: MobileWorkspacePreview.ID(rawValue: "workspace-b")
         )
 
-        #expect(path == [MobileWorkspacePreview.ID(rawValue: "workspace-a")])
+        #expect(path == [MobileWorkspacePreview.ID(rawValue: "workspace-b")])
     }
 
-    @Test func keepsExplicitRouteWhenSelectionClears() {
+    @Test func clearsWhenSelectionClears() {
         let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
             selectedWorkspaceID: nil,
             visibleWorkspaceIDs: [MobileWorkspacePreview.ID(rawValue: "workspace-b")]
         )
 
-        #expect(path == [MobileWorkspacePreview.ID(rawValue: "workspace-a")])
+        #expect(path.isEmpty)
     }
 
-    @Test func keepsVisibleDetailRouteWhenSelectionClearsTransiently() {
+    @Test func clearsVisibleDetailRouteWhenSelectionClears() {
         let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
         let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
             currentPath: [selectedID],
@@ -76,7 +76,7 @@ import Testing
             visibleWorkspaceIDs: [selectedID, MobileWorkspacePreview.ID(rawValue: "workspace-b")]
         )
 
-        #expect(path == [selectedID])
+        #expect(path.isEmpty)
     }
 
     @Test func keepsSelectedDetailRouteWhenVisibleWorkspaceIDsTemporarilyOmitIt() {

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
@@ -4,8 +4,10 @@ import Testing
 @testable import CmuxMobileWorkspace
 
 @Suite struct WorkspaceShellCompactNavigationPolicyTests {
+    private let policy = WorkspaceShellCompactNavigationPolicy()
+
     @Test func doesNotAutoPushWhenAttachSelectsWorkspace() {
-        let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
+        let path = policy.pathForSelectionChange(
             currentPath: [MobileWorkspacePreview.ID](),
             selectedWorkspaceID: .init(rawValue: "workspace-a")
         )
@@ -14,7 +16,7 @@ import Testing
     }
 
     @Test func pushesNewlyCreatedWorkspaceFromList() {
-        let path = WorkspaceShellCompactNavigationPolicy.pathForCreatedWorkspaceSelection(
+        let path = policy.pathForCreatedWorkspaceSelection(
             currentPath: [MobileWorkspacePreview.ID](),
             selectedWorkspaceID: .init(rawValue: "workspace-created"),
             existingWorkspaceIDs: [
@@ -27,7 +29,7 @@ import Testing
     }
 
     @Test func doesNotTreatExistingSelectionAsCreatedWorkspace() {
-        let path = WorkspaceShellCompactNavigationPolicy.pathForCreatedWorkspaceSelection(
+        let path = policy.pathForCreatedWorkspaceSelection(
             currentPath: [MobileWorkspacePreview.ID](),
             selectedWorkspaceID: .init(rawValue: "workspace-a"),
             existingWorkspaceIDs: [
@@ -40,7 +42,7 @@ import Testing
     }
 
     @Test func ignoresCreatedWorkspaceSelectionWhenNoCreateIsPending() {
-        let path = WorkspaceShellCompactNavigationPolicy.pathForCreatedWorkspaceSelection(
+        let path = policy.pathForCreatedWorkspaceSelection(
             currentPath: [MobileWorkspacePreview.ID](),
             selectedWorkspaceID: .init(rawValue: "workspace-created"),
             existingWorkspaceIDs: nil
@@ -50,7 +52,7 @@ import Testing
     }
 
     @Test func tracksSelectionAfterUserOpenedWorkspace() {
-        let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
+        let path = policy.pathForSelectionChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
             selectedWorkspaceID: MobileWorkspacePreview.ID(rawValue: "workspace-b")
         )
@@ -59,7 +61,7 @@ import Testing
     }
 
     @Test func clearsWhenSelectionClears() {
-        let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
+        let path = policy.pathForSelectionChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
             selectedWorkspaceID: nil,
             visibleWorkspaceIDs: [MobileWorkspacePreview.ID(rawValue: "workspace-b")]
@@ -70,7 +72,7 @@ import Testing
 
     @Test func clearsVisibleDetailRouteWhenSelectionClears() {
         let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
-        let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
+        let path = policy.pathForSelectionChange(
             currentPath: [selectedID],
             selectedWorkspaceID: nil,
             visibleWorkspaceIDs: [selectedID, MobileWorkspacePreview.ID(rawValue: "workspace-b")]
@@ -81,7 +83,7 @@ import Testing
 
     @Test func keepsSelectedDetailRouteWhenVisibleWorkspaceIDsTemporarilyOmitIt() {
         let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-created")
-        let path = WorkspaceShellCompactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
+        let path = policy.pathForVisibleWorkspaceIDsChange(
             currentPath: [selectedID],
             visibleWorkspaceIDs: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
             selectedWorkspaceID: selectedID
@@ -92,7 +94,7 @@ import Testing
 
     @Test func remapsDetailRouteWhenListRefreshOmitsItAfterSelectionRetargets() {
         let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-b")
-        let path = WorkspaceShellCompactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
+        let path = policy.pathForVisibleWorkspaceIDsChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
             visibleWorkspaceIDs: [selectedID],
             selectedWorkspaceID: selectedID
@@ -102,7 +104,7 @@ import Testing
     }
 
     @Test func removesMissingDetailRouteWhenSelectionClears() {
-        let path = WorkspaceShellCompactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
+        let path = policy.pathForVisibleWorkspaceIDsChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
             visibleWorkspaceIDs: [MobileWorkspacePreview.ID(rawValue: "workspace-b")],
             selectedWorkspaceID: nil

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
@@ -90,7 +90,7 @@ import Testing
         #expect(path == [selectedID])
     }
 
-    @Test func keepsDetailRouteWhenListRefreshTemporarilyOmitsItAfterSelectionRetargets() {
+    @Test func remapsDetailRouteWhenListRefreshOmitsItAfterSelectionRetargets() {
         let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-b")
         let path = WorkspaceShellCompactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
@@ -98,6 +98,16 @@ import Testing
             selectedWorkspaceID: selectedID
         )
 
-        #expect(path == [MobileWorkspacePreview.ID(rawValue: "workspace-a")])
+        #expect(path == [selectedID])
+    }
+
+    @Test func removesMissingDetailRouteWhenSelectionClears() {
+        let path = WorkspaceShellCompactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
+            currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
+            visibleWorkspaceIDs: [MobileWorkspacePreview.ID(rawValue: "workspace-b")],
+            selectedWorkspaceID: nil
+        )
+
+        #expect(path.isEmpty)
     }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
@@ -66,4 +66,26 @@ import Testing
 
         #expect(path.isEmpty)
     }
+
+    @Test func keepsSelectedDetailRouteWhenVisibleWorkspaceIDsTemporarilyOmitIt() {
+        let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-created")
+        let path = WorkspaceShellCompactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
+            currentPath: [selectedID],
+            visibleWorkspaceIDs: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
+            selectedWorkspaceID: selectedID
+        )
+
+        #expect(path == [selectedID])
+    }
+
+    @Test func removesMissingDetailRouteWhenItIsNoLongerSelected() {
+        let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-b")
+        let path = WorkspaceShellCompactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
+            currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
+            visibleWorkspaceIDs: [selectedID],
+            selectedWorkspaceID: selectedID
+        )
+
+        #expect(path.isEmpty)
+    }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
@@ -49,23 +49,23 @@ import Testing
         #expect(path == nil)
     }
 
-    @Test func tracksSelectionAfterUserOpenedWorkspace() {
+    @Test func keepsExplicitRouteWhenStoreSelectionRetargets() {
         let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
             selectedWorkspaceID: MobileWorkspacePreview.ID(rawValue: "workspace-b")
         )
 
-        #expect(path == [MobileWorkspacePreview.ID(rawValue: "workspace-b")])
+        #expect(path == [MobileWorkspacePreview.ID(rawValue: "workspace-a")])
     }
 
-    @Test func clearsWhenSelectedWorkspaceDisappears() {
+    @Test func keepsExplicitRouteWhenSelectionClears() {
         let path = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
             selectedWorkspaceID: nil,
             visibleWorkspaceIDs: [MobileWorkspacePreview.ID(rawValue: "workspace-b")]
         )
 
-        #expect(path.isEmpty)
+        #expect(path == [MobileWorkspacePreview.ID(rawValue: "workspace-a")])
     }
 
     @Test func keepsVisibleDetailRouteWhenSelectionClearsTransiently() {
@@ -90,7 +90,7 @@ import Testing
         #expect(path == [selectedID])
     }
 
-    @Test func removesMissingDetailRouteWhenItIsNoLongerSelected() {
+    @Test func keepsDetailRouteWhenListRefreshTemporarilyOmitsItAfterSelectionRetargets() {
         let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-b")
         let path = WorkspaceShellCompactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
             currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
@@ -98,6 +98,6 @@ import Testing
             selectedWorkspaceID: selectedID
         )
 
-        #expect(path.isEmpty)
+        #expect(path == [MobileWorkspacePreview.ID(rawValue: "workspace-a")])
     }
 }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -3969,7 +3969,7 @@ private struct InertPushRegistration: PushRegistering {
 
     // Root view mounts: store binds already carrying the attached list.
     let store = deeplinkTestStore()
-    store.setWorkspacesForTesting(PreviewMobileHost.workspaces)
+    store.replaceForegroundWorkspaceState(PreviewMobileHost.workspaces)
     coordinator.bind(store: store)
 
     #expect(store.selectedWorkspaceID == MobileWorkspacePreview.ID(rawValue: "workspace-docs"))
@@ -3988,7 +3988,7 @@ private struct InertPushRegistration: PushRegistering {
     // Target not loaded yet: no navigation to an absent workspace.
     #expect(store.selectedWorkspaceID == nil)
 
-    store.setWorkspacesForTesting(PreviewMobileHost.workspaces)
+    store.replaceForegroundWorkspaceState(PreviewMobileHost.workspaces)
     coordinator.workspacesDidChange()
 
     #expect(store.selectedWorkspaceID == MobileWorkspacePreview.ID(rawValue: "workspace-docs"))
@@ -4007,7 +4007,7 @@ private struct InertPushRegistration: PushRegistering {
 
     currentTime = currentTime.addingTimeInterval(121)
     let store = deeplinkTestStore()
-    store.setWorkspacesForTesting(PreviewMobileHost.workspaces)
+    store.replaceForegroundWorkspaceState(PreviewMobileHost.workspaces)
     coordinator.bind(store: store)
 
     #expect(store.selectedWorkspaceID == nil)
@@ -4028,7 +4028,7 @@ private struct InertPushRegistration: PushRegistering {
     // Nothing loaded yet: the tap must stay parked, not be spent.
     #expect(store.selectedTerminalID == nil)
 
-    store.setWorkspacesForTesting(PreviewMobileHost.workspaces)
+    store.replaceForegroundWorkspaceState(PreviewMobileHost.workspaces)
     coordinator.workspacesDidChange()
 
     #expect(store.selectedWorkspaceID == MobileWorkspacePreview.ID(rawValue: "workspace-docs"))
@@ -4045,7 +4045,7 @@ private struct InertPushRegistration: PushRegistering {
     coordinator.bind(store: store)
 
     coordinator.handleTap(workspaceId: "workspace-docs", surfaceId: "terminal-notes")
-    store.setWorkspacesForTesting([
+    store.replaceForegroundWorkspaceState([
         MobileWorkspacePreview(id: "workspace-docs", name: "Docs", terminals: [])
     ])
     coordinator.workspacesDidChange()
@@ -4054,7 +4054,7 @@ private struct InertPushRegistration: PushRegistering {
     #expect(store.selectedWorkspaceID == MobileWorkspacePreview.ID(rawValue: "workspace-docs"))
     #expect(store.selectedTerminalID == nil)
 
-    store.setWorkspacesForTesting(PreviewMobileHost.workspaces)
+    store.replaceForegroundWorkspaceState(PreviewMobileHost.workspaces)
     coordinator.workspacesDidChange()
 
     #expect(store.selectedTerminalID == MobileTerminalPreview.ID(rawValue: "terminal-notes"))
@@ -4067,7 +4067,7 @@ private struct InertPushRegistration: PushRegistering {
 @Test @MainActor func notificationTapEmitsConsumableCompactNavigationIntent() async throws {
     let coordinator = MobilePushCoordinator(registration: InertPushRegistration())
     let store = deeplinkTestStore()
-    store.setWorkspacesForTesting(PreviewMobileHost.workspaces)
+    store.replaceForegroundWorkspaceState(PreviewMobileHost.workspaces)
     coordinator.bind(store: store)
 
     coordinator.handleTap(workspaceId: "workspace-docs", surfaceId: nil)

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -415,6 +415,41 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
+    func testWorkspaceDetailToolbarSurvivesCreateWorkspaceDelayedTerminalLifecycle() throws {
+        let app = launchWorkspaceDetailCreateDelayedTerminalPreviewApp()
+        let initialTerminalDropdown = app.buttons["MobileTerminalDropdown"]
+        tap(initialTerminalDropdown, in: app)
+        tapMenuItem(app.buttons["MobileNewWorkspaceMenuItem"], in: app)
+
+        let backButton = app.buttons["MobileWorkspaceBackButton"]
+        let titleMenu = app.buttons["MobileWorkspaceTitleMenu"]
+        let terminalDropdown = app.buttons["MobileTerminalDropdown"]
+
+        assertWorkspaceToolbarVisible(
+            backButton: backButton,
+            titleMenu: titleMenu,
+            terminalDropdown: terminalDropdown,
+            in: app,
+            context: "created no-agent workspace before delayed terminal"
+        )
+        assertMenuButtonDoesNotExist("MobileWorkspaceSettingsMenu", in: app)
+
+        RunLoop.current.run(until: Date().addingTimeInterval(2.5))
+        assertWorkspaceToolbarVisible(
+            backButton: backButton,
+            titleMenu: titleMenu,
+            terminalDropdown: terminalDropdown,
+            in: app,
+            context: "created no-agent workspace after delayed terminal appears"
+        )
+        assertMenuButtonDoesNotExist("MobileWorkspaceSettingsMenu", in: app)
+        assertBackButtonFrameStaysCompactAroundPress(backButton, in: app)
+
+        tap(terminalDropdown, in: app)
+        assertTerminalMenuItemExists("workspace-3-terminal-1", in: app)
+    }
+
+    @MainActor
     func testTerminalDropdownScrollsLongTerminalList() async throws {
         let server = try MobileSyncMockHostServer(additionalMainTerminalCount: 24)
         let port = try await server.start()
@@ -1738,6 +1773,22 @@ final class cmuxUITests: XCTestCase {
             "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
         ])
         XCTAssertTrue(app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 8))
+        return app
+    }
+
+    @MainActor
+    private func launchWorkspaceDetailCreateDelayedTerminalPreviewApp() -> XCUIApplication {
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_WORKSPACE_DETAIL_CREATE_DELAYED_TERMINAL": "1",
+            "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
+        ])
+        if !app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 4) {
+            let row = app.descendants(matching: .any)["MobileWorkspaceRow-workspace-main"]
+            XCTAssertTrue(row.waitForExistence(timeout: 8))
+            row.tap()
+        }
+        XCTAssertTrue(app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.buttons["MobileTerminalDropdown"].waitForExistence(timeout: 8))
         return app
     }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -325,7 +325,7 @@ final class cmuxUITests: XCTestCase {
 
     @MainActor
     func testWorkspaceToolbarCreatesWorkspaceAndTerminal() async throws {
-        let server = try MobileSyncMockHostServer()
+        let server = try MobileSyncMockHostServer(createdWorkspaceTerminalDelay: 1.5)
         let port = try await server.start()
         defer { server.stop() }
 
@@ -342,11 +342,6 @@ final class cmuxUITests: XCTestCase {
         dismissOpenMenu(in: app)
 
         tap(app.buttons["MobileTerminalNewWorkspaceButton"], in: app)
-        await assertHostSelection(
-            workspaceID: "workspace-3",
-            terminalID: "workspace-3-terminal-1",
-            server: server
-        )
         let freshBackButton = app.buttons["MobileWorkspaceBackButton"]
         let freshTitleMenu = app.buttons["MobileWorkspaceTitleMenu"]
         let freshTerminalDropdown = app.buttons["MobileTerminalDropdown"]
@@ -357,7 +352,14 @@ final class cmuxUITests: XCTestCase {
             in: app,
             context: "fresh no-agent workspace immediately after create"
         )
+        assertMenuButtonDoesNotExist("MobileWorkspaceSettingsMenu", in: app)
+        assertToolbarOverflowButtonDoesNotExist(in: app)
         RunLoop.current.run(until: Date().addingTimeInterval(5))
+        await assertHostSelection(
+            workspaceID: "workspace-3",
+            terminalID: "workspace-3-terminal-1",
+            server: server
+        )
         assertWorkspaceToolbarVisible(
             backButton: freshBackButton,
             titleMenu: freshTitleMenu,
@@ -365,6 +367,8 @@ final class cmuxUITests: XCTestCase {
             in: app,
             context: "fresh no-agent workspace after 5s"
         )
+        assertMenuButtonDoesNotExist("MobileWorkspaceSettingsMenu", in: app)
+        assertToolbarOverflowButtonDoesNotExist(in: app)
         assertBackButtonFrameStaysCompactAroundPress(freshBackButton, in: app)
 
         tap(app.buttons["MobileTerminalDropdown"], in: app)
@@ -412,6 +416,55 @@ final class cmuxUITests: XCTestCase {
         assertToolbarOverflowButtonDoesNotExist(in: app)
         assertBackButtonFrameStaysCompactAroundPress(backButton, in: app)
 
+        tap(terminalDropdown, in: app)
+        assertTerminalMenuItemExists("terminal-delayed", in: app)
+    }
+
+    @MainActor
+    func testWorkspaceDetailToolbarKeepsTerminalPickerVisibleWithLongTitle() throws {
+        let app = launchWorkspaceDetailDelayedTerminalPreviewApp(environment: [
+            "CMUX_UITEST_WORKSPACE_DETAIL_LONG_TITLE": "1",
+        ])
+        let backButton = app.buttons["MobileWorkspaceBackButton"]
+        let titleMenu = app.buttons["MobileWorkspaceTitleMenu"]
+        let terminalDropdown = app.buttons["MobileTerminalDropdown"]
+
+        RunLoop.current.run(until: Date().addingTimeInterval(2.5))
+        assertWorkspaceToolbarVisible(
+            backButton: backButton,
+            titleMenu: titleMenu,
+            terminalDropdown: terminalDropdown,
+            in: app,
+            context: "long workspace title without chat toggle"
+        )
+        XCTAssertFalse(app.buttons["MobileWorkspaceAgentChatButton"].exists)
+        assertToolbarOverflowButtonDoesNotExist(in: app)
+        tap(terminalDropdown, in: app)
+        assertTerminalMenuItemExists("terminal-delayed", in: app)
+    }
+
+    @MainActor
+    func testWorkspaceDetailToolbarKeepsTerminalPickerVisibleWithLongTitleAndChatToggle() throws {
+        let app = launchWorkspaceDetailDelayedTerminalPreviewApp(environment: [
+            "CMUX_UITEST_WORKSPACE_DETAIL_LONG_TITLE": "1",
+            "CMUX_UITEST_WORKSPACE_DETAIL_CHAT_TOGGLE": "1",
+        ])
+        let backButton = app.buttons["MobileWorkspaceBackButton"]
+        let titleMenu = app.buttons["MobileWorkspaceTitleMenu"]
+        let chatButton = app.buttons["MobileWorkspaceAgentChatButton"]
+        let terminalDropdown = app.buttons["MobileTerminalDropdown"]
+
+        RunLoop.current.run(until: Date().addingTimeInterval(2.5))
+        assertWorkspaceToolbarVisible(
+            backButton: backButton,
+            titleMenu: titleMenu,
+            terminalDropdown: terminalDropdown,
+            in: app,
+            context: "long workspace title with chat toggle"
+        )
+        XCTAssertTrue(chatButton.waitForExistence(timeout: 4))
+        XCTAssertTrue(chatButton.isHittable)
+        assertToolbarOverflowButtonDoesNotExist(in: app)
         tap(terminalDropdown, in: app)
         assertTerminalMenuItemExists("terminal-delayed", in: app)
     }
@@ -1771,11 +1824,15 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    private func launchWorkspaceDetailDelayedTerminalPreviewApp() -> XCUIApplication {
-        let app = launchApp(mockData: false, environment: [
+    private func launchWorkspaceDetailDelayedTerminalPreviewApp(environment: [String: String] = [:]) -> XCUIApplication {
+        var launchEnvironment = [
             "CMUX_UITEST_WORKSPACE_DETAIL_DELAYED_TERMINAL": "1",
             "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
-        ])
+        ]
+        for (key, value) in environment {
+            launchEnvironment[key] = value
+        }
+        let app = launchApp(mockData: false, environment: launchEnvironment)
         XCTAssertTrue(app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 8))
         return app
     }
@@ -3720,6 +3777,7 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
 
     private let listener: NWListener
     private let queue = DispatchQueue(label: "dev.cmux.ios-ui-tests.mobile-sync-server")
+    private let createdWorkspaceTerminalDelay: TimeInterval?
     private var readyContinuation: CheckedContinuation<UInt16, Error>?
     private var connections: [NWConnection] = []
     private var selectedWorkspaceID = "workspace-main"
@@ -3775,8 +3833,13 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         ),
     ]
 
-    init(defaultTerminalLines: [String]? = nil, additionalMainTerminalCount: Int = 0) throws {
+    init(
+        defaultTerminalLines: [String]? = nil,
+        additionalMainTerminalCount: Int = 0,
+        createdWorkspaceTerminalDelay: TimeInterval? = nil
+    ) throws {
         listener = try NWListener(using: .tcp, on: .any)
+        self.createdWorkspaceTerminalDelay = createdWorkspaceTerminalDelay
         appendMainTerminals(count: additionalMainTerminalCount)
         // Optionally replace the selected terminal's content (used by the
         // color-band render test so the bands stream on attach without a flaky
@@ -3988,7 +4051,7 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         let result: [String: Any]
 
         switch method {
-        case "workspace.list":
+        case "mobile.workspace.list", "workspace.list":
             result = workspaceListResult()
         case "workspace.create":
             result = createWorkspaceResult()
@@ -4044,30 +4107,48 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         let nextIndex = workspaces.count + 1
         let workspaceID = "workspace-\(nextIndex)"
         let terminalID = "\(workspaceID)-terminal-1"
+        let terminal = Terminal(
+            id: terminalID,
+            title: "Terminal 1",
+            currentDirectory: "~/workspace-\(nextIndex)",
+            lines: [
+                "$ cmux ios",
+                "workspace: Workspace \(nextIndex)",
+                "terminal: Terminal 1",
+            ]
+        )
         let workspace = Workspace(
             id: workspaceID,
             title: "Workspace \(nextIndex)",
             currentDirectory: "~/workspace-\(nextIndex)",
-            terminals: [
-                Terminal(
-                    id: terminalID,
-                    title: "Terminal 1",
-                    currentDirectory: "~/workspace-\(nextIndex)",
-                    lines: [
-                        "$ cmux ios",
-                        "workspace: Workspace \(nextIndex)",
-                        "terminal: Terminal 1",
-                    ]
-                ),
-            ]
+            terminals: createdWorkspaceTerminalDelay == nil ? [terminal] : []
         )
         workspaces.append(workspace)
         selectedWorkspaceID = workspaceID
-        selectedTerminalID = terminalID
+        if createdWorkspaceTerminalDelay == nil {
+            selectedTerminalID = terminalID
+        } else {
+            scheduleCreatedWorkspaceTerminal(terminal, workspaceID: workspaceID)
+        }
 
         var result = workspaceListResult()
         result["created_workspace_id"] = workspaceID
         return result
+    }
+
+    private func scheduleCreatedWorkspaceTerminal(_ terminal: Terminal, workspaceID: String) {
+        let delay = createdWorkspaceTerminalDelay ?? 0
+        queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self,
+                  let workspaceIndex = self.workspaces.firstIndex(where: { $0.id == workspaceID }),
+                  self.workspaces[workspaceIndex].terminals.isEmpty else {
+                return
+            }
+            self.workspaces[workspaceIndex].terminals.append(terminal)
+            self.selectedWorkspaceID = workspaceID
+            self.selectedTerminalID = terminal.id
+            self.sendWorkspaceUpdatedEvent()
+        }
     }
 
     private func createTerminalResult(params: [String: Any]) -> [String: Any] {
@@ -4131,6 +4212,26 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         text += terminal.lines.joined(separator: "\r\n")
         text += "\r\n"
         return Data(text.utf8)
+    }
+
+    private func sendWorkspaceUpdatedEvent() {
+        let envelope: [String: Any] = [
+            "kind": "event",
+            "topic": "workspace.updated",
+            "payload": [:],
+        ]
+        guard let payload = try? JSONSerialization.data(withJSONObject: envelope) else {
+            return
+        }
+        let frame = Self.frame(payload)
+        for connection in connections {
+            connection.send(
+                content: frame,
+                contentContext: .defaultMessage,
+                isComplete: false,
+                completion: .idempotent
+            )
+        }
     }
 
     private func workspaceListResult() -> [String: Any] {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -384,6 +384,37 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
+    func testWorkspaceDetailToolbarSurvivesDelayedTerminalLifecycle() throws {
+        let app = launchWorkspaceDetailDelayedTerminalPreviewApp()
+        let backButton = app.buttons["MobileWorkspaceBackButton"]
+        let titleMenu = app.buttons["MobileWorkspaceTitleMenu"]
+        let terminalDropdown = app.buttons["MobileTerminalDropdown"]
+
+        assertWorkspaceToolbarVisible(
+            backButton: backButton,
+            titleMenu: titleMenu,
+            terminalDropdown: terminalDropdown,
+            in: app,
+            context: "fresh no-agent workspace before delayed terminal"
+        )
+        assertMenuButtonDoesNotExist("MobileWorkspaceSettingsMenu", in: app)
+
+        RunLoop.current.run(until: Date().addingTimeInterval(2.5))
+        assertWorkspaceToolbarVisible(
+            backButton: backButton,
+            titleMenu: titleMenu,
+            terminalDropdown: terminalDropdown,
+            in: app,
+            context: "fresh no-agent workspace after delayed terminal appears"
+        )
+        assertMenuButtonDoesNotExist("MobileWorkspaceSettingsMenu", in: app)
+        assertBackButtonFrameStaysCompactAroundPress(backButton, in: app)
+
+        tap(terminalDropdown, in: app)
+        assertTerminalMenuItemExists("terminal-delayed", in: app)
+    }
+
+    @MainActor
     func testTerminalDropdownScrollsLongTerminalList() async throws {
         let server = try MobileSyncMockHostServer(additionalMainTerminalCount: 24)
         let port = try await server.start()
@@ -1697,6 +1728,16 @@ final class cmuxUITests: XCTestCase {
             settleChatPreviewKeyboardDown(in: app, table: table),
             "Chat preview must start keyboard-down before keyboard evidence is collected. metrics=\(String(describing: transcriptMetrics(from: table)))"
         )
+        return app
+    }
+
+    @MainActor
+    private func launchWorkspaceDetailDelayedTerminalPreviewApp() -> XCUIApplication {
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_WORKSPACE_DETAIL_DELAYED_TERMINAL": "1",
+            "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
+        ])
+        XCTAssertTrue(app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 8))
         return app
     }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -343,7 +343,7 @@ final class cmuxUITests: XCTestCase {
 
         tap(app.buttons["MobileTerminalNewWorkspaceButton"], in: app)
         let freshBackButton = app.buttons["MobileWorkspaceBackButton"]
-        let freshTitleMenu = app.buttons["MobileWorkspaceTitleMenu"]
+        let freshTitleMenu = workspaceTitleElement(in: app)
         let freshTerminalDropdown = app.buttons["MobileTerminalDropdown"]
         assertWorkspaceToolbarVisible(
             backButton: freshBackButton,
@@ -391,7 +391,7 @@ final class cmuxUITests: XCTestCase {
     func testWorkspaceDetailToolbarSurvivesDelayedTerminalLifecycle() throws {
         let app = launchWorkspaceDetailDelayedTerminalPreviewApp()
         let backButton = app.buttons["MobileWorkspaceBackButton"]
-        let titleMenu = app.buttons["MobileWorkspaceTitleMenu"]
+        let titleMenu = workspaceTitleElement(in: app)
         let terminalDropdown = app.buttons["MobileTerminalDropdown"]
 
         assertWorkspaceToolbarVisible(
@@ -426,7 +426,7 @@ final class cmuxUITests: XCTestCase {
             "CMUX_UITEST_WORKSPACE_DETAIL_LONG_TITLE": "1",
         ])
         let backButton = app.buttons["MobileWorkspaceBackButton"]
-        let titleMenu = app.buttons["MobileWorkspaceTitleMenu"]
+        let titleMenu = workspaceTitleElement(in: app)
         let terminalDropdown = app.buttons["MobileTerminalDropdown"]
 
         RunLoop.current.run(until: Date().addingTimeInterval(2.5))
@@ -450,7 +450,7 @@ final class cmuxUITests: XCTestCase {
             "CMUX_UITEST_WORKSPACE_DETAIL_CHAT_TOGGLE": "1",
         ])
         let backButton = app.buttons["MobileWorkspaceBackButton"]
-        let titleMenu = app.buttons["MobileWorkspaceTitleMenu"]
+        let titleMenu = workspaceTitleElement(in: app)
         let chatButton = app.buttons["MobileWorkspaceAgentChatButton"]
         let terminalDropdown = app.buttons["MobileTerminalDropdown"]
 
@@ -477,7 +477,7 @@ final class cmuxUITests: XCTestCase {
         tapMenuItem(app.buttons["MobileNewWorkspaceMenuItem"], in: app)
 
         let backButton = app.buttons["MobileWorkspaceBackButton"]
-        let titleMenu = app.buttons["MobileWorkspaceTitleMenu"]
+        let titleMenu = workspaceTitleElement(in: app)
         let terminalDropdown = app.buttons["MobileTerminalDropdown"]
 
         assertWorkspaceToolbarVisible(
@@ -1833,7 +1833,7 @@ final class cmuxUITests: XCTestCase {
             launchEnvironment[key] = value
         }
         let app = launchApp(mockData: false, environment: launchEnvironment)
-        XCTAssertTrue(app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 8))
+        XCTAssertTrue(workspaceTitleElement(in: app).waitForExistence(timeout: 8))
         return app
     }
 
@@ -1843,12 +1843,12 @@ final class cmuxUITests: XCTestCase {
             "CMUX_UITEST_WORKSPACE_DETAIL_CREATE_DELAYED_TERMINAL": "1",
             "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
         ])
-        if !app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 4) {
+        if !workspaceTitleElement(in: app).waitForExistence(timeout: 4) {
             let row = app.descendants(matching: .any)["MobileWorkspaceRow-workspace-main"]
             XCTAssertTrue(row.waitForExistence(timeout: 8))
             row.tap()
         }
-        XCTAssertTrue(app.buttons["MobileWorkspaceTitleMenu"].waitForExistence(timeout: 8))
+        XCTAssertTrue(workspaceTitleElement(in: app).waitForExistence(timeout: 8))
         XCTAssertTrue(app.buttons["MobileTerminalDropdown"].waitForExistence(timeout: 8))
         return app
     }
@@ -2422,6 +2422,11 @@ final class cmuxUITests: XCTestCase {
             file: file,
             line: line
         )
+    }
+
+    @MainActor
+    private func workspaceTitleElement(in app: XCUIApplication) -> XCUIElement {
+        app.descendants(matching: .any)["MobileWorkspaceTitleMenu"].firstMatch
     }
 
     @MainActor

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -398,6 +398,7 @@ final class cmuxUITests: XCTestCase {
             context: "fresh no-agent workspace before delayed terminal"
         )
         assertMenuButtonDoesNotExist("MobileWorkspaceSettingsMenu", in: app)
+        assertToolbarOverflowButtonDoesNotExist(in: app)
 
         RunLoop.current.run(until: Date().addingTimeInterval(2.5))
         assertWorkspaceToolbarVisible(
@@ -408,6 +409,7 @@ final class cmuxUITests: XCTestCase {
             context: "fresh no-agent workspace after delayed terminal appears"
         )
         assertMenuButtonDoesNotExist("MobileWorkspaceSettingsMenu", in: app)
+        assertToolbarOverflowButtonDoesNotExist(in: app)
         assertBackButtonFrameStaysCompactAroundPress(backButton, in: app)
 
         tap(terminalDropdown, in: app)
@@ -433,6 +435,7 @@ final class cmuxUITests: XCTestCase {
             context: "created no-agent workspace before delayed terminal"
         )
         assertMenuButtonDoesNotExist("MobileWorkspaceSettingsMenu", in: app)
+        assertToolbarOverflowButtonDoesNotExist(in: app)
 
         RunLoop.current.run(until: Date().addingTimeInterval(2.5))
         assertWorkspaceToolbarVisible(
@@ -443,6 +446,7 @@ final class cmuxUITests: XCTestCase {
             context: "created no-agent workspace after delayed terminal appears"
         )
         assertMenuButtonDoesNotExist("MobileWorkspaceSettingsMenu", in: app)
+        assertToolbarOverflowButtonDoesNotExist(in: app)
         assertBackButtonFrameStaysCompactAroundPress(backButton, in: app)
 
         tap(terminalDropdown, in: app)
@@ -1976,6 +1980,21 @@ final class cmuxUITests: XCTestCase {
         XCTAssertFalse(
             app.buttons[identifier].exists,
             "Expected menu to exclude \(identifier).",
+            file: file,
+            line: line
+        )
+    }
+
+    @MainActor
+    private func assertToolbarOverflowButtonDoesNotExist(
+        in app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let overflowButton = app.buttons["More"]
+        XCTAssertFalse(
+            overflowButton.exists && overflowButton.frame.minY < 140,
+            "Workspace detail toolbar must not collapse into SwiftUI's overflow button.",
             file: file,
             line: line
         )


### PR DESCRIPTION
## Summary
- keep iOS workspace detail on native SwiftUI toolbar/glass controls, with no custom material capsules or fake toolbar UI
- remove the workspace-list toolbar modifier entirely while a compact detail route is pushed, so the list settings ellipsis cannot leak into the detail toolbar
- add DEBUG-only delayed-terminal previews and UI tests for both the fresh no-agent workspace lifecycle and the real create-workspace lifecycle

## Root Cause
The ellipsis is `WorkspaceListView.settingsMenu`, not a detail toolbar item. `WorkspaceShellView` already passes `showsNavigationToolbar: compactNavigationPath.isEmpty`, but the list still always had a `.toolbar { ... }` modifier with conditional contents. During the delayed terminal update, SwiftUI could keep the root list toolbar contribution alive under the pushed detail and collapse it into the detail navigation bar. The fix changes the view structure so the list has no toolbar modifier at all when the detail screen owns the toolbar.

## Verification
- `python3 scripts/swift_file_length_budget.py`
- `git diff --check`
- `xcodebuild test -workspace ios/cmux.xcworkspace -scheme cmux-ios -destination 'platform=iOS Simulator,id=C9D82663-886D-4EBD-92A0-96CF38A42FF3' -derivedDataPath /tmp/cmux-ios-toolbar-create-delayed-test -only-testing:cmuxUITests/cmuxUITests/testWorkspaceDetailToolbarSurvivesDelayedTerminalLifecycle -only-testing:cmuxUITests/cmuxUITests/testWorkspaceDetailToolbarSurvivesCreateWorkspaceDelayedTerminalLifecycle`
- local simulator reload: `./ios/scripts/reload.sh --tag tbx3` succeeded, signed in as `aziz@manaflow.ai`, bundle `dev.cmux.ios.tbx3`
- local macOS reload: `./scripts/reload-cloud.sh --tag tbx3` fell back to local build and succeeded

## Device Reload
- iOS cloud device reload failed because App Store Connect signing credentials are unavailable locally
- fallback `./ios/scripts/reload.sh --tag tbx3 --device-only --device-id 4A52829D-6427-599F-A166-4058881D2DF4` failed because CoreDevice reports `Aziz` as unavailable with `tunnel=unavailable`
- `xcrun devicectl list devices` currently reports `Aziz`, `MyPhone`, and `Abdulaziz’s iPad` as unavailable; `system_profiler SPUSBDataType` did not show an attached iPhone/iPad

Do not merge until dogfood approval.
