### PR TITLE
Add swipe actions to sidebar workspace rows

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
@@ -68,6 +68,8 @@ extension ControlCommandCoordinator {
             return debugRightSidebarFocus(request.params)
         case "debug.sidebar.visible":
             return debugSidebarVisible(request.params)
+        case "debug.sidebar.simulate_swipe":
+            return debugSidebarSimulateSwipe(request.params)
         case "debug.terminal.is_focused":
             return debugIsTerminalFocused(request.params)
         case "debug.terminal.simulate_file_drop":

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug2.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug2.swift
@@ -112,6 +112,55 @@ extension ControlCommandCoordinator {
         ]))
     }
 
+    /// `debug.sidebar.simulate_swipe` — drive a visible sidebar row's swipe
+    /// capture path without HID synthesis.
+    func debugSidebarSimulateSwipe(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let workspaceID = uuid(params, "workspace_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
+        }
+        guard let actionRaw = string(params, "action")?.lowercased(),
+              let action = ControlDebugSidebarSwipeAction(rawValue: actionRaw) else {
+            return .err(
+                code: "invalid_params",
+                message: "Missing or invalid action",
+                data: .object([
+                    "actions": .array([
+                        .string(ControlDebugSidebarSwipeAction.revealLeading.rawValue),
+                        .string(ControlDebugSidebarSwipeAction.revealTrailing.rawValue),
+                        .string(ControlDebugSidebarSwipeAction.commitLeading.rawValue),
+                        .string(ControlDebugSidebarSwipeAction.commitTrailing.rawValue),
+                        .string(ControlDebugSidebarSwipeAction.release.rawValue),
+                    ])
+                ])
+            )
+        }
+
+        let resolution = debugContext?.controlDebugSimulateSidebarSwipe(
+            workspaceID: workspaceID,
+            action: action
+        ) ?? .rowNotRegistered
+        switch resolution {
+        case .rowNotRegistered:
+            return .err(
+                code: "not_found",
+                message: "Sidebar row is not registered",
+                data: .object([
+                    "workspace_id": .string(workspaceID.uuidString),
+                    "workspace_ref": ref(.workspace, workspaceID),
+                ])
+            )
+        case let .simulated(committed, offset, released):
+            return .ok(.object([
+                "workspace_id": .string(workspaceID.uuidString),
+                "workspace_ref": ref(.workspace, workspaceID),
+                "action": .string(action.rawValue),
+                "committed": .bool(committed),
+                "offset": .double(offset),
+                "released": .bool(released),
+            ]))
+        }
+    }
+
     // MARK: - debug.terminal.*
 
     /// `debug.terminal.is_focused` — whether a terminal surface has focus

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug2.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug2.swift
@@ -124,13 +124,9 @@ extension ControlCommandCoordinator {
                 code: "invalid_params",
                 message: "Missing or invalid action",
                 data: .object([
-                    "actions": .array([
-                        .string(ControlDebugSidebarSwipeAction.revealLeading.rawValue),
-                        .string(ControlDebugSidebarSwipeAction.revealTrailing.rawValue),
-                        .string(ControlDebugSidebarSwipeAction.commitLeading.rawValue),
-                        .string(ControlDebugSidebarSwipeAction.commitTrailing.rawValue),
-                        .string(ControlDebugSidebarSwipeAction.release.rawValue),
-                    ])
+                    "actions": .array(ControlDebugSidebarSwipeAction.allCases.map {
+                        .string($0.rawValue)
+                    })
                 ])
             )
         }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugContext.swift
@@ -282,6 +282,18 @@ public protocol ControlDebugContext: AnyObject {
     ///   legacy `not_found` error).
     func controlDebugSidebarVisibility(windowID: UUID) -> Bool?
 
+    /// Drives a visible workspace row's swipe capture view for
+    /// `debug.sidebar.simulate_swipe`.
+    ///
+    /// - Parameters:
+    ///   - workspaceID: The workspace row to drive.
+    ///   - action: The synthetic swipe action to perform.
+    /// - Returns: The simulation outcome.
+    func controlDebugSimulateSidebarSwipe(
+        workspaceID: UUID,
+        action: ControlDebugSidebarSwipeAction
+    ) -> ControlDebugSidebarSwipeResolution
+
     /// Simulates a file drop onto a terminal for
     /// `debug.terminal.simulate_file_drop`.
     ///

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugSidebarSwipeAction.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugSidebarSwipeAction.swift
@@ -1,7 +1,7 @@
 #if DEBUG
 /// Synthetic sidebar-row swipe actions accepted by
 /// `debug.sidebar.simulate_swipe`.
-public enum ControlDebugSidebarSwipeAction: String, Sendable, Equatable {
+public enum ControlDebugSidebarSwipeAction: String, Sendable, Equatable, CaseIterable {
     /// Reveal the leading swipe action and leave it visible.
     case revealLeading = "reveal-leading"
     /// Reveal the trailing swipe action and leave it visible.

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugSidebarSwipeAction.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugSidebarSwipeAction.swift
@@ -1,0 +1,16 @@
+#if DEBUG
+/// Synthetic sidebar-row swipe actions accepted by
+/// `debug.sidebar.simulate_swipe`.
+public enum ControlDebugSidebarSwipeAction: String, Sendable, Equatable {
+    /// Reveal the leading swipe action and leave it visible.
+    case revealLeading = "reveal-leading"
+    /// Reveal the trailing swipe action and leave it visible.
+    case revealTrailing = "reveal-trailing"
+    /// Swipe past the leading commit threshold and release.
+    case commitLeading = "commit-leading"
+    /// Swipe past the trailing commit threshold and release.
+    case commitTrailing = "commit-trailing"
+    /// Release any currently revealed sidebar row.
+    case release
+}
+#endif

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugSidebarSwipeResolution.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugSidebarSwipeResolution.swift
@@ -1,0 +1,15 @@
+#if DEBUG
+/// The outcome of `debug.sidebar.simulate_swipe`.
+public enum ControlDebugSidebarSwipeResolution: Sendable, Equatable {
+    /// The requested workspace row is not currently registered in the visible
+    /// sidebar swipe registry.
+    case rowNotRegistered
+    /// The synthetic sequence was delivered to the row's swipe capture view.
+    ///
+    /// - Parameters:
+    ///   - committed: Whether the sequence produced a real swipe commit.
+    ///   - offset: The row offset left visible after the sequence.
+    ///   - released: Whether the sequence ended or cancelled the gesture.
+    case simulated(committed: Bool, offset: Double, released: Bool)
+}
+#endif

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+Debug.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+Debug.swift
@@ -58,6 +58,10 @@ extension ControlDebugContext {
         focusFirstItem: Bool
     ) -> ControlDebugRightSidebarFocusResolution { .windowNotFound }
     func controlDebugSidebarVisibility(windowID: UUID) -> Bool? { nil }
+    func controlDebugSimulateSidebarSwipe(
+        workspaceID: UUID,
+        action: ControlDebugSidebarSwipeAction
+    ) -> ControlDebugSidebarSwipeResolution { .rowNotRegistered }
     func controlDebugSimulateTerminalFileDrop(
         surfaceArgument: String,
         paths: [String],

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorDebugSidebarSwipeTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorDebugSidebarSwipeTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+#if DEBUG
+@MainActor
+private final class FakeDebugSidebarSwipeControlCommandContext: ControlCommandContext {
+    var requestedWorkspaceID: UUID?
+    var requestedAction: ControlDebugSidebarSwipeAction?
+    var resolution: ControlDebugSidebarSwipeResolution = .simulated(
+        committed: false,
+        offset: 80,
+        released: false
+    )
+
+    func controlDebugSimulateSidebarSwipe(
+        workspaceID: UUID,
+        action: ControlDebugSidebarSwipeAction
+    ) -> ControlDebugSidebarSwipeResolution {
+        requestedWorkspaceID = workspaceID
+        requestedAction = action
+        return resolution
+    }
+}
+
+@MainActor
+@Suite("ControlCommandCoordinator debug sidebar swipe dispatch")
+struct ControlCommandCoordinatorDebugSidebarSwipeTests {
+    private func makeCoordinator() -> (ControlCommandCoordinator, FakeDebugSidebarSwipeControlCommandContext) {
+        let context = FakeDebugSidebarSwipeControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        return (coordinator, context)
+    }
+
+    private func request(_ params: [String: JSONValue] = [:]) -> ControlRequest {
+        ControlRequest(id: .int(1), method: "debug.sidebar.simulate_swipe", params: params)
+    }
+
+    @Test func simulateSwipeDispatchesToDebugSeam() {
+        let (coordinator, context) = makeCoordinator()
+        let workspaceID = UUID()
+
+        let result = coordinator.handle(request([
+            "workspace_id": .string(workspaceID.uuidString),
+            "action": .string("reveal-leading"),
+        ]))
+
+        #expect(context.requestedWorkspaceID == workspaceID)
+        #expect(context.requestedAction == .revealLeading)
+        #expect(result == .ok(.object([
+            "workspace_id": .string(workspaceID.uuidString),
+            "workspace_ref": .string("workspace:1"),
+            "action": .string("reveal-leading"),
+            "committed": .bool(false),
+            "offset": .double(80),
+            "released": .bool(false),
+        ])))
+    }
+
+    @Test func simulateSwipeRequiresWorkspaceID() {
+        let (coordinator, _) = makeCoordinator()
+
+        guard case .err(let code, let message, _) = coordinator.handle(request([
+            "action": .string("release")
+        ])) else {
+            Issue.record("expected err")
+            return
+        }
+
+        #expect(code == "invalid_params")
+        #expect(message == "Missing or invalid workspace_id")
+    }
+
+    @Test func simulateSwipeRequiresKnownAction() {
+        let (coordinator, _) = makeCoordinator()
+        let workspaceID = UUID()
+
+        guard case .err(let code, let message, let data) = coordinator.handle(request([
+            "workspace_id": .string(workspaceID.uuidString),
+            "action": .string("bogus"),
+        ])) else {
+            Issue.record("expected err")
+            return
+        }
+
+        #expect(code == "invalid_params")
+        #expect(message == "Missing or invalid action")
+        #expect(data == .object([
+            "actions": .array([
+                .string("reveal-leading"),
+                .string("reveal-trailing"),
+                .string("commit-leading"),
+                .string("commit-trailing"),
+                .string("release"),
+            ])
+        ]))
+    }
+
+    @Test func simulateSwipeReturnsNotFoundWhenRowIsNotRegistered() {
+        let (coordinator, context) = makeCoordinator()
+        context.resolution = .rowNotRegistered
+        let workspaceID = UUID()
+
+        guard case .err(let code, let message, let data) = coordinator.handle(request([
+            "workspace_id": .string(workspaceID.uuidString),
+            "action": .string("release"),
+        ])) else {
+            Issue.record("expected err")
+            return
+        }
+
+        #expect(code == "not_found")
+        #expect(message == "Sidebar row is not registered")
+        #expect(data == .object([
+            "workspace_id": .string(workspaceID.uuidString),
+            "workspace_ref": .string("workspace:1"),
+        ]))
+    }
+}
+#endif

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -875,6 +875,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// `SidebarDragState`, read by the `debug.sidebar.simulate_drag` handler.
     // TODO(de-singletonize): move SidebarDragStateRegistry off AppDelegate.shared when AppDelegate is decomposed.
     let sidebarDragStateRegistry = SidebarDragStateRegistry()
+    /// Debug-only registry mapping visible workspace rows to their swipe
+    /// capture views so automation can drive the real swipe model without HID.
+    // TODO(de-singletonize): move SidebarRowSwipeDebugRegistry off AppDelegate.shared when AppDelegate is decomposed.
+    let sidebarRowSwipeDebugRegistry = SidebarRowSwipeDebugRegistry()
     var debugFocusedTerminalKeyRepairObserverForTesting: ((NSWindow, NSEvent, NSResponder?) -> Void)?
     #endif
     private lazy var updateController = UpdateController(log: updateLog)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -875,10 +875,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// `SidebarDragState`, read by the `debug.sidebar.simulate_drag` handler.
     // TODO(de-singletonize): move SidebarDragStateRegistry off AppDelegate.shared when AppDelegate is decomposed.
     let sidebarDragStateRegistry = SidebarDragStateRegistry()
-    /// Debug-only registry mapping visible workspace rows to their swipe
-    /// capture views so automation can drive the real swipe model without HID.
-    // TODO(de-singletonize): move SidebarRowSwipeDebugRegistry off AppDelegate.shared when AppDelegate is decomposed.
-    let sidebarRowSwipeDebugRegistry = SidebarRowSwipeDebugRegistry()
     var debugFocusedTerminalKeyRepairObserverForTesting: ((NSWindow, NSEvent, NSResponder?) -> Void)?
     #endif
     private lazy var updateController = UpdateController(log: updateLog)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12422,47 +12422,63 @@ struct VerticalTabsSidebar: View {
                 lastSidebarSelectionIndex = nil
             }
         }
