### PR TITLE
Document one-time iOS dev auth setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ This creates an isolated app with its own name, bundle ID, socket, and derived d
 
 Before launching a new tagged run, clean up any older tags you started in this session (quit old tagged app + remove its `/tmp` socket/derived data).
 
+For iOS dev auth, `ios/scripts/reload.sh` and `scripts/mobile-dev-launch.sh` auto-sign-in from `~/.secrets/cmuxterm-dev.env`. If the phone lands on the login screen or the helper reports missing dev sign-in credentials, do not ask the user to manually authenticate every build. Tell them to run `scripts/setup-team-dev.sh` once from any cmux checkout; it prompts for and verifies their Stack login, writes `~/.secrets/cmuxterm-dev.env` with chmod 600, and future agents can auto-auth iOS DEBUG reloads. Manual fallback: create that file with `CMUX_DOGFOOD_STACK_EMAIL=...` and `CMUX_DOGFOOD_STACK_PASSWORD=...`.
+
 ## Regression test commit policy
 
 When adding a regression test for a bug fix, use a two-commit structure so CI proves the test catches the bug:


### PR DESCRIPTION
## Summary
- add top-level agent guidance for one-time iOS dev auth setup
- direct agents to `scripts/setup-team-dev.sh` when phone builds land on login
- document the manual `~/.secrets/cmuxterm-dev.env` fallback

## Test
- git diff --check

Docs-only, no tagged reload.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785610663&installation_id=133855650&pr_number=7215&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7215&signature=f6fb0a47fd5192096cc4952ec50108e752041ae15daa91680de6b1a62384b6c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented one-time iOS dev auth so agents can auto-sign in during iOS DEBUG reloads. This stops asking users to log in on every build by using `~/.secrets/cmuxterm-dev.env`.

- **Migration**
  - Run `scripts/setup-team-dev.sh` once from any `cmux` checkout.
  - It verifies Stack login and writes `~/.secrets/cmuxterm-dev.env` (chmod 600) used by `ios/scripts/reload.sh` and `scripts/mobile-dev-launch.sh`.
  - Fallback: create `~/.secrets/cmuxterm-dev.env` with `CMUX_DOGFOOD_STACK_EMAIL` and `CMUX_DOGFOOD_STACK_PASSWORD`.

<sup>Written for commit 1025226efa11e0c4d0b1aa6e4978960efb58a267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for iOS development sign-in behavior during app reloads and mobile launches.
  * Clarified what to do if the device opens to the login screen or credentials are unavailable.
  * Included a manual fallback for setting up local sign-in credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->