### PR TITLE
Keep managed default theme when user sets individual color keys

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -9,9 +9,10 @@ public import Foundation
 /// `GhosttyConfig` is the value type that drives the embedded ghostty runtime's
 /// appearance. It parses ghostty's textual config format (``parse(_:loadingThemesImmediatelyFor:)``),
 /// resolves themes by light/dark color scheme, and folds in cmux's managed
-/// default appearance when the user has set neither a `theme` nor explicit
-/// terminal color directives. The wire format it reads (directive keys, theme
-/// resolution, NSColor hex codecs) is frozen and pinned by tests.
+/// default appearance — as a base underneath the user's explicit color
+/// directives — whenever the user has not set a `theme`. The wire format it
+/// reads (directive keys, theme resolution, NSColor hex codecs) is frozen and
+/// pinned by tests.
 public struct GhosttyConfig {
     /// The light/dark terminal theme preference. An alias for
     /// ``TerminalColorSchemePreference``; the nested name keeps the
@@ -300,20 +301,10 @@ public struct GhosttyConfig {
         #if DEBUG
         let startupPreviewOverride = TerminalStartupAppearancePreviewOverride.installed
         if startupPreviewOverride?.loadsRealUserConfig ?? true {
-            loadConfigFiles(
-                configPaths,
-                into: &config,
+            config.loadResolvedUserConfig(
+                configPaths: configPaths,
                 preferredColorScheme: preferredColorScheme
             )
-
-            if config.theme == nil,
-               Self.shouldApplyManagedDefaultAppearance(configPaths: configPaths) {
-                config.applyCmuxDefaultAppearance(
-                    environment: ProcessInfo.processInfo.environment,
-                    bundleResourceURL: Bundle.main.resourceURL,
-                    preferredColorScheme: preferredColorScheme
-                )
-            }
         } else if let contents = startupPreviewOverride?.previewConfigContents(
             preferredColorScheme
         ) {
@@ -323,26 +314,41 @@ public struct GhosttyConfig {
             )
         }
         #else
-        loadConfigFiles(
-            configPaths,
-            into: &config,
+        config.loadResolvedUserConfig(
+            configPaths: configPaths,
             preferredColorScheme: preferredColorScheme
         )
-
-        if config.theme == nil,
-           Self.shouldApplyManagedDefaultAppearance(configPaths: configPaths) {
-            config.applyCmuxDefaultAppearance(
-                environment: ProcessInfo.processInfo.environment,
-                bundleResourceURL: Bundle.main.resourceURL,
-                preferredColorScheme: preferredColorScheme
-            )
-        }
         #endif
 
         config.resolveSidebarBackground(preferredColorScheme: preferredColorScheme)
         config.applySidebarAppearanceToUserDefaults()
 
         return config
+    }
+
+    /// Applies cmux's managed default appearance (when the user has not chosen
+    /// a `theme`) as the base, then parses the user's config files on top so
+    /// explicit color directives override just those colors — matching
+    /// ghostty's own theme semantics
+    /// (https://github.com/manaflow-ai/cmux/issues/7161).
+    mutating func loadResolvedUserConfig(
+        configPaths: [String],
+        preferredColorScheme: ColorSchemePreference,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundleResourceURL: URL? = Bundle.main.resourceURL
+    ) {
+        if Self.shouldApplyManagedDefaultAppearance(configPaths: configPaths) {
+            applyCmuxDefaultAppearance(
+                environment: environment,
+                bundleResourceURL: bundleResourceURL,
+                preferredColorScheme: preferredColorScheme
+            )
+        }
+        Self.loadConfigFiles(
+            configPaths,
+            into: &self,
+            preferredColorScheme: preferredColorScheme
+        )
     }
 
     mutating func applyGlobalMagnification(percent: Int) {
@@ -353,7 +359,9 @@ public struct GhosttyConfig {
     }
 
     /// Applies cmux's managed default theme for `preferredColorScheme` by parsing
-    /// the bundled (or fallback) theme config contents into this config.
+    /// the bundled (or fallback) theme config contents into this config. Apply it
+    /// before parsing the user's config files so their explicit color directives
+    /// override individual managed colors.
     public mutating func applyCmuxDefaultAppearance(
         environment: [String: String],
         bundleResourceURL: URL?,
@@ -773,19 +781,19 @@ public struct GhosttyConfig {
     public struct UserAppearanceConfigSummary {
         /// Whether any `theme` directive was seen.
         public var hasThemeDirective = false
-        /// Whether any explicit terminal color directive (background, foreground,
-        /// palette, cursor, selection) was seen.
-        public var hasExplicitTerminalColorDirective = false
         /// The last non-empty `theme` directive value seen, or `nil`.
         public var lastThemeDirective: String?
 
         /// Creates an empty summary.
         public init() {}
 
-        /// Whether cmux should apply its managed default appearance: true only
-        /// when neither a theme nor an explicit terminal color directive was seen.
+        /// Whether cmux should apply its managed default appearance: true unless
+        /// the user chose a `theme`. Explicit color directives (background,
+        /// foreground, palette, cursor, selection) do not suppress the managed
+        /// theme — they are loaded after it, overriding just those colors
+        /// (https://github.com/manaflow-ai/cmux/issues/7161).
         public var shouldApplyDefaultAppearance: Bool {
-            !hasThemeDirective && !hasExplicitTerminalColorDirective
+            !hasThemeDirective
         }
 
         /// Records one config directive into the summary.
@@ -795,23 +803,14 @@ public struct GhosttyConfig {
                 hasThemeDirective = true
                 let trimmedValue = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                 lastThemeDirective = trimmedValue.isEmpty ? nil : trimmedValue
-            case "background",
-                 "foreground",
-                 "palette",
-                 "cursor-color",
-                 "cursor-text",
-                 "selection-background",
-                 "selection-foreground":
-                hasExplicitTerminalColorDirective = true
             default:
                 break
             }
         }
     }
 
-    /// Whether cmux should inject its managed default appearance: true only when
-    /// the user has set neither a `theme` nor any explicit terminal color
-    /// directive across the resolved config paths.
+    /// Whether cmux should inject its managed default appearance: true unless
+    /// the user has set an explicit `theme` across the resolved config paths.
     public static func shouldApplyManagedDefaultAppearance(
         configPaths: [String]
     ) -> Bool {
@@ -866,14 +865,7 @@ public struct GhosttyConfig {
             guard let entry = parsedConfigEntry(from: line) else { continue }
 
             switch entry.key {
-            case "theme",
-                 "background",
-                 "foreground",
-                 "palette",
-                 "cursor-color",
-                 "cursor-text",
-                 "selection-background",
-                 "selection-foreground":
+            case "theme":
                 summary.recordDirective(key: entry.key, value: entry.value)
             case "config-file":
                 guard let value = entry.value else { continue }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -326,11 +326,9 @@ public struct GhosttyConfig {
         return config
     }
 
-    /// Applies cmux's managed default appearance (when the user has not chosen
-    /// a `theme`) as the base, then parses the user's config files on top so
-    /// explicit color directives override just those colors — matching
-    /// ghostty's own theme semantics
-    /// (https://github.com/manaflow-ai/cmux/issues/7161).
+    /// Applies cmux's managed default appearance (when the user has not chosen a
+    /// `theme`) as the base, then parses the user's config files on top so explicit
+    /// color directives override just those colors (issue #7161).
     mutating func loadResolvedUserConfig(
         configPaths: [String],
         preferredColorScheme: ColorSchemePreference,
@@ -781,6 +779,9 @@ public struct GhosttyConfig {
     public struct UserAppearanceConfigSummary {
         /// Whether any `theme` directive was seen.
         public var hasThemeDirective = false
+        /// Whether any explicit terminal color directive (background, foreground,
+        /// palette, cursor, selection) was seen.
+        public var hasExplicitTerminalColorDirective = false
         /// The last non-empty `theme` directive value seen, or `nil`.
         public var lastThemeDirective: String?
 
@@ -788,9 +789,8 @@ public struct GhosttyConfig {
         public init() {}
 
         /// Whether cmux should apply its managed default appearance: true unless
-        /// the user chose a `theme`. Explicit color directives (background,
-        /// foreground, palette, cursor, selection) do not suppress the managed
-        /// theme — they are loaded after it, overriding just those colors
+        /// the user chose a `theme`. Explicit color directives do not suppress
+        /// the managed theme — they load after it, overriding just those colors
         /// (https://github.com/manaflow-ai/cmux/issues/7161).
         public var shouldApplyDefaultAppearance: Bool {
             !hasThemeDirective
@@ -803,6 +803,9 @@ public struct GhosttyConfig {
                 hasThemeDirective = true
                 let trimmedValue = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                 lastThemeDirective = trimmedValue.isEmpty ? nil : trimmedValue
+            case "background", "foreground", "palette", "cursor-color", "cursor-text",
+                 "selection-background", "selection-foreground":
+                hasExplicitTerminalColorDirective = true
             default:
                 break
             }
@@ -865,7 +868,8 @@ public struct GhosttyConfig {
             guard let entry = parsedConfigEntry(from: line) else { continue }
 
             switch entry.key {
-            case "theme":
+            case "theme", "background", "foreground", "palette", "cursor-color",
+                 "cursor-text", "selection-background", "selection-foreground":
                 summary.recordDirective(key: entry.key, value: entry.value)
             case "config-file":
                 guard let value = entry.value else { continue }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests.swift
@@ -85,6 +85,25 @@ import Testing
         }
     }
 
+    /// The summary still tracks explicit color directives separately: the runtime
+    /// uses that flag to re-assert the managed default over a stale legacy
+    /// app-support config only when the user set no appearance directives at all.
+    @Test func summaryTracksColorDirectivesWithoutSuppressingManagedDefault() throws {
+        try withTempConfig("background = black\n") { path in
+            let summary = GhosttyConfig.userAppearanceConfigSummary(configPaths: [path])
+            #expect(summary.shouldApplyDefaultAppearance)
+            #expect(summary.hasExplicitTerminalColorDirective)
+        }
+    }
+
+    @Test func summaryReportsNoColorDirectivesForNonAppearanceConfig() throws {
+        try withTempConfig("font-family = JetBrains Mono\nbackground-opacity = 0.92\n") { path in
+            let summary = GhosttyConfig.userAppearanceConfigSummary(configPaths: [path])
+            #expect(summary.shouldApplyDefaultAppearance)
+            #expect(!summary.hasExplicitTerminalColorDirective)
+        }
+    }
+
     // MARK: Managed base + user override precedence
 
     /// Writes sentinel "Apple System Colors" theme files into a themes root the

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+import Foundation
+import Testing
+@testable import CmuxTerminalCore
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/7161.
+///
+/// cmux applies its managed default terminal theme ("Apple System Colors")
+/// whenever the user has not chosen a `theme` themselves. Individual explicit
+/// color keys such as a lone `background = black` must NOT suppress the managed
+/// theme: Ghostty's documented semantics are that explicit color keys override
+/// only those colors on top of the active theme. Before the fix, any color
+/// directive made cmux skip the managed theme entirely, so Ghostty silently
+/// fell back to its built-in default palette and all 16 ANSI colors plus the
+/// foreground changed from a single `background` override.
+@Suite struct GhosttyConfigManagedDefaultAppearanceTests {
+    private func withTempConfigDir(
+        body: (_ dir: URL) throws -> Void
+    ) throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-7161-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try body(dir)
+    }
+
+    private func withTempConfig(
+        _ contents: String,
+        body: (_ path: String) throws -> Void
+    ) throws {
+        try withTempConfigDir { dir in
+            let file = dir.appendingPathComponent("config", isDirectory: false)
+            try contents.write(to: file, atomically: true, encoding: .utf8)
+            try body(file.path)
+        }
+    }
+
+    // MARK: Managed-default-theme gate (issue #7161)
+
+    @Test func backgroundOnlyConfigStillAppliesManagedDefaultTheme() throws {
+        try withTempConfig("background = black\n") { path in
+            #expect(GhosttyConfig.shouldApplyManagedDefaultAppearance(configPaths: [path]))
+        }
+    }
+
+    @Test func paletteAndCursorColorConfigStillAppliesManagedDefaultTheme() throws {
+        try withTempConfig(
+            """
+            palette = 1=#ff0000
+            cursor-color = #ffcc00
+            selection-background = #333333
+            """
+        ) { path in
+            #expect(GhosttyConfig.shouldApplyManagedDefaultAppearance(configPaths: [path]))
+        }
+    }
+
+    @Test func explicitColorInIncludedConfigFileStillAppliesManagedDefaultTheme() throws {
+        try withTempConfigDir { dir in
+            let included = dir.appendingPathComponent("appearance.conf", isDirectory: false)
+            try "background = #101820\n".write(to: included, atomically: true, encoding: .utf8)
+
+            let main = dir.appendingPathComponent("config", isDirectory: false)
+            try "config-file = appearance.conf\n".write(to: main, atomically: true, encoding: .utf8)
+
+            #expect(GhosttyConfig.shouldApplyManagedDefaultAppearance(configPaths: [main.path]))
+        }
+    }
+
+    @Test func explicitThemeSuppressesManagedDefaultTheme() throws {
+        try withTempConfig("theme = Catppuccin Mocha\n") { path in
+            #expect(!GhosttyConfig.shouldApplyManagedDefaultAppearance(configPaths: [path]))
+        }
+    }
+
+    @Test func explicitThemeWithColorOverridesSuppressesManagedDefaultTheme() throws {
+        try withTempConfig("theme = Catppuccin Mocha\nbackground = black\n") { path in
+            #expect(!GhosttyConfig.shouldApplyManagedDefaultAppearance(configPaths: [path]))
+        }
+    }
+
+    @Test func nonAppearanceConfigAppliesManagedDefaultTheme() throws {
+        try withTempConfig("font-family = JetBrains Mono\nbackground-opacity = 0.92\n") { path in
+            #expect(GhosttyConfig.shouldApplyManagedDefaultAppearance(configPaths: [path]))
+        }
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests.swift
@@ -84,4 +84,82 @@ import Testing
             #expect(GhosttyConfig.shouldApplyManagedDefaultAppearance(configPaths: [path]))
         }
     }
+
+    // MARK: Managed base + user override precedence
+
+    /// Writes sentinel "Apple System Colors" theme files into a themes root the
+    /// managed-default resolution finds via `GHOSTTY_RESOURCES_DIR`, keeping the
+    /// resolved managed colors deterministic on machines with Ghostty installed.
+    private func makeManagedThemesRoot(in dir: URL) throws -> URL {
+        let root = dir.appendingPathComponent("resources", isDirectory: true)
+        let themesDir = root.appendingPathComponent("themes", isDirectory: true)
+        try FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
+
+        let managedTheme = """
+        palette = 1=#c0ffee
+        background = #112233
+        foreground = #445566
+        cursor-color = #778899
+        """
+        for name in [GhosttyConfig.cmuxDefaultDarkThemeName, GhosttyConfig.cmuxDefaultLightThemeName] {
+            try managedTheme.write(
+                to: themesDir.appendingPathComponent(name, isDirectory: false),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+        return root
+    }
+
+    private func loadResolvedConfig(
+        userConfig: String,
+        body: (GhosttyConfig) throws -> Void
+    ) throws {
+        try withTempConfigDir { dir in
+            let themesRoot = try makeManagedThemesRoot(in: dir)
+            let file = dir.appendingPathComponent("config", isDirectory: false)
+            try userConfig.write(to: file, atomically: true, encoding: .utf8)
+
+            var config = GhosttyConfig()
+            config.loadResolvedUserConfig(
+                configPaths: [file.path],
+                preferredColorScheme: .dark,
+                environment: ["GHOSTTY_RESOURCES_DIR": themesRoot.path],
+                bundleResourceURL: nil
+            )
+            try body(config)
+        }
+    }
+
+    @Test func managedDefaultThemeAppliedWhenNoAppearanceDirectives() throws {
+        try loadResolvedConfig(userConfig: "font-family = JetBrains Mono\n") { config in
+            #expect(config.theme == nil)
+            #expect(config.backgroundColor.hexString() == "#112233")
+            #expect(config.foregroundColor.hexString() == "#445566")
+            #expect(config.palette[1]?.hexString() == "#C0FFEE")
+        }
+    }
+
+    /// The issue-#7161 repro: a lone `background` override must keep the rest
+    /// of the managed default theme instead of swapping the entire palette.
+    @Test func backgroundOverrideKeepsManagedPaletteAndForeground() throws {
+        try loadResolvedConfig(userConfig: "background = #000000\n") { config in
+            #expect(config.theme == nil)
+            #expect(config.backgroundColor.hexString() == "#000000")
+            #expect(config.foregroundColor.hexString() == "#445566")
+            #expect(config.palette[1]?.hexString() == "#C0FFEE")
+            #expect(config.cursorColor.hexString() == "#778899")
+        }
+    }
+
+    @Test func explicitThemeDirectiveSkipsManagedDefaultBase() throws {
+        let defaultBackgroundHex = GhosttyConfig().backgroundColor.hexString()
+        try loadResolvedConfig(userConfig: "theme = Cmux Nonexistent Theme 7161\n") { config in
+            #expect(config.theme == "Cmux Nonexistent Theme 7161")
+            // The unresolvable user theme leaves the built-in defaults in place;
+            // the managed base must not have been applied underneath it.
+            #expect(config.backgroundColor.hexString() == defaultBackgroundHex)
+            #expect(config.palette[1] == nil)
+        }
+    }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1155,6 +1155,32 @@ class GhosttyApp {
         )
     }
 
+    /// Loads the user's resolved Ghostty config with cmux's managed default
+    /// appearance applied first, as the base: only an explicit user `theme`
+    /// suppresses it, while individual color keys (`background`, `palette`, ...)
+    /// load after it and override just those colors, matching ghostty's theme
+    /// semantics (https://github.com/manaflow-ai/cmux/issues/7161).
+    private func loadRealUserGhosttyConfig(
+        _ config: ghostty_config_t,
+        preferredColorScheme: GhosttyConfig.ColorSchemePreference,
+        themeColorScheme: GhosttyConfig.ColorSchemePreference
+    ) {
+        if Self.shouldApplyManagedDefaultAppearance() {
+            loadCmuxDefaultAppearanceConfig(
+                config,
+                preferredColorScheme: preferredColorScheme
+            )
+        }
+        ghostty_config_load_default_files(config)
+        loadLegacyGhosttyConfigIfNeeded(config)
+        loadCmuxAppSupportGhosttyConfigIfNeeded(config)
+        ghostty_config_load_recursive_files(config)
+        loadConditionalThemeOverrideIfNeeded(
+            config,
+            preferredColorScheme: themeColorScheme
+        )
+    }
+
     func loadDefaultConfigFilesWithLegacyFallback(
         _ config: ghostty_config_t,
         preferredColorScheme: GhosttyConfig.ColorSchemePreference = GhosttyConfig.currentColorSchemePreference(),
@@ -1167,20 +1193,7 @@ class GhosttyApp {
         #if DEBUG
         let startupPreviewProfile = GhosttyStartupAppearancePreviewState.profile
         if startupPreviewProfile.loadsRealUserConfig {
-            ghostty_config_load_default_files(config)
-            loadLegacyGhosttyConfigIfNeeded(config)
-            loadCmuxAppSupportGhosttyConfigIfNeeded(config)
-            ghostty_config_load_recursive_files(config)
-            loadConditionalThemeOverrideIfNeeded(
-                config,
-                preferredColorScheme: themeColorScheme
-            )
-            if Self.shouldApplyManagedDefaultAppearance() {
-                loadCmuxDefaultAppearanceConfig(
-                    config,
-                    preferredColorScheme: preferredColorScheme
-                )
-            }
+            loadRealUserGhosttyConfig(config, preferredColorScheme: preferredColorScheme, themeColorScheme: themeColorScheme)
         } else {
             loadStartupPreviewProfile(
                 startupPreviewProfile,
@@ -1189,20 +1202,7 @@ class GhosttyApp {
             )
         }
         #else
-        ghostty_config_load_default_files(config)
-        loadLegacyGhosttyConfigIfNeeded(config)
-        loadCmuxAppSupportGhosttyConfigIfNeeded(config)
-        ghostty_config_load_recursive_files(config)
-        loadConditionalThemeOverrideIfNeeded(
-            config,
-            preferredColorScheme: themeColorScheme
-        )
-        if Self.shouldApplyManagedDefaultAppearance() {
-            loadCmuxDefaultAppearanceConfig(
-                config,
-                preferredColorScheme: preferredColorScheme
-            )
-        }
+        loadRealUserGhosttyConfig(config, preferredColorScheme: preferredColorScheme, themeColorScheme: themeColorScheme)
         #endif
         loadCJKFontFallbackIfNeeded(config)
         let renderingModeChanged = setUsesHostLayerBackground(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1155,30 +1155,30 @@ class GhosttyApp {
         )
     }
 
-    /// Loads the user's resolved Ghostty config with cmux's managed default
-    /// appearance applied first, as the base: only an explicit user `theme`
-    /// suppresses it, while individual color keys (`background`, `palette`, ...)
-    /// load after it and override just those colors, matching ghostty's theme
-    /// semantics (https://github.com/manaflow-ai/cmux/issues/7161).
+    /// Loads the user's resolved Ghostty config with cmux's managed default appearance
+    /// applied first, as the base: only an explicit user `theme` suppresses it, while
+    /// individual color keys override just those colors (issue #7161).
     private func loadRealUserGhosttyConfig(
         _ config: ghostty_config_t,
         preferredColorScheme: GhosttyConfig.ColorSchemePreference,
         themeColorScheme: GhosttyConfig.ColorSchemePreference
     ) {
-        if Self.shouldApplyManagedDefaultAppearance() {
-            loadCmuxDefaultAppearanceConfig(
-                config,
-                preferredColorScheme: preferredColorScheme
-            )
+        let appearanceSummary = Self.userAppearanceConfigSummary()
+        if appearanceSummary.shouldApplyDefaultAppearance {
+            loadCmuxDefaultAppearanceConfig(config, preferredColorScheme: preferredColorScheme)
         }
         ghostty_config_load_default_files(config)
         loadLegacyGhosttyConfigIfNeeded(config)
         loadCmuxAppSupportGhosttyConfigIfNeeded(config)
         ghostty_config_load_recursive_files(config)
-        loadConditionalThemeOverrideIfNeeded(
-            config,
-            preferredColorScheme: themeColorScheme
-        )
+        loadConditionalThemeOverrideIfNeeded(config, preferredColorScheme: themeColorScheme)
+        // Ghostty's own default-file load also reads the native legacy app-support
+        // `config` that cmux's scan-path policy treats as stale when `config.ghostty`
+        // is non-empty. When the user set no appearance directives at all, re-assert
+        // the managed default so that skipped legacy file's colors cannot override it.
+        if appearanceSummary.shouldApplyDefaultAppearance, !appearanceSummary.hasExplicitTerminalColorDirective {
+            loadCmuxDefaultAppearanceConfig(config, preferredColorScheme: preferredColorScheme)
+        }
     }
 
     func loadDefaultConfigFilesWithLegacyFallback(
@@ -1195,11 +1195,7 @@ class GhosttyApp {
         if startupPreviewProfile.loadsRealUserConfig {
             loadRealUserGhosttyConfig(config, preferredColorScheme: preferredColorScheme, themeColorScheme: themeColorScheme)
         } else {
-            loadStartupPreviewProfile(
-                startupPreviewProfile,
-                into: config,
-                preferredColorScheme: preferredColorScheme
-            )
+            loadStartupPreviewProfile(startupPreviewProfile, into: config, preferredColorScheme: preferredColorScheme)
         }
         #else
         loadRealUserGhosttyConfig(config, preferredColorScheme: preferredColorScheme, themeColorScheme: themeColorScheme)
@@ -1401,6 +1397,10 @@ class GhosttyApp {
         configPaths: [String]? = nil
     ) -> Bool {
         configDiscovery.shouldApplyManagedDefaultAppearance(configPaths: configPaths)
+    }
+
+    static func userAppearanceConfigSummary(configPaths: [String]? = nil) -> GhosttyConfig.UserAppearanceConfigSummary {
+        GhosttyConfig.userAppearanceConfigSummary(configPaths: configPaths ?? loadedGhosttyConfigScanPaths())
     }
 
     static func conditionalThemeOverrideConfigContents(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -4309,11 +4309,10 @@ final class GhosttyMouseFocusTests: XCTestCase {
         }
     }
 
-    func testShouldApplyManagedDefaultAppearanceSkipsExplicitTerminalColorDirective() throws {
-        try withTempConfig("background = #101010\n") { path in
-            XCTAssertFalse(
-                GhosttyApp.shouldApplyManagedDefaultAppearance(configPaths: [path])
-            )
+    func testShouldApplyManagedDefaultAppearanceAppliesWithExplicitTerminalColorDirective() throws {
+        // A lone color key must not suppress the managed default theme (#7161).
+        try withTempConfig("background = black\n") { path in
+            XCTAssertTrue(GhosttyApp.shouldApplyManagedDefaultAppearance(configPaths: [path]))
         }
     }
 


### PR DESCRIPTION
Fixes #7161

## Problem

With default settings on macOS, cmux applies **Apple System Colors** as the managed terminal theme. If the user's Ghostty config contained **any** explicit color key — e.g. a single `background = black` — cmux stopped applying the managed theme entirely, and Ghostty fell back to its built-in default palette (`Ghostty Default Style Dark`). Setting only the background silently swapped **all 16 ANSI colors and the foreground**.

This violated Ghostty's own documented semantics: *"colors specified via `background`, `foreground`, `palette`, etc. override the colors specified in the theme"* — an explicit color key should override only that color, with the rest of the active theme preserved.

## Root cause

`GhosttyConfig.UserAppearanceConfigSummary.shouldApplyDefaultAppearance` required **neither** a `theme` directive **nor** any explicit terminal color directive. That color-key suppression existed because the managed theme was loaded **after** the user's config files, so applying it with user color keys present would have clobbered them.

## Fix

Load the managed default appearance **before** the user's config files, as the base, and gate it only on the user not having set an explicit `theme`:

- **Ghostty runtime path** (`GhosttyApp.loadRealUserGhosttyConfig`, extracted from the duplicated DEBUG/RELEASE branches of `loadDefaultConfigFilesWithLegacyFallback`): the managed theme file loads first, then `ghostty_config_load_default_files` + legacy/app-support/recursive files. Ghostty config is last-wins per key (per palette entry for `palette`), so the user's explicit colors override just those colors.
- **Swift config mirror** (`GhosttyConfig.loadResolvedUserConfig`, extracted from the duplicated DEBUG/RELEASE branches of `loadFromDisk`): same ordering, so cmux chrome (sidebar tint, split dividers, host-layer background) resolves the same colors the terminal renders. The seam takes injectable `environment`/`bundleResourceURL` for deterministic tests.
- Only an explicit user `theme` suppresses the managed default (unchanged behavior for themed users, including conditional `light:…,dark:…` themes).

## Regression tests (two-commit red/green)

1. **Commit 1** (red): regression tests only — `CmuxTerminalCoreTests/GhosttyConfigManagedDefaultAppearanceTests` gate tests (`background = black` only, palette/cursor-only, color-in-include → managed theme must still apply; explicit `theme` → suppressed) + flipped the existing cmuxTests pin to the new semantics.
2. **Commit 2** (green): the fix, plus precedence tests through the new seam covering the issue's three cases:
   - (a) no color keys → managed theme applied
   - (b) `background` only → managed theme still applied, background override preserved, palette/foreground/cursor from the managed base
   - (c) explicit user `theme` → managed theme not injected

Verified locally: `swift test` in `Packages/macOS/CmuxTerminalCore` — 182 tests, 35 suites, all pass (and the new gate tests fail on commit 1 as intended). The ghostty-runtime ordering change can't be unit-driven without a full app build; it is the same ordering contract exercised by the mirror tests, and all runtime call sites funnel through the one extracted helper.

## Reproduction (from the issue)

1. Fresh cmux, default appearance, no terminal theme selected → colors render in Apple System Colors.
2. cmux → Ghostty Settings…, add `background = black`.
3. Reload Configuration (⇧⌘,).

Before: entire palette swaps to Ghostty's built-in default theme. After: only the background changes.

## Localization audit

No user-facing strings changed (code comments and tests only), so no `Localizable.xcstrings` / message-catalog changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785617392&installation_id=133855650&pr_number=7217&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7217&signature=83fa41c8dee0d7ca6cd3eef6b6c460104bd86a23fdcc61fcd58d7a00a9040cfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the managed “Apple System Colors” theme active when users set individual color keys, so only those keys override and the rest of the theme stays intact. The managed theme now loads before user configs, is only skipped when a `theme` is set, and is re-asserted to avoid legacy overrides, fixing #7161.

- **Bug Fixes**
  - Load the managed default first in both the Ghostty runtime and the Swift config mirror so single color keys override per-key.
  - Suppress the managed default only when a user `theme` is present; explicit color keys no longer disable it.
  - Re-assert the managed default after loading user files when no appearance directives are set, preventing legacy app-support configs from overriding it; added tests for this and for single-key overrides, includes, and explicit `theme`.

<sup>Written for commit ff8abc7dd5ffeccb7a2f3b88fa1f17b9d215b6e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refined Ghostty appearance resolution so the managed default appearance remains active unless you explicitly set a `theme`.
  * User config resolution now applies the managed default base consistently before processing resolved config files.

* **Bug Fixes**
  * Explicit terminal color directives (background/foreground/palette/cursor/selection), including when expressed in included configs, no longer disable the managed default appearance.
  * When an explicit `theme` can’t be resolved, the managed default base is not applied under it.

* **Tests**
  * Added/expanded test coverage for managed default behavior, resolved color outcomes, and flag tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Autoreview triage (legacy app-support config)

Ghostty's `ghostty_config_load_default_files` also reads the native legacy `~/Library/Application Support/com.mitchellh.ghostty/config`, which cmux's scan-path policy deliberately treats as stale when `config.ghostty` is non-empty. Two autoreview findings were triaged around this:

- **Fixed:** with the managed base loaded first, a skipped stale legacy file's explicit colors could override it in the *no-user-appearance-config* case (previously masked by the managed-last load). The runtime now re-asserts the managed default after the user's files exactly when the user set no appearance directives at all — restoring the old masking without re-clobbering user color keys.
- **Rejected (pre-existing, unchanged):** when the user's scanned config *does* contain explicit color keys and a stale non-empty legacy `config` coexists with a non-empty `config.ghostty`, that legacy file's colors leak at ghostty-native precedence. This leak is byte-for-byte identical pre- and post-fix (pre-fix the gate was false in that case, so no managed theme loaded either); the fix strictly improves the base palette there. Fully enforcing the policy would mean replacing ghostty's default-file loading (template creation, dual-file warnings) or re-serializing scanned user color values into the runtime config — both out of scope for this bug fix and a larger risk surface than the dual-file migration edge they'd close.