-        let row = TabItemView(
-            tabManager: tabManager,
-            notificationStore: notificationStore,
-            tab: tab,
-            index: index,
-            workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
-                at: index,
-                workspaceCount: renderContext.workspaceCount
-            ),
-            workspaceShortcutModifierSymbol: renderContext.workspaceNumberShortcut.numberedDigitHintPrefix,
-            canCloseWorkspace: renderContext.canCloseWorkspace,
-            accessibilityWorkspaceCount: renderContext.workspaceCount,
-            unreadCount: liveUnreadCount,
-            latestNotificationText: liveLatestNotificationText,
-            rowSpacing: tabRowSpacing,
-            setSelectionToTabs: { selection = .tabs },
-            selectedTabIds: $selectedTabIds,
-            lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-            showsModifierShortcutHints: resolvedShowsModifierShortcutHints,
-            dragAutoScrollController: dragAutoScrollController,
-            isBeingDragged: isBeingDragged,
-            topDropIndicatorVisible: topDropIndicatorVisible,
-            bottomDropIndicatorVisible: bottomDropIndicatorVisible,
-            isBonsplitWorkspaceDropActive: isBonsplitWorkspaceDropTargetCollectionActive,
-            bonsplitSourceWorkspaceId: bonsplitSourceWorkspaceId,
-            moveBonsplitTabToWorkspace: moveBonsplitTabToWorkspace,
-            syncSidebarSelectionAfterBonsplitDrop: syncSidebarSelectionAfterBonsplitDrop,
-            onDragStart: onDragStart,
-            contextMenuWorkspaceIds: contextMenuWorkspaceIds,
-            remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
-            allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
-            allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
-            contextMenuPinState: contextMenuPinState,
-            workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
-            settings: renderContext.tabItemSettings,
-            onContextMenuAppear: onContextMenuAppear,
-            onContextMenuDisappear: onContextMenuDisappear
-        )
-        .equatable()
-        .id(tab.id)
-        .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
+        let workspaceIsUnread = liveUnreadCount > 0
+        let row = SidebarSwipeableRow(
+            workspaceId: tab.id,
+            isUnread: workspaceIsUnread,
+            onToggleReadState: { [notificationStore, tabId = tab.id, workspaceIsUnread] in
+                if workspaceIsUnread {
+                    notificationStore.markRead(forTabId: tabId)
+                } else {
+                    notificationStore.markUnread(forTabId: tabId)
+                }
+            },
+            onDelete: { [tabManager, tab] in
+                tabManager.closeWorkspaceWithConfirmation(tab)
+            }
+        ) {
+            TabItemView(
+                tabManager: tabManager,
+                notificationStore: notificationStore,
+                tab: tab,
+                index: index,
+                workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
+                    at: index,
+                    workspaceCount: renderContext.workspaceCount
+                ),
+                workspaceShortcutModifierSymbol: renderContext.workspaceNumberShortcut.numberedDigitHintPrefix,
+                canCloseWorkspace: renderContext.canCloseWorkspace,
+                accessibilityWorkspaceCount: renderContext.workspaceCount,
+                unreadCount: liveUnreadCount,
+                latestNotificationText: liveLatestNotificationText,
+                rowSpacing: tabRowSpacing,
+                setSelectionToTabs: { selection = .tabs },
+                selectedTabIds: $selectedTabIds,
+                lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                showsModifierShortcutHints: resolvedShowsModifierShortcutHints,
+                dragAutoScrollController: dragAutoScrollController,
+                isBeingDragged: isBeingDragged,
+                topDropIndicatorVisible: topDropIndicatorVisible,
+                bottomDropIndicatorVisible: bottomDropIndicatorVisible,
+                isBonsplitWorkspaceDropActive: isBonsplitWorkspaceDropTargetCollectionActive,
+                bonsplitSourceWorkspaceId: bonsplitSourceWorkspaceId,
+                moveBonsplitTabToWorkspace: moveBonsplitTabToWorkspace,
+                syncSidebarSelectionAfterBonsplitDrop: syncSidebarSelectionAfterBonsplitDrop,
+                onDragStart: onDragStart,
+                contextMenuWorkspaceIds: contextMenuWorkspaceIds,
+                remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
+                allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
+                allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
+                contextMenuPinState: contextMenuPinState,
+                workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
+                settings: renderContext.tabItemSettings,
+                onContextMenuAppear: onContextMenuAppear,
+                onContextMenuDisappear: onContextMenuDisappear
+            )
+            .equatable()
+            .id(tab.id)
+            .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
+        }
 
         row
             .sidebarWorkspaceFrameAnchor(id: tab.id, isEnabled: shouldCollectWorkspaceDropTargets)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12426,6 +12426,7 @@ struct VerticalTabsSidebar: View {
         let row = SidebarSwipeableRow(
             workspaceId: tab.id,
             isUnread: workspaceIsUnread,
+            isSelected: usesSelectedContextMenuTargets,
             onToggleReadState: { [notificationStore, tabId = tab.id, workspaceIsUnread] in
                 if workspaceIsUnread {
                     notificationStore.markRead(forTabId: tabId)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10037,7 +10037,7 @@ struct VerticalTabsSidebar: View {
     @State var dragState = SidebarDragState()
     // Bonsplit tab drags arrive through AppKit pasteboard callbacks, not
     // `SidebarDragState`, so they need a separate transient collection flag.
-    @State private var isBonsplitWorkspaceDropTargetCollectionActive = false
+    @State var isBonsplitWorkspaceDropTargetCollectionActive = false
     @State private var bonsplitWorkspaceDropTargetBridge = SidebarBonsplitTabWorkspaceDropOverlay.TargetBridge()
     @State private var isWorkspaceReorderDropTargetCollectionActive = false
     @State private var workspaceReorderDropTargetBridge = SidebarWorkspaceReorderDropOverlay.TargetBridge()
@@ -10045,8 +10045,8 @@ struct VerticalTabsSidebar: View {
     // is open. Set on the row's contextMenu.onAppear and cleared on
     // .onDisappear so modifier-key transitions don't flip the badges on the
     // row sitting behind the open menu. See `SidebarShortcutHintFreezePolicy`.
-    @State private var frozenShortcutHintsTabId: UUID?
-    @State private var frozenShortcutHintsValue: Bool = false
+    @State var frozenShortcutHintsTabId: UUID?
+    @State var frozenShortcutHintsValue: Bool = false
     @State private var pendingSelectedWorkspaceScrollId: UUID?
     @State private var collapsedExtensionSidebarSectionIds: Set<String> = []
     @State private var extensionSidebarWorktreeCreationInFlightSectionIds: Set<String> = []
@@ -10075,7 +10075,7 @@ struct VerticalTabsSidebar: View {
     @LiveSetting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
     @LiveSetting(\.betaFeatures.customSidebars) private var customSidebarsExperimentalEnabled
     @LiveSetting(\.customSidebars.renderer) private var customSidebarRenderer
-    @LiveSetting(\.shortcuts.showModifierHoldHints) private var showModifierHoldHints
+    @LiveSetting(\.shortcuts.showModifierHoldHints) var showModifierHoldHints
 #if DEBUG
     @Environment(\.minimalModeInvalidationProbe) private var minimalModeInvalidationProbe
 #endif
@@ -10324,7 +10324,7 @@ struct VerticalTabsSidebar: View {
         return minimalModeSidebarTitlebarControlsTopInset(in: observedWindow)
     }
 
-    private var showsSidebarNotificationMessage: Bool {
+    var showsSidebarNotificationMessage: Bool {
         tabItemSettingsStore.snapshot.showsNotificationMessage
     }
 
@@ -12321,171 +12321,6 @@ struct VerticalTabsSidebar: View {
             focusedWorkspaceId: tabManager.selectedTabId,
             liveWorkspaceIds: liveWorkspaceIds
         )
-    }
-
-    @ViewBuilder
-    private func workspaceRow(
-        _ tab: Workspace,
-        renderContext: WorkspaceListRenderContext,
-        shouldCollectWorkspaceDropTargets: Bool
-    ) -> some View {
-        let index = renderContext.tabIndexById[tab.id] ?? 0
-        let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
-        let contextMenuWorkspaceIds = usesSelectedContextMenuTargets
-            ? renderContext.selectedContextTargetIds
-            : [tab.id]
-        let remoteContextMenuWorkspaceIds = usesSelectedContextMenuTargets
-            ? renderContext.selectedRemoteContextMenuWorkspaceIds
-            : (tab.isRemoteWorkspace ? [tab.id] : [])
-        let allRemoteContextMenuTargetsConnecting = usesSelectedContextMenuTargets
-            ? renderContext.allSelectedRemoteContextMenuTargetsConnecting
-            : (
-                tab.isRemoteWorkspace &&
-                    (tab.remoteConnectionState == .connecting || tab.remoteConnectionState == .reconnecting)
-            )
-        let allRemoteContextMenuTargetsDisconnected = usesSelectedContextMenuTargets
-            ? renderContext.allSelectedRemoteContextMenuTargetsDisconnected
-            : (tab.isRemoteWorkspace && tab.remoteConnectionState == .disconnected)
-        let contextMenuPinTarget = WorkspaceActionDispatcher.Target(
-            workspaceIds: contextMenuWorkspaceIds,
-            anchorWorkspaceId: tab.id
-        )
-        let contextMenuPinState = WorkspaceActionDispatcher.pinState(
-            in: renderContext.pinResolutionContext,
-            target: contextMenuPinTarget
-        )
-        let liveUnreadCount = sidebarUnread.unreadCount(forWorkspaceId: tab.id)
-        let liveLatestNotificationText: String? = showsSidebarNotificationMessage
-            ? sidebarUnread.latestNotificationText(forWorkspaceId: tab.id)
-            : nil
-        let liveShowsModifierShortcutHints = showModifierHoldHints && modifierKeyMonitor.isModifierPressed
-        let resolvedShowsModifierShortcutHints = SidebarShortcutHintFreezePolicy().resolved(
-            live: liveShowsModifierShortcutHints,
-            currentTabId: tab.id,
-            frozenTabId: frozenShortcutHintsTabId,
-            frozenValue: frozenShortcutHintsValue
-        )
-        let onContextMenuAppear: () -> Void = { [tabId = tab.id, snapshot = resolvedShowsModifierShortcutHints] in
-            frozenShortcutHintsTabId = tabId
-            frozenShortcutHintsValue = snapshot
-        }
-        let onContextMenuDisappear: () -> Void = { [tabId = tab.id] in
-            if frozenShortcutHintsTabId == tabId {
-                frozenShortcutHintsTabId = nil
-            }
-        }
-
-        // Per-row drag/drop snapshots. Reading `dragState` here in the parent
-        // is intentional: the parent owns the @Observable store, and these
-        // value snapshots are what get passed to the row. The row's
-        // Equatable conformance ignores closures, so rows whose snapshot is
-        // unchanged skip re-render when drag state moves.
-        let isBeingDragged = dragState.draggedTabId == tab.id
-        let sidebarReorderIds = renderContext.sidebarReorderIds
-        let topDropIndicatorVisible = SidebarTabDropIndicatorPredicate().topVisible(
-            forTabId: tab.id,
-            draggedTabId: dragState.draggedTabId,
-            dropIndicator: dragState.dropIndicator,
-            tabIds: sidebarReorderIds
-        )
-        let bottomDropIndicatorVisible = SidebarTabDropIndicatorPredicate().bottomVisible(
-            forTabId: tab.id,
-            draggedTabId: dragState.draggedTabId,
-            dropIndicator: dragState.dropIndicator,
-            tabIds: sidebarReorderIds,
-            indicatorScope: dragState.dropIndicatorScope
-        )
-        let onDragStart: () -> NSItemProvider = { [tabId = tab.id] in
-            #if DEBUG
-            cmuxDebugLog("sidebar.onDrag tab=\(tabId.uuidString.prefix(5))")
-            #endif
-            dragState.beginDragging(tabId: tabId)
-            return SidebarTabDragPayload.provider(for: tabId)
-        }
-        let bonsplitSourceWorkspaceId: @MainActor (UUID) -> UUID? = { tabId in
-            guard let app = AppDelegate.shared else { return nil }
-            return app.locateBonsplitSurface(tabId: tabId)?.workspaceId
-        }
-        let moveBonsplitTabToWorkspace: @MainActor (BonsplitTabDragPayload.Transfer, UUID) -> Bool = { transfer, workspaceId in
-            guard let app = AppDelegate.shared else { return false }
-            return app.moveBonsplitTab(
-                tabId: transfer.tab.id,
-                toWorkspace: workspaceId,
-                focus: true,
-                focusWindow: true
-            )
-        }
-        let syncSidebarSelectionAfterBonsplitDrop: @MainActor () -> Void = {
-            if let selectedId = tabManager.selectedTabId {
-                lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
-            } else {
-                lastSidebarSelectionIndex = nil
-            }
-        }
-        let workspaceIsUnread = liveUnreadCount > 0
-        let row = SidebarSwipeableRow(
-            workspaceId: tab.id,
-            isUnread: workspaceIsUnread,
-            isSelected: usesSelectedContextMenuTargets,
-            onToggleReadState: { [notificationStore, tabId = tab.id, workspaceIsUnread] in
-                if workspaceIsUnread {
-                    notificationStore.markRead(forTabId: tabId)
-                } else {
-                    notificationStore.markUnread(forTabId: tabId)
-                }
-            },
-            onDelete: { [tabManager, tab] in
-                tabManager.closeWorkspaceWithConfirmation(tab)
-            }
-        ) {
-            TabItemView(
-                tabManager: tabManager,
-                notificationStore: notificationStore,
-                tab: tab,
-                index: index,
-                workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
-                    at: index,
-                    workspaceCount: renderContext.workspaceCount
-                ),
-                workspaceShortcutModifierSymbol: renderContext.workspaceNumberShortcut.numberedDigitHintPrefix,
-                canCloseWorkspace: renderContext.canCloseWorkspace,
-                accessibilityWorkspaceCount: renderContext.workspaceCount,
-                unreadCount: liveUnreadCount,
-                latestNotificationText: liveLatestNotificationText,
-                rowSpacing: tabRowSpacing,
-                setSelectionToTabs: { selection = .tabs },
-                selectedTabIds: $selectedTabIds,
-                lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                showsModifierShortcutHints: resolvedShowsModifierShortcutHints,
-                dragAutoScrollController: dragAutoScrollController,
-                isBeingDragged: isBeingDragged,
-                topDropIndicatorVisible: topDropIndicatorVisible,
-                bottomDropIndicatorVisible: bottomDropIndicatorVisible,
-                isBonsplitWorkspaceDropActive: isBonsplitWorkspaceDropTargetCollectionActive,
-                bonsplitSourceWorkspaceId: bonsplitSourceWorkspaceId,
-                moveBonsplitTabToWorkspace: moveBonsplitTabToWorkspace,
-                syncSidebarSelectionAfterBonsplitDrop: syncSidebarSelectionAfterBonsplitDrop,
-                onDragStart: onDragStart,
-                contextMenuWorkspaceIds: contextMenuWorkspaceIds,
-                remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
-                allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
-                allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
-                contextMenuPinState: contextMenuPinState,
-                workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
-                settings: renderContext.tabItemSettings,
-                onContextMenuAppear: onContextMenuAppear,
-                onContextMenuDisappear: onContextMenuDisappear
-            )
-            .equatable()
-            .id(tab.id)
-            .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
-        }
-
-        row
-            .sidebarWorkspaceFrameAnchor(id: tab.id, isEnabled: shouldCollectWorkspaceDropTargets)
-            .padding(.leading, tab.groupId != nil ? SidebarWorkspaceGroupingMetrics.memberIndent : 0)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
     }
 
     private func debugShortSidebarTabId(_ id: UUID?) -> String {

--- a/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
+++ b/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
@@ -2,6 +2,8 @@ import AppKit
 
 @MainActor
 final class SidebarRowSwipeCaptureNSView: NSView {
+    static weak var activeSwipeView: SidebarRowSwipeCaptureNSView?
+
     var workspaceId: UUID {
         didSet {
 #if DEBUG
@@ -12,8 +14,8 @@ final class SidebarRowSwipeCaptureNSView: NSView {
         }
     }
 
-    var onOffsetChanged: ((CGFloat, Bool) -> Void)?
-    var onCommit: ((SidebarRowSwipeGestureModel.Action) -> Void)?
+    var onOffsetChanged: ((CGFloat, Bool, Bool) -> Void)?
+    var onCommit: ((SidebarRowSwipeGestureModel.Action, CGFloat) -> Void)?
 
     private var model = SidebarRowSwipeGestureModel()
 
@@ -67,16 +69,59 @@ final class SidebarRowSwipeCaptureNSView: NSView {
             SidebarRowSwipeGestureModel.Event(
                 phase: phase,
                 scrollingDeltaX: deltaX,
-                scrollingDeltaY: deltaY
+                scrollingDeltaY: deltaY,
+                containerWidth: bounds.width
             )
         )
-        guard result.claimed else { return result }
-
-        onOffsetChanged?(result.offset, result.shouldAnimateOffset)
-        if let commit = result.commit {
-            onCommit?(commit)
+        if result.claimed, phase != .momentum {
+            activateSwipe()
         }
+        guard result.claimed else {
+            clearActiveSwipeIfNeeded(for: phase)
+            return result
+        }
+
+        if result.enteredCommitZone {
+            NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+        }
+        if result.commit == .trailing {
+            onCommit?(.trailing, bounds.width)
+        } else {
+            onOffsetChanged?(result.offset, result.shouldAnimateOffset, result.isInCommitZone)
+            if let commit = result.commit {
+                onCommit?(commit, bounds.width)
+            }
+        }
+        clearActiveSwipeIfNeeded(for: phase)
         return result
+    }
+
+    private func activateSwipe() {
+        if let activeSwipeView = Self.activeSwipeView, activeSwipeView !== self {
+            activeSwipeView.resetSwipe()
+        }
+        Self.activeSwipeView = self
+    }
+
+    private func clearActiveSwipeIfNeeded(for phase: SidebarRowSwipeGestureModel.Phase) {
+        guard phase == .ended || phase == .cancelled else { return }
+        guard Self.activeSwipeView === self else { return }
+        Self.activeSwipeView = nil
+    }
+
+    func resetSwipe() {
+        let result = model.handle(SidebarRowSwipeGestureModel.Event(
+            phase: .cancelled,
+            scrollingDeltaX: 0,
+            scrollingDeltaY: 0,
+            containerWidth: bounds.width
+        ))
+        if result.claimed {
+            onOffsetChanged?(result.offset, result.shouldAnimateOffset, result.isInCommitZone)
+        }
+        if Self.activeSwipeView === self {
+            Self.activeSwipeView = nil
+        }
     }
 
     private static func phase(for event: NSEvent) -> SidebarRowSwipeGestureModel.Phase? {

--- a/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
+++ b/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
@@ -8,8 +8,8 @@ final class SidebarRowSwipeCaptureNSView: NSView {
         didSet {
 #if DEBUG
             guard workspaceId != oldValue, window != nil else { return }
-            AppDelegate.shared?.sidebarRowSwipeDebugRegistry.unregister(workspaceId: oldValue, view: self)
-            AppDelegate.shared?.sidebarRowSwipeDebugRegistry.register(workspaceId: workspaceId, view: self)
+            SidebarRowSwipeDebugRegistry.shared.unregister(workspaceId: oldValue, view: self)
+            SidebarRowSwipeDebugRegistry.shared.register(workspaceId: workspaceId, view: self)
 #endif
         }
     }
@@ -35,9 +35,9 @@ final class SidebarRowSwipeCaptureNSView: NSView {
         super.viewDidMoveToWindow()
 #if DEBUG
         if window == nil {
-            AppDelegate.shared?.sidebarRowSwipeDebugRegistry.unregister(workspaceId: workspaceId, view: self)
+            SidebarRowSwipeDebugRegistry.shared.unregister(workspaceId: workspaceId, view: self)
         } else {
-            AppDelegate.shared?.sidebarRowSwipeDebugRegistry.register(workspaceId: workspaceId, view: self)
+            SidebarRowSwipeDebugRegistry.shared.register(workspaceId: workspaceId, view: self)
         }
 #endif
     }

--- a/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
+++ b/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
@@ -53,7 +53,10 @@ final class SidebarRowSwipeCaptureNSView: NSView {
             return
         }
 
-        let result = handle(phase: phase, deltaX: event.scrollingDeltaX, deltaY: event.scrollingDeltaY)
+        // The gesture model consumes finger-space deltas: positive X reveals the leading action.
+        let deltaX = event.isDirectionInvertedFromDevice ? event.scrollingDeltaX : -event.scrollingDeltaX
+        let deltaY = event.isDirectionInvertedFromDevice ? event.scrollingDeltaY : -event.scrollingDeltaY
+        let result = handle(phase: phase, deltaX: deltaX, deltaY: deltaY)
         guard result.claimed else {
             super.scrollWheel(with: event)
             return

--- a/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
+++ b/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
@@ -53,9 +53,12 @@ final class SidebarRowSwipeCaptureNSView: NSView {
             return
         }
 
-        // The gesture model consumes finger-space deltas: positive X reveals the leading action.
-        let deltaX = event.isDirectionInvertedFromDevice ? event.scrollingDeltaX : -event.scrollingDeltaX
-        let deltaY = event.isDirectionInvertedFromDevice ? event.scrollingDeltaY : -event.scrollingDeltaY
+        // The gesture model consumes finger-space deltas: positive X reveals the
+        // leading action. scrollingDelta is content-space; with natural scrolling
+        // (isDirectionInvertedFromDevice) a rightward finger swipe reports a
+        // NEGATIVE scrollingDeltaX (verified on hardware), so negate it there.
+        let deltaX = event.isDirectionInvertedFromDevice ? -event.scrollingDeltaX : event.scrollingDeltaX
+        let deltaY = event.isDirectionInvertedFromDevice ? -event.scrollingDeltaY : event.scrollingDeltaY
         let result = handle(phase: phase, deltaX: deltaX, deltaY: deltaY)
         guard result.claimed else {
             super.scrollWheel(with: event)

--- a/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
+++ b/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
@@ -155,8 +155,10 @@ final class SidebarRowSwipeCaptureNSView: NSView {
                 (.ended, 0, 0),
             ]
         case .release:
+            // Cancelled, not ended: reveal sequences sit past the commit
+            // threshold, and release must always snap back without committing.
             return [
-                (.ended, 0, 0),
+                (.cancelled, 0, 0),
             ]
         }
     }

--- a/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
+++ b/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
@@ -2,6 +2,16 @@ import AppKit
 
 @MainActor
 final class SidebarRowSwipeCaptureNSView: NSView {
+    var workspaceId: UUID {
+        didSet {
+#if DEBUG
+            guard workspaceId != oldValue, window != nil else { return }
+            AppDelegate.shared?.sidebarRowSwipeDebugRegistry.unregister(workspaceId: oldValue, view: self)
+            AppDelegate.shared?.sidebarRowSwipeDebugRegistry.register(workspaceId: workspaceId, view: self)
+#endif
+        }
+    }
+
     var onOffsetChanged: ((CGFloat, Bool) -> Void)?
     var onCommit: ((SidebarRowSwipeGestureModel.Action) -> Void)?
 
@@ -9,13 +19,25 @@ final class SidebarRowSwipeCaptureNSView: NSView {
 
     override var acceptsFirstResponder: Bool { false }
 
-    override init(frame frameRect: NSRect) {
+    init(workspaceId: UUID, frame frameRect: NSRect) {
+        self.workspaceId = workspaceId
         super.init(frame: frameRect)
         wantsLayer = false
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+#if DEBUG
+        if window == nil {
+            AppDelegate.shared?.sidebarRowSwipeDebugRegistry.unregister(workspaceId: workspaceId, view: self)
+        } else {
+            AppDelegate.shared?.sidebarRowSwipeDebugRegistry.register(workspaceId: workspaceId, view: self)
+        }
+#endif
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
@@ -29,22 +51,32 @@ final class SidebarRowSwipeCaptureNSView: NSView {
             return
         }
 
-        let result = model.handle(
-            SidebarRowSwipeGestureModel.Event(
-                phase: phase,
-                scrollingDeltaX: event.scrollingDeltaX,
-                scrollingDeltaY: event.scrollingDeltaY
-            )
-        )
+        let result = handle(phase: phase, deltaX: event.scrollingDeltaX, deltaY: event.scrollingDeltaY)
         guard result.claimed else {
             super.scrollWheel(with: event)
             return
         }
+    }
+
+    private func handle(
+        phase: SidebarRowSwipeGestureModel.Phase,
+        deltaX: CGFloat,
+        deltaY: CGFloat
+    ) -> SidebarRowSwipeGestureModel.Result {
+        let result = model.handle(
+            SidebarRowSwipeGestureModel.Event(
+                phase: phase,
+                scrollingDeltaX: deltaX,
+                scrollingDeltaY: deltaY
+            )
+        )
+        guard result.claimed else { return result }
 
         onOffsetChanged?(result.offset, result.shouldAnimateOffset)
         if let commit = result.commit {
             onCommit?(commit)
         }
+        return result
     }
 
     private static func phase(for event: NSEvent) -> SidebarRowSwipeGestureModel.Phase? {
@@ -67,4 +99,66 @@ final class SidebarRowSwipeCaptureNSView: NSView {
         }
         return nil
     }
+
+#if DEBUG
+    func debugSimulateSwipe(_ action: SidebarRowSwipeDebugRegistry.Action) -> SidebarRowSwipeDebugRegistry.Result {
+        var committed = false
+        var offset: CGFloat = 0
+        var released = false
+
+        for event in debugEvents(for: action) {
+            let result = handle(phase: event.phase, deltaX: event.deltaX, deltaY: event.deltaY)
+            committed = committed || result.commit != nil
+            offset = result.offset
+            released = event.phase == .ended || event.phase == .cancelled
+        }
+
+        return SidebarRowSwipeDebugRegistry.Result(
+            committed: committed,
+            offset: offset,
+            released: released
+        )
+    }
+
+    private func debugEvents(
+        for action: SidebarRowSwipeDebugRegistry.Action
+    ) -> [(phase: SidebarRowSwipeGestureModel.Phase, deltaX: CGFloat, deltaY: CGFloat)] {
+        switch action {
+        case .revealLeading:
+            return [
+                (.began, 0, 0),
+                (.changed, 20, 0),
+                (.changed, 20, 0),
+                (.changed, 20, 0),
+                (.changed, 20, 0),
+            ]
+        case .revealTrailing:
+            return [
+                (.began, 0, 0),
+                (.changed, -20, 0),
+                (.changed, -20, 0),
+                (.changed, -20, 0),
+                (.changed, -20, 0),
+            ]
+        case .commitLeading:
+            return [
+                (.began, 0, 0),
+                (.changed, 40, 0),
+                (.changed, 40, 0),
+                (.ended, 0, 0),
+            ]
+        case .commitTrailing:
+            return [
+                (.began, 0, 0),
+                (.changed, -40, 0),
+                (.changed, -40, 0),
+                (.ended, 0, 0),
+            ]
+        case .release:
+            return [
+                (.ended, 0, 0),
+            ]
+        }
+    }
+#endif
 }

--- a/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
+++ b/Sources/Sidebar/SidebarRowSwipeCaptureNSView.swift
@@ -1,0 +1,70 @@
+import AppKit
+
+@MainActor
+final class SidebarRowSwipeCaptureNSView: NSView {
+    var onOffsetChanged: ((CGFloat, Bool) -> Void)?
+    var onCommit: ((SidebarRowSwipeGestureModel.Action) -> Void)?
+
+    private var model = SidebarRowSwipeGestureModel()
+
+    override var acceptsFirstResponder: Bool { false }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard NSApp.currentEvent?.type == .scrollWheel else { return nil }
+        return super.hitTest(point)
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        guard let phase = Self.phase(for: event) else {
+            super.scrollWheel(with: event)
+            return
+        }
+
+        let result = model.handle(
+            SidebarRowSwipeGestureModel.Event(
+                phase: phase,
+                scrollingDeltaX: event.scrollingDeltaX,
+                scrollingDeltaY: event.scrollingDeltaY
+            )
+        )
+        guard result.claimed else {
+            super.scrollWheel(with: event)
+            return
+        }
+
+        onOffsetChanged?(result.offset, result.shouldAnimateOffset)
+        if let commit = result.commit {
+            onCommit?(commit)
+        }
+    }
+
+    private static func phase(for event: NSEvent) -> SidebarRowSwipeGestureModel.Phase? {
+        if !event.momentumPhase.isEmpty {
+            return .momentum
+        }
+
+        let phase = event.phase
+        if phase.contains(.cancelled) {
+            return .cancelled
+        }
+        if phase.contains(.ended) {
+            return .ended
+        }
+        if phase.contains(.began) {
+            return .began
+        }
+        if phase.contains(.changed) || phase.contains(.stationary) || phase.isEmpty {
+            return .changed
+        }
+        return nil
+    }
+}

--- a/Sources/Sidebar/SidebarRowSwipeCaptureView.swift
+++ b/Sources/Sidebar/SidebarRowSwipeCaptureView.swift
@@ -1,17 +1,20 @@
+import Foundation
 import SwiftUI
 
 @MainActor
 struct SidebarRowSwipeCaptureView: NSViewRepresentable {
+    let workspaceId: UUID
     let onOffsetChanged: (CGFloat, Bool) -> Void
     let onCommit: (SidebarRowSwipeGestureModel.Action) -> Void
 
     func makeNSView(context: Context) -> SidebarRowSwipeCaptureNSView {
-        let view = SidebarRowSwipeCaptureNSView(frame: .zero)
+        let view = SidebarRowSwipeCaptureNSView(workspaceId: workspaceId, frame: .zero)
         updateNSView(view, context: context)
         return view
     }
 
     func updateNSView(_ nsView: SidebarRowSwipeCaptureNSView, context: Context) {
+        nsView.workspaceId = workspaceId
         nsView.onOffsetChanged = onOffsetChanged
         nsView.onCommit = onCommit
     }

--- a/Sources/Sidebar/SidebarRowSwipeCaptureView.swift
+++ b/Sources/Sidebar/SidebarRowSwipeCaptureView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+@MainActor
+struct SidebarRowSwipeCaptureView: NSViewRepresentable {
+    let onOffsetChanged: (CGFloat, Bool) -> Void
+    let onCommit: (SidebarRowSwipeGestureModel.Action) -> Void
+
+    func makeNSView(context: Context) -> SidebarRowSwipeCaptureNSView {
+        let view = SidebarRowSwipeCaptureNSView(frame: .zero)
+        updateNSView(view, context: context)
+        return view
+    }
+
+    func updateNSView(_ nsView: SidebarRowSwipeCaptureNSView, context: Context) {
+        nsView.onOffsetChanged = onOffsetChanged
+        nsView.onCommit = onCommit
+    }
+}

--- a/Sources/Sidebar/SidebarRowSwipeCaptureView.swift
+++ b/Sources/Sidebar/SidebarRowSwipeCaptureView.swift
@@ -4,8 +4,8 @@ import SwiftUI
 @MainActor
 struct SidebarRowSwipeCaptureView: NSViewRepresentable {
     let workspaceId: UUID
-    let onOffsetChanged: (CGFloat, Bool) -> Void
-    let onCommit: (SidebarRowSwipeGestureModel.Action) -> Void
+    let onOffsetChanged: (CGFloat, Bool, Bool) -> Void
+    let onCommit: (SidebarRowSwipeGestureModel.Action, CGFloat) -> Void
 
     func makeNSView(context: Context) -> SidebarRowSwipeCaptureNSView {
         let view = SidebarRowSwipeCaptureNSView(workspaceId: workspaceId, frame: .zero)

--- a/Sources/Sidebar/SidebarRowSwipeDebugRegistry.swift
+++ b/Sources/Sidebar/SidebarRowSwipeDebugRegistry.swift
@@ -1,0 +1,48 @@
+import AppKit
+
+#if DEBUG
+@MainActor
+final class SidebarRowSwipeDebugRegistry {
+    enum Action: Equatable {
+        case revealLeading
+        case revealTrailing
+        case commitLeading
+        case commitTrailing
+        case release
+    }
+
+    struct Result: Equatable {
+        let committed: Bool
+        let offset: CGFloat
+        let released: Bool
+    }
+
+    private final class Entry {
+        weak var view: SidebarRowSwipeCaptureNSView?
+
+        init(view: SidebarRowSwipeCaptureNSView) {
+            self.view = view
+        }
+    }
+
+    private var entriesByWorkspaceId: [UUID: Entry] = [:]
+
+    func register(workspaceId: UUID, view: SidebarRowSwipeCaptureNSView) {
+        entriesByWorkspaceId[workspaceId] = Entry(view: view)
+    }
+
+    func unregister(workspaceId: UUID, view: SidebarRowSwipeCaptureNSView) {
+        guard entriesByWorkspaceId[workspaceId]?.view === view else { return }
+        entriesByWorkspaceId.removeValue(forKey: workspaceId)
+    }
+
+    func simulateSwipe(workspaceId: UUID, action: Action) -> Result? {
+        guard let entry = entriesByWorkspaceId[workspaceId],
+              let view = entry.view else {
+            entriesByWorkspaceId.removeValue(forKey: workspaceId)
+            return nil
+        }
+        return view.debugSimulateSwipe(action)
+    }
+}
+#endif

--- a/Sources/Sidebar/SidebarRowSwipeDebugRegistry.swift
+++ b/Sources/Sidebar/SidebarRowSwipeDebugRegistry.swift
@@ -3,6 +3,8 @@ import AppKit
 #if DEBUG
 @MainActor
 final class SidebarRowSwipeDebugRegistry {
+    static let shared = SidebarRowSwipeDebugRegistry()
+
     enum Action: Equatable {
         case revealLeading
         case revealTrailing

--- a/Sources/Sidebar/SidebarRowSwipeGestureModel.swift
+++ b/Sources/Sidebar/SidebarRowSwipeGestureModel.swift
@@ -1,0 +1,198 @@
+import CoreGraphics
+
+struct SidebarRowSwipeGestureModel {
+    struct Configuration: Equatable, Sendable {
+        let maxRevealDistance: CGFloat
+        let commitThreshold: CGFloat
+        let rubberBandDamping: CGFloat
+        let rubberBandExtraLimitFraction: CGFloat
+
+        init(
+            maxRevealDistance: CGFloat = 96,
+            commitThreshold: CGFloat = 64,
+            rubberBandDamping: CGFloat = 0.25,
+            rubberBandExtraLimitFraction: CGFloat = 0.35
+        ) {
+            self.maxRevealDistance = maxRevealDistance
+            self.commitThreshold = commitThreshold
+            self.rubberBandDamping = rubberBandDamping
+            self.rubberBandExtraLimitFraction = rubberBandExtraLimitFraction
+        }
+    }
+
+    enum Phase: Equatable, Sendable {
+        case began
+        case changed
+        case ended
+        case cancelled
+        case momentum
+    }
+
+    enum Action: Equatable, Sendable {
+        case leading
+        case trailing
+    }
+
+    struct Event: Equatable, Sendable {
+        let phase: Phase
+        let scrollingDeltaX: CGFloat
+        let scrollingDeltaY: CGFloat
+
+        init(phase: Phase, scrollingDeltaX: CGFloat, scrollingDeltaY: CGFloat) {
+            self.phase = phase
+            self.scrollingDeltaX = scrollingDeltaX
+            self.scrollingDeltaY = scrollingDeltaY
+        }
+    }
+
+    struct Result: Equatable, Sendable {
+        let claimed: Bool
+        let offset: CGFloat
+        let commit: Action?
+        let shouldAnimateOffset: Bool
+    }
+
+    private enum GestureState: Equatable, Sendable {
+        case idle
+        case tracking(direction: Action, accumulatedOffset: CGFloat)
+        case ignoringUntilEnd
+        case suppressingMomentum
+    }
+
+    private let configuration: Configuration
+    private var state: GestureState = .idle
+
+    init(configuration: Configuration = Configuration()) {
+        self.configuration = configuration
+    }
+
+    mutating func handle(_ event: Event) -> Result {
+        switch event.phase {
+        case .began:
+            return begin(event)
+        case .changed:
+            return change(event)
+        case .ended:
+            return end(event)
+        case .cancelled:
+            return cancel()
+        case .momentum:
+            return momentum()
+        }
+    }
+
+    private mutating func begin(_ event: Event) -> Result {
+        let deltaX = normalized(event.scrollingDeltaX)
+        let deltaY = normalized(event.scrollingDeltaY)
+        guard abs(deltaX) > abs(deltaY), deltaX != 0 else {
+            state = .ignoringUntilEnd
+            return Result(claimed: false, offset: 0, commit: nil, shouldAnimateOffset: false)
+        }
+
+        let direction: Action = deltaX > 0 ? .leading : .trailing
+        let accumulatedOffset = constrainedOffset(deltaX, direction: direction)
+        state = .tracking(direction: direction, accumulatedOffset: accumulatedOffset)
+        return Result(
+            claimed: true,
+            offset: visibleOffset(for: accumulatedOffset),
+            commit: nil,
+            shouldAnimateOffset: false
+        )
+    }
+
+    private mutating func change(_ event: Event) -> Result {
+        guard case let .tracking(direction, accumulatedOffset) = state else {
+            return Result(
+                claimed: state == .suppressingMomentum,
+                offset: 0,
+                commit: nil,
+                shouldAnimateOffset: false
+            )
+        }
+
+        let nextOffset = constrainedOffset(accumulatedOffset + normalized(event.scrollingDeltaX), direction: direction)
+        state = .tracking(direction: direction, accumulatedOffset: nextOffset)
+        return Result(
+            claimed: true,
+            offset: visibleOffset(for: nextOffset),
+            commit: nil,
+            shouldAnimateOffset: false
+        )
+    }
+
+    private mutating func end(_ event: Event) -> Result {
+        guard case let .tracking(direction, accumulatedOffset) = state else {
+            if state == .ignoringUntilEnd {
+                state = .idle
+            }
+            return Result(
+                claimed: state == .suppressingMomentum,
+                offset: 0,
+                commit: nil,
+                shouldAnimateOffset: false
+            )
+        }
+
+        let finalOffset = constrainedOffset(accumulatedOffset + normalized(event.scrollingDeltaX), direction: direction)
+        let commit = abs(visibleOffset(for: finalOffset)) > configuration.commitThreshold ? direction : nil
+        state = .suppressingMomentum
+        return Result(claimed: true, offset: 0, commit: commit, shouldAnimateOffset: true)
+    }
+
+    private mutating func cancel() -> Result {
+        guard case .tracking = state else {
+            if state == .ignoringUntilEnd {
+                state = .idle
+            }
+            return Result(
+                claimed: state == .suppressingMomentum,
+                offset: 0,
+                commit: nil,
+                shouldAnimateOffset: false
+            )
+        }
+
+        state = .suppressingMomentum
+        return Result(claimed: true, offset: 0, commit: nil, shouldAnimateOffset: true)
+    }
+
+    private mutating func momentum() -> Result {
+        switch state {
+        case .suppressingMomentum:
+            return Result(claimed: true, offset: 0, commit: nil, shouldAnimateOffset: false)
+        case .tracking:
+            state = .suppressingMomentum
+            return Result(claimed: true, offset: 0, commit: nil, shouldAnimateOffset: true)
+        case .ignoringUntilEnd, .idle:
+            return Result(claimed: false, offset: 0, commit: nil, shouldAnimateOffset: false)
+        }
+    }
+
+    private func normalized(_ delta: CGFloat) -> CGFloat {
+        delta.isFinite ? delta : 0
+    }
+
+    private func constrainedOffset(_ offset: CGFloat, direction: Action) -> CGFloat {
+        switch direction {
+        case .leading:
+            return max(0, offset)
+        case .trailing:
+            return min(0, offset)
+        }
+    }
+
+    private func visibleOffset(for accumulatedOffset: CGFloat) -> CGFloat {
+        let sign: CGFloat = accumulatedOffset >= 0 ? 1 : -1
+        return sign * rubberBandedDistance(abs(accumulatedOffset))
+    }
+
+    private func rubberBandedDistance(_ distance: CGFloat) -> CGFloat {
+        guard distance > configuration.maxRevealDistance else { return distance }
+        let extra = distance - configuration.maxRevealDistance
+        let cappedExtra = min(
+            extra * configuration.rubberBandDamping,
+            configuration.maxRevealDistance * configuration.rubberBandExtraLimitFraction
+        )
+        return configuration.maxRevealDistance + cappedExtra
+    }
+}

--- a/Sources/Sidebar/SidebarRowSwipeGestureModel.swift
+++ b/Sources/Sidebar/SidebarRowSwipeGestureModel.swift
@@ -54,6 +54,7 @@ struct SidebarRowSwipeGestureModel {
 
     private enum GestureState: Equatable, Sendable {
         case idle
+        case pending(accumulatedDeltaX: CGFloat, accumulatedDeltaY: CGFloat)
         case tracking(direction: Action, accumulatedOffset: CGFloat)
         case ignoringUntilEnd
         case suppressingMomentum
@@ -82,25 +83,15 @@ struct SidebarRowSwipeGestureModel {
     }
 
     private mutating func begin(_ event: Event) -> Result {
-        let deltaX = normalized(event.scrollingDeltaX)
-        let deltaY = normalized(event.scrollingDeltaY)
-        guard abs(deltaX) > abs(deltaY), deltaX != 0 else {
-            state = .ignoringUntilEnd
-            return Result(claimed: false, offset: 0, commit: nil, shouldAnimateOffset: false)
-        }
-
-        let direction: Action = deltaX > 0 ? .leading : .trailing
-        let accumulatedOffset = constrainedOffset(deltaX, direction: direction)
-        state = .tracking(direction: direction, accumulatedOffset: accumulatedOffset)
-        return Result(
-            claimed: true,
-            offset: visibleOffset(for: accumulatedOffset),
-            commit: nil,
-            shouldAnimateOffset: false
-        )
+        state = .pending(accumulatedDeltaX: 0, accumulatedDeltaY: 0)
+        return updatePending(with: event)
     }
 
     private mutating func change(_ event: Event) -> Result {
+        if case .pending = state {
+            return updatePending(with: event)
+        }
+
         guard case let .tracking(direction, accumulatedOffset) = state else {
             return Result(
                 claimed: state == .suppressingMomentum,
@@ -122,7 +113,7 @@ struct SidebarRowSwipeGestureModel {
 
     private mutating func end(_ event: Event) -> Result {
         guard case let .tracking(direction, accumulatedOffset) = state else {
-            if state == .ignoringUntilEnd {
+            if state == .ignoringUntilEnd || isPending {
                 state = .idle
             }
             return Result(
@@ -141,7 +132,7 @@ struct SidebarRowSwipeGestureModel {
 
     private mutating func cancel() -> Result {
         guard case .tracking = state else {
-            if state == .ignoringUntilEnd {
+            if state == .ignoringUntilEnd || isPending {
                 state = .idle
             }
             return Result(
@@ -163,9 +154,44 @@ struct SidebarRowSwipeGestureModel {
         case .tracking:
             state = .suppressingMomentum
             return Result(claimed: true, offset: 0, commit: nil, shouldAnimateOffset: true)
+        case .pending:
+            state = .idle
+            return Result(claimed: false, offset: 0, commit: nil, shouldAnimateOffset: false)
         case .ignoringUntilEnd, .idle:
             return Result(claimed: false, offset: 0, commit: nil, shouldAnimateOffset: false)
         }
+    }
+
+    private mutating func updatePending(with event: Event) -> Result {
+        guard case let .pending(accumulatedDeltaX, accumulatedDeltaY) = state else {
+            return Result(claimed: false, offset: 0, commit: nil, shouldAnimateOffset: false)
+        }
+
+        let nextDeltaX = accumulatedDeltaX + normalized(event.scrollingDeltaX)
+        let nextDeltaY = accumulatedDeltaY + normalized(event.scrollingDeltaY)
+        guard abs(nextDeltaX) + abs(nextDeltaY) > 0 else {
+            state = .pending(accumulatedDeltaX: nextDeltaX, accumulatedDeltaY: nextDeltaY)
+            return Result(claimed: false, offset: 0, commit: nil, shouldAnimateOffset: false)
+        }
+        guard abs(nextDeltaX) > abs(nextDeltaY), nextDeltaX != 0 else {
+            state = .ignoringUntilEnd
+            return Result(claimed: false, offset: 0, commit: nil, shouldAnimateOffset: false)
+        }
+
+        let direction: Action = nextDeltaX > 0 ? .leading : .trailing
+        let accumulatedOffset = constrainedOffset(nextDeltaX, direction: direction)
+        state = .tracking(direction: direction, accumulatedOffset: accumulatedOffset)
+        return Result(
+            claimed: true,
+            offset: visibleOffset(for: accumulatedOffset),
+            commit: nil,
+            shouldAnimateOffset: false
+        )
+    }
+
+    private var isPending: Bool {
+        if case .pending = state { return true }
+        return false
     }
 
     private func normalized(_ delta: CGFloat) -> CGFloat {

--- a/Sources/Sidebar/SidebarRowSwipeGestureModel.swift
+++ b/Sources/Sidebar/SidebarRowSwipeGestureModel.swift
@@ -4,17 +4,23 @@ struct SidebarRowSwipeGestureModel {
     struct Configuration: Equatable, Sendable {
         let maxRevealDistance: CGFloat
         let commitThreshold: CGFloat
+        let commitZoneHysteresis: CGFloat
+        let minimumLeadingActionContainerWidth: CGFloat
         let rubberBandDamping: CGFloat
         let rubberBandExtraLimitFraction: CGFloat
 
         init(
             maxRevealDistance: CGFloat = 96,
             commitThreshold: CGFloat = 64,
+            commitZoneHysteresis: CGFloat = 4,
+            minimumLeadingActionContainerWidth: CGFloat = 128,
             rubberBandDamping: CGFloat = 0.25,
             rubberBandExtraLimitFraction: CGFloat = 0.35
         ) {
             self.maxRevealDistance = maxRevealDistance
             self.commitThreshold = commitThreshold
+            self.commitZoneHysteresis = commitZoneHysteresis
+            self.minimumLeadingActionContainerWidth = minimumLeadingActionContainerWidth
             self.rubberBandDamping = rubberBandDamping
             self.rubberBandExtraLimitFraction = rubberBandExtraLimitFraction
         }
@@ -37,11 +43,18 @@ struct SidebarRowSwipeGestureModel {
         let phase: Phase
         let scrollingDeltaX: CGFloat
         let scrollingDeltaY: CGFloat
+        let containerWidth: CGFloat
 
-        init(phase: Phase, scrollingDeltaX: CGFloat, scrollingDeltaY: CGFloat) {
+        init(
+            phase: Phase,
+            scrollingDeltaX: CGFloat,
+            scrollingDeltaY: CGFloat,
+            containerWidth: CGFloat = .infinity
+        ) {
             self.phase = phase
             self.scrollingDeltaX = scrollingDeltaX
             self.scrollingDeltaY = scrollingDeltaY
+            self.containerWidth = containerWidth
         }
     }
 
@@ -50,6 +63,24 @@ struct SidebarRowSwipeGestureModel {
         let offset: CGFloat
         let commit: Action?
         let shouldAnimateOffset: Bool
+        let isInCommitZone: Bool
+        let enteredCommitZone: Bool
+
+        init(
+            claimed: Bool,
+            offset: CGFloat,
+            commit: Action?,
+            shouldAnimateOffset: Bool,
+            isInCommitZone: Bool = false,
+            enteredCommitZone: Bool = false
+        ) {
+            self.claimed = claimed
+            self.offset = offset
+            self.commit = commit
+            self.shouldAnimateOffset = shouldAnimateOffset
+            self.isInCommitZone = isInCommitZone
+            self.enteredCommitZone = enteredCommitZone
+        }
     }
 
     private enum GestureState: Equatable, Sendable {
@@ -62,6 +93,7 @@ struct SidebarRowSwipeGestureModel {
 
     private let configuration: Configuration
     private var state: GestureState = .idle
+    private var isInCommitZone = false
 
     init(configuration: Configuration = Configuration()) {
         self.configuration = configuration
@@ -83,6 +115,7 @@ struct SidebarRowSwipeGestureModel {
     }
 
     private mutating func begin(_ event: Event) -> Result {
+        resetCommitZone()
         state = .pending(accumulatedDeltaX: 0, accumulatedDeltaY: 0)
         return updatePending(with: event)
     }
@@ -102,12 +135,16 @@ struct SidebarRowSwipeGestureModel {
         }
 
         let nextOffset = constrainedOffset(accumulatedOffset + normalized(event.scrollingDeltaX), direction: direction)
+        let visibleOffset = visibleOffset(for: nextOffset)
+        let commitZone = updateCommitZone(for: visibleOffset)
         state = .tracking(direction: direction, accumulatedOffset: nextOffset)
         return Result(
             claimed: true,
-            offset: visibleOffset(for: nextOffset),
+            offset: visibleOffset,
             commit: nil,
-            shouldAnimateOffset: false
+            shouldAnimateOffset: false,
+            isInCommitZone: commitZone.isInCommitZone,
+            enteredCommitZone: commitZone.enteredCommitZone
         )
     }
 
@@ -116,6 +153,7 @@ struct SidebarRowSwipeGestureModel {
             if state == .ignoringUntilEnd || isPending {
                 state = .idle
             }
+            resetCommitZone()
             return Result(
                 claimed: state == .suppressingMomentum,
                 offset: 0,
@@ -125,7 +163,8 @@ struct SidebarRowSwipeGestureModel {
         }
 
         let finalOffset = constrainedOffset(accumulatedOffset + normalized(event.scrollingDeltaX), direction: direction)
-        let commit = abs(visibleOffset(for: finalOffset)) > configuration.commitThreshold ? direction : nil
+        let commit = shouldCommit(visibleOffset: visibleOffset(for: finalOffset)) ? direction : nil
+        resetCommitZone()
         state = .suppressingMomentum
         return Result(claimed: true, offset: 0, commit: commit, shouldAnimateOffset: true)
     }
@@ -135,6 +174,7 @@ struct SidebarRowSwipeGestureModel {
             if state == .ignoringUntilEnd || isPending {
                 state = .idle
             }
+            resetCommitZone()
             return Result(
                 claimed: state == .suppressingMomentum,
                 offset: 0,
@@ -143,6 +183,7 @@ struct SidebarRowSwipeGestureModel {
             )
         }
 
+        resetCommitZone()
         state = .suppressingMomentum
         return Result(claimed: true, offset: 0, commit: nil, shouldAnimateOffset: true)
     }
@@ -152,9 +193,11 @@ struct SidebarRowSwipeGestureModel {
         case .suppressingMomentum:
             return Result(claimed: true, offset: 0, commit: nil, shouldAnimateOffset: false)
         case .tracking:
+            resetCommitZone()
             state = .suppressingMomentum
             return Result(claimed: true, offset: 0, commit: nil, shouldAnimateOffset: true)
         case .pending:
+            resetCommitZone()
             state = .idle
             return Result(claimed: false, offset: 0, commit: nil, shouldAnimateOffset: false)
         case .ignoringUntilEnd, .idle:
@@ -179,13 +222,22 @@ struct SidebarRowSwipeGestureModel {
         }
 
         let direction: Action = nextDeltaX > 0 ? .leading : .trailing
+        guard direction != .leading || isLeadingActionEnabled(containerWidth: event.containerWidth) else {
+            state = .ignoringUntilEnd
+            return Result(claimed: false, offset: 0, commit: nil, shouldAnimateOffset: false)
+        }
+
         let accumulatedOffset = constrainedOffset(nextDeltaX, direction: direction)
+        let visibleOffset = visibleOffset(for: accumulatedOffset)
+        let commitZone = updateCommitZone(for: visibleOffset)
         state = .tracking(direction: direction, accumulatedOffset: accumulatedOffset)
         return Result(
             claimed: true,
-            offset: visibleOffset(for: accumulatedOffset),
+            offset: visibleOffset,
             commit: nil,
-            shouldAnimateOffset: false
+            shouldAnimateOffset: false,
+            isInCommitZone: commitZone.isInCommitZone,
+            enteredCommitZone: commitZone.enteredCommitZone
         )
     }
 
@@ -196,6 +248,12 @@ struct SidebarRowSwipeGestureModel {
 
     private func normalized(_ delta: CGFloat) -> CGFloat {
         delta.isFinite ? delta : 0
+    }
+
+    private func isLeadingActionEnabled(containerWidth: CGFloat) -> Bool {
+        guard !containerWidth.isNaN else { return false }
+        guard containerWidth.isFinite else { return true }
+        return containerWidth >= configuration.minimumLeadingActionContainerWidth
     }
 
     private func constrainedOffset(_ offset: CGFloat, direction: Action) -> CGFloat {
@@ -220,5 +278,31 @@ struct SidebarRowSwipeGestureModel {
             configuration.maxRevealDistance * configuration.rubberBandExtraLimitFraction
         )
         return configuration.maxRevealDistance + cappedExtra
+    }
+
+    private mutating func updateCommitZone(for visibleOffset: CGFloat) -> (
+        isInCommitZone: Bool,
+        enteredCommitZone: Bool
+    ) {
+        let visibleMagnitude = abs(visibleOffset)
+        let disengageThreshold = max(0, configuration.commitThreshold - configuration.commitZoneHysteresis)
+        let nextIsInCommitZone = isInCommitZone
+            ? visibleMagnitude >= disengageThreshold
+            : visibleMagnitude >= configuration.commitThreshold
+        let enteredCommitZone = !isInCommitZone && nextIsInCommitZone
+        isInCommitZone = nextIsInCommitZone
+        return (nextIsInCommitZone, enteredCommitZone)
+    }
+
+    private func shouldCommit(visibleOffset: CGFloat) -> Bool {
+        let visibleMagnitude = abs(visibleOffset)
+        if isInCommitZone {
+            return visibleMagnitude >= max(0, configuration.commitThreshold - configuration.commitZoneHysteresis)
+        }
+        return visibleMagnitude >= configuration.commitThreshold
+    }
+
+    private mutating func resetCommitZone() {
+        isInCommitZone = false
     }
 }

--- a/Sources/Sidebar/SidebarRowSwipeGestureModel.swift
+++ b/Sources/Sidebar/SidebarRowSwipeGestureModel.swift
@@ -2,6 +2,8 @@ import CoreGraphics
 
 struct SidebarRowSwipeGestureModel {
     struct Configuration: Equatable, Sendable {
+        static let defaultMaxRevealDistance: CGFloat = 96
+
         let maxRevealDistance: CGFloat
         let commitThreshold: CGFloat
         let commitZoneHysteresis: CGFloat
@@ -10,7 +12,7 @@ struct SidebarRowSwipeGestureModel {
         let rubberBandExtraLimitFraction: CGFloat
 
         init(
-            maxRevealDistance: CGFloat = 96,
+            maxRevealDistance: CGFloat = Self.defaultMaxRevealDistance,
             commitThreshold: CGFloat = 64,
             commitZoneHysteresis: CGFloat = 4,
             minimumLeadingActionContainerWidth: CGFloat = 128,
@@ -126,8 +128,11 @@ struct SidebarRowSwipeGestureModel {
         }
 
         guard case let .tracking(direction, accumulatedOffset) = state else {
+            if state == .suppressingMomentum {
+                state = .idle
+            }
             return Result(
-                claimed: state == .suppressingMomentum,
+                claimed: false,
                 offset: 0,
                 commit: nil,
                 shouldAnimateOffset: false
@@ -150,12 +155,12 @@ struct SidebarRowSwipeGestureModel {
 
     private mutating func end(_ event: Event) -> Result {
         guard case let .tracking(direction, accumulatedOffset) = state else {
-            if state == .ignoringUntilEnd || isPending {
+            if state == .ignoringUntilEnd || isPending || state == .suppressingMomentum {
                 state = .idle
             }
             resetCommitZone()
             return Result(
-                claimed: state == .suppressingMomentum,
+                claimed: false,
                 offset: 0,
                 commit: nil,
                 shouldAnimateOffset: false
@@ -171,12 +176,12 @@ struct SidebarRowSwipeGestureModel {
 
     private mutating func cancel() -> Result {
         guard case .tracking = state else {
-            if state == .ignoringUntilEnd || isPending {
+            if state == .ignoringUntilEnd || isPending || state == .suppressingMomentum {
                 state = .idle
             }
             resetCommitZone()
             return Result(
-                claimed: state == .suppressingMomentum,
+                claimed: false,
                 offset: 0,
                 commit: nil,
                 shouldAnimateOffset: false

--- a/Sources/Sidebar/SidebarSwipeableRow.swift
+++ b/Sources/Sidebar/SidebarSwipeableRow.swift
@@ -1,0 +1,136 @@
+import Foundation
+import SwiftUI
+
+struct SidebarSwipeableRow<Content: View>: View {
+    let workspaceId: UUID
+    let isUnread: Bool
+    let onToggleReadState: () -> Void
+    let onDelete: () -> Void
+
+    private let content: Content
+    @State private var offset: CGFloat = 0
+
+    init(
+        workspaceId: UUID,
+        isUnread: Bool,
+        onToggleReadState: @escaping () -> Void,
+        onDelete: @escaping () -> Void,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.workspaceId = workspaceId
+        self.isUnread = isUnread
+        self.onToggleReadState = onToggleReadState
+        self.onDelete = onDelete
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .background {
+                actionBackgrounds
+                    .offset(x: -offset)
+            }
+            .offset(x: offset)
+            .clipped()
+            .overlay {
+                SidebarRowSwipeCaptureView(
+                    onOffsetChanged: updateOffset(_:animated:),
+                    onCommit: commit(_:)
+                )
+            }
+    }
+
+    @ViewBuilder
+    private var actionBackgrounds: some View {
+        HStack(spacing: 0) {
+            if offset > 0 {
+                swipeActionBackground(
+                    width: abs(offset),
+                    color: Color(nsColor: .systemBlue),
+                    systemImage: readStateSystemImage,
+                    title: readStateTitle,
+                    accessibilityIdentifier: "SidebarWorkspaceReadStateSwipeAction-\(workspaceId.uuidString)"
+                )
+            }
+
+            Spacer(minLength: 0)
+
+            if offset < 0 {
+                swipeActionBackground(
+                    width: abs(offset),
+                    color: Color(nsColor: .systemRed),
+                    systemImage: "trash",
+                    title: deleteTitle,
+                    accessibilityIdentifier: "SidebarWorkspaceDeleteSwipeAction-\(workspaceId.uuidString)"
+                )
+            }
+        }
+        .allowsHitTesting(false)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var readStateTitle: String {
+        isUnread
+            ? String(localized: "sidebar.workspaceSwipe.markRead", defaultValue: "Mark as Read")
+            : String(localized: "sidebar.workspaceSwipe.markUnread", defaultValue: "Mark as Unread")
+    }
+
+    private var readStateSystemImage: String {
+        isUnread ? "envelope.open" : "envelope.badge"
+    }
+
+    private var deleteTitle: String {
+        String(localized: "sidebar.workspaceSwipe.delete", defaultValue: "Delete")
+    }
+
+    private func swipeActionBackground(
+        width: CGFloat,
+        color: Color,
+        systemImage: String,
+        title: String,
+        accessibilityIdentifier: String
+    ) -> some View {
+        ZStack {
+            color
+
+            VStack(spacing: 3) {
+                CmuxSystemSymbolImage(systemName: systemImage, pointSize: 15, weight: .semibold)
+                    .foregroundColor(.white)
+
+                Text(title)
+                    .font(.system(size: 10, weight: .semibold))
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.72)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.white)
+                    .frame(width: 88)
+            }
+            .frame(width: 96)
+        }
+        .frame(width: width)
+        .frame(maxHeight: .infinity)
+        .clipped()
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(title)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private func updateOffset(_ nextOffset: CGFloat, animated: Bool) {
+        var transaction = Transaction()
+        transaction.animation = animated
+            ? .spring(response: 0.22, dampingFraction: 0.86)
+            : nil
+        withTransaction(transaction) {
+            offset = nextOffset
+        }
+    }
+
+    private func commit(_ action: SidebarRowSwipeGestureModel.Action) {
+        switch action {
+        case .leading:
+            onToggleReadState()
+        case .trailing:
+            onDelete()
+        }
+    }
+}

--- a/Sources/Sidebar/SidebarSwipeableRow.swift
+++ b/Sources/Sidebar/SidebarSwipeableRow.swift
@@ -81,7 +81,7 @@ struct SidebarSwipeableRow<Content: View>: View {
     }
 
     private var iconRevealWidth: CGFloat {
-        min(abs(offset), 96)
+        min(abs(offset), SidebarRowSwipeGestureModel.Configuration.defaultMaxRevealDistance)
     }
 
     private var iconOpacity: Double {

--- a/Sources/Sidebar/SidebarSwipeableRow.swift
+++ b/Sources/Sidebar/SidebarSwipeableRow.swift
@@ -34,6 +34,7 @@ struct SidebarSwipeableRow<Content: View>: View {
             .clipped()
             .overlay {
                 SidebarRowSwipeCaptureView(
+                    workspaceId: workspaceId,
                     onOffsetChanged: updateOffset(_:animated:),
                     onCommit: commit(_:)
                 )

--- a/Sources/Sidebar/SidebarSwipeableRow.swift
+++ b/Sources/Sidebar/SidebarSwipeableRow.swift
@@ -4,70 +4,60 @@ import SwiftUI
 struct SidebarSwipeableRow<Content: View>: View {
     let workspaceId: UUID
     let isUnread: Bool
+    let isSelected: Bool
     let onToggleReadState: () -> Void
     let onDelete: () -> Void
 
     private let content: Content
     @State private var offset: CGFloat = 0
+    @State private var isInCommitZone = false
 
     init(
         workspaceId: UUID,
         isUnread: Bool,
+        isSelected: Bool,
         onToggleReadState: @escaping () -> Void,
         onDelete: @escaping () -> Void,
         @ViewBuilder content: () -> Content
     ) {
         self.workspaceId = workspaceId
         self.isUnread = isUnread
+        self.isSelected = isSelected
         self.onToggleReadState = onToggleReadState
         self.onDelete = onDelete
         self.content = content()
     }
 
     var body: some View {
-        content
-            .background {
-                actionBackgrounds
-                    .offset(x: -offset)
-            }
-            .offset(x: offset)
-            .clipped()
+        ZStack {
+            actionFillLayer
+            content
+                .offset(x: offset)
+        }
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
             .overlay {
                 SidebarRowSwipeCaptureView(
                     workspaceId: workspaceId,
-                    onOffsetChanged: updateOffset(_:animated:),
-                    onCommit: commit(_:)
+                    onOffsetChanged: updateOffset(_:animated:isInCommitZone:),
+                    onCommit: commit(_:containerWidth:)
                 )
             }
     }
 
     @ViewBuilder
-    private var actionBackgrounds: some View {
-        HStack(spacing: 0) {
-            if offset > 0 {
-                swipeActionBackground(
-                    width: abs(offset),
-                    color: Color(nsColor: .systemBlue),
-                    systemImage: readStateSystemImage,
-                    title: readStateTitle,
-                    accessibilityIdentifier: "SidebarWorkspaceReadStateSwipeAction-\(workspaceId.uuidString)"
-                )
-            }
-
-            Spacer(minLength: 0)
-
-            if offset < 0 {
-                swipeActionBackground(
-                    width: abs(offset),
-                    color: Color(nsColor: .systemRed),
-                    systemImage: "trash",
-                    title: deleteTitle,
-                    accessibilityIdentifier: "SidebarWorkspaceDeleteSwipeAction-\(workspaceId.uuidString)"
-                )
-            }
+    private var actionFillLayer: some View {
+        if let activeAction {
+            swipeActionFill(for: activeAction)
+        } else {
+            Color.clear
+                .allowsHitTesting(false)
         }
-        .allowsHitTesting(false)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var activeAction: SidebarRowSwipeGestureModel.Action? {
+        if offset > 0 { return .leading }
+        if offset < 0 { return .trailing }
+        return nil
     }
 
     private var readStateTitle: String {
@@ -77,61 +67,136 @@ struct SidebarSwipeableRow<Content: View>: View {
     }
 
     private var readStateSystemImage: String {
-        isUnread ? "envelope.open" : "envelope.badge"
+        let preferred = isUnread ? "envelope.open.fill" : "envelope.badge.fill"
+        let fallback = isUnread ? "envelope.open" : "envelope.badge"
+        return RenderableSystemSymbol.isRenderable(preferred) ? preferred : fallback
     }
 
     private var deleteTitle: String {
         String(localized: "sidebar.workspaceSwipe.delete", defaultValue: "Delete")
     }
 
-    private func swipeActionBackground(
-        width: CGFloat,
-        color: Color,
-        systemImage: String,
-        title: String,
-        accessibilityIdentifier: String
-    ) -> some View {
-        ZStack {
-            color
-
-            VStack(spacing: 3) {
-                CmuxSystemSymbolImage(systemName: systemImage, pointSize: 15, weight: .semibold)
-                    .foregroundColor(.white)
-
-                Text(title)
-                    .font(.system(size: 10, weight: .semibold))
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.72)
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(.white)
-                    .frame(width: 88)
-            }
-            .frame(width: 96)
-        }
-        .frame(width: width)
-        .frame(maxHeight: .infinity)
-        .clipped()
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(title)
-        .accessibilityIdentifier(accessibilityIdentifier)
+    private var deleteSystemImage: String {
+        RenderableSystemSymbol.isRenderable("trash.fill") ? "trash.fill" : "trash"
     }
 
-    private func updateOffset(_ nextOffset: CGFloat, animated: Bool) {
+    private var iconRevealWidth: CGFloat {
+        min(abs(offset), 96)
+    }
+
+    private var iconOpacity: Double {
+        let revealedDistance = abs(offset)
+        guard revealedDistance >= 16 else { return 0 }
+        return min(1, Double((revealedDistance - 16) / 16))
+    }
+
+    private func swipeActionFill(for action: SidebarRowSwipeGestureModel.Action) -> some View {
+        ZStack(alignment: alignment(for: action)) {
+            color(for: action)
+
+            if action == .leading, isSelected {
+                Color.black.opacity(0.15)
+            }
+
+            if isInCommitZone {
+                Color.white.opacity(0.12)
+            }
+
+            swipeActionIcon(for: action)
+        }
+        .allowsHitTesting(false)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(title(for: action))
+        .accessibilityIdentifier(accessibilityIdentifier(for: action))
+        .help(title(for: action))
+    }
+
+    private func swipeActionIcon(for action: SidebarRowSwipeGestureModel.Action) -> some View {
+        CmuxSystemSymbolImage(systemName: systemImage(for: action), pointSize: 15, weight: .semibold)
+            .foregroundColor(.white)
+            .scaleEffect(isInCommitZone ? 1.15 : 1)
+            .animation(.spring(response: 0.25, dampingFraction: 0.6), value: isInCommitZone)
+            .opacity(iconOpacity)
+            .frame(width: iconRevealWidth)
+    }
+
+    private func alignment(for action: SidebarRowSwipeGestureModel.Action) -> Alignment {
+        switch action {
+        case .leading:
+            return .leading
+        case .trailing:
+            return .trailing
+        }
+    }
+
+    private func color(for action: SidebarRowSwipeGestureModel.Action) -> Color {
+        switch action {
+        case .leading:
+            return Color(nsColor: .systemBlue)
+        case .trailing:
+            return Color(nsColor: .systemRed)
+        }
+    }
+
+    private func systemImage(for action: SidebarRowSwipeGestureModel.Action) -> String {
+        switch action {
+        case .leading:
+            return readStateSystemImage
+        case .trailing:
+            return deleteSystemImage
+        }
+    }
+
+    private func title(for action: SidebarRowSwipeGestureModel.Action) -> String {
+        switch action {
+        case .leading:
+            return readStateTitle
+        case .trailing:
+            return deleteTitle
+        }
+    }
+
+    private func accessibilityIdentifier(for action: SidebarRowSwipeGestureModel.Action) -> String {
+        switch action {
+        case .leading:
+            return "SidebarWorkspaceReadStateSwipeAction-\(workspaceId.uuidString)"
+        case .trailing:
+            return "SidebarWorkspaceDeleteSwipeAction-\(workspaceId.uuidString)"
+        }
+    }
+
+    private func updateOffset(_ nextOffset: CGFloat, animated: Bool, isInCommitZone: Bool) {
         var transaction = Transaction()
         transaction.animation = animated
-            ? .spring(response: 0.22, dampingFraction: 0.86)
+            ? .spring(response: 0.25, dampingFraction: 0.85)
             : nil
         withTransaction(transaction) {
             offset = nextOffset
+            self.isInCommitZone = isInCommitZone
         }
     }
 
-    private func commit(_ action: SidebarRowSwipeGestureModel.Action) {
+    private func commit(_ action: SidebarRowSwipeGestureModel.Action, containerWidth: CGFloat) {
         switch action {
         case .leading:
             onToggleReadState()
         case .trailing:
+            commitDelete(containerWidth: containerWidth)
+        }
+    }
+
+    private func commitDelete(containerWidth: CGFloat) {
+        isInCommitZone = false
+        if #available(macOS 14.0, *) {
+            withAnimation(.easeIn(duration: 0.18), completionCriteria: .logicallyComplete) {
+                offset = -containerWidth
+            } completion: {
+                onDelete()
+                updateOffset(0, animated: true, isInCommitZone: false)
+            }
+        } else {
             onDelete()
+            updateOffset(0, animated: true, isInCommitZone: false)
         }
     }
 }

--- a/Sources/Sidebar/SidebarSwipeableRow.swift
+++ b/Sources/Sidebar/SidebarSwipeableRow.swift
@@ -104,6 +104,11 @@ struct SidebarSwipeableRow<Content: View>: View {
 
             swipeActionIcon(for: action)
         }
+        // Unselected row cards have a transparent background, so a fill that
+        // spans the whole container would show through the card. Limit the
+        // fill to the revealed strip; the outer clipShape rounds its corners.
+        .frame(width: abs(offset))
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment(for: action))
         .allowsHitTesting(false)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(title(for: action))

--- a/Sources/TerminalController+ControlDebugContext.swift
+++ b/Sources/TerminalController+ControlDebugContext.swift
@@ -383,6 +383,38 @@ extension TerminalController: ControlDebugContext {
         AppDelegate.shared?.sidebarVisibility(windowId: windowID)
     }
 
+    func controlDebugSimulateSidebarSwipe(
+        workspaceID: UUID,
+        action: ControlDebugSidebarSwipeAction
+    ) -> ControlDebugSidebarSwipeResolution {
+        let registryAction: SidebarRowSwipeDebugRegistry.Action
+        switch action {
+        case .revealLeading:
+            registryAction = .revealLeading
+        case .revealTrailing:
+            registryAction = .revealTrailing
+        case .commitLeading:
+            registryAction = .commitLeading
+        case .commitTrailing:
+            registryAction = .commitTrailing
+        case .release:
+            registryAction = .release
+        }
+
+        guard let result = AppDelegate.shared?.sidebarRowSwipeDebugRegistry.simulateSwipe(
+            workspaceId: workspaceID,
+            action: registryAction
+        ) else {
+            return .rowNotRegistered
+        }
+
+        return .simulated(
+            committed: result.committed,
+            offset: Double(result.offset),
+            released: result.released
+        )
+    }
+
     // MARK: - debug.terminal.simulate_file_drop
 
     func controlDebugSimulateTerminalFileDrop(

--- a/Sources/TerminalController+ControlDebugContext.swift
+++ b/Sources/TerminalController+ControlDebugContext.swift
@@ -401,7 +401,7 @@ extension TerminalController: ControlDebugContext {
             registryAction = .release
         }
 
-        guard let result = AppDelegate.shared?.sidebarRowSwipeDebugRegistry.simulateSwipe(
+        guard let result = SidebarRowSwipeDebugRegistry.shared.simulateSwipe(
             workspaceId: workspaceID,
             action: registryAction
         ) else {

--- a/Sources/TerminalController+DebugMethodNames.swift
+++ b/Sources/TerminalController+DebugMethodNames.swift
@@ -40,6 +40,7 @@ extension TerminalController {
         "debug.window.screenshot",
         "debug.terminal.simulate_file_drop",
         "debug.sidebar.simulate_drag",
+        "debug.sidebar.simulate_swipe",
         "mobile.dev_stack_auth.configure",
     ]
 }

--- a/Sources/VerticalTabsSidebar+WorkspaceRow.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceRow.swift
@@ -1,0 +1,172 @@
+import AppKit
+import CmuxFoundation
+import CmuxSettings
+import CmuxWorkspaces
+import SwiftUI
+
+extension VerticalTabsSidebar {
+    @ViewBuilder
+    func workspaceRow(
+        _ tab: Workspace,
+        renderContext: WorkspaceListRenderContext,
+        shouldCollectWorkspaceDropTargets: Bool
+    ) -> some View {
+        let index = renderContext.tabIndexById[tab.id] ?? 0
+        let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
+        let contextMenuWorkspaceIds = usesSelectedContextMenuTargets
+            ? renderContext.selectedContextTargetIds
+            : [tab.id]
+        let remoteContextMenuWorkspaceIds = usesSelectedContextMenuTargets
+            ? renderContext.selectedRemoteContextMenuWorkspaceIds
+            : (tab.isRemoteWorkspace ? [tab.id] : [])
+        let allRemoteContextMenuTargetsConnecting = usesSelectedContextMenuTargets
+            ? renderContext.allSelectedRemoteContextMenuTargetsConnecting
+            : (
+                tab.isRemoteWorkspace &&
+                    (tab.remoteConnectionState == .connecting || tab.remoteConnectionState == .reconnecting)
+            )
+        let allRemoteContextMenuTargetsDisconnected = usesSelectedContextMenuTargets
+            ? renderContext.allSelectedRemoteContextMenuTargetsDisconnected
+            : (tab.isRemoteWorkspace && tab.remoteConnectionState == .disconnected)
+        let contextMenuPinTarget = WorkspaceActionDispatcher.Target(
+            workspaceIds: contextMenuWorkspaceIds,
+            anchorWorkspaceId: tab.id
+        )
+        let contextMenuPinState = WorkspaceActionDispatcher.pinState(
+            in: renderContext.pinResolutionContext,
+            target: contextMenuPinTarget
+        )
+        let liveUnreadCount = sidebarUnread.unreadCount(forWorkspaceId: tab.id)
+        let liveLatestNotificationText: String? = showsSidebarNotificationMessage
+            ? sidebarUnread.latestNotificationText(forWorkspaceId: tab.id)
+            : nil
+        let liveShowsModifierShortcutHints = showModifierHoldHints && modifierKeyMonitor.isModifierPressed
+        let resolvedShowsModifierShortcutHints = SidebarShortcutHintFreezePolicy().resolved(
+            live: liveShowsModifierShortcutHints,
+            currentTabId: tab.id,
+            frozenTabId: frozenShortcutHintsTabId,
+            frozenValue: frozenShortcutHintsValue
+        )
+        let onContextMenuAppear: () -> Void = { [tabId = tab.id, snapshot = resolvedShowsModifierShortcutHints] in
+            frozenShortcutHintsTabId = tabId
+            frozenShortcutHintsValue = snapshot
+        }
+        let onContextMenuDisappear: () -> Void = { [tabId = tab.id] in
+            if frozenShortcutHintsTabId == tabId {
+                frozenShortcutHintsTabId = nil
+            }
+        }
+
+        // Per-row drag/drop snapshots. Reading `dragState` here in the parent
+        // is intentional: the parent owns the @Observable store, and these
+        // value snapshots are what get passed to the row. The row's
+        // Equatable conformance ignores closures, so rows whose snapshot is
+        // unchanged skip re-render when drag state moves.
+        let isBeingDragged = dragState.draggedTabId == tab.id
+        let sidebarReorderIds = renderContext.sidebarReorderIds
+        let topDropIndicatorVisible = SidebarTabDropIndicatorPredicate().topVisible(
+            forTabId: tab.id,
+            draggedTabId: dragState.draggedTabId,
+            dropIndicator: dragState.dropIndicator,
+            tabIds: sidebarReorderIds
+        )
+        let bottomDropIndicatorVisible = SidebarTabDropIndicatorPredicate().bottomVisible(
+            forTabId: tab.id,
+            draggedTabId: dragState.draggedTabId,
+            dropIndicator: dragState.dropIndicator,
+            tabIds: sidebarReorderIds,
+            indicatorScope: dragState.dropIndicatorScope
+        )
+        let onDragStart: () -> NSItemProvider = { [tabId = tab.id] in
+            #if DEBUG
+            cmuxDebugLog("sidebar.onDrag tab=\(tabId.uuidString.prefix(5))")
+            #endif
+            dragState.beginDragging(tabId: tabId)
+            return SidebarTabDragPayload.provider(for: tabId)
+        }
+        let bonsplitSourceWorkspaceId: @MainActor (UUID) -> UUID? = { tabId in
+            guard let app = AppDelegate.shared else { return nil }
+            return app.locateBonsplitSurface(tabId: tabId)?.workspaceId
+        }
+        let moveBonsplitTabToWorkspace: @MainActor (BonsplitTabDragPayload.Transfer, UUID) -> Bool = { transfer, workspaceId in
+            guard let app = AppDelegate.shared else { return false }
+            return app.moveBonsplitTab(
+                tabId: transfer.tab.id,
+                toWorkspace: workspaceId,
+                focus: true,
+                focusWindow: true
+            )
+        }
+        let syncSidebarSelectionAfterBonsplitDrop: @MainActor () -> Void = {
+            if let selectedId = tabManager.selectedTabId {
+                lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+            } else {
+                lastSidebarSelectionIndex = nil
+            }
+        }
+        let workspaceIsUnread = liveUnreadCount > 0
+        let row = SidebarSwipeableRow(
+            workspaceId: tab.id,
+            isUnread: workspaceIsUnread,
+            isSelected: usesSelectedContextMenuTargets,
+            onToggleReadState: { [notificationStore, tabId = tab.id, workspaceIsUnread] in
+                if workspaceIsUnread {
+                    notificationStore.markRead(forTabId: tabId)
+                } else {
+                    notificationStore.markUnread(forTabId: tabId)
+                }
+            },
+            onDelete: { [tabManager, tab] in
+                tabManager.closeWorkspaceWithConfirmation(tab)
+            }
+        ) {
+            TabItemView(
+                tabManager: tabManager,
+                notificationStore: notificationStore,
+                tab: tab,
+                index: index,
+                workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
+                    at: index,
+                    workspaceCount: renderContext.workspaceCount
+                ),
+                workspaceShortcutModifierSymbol: renderContext.workspaceNumberShortcut.numberedDigitHintPrefix,
+                canCloseWorkspace: renderContext.canCloseWorkspace,
+                accessibilityWorkspaceCount: renderContext.workspaceCount,
+                unreadCount: liveUnreadCount,
+                latestNotificationText: liveLatestNotificationText,
+                rowSpacing: tabRowSpacing,
+                setSelectionToTabs: { selection = .tabs },
+                selectedTabIds: $selectedTabIds,
+                lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                showsModifierShortcutHints: resolvedShowsModifierShortcutHints,
+                dragAutoScrollController: dragAutoScrollController,
+                isBeingDragged: isBeingDragged,
+                topDropIndicatorVisible: topDropIndicatorVisible,
+                bottomDropIndicatorVisible: bottomDropIndicatorVisible,
+                isBonsplitWorkspaceDropActive: isBonsplitWorkspaceDropTargetCollectionActive,
+                bonsplitSourceWorkspaceId: bonsplitSourceWorkspaceId,
+                moveBonsplitTabToWorkspace: moveBonsplitTabToWorkspace,
+                syncSidebarSelectionAfterBonsplitDrop: syncSidebarSelectionAfterBonsplitDrop,
+                onDragStart: onDragStart,
+                contextMenuWorkspaceIds: contextMenuWorkspaceIds,
+                remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
+                allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
+                allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
+                contextMenuPinState: contextMenuPinState,
+                workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
+                settings: renderContext.tabItemSettings,
+                onContextMenuAppear: onContextMenuAppear,
+                onContextMenuDisappear: onContextMenuDisappear
+            )
+            .equatable()
+            .id(tab.id)
+            .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
+        }
+
+        row
+            .sidebarWorkspaceFrameAnchor(id: tab.id, isEnabled: shouldCollectWorkspaceDropTargets)
+            .padding(.leading, tab.groupId != nil ? SidebarWorkspaceGroupingMetrics.memberIndent : 0)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -951,10 +951,15 @@
 		C0DE48000000000000000001 /* SidebarProviderMenuRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE48000000000000000002 /* SidebarProviderMenuRegressionTests.swift */; };
 		B9000130A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */; };
 		B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
+		7230AA20DCFC4BE5B7B83608 /* SidebarRowSwipeCaptureNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F672B6831940CC8B902CB6 /* SidebarRowSwipeCaptureNSView.swift */; };
+		554E8D4DA51C451FA8A8102A /* SidebarRowSwipeCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777E3D68E3AF472BBF0EAD64 /* SidebarRowSwipeCaptureView.swift */; };
+		EE7DECEED1BA4665AA8ACF79 /* SidebarRowSwipeGestureModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE826BD4DFFA462F922FF6ED /* SidebarRowSwipeGestureModel.swift */; };
+		A83F90BF7F064BB181F9A3BB /* SidebarRowSwipeGestureModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6EBE86096A24430875B06EE /* SidebarRowSwipeGestureModelTests.swift */; };
 		C0DE35010000000000000001 /* SidebarScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35010000000000000002 /* SidebarScrim.swift */; };
 		C9A57513C9A57513C9A57513 /* SidebarScrollViewConfiguratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */; };
 		E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */; };
 		F57072635F25EBCA741E125D /* SidebarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */; };
+		208E185E363A495D87721010 /* SidebarSwipeableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D147A4AA674431FAAC60909 /* SidebarSwipeableRow.swift */; };
 		D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */; };
 		CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
 		D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */; };
@@ -2225,10 +2230,15 @@
 		C0DE48000000000000000002 /* SidebarProviderMenuRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarProviderMenuRegressionTests.swift; sourceTree = "<group>"; };
 		B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPullRequestInteractivityUITests.swift; sourceTree = "<group>"; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
+		D2F672B6831940CC8B902CB6 /* SidebarRowSwipeCaptureNSView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarRowSwipeCaptureNSView.swift; sourceTree = "<group>"; };
+		777E3D68E3AF472BBF0EAD64 /* SidebarRowSwipeCaptureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarRowSwipeCaptureView.swift; sourceTree = "<group>"; };
+		FE826BD4DFFA462F922FF6ED /* SidebarRowSwipeGestureModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarRowSwipeGestureModel.swift; sourceTree = "<group>"; };
+		A6EBE86096A24430875B06EE /* SidebarRowSwipeGestureModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarRowSwipeGestureModelTests.swift; sourceTree = "<group>"; };
 		C0DE35010000000000000002 /* SidebarScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrim.swift; sourceTree = "<group>"; };
 		C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrollViewConfiguratorTests.swift; sourceTree = "<group>"; };
 		9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
 		D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarState.swift; sourceTree = "<group>"; };
+		9D147A4AA674431FAAC60909 /* SidebarSwipeableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarSwipeableRow.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabDropIndicatorPredicateTests.swift; sourceTree = "<group>"; };
 		EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceDropPlannerTests.swift; sourceTree = "<group>"; };
@@ -2879,6 +2889,10 @@
 				D36A00060000000000000002 /* RendererRealizationPlanner.swift */,
 				D36A00070000000000000002 /* RendererRealizationReclaimTrigger.swift */,
 				243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */,
+				D2F672B6831940CC8B902CB6 /* SidebarRowSwipeCaptureNSView.swift */,
+				777E3D68E3AF472BBF0EAD64 /* SidebarRowSwipeCaptureView.swift */,
+				FE826BD4DFFA462F922FF6ED /* SidebarRowSwipeGestureModel.swift */,
+				9D147A4AA674431FAAC60909 /* SidebarSwipeableRow.swift */,
 				D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */,
 				C9A57104C9A57104C9A57104 /* SidebarWorkspaceGroupConfigOpener.swift */,
 				C9A57106C9A57106C9A57106 /* SidebarWorkspaceGroupContextMenuRunner.swift */,
@@ -3739,6 +3753,7 @@
 				D7AB3605C10DEF0000000002 /* WorkspaceCloseTabsContextMenuTests.swift */,
 				4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */,
 				D0B10009A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift */,
+				A6EBE86096A24430875B06EE /* SidebarRowSwipeGestureModelTests.swift */,
 				C0DE56010000000000000002 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift */,
 				71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */,
 				CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */,
@@ -4898,9 +4913,13 @@
 				C0DE5F210000000000000001 /* SidebarMetadataMarkdownRenderer.swift in Sources */,
 				EA1F00000000000000000001 /* SidebarPathFormatter.swift in Sources */,
 				C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */,
+				7230AA20DCFC4BE5B7B83608 /* SidebarRowSwipeCaptureNSView.swift in Sources */,
+				554E8D4DA51C451FA8A8102A /* SidebarRowSwipeCaptureView.swift in Sources */,
+				EE7DECEED1BA4665AA8ACF79 /* SidebarRowSwipeGestureModel.swift in Sources */,
 				C0DE35010000000000000001 /* SidebarScrim.swift in Sources */,
 				E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */,
 				F57072635F25EBCA741E125D /* SidebarState.swift in Sources */,
+				208E185E363A495D87721010 /* SidebarSwipeableRow.swift in Sources */,
 				C9A57605C9A57605C9A57605 /* SidebarWorkspaceDropTargetWriters.swift in Sources */,
 				C9A57103C9A57103C9A57103 /* SidebarWorkspaceGroupConfigOpener.swift in Sources */,
 				C9A57105C9A57105C9A57105 /* SidebarWorkspaceGroupContextMenuRunner.swift in Sources */,
@@ -5489,6 +5508,7 @@
 				385C6BA7E78DB87460E5D930 /* SidebarMarkdownRendererTests.swift in Sources */,
 				CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */,
 				C0DE48000000000000000001 /* SidebarProviderMenuRegressionTests.swift in Sources */,
+				A83F90BF7F064BB181F9A3BB /* SidebarRowSwipeGestureModelTests.swift in Sources */,
 				C9A57513C9A57513C9A57513 /* SidebarScrollViewConfiguratorTests.swift in Sources */,
 				D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */,
 				CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1180,6 +1180,7 @@
 		B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000005 /* VaultAgentProcessScanner.swift */; };
 		B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000001 /* VaultAgentRegistry.swift */; };
 		C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */; };
+		C9A57213C9A57213C9A57213 /* VerticalTabsSidebar+WorkspaceRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57214C9A57214C9A57214 /* VerticalTabsSidebar+WorkspaceRow.swift */; };
 		ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */; };
 		ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */; };
 		C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000002 /* VMSSHCommandTests.swift */; };
@@ -2455,6 +2456,7 @@
 		B35750000000000000000005 /* VaultAgentProcessScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentProcessScanner.swift; sourceTree = "<group>"; };
 		B35750000000000000000001 /* VaultAgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentRegistry.swift; sourceTree = "<group>"; };
 		C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalTabsSidebar+WorkspaceGroups.swift"; sourceTree = "<group>"; };
+		C9A57214C9A57214C9A57214 /* VerticalTabsSidebar+WorkspaceRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalTabsSidebar+WorkspaceRow.swift"; sourceTree = "<group>"; };
 		9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClient.swift; sourceTree = "<group>"; };
 		9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClientSocketCommands.swift; sourceTree = "<group>"; };
 		C37800000000000000000002 /* VMSSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSSHCommandTests.swift; sourceTree = "<group>"; };
@@ -2919,6 +2921,7 @@
 				C9A57602C9A57602C9A57602 /* SidebarWorkspaceTopDropIndicator.swift */,
 				C9A5720CC9A5720CC9A5720C /* TabItemView+WorkspaceGroups.swift */,
 				C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */,
+				C9A57214C9A57214C9A57214 /* VerticalTabsSidebar+WorkspaceRow.swift */,
 				C9A57204C9A57204C9A57204 /* WorkspaceGroupMenuSnapshot.swift */,
 				C9A57205C9A57205C9A57205 /* WorkspaceGroupMoveToMenuState.swift */,
 				C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */,
@@ -5084,6 +5087,7 @@
 				B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */,
 				B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */,
 				C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */,
+				C9A57213C9A57213C9A57213 /* VerticalTabsSidebar+WorkspaceRow.swift in Sources */,
 				ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */,
 				ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -953,6 +953,7 @@
 		B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
 		7230AA20DCFC4BE5B7B83608 /* SidebarRowSwipeCaptureNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F672B6831940CC8B902CB6 /* SidebarRowSwipeCaptureNSView.swift */; };
 		554E8D4DA51C451FA8A8102A /* SidebarRowSwipeCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777E3D68E3AF472BBF0EAD64 /* SidebarRowSwipeCaptureView.swift */; };
+		B7A500000000000000000002 /* SidebarRowSwipeDebugRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A500000000000000000001 /* SidebarRowSwipeDebugRegistry.swift */; };
 		EE7DECEED1BA4665AA8ACF79 /* SidebarRowSwipeGestureModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE826BD4DFFA462F922FF6ED /* SidebarRowSwipeGestureModel.swift */; };
 		A83F90BF7F064BB181F9A3BB /* SidebarRowSwipeGestureModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6EBE86096A24430875B06EE /* SidebarRowSwipeGestureModelTests.swift */; };
 		C0DE35010000000000000001 /* SidebarScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35010000000000000002 /* SidebarScrim.swift */; };
@@ -2232,6 +2233,7 @@
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		D2F672B6831940CC8B902CB6 /* SidebarRowSwipeCaptureNSView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarRowSwipeCaptureNSView.swift; sourceTree = "<group>"; };
 		777E3D68E3AF472BBF0EAD64 /* SidebarRowSwipeCaptureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarRowSwipeCaptureView.swift; sourceTree = "<group>"; };
+		B7A500000000000000000001 /* SidebarRowSwipeDebugRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarRowSwipeDebugRegistry.swift; sourceTree = "<group>"; };
 		FE826BD4DFFA462F922FF6ED /* SidebarRowSwipeGestureModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarRowSwipeGestureModel.swift; sourceTree = "<group>"; };
 		A6EBE86096A24430875B06EE /* SidebarRowSwipeGestureModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarRowSwipeGestureModelTests.swift; sourceTree = "<group>"; };
 		C0DE35010000000000000002 /* SidebarScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrim.swift; sourceTree = "<group>"; };
@@ -2891,6 +2893,7 @@
 				243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */,
 				D2F672B6831940CC8B902CB6 /* SidebarRowSwipeCaptureNSView.swift */,
 				777E3D68E3AF472BBF0EAD64 /* SidebarRowSwipeCaptureView.swift */,
+				B7A500000000000000000001 /* SidebarRowSwipeDebugRegistry.swift */,
 				FE826BD4DFFA462F922FF6ED /* SidebarRowSwipeGestureModel.swift */,
 				9D147A4AA674431FAAC60909 /* SidebarSwipeableRow.swift */,
 				D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */,
@@ -4915,6 +4918,7 @@
 				C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */,
 				7230AA20DCFC4BE5B7B83608 /* SidebarRowSwipeCaptureNSView.swift in Sources */,
 				554E8D4DA51C451FA8A8102A /* SidebarRowSwipeCaptureView.swift in Sources */,
+				B7A500000000000000000002 /* SidebarRowSwipeDebugRegistry.swift in Sources */,
 				EE7DECEED1BA4665AA8ACF79 /* SidebarRowSwipeGestureModel.swift in Sources */,
 				C0DE35010000000000000001 /* SidebarScrim.swift in Sources */,
 				E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */,

--- a/cmuxTests/SidebarRowSwipeGestureModelTests.swift
+++ b/cmuxTests/SidebarRowSwipeGestureModelTests.swift
@@ -139,4 +139,104 @@ import Testing
         #expect(nextSwipe.claimed)
         #expect(nextSwipe.offset == 18)
     }
+
+    @Test func commitZoneEngagesAtThreshold() {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let threshold = model.handle(.init(phase: .changed, scrollingDeltaX: 64, scrollingDeltaY: 1))
+
+        #expect(threshold.claimed)
+        #expect(threshold.offset == 64)
+        #expect(threshold.isInCommitZone)
+        #expect(threshold.enteredCommitZone)
+    }
+
+    @Test func commitZoneDoesNotFlickerBetweenDisengageAndCommitThresholds() {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        _ = model.handle(.init(phase: .changed, scrollingDeltaX: 64, scrollingDeltaY: 1))
+        let insideHysteresis = model.handle(.init(phase: .changed, scrollingDeltaX: -2, scrollingDeltaY: 0))
+        let atDisengageThreshold = model.handle(.init(phase: .changed, scrollingDeltaX: -2, scrollingDeltaY: 0))
+        let belowDisengageThreshold = model.handle(.init(phase: .changed, scrollingDeltaX: -0.5, scrollingDeltaY: 0))
+
+        #expect(insideHysteresis.offset == 62)
+        #expect(insideHysteresis.isInCommitZone)
+        #expect(insideHysteresis.enteredCommitZone == false)
+        #expect(atDisengageThreshold.offset == 60)
+        #expect(atDisengageThreshold.isInCommitZone)
+        #expect(atDisengageThreshold.enteredCommitZone == false)
+        #expect(belowDisengageThreshold.offset == 59.5)
+        #expect(belowDisengageThreshold.isInCommitZone == false)
+        #expect(belowDisengageThreshold.enteredCommitZone == false)
+    }
+
+    @Test func enteredCommitZoneFiresOncePerEntry() {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let firstEntry = model.handle(.init(phase: .changed, scrollingDeltaX: 64, scrollingDeltaY: 1))
+        let stillInZone = model.handle(.init(phase: .changed, scrollingDeltaX: 6, scrollingDeltaY: 0))
+        let exitZone = model.handle(.init(phase: .changed, scrollingDeltaX: -11, scrollingDeltaY: 0))
+        let secondEntry = model.handle(.init(phase: .changed, scrollingDeltaX: 5, scrollingDeltaY: 0))
+
+        #expect(firstEntry.isInCommitZone)
+        #expect(firstEntry.enteredCommitZone)
+        #expect(stillInZone.isInCommitZone)
+        #expect(stillInZone.enteredCommitZone == false)
+        #expect(exitZone.offset == 59)
+        #expect(exitZone.isInCommitZone == false)
+        #expect(exitZone.enteredCommitZone == false)
+        #expect(secondEntry.offset == 64)
+        #expect(secondEntry.isInCommitZone)
+        #expect(secondEntry.enteredCommitZone)
+    }
+
+    @Test func commitZoneEntryResetsAcrossGestures() {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let firstEntry = model.handle(.init(phase: .changed, scrollingDeltaX: 64, scrollingDeltaY: 1))
+        let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let secondEntry = model.handle(.init(phase: .changed, scrollingDeltaX: 64, scrollingDeltaY: 1))
+
+        #expect(firstEntry.enteredCommitZone)
+        #expect(release.isInCommitZone == false)
+        #expect(release.enteredCommitZone == false)
+        #expect(secondEntry.enteredCommitZone)
+    }
+
+    @Test func narrowSidebarDisablesLeadingActionOnly() {
+        var narrowLeadingModel = SidebarRowSwipeGestureModel()
+        var narrowTrailingModel = SidebarRowSwipeGestureModel()
+        var wideLeadingModel = SidebarRowSwipeGestureModel()
+
+        let narrowLeading = narrowLeadingModel.handle(.init(
+            phase: .began,
+            scrollingDeltaX: 20,
+            scrollingDeltaY: 0,
+            containerWidth: 120
+        ))
+        let narrowTrailing = narrowTrailingModel.handle(.init(
+            phase: .began,
+            scrollingDeltaX: -20,
+            scrollingDeltaY: 0,
+            containerWidth: 120
+        ))
+        let wideLeading = wideLeadingModel.handle(.init(
+            phase: .began,
+            scrollingDeltaX: 20,
+            scrollingDeltaY: 0,
+            containerWidth: 200
+        ))
+
+        #expect(narrowLeading.claimed == false)
+        #expect(narrowLeading.offset == 0)
+        #expect(narrowTrailing.claimed)
+        #expect(narrowTrailing.offset == -20)
+        #expect(wideLeading.claimed)
+        #expect(wideLeading.offset == 20)
+    }
 }

--- a/cmuxTests/SidebarRowSwipeGestureModelTests.swift
+++ b/cmuxTests/SidebarRowSwipeGestureModelTests.swift
@@ -8,32 +8,50 @@ import Testing
 #endif
 
 @Suite struct SidebarRowSwipeGestureModelTests {
-    @Test func verticalDominantGestureAtBeganIsNotClaimed() {
+    @Test func verticalDominantGestureAfterZeroDeltaBeganIsNotClaimed() {
         var model = SidebarRowSwipeGestureModel()
 
-        let result = model.handle(.init(phase: .began, scrollingDeltaX: 8, scrollingDeltaY: 12))
+        let began = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let changed = model.handle(.init(phase: .changed, scrollingDeltaX: 8, scrollingDeltaY: 12))
+        let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
 
-        #expect(result.claimed == false)
-        #expect(result.offset == 0)
-        #expect(result.commit == nil)
+        #expect(began.claimed == false)
+        #expect(began.offset == 0)
+        #expect(changed.claimed == false)
+        #expect(changed.offset == 0)
+        #expect(changed.commit == nil)
+        #expect(release.claimed == false)
     }
 
-    @Test func horizontalDominantGestureIsClaimedAndTracksAccumulatedDeltaX() {
+    @Test func horizontalDominantGestureAfterZeroDeltaBeganTracksAccumulatedDeltaX() {
+        var model = SidebarRowSwipeGestureModel()
+
+        let began = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let firstChanged = model.handle(.init(phase: .changed, scrollingDeltaX: 18, scrollingDeltaY: 4))
+        let changed = model.handle(.init(phase: .changed, scrollingDeltaX: 22, scrollingDeltaY: 3))
+
+        #expect(began.claimed == false)
+        #expect(firstChanged.claimed)
+        #expect(firstChanged.offset == 18)
+        #expect(changed.claimed)
+        #expect(changed.offset == 40)
+    }
+
+    @Test func nonzeroDeltaBeganStillClaimsHorizontalGesture() {
         var model = SidebarRowSwipeGestureModel()
 
         let began = model.handle(.init(phase: .began, scrollingDeltaX: 18, scrollingDeltaY: 4))
-        let changed = model.handle(.init(phase: .changed, scrollingDeltaX: 22, scrollingDeltaY: 3))
 
         #expect(began.claimed)
         #expect(began.offset == 18)
-        #expect(changed.claimed)
-        #expect(changed.offset == 40)
+        #expect(began.commit == nil)
     }
 
     @Test func directionLockPreventsSwitchingSidesWithinOneGesture() {
         var model = SidebarRowSwipeGestureModel()
 
-        _ = model.handle(.init(phase: .began, scrollingDeltaX: 36, scrollingDeltaY: 2))
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        _ = model.handle(.init(phase: .changed, scrollingDeltaX: 36, scrollingDeltaY: 2))
         let reversed = model.handle(.init(phase: .changed, scrollingDeltaX: -90, scrollingDeltaY: 1))
         let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
 
@@ -46,7 +64,8 @@ import Testing
     @Test func releaseBelowThresholdSnapsBackWithoutCommit() {
         var model = SidebarRowSwipeGestureModel()
 
-        _ = model.handle(.init(phase: .began, scrollingDeltaX: 28, scrollingDeltaY: 2))
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        _ = model.handle(.init(phase: .changed, scrollingDeltaX: 28, scrollingDeltaY: 2))
         _ = model.handle(.init(phase: .changed, scrollingDeltaX: 20, scrollingDeltaY: 0))
         let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
 
@@ -66,7 +85,8 @@ import Testing
     ) {
         var model = SidebarRowSwipeGestureModel()
 
-        _ = model.handle(.init(phase: .began, scrollingDeltaX: deltaX, scrollingDeltaY: 1))
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        _ = model.handle(.init(phase: .changed, scrollingDeltaX: deltaX, scrollingDeltaY: 1))
         let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
 
         #expect(release.claimed)
@@ -78,7 +98,8 @@ import Testing
     @Test func momentumAfterEndIsIgnoredWithoutReopeningRow() {
         var model = SidebarRowSwipeGestureModel()
 
-        _ = model.handle(.init(phase: .began, scrollingDeltaX: 70, scrollingDeltaY: 2))
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        _ = model.handle(.init(phase: .changed, scrollingDeltaX: 70, scrollingDeltaY: 2))
         let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
         let momentum = model.handle(.init(phase: .momentum, scrollingDeltaX: 80, scrollingDeltaY: 0))
 
@@ -93,7 +114,8 @@ import Testing
         let configuration = SidebarRowSwipeGestureModel.Configuration()
         var model = SidebarRowSwipeGestureModel(configuration: configuration)
 
-        let result = model.handle(.init(phase: .began, scrollingDeltaX: 260, scrollingDeltaY: 4))
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let result = model.handle(.init(phase: .changed, scrollingDeltaX: 260, scrollingDeltaY: 4))
         let maximumRubberBandedOffset = configuration.maxRevealDistance +
             configuration.maxRevealDistance * configuration.rubberBandExtraLimitFraction
 
@@ -101,5 +123,20 @@ import Testing
         #expect(result.offset > configuration.maxRevealDistance)
         #expect(result.offset < 260)
         #expect(result.offset == maximumRubberBandedOffset)
+    }
+
+    @Test func endingWhileUndecidedResetsToIdleWithoutClaiming() {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let undecidedRelease = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let nextSwipe = model.handle(.init(phase: .changed, scrollingDeltaX: 18, scrollingDeltaY: 2))
+
+        #expect(undecidedRelease.claimed == false)
+        #expect(undecidedRelease.offset == 0)
+        #expect(undecidedRelease.commit == nil)
+        #expect(nextSwipe.claimed)
+        #expect(nextSwipe.offset == 18)
     }
 }

--- a/cmuxTests/SidebarRowSwipeGestureModelTests.swift
+++ b/cmuxTests/SidebarRowSwipeGestureModelTests.swift
@@ -110,6 +110,50 @@ import Testing
         #expect(momentum.shouldAnimateOffset == false)
     }
 
+    @Test func phaselessWheelEventsAfterSwipeAreForwardedAndResetMomentumSuppression() {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        _ = model.handle(.init(phase: .changed, scrollingDeltaX: 70, scrollingDeltaY: 2))
+        let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let firstWheel = model.handle(.init(phase: .changed, scrollingDeltaX: 0, scrollingDeltaY: 18))
+        let secondWheel = model.handle(.init(phase: .changed, scrollingDeltaX: 0, scrollingDeltaY: 24))
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let freshSwipe = model.handle(.init(phase: .changed, scrollingDeltaX: 18, scrollingDeltaY: 1))
+
+        #expect(release.claimed)
+        #expect(release.commit == .leading)
+        #expect(firstWheel.claimed == false)
+        #expect(firstWheel.offset == 0)
+        #expect(firstWheel.commit == nil)
+        #expect(secondWheel.claimed == false)
+        #expect(secondWheel.offset == 0)
+        #expect(secondWheel.commit == nil)
+        #expect(freshSwipe.claimed)
+        #expect(freshSwipe.offset == 18)
+    }
+
+    @Test func momentumEventsAfterSwipeRemainSuppressed() {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        _ = model.handle(.init(phase: .changed, scrollingDeltaX: 70, scrollingDeltaY: 2))
+        let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let firstMomentum = model.handle(.init(phase: .momentum, scrollingDeltaX: 80, scrollingDeltaY: 0))
+        let secondMomentum = model.handle(.init(phase: .momentum, scrollingDeltaX: 40, scrollingDeltaY: 0))
+
+        #expect(release.claimed)
+        #expect(release.commit == .leading)
+        #expect(firstMomentum.claimed)
+        #expect(firstMomentum.offset == 0)
+        #expect(firstMomentum.commit == nil)
+        #expect(firstMomentum.shouldAnimateOffset == false)
+        #expect(secondMomentum.claimed)
+        #expect(secondMomentum.offset == 0)
+        #expect(secondMomentum.commit == nil)
+        #expect(secondMomentum.shouldAnimateOffset == false)
+    }
+
     @Test func rubberBandDampingCapsOffsetGrowthBeyondMaxReveal() {
         let configuration = SidebarRowSwipeGestureModel.Configuration()
         var model = SidebarRowSwipeGestureModel(configuration: configuration)

--- a/cmuxTests/SidebarRowSwipeGestureModelTests.swift
+++ b/cmuxTests/SidebarRowSwipeGestureModelTests.swift
@@ -1,0 +1,105 @@
+import CoreGraphics
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct SidebarRowSwipeGestureModelTests {
+    @Test func verticalDominantGestureAtBeganIsNotClaimed() {
+        var model = SidebarRowSwipeGestureModel()
+
+        let result = model.handle(.init(phase: .began, scrollingDeltaX: 8, scrollingDeltaY: 12))
+
+        #expect(result.claimed == false)
+        #expect(result.offset == 0)
+        #expect(result.commit == nil)
+    }
+
+    @Test func horizontalDominantGestureIsClaimedAndTracksAccumulatedDeltaX() {
+        var model = SidebarRowSwipeGestureModel()
+
+        let began = model.handle(.init(phase: .began, scrollingDeltaX: 18, scrollingDeltaY: 4))
+        let changed = model.handle(.init(phase: .changed, scrollingDeltaX: 22, scrollingDeltaY: 3))
+
+        #expect(began.claimed)
+        #expect(began.offset == 18)
+        #expect(changed.claimed)
+        #expect(changed.offset == 40)
+    }
+
+    @Test func directionLockPreventsSwitchingSidesWithinOneGesture() {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 36, scrollingDeltaY: 2))
+        let reversed = model.handle(.init(phase: .changed, scrollingDeltaX: -90, scrollingDeltaY: 1))
+        let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
+
+        #expect(reversed.claimed)
+        #expect(reversed.offset == 0)
+        #expect(release.claimed)
+        #expect(release.commit == nil)
+    }
+
+    @Test func releaseBelowThresholdSnapsBackWithoutCommit() {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 28, scrollingDeltaY: 2))
+        _ = model.handle(.init(phase: .changed, scrollingDeltaX: 20, scrollingDeltaY: 0))
+        let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
+
+        #expect(release.claimed)
+        #expect(release.offset == 0)
+        #expect(release.commit == nil)
+        #expect(release.shouldAnimateOffset)
+    }
+
+    @Test(arguments: [
+        (CGFloat(70), SidebarRowSwipeGestureModel.Action.leading),
+        (CGFloat(-70), SidebarRowSwipeGestureModel.Action.trailing),
+    ])
+    func releaseBeyondThresholdCommitsCorrectActionSide(
+        deltaX: CGFloat,
+        expectedAction: SidebarRowSwipeGestureModel.Action
+    ) {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: deltaX, scrollingDeltaY: 1))
+        let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
+
+        #expect(release.claimed)
+        #expect(release.offset == 0)
+        #expect(release.commit == expectedAction)
+        #expect(release.shouldAnimateOffset)
+    }
+
+    @Test func momentumAfterEndIsIgnoredWithoutReopeningRow() {
+        var model = SidebarRowSwipeGestureModel()
+
+        _ = model.handle(.init(phase: .began, scrollingDeltaX: 70, scrollingDeltaY: 2))
+        let release = model.handle(.init(phase: .ended, scrollingDeltaX: 0, scrollingDeltaY: 0))
+        let momentum = model.handle(.init(phase: .momentum, scrollingDeltaX: 80, scrollingDeltaY: 0))
+
+        #expect(release.commit == .leading)
+        #expect(momentum.claimed)
+        #expect(momentum.offset == 0)
+        #expect(momentum.commit == nil)
+        #expect(momentum.shouldAnimateOffset == false)
+    }
+
+    @Test func rubberBandDampingCapsOffsetGrowthBeyondMaxReveal() {
+        let configuration = SidebarRowSwipeGestureModel.Configuration()
+        var model = SidebarRowSwipeGestureModel(configuration: configuration)
+
+        let result = model.handle(.init(phase: .began, scrollingDeltaX: 260, scrollingDeltaY: 4))
+        let maximumRubberBandedOffset = configuration.maxRevealDistance +
+            configuration.maxRevealDistance * configuration.rubberBandExtraLimitFraction
+
+        #expect(result.claimed)
+        #expect(result.offset > configuration.maxRevealDistance)
+        #expect(result.offset < 260)
+        #expect(result.offset == maximumRubberBandedOffset)
+    }
+}


### PR DESCRIPTION
Two-finger trackpad swipe on a sidebar workspace row now works like Mail: swiping right reveals a blue leading action that toggles the workspace read/unread (envelope icon and label flip with the current state), swiping left reveals a red trailing Delete action that closes the workspace through the existing confirmation path. Releasing past 64pt commits, releasing earlier snaps back; reveal is capped at 96pt with rubber-banding.

The sidebar is a ScrollView+LazyVStack, so native swipeActions is unavailable, and trackpad swipes arrive as horizontal scrollWheel events, not DragGestures. A per-row NSView (SidebarRowSwipeCaptureNSView) claims horizontal-dominant scroll gestures and forwards everything else to the scroll view, so vertical scrolling is untouched. Gesture logic lives in a pure state machine (SidebarRowSwipeGestureModel) with unit tests covering dominance decided on the first nonzero deltas (real trackpads send zero-delta began events), direction locking, commit thresholds, momentum suppression, and rubber-band damping. SidebarSwipeableRow wraps the existing TabItemView without touching its Equatable hot path and receives only value snapshots plus closures per the LazyVStack snapshot-boundary rule. Actions route through the shared entrypoints: notificationStore.markRead/markUnread(forTabId:) and tabManager.closeWorkspaceWithConfirmation(_:).

A DEBUG-only debug.sidebar.simulate_swipe socket verb (reveal-leading/reveal-trailing/commit-leading/commit-trailing/release) drives the same model and callbacks as the trackpad, following the debug.sidebar.simulate_drag precedent; this is what the preflight screenshots below used. Swipe labels are localized (en/ja) under sidebar.workspaceSwipe.*.

Preflight on the tagged build via the debug socket: leading reveal renders the blue Mark as Unread action, commit marks the workspace unread (badge appears), trailing reveal renders the red Delete action, commit closes the workspace, and a second leading commit marks it read again. Raw trackpad event routing needs human dogfood since the socket cannot synthesize HID scroll events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785617717&installation_id=133855650&pr_number=7218&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7218&signature=05b153ebecb9229d596bb979968c8eea9141223c73381a2335c4f62ff39f731e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Mail-style swipe actions to sidebar workspace rows: swipe right to mark read/unread, swipe left to delete. This speeds up triage while preserving smooth vertical scrolling.

- **New Features**
  - Two-finger horizontal swipes on workspace rows reveal actions; vertical scroll remains unchanged; swipe is exclusive to one row; haptic tap on commit-zone entry.
  - Leading action toggles read state; trailing action deletes with confirmation; labels localized (en/ja); delete animates sliding the row out on macOS 14.
  - Gesture engine with 64pt commit, 96pt max reveal, rubber-banding, direction lock, fixed momentum suppression, and commit-zone hysteresis; leading action auto-disables on very narrow sidebars (<128pt).
  - New SidebarSwipeableRow and an AppKit capture view wrap the existing row UI without touching its Equatable path; actions route via notificationStore.markRead/markUnread and tabManager.closeWorkspaceWithConfirmation.
  - Debug-only socket `debug.sidebar.simulate_swipe` (reveal-leading | reveal-trailing | commit-leading | commit-trailing | release) drives the real model and returns committed/offset/released; clearer errors for missing/invalid params and when a row isn’t registered; unit tests added for the gesture model and command dispatch.

- **Bug Fixes**
  - Prevented swipe action fill from bleeding through transparent unselected rows by limiting the fill to the revealed strip; corrected trackpad direction mapping for natural scrolling so rightward finger swipes reveal the leading action.

<sup>Written for commit 7aa89cc90789f955251299f6e73b4564acffc698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added horizontal swipe gestures to sidebar rows, letting you reveal action controls.
  * Added swipe actions to **mark read/unread** and **delete** sidebar items.
  * Wired the swipe interactions into existing sidebar row behavior, including drag/drop and context-menu handling.
  * Added localized labels for the new swipe actions (English and Japanese).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->