### PR TITLE
Detach browser portal on close

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5369,6 +5369,7 @@ final class BrowserPanel: Panel, ObservableObject {
         GlobalSearchCoordinator.shared.purgePanel(id: id)
         closeDeveloperToolsForTeardown()
         unfocus()
+        BrowserWindowPortalRegistry.detach(webView: webView)
         navigationDelegate?.cancelPendingAuthenticationPrompts()
         cancelPendingInteractiveBrowserPrompts(reason: "close", cancelAuthenticationPrompts: false)
         closeBackgroundPreloadHost(reason: "close")


### PR DESCRIPTION
Fixes #7204.

Closing a browser tab while omnibar autocomplete is open could leave the browser portal rendered after the tab was gone.

Root cause: portal cleanup only happened from `BrowserPanel.deinit`. Autocomplete UI callbacks can retain the browser panel/view graph, so `deinit` may not run when the tab is closed.

Fix: detach the browser web view from `BrowserWindowPortalRegistry` during `BrowserPanel.close()`, before the rest of browser teardown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser panel closing behavior so the active page is fully disconnected during teardown, reducing the chance of stale UI or lingering interactions after close.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->