### PR TITLE
refactor(wave1-3): de-singletonize AppDelegate.shared — AppEnvironment, WindowRegistry resolver family, MainWindowRouter, TabManager reach path

### DIFF
--- a/Sources/App/CmuxHelpCommands.swift
+++ b/Sources/App/CmuxHelpCommands.swift
@@ -85,7 +85,7 @@ extension cmuxApp {
             return
         }
 
-        if let targetWindow = AppDelegate.shared?.showMainWindowFromMenuBar() {
+        if let targetWindow = appDelegate.environment.mainWindowRouter.showMainWindowFromMenuBar() {
             FeedbackComposerBridge().openComposer(in: targetWindow)
         }
     }

--- a/Sources/AppDelegate+ClosedItemHistory.swift
+++ b/Sources/AppDelegate+ClosedItemHistory.swift
@@ -177,7 +177,7 @@ extension AppDelegate {
               let windowId = windowId(for: manager) else {
             return
         }
-        _ = focusMainWindow(windowId: windowId)
+        _ = environment.mainWindowRouter.focusMainWindow(windowId: windowId)
     }
 }
 

--- a/Sources/AppDelegate+CmuxSSHURL.swift
+++ b/Sources/AppDelegate+CmuxSSHURL.swift
@@ -320,7 +320,7 @@ extension AppDelegate {
 
         prepareForExplicitOpenIntentAtStartup()
         setActiveMainWindow(window)
-        _ = focusMainWindow(windowId: context.windowId)
+        _ = environment.mainWindowRouter.focusMainWindow(windowId: context.windowId)
         context.tabManager.focusTab(
             workspaceId,
             surfaceId: targetPanelId,

--- a/Sources/AppDelegate+MoveTabToNewWorkspace.swift
+++ b/Sources/AppDelegate+MoveTabToNewWorkspace.swift
@@ -5,44 +5,26 @@ import CmuxWindowing
 @MainActor
 extension AppDelegate {
     func canMoveSurfaceToNewWorkspace(panelId: UUID) -> Bool {
-        guard let source = locateSurface(surfaceId: panelId),
-              let sourceWorkspace = source.tabManager.tabs.first(where: { $0.id == source.workspaceId }),
-              sourceWorkspace.panels[panelId] != nil else {
-            return false
-        }
-        return sourceWorkspace.panels.count > 1
+        environment.mainWindowRouter.canMoveSurfaceToNewWorkspace(panelId: panelId)
     }
 
     func canMoveBonsplitTabToNewWorkspace(tabId: UUID) -> Bool {
-        guard let located = locateBonsplitSurface(tabId: tabId) else { return false }
-        return canMoveSurfaceToNewWorkspace(panelId: located.panelId)
+        environment.mainWindowRouter.canMoveBonsplitTabToNewWorkspace(tabId: tabId)
     }
 
     func canMoveBonsplitTab(tabId: UUID, toWorkspace targetWorkspaceId: UUID) -> Bool {
-        guard let located = locateBonsplitSurface(tabId: tabId),
-              let sourceWorkspace = located.tabManager.tabs.first(where: { $0.id == located.workspaceId }),
-              sourceWorkspace.panels[located.panelId] != nil,
-              let destinationManager = tabManagerFor(tabId: targetWorkspaceId),
-              destinationManager.tabs.contains(where: { $0.id == targetWorkspaceId }) else {
-            return false
-        }
-        return true
+        environment.mainWindowRouter.canMoveBonsplitTab(
+            tabId: tabId,
+            toWorkspace: targetWorkspaceId
+        )
     }
 
     func workspaceMoveTargets(forSurface panelId: UUID) -> [WorkspaceMoveTarget] {
-        guard let source = locateSurface(surfaceId: panelId) else { return [] }
-        return workspaceMoveTargets(
-            excludingWorkspaceId: source.workspaceId,
-            referenceWindowId: source.windowId
-        )
+        environment.mainWindowRouter.workspaceMoveTargets(forSurface: panelId)
     }
 
     func workspaceMoveTargets(forBonsplitTab tabId: UUID) -> [WorkspaceMoveTarget] {
-        guard let located = locateBonsplitSurface(tabId: tabId) else { return [] }
-        return workspaceMoveTargets(
-            excludingWorkspaceId: located.workspaceId,
-            referenceWindowId: located.windowId
-        )
+        environment.mainWindowRouter.workspaceMoveTargets(forBonsplitTab: tabId)
     }
 
     @discardableResult
@@ -55,9 +37,8 @@ extension AppDelegate {
         placementOverride: WorkspacePlacement? = nil,
         insertionIndexOverride: Int? = nil
     ) -> SurfaceNewWorkspaceMoveResult? {
-        guard let located = locateBonsplitSurface(tabId: tabId) else { return nil }
-        return moveSurfaceToNewWorkspace(
-            panelId: located.panelId,
+        environment.mainWindowRouter.moveBonsplitTabToNewWorkspace(
+            tabId: tabId,
             destinationManager: destinationManager,
             title: title,
             focus: focus,
@@ -77,78 +58,14 @@ extension AppDelegate {
         placementOverride: WorkspacePlacement? = nil,
         insertionIndexOverride: Int? = nil
     ) -> SurfaceNewWorkspaceMoveResult? {
-        guard let source = locateSurface(surfaceId: panelId),
-              let sourceWorkspace = source.tabManager.tabs.first(where: { $0.id == source.workspaceId }),
-              let sourcePanel = sourceWorkspace.panels[panelId],
-              sourceWorkspace.panels.count > 1 else {
-            return nil
-        }
-
-        let targetManager = destinationManager ?? source.tabManager
-        let destinationTitle = titleForDetachedWorkspace(
-            explicitTitle: title,
-            workspace: sourceWorkspace,
+        environment.mainWindowRouter.moveSurfaceToNewWorkspace(
             panelId: panelId,
-            panel: sourcePanel
-        )
-        let sourcePane = sourceWorkspace.paneId(forPanelId: panelId)
-        let sourceIndex = sourceWorkspace.indexInPane(forPanelId: panelId)
-        let activationIntent = focusIntentForNewWorkspaceMove(panel: sourcePanel)
-        guard let detached = sourceWorkspace.detachSurface(panelId: panelId) else { return nil }
-
-        guard let destinationWorkspace = targetManager.addWorkspace(
-            fromDetachedSurface: detached,
-            title: destinationTitle,
-            select: false,
+            destinationManager: destinationManager,
+            title: title,
+            focus: focus,
+            focusWindow: focusWindow,
             placementOverride: placementOverride,
-            insertionIndexOverride: insertionIndexOverride,
-            focusIntent: activationIntent
-        ) else {
-            rollbackDetachedSurface(
-                detached,
-                to: sourceWorkspace,
-                sourcePane: sourcePane,
-                sourceIndex: sourceIndex,
-                focus: focus
-            )
-            return nil
-        }
-
-        cleanupEmptySourceWorkspaceAfterSurfaceMove(
-            sourceWorkspace: sourceWorkspace,
-            sourceManager: source.tabManager,
-            sourceWindowId: source.windowId
-        )
-
-        if focus {
-            let destinationWindowId = focusWindow ? windowId(for: targetManager) : nil
-            if let destinationWindowId {
-                _ = focusMainWindow(windowId: destinationWindowId)
-            }
-            targetManager.focusTab(
-                destinationWorkspace.id,
-                surfaceId: panelId,
-                suppressFlash: true,
-                focusIntent: activationIntent
-            )
-            if let destinationWindowId {
-                reassertCrossWindowSurfaceMoveFocusIfNeeded(
-                    destinationWindowId: destinationWindowId,
-                    sourceWindowId: source.windowId,
-                    destinationWorkspaceId: destinationWorkspace.id,
-                    destinationPanelId: panelId,
-                    destinationManager: targetManager
-                )
-            }
-        }
-
-        return SurfaceNewWorkspaceMoveResult(
-            sourceWindowId: source.windowId,
-            sourceWorkspaceId: source.workspaceId,
-            destinationWindowId: windowId(for: targetManager),
-            destinationWorkspaceId: destinationWorkspace.id,
-            surfaceId: panelId,
-            paneId: destinationWorkspace.paneId(forPanelId: panelId)?.id
+            insertionIndexOverride: insertionIndexOverride
         )
     }
 
@@ -157,54 +74,10 @@ extension AppDelegate {
         sourceManager: TabManager,
         sourceWindowId: UUID
     ) {
-        // The branch between leave-alone / close-workspace / close-window is the
-        // windowing-domain ``DetachedSourceWorkspaceCleanupPolicy``; this shim
-        // resolves the app-coupled inputs (live `Workspace`/`TabManager` state)
-        // and applies the chosen effect (which reaches `NSWindow` via
-        // ``closeMainWindow(windowId:recordHistory:)``).
-        let outcome = DetachedSourceWorkspaceCleanupPolicy().outcome(
-            sourceWorkspaceIsEmpty: sourceWorkspace.panels.isEmpty,
-            sourceWorkspaceStillInManager: sourceManager.tabs.contains(where: { $0.id == sourceWorkspace.id }),
-            sourceManagerWorkspaceCount: sourceManager.tabs.count
-        )
-        switch outcome {
-        case .none:
-            return
-        case .closeWorkspace:
-            sourceManager.closeWorkspace(sourceWorkspace, recordHistory: false)
-        case .closeWindow:
-            _ = closeMainWindow(windowId: sourceWindowId, recordHistory: false)
-        }
-    }
-
-    private func focusIntentForNewWorkspaceMove(panel: any Panel) -> PanelFocusIntent {
-        if panel is BrowserPanel {
-            // Moving a browser tab into a standalone workspace should expose browser chrome,
-            // even if web content was the last in-panel responder before the drag.
-            return .browser(.addressBar)
-        }
-        return panel.preferredFocusIntentForActivation()
-    }
-
-    private func titleForDetachedWorkspace(
-        explicitTitle: String?,
-        workspace: Workspace,
-        panelId: UUID,
-        panel: any Panel
-    ) -> String {
-        // The decision (which trimmed candidate wins) is the windowing-domain
-        // ``DetachedWorkspaceTitlePolicy``; this shim resolves the app-coupled
-        // candidate strings (surface title from the `Workspace`/`Panel`) and the
-        // app-bundle localized fallback, then forwards. The fallback MUST be
-        // resolved here in the app bundle so non-English (Japanese) translations
-        // are not dropped.
-        DetachedWorkspaceTitlePolicy().title(
-            explicitTitle: explicitTitle,
-            surfaceTitle: workspace.panelTitle(panelId: panelId) ?? panel.displayTitle,
-            localizedFallback: String(
-                localized: "commandPalette.subtitle.tabFallback",
-                defaultValue: "Tab"
-            )
+        environment.mainWindowRouter.cleanupEmptySourceWorkspaceAfterSurfaceMove(
+            sourceWorkspace: sourceWorkspace,
+            sourceManager: sourceManager,
+            sourceWindowId: sourceWindowId
         )
     }
 }

--- a/Sources/AppDelegate+PaneSurfaceMoveHosting.swift
+++ b/Sources/AppDelegate+PaneSurfaceMoveHosting.swift
@@ -18,7 +18,7 @@ import Foundation
 @MainActor
 extension AppDelegate: PaneSurfaceMoveHosting {
     func resolveSourceLocation(surfaceId: UUID) -> PaneSurfaceMoveSourceLocation? {
-        guard let located = locateSurface(surfaceId: surfaceId) else { return nil }
+        guard let located = windowRegistry.locateSurface(surfaceId: surfaceId) else { return nil }
         return PaneSurfaceMoveSourceLocation(
             windowId: located.windowId,
             workspaceId: located.workspaceId
@@ -166,7 +166,7 @@ extension AppDelegate: PaneSurfaceMoveHosting {
         if plan.focus {
             let destinationWindowId = plan.destinationWindowId
             if let destinationWindowId {
-                _ = focusMainWindow(windowId: destinationWindowId)
+                _ = environment.mainWindowRouter.focusMainWindow(windowId: destinationWindowId)
             }
             destinationManager.focusTab(plan.destinationWorkspaceId, surfaceId: panelId, suppressFlash: true)
             if let destinationWindowId {

--- a/Sources/AppDelegate+RecoverableMainWindowRoutes.swift
+++ b/Sources/AppDelegate+RecoverableMainWindowRoutes.swift
@@ -1,29 +1,6 @@
 import AppKit
 import CmuxTerminalCore
-import CmuxTerminal
 import CmuxWindowing
-
-@MainActor
-final class RecoverableMainWindowRoute {
-    let windowId: UUID
-    weak var tabManager: TabManager?
-    weak var window: NSWindow?
-    let order: UInt64
-
-    init(windowId: UUID, tabManager: TabManager, window: NSWindow?, order: UInt64) {
-        self.windowId = windowId
-        self.tabManager = tabManager
-        self.window = window
-        self.order = order
-    }
-}
-
-@MainActor
-private struct MainWindowRouteSnapshot {
-    let windowId: UUID
-    let tabManager: TabManager
-    let window: NSWindow?
-}
 
 // The retire sweep is the MainWindowRouteRetiring witness: the terminal
 // surface registry (CmuxTerminalEngine) calls it through the seam instead of
@@ -31,307 +8,60 @@ private struct MainWindowRouteSnapshot {
 extension AppDelegate: MainWindowRouteRetiring {}
 
 extension AppDelegate {
-    private func tabManagerHasRegisteredTerminalSurface(_ manager: TabManager) -> Bool {
-        for workspace in manager.tabs {
-            for panel in workspace.panels.values {
-                guard let terminalPanel = panel as? TerminalPanel else { continue }
-                if GhosttyApp.terminalSurfaceRegistry.surface(id: terminalPanel.id) === terminalPanel.surface {
-                    return true
-                }
-            }
-        }
-        return false
-    }
-
-    private func liveRecoverableMainWindow(windowId: UUID, cachedWindow: NSWindow?) -> NSWindow? {
-        cachedWindow ?? windowForMainWindowId(windowId)
-    }
-
-    private func sortedRecoverableMainWindowRoutes() -> [RecoverableMainWindowRoute] {
-        recoverableMainWindowRouteLedger.sortedByMostRecentFirst()
-    }
-
-    private func recoverableMainWindowRouteSnapshot(windowId: UUID) -> MainWindowRouteSnapshot? {
-        guard let route = recoverableMainWindowRouteLedger.route(for: WindowID(windowId)),
-              let manager = route.tabManager,
-              let window = liveRecoverableMainWindow(windowId: route.windowId, cachedWindow: route.window) else {
-            return nil
-        }
-        return MainWindowRouteSnapshot(windowId: route.windowId, tabManager: manager, window: window)
-    }
-
-    private func recoverableMainWindowRouteSnapshots() -> [MainWindowRouteSnapshot] {
-        sortedRecoverableMainWindowRoutes().compactMap { route in
-            guard let manager = route.tabManager,
-                  let window = liveRecoverableMainWindow(windowId: route.windowId, cachedWindow: route.window) else {
-                return nil
-            }
-            return MainWindowRouteSnapshot(windowId: route.windowId, tabManager: manager, window: window)
-        }
-    }
-
-    private func liveRegisteredMainWindowRouteSnapshots() -> [MainWindowRouteSnapshot] {
-        registeredMainWindows.compactMap { context in
-            guard let window = context.window ?? windowForMainWindowId(context.windowId) else { return nil }
-            return MainWindowRouteSnapshot(
-                windowId: context.windowId,
-                tabManager: context.tabManager,
-                window: window
-            )
-        }
-    }
-
     func retireRecoverableMainWindowRoutesWithoutRegisteredTerminalSurfaces(reason: String) {
-        let before = recoverableMainWindowRouteLedger.count
-        recoverableMainWindowRouteLedger.retainRoutes { _, route in
-            guard let manager = route.tabManager else { return false }
-            guard let window = liveRecoverableMainWindow(windowId: route.windowId, cachedWindow: route.window) else { return false }
-            route.window = window
-            return tabManagerHasRegisteredTerminalSurface(manager)
-        }
-        let after = recoverableMainWindowRouteLedger.count
-#if DEBUG
-        if after != before {
-            cmuxDebugLog("recoverableRoute.prune reason=\(reason) removed=\(before - after) remaining=\(after)")
-        }
-#endif
+        windowRegistry.retireRecoverableMainWindowRoutesWithoutRegisteredTerminalSurfaces(reason: reason)
     }
 
     func forgetRecoverableMainWindowRoute(windowId: UUID) {
-        if recoverableMainWindowRouteLedger.remove(WindowID(windowId)) != nil {
-#if DEBUG
-            cmuxDebugLog("recoverableRoute.forget windowId=\(String(windowId.uuidString.prefix(8)))")
-#endif
-        }
+        windowRegistry.forgetRecoverableMainWindowRoute(windowId: windowId)
     }
 
     func rememberRecoverableMainWindowRoute(windowId: UUID, tabManager: TabManager, window: NSWindow?) {
-        guard let window = liveRecoverableMainWindow(windowId: windowId, cachedWindow: window) else { return }
-        guard tabManagerHasRegisteredTerminalSurface(tabManager) else { return }
-        let order = recoverableMainWindowRouteLedger.issueOrder()
-        recoverableMainWindowRouteLedger.setRoute(
-            RecoverableMainWindowRoute(
-                windowId: windowId,
-                tabManager: tabManager,
-                window: window,
-                order: order
-            ),
-            order: order,
-            for: WindowID(windowId)
-        )
-#if DEBUG
-        cmuxDebugLog("recoverableRoute.remember windowId=\(String(windowId.uuidString.prefix(8)))")
-#endif
+        windowRegistry.rememberRecoverableMainWindowRoute(windowId: windowId, tabManager: tabManager, window: window)
     }
 
     func recoverableMainWindowRoute(windowId: UUID) -> RecoverableMainWindowRoute? {
-        guard recoverableMainWindowRouteSnapshot(windowId: windowId) != nil else { return nil }
-        return recoverableMainWindowRouteLedger.route(for: WindowID(windowId))
+        windowRegistry.recoverableMainWindowRoute(windowId: windowId)
     }
 
     func recoverableMainWindowRoutes() -> [RecoverableMainWindowRoute] {
-        let validWindowIds = Set(recoverableMainWindowRouteSnapshots().map(\.windowId))
-        return sortedRecoverableMainWindowRoutes().filter { validWindowIds.contains($0.windowId) }
-    }
-
-    private func mainWindowSummary(from snapshot: MainWindowRouteSnapshot) -> MainWindowSummary {
-        MainWindowSummary(
-            windowId: snapshot.windowId,
-            isKeyWindow: snapshot.window?.isKeyWindow ?? false,
-            isVisible: snapshot.window?.isVisible ?? false,
-            workspaceCount: snapshot.tabManager.tabs.count,
-            selectedWorkspaceId: snapshot.tabManager.selectedTabId
-        )
+        windowRegistry.recoverableMainWindowRoutes()
     }
 
     func listMainWindowSummaries() -> [MainWindowSummary] {
-        var seen: Set<WindowID> = []
-        var summaries: [MainWindowSummary] = []
-        for snapshot in liveRegisteredMainWindowRouteSnapshots() {
-            seen.insert(WindowID(snapshot.windowId))
-            summaries.append(mainWindowSummary(from: snapshot))
-        }
-        recoverableMainWindowRouteLedger.appendingDeduplicatedProjections(into: &summaries, seen: &seen) { route in
-            guard let snapshot = recoverableMainWindowRouteSnapshot(windowId: route.windowId) else { return nil }
-            return (id: WindowID(snapshot.windowId), projection: mainWindowSummary(from: snapshot))
-        }
-        return summaries
+        windowRegistry.listMainWindowSummaries()
     }
 
     func tabManagerFor(windowId: UUID) -> TabManager? {
-        if let snapshot = liveRegisteredMainWindowRouteSnapshots().first(where: { $0.windowId == windowId }) {
-            return snapshot.tabManager
-        }
-        return recoverableMainWindowRouteSnapshot(windowId: windowId)?.tabManager
+        windowRegistry.tabManagerFor(windowId: windowId)
     }
 
     func windowId(for tabManager: TabManager) -> UUID? {
-        if let windowId = registeredMainWindow(forManager: tabManager)?.windowId {
-            return windowId
-        }
-        return recoverableMainWindowRouteSnapshots().first(where: { $0.tabManager === tabManager })?.windowId
+        windowRegistry.windowId(for: tabManager)
     }
 
     func mainWindowContainingWorkspace(_ workspaceId: UUID) -> NSWindow? {
-        for context in registeredMainWindows where context.tabManager.tabs.contains(where: { $0.id == workspaceId }) {
-            if let window = context.window ?? windowForMainWindowId(context.windowId) {
-                return window
-            }
-        }
-        for snapshot in recoverableMainWindowRouteSnapshots() {
-            guard snapshot.tabManager.tabs.contains(where: { $0.id == workspaceId }) else {
-                continue
-            }
-            return snapshot.window
-        }
-        return nil
-    }
-
-    private func scriptableMainWindow(for window: NSWindow) -> ScriptableMainWindowState? {
-        if let context = contextForMainTerminalWindow(window, reindex: false) {
-            return ScriptableMainWindowState(
-                windowId: context.windowId,
-                tabManager: context.tabManager,
-                window: context.window ?? windowForMainWindowId(context.windowId)
-            )
-        }
-
-        if let windowId = mainWindowId(from: window),
-           let snapshot = recoverableMainWindowRouteSnapshot(windowId: windowId) {
-            return ScriptableMainWindowState(
-                windowId: snapshot.windowId,
-                tabManager: snapshot.tabManager,
-                window: snapshot.window
-            )
-        }
-
-        let windowNumber = window.windowNumber
-        guard windowNumber >= 0 else { return nil }
-        for snapshot in recoverableMainWindowRouteSnapshots() {
-            guard let routeWindow = snapshot.window,
-                  routeWindow === window || routeWindow.windowNumber == windowNumber else {
-                continue
-            }
-            return ScriptableMainWindowState(
-                windowId: snapshot.windowId,
-                tabManager: snapshot.tabManager,
-                window: routeWindow
-            )
-        }
-        return nil
-    }
-
-    private func makeOrderedMainWindowResolver() -> OrderedMainWindowResolver {
-        OrderedMainWindowResolver(
-            keyWindow: { NSApp.keyWindow },
-            mainWindow: { NSApp.mainWindow },
-            orderedWindows: { NSApp.orderedWindows }
-        )
+        windowRegistry.mainWindowContainingWorkspace(workspaceId)
     }
 
     func currentScriptableMainWindow() -> ScriptableMainWindowState? {
-        makeOrderedMainWindowResolver().resolve(
-            project: { scriptableMainWindow(for: $0) },
-            fallback: { scriptableMainWindows().first }
-        )
+        windowRegistry.currentScriptableMainWindow()
     }
 
     func scriptableMainWindows() -> [ScriptableMainWindowState] {
-        var results: [ScriptableMainWindowState] = []
-        var seen: Set<WindowID> = []
-
-        for window in NSApp.orderedWindows {
-            guard let state = scriptableMainWindow(for: window) else { continue }
-            guard seen.insert(WindowID(state.windowId)).inserted else { continue }
-            results.append(state)
-        }
-
-        let remaining = liveRegisteredMainWindowRouteSnapshots()
-            .sorted { $0.windowId.uuidString < $1.windowId.uuidString }
-            .filter { seen.insert(WindowID($0.windowId)).inserted }
-
-        for snapshot in remaining {
-            results.append(
-                ScriptableMainWindowState(
-                    windowId: snapshot.windowId,
-                    tabManager: snapshot.tabManager,
-                    window: snapshot.window
-                )
-            )
-        }
-
-        recoverableMainWindowRouteLedger.appendingDeduplicatedProjections(into: &results, seen: &seen) { route in
-            guard let snapshot = recoverableMainWindowRouteSnapshot(windowId: route.windowId) else { return nil }
-            return (
-                id: WindowID(snapshot.windowId),
-                projection: ScriptableMainWindowState(
-                    windowId: snapshot.windowId,
-                    tabManager: snapshot.tabManager,
-                    window: snapshot.window
-                )
-            )
-        }
-
-        return results
+        windowRegistry.scriptableMainWindows()
     }
 
     func scriptableMainWindow(windowId: UUID) -> ScriptableMainWindowState? {
-        if let context = registeredMainWindow(forWindowId: windowId),
-           let window = context.window ?? windowForMainWindowId(context.windowId) {
-            return ScriptableMainWindowState(
-                windowId: context.windowId,
-                tabManager: context.tabManager,
-                window: window
-            )
-        }
-        guard let snapshot = recoverableMainWindowRouteSnapshot(windowId: windowId) else { return nil }
-        return ScriptableMainWindowState(
-            windowId: snapshot.windowId,
-            tabManager: snapshot.tabManager,
-            window: snapshot.window
-        )
+        windowRegistry.scriptableMainWindow(windowId: windowId)
     }
 
     func scriptableMainWindowForTab(_ tabId: UUID) -> ScriptableMainWindowState? {
-        if let context = contextContainingTabId(tabId) {
-            guard let window = context.window ?? windowForMainWindowId(context.windowId) else { return nil }
-            return ScriptableMainWindowState(
-                windowId: context.windowId,
-                tabManager: context.tabManager,
-                window: window
-            )
-        }
-        for snapshot in recoverableMainWindowRouteSnapshots() {
-            guard snapshot.tabManager.tabs.contains(where: { $0.id == tabId }) else {
-                continue
-            }
-            return ScriptableMainWindowState(
-                windowId: snapshot.windowId,
-                tabManager: snapshot.tabManager,
-                window: snapshot.window
-            )
-        }
-        return nil
-    }
-
-    func contextContainingTabId(_ tabId: UUID) -> RegisteredMainWindow? {
-        for context in registeredMainWindows {
-            if context.tabManager.tabs.contains(where: { $0.id == tabId }) {
-                return context
-            }
-        }
-        return nil
+        windowRegistry.scriptableMainWindowForTab(tabId)
     }
 
     /// Returns the `TabManager` that owns `tabId`, if any.
     func tabManagerFor(tabId: UUID) -> TabManager? {
-        if let manager = contextContainingTabId(tabId)?.tabManager {
-            return manager
-        }
-        return recoverableMainWindowRoutes()
-            .compactMap(\.tabManager)
-            .first { manager in
-                manager.tabs.contains(where: { $0.id == tabId })
-            }
+        windowRegistry.tabManagerFor(tabId: tabId)
     }
 }

--- a/Sources/AppDelegate+ShortcutRoutingWindow.swift
+++ b/Sources/AppDelegate+ShortcutRoutingWindow.swift
@@ -35,22 +35,7 @@ extension AppDelegate {
     }
 
     func activeTabManagerForCommands(preferredWindow: NSWindow? = nil) -> TabManager? {
-        if let context = contextForMainWindow(preferredWindow) {
-            return context.tabManager
-        }
-        if let context = contextForMainWindow(shortcutRoutingKeyWindow) {
-            return context.tabManager
-        }
-        if let context = contextForMainWindow(NSApp.mainWindow) {
-            return context.tabManager
-        }
-        if let activeManager = tabManager,
-           let activeContext = liveMainWindowContext(for: activeManager) {
-            return activeContext.tabManager
-        }
-        return registeredMainWindows.first { context in
-            resolvedWindow(for: context) != nil
-        }?.tabManager
+        environment.mainWindowRouter.activeTabManagerForCommands(preferredWindow: preferredWindow)
     }
 
     func repairFocusedTerminalKeyboardRoutingIfNeeded(
@@ -70,12 +55,4 @@ extension AppDelegate {
         )
     }
 
-    private func liveMainWindowContext(for tabManager: TabManager) -> RegisteredMainWindow? {
-        for context in Array(registeredMainWindows) where context.tabManager === tabManager {
-            if resolvedWindow(for: context) != nil {
-                return context
-            }
-        }
-        return nil
-    }
 }

--- a/Sources/AppDelegate+WindowIdentity.swift
+++ b/Sources/AppDelegate+WindowIdentity.swift
@@ -6,7 +6,7 @@ import Foundation
 @MainActor
 extension AppDelegate {
     func mainWindow(for windowId: UUID) -> NSWindow? {
-        windowForMainWindowId(windowId)
+        windowRegistry.mainWindow(for: windowId)
     }
 
     func windowForMainWindowId(_ windowId: UUID) -> NSWindow? {

--- a/Sources/AppDelegate+WorkspaceCreationActionHosting.swift
+++ b/Sources/AppDelegate+WorkspaceCreationActionHosting.swift
@@ -209,7 +209,7 @@ extension AppDelegate: WorkspaceCreationActionHosting {
         in windowToken: WindowID,
         anchorCwd: String?
     ) -> WorkspaceGroupNewPlacement? {
-        windowConfigStores.model(for: windowToken)?
+        windowContext(for: windowToken)?.configStore?
             .resolveWorkspaceGroupConfig(forCwd: anchorCwd)?
             .newWorkspacePlacement
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -253,12 +253,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// `MainWindowContext` *class* — a stored per-window aggregate fusing tabs,
     /// sidebar, focus, file-explorer, config and `NSWindow` — is REJECTED). The
     /// last live per-window fields it still held (`tabManager`,
-    /// `keyboardFocusCoordinator`, and the `NSWindow` handle) now live in their
-    /// own `WindowID`-keyed homes: ``windowTabManagers``,
-    /// ``windowFocusControllers``, and ``windowCoordinator`` respectively. The
-    /// other slices were drained in stages 1-3 (``windowSidebarStates``,
-    /// ``windowSidebarSelectionStates``, ``windowFileExplorerStates``,
-    /// ``windowConfigStores``).
+    /// `keyboardFocusCoordinator`, the `NSWindow` handle, and the sidebar /
+    /// sidebar-selection / file-explorer / config slices) now live in one
+    /// ``WindowContext`` per window, indexed by ``windowRegistry`` and held
+    /// (weakly) by the per-window `MainWindowController`; the `NSWindow` handle
+    /// stays in ``windowCoordinator``.
     ///
     /// `RegisteredMainWindow` is NOT stored anywhere and owns no state: it is a
     /// value snapshot built on demand by the resolver methods
@@ -295,6 +294,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private final class MainWindowController: NSWindowController, NSWindowDelegate {
         var onClose: (() -> Void)?
         var shouldClose: (() -> Bool)?
+
+        /// This window's per-window state. Held weakly: the strong owner is
+        /// ``AppDelegate/windowRegistry`` (exactly replacing the old per-slice
+        /// dictionaries' strong ownership), so the context's lifetime is
+        /// unchanged and the controller only expresses the per-window
+        /// association. Set after `registerMainWindow` seeds the context.
+        weak var windowContext: WindowContext?
 
         #if DEBUG
         private func logWindowEvent(_ event: String, notification: Notification) {
@@ -912,25 +918,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 #endif
 
-    /// Per-window `TabManager` handles, keyed by ``WindowID`` (the second-to-last
-    /// domain peeled out of the rejected `MainWindowContext` aggregate; owner
-    /// ruling 2026-06-18: per-window state is domain-owned and `WindowID`-keyed).
-    /// The handle stays app-target window-owned (the task scope note): the
-    /// `TabManager` lifecycle is the per-window tabs domain's, but the
-    /// window→manager association is window identity, owned here next to
-    /// ``windowCoordinator``. Mirrors ``windowConfigStores``: a passive
-    /// dictionary whose slice is seeded at `registerMainWindow` and dropped by
-    /// the window teardown paths (`unregisterMainWindowContext` /
-    /// `discardOrphanedMainWindowContext`), which run for every closing window.
-    let windowTabManagers = WindowScopedStore<TabManager>()
+    /// The single `WindowID`→``WindowContext`` index that replaces the six
+    /// parallel `WindowScopedStore<…>` dictionaries this delegate used to hold
+    /// (`windowTabManagers`, `windowFocusControllers`, `windowConfigStores`,
+    /// `windowSidebarSelectionStates`, `windowSidebarStates`,
+    /// `windowFileExplorerStates`). Each main `NSWindow` now has one
+    /// ``WindowContext`` holding all six slices; this registry is the single
+    /// strong owner + lookup the window-lifecycle seam and the per-window
+    /// config/sidebar/file-explorer accessors resolve through. The cross-window
+    /// resolver family (`tabManagerFor`, `locateSurface`, …) is unchanged: it
+    /// iterates `registeredMainWindows` (funnelling through
+    /// `resolveRegisteredWindow`, which reads this registry) plus the
+    /// `recoverableMainWindowRoutes()` pass. A passive index: it does NOT
+    /// subscribe to the single-consumer `windowCoordinator.windowClosed` stream;
+    /// slice removal is driven by the one `removeWindowModelSlices` teardown
+    /// funnel.
+    let windowRegistry = WindowRegistry()
 
-    /// Per-window keyboard-focus coordinators, keyed by ``WindowID`` (the LAST
-    /// domain peeled out of the rejected `MainWindowContext` aggregate; owner
-    /// ruling 2026-06-18). `MainWindowFocusController` owns the per-window
-    /// keyboard-focus/right-sidebar-mode state; it lives in the windowing focus
-    /// domain. Mirrors ``windowTabManagers`` exactly: seeded at
-    /// `registerMainWindow`, dropped by the window teardown paths.
-    let windowFocusControllers = WindowScopedStore<MainWindowFocusController>()
+    /// The ``WindowContext`` for `id`, or `nil` if no window is registered under
+    /// `id`. The single forwarder the seam methods and config/sidebar accessors
+    /// resolve their per-window slices through.
+    func windowContext(for id: WindowID) -> WindowContext? {
+        windowRegistry.context(for: id)
+    }
 
     private var mainWindowControllers: [MainWindowController] = []
 
@@ -989,29 +999,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     /// Builds the ephemeral ``RegisteredMainWindow`` resolved value for `id`, or
     /// `nil` if no window is registered under `id`. The god-type leaf the
-    /// coordinator's resolvers funnel through: it reads the per-domain stores
-    /// (``windowTabManagers`` / ``windowFocusControllers``) and resolves the live
-    /// `NSWindow` through ``windowCoordinator`` then the identifier fallback,
-    /// reproducing the old class's `window ?? windowForMainWindowId(windowId)`
-    /// read.
+    /// coordinator's resolvers funnel through: it reads the window's
+    /// ``WindowContext`` (`tabManager` + `focusController`) from
+    /// ``windowRegistry`` and resolves the live `NSWindow` through
+    /// ``windowCoordinator`` then the identifier fallback, reproducing the old
+    /// class's `window ?? windowForMainWindowId(windowId)` read. (A context only
+    /// exists once both tab manager and focus controller are seeded together, so
+    /// `context != nil` is exactly the old "both slices present" guard.)
     func resolveRegisteredWindow(for id: WindowID) -> RegisteredMainWindow? {
-        guard
-            let tabManager = windowTabManagers.model(for: id),
-            let focusController = windowFocusControllers.model(for: id)
-        else { return nil }
+        guard let context = windowRegistry.context(for: id) else { return nil }
         let window = windowCoordinator.window(for: id) ?? windowForMainWindowId(id.rawValue)
         return RegisteredMainWindow(
             windowId: id.rawValue,
-            tabManager: tabManager,
-            keyboardFocusCoordinator: focusController,
+            tabManager: context.tabManager,
+            keyboardFocusCoordinator: context.focusController,
             window: window
         )
     }
 
     /// The ``WindowID``s currently registered, in no guaranteed order (the
-    /// ``windowTabManagers`` id set). Backs the coordinator's `registeredWindows`.
+    /// ``windowRegistry`` id set). Backs the coordinator's `registeredWindows`.
     var registeredWindowIds: [WindowID] {
-        windowTabManagers.ids
+        windowRegistry.ids
     }
 
     /// The live `NSWindow` bound to `registeredWindow`, for the coordinator's
@@ -1020,31 +1029,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         registeredWindow.window
     }
 
-    /// Binds `tabManager` to `id` in ``windowTabManagers``, returning the
+    /// Rebinds `tabManager` on the window's ``WindowContext``, returning the
     /// `ObjectIdentifier` of the distinct manager previously bound to `id` (for
     /// the coordinator's stale reverse-index drop), or `nil`. Faithfully preserves
-    /// the old `previous !== tabManager` guard.
+    /// the old `previous !== tabManager` guard. Always called right after a
+    /// seed/rebind, so the context exists; the `else` never triggers.
     func rebindTabManagerSlice(_ tabManager: TabManager, for id: WindowID) -> ObjectIdentifier? {
-        let previous = windowTabManagers.model(for: id)
-        windowTabManagers.setModel(tabManager, for: id)
-        if let previous, previous !== tabManager {
+        guard let context = windowRegistry.context(for: id) else { return nil }
+        let previous = context.tabManager
+        context.tabManager = tabManager
+        if previous !== tabManager {
             return ObjectIdentifier(previous)
         }
         return nil
     }
 
-    /// Drops every per-window slice for `id` across the app-side domain stores,
+    /// Drops the window's ``WindowContext`` for `id` (and with it all six slices),
     /// returning the removed tab manager and focus controller, or `nil` if nothing
     /// was registered under `id`. Faithfully reproduces the old per-store
     /// `remove(_:)` calls; the reverse-index drop now lives on the coordinator.
     func removeWindowModelSlices(for id: WindowID) -> (tabManager: TabManager, focusController: MainWindowFocusController?)? {
-        guard let tabManager = windowTabManagers.remove(id) else { return nil }
-        let focusController = windowFocusControllers.remove(id)
-        windowConfigStores.remove(id)
-        windowSidebarSelectionStates.remove(id)
-        windowSidebarStates.remove(id)
-        windowFileExplorerStates.remove(id)
-        return (tabManager, focusController)
+        guard let context = windowRegistry.removeContext(for: id) else { return nil }
+        return (context.tabManager, context.focusController)
     }
 
     /// The window id carried by `registeredWindow`. Lets the coordinator key
@@ -1072,10 +1078,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     // MARK: - WindowLifecycleHosting registration ingest seam
 
-    /// Whether a tab-manager slice is registered under `id`. Backs the
-    /// coordinator's rebind-vs-seed branch decision.
+    /// Whether a window is registered under `id`. Backs the coordinator's
+    /// rebind-vs-seed branch decision. A context exists iff the tab manager was
+    /// seeded, so this is exactly the old `windowTabManagers` membership check.
     func isMainWindowRegistered(_ id: WindowID) -> Bool {
-        windowTabManagers.model(for: id) != nil
+        windowRegistry.context(for: id) != nil
     }
 
     /// Re-points the existing live window registered under `existingId` when a
@@ -1095,13 +1102,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 "existing={\(debugWindowToken(existingWindow))} duplicate={\(debugWindowToken(duplicate))}"
         )
 #endif
-        if let existingManager = windowTabManagers.model(for: existingId) {
+        if let context = windowRegistry.context(for: existingId) {
+            let existingManager = context.tabManager
             existingManager.window = existingWindow
             existingManager.windowId = windowId
-            windowFocusControllers.model(for: existingId)?.update(
+            context.focusController.update(
                 window: existingWindow,
                 tabManager: existingManager,
-                fileExplorerState: windowFileExplorerStates.model(for: existingId)
+                fileExplorerState: context.fileExplorerState
             )
         }
     }
@@ -1119,17 +1127,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     ) {
         tabManager.window = window
         tabManager.windowId = resolvedId.rawValue
-        let resolvedFileExplorerState = slices.fileExplorerState ?? windowFileExplorerStates.model(for: resolvedId)
+        // The coordinator only takes the rebind branch when the window is already
+        // registered, so the context exists. Note the tab-manager rebind on the
+        // context itself happens in `rebindTabManagerSlice`, called right after;
+        // the focus-controller update below uses the new `tabManager` param, not
+        // `context.tabManager` (which is still the old manager here), exactly as
+        // before.
+        guard let context = windowRegistry.context(for: resolvedId) else { return }
+        let resolvedFileExplorerState = slices.fileExplorerState ?? context.fileExplorerState
         if let fileExplorerState = slices.fileExplorerState {
-            windowFileExplorerStates.setModel(fileExplorerState, for: resolvedId)
+            context.fileExplorerState = fileExplorerState
         }
-        windowFocusControllers.model(for: resolvedId)?.update(
+        context.focusController.update(
             window: window,
             tabManager: tabManager,
             fileExplorerState: resolvedFileExplorerState
         )
         if let cmuxConfigStore = slices.cmuxConfigStore {
-            windowConfigStores.setModel(cmuxConfigStore, for: resolvedId)
+            context.configStore = cmuxConfigStore
         }
     }
 
@@ -1154,15 +1169,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             fileExplorerState: slices.fileExplorerState,
             surfaceFocusResolver: AppTerminalSurfaceFocusResolver()
         )
-        windowFocusControllers.setModel(focusController, for: newId)
-        windowSidebarStates.setModel(slices.sidebarState, for: newId)
-        windowSidebarSelectionStates.setModel(slices.sidebarSelectionState, for: newId)
-        if let fileExplorerState = slices.fileExplorerState {
-            windowFileExplorerStates.setModel(fileExplorerState, for: newId)
-        }
-        if let cmuxConfigStore = slices.cmuxConfigStore {
-            windowConfigStores.setModel(cmuxConfigStore, for: newId)
-        }
+        windowRegistry.setContext(
+            WindowContext(
+                windowId: newId,
+                tabManager: tabManager,
+                focusController: focusController,
+                sidebarState: slices.sidebarState,
+                sidebarSelectionState: slices.sidebarSelectionState,
+                fileExplorerState: slices.fileExplorerState,
+                configStore: slices.cmuxConfigStore
+            ),
+            for: newId
+        )
     }
 
     /// Registers `windowId` with the command-palette presentation coordinator.
@@ -1228,24 +1246,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         slices: MainWindowRegistrationSlices
     ) {
         tabManager.windowId = windowId
-        windowFocusControllers.setModel(
-            MainWindowFocusController(
-                windowId: windowId,
-                window: nil,
+        let focusController = MainWindowFocusController(
+            windowId: windowId,
+            window: nil,
+            tabManager: tabManager,
+            fileExplorerState: slices.fileExplorerState,
+            surfaceFocusResolver: AppTerminalSurfaceFocusResolver()
+        )
+        windowRegistry.setContext(
+            WindowContext(
+                windowId: testId,
                 tabManager: tabManager,
+                focusController: focusController,
+                sidebarState: slices.sidebarState,
+                sidebarSelectionState: slices.sidebarSelectionState,
                 fileExplorerState: slices.fileExplorerState,
-                surfaceFocusResolver: AppTerminalSurfaceFocusResolver()
+                configStore: slices.cmuxConfigStore
             ),
             for: testId
         )
-        windowSidebarStates.setModel(slices.sidebarState, for: testId)
-        windowSidebarSelectionStates.setModel(slices.sidebarSelectionState, for: testId)
-        if let fileExplorerState = slices.fileExplorerState {
-            windowFileExplorerStates.setModel(fileExplorerState, for: testId)
-        }
-        if let cmuxConfigStore = slices.cmuxConfigStore {
-            windowConfigStores.setModel(cmuxConfigStore, for: testId)
-        }
     }
 #endif
 
@@ -1281,94 +1300,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// window/tab/surface state.
     let recoverableMainWindowRouteLedger = RecoverableWindowRouteLedger<RecoverableMainWindowRoute>()
 
-    /// Per-window config stores, keyed by ``WindowID`` (first domain peeled out
-    /// of the rejected `MainWindowContext` aggregate; owner ruling 2026-06-18).
-    /// A passive dictionary: its slice is dropped by the window teardown paths
-    /// (`unregisterMainWindowContext` / `discardOrphanedMainWindowContext`),
-    /// reached for every closing window. It deliberately does NOT subscribe to
-    /// the single-consumer `windowCoordinator.windowClosed` stream (whose sole
-    /// consumer is `WindowLifecycleCoordinator.observeWindowCoordinatorClosures()`),
-    /// which would split close events with the teardown loop and starve it.
-    let windowConfigStores = WindowScopedStore<CmuxConfigStore>()
+    /// The per-window ``SidebarSelectionState`` for `context`, resolved through
+    /// the window's ``WindowContext`` in ``windowRegistry``. `registerMainWindow`
+    /// always seeds the slice before the context is reachable, so a live context
+    /// always has one; the empty-state fallback only guards an already-torn-down
+    /// context (whose ``WindowContext`` has been dropped) and preserves the
+    /// never-`nil` invariant the lifted `let` field had.
+    func sidebarSelectionState(for context: RegisteredMainWindow) -> SidebarSelectionState {
+        if let wctx = windowRegistry.context(for: WindowID(context.windowId)) {
+            return wctx.sidebarSelectionState
+        }
+        return SidebarSelectionState()
+    }
 
-    /// Per-window sidebar-selection states, keyed by ``WindowID`` (peeled out of
-    /// the rejected `MainWindowContext` aggregate; owner ruling 2026-06-18:
-    /// per-window state is domain-owned and `WindowID`-keyed, never bundled into
-    /// one per-window aggregate). Mirrors ``windowConfigStores`` exactly: a
-    /// passive dictionary whose slice is set at `registerMainWindow` and dropped
-    /// by the window teardown paths (`unregisterMainWindowContext` /
-    /// `discardOrphanedMainWindowContext`), which run for every closing window.
-    /// It deliberately does NOT subscribe to the single-consumer
-    /// `windowCoordinator.windowClosed` stream, which would split close events
-    /// with the teardown loop and starve it.
-    let windowSidebarSelectionStates = WindowScopedStore<SidebarSelectionState>()
-
-    /// The per-window ``SidebarSelectionState`` for `context`, resolved by
-    /// ``WindowID`` through ``windowSidebarSelectionStates``. `registerMainWindow`
+    /// The per-window ``SidebarState`` for `context`, resolved through the
+    /// window's ``WindowContext`` in ``windowRegistry``. `registerMainWindow`
     /// always seeds the slice before the context is reachable, so a live context
     /// always has one; the empty-state fallback only guards an already-torn-down
     /// context and preserves the never-`nil` invariant the lifted `let` field had.
-    func sidebarSelectionState(for context: RegisteredMainWindow) -> SidebarSelectionState {
-        if let state = windowSidebarSelectionStates.model(for: WindowID(context.windowId)) {
-            return state
-        }
-        let fallback = SidebarSelectionState()
-        windowSidebarSelectionStates.setModel(fallback, for: WindowID(context.windowId))
-        return fallback
-    }
-
-    /// Per-window ``SidebarState`` (sidebar visibility + persisted width), keyed
-    /// by ``WindowID`` (peeled out of the rejected `MainWindowContext` aggregate;
-    /// owner ruling 2026-06-18: per-window state is domain-owned and
-    /// `WindowID`-keyed, never bundled into one per-window aggregate). Mirrors
-    /// ``windowSidebarSelectionStates`` exactly: a passive dictionary whose slice
-    /// is seeded at `registerMainWindow` and dropped by the window teardown paths
-    /// (`unregisterMainWindowContext` / `discardOrphanedMainWindowContext`), which
-    /// run for every closing window. It deliberately does NOT subscribe to the
-    /// single-consumer `windowCoordinator.windowClosed` stream, which would split
-    /// close events with the teardown loop and starve it.
-    let windowSidebarStates = WindowScopedStore<SidebarState>()
-
-    /// The per-window ``SidebarState`` for `context`, resolved by ``WindowID``
-    /// through ``windowSidebarStates``. `registerMainWindow` always seeds the
-    /// slice before the context is reachable, so a live context always has one;
-    /// the empty-state fallback only guards an already-torn-down context and
-    /// preserves the never-`nil` invariant the lifted `let` field had.
     func sidebarState(for context: RegisteredMainWindow) -> SidebarState {
-        if let state = windowSidebarStates.model(for: WindowID(context.windowId)) {
-            return state
+        if let wctx = windowRegistry.context(for: WindowID(context.windowId)) {
+            return wctx.sidebarState
         }
-        let fallback = SidebarState()
-        windowSidebarStates.setModel(fallback, for: WindowID(context.windowId))
-        return fallback
+        return SidebarState()
     }
 
-    /// Per-window right-sidebar (file-explorer) states, keyed by ``WindowID``
-    /// (peeled out of the rejected `MainWindowContext` aggregate; owner ruling
-    /// 2026-06-18: per-window state is domain-owned and `WindowID`-keyed, never
-    /// bundled into one per-window aggregate). Mirrors ``windowSidebarStates``
-    /// exactly EXCEPT that the slice is OPTIONAL by design: the legacy
-    /// `MainWindowContext.fileExplorerState` was a lazily-bound `var
-    /// FileExplorerState?` (nil until the window's content view seeds it), so an
-    /// absent entry faithfully encodes "no file-explorer state yet" and the
-    /// resolver returns `nil` rather than synthesizing an empty one. Its slice is
-    /// seeded/late-bound at `registerMainWindow` and dropped by the window
-    /// teardown paths (`unregisterMainWindowContext` /
-    /// `discardOrphanedMainWindowContext`), which run for every closing window.
-    /// It deliberately does NOT subscribe to the single-consumer
-    /// `windowCoordinator.windowClosed` stream, which would split close events
-    /// with the teardown loop and starve it.
-    let windowFileExplorerStates = WindowScopedStore<FileExplorerState>()
-
-    /// The per-window ``FileExplorerState`` for `context`, resolved by
-    /// ``WindowID`` through ``windowFileExplorerStates``, or `nil` when the
-    /// window has none yet. Unlike ``sidebarState(for:)`` this has NO empty-state
+    /// The per-window ``FileExplorerState`` for `context`, resolved through the
+    /// window's ``WindowContext`` in ``windowRegistry``, or `nil` when the window
+    /// has none yet. Unlike ``sidebarState(for:)`` this has NO empty-state
     /// fallback: the lifted field was an optional `var FileExplorerState?` that
     /// was nil until lazily bound, so a missing slice must read back as `nil` to
     /// preserve that exact semantics (callers already coalesce against the
     /// active-window mirror or bail on `nil`).
     func fileExplorerState(for context: RegisteredMainWindow) -> FileExplorerState? {
-        windowFileExplorerStates.model(for: WindowID(context.windowId))
+        windowRegistry.context(for: WindowID(context.windowId))?.fileExplorerState
     }
 
     /// Tracks the cascade point for new windows, matching Ghostty's upstream algorithm.
@@ -5264,7 +5229,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }) else {
             return false
         }
-        guard let cmuxConfigStore = windowConfigStores.model(for: WindowID(context.windowId)),
+        guard let cmuxConfigStore = windowRegistry.context(for: WindowID(context.windowId))?.configStore,
               let action = cmuxConfigStore.resolvedNewWorkspaceAction() else {
             return false
         }
@@ -5356,7 +5321,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ?? mainWindowContext(forShortcutEvent: event, debugSource: debugSource)
             ?? preferredMainWindowContextForWorkspaceCreation(event: event, debugSource: debugSource)
         guard let context,
-              let cmuxConfigStore = windowConfigStores.model(for: WindowID(context.windowId)) else {
+              let cmuxConfigStore = windowRegistry.context(for: WindowID(context.windowId))?.configStore else {
             return false
         }
 
@@ -6312,6 +6277,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             fileExplorerState: fileExplorerState,
             cmuxConfigStore: cmuxConfigStore
         )
+        // Express the per-window association: the controller weakly references the
+        // ``WindowContext`` the registration just seeded (the registry stays the
+        // strong owner, so this does not extend the context's lifetime).
+        controller.windowContext = windowRegistry.context(for: WindowID(windowId))
         publishCmuxWindowLifecycle(name: "window.created", windowId: windowId, origin: "create")
         AppFileDropTarget.installFileDropOverlay(on: window, tabManager: tabManager)
         if !shouldActivate || TerminalController.shouldSuppressSocketCommandActivation() {
@@ -7517,13 +7486,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     var reloadableConfigStores: [any CmuxConfigStoreReloading] {
-        windowConfigStores.models
+        windowRegistry.contexts.compactMap { $0.configStore }
     }
 
-    /// The per-window config store for `context`, resolved by ``WindowID``
-    /// through ``windowConfigStores`` (the slice peeled out of `MainWindowContext`).
+    /// The per-window config store for `context`, resolved through the window's
+    /// ``WindowContext`` in ``windowRegistry``.
     func configStore(for context: RegisteredMainWindow) -> CmuxConfigStore? {
-        windowConfigStores.model(for: WindowID(context.windowId))
+        windowRegistry.context(for: WindowID(context.windowId))?.configStore
     }
 
     /// The per-window config store for the window owning `tabManager`, if any.
@@ -7531,12 +7500,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard let context = registeredMainWindow(forManager: tabManager) else {
             return nil
         }
-        return windowConfigStores.model(for: WindowID(context.windowId))
+        return windowRegistry.context(for: WindowID(context.windowId))?.configStore
     }
 
     /// The first registered context whose window has a config store.
     func firstContextWithConfigStore() -> RegisteredMainWindow? {
-        registeredMainWindows.first { windowConfigStores.model(for: WindowID($0.windowId)) != nil }
+        registeredMainWindows.first { windowRegistry.context(for: WindowID($0.windowId))?.configStore != nil }
     }
 
     func refreshWindowTitlesAfterConfigReload() {
@@ -9946,7 +9915,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         for context: RegisteredMainWindow?
     ) -> [CmuxResolvedConfigAction] {
         guard let context else { return [] }
-        return windowConfigStores.model(for: WindowID(context.windowId))?.shortcutActions() ?? []
+        return windowRegistry.context(for: WindowID(context.windowId))?.configStore?.shortcutActions() ?? []
     }
 
     private func handleConfiguredCmuxShortcut(
@@ -9998,7 +9967,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             let cwd = anchorId.flatMap { id in
                 tabManager.tabs.first(where: { $0.id == id })?.currentDirectory
             }
-            let configured = windowConfigStores.model(for: WindowID(context.windowId))?.resolveWorkspaceGroupConfig(forCwd: cwd)?.newWorkspacePlacement
+            let configured = windowRegistry.context(for: WindowID(context.windowId))?.configStore?.resolveWorkspaceGroupConfig(forCwd: cwd)?.newWorkspacePlacement
             return configured
                 ?? UserDefaultsSettingsClient(defaults: .standard).value(for: SettingCatalog().workspaceGroups.newWorkspacePlacement)
         }()
@@ -10172,7 +10141,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 return didSplit
             }
         case .command, .agent, .workspaceCommand:
-            guard let cmuxConfigStore = windowConfigStores.model(for: WindowID(context.windowId)) else {
+            guard let cmuxConfigStore = windowRegistry.context(for: WindowID(context.windowId))?.configStore else {
                 return false
             }
             let rawCwd = context.tabManager.selectedWorkspace?.currentDirectory

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -60,6 +60,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private(set) lazy var terminalControl: TerminalController = {
         let instance = TerminalController.shared
         TerminalController.installCompositionRootInstance(instance)
+        instance.attachAppEnvironment(environment)
         return instance
     }()
 
@@ -403,7 +404,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         legacyDefaultsKeys: legacyPersistedWindowGeometryDefaultsKeys
     )
 
-    weak var tabManager: TabManager?
+    var tabManager: TabManager? {
+        get { environment.mainWindowRouter.activeTabManager }
+        set { environment.mainWindowRouter.activeTabManager = newValue }
+    }
     /// The single `TerminalNotificationStore` (owned by the `cmuxApp`
     /// `@StateObject`). Storage moved to ``AppEnvironment``, which holds it
     /// weakly exactly as the former `weak var` here did; this get/set forwarder
@@ -413,7 +417,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         get { environment.notificationStore }
         set { environment.notificationStore = newValue }
     }
-    weak var sidebarState: SidebarState?
+    var sidebarState: SidebarState? {
+        get { environment.mainWindowRouter.activeSidebarState }
+        set { environment.mainWindowRouter.activeSidebarState = newValue }
+    }
 
     /// Notification jump/open navigation, extracted into `CmuxNotifications`.
     /// `AppDelegate` is the composition root: it conforms to every seam (see
@@ -581,11 +588,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// Combine subscriptions that publish workspace.updated to mobile clients.
     private var mobileWorkspaceListObservers: [ObjectIdentifier: MobileWorkspaceListObserver] = [:]
     private let agentChatTranscriptService = AgentChatTranscriptService()
-    /// Per-pane runaway-memory guardrail, wired at startup (replaces the former
-    /// `PaneMemoryGuardrail.shared` singleton) and read by `ContentView` for the
-    /// warning banner. Storage moved to ``AppEnvironment``; forwarder preserved
-    /// for not-yet-migrated sites.
-    var paneMemoryGuardrail: PaneMemoryGuardrailService { environment.paneMemoryGuardrail }
     /// The app's settings dependency container, handed over by `cmuxApp` via
     /// `configure(...)` before any main window is created. AppKit builds the
     /// main window's `NSHostingView` itself, so it injects this into the
@@ -598,9 +600,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         get { environment.settingsRuntime }
         set { environment.settingsRuntime = newValue }
     }
-    weak var fileExplorerState: FileExplorerState?
+    var fileExplorerState: FileExplorerState? {
+        get { environment.mainWindowRouter.activeFileExplorerState }
+        set { environment.mainWindowRouter.activeFileExplorerState = newValue }
+    }
     weak var fullscreenControlsViewModel: TitlebarControlsViewModel?
-    weak var sidebarSelectionState: SidebarSelectionState?
+    var sidebarSelectionState: SidebarSelectionState? {
+        get { environment.mainWindowRouter.activeSidebarSelectionState }
+        set { environment.mainWindowRouter.activeSidebarSelectionState = newValue }
+    }
     /// Owns the keyboard-shortcut event decode (layout-character resolution and
     /// numbered-digit/character normalization) in the `CmuxShortcuts` package.
     /// The per-keystroke dispatch stays app-side and reaches the decode through
@@ -705,9 +713,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var browserAddressBarFocusObserver: NSObjectProtocol?
     private var browserAddressBarBlurObserver: NSObjectProtocol?
     private var browserWebViewFirstResponderObserver: NSObjectProtocol?
-    /// Update-pill / Sparkle update log store. Storage moved to
-    /// ``AppEnvironment``; forwarder preserved for not-yet-migrated sites.
-    var updateLog: UpdateLogStore { environment.updateLog }
     /// Keyboard-focus diagnostics log store. Storage moved to
     /// ``AppEnvironment``; forwarder preserved for not-yet-migrated sites.
     var focusLog: FocusLogStore { environment.focusLog }
@@ -732,8 +737,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// static `pending` registry, so the watcher state no longer lives on this
     /// singleton.
     let workspaceGroupJoinCoordinator = WorkspaceGroupJoinCoordinator()
-    private lazy var updateController = UpdateController(log: updateLog)
-    private lazy var titlebarAccessoryController = UpdateTitlebarAccessoryController(updateLog: updateLog, settingsRuntime: settingsRuntime)
+    private lazy var updateController = UpdateController(log: environment.updateLog)
+    private lazy var titlebarAccessoryController = UpdateTitlebarAccessoryController(updateLog: environment.updateLog, settingsRuntime: settingsRuntime)
     private let windowDecorationsController = WindowDecorationsController()
     private let systemWideHotkeyController = SystemWideHotkeyController()
     /// Owns the menu-bar status item lifecycle and application-presentation
@@ -956,15 +961,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// `windowFileExplorerStates`). Each main `NSWindow` now has one
     /// ``WindowContext`` holding all six slices; this registry is the single
     /// strong owner + lookup the window-lifecycle seam and the per-window
-    /// config/sidebar/file-explorer accessors resolve through. The cross-window
-    /// resolver family (`tabManagerFor`, `locateSurface`, …) is unchanged: it
-    /// iterates `registeredMainWindows` (funnelling through
-    /// `resolveRegisteredWindow`, which reads this registry) plus the
-    /// `recoverableMainWindowRoutes()` pass. A passive index: it does NOT
+    /// config/sidebar/file-explorer accessors resolve through. Storage moved to
+    /// ``AppEnvironment``; this forwarder keeps the not-yet-migrated
+    /// `AppDelegate.windowRegistry` sites resolving to the same instance. The
+    /// cross-window resolver family now lives on the registry and AppDelegate
+    /// keeps thin compatibility forwarders. A passive index: it does NOT
     /// subscribe to the single-consumer `windowCoordinator.windowClosed` stream;
     /// slice removal is driven by the one `removeWindowModelSlices` teardown
     /// funnel.
-    let windowRegistry = WindowRegistry()
+    var windowRegistry: WindowRegistry { environment.windowRegistry }
 
     /// The ``WindowContext`` for `id`, or `nil` if no window is registered under
     /// `id`. The single forwarder the seam methods and config/sidebar accessors
@@ -1318,19 +1323,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// owns window↔id identity and the single window-closed stream.
     var windowCoordinator: any WindowManaging { windowLifecycle.windowCoordinator }
 
-    /// Ordered ``WindowID``-keyed ledger of recoverable main-window routes,
-    /// peeled out of the rejected `MainWindowContext` aggregate (owner ruling
-    /// 2026-06-18: per-window state is domain-owned and `WindowID`-keyed). This
-    /// is the constructor-held replacement for the legacy
-    /// `objc_getAssociatedObject` association that hid a `MainWindowRouteLedger`
-    /// class on the `AppDelegate` singleton: ``RecoverableWindowRouteLedger``
-    /// owns the bookkeeping (the `[WindowID: route]` storage, the monotonic order
-    /// issued per remembered route, and the most-recently-remembered-first sort),
-    /// while the app-side methods in `AppDelegate+RecoverableMainWindowRoutes`
-    /// keep the route-resolution logic that reaches into app-target
-    /// window/tab/surface state.
-    let recoverableMainWindowRouteLedger = RecoverableWindowRouteLedger<RecoverableMainWindowRoute>()
-
     /// The per-window ``SidebarSelectionState`` for `context`, resolved through
     /// the window's ``WindowContext`` in ``windowRegistry``. `registerMainWindow`
     /// always seeds the slice before the context is reachable, so a live context
@@ -1649,6 +1641,161 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // may not call AppEnvironment's main-actor init.
         self.environment = AppEnvironment()
         super.init()
+        windowRegistry.configureHostSeams(
+            WindowRegistryHostSeams(
+                registeredMainWindows: { [weak self] in
+                    self?.registeredMainWindows ?? []
+                },
+                registeredMainWindowForManager: { [weak self] tabManager in
+                    self?.registeredMainWindow(forManager: tabManager)
+                },
+                registeredMainWindowForWindowId: { [weak self] windowId in
+                    self?.registeredMainWindow(forWindowId: windowId)
+                },
+                contextForMainTerminalWindow: { [weak self] window, reindex in
+                    self?.contextForMainTerminalWindow(window, reindex: reindex)
+                },
+                mainWindowIdFromWindow: { [weak self] window in
+                    self?.mainWindowId(from: window)
+                },
+                windowForMainWindowId: { [weak self] windowId in
+                    self?.windowForMainWindowId(windowId)
+                }
+            )
+        )
+        // Built as a mutable local so the DEBUG-only seams can be assigned in a
+        // statement-level `#if DEBUG` block below: `#if` cannot split an
+        // argument list, so the conditional closures stay out of the init call.
+        var routerSeams = MainWindowRouterHostSeams(
+                shortcutRoutingKeyWindow: { [weak self] in
+                    self?.shortcutRoutingKeyWindow
+                },
+                contextForMainWindow: { [weak self] window in
+                    self?.contextForMainWindow(window)
+                },
+                registeredMainWindows: { [weak self] in
+                    self?.registeredMainWindows ?? []
+                },
+                registeredMainWindowForManager: { [weak self] tabManager in
+                    self?.registeredMainWindow(forManager: tabManager)
+                },
+                resolvedWindow: { [weak self] context in
+                    self?.resolvedWindow(for: context)
+                },
+                windowForMainWindowId: { [weak self] windowId in
+                    self?.windowForMainWindowId(windowId)
+                },
+                setActiveMainWindow: { [weak self] window in
+                    self?.setActiveMainWindow(window)
+                },
+                discardOrphanedMainWindowContext: { [weak self] context in
+                    self?.discardOrphanedMainWindowContext(context)
+                },
+                focusMainWindow: { [weak self] windowId in
+                    self?.windowLifecycle.focusMainWindow(windowId: windowId) ?? false
+                },
+                closeMainWindow: { [weak self] windowId, recordHistory in
+                    self?.windowLifecycle.closeMainWindow(windowId: windowId, recordHistory: recordHistory) ?? false
+                },
+                discardMainWindowWithoutClosedHistory: { [weak self] windowId in
+                    self?.discardMainWindowWithoutClosedHistory(windowId: windowId)
+                },
+                closeWindowContainingTabId: { [weak self] tabId, recordHistory in
+                    self?.closeMainWindowContainingTabId(tabId, recordHistory: recordHistory)
+                },
+                createMainWindow: { [weak self] in
+                    self?.createMainWindow()
+                },
+                focusForInWindowCommand: { [weak self] window, reason in
+                    self?.mainWindowVisibilityController.focusForInWindowCommand(window, reason: reason)
+                },
+                setActiveTerminalControlTabManager: { [weak self] tabManager in
+                    self?.terminalControl.setActiveTabManager(tabManager)
+                },
+                reassertCrossWindowSurfaceMoveFocus: { [weak self] destinationWindowId, sourceWindowId, destinationWorkspaceId, destinationPanelId, destinationManager in
+                    self?.reassertCrossWindowSurfaceMoveFocusIfNeeded(
+                        destinationWindowId: destinationWindowId,
+                        sourceWindowId: sourceWindowId,
+                        destinationWorkspaceId: destinationWorkspaceId,
+                        destinationPanelId: destinationPanelId,
+                        destinationManager: destinationManager
+                    )
+                },
+                paneSurfaceMoveTargets: { [weak self] summaries, excludingWorkspaceId in
+                    self?.paneSurfaceMove.moveTargets(for: summaries, excludingWorkspaceId: excludingWorkspaceId) ?? []
+                },
+                bringToFront: { [weak self] window in
+                    self?.bringToFront(window)
+                },
+                showMainWindowFromMenuBar: { [weak self] in
+                    self?.showMainWindowFromMenuBar()
+                },
+                activateMainWindowFromSocket: { [weak self] in
+                    self?.activateMainWindowFromSocket() ?? false
+                },
+                focusWindowForAppActivation: { [weak self] window, reason in
+                    self?.focusWindowForAppActivation(window, reason: reason) ?? false
+                },
+                preferredWindowForSettingsPresentation: { [weak self] in
+                    self?.preferredMainWindowForSettingsPresentation()
+                },
+                performNewWorkspaceAction: { [weak self] preferredTabManager, event, debugSource in
+                    self?.performNewWorkspaceAction(
+                        tabManager: preferredTabManager,
+                        event: event,
+                        debugSource: debugSource
+                    ) ?? false
+                },
+                performNewBrowserWorkspaceAction: { [weak self] preferredTabManager, event, debugSource in
+                    self?.performNewBrowserWorkspaceAction(
+                        tabManager: preferredTabManager,
+                        event: event,
+                        debugSource: debugSource
+                    ) ?? false
+                },
+                performCloudVMAction: { [weak self] preferredTabManager, preferredWindow, debugSource, onCompletion in
+                    self?.performCloudVMAction(
+                        tabManager: preferredTabManager,
+                        preferredWindow: preferredWindow,
+                        debugSource: debugSource,
+                        onCompletion: onCompletion
+                    ) ?? false
+                },
+                showNewWorkspaceContextMenu: { [weak self] anchorView, event, debugSource in
+                    self?.showNewWorkspaceContextMenu(
+                        anchorView: anchorView,
+                        event: event,
+                        debugSource: debugSource
+                    ) ?? false
+                },
+                showOpenFolderInInlineVSCodePanel: { [weak self] preferredTabManager in
+                    self?.showOpenFolderInInlineVSCodePanel(tabManager: preferredTabManager)
+                },
+                showFocusHistoryContextMenu: { [weak self] anchorView, event, direction, showFullHistory, debugSource in
+                    self?.showFocusHistoryContextMenu(
+                        anchorView: anchorView,
+                        event: event,
+                        direction: direction,
+                        showFullHistory: showFullHistory,
+                        debugSource: debugSource
+                    ) ?? false
+                }
+        )
+#if DEBUG
+        routerSeams.debugManagerToken = { [weak self] manager in
+            self?.debugManagerToken(manager) ?? "nil"
+        }
+        routerSeams.debugWindowToken = { [weak self] window in
+            self?.debugWindowToken(window) ?? "nil"
+        }
+        routerSeams.debugContextToken = { [weak self] context in
+            self?.debugContextToken(context) ?? "nil"
+        }
+        routerSeams.debugRouteSnapshot = { [weak self] event in
+            self?.debugShortcutRouteSnapshot(event: event) ?? ""
+        }
+#endif
+        environment.mainWindowRouter.configureHostSeams(routerSeams)
         Self.shared = self
         // Inverts the surface registry's legacy AppDelegate.shared reach-up:
         // the registry asks this delegate (via MainWindowRouteRetiring) to
@@ -2215,7 +2362,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // command palette) resolves to this same injected instance instead of a
         // self-vivified lazy singleton.
         TaskManagerWindowController.installCompositionRootInstance(taskManagerWindowController)
-        self.sidebarState = sidebarState
+        environment.mainWindowRouter.activeSidebarState = sidebarState
         environment.auth = auth
         VMClient.bootstrap(auth: auth.coordinator)
         RemotesClient.bootstrap(auth: auth.coordinator)
@@ -2261,7 +2408,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// (sidebar badge + dismissible banner with a kill action) before a single
     /// leaking pane can OOM-suspend the whole app (issue #6313).
     private func startPaneMemoryGuardrailIfNeeded(notificationStore: TerminalNotificationStore) {
-        let guardrail = paneMemoryGuardrail
+        let guardrail = environment.paneMemoryGuardrail
         guardrail.paneProvider = { [weak self] in
             self?.paneMemoryGuardrailDescriptors() ?? []
         }
@@ -3300,111 +3447,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     typealias WorkspaceMoveTarget = CmuxWorkspaces.WorkspaceMoveTarget
 
     func windowMoveTargets(referenceWindowId: UUID?) -> [WindowMoveTarget] {
-        let orderedSummaries = orderedMainWindowSummaries(referenceWindowId: referenceWindowId)
-        let labels = windowLabelsById(orderedSummaries: orderedSummaries, referenceWindowId: referenceWindowId)
-        return orderedSummaries.compactMap { summary in
-            guard tabManagerFor(windowId: summary.windowId) != nil else { return nil }
-            let label = labels[summary.windowId] ?? "Window"
-            return WindowMoveTarget(
-                windowId: summary.windowId,
-                label: label,
-                isCurrentWindow: summary.windowId == referenceWindowId
-            )
-        }
+        environment.mainWindowRouter.windowMoveTargets(referenceWindowId: referenceWindowId)
     }
 
     func workspaceMoveTargets(excludingWorkspaceId: UUID? = nil, referenceWindowId: UUID?) -> [WorkspaceMoveTarget] {
-        // App-side: resolve the window ordering + localized labels (window-domain,
-        // app-bundle concerns), project each window's live workspaces into the
-        // Sendable summary, then let ``PaneSurfaceMoveCoordinator`` own the
-        // exclusion filter + ``WorkspaceMoveTarget`` projection (the loop the god
-        // kept inline).
-        let orderedSummaries = orderedMainWindowSummaries(referenceWindowId: referenceWindowId)
-        let labels = windowLabelsById(orderedSummaries: orderedSummaries, referenceWindowId: referenceWindowId)
-
-        let summaries: [PaneSurfaceMoveWindowSummary] = orderedSummaries.compactMap { summary in
-            guard let manager = tabManagerFor(windowId: summary.windowId) else { return nil }
-            return PaneSurfaceMoveWindowSummary(
-                windowId: summary.windowId,
-                windowLabel: labels[summary.windowId] ?? "Window",
-                isCurrentWindow: summary.windowId == referenceWindowId,
-                workspaces: manager.tabs.map { workspace in
-                    PaneSurfaceMoveWindowSummary.Workspace(
-                        workspaceId: workspace.id,
-                        title: workspaceDisplayName(workspace)
-                    )
-                }
-            )
-        }
-
-        return paneSurfaceMove.moveTargets(for: summaries, excludingWorkspaceId: excludingWorkspaceId)
+        environment.mainWindowRouter.workspaceMoveTargets(
+            excludingWorkspaceId: excludingWorkspaceId,
+            referenceWindowId: referenceWindowId
+        )
     }
 
     @discardableResult
     func moveWorkspaceToWindow(workspaceId: UUID, windowId: UUID, atIndex: Int? = nil, focus: Bool = true) -> Bool {
-        guard let sourceManager = tabManagerFor(tabId: workspaceId),
-              let destinationManager = tabManagerFor(windowId: windowId) else {
-            return false
-        }
-
-        if sourceManager === destinationManager {
-            if focus {
-                destinationManager.focusTab(workspaceId, suppressFlash: true)
-                _ = focusMainWindow(windowId: windowId)
-                terminalControl.setActiveTabManager(destinationManager)
-            }
-            return true
-        }
-
-        guard let workspace = sourceManager.detachWorkspace(tabId: workspaceId) else { return false }
-        destinationManager.attachWorkspace(workspace, at: atIndex, select: focus)
-
-        if focus {
-            _ = focusMainWindow(windowId: windowId)
-            terminalControl.setActiveTabManager(destinationManager)
-        }
-        return true
+        environment.mainWindowRouter.moveWorkspaceToWindow(
+            workspaceId: workspaceId,
+            windowId: windowId,
+            atIndex: atIndex,
+            focus: focus
+        )
     }
 
     @discardableResult
     func moveWorkspaceToNewWindow(workspaceId: UUID, focus: Bool = true) -> UUID? {
-        let windowId = createMainWindow()
-        guard let destinationManager = tabManagerFor(windowId: windowId) else { return nil }
-        let bootstrapWorkspaceId = destinationManager.tabs.first?.id
-
-        guard moveWorkspaceToWindow(workspaceId: workspaceId, windowId: windowId, focus: focus) else {
-            _ = closeMainWindow(windowId: windowId, recordHistory: false)
-            return nil
-        }
-
-        // Remove the bootstrap workspace from the new window once the moved workspace arrives.
-        if let bootstrapWorkspaceId,
-           bootstrapWorkspaceId != workspaceId,
-           let bootstrapWorkspace = destinationManager.tabs.first(where: { $0.id == bootstrapWorkspaceId }),
-           destinationManager.tabs.count > 1 {
-            destinationManager.closeWorkspace(bootstrapWorkspace, recordHistory: false)
-        }
-        return windowId
+        environment.mainWindowRouter.moveWorkspaceToNewWindow(workspaceId: workspaceId, focus: focus)
     }
 
     func locateBonsplitSurface(tabId: UUID) -> (windowId: UUID, workspaceId: UUID, panelId: UUID, tabManager: TabManager)? {
-        let bonsplitTabId = TabID(uuid: tabId)
-        for context in registeredMainWindows {
-            for workspace in context.tabManager.tabs {
-                if let panelId = workspace.panelIdFromSurfaceId(bonsplitTabId) {
-                    return (context.windowId, workspace.id, panelId, context.tabManager)
-                }
-            }
-        }
-        for route in recoverableMainWindowRoutes() {
-            guard let manager = route.tabManager else { continue }
-            for workspace in manager.tabs {
-                if let panelId = workspace.panelIdFromSurfaceId(bonsplitTabId) {
-                    return (route.windowId, workspace.id, panelId, manager)
-                }
-            }
-        }
-        return nil
+        windowRegistry.locateBonsplitSurface(tabId: tabId)
     }
 
     /// Moves the surface `panelId` into `targetWorkspaceId` at the resolved
@@ -3465,15 +3534,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     func focusScriptableMainWindow(windowId: UUID, bringToFront shouldBringToFront: Bool) -> Bool {
-        guard let state = scriptableMainWindow(windowId: windowId),
-              let window = state.window else {
-            return false
-        }
-        setActiveMainWindow(window)
-        if shouldBringToFront {
-            bringToFront(window)
-        }
-        return true
+        environment.mainWindowRouter.focusScriptableWindow(
+            windowId: windowId,
+            bringToFront: shouldBringToFront
+        )
     }
 
     @discardableResult
@@ -3864,25 +3928,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
     }
 
-    func locateSurface(surfaceId: UUID) -> (windowId: UUID, workspaceId: UUID, tabManager: TabManager)? {
-        for ctx in registeredMainWindows {
-            for ws in ctx.tabManager.tabs {
-                if ws.panels[surfaceId] != nil, ws.surfaceIdFromPanelId(surfaceId) != nil {
-                    return (ctx.windowId, ws.id, ctx.tabManager)
-                }
-            }
-        }
-        for route in recoverableMainWindowRoutes() {
-            guard let manager = route.tabManager else { continue }
-            for ws in manager.tabs {
-                if ws.panels[surfaceId] != nil, ws.surfaceIdFromPanelId(surfaceId) != nil {
-                    return (route.windowId, ws.id, manager)
-                }
-            }
-        }
-        return nil
-    }
-
     /// Resolve the workspace that currently owns a panel/surface ID.
     /// Prefer the provided workspace when available, then fall back to global lookup.
     func workspaceContainingPanel(
@@ -3897,7 +3942,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return (workspace, manager)
         }
 
-        if let located = locateSurface(surfaceId: panelId),
+        if let located = windowRegistry.locateSurface(surfaceId: panelId),
            let workspace = located.tabManager.tabs.first(where: { $0.id == located.workspaceId }),
            workspace.panels[panelId] != nil,
            workspace.surfaceIdFromPanelId(panelId) != nil {
@@ -4015,13 +4060,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         windowLifecycle.focusMainWindow(windowId: windowId)
     }
 
-    /// Closes the main window for `windowId`, suppressing closed-window history
-    /// when `recordHistory` is false. Forwards to ``windowLifecycle``, which owns
-    /// the suppression set; the `performClose` stays an app-side witness.
-    func closeMainWindow(windowId: UUID, recordHistory: Bool = true) -> Bool {
-        windowLifecycle.closeMainWindow(windowId: windowId, recordHistory: recordHistory)
-    }
-
     /// Discards the main window for `windowId` without recording closed-window
     /// history. Forwards to ``windowLifecycle``; the `close` stays an app-side
     /// witness.
@@ -4069,30 +4107,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         windowLifecycle.closeWindowWithConfirmation(window)
     }
 
-    private func orderedMainWindowSummaries(referenceWindowId: UUID?) -> [MainWindowSummary] {
-        // App-side: read the live NSWindow/TabManager state into the Sendable
-        // summaries, then defer the pure ordering to ``CmuxWindowing``.
-        listMainWindowSummaries().orderedByReference(referenceWindowId: referenceWindowId)
-    }
-
-    private func windowLabelsById(orderedSummaries: [MainWindowSummary], referenceWindowId: UUID?) -> [UUID: String] {
-        var labels: [UUID: String] = [:]
-        for (index, summary) in orderedSummaries.enumerated() {
-            if summary.windowId == referenceWindowId {
-                labels[summary.windowId] = String(localized: "menu.currentWindow", defaultValue: "Current Window")
-            } else {
-                let number = index + 1
-                labels[summary.windowId] = String(localized: "menu.windowNumber", defaultValue: "Window \(number)")
-            }
-        }
-        return labels
-    }
-
-    private func workspaceDisplayName(_ workspace: Workspace) -> String {
-        let trimmed = workspace.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? String(localized: "workspace.displayName.fallback", defaultValue: "Workspace") : trimmed
-    }
-
     func rollbackDetachedSurface(
         _ detached: Workspace.DetachedSurfaceTransfer,
         to workspace: Workspace,
@@ -4100,15 +4114,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         sourceIndex: Int?,
         focus: Bool
     ) {
-        let rollbackPane = sourcePane.flatMap { pane in
-            workspace.bonsplitController.allPaneIds.first(where: { $0 == pane })
-        } ?? workspace.bonsplitController.focusedPaneId
-            ?? workspace.bonsplitController.allPaneIds.first
-        guard let rollbackPane else { return }
-        _ = workspace.attachDetachedSurface(
+        environment.mainWindowRouter.rollbackDetachedSurface(
             detached,
-            inPane: rollbackPane,
-            atIndex: sourceIndex,
+            to: workspace,
+            sourcePane: sourcePane,
+            sourceIndex: sourceIndex,
             focus: focus
         )
     }
@@ -4301,9 +4311,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func allMainWindowTabManagersForDebug() -> [TabManager] {
-        Array(registeredMainWindows).compactMap { context in
-            resolvedWindow(for: context) == nil ? nil : context.tabManager
-        }
+        environment.mainWindowRouter.allMainWindowTabManagersForDebug()
     }
 #if DEBUG
     func debugManagerToken(_ manager: TabManager?) -> String {
@@ -4419,58 +4427,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// This keeps menu/shortcut actions window-scoped even if the cached `tabManager` drifts.
     @discardableResult
     func synchronizeActiveMainWindowContext(preferredWindow: NSWindow? = nil) -> TabManager? {
-        let (context, source): (RegisteredMainWindow?, String) = {
-            if let preferredWindow,
-               let context = contextForMainWindow(preferredWindow) {
-                return (context, "preferredWindow")
-            }
-            if let context = contextForMainWindow(shortcutRoutingKeyWindow) {
-                return (context, "keyWindow")
-            }
-            if let context = contextForMainWindow(NSApp.mainWindow) {
-                return (context, "mainWindow")
-            }
-            if let activeManager = tabManager,
-               let activeContext = registeredMainWindow(forManager: activeManager) {
-                return (activeContext, "activeManager")
-            }
-            return (registeredMainWindows.first, "firstContextFallback")
-        }()
-
-#if DEBUG
-        let beforeManagerToken = debugManagerToken(tabManager)
-        cmuxDebugLog(
-            "shortcut.sync.pre source=\(source) preferred={\(debugWindowToken(preferredWindow))} chosen={\(debugContextToken(context))} \(debugShortcutRouteSnapshot())"
-        )
-#endif
-        guard let context else { return tabManager }
-        let alreadyActive =
-            tabManager === context.tabManager
-            && sidebarState === sidebarState(for: context)
-            && sidebarSelectionState === sidebarSelectionState(for: context)
-        if alreadyActive {
-#if DEBUG
-            cmuxDebugLog(
-                "shortcut.sync.post source=\(source) beforeMgr=\(beforeManagerToken) afterMgr=\(debugManagerToken(tabManager)) chosen={\(debugContextToken(context))} nochange=1 \(debugShortcutRouteSnapshot())"
-            )
-#endif
-            return context.tabManager
-        }
-        if let window = context.window ?? windowForMainWindowId(context.windowId) {
-            setActiveMainWindow(window)
-        } else {
-            tabManager = context.tabManager
-            sidebarState = sidebarState(for: context)
-            sidebarSelectionState = sidebarSelectionState(for: context)
-            fileExplorerState = fileExplorerState(for: context)
-            terminalControl.setActiveTabManager(context.tabManager)
-        }
-#if DEBUG
-        cmuxDebugLog(
-            "shortcut.sync.post source=\(source) beforeMgr=\(beforeManagerToken) afterMgr=\(debugManagerToken(tabManager)) chosen={\(debugContextToken(context))} \(debugShortcutRouteSnapshot())"
-        )
-#endif
-        return context.tabManager
+        environment.mainWindowRouter.synchronizeActiveWindowContext(preferredWindow: preferredWindow)
     }
 
     private struct FocusedTerminalShortcutContext {
@@ -4555,21 +4512,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func preferredRegisteredMainWindowContext(preferredWindow: NSWindow? = nil) -> RegisteredMainWindow? {
-        if let preferredWindow,
-           let context = contextForMainWindow(preferredWindow) {
-            return context
-        }
-        if let context = contextForMainWindow(shortcutRoutingKeyWindow) {
-            return context
-        }
-        if let context = contextForMainWindow(NSApp.mainWindow) {
-            return context
-        }
-        if let activeManager = tabManager,
-           let activeContext = registeredMainWindow(forManager: activeManager) {
-            return activeContext
-        }
-        return registeredMainWindows.first
+        environment.mainWindowRouter.preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
     }
 
     private func activateMainWindowContextForShortcutEvent(_ event: NSEvent) {
@@ -4589,92 +4532,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     func toggleSidebarInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
-        func toggle(_ context: RegisteredMainWindow) -> Bool {
-            guard let window = resolvedWindow(for: context) else {
-                discardOrphanedMainWindowContext(context)
-                return false
-            }
-            setActiveMainWindow(window)
-            sidebarState(for: context).toggle()
-            return true
-        }
-
-        if let preferredWindow,
-           let preferredContext = contextForMainTerminalWindow(preferredWindow),
-           toggle(preferredContext) {
-            return true
-        }
-        if let keyWindow = shortcutRoutingKeyWindow,
-           let keyContext = contextForMainTerminalWindow(keyWindow),
-           toggle(keyContext) {
-            return true
-        }
-        if let mainWindow = NSApp.mainWindow,
-           let mainContext = contextForMainTerminalWindow(mainWindow),
-           toggle(mainContext) {
-            return true
-        }
-        if let activeManager = tabManager,
-           let activeContext = registeredMainWindow(forManager: activeManager),
-           toggle(activeContext) {
-            return true
-        }
-        for fallbackContext in Array(registeredMainWindows) where toggle(fallbackContext) {
-            return true
-        }
-        return false
+        environment.mainWindowRouter.toggleSidebarInActiveWindow(preferredWindow: preferredWindow)
     }
 
     @discardableResult
     func toggleRightSidebarInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
-        guard let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow) else {
-            if let fileExplorerState {
-                fileExplorerState.toggle()
-                return true
-            }
-            return false
-        }
-
-        let window = context.window ?? windowForMainWindowId(context.windowId)
-        if let window {
-            setActiveMainWindow(window)
-        }
-
-        guard let state = fileExplorerState(for: context) ?? fileExplorerState else {
-            return false
-        }
-        let wasVisible = state.isVisible
-        state.toggle()
-        if wasVisible && !state.isVisible {
-            _ = context.keyboardFocusCoordinator.restoreTerminalFocusAfterRightSidebarHiddenIfNeeded()
-        }
-        return true
+        environment.mainWindowRouter.toggleRightSidebarInActiveWindow(preferredWindow: preferredWindow)
     }
 
     @discardableResult
     func closeRightSidebarInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
-        guard let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow) else {
-            guard let fileExplorerState else {
-                return false
-            }
-            fileExplorerState.setVisible(false)
-            return true
-        }
-
-        let window = context.window ?? windowForMainWindowId(context.windowId)
-        if let window {
-            setActiveMainWindow(window)
-        }
-
-        guard let state = fileExplorerState(for: context) ?? fileExplorerState else {
-            return false
-        }
-        let wasVisible = state.isVisible
-        state.setVisible(false)
-        if wasVisible && !state.isVisible {
-            _ = context.keyboardFocusCoordinator.restoreTerminalFocusAfterRightSidebarHiddenIfNeeded()
-        }
-        return true
+        environment.mainWindowRouter.closeRightSidebarInActiveWindow(preferredWindow: preferredWindow)
     }
 
     @discardableResult
@@ -4806,44 +4674,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         focusFirstItem: Bool = true,
         preferredWindow: NSWindow? = nil
     ) -> Bool {
-        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
-
-        guard let context else {
-#if DEBUG
-            dlog(
-                "rs.focus.app.abort reason=noContext preferred={\(debugWindowToken(preferredWindow))} " +
-                "\(debugShortcutRouteSnapshot())"
-            )
-#endif
-            return false
-        }
-        let window = context.window ?? windowForMainWindowId(context.windowId)
-#if DEBUG
-        let beforeResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
-        let beforeState = fileExplorerState(for: context) ?? fileExplorerState
-        dlog(
-            "rs.focus.app.begin preferred={\(debugWindowToken(preferredWindow))} " +
-            "context={\(debugContextToken(context))} targetWin={\(debugWindowToken(window))} " +
-            "visible=\((beforeState?.isVisible ?? false) ? 1 : 0) mode=\(beforeState?.mode.rawValue ?? "nil") " +
-            "fr=\(beforeResponder)"
-        )
-#endif
-        if let window {
-            mainWindowVisibilityController.focusForInWindowCommand(window, reason: .rightSidebarFocus)
-        }
-        let result = context.keyboardFocusCoordinator.focusRightSidebar(
+        environment.mainWindowRouter.focusRightSidebarInActiveWindow(
             mode: requestedMode,
-            focusFirstItem: focusFirstItem
+            focusFirstItem: focusFirstItem,
+            preferredWindow: preferredWindow
         )
-#if DEBUG
-        let afterResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
-        dlog(
-            "rs.focus.app.end requested=1 result=\(result ? 1 : 0) " +
-            "mode=\(requestedMode?.rawValue ?? (fileExplorerState(for: context)?.mode.rawValue ?? "nil")) " +
-            "targetWin={\(debugWindowToken(window))} fr=\(afterResponder)"
-        )
-#endif
-        return result
     }
 
 #if DEBUG
@@ -4859,178 +4694,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         visible: Bool,
         activeMode: String?
     ) {
-        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
-        let window = context.flatMap { $0.window ?? windowForMainWindowId($0.windowId) }
-        if let window {
-            if !window.isKeyWindow {
-                if !NSApp.isActive {
-                    NSRunningApplication.current.activate(options: [.activateAllWindows])
-                }
-                window.makeKeyAndOrderFront(nil)
-            }
-            setActiveMainWindow(window)
-        }
-
-        guard let state = context.flatMap({ fileExplorerState(for: $0) }) ?? fileExplorerState else {
-            return (
-                revealed: false,
-                focusApplied: false,
-                contextFound: context != nil,
-                stateFound: false,
-                visible: false,
-                activeMode: nil
-            )
-        }
-
-        if state.mode != mode {
-            state.mode = mode
-        }
-        state.setVisible(true)
-
-        let focusApplied = context?.keyboardFocusCoordinator.focusRightSidebar(
+        environment.mainWindowRouter.debugRevealRightSidebarInActiveWindow(
             mode: mode,
-            focusFirstItem: focusFirstItem
-        ) ?? false
-
-        return (
-            revealed: state.isVisible && state.mode == mode,
-            focusApplied: focusApplied,
-            contextFound: context != nil,
-            stateFound: true,
-            visible: state.isVisible,
-            activeMode: state.mode.rawValue
+            focusFirstItem: focusFirstItem,
+            preferredWindow: preferredWindow
         )
     }
 #endif
 
     @discardableResult
     func focusFileSearchInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
-        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
-
-        guard let context else {
-#if DEBUG
-            dlog(
-                "file.search.focus.app.abort reason=noContext preferred={\(debugWindowToken(preferredWindow))} " +
-                "\(debugShortcutRouteSnapshot())"
-            )
-#endif
-            return false
-        }
-        let window = context.window ?? windowForMainWindowId(context.windowId)
-#if DEBUG
-        let beforeResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
-        dlog(
-            "file.search.focus.app.begin preferred={\(debugWindowToken(preferredWindow))} " +
-            "context={\(debugContextToken(context))} targetWin={\(debugWindowToken(window))} " +
-            "fr=\(beforeResponder)"
-        )
-#endif
-        if let window {
-            mainWindowVisibilityController.focusForInWindowCommand(window, reason: .fileSearchFocus)
-        }
-        let result = context.keyboardFocusCoordinator.focusFileSearch()
-#if DEBUG
-        let afterResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
-        dlog(
-            "file.search.focus.app.end result=\(result ? 1 : 0) " +
-            "targetWin={\(debugWindowToken(window))} fr=\(afterResponder)"
-        )
-#endif
-        return result
+        environment.mainWindowRouter.focusFileSearchInActiveWindow(preferredWindow: preferredWindow)
     }
 
     @discardableResult
     func performFindShortcutInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
-        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
-
-        guard let context else {
-#if DEBUG
-            dlog(
-                "find.shortcut.app.abort reason=noContext preferred={\(debugWindowToken(preferredWindow))} " +
-                "\(debugShortcutRouteSnapshot())"
-            )
-#endif
-            return false
-        }
-        let window = context.window ?? windowForMainWindowId(context.windowId)
-#if DEBUG
-        let beforeResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
-        dlog(
-            "find.shortcut.app.begin preferred={\(debugWindowToken(preferredWindow))} " +
-            "context={\(debugContextToken(context))} targetWin={\(debugWindowToken(window))} " +
-            "fr=\(beforeResponder)"
-        )
-#endif
-        let target = context.keyboardFocusCoordinator.findShortcutTarget(
-            currentResponder: window?.firstResponder
-        )
-        guard target != .none else {
-#if DEBUG
-            dlog(
-                "find.shortcut.app.end target=\(target) result=0 " +
-                "targetWin={\(debugWindowToken(window))} fr=\(beforeResponder)"
-            )
-#endif
-            return false
-        }
-
-        if let window {
-            mainWindowVisibilityController.focusForInWindowCommand(window, reason: .findShortcut)
-        }
-
-        let result: Bool
-        switch target {
-        case .rightSidebarFileSearch:
-            result = context.keyboardFocusCoordinator.focusFileSearch()
-        case .mainPanelFind:
-            result = context.tabManager.startSearch()
-        case .none:
-            return false
-        }
-#if DEBUG
-        let afterResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
-        dlog(
-            "find.shortcut.app.end target=\(target) result=\(result ? 1 : 0) " +
-            "targetWin={\(debugWindowToken(window))} fr=\(afterResponder)"
-        )
-#endif
-        return result
+        environment.mainWindowRouter.performFindInActiveWindow(preferredWindow: preferredWindow)
     }
 
     @discardableResult
     func toggleRightSidebarKeyboardFocusInActiveMainWindow(preferredWindow: NSWindow? = nil) -> Bool {
-        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
-
-        guard let context else {
-#if DEBUG
-            dlog(
-                "rs.focus.toggle.abort reason=noContext preferred={\(debugWindowToken(preferredWindow))} " +
-                "\(debugShortcutRouteSnapshot())"
-            )
-#endif
-            return false
-        }
-        let window = context.window ?? windowForMainWindowId(context.windowId)
-#if DEBUG
-        let beforeResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
-        dlog(
-            "rs.focus.toggle.begin preferred={\(debugWindowToken(preferredWindow))} " +
-            "context={\(debugContextToken(context))} targetWin={\(debugWindowToken(window))} " +
-            "fr=\(beforeResponder)"
-        )
-#endif
-        if let window {
-            mainWindowVisibilityController.focusForInWindowCommand(window, reason: .rightSidebarToggle)
-        }
-        let result = context.keyboardFocusCoordinator.toggleRightSidebarOrTerminalFocus()
-#if DEBUG
-        let afterResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
-        dlog(
-            "rs.focus.toggle.end result=\(result ? 1 : 0) " +
-            "targetWin={\(debugWindowToken(window))} fr=\(afterResponder)"
-        )
-#endif
-        return result
+        environment.mainWindowRouter.toggleRightSidebarKeyboardFocusInActiveWindow(preferredWindow: preferredWindow)
     }
 
     func sidebarVisibility(windowId: UUID) -> Bool? {
@@ -6021,7 +5705,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let alreadyActive =
             tabManager === context.tabManager
-            && sidebarState === sidebarState(for: context)
+            && environment.mainWindowRouter.activeSidebarState === sidebarState(for: context)
             && sidebarSelectionState === sidebarSelectionState(for: context)
         if alreadyActive { return true }
 
@@ -6029,7 +5713,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             setActiveMainWindow(window)
         } else {
             tabManager = context.tabManager
-            sidebarState = sidebarState(for: context)
+            environment.mainWindowRouter.activeSidebarState = sidebarState(for: context)
             sidebarSelectionState = sidebarSelectionState(for: context)
             fileExplorerState = fileExplorerState(for: context)
             terminalControl.setActiveTabManager(context.tabManager)
@@ -6092,6 +5776,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             autoWelcomeIfNeeded: initialTerminalInput == nil,
             closedItemHistory: closedItemHistory
         )
+        tabManager.attachAppEnvironment(environment)
         tabManager.windowId = windowId
         if let sessionWindowSnapshot {
             let restoredPanelIdsByWorkspaceIndex = tabManager.restoreSessionSnapshot(
@@ -6723,7 +6408,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     @objc func copyUpdateLogs(_ sender: Any?) {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(updateLog.clipboardPayload(), forType: .string)
+        pasteboard.setString(environment.updateLog.clipboardPayload(), forType: .string)
     }
     @objc func copyFocusLogs(_ sender: Any?) {
         let logText = focusLog.snapshot()
@@ -10677,38 +10362,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     /// Repoints the app's active-window pointers at `context` (or clears them
-    /// when `nil`). The ``WindowLifecycleHosting`` active-pointer witness the
-    /// coordinator drives during teardown; these god-type writes stay app-side.
+    /// when `nil`). The ``WindowLifecycleHosting`` witness stays on AppDelegate;
+    /// active mirror storage lives on ``MainWindowRouter``.
     func repointActiveMainWindow(to context: RegisteredMainWindow?) {
-        guard let context else {
-            tabManager = nil
-            sidebarState = nil
-            sidebarSelectionState = nil
-            fileExplorerState = nil
-            terminalControl.setActiveTabManager(nil)
-            return
-        }
-        tabManager = context.tabManager
-        sidebarState = sidebarState(for: context)
-        sidebarSelectionState = sidebarSelectionState(for: context)
-        fileExplorerState = fileExplorerState(for: context)
-        terminalControl.setActiveTabManager(context.tabManager)
+        environment.mainWindowRouter.repointActiveWindow(to: context)
     }
 
-    /// Activates `context` for a key `window`, capturing the before-state debug
-    /// token and emitting the `mainWindow.active` log around the active-pointer
-    /// repoint. The ``WindowLifecycleHosting`` witness that keeps the debug
-    /// ordering app-side; the coordinator resolves the context and calls here.
+    /// Activates `context` for a key `window`. The ``WindowLifecycleHosting``
+    /// witness stays on AppDelegate while the router preserves the legacy debug
+    /// logging order around the active-pointer repoint.
     func setActiveMainWindowContext(_ context: RegisteredMainWindow, keyWindow window: NSWindow) {
-#if DEBUG
-        let beforeManagerToken = debugManagerToken(tabManager)
-#endif
-        repointActiveMainWindow(to: context)
-#if DEBUG
-        cmuxDebugLog(
-            "mainWindow.active window={\(debugWindowToken(window))} context={\(debugContextToken(context))} beforeMgr=\(beforeManagerToken) afterMgr=\(debugManagerToken(tabManager)) \(debugShortcutRouteSnapshot())"
-        )
-#endif
+        environment.mainWindowRouter.setActiveWindowContext(context, keyWindow: window)
     }
 
     /// Makes `window` the active main window. Forwards to ``windowLifecycle``,
@@ -10865,21 +10529,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return MainTerminalWindowIdentifier.matches(rawIdentifier: raw)
     }
 
-    private func workspaceForMainActor(tabId: UUID) -> Workspace? {
-        tabManagerFor(tabId: tabId)?.tabs.first(where: { $0.id == tabId })
-    }
-
     /// Returns the `Workspace` that owns `tabId`, if any.
     @MainActor
     func workspaceFor(tabId: UUID) -> Workspace? {
-        workspaceForMainActor(tabId: tabId)
+        windowRegistry.workspaceFor(tabId: tabId)
     }
 
     func closeMainWindowContainingTabId(_ tabId: UUID, recordHistory: Bool = true) {
 #if DEBUG
         closeMainWindowContainingTabIdObserverForTesting?(tabId, recordHistory)
 #endif
-        guard let context = contextContainingTabId(tabId) else { return }
+        guard let context = windowRegistry.contextContainingTabId(tabId) else { return }
         let expectedIdentifier = MainTerminalWindowIdentifier(forWindowId: context.windowId).expectedIdentifier
         let window: NSWindow? = context.window ?? NSApp.windows.first(where: { $0.identifier?.rawValue == expectedIdentifier })
         if !recordHistory {
@@ -10957,9 +10617,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     // Behavior is byte-identical to the previous inlined branches.
 
     /// Resolves the registered window context that owns `tabId`, boxed for the
-    /// open-routing seam. Mirrors `contextContainingTabId(_:)`, resolving once.
+    /// open-routing seam. Mirrors the window-registry lookup, resolving once.
     func openRoutingContextToken(forTabId tabId: UUID) -> AnyObject? {
-        guard let context = contextContainingTabId(tabId) else { return nil }
+        guard let context = windowRegistry.contextContainingTabId(tabId) else { return nil }
         return RegisteredMainWindowToken(context)
     }
 
@@ -11198,7 +10858,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
 
     func tabTitle(for tabId: UUID) -> String? {
-        if let context = contextContainingTabId(tabId) {
+        if let context = windowRegistry.contextContainingTabId(tabId) {
             return context.tabManager.tabs.first(where: { $0.id == tabId })?.title
         }
         return tabManager?.tabs.first(where: { $0.id == tabId })?.title
@@ -12520,39 +12180,19 @@ extension AppDelegate: UpdateActionDelegate, UpdateActionsHost {
     }
 
     var updateLogPath: String {
-        updateLog.logPath()
+        environment.updateLog.logPath()
     }
 }
 
 // MARK: - Window display placement (`window.display` / `window.displays`)
 
 extension AppDelegate {
-    /// Move a single main window onto the display matched by `query`, preserving
-    /// its size. Returns the resolved display name, or nil when the window or the
-    /// display can't be resolved. Resolves the window here (AppDelegate owns the
-    /// window registry) and forwards the screen match + reposition to the lifted
-    /// ``CmuxWindowing`` helpers.
-    @discardableResult
-    func moveMainWindow(windowId: UUID, toDisplayMatching query: String) -> String? {
-        guard let window = windowForMainWindowId(windowId),
-              let screen = NSScreen.cmuxScreen(matching: query) else { return nil }
-        window.cmuxRepositionPreservingSize(onto: screen)
-        return screen.localizedName
-    }
-
     /// Move every main window onto the display matched by `query`, preserving
     /// sizes. Returns the resolved display name and the moved window ids, or nil
-    /// when the display can't be resolved. Resolves windows here and forwards the
-    /// screen match + reposition to the lifted ``CmuxWindowing`` helpers.
+    /// when the display can't be resolved. Compatibility forwarder to
+    /// ``MainWindowRouter``.
     func moveAllMainWindows(toDisplayMatching query: String) -> (display: String, windowIds: [UUID])? {
-        guard let screen = NSScreen.cmuxScreen(matching: query) else { return nil }
-        var moved: [UUID] = []
-        for summary in listMainWindowSummaries() {
-            guard let window = windowForMainWindowId(summary.windowId) else { continue }
-            window.cmuxRepositionPreservingSize(onto: screen)
-            moved.append(summary.windowId)
-        }
-        return (screen.localizedName, moved)
+        environment.mainWindowRouter.moveAllWindows(toDisplayMatching: query)
     }
 }
 
@@ -12634,21 +12274,21 @@ extension AppDelegate: UITestRecorderInstalling {
 // stay here and the scaffold (CmuxTestSupport) owns the gates + schedule.
 extension AppDelegate: StartupUITestScaffoldDriving {
     func applyUpdateTestSupport() {
-        UpdateTestSupport(model: updateController.model, log: updateLog).applyIfNeeded()
+        UpdateTestSupport(model: updateController.model, log: environment.updateLog).applyIfNeeded()
     }
 
     func logUpdateTestEnvironment(trigger: String, feed: String) {
-        updateLog.append("ui test env: trigger=\(trigger) feed=\(feed)")
+        environment.updateLog.append("ui test env: trigger=\(trigger) feed=\(feed)")
     }
 
     func logTriggerUpdateCheckDetected() {
-        updateLog.append("ui test trigger update check detected")
+        environment.updateLog.append("ui test trigger update check detected")
     }
 
     func performTriggerUpdateCheck() {
         let windowIds = NSApp.windows.map { $0.identifier?.rawValue ?? "<nil>" }
-        updateLog.append("ui test windows: count=\(NSApp.windows.count) ids=\(windowIds.joined(separator: ","))")
-        if UpdateTestSupport(model: updateController.model, log: updateLog).performMockFeedCheckIfNeeded() {
+        environment.updateLog.append("ui test windows: count=\(NSApp.windows.count) ids=\(windowIds.joined(separator: ","))")
+        if UpdateTestSupport(model: updateController.model, log: environment.updateLog).performMockFeedCheckIfNeeded() {
             return
         }
         checkForUpdates(nil)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -35,6 +35,16 @@ import CmuxTestSupport
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate, NSMenuItemValidation, NSMenuDelegate, CmuxConfigStoreReloadEnvironment, ExternalOpenIntentHosting, WindowLifecycleHosting, AppMenuHosting {
     nonisolated(unsafe) static var shared: AppDelegate?
+    /// Process-lifetime service holder (Wave 1 of the `AppDelegate.shared`
+    /// de-singletonization). Owns the service objects whose lifetime is the whole
+    /// process; constructed once here at the composition root and injected into
+    /// the per-window SwiftUI tree via `.environment(\.appEnvironment, …)`. The
+    /// moved members keep their exact names/types/optionality/isolation, and
+    /// `AppDelegate` exposes a computed forwarder for each so the not-yet-migrated
+    /// `AppDelegate.shared.X` sites resolve to this same instance.
+    /// `nonisolated(unsafe)`: read from the `nonisolated` accessibility-swizzle
+    /// path (via the `accessibilityWindowCache` forwarder), mirroring `shared`.
+    nonisolated(unsafe) let environment: AppEnvironment
     /// Stateless control-socket syscall layer (CmuxControlSocket); composition-root owned.
     nonisolated let socketTransport = SocketTransport()
     /// The app-target composition owner for external programmatic control: the
@@ -90,21 +100,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
     /// Owns the inline VS Code `serve-web` process lifecycle
     /// (``VSCodeServeWebController``, CmuxWorkspaces); composition-root owned so
-    /// the type no longer exposes a `static let shared`. The ContentView and
-    /// shortcut-routing call sites reach this same instance through
-    /// ``AppDelegate/shared``.
-    let vscodeServeWebController = VSCodeServeWebController()
+    /// the type no longer exposes a `static let shared`. Storage moved to
+    /// ``AppEnvironment``; this forwarder keeps the not-yet-migrated
+    /// `AppDelegate.shared.vscodeServeWebController` sites resolving to it.
+    /// `nonisolated` because the stored `let` it replaced was cross-actor
+    /// readable (ShortcutRoutingSupport's default-argument closure reads it
+    /// from a nonisolated context); the body performs that same immutable read
+    /// through the `nonisolated(unsafe)` `environment` reference.
+    nonisolated var vscodeServeWebController: VSCodeServeWebController { environment.vscodeServeWebController }
     #if DEBUG
-    /// DEBUG main-run-loop stall probe (CmuxTestSupport); composition-root owned,
-    /// injected behind ``RunLoopStallMonitoring`` to retire the former
-    /// `CmuxMainRunLoopStallMonitor.shared` singleton.
-    let runLoopStallMonitor: any RunLoopStallMonitoring = CmuxMainRunLoopStallMonitor()
-    /// DEBUG main-thread turn profiler (CmuxTestSupport); composition-root owned,
-    /// injected behind ``MainThreadTurnProfiling``. Installed as
-    /// `CmuxTypingTiming.turnProfiler` in `applicationDidFinishLaunching` so the
-    /// typing probe's `logDuration` forwards to this instance, retiring the former
-    /// `CmuxMainThreadTurnProfiler.shared` singleton.
-    let mainThreadTurnProfiler: any MainThreadTurnProfiling = CmuxMainThreadTurnProfiler()
+    /// DEBUG main-run-loop stall probe (CmuxTestSupport). Storage moved to
+    /// ``AppEnvironment``; forwarder preserved for not-yet-migrated sites.
+    var runLoopStallMonitor: any RunLoopStallMonitoring { environment.runLoopStallMonitor }
+    /// DEBUG main-thread turn profiler (CmuxTestSupport). Storage moved to
+    /// ``AppEnvironment``; forwarder preserved for not-yet-migrated sites.
+    var mainThreadTurnProfiler: any MainThreadTurnProfiling { environment.mainThreadTurnProfiler }
     #endif
     /// Owns the About Titlebar Debug subsystem (CmuxAppKitSupportUI); composition-root
     /// owned and created lazily so the window-decoration seam can point back at `self`.
@@ -215,8 +225,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return provider
     }
 
-    /// Coordinates remote tmux (`ssh … tmux -CC`) mirroring; composition-root owned.
-    let remoteTmuxController = RemoteTmuxController()
+    /// Coordinates remote tmux (`ssh … tmux -CC`) mirroring. Storage moved to
+    /// ``AppEnvironment``; this forwarder keeps the not-yet-migrated
+    /// `AppDelegate.shared.remoteTmuxController` sites resolving to it.
+    var remoteTmuxController: RemoteTmuxController { environment.remoteTmuxController }
     private static let reloadConfigurationMenuItemIdentifier = NSUserInterfaceItemIdentifier("com.cmux.reloadConfiguration")
 
     private static let cachedIsRunningUnderXCTest = detectRunningUnderXCTest(ProcessInfo.processInfo.environment)
@@ -392,7 +404,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     )
 
     weak var tabManager: TabManager?
-    weak var notificationStore: TerminalNotificationStore?
+    /// The single `TerminalNotificationStore` (owned by the `cmuxApp`
+    /// `@StateObject`). Storage moved to ``AppEnvironment``, which holds it
+    /// weakly exactly as the former `weak var` here did; this get/set forwarder
+    /// keeps the not-yet-migrated `AppDelegate.shared.notificationStore` sites
+    /// (and the `configure(...)` write) resolving to it.
+    var notificationStore: TerminalNotificationStore? {
+        get { environment.notificationStore }
+        set { environment.notificationStore = newValue }
+    }
     weak var sidebarState: SidebarState?
 
     /// Notification jump/open navigation, extracted into `CmuxNotifications`.
@@ -553,24 +573,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     // focused-mark state machine lives in `FocusedNotificationMarker` (behind
     // `FocusedNotificationResolving`).
     /// The auth graph, injected once via `configure(...)` at app startup.
-    private(set) var auth: MacAuthComposition?
+    /// Storage moved to ``AppEnvironment``; this read-only forwarder preserves
+    /// the former `private(set)` contract (the single write in `configure(...)`
+    /// assigns `environment.auth` directly).
+    var auth: MacAuthComposition? { environment.auth }
     /// Strongly-held observers for every active TabManager. Each observer owns
     /// Combine subscriptions that publish workspace.updated to mobile clients.
     private var mobileWorkspaceListObservers: [ObjectIdentifier: MobileWorkspaceListObserver] = [:]
     private let agentChatTranscriptService = AgentChatTranscriptService()
-    /// Per-pane runaway-memory guardrail, constructed and wired at startup
-    /// (replaces the former `PaneMemoryGuardrail.shared` singleton). Held by the
-    /// composition root and read by `ContentView` for the warning banner.
-    let paneMemoryGuardrail = PaneMemoryGuardrailService(
-        sampleProvider: PaneMemorySampleProvider(),
-        settings: PaneMemoryGuardrailSettings()
-    )
+    /// Per-pane runaway-memory guardrail, wired at startup (replaces the former
+    /// `PaneMemoryGuardrail.shared` singleton) and read by `ContentView` for the
+    /// warning banner. Storage moved to ``AppEnvironment``; forwarder preserved
+    /// for not-yet-migrated sites.
+    var paneMemoryGuardrail: PaneMemoryGuardrailService { environment.paneMemoryGuardrail }
     /// The app's settings dependency container, handed over by `cmuxApp` via
     /// `configure(...)` before any main window is created. AppKit builds the
     /// main window's `NSHostingView` itself, so it injects this into the
     /// `ContentView` environment so `@LiveSetting` can resolve the stores it
-    /// observes inside the sidebar.
-    var settingsRuntime: SettingsRuntime?
+    /// observes inside the sidebar. Storage moved to ``AppEnvironment``; this
+    /// get/set forwarder keeps the not-yet-migrated
+    /// `AppDelegate.shared.settingsRuntime` sites (and the `configure(...)`
+    /// write) resolving to it.
+    var settingsRuntime: SettingsRuntime? {
+        get { environment.settingsRuntime }
+        set { environment.settingsRuntime = newValue }
+    }
     weak var fileExplorerState: FileExplorerState?
     weak var fullscreenControlsViewModel: TitlebarControlsViewModel?
     weak var sidebarSelectionState: SidebarSelectionState?
@@ -678,8 +705,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var browserAddressBarFocusObserver: NSObjectProtocol?
     private var browserAddressBarBlurObserver: NSObjectProtocol?
     private var browserWebViewFirstResponderObserver: NSObjectProtocol?
-    let updateLog = UpdateLogStore()
-    let focusLog = FocusLogStore()
+    /// Update-pill / Sparkle update log store. Storage moved to
+    /// ``AppEnvironment``; forwarder preserved for not-yet-migrated sites.
+    var updateLog: UpdateLogStore { environment.updateLog }
+    /// Keyboard-focus diagnostics log store. Storage moved to
+    /// ``AppEnvironment``; forwarder preserved for not-yet-migrated sites.
+    var focusLog: FocusLogStore { environment.focusLog }
     /// Process-wide identity of the workspace currently being sidebar-dragged in
     /// any window. Owned here (the composition root) and injected into every
     /// window's `SidebarDragState` so cross-window drops resolve a single drag.
@@ -690,9 +721,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// `SidebarDragState`. Owned here (the composition root) and injected into the
     /// sidebar (via `\.sidebarDragStateRegistry`) and the
     /// `debug.sidebar.simulate_drag` reader (via the reader's constructor), so
-    /// neither reaches `AppDelegate.shared` for it.
-    // TODO(de-singletonize): move SidebarDragStateRegistry off AppDelegate when AppDelegate is decomposed.
-    let sidebarDragStateRegistry = SidebarDragStateRegistry()
+    /// neither reaches `AppDelegate.shared` for it. Storage moved to
+    /// ``AppEnvironment``; forwarder preserved for not-yet-migrated sites.
+    var sidebarDragStateRegistry: SidebarDragStateRegistry { environment.sidebarDragStateRegistry }
     var debugFocusedTerminalKeyRepairObserverForTesting: ((NSWindow, NSEvent, NSResponder?) -> Void)?
     #endif
     /// Owns the in-flight "join the next async-created workspace to this group"
@@ -1463,13 +1494,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         router: DeepLinkOpenPlanner(),
         host: self
     )
-    /// Accessibility window-hierarchy cache (CmuxWindowing); composition-root
-    /// owned. The `NSApplication` AX swizzle forwards to it behind
-    /// ``AccessibilityWindowCaching``.
-    /// `nonisolated(unsafe)`: the existential is non-Sendable, but it is only
-    /// touched from the main-actor AX swizzle path (callers hold it on main),
-    /// matching the other non-Sendable composition-root members (`shared`).
-    nonisolated(unsafe) let accessibilityWindowCache: any AccessibilityWindowCaching = AccessibilityWindowCache()
+    /// Accessibility window-hierarchy cache (CmuxWindowing). The `NSApplication`
+    /// AX swizzle forwards to it behind ``AccessibilityWindowCaching``. Storage
+    /// moved to ``AppEnvironment`` (still `nonisolated(unsafe)` there); this
+    /// `nonisolated` forwarder keeps the swizzle's `nonisolated` `@objc` read
+    /// path working, guarded by `Thread.isMainThread` at the call site exactly
+    /// as before.
+    nonisolated var accessibilityWindowCache: any AccessibilityWindowCaching { environment.accessibilityWindowCache }
     /// First-responder bypass guard (CmuxBrowserPanel); composition-root owned.
     /// The `NSWindow.makeFirstResponder` swizzle reads `isActive` and
     /// `BrowserPanel` wraps responder-churning devtools work in `withBypass(_:)`.
@@ -1612,6 +1643,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
 
     override init() {
+        // Constructed here (a main-actor context) rather than as the stored
+        // default: the property is `nonisolated(unsafe)` so the accessibility
+        // swizzle can read through it, and a nonisolated default-value context
+        // may not call AppEnvironment's main-actor init.
+        self.environment = AppEnvironment()
         super.init()
         Self.shared = self
         // Inverts the surface registry's legacy AppDelegate.shared reach-up:
@@ -2180,7 +2216,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // self-vivified lazy singleton.
         TaskManagerWindowController.installCompositionRootInstance(taskManagerWindowController)
         self.sidebarState = sidebarState
-        self.auth = auth
+        environment.auth = auth
         VMClient.bootstrap(auth: auth.coordinator)
         RemotesClient.bootstrap(auth: auth.coordinator)
         PhonePushClient.shared.configure(auth: auth.coordinator)
@@ -6131,6 +6167,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             // optional, so a nil runtime just leaves reads at their seeded
             // catalog default.
             .environment(\.settingsRuntime, settingsRuntime)
+            // Inject the composition-root-owned process-lifetime service holder
+            // (Wave 1 of the `AppDelegate.shared` de-singletonization) so views
+            // read process services via `@Environment(\.appEnvironment)` instead
+            // of the singleton. Nil-default key: a view rendered outside this
+            // injected scope short-circuits exactly like `AppDelegate.shared?`.
+            .environment(\.appEnvironment, environment)
             // Inject the composition-root-owned cross-window sidebar drag
             // registry so the sidebar's `SidebarDragState` wires to the shared
             // registry by injection instead of an `AppDelegate.shared` lookup.

--- a/Sources/AppEnvironment.swift
+++ b/Sources/AppEnvironment.swift
@@ -89,6 +89,13 @@ final class AppEnvironment {
     /// (`var` optional), matching the former `AppDelegate.settingsRuntime`.
     var settingsRuntime: SettingsRuntime?
 
+    /// Process-wide cross-window registry and recoverable-route owner. AppDelegate
+    /// keeps a computed forwarder while resolver call sites migrate.
+    let windowRegistry: WindowRegistry
+
+    /// Active/key-main-window router for command, sidebar, and move actions.
+    let mainWindowRouter: MainWindowRouter
+
     /// Update-pill / Sparkle update log store; composition-root owned.
     let updateLog = UpdateLogStore()
 
@@ -122,5 +129,9 @@ final class AppEnvironment {
     let mainThreadTurnProfiler: any MainThreadTurnProfiling = CmuxMainThreadTurnProfiler()
     #endif
 
-    init() {}
+    init() {
+        let windowRegistry = WindowRegistry()
+        self.windowRegistry = windowRegistry
+        self.mainWindowRouter = MainWindowRouter(windowRegistry: windowRegistry)
+    }
 }

--- a/Sources/AppEnvironment.swift
+++ b/Sources/AppEnvironment.swift
@@ -1,0 +1,126 @@
+import AppKit
+import CmuxAppKitSupportUI
+import CmuxAuthRuntime
+import CmuxBrowser
+import CmuxCommandPalette
+import CmuxCommandPaletteUI
+import CmuxPanes
+import CmuxControlSocket
+import CmuxWindowing
+import CmuxNotifications
+import CmuxTerminalCore
+import CmuxTerminal
+import CmuxSettings
+import CmuxSettingsUI
+import CmuxShortcuts
+import CmuxUpdater
+import CmuxWorkspaces
+import CmuxUpdaterUI
+import SwiftUI
+import Bonsplit
+import CMUXAgentLaunch
+import CoreServices
+import UserNotifications
+import WebKit
+import Combine
+import CmuxFoundation
+import CmuxSidebar
+#if DEBUG
+import CmuxTestSupport
+#endif
+
+/// Process-lifetime service holder extracted from `AppDelegate` (Wave 1 of the
+/// `AppDelegate.shared` de-singletonization).
+///
+/// `AppEnvironment` is a focused composition-root holder for the service objects
+/// whose lifetime is the whole process (not per-window, not per-session). It is
+/// deliberately *not* a god: it stores the service objects and nothing else, and
+/// the members keep the exact names, types, optionality, and isolation they had
+/// as stored properties on `AppDelegate`, so migrating a call site is a literal
+/// `AppDelegate.shared.notificationStore` → `environment.notificationStore`
+/// rewrite.
+///
+/// The single instance is owned by `AppDelegate` (`AppDelegate.environment`),
+/// constructed once during app init, and injected into the per-window SwiftUI
+/// tree via `.environment(\.appEnvironment, …)` (see `AppEnvironmentKey.swift`).
+/// `AppDelegate` keeps computed forwarders for each moved member so the not-yet-
+/// migrated `AppDelegate.shared.X` call sites continue to resolve to this same
+/// instance during the migration.
+///
+/// ## Isolation
+///
+/// `@MainActor` because every service here is created and mutated on the main
+/// actor alongside `AppDelegate`. The sole exception is
+/// ``accessibilityWindowCache``, which stays `nonisolated(unsafe)` exactly as it
+/// was on `AppDelegate`: the `NSApplication` accessibility swizzle reaches it
+/// from a `nonisolated` `@objc` context (guarded by `Thread.isMainThread` at the
+/// call site), and the existential is non-Sendable.
+@MainActor
+final class AppEnvironment {
+    /// The single `TerminalNotificationStore` owned by the `cmuxApp`
+    /// `@StateObject`; recorded here (weakly) at `configure(...)` so the
+    /// composition-root forwarders resolve to that instance. Weak, matching the
+    /// former `AppDelegate.notificationStore`.
+    weak var notificationStore: TerminalNotificationStore?
+
+    /// Coordinates remote tmux (`ssh … tmux -CC`) mirroring; composition-root owned.
+    let remoteTmuxController = RemoteTmuxController()
+
+    /// The auth graph, injected once via `AppDelegate.configure(...)` at app
+    /// startup. Late-bound (`nil` until configured), matching the former
+    /// `private(set) var auth` on `AppDelegate`; the read-only contract is kept
+    /// by `AppDelegate` exposing only a getter forwarder.
+    var auth: MacAuthComposition?
+
+    /// Owns the inline VS Code `serve-web` process lifecycle
+    /// (``VSCodeServeWebController``, CmuxWorkspaces); composition-root owned.
+    let vscodeServeWebController = VSCodeServeWebController()
+
+    /// Per-pane runaway-memory guardrail (replaces the former
+    /// `PaneMemoryGuardrail.shared` singleton). Read by `ContentView` for the
+    /// warning banner.
+    let paneMemoryGuardrail = PaneMemoryGuardrailService(
+        sampleProvider: PaneMemorySampleProvider(),
+        settings: PaneMemoryGuardrailSettings()
+    )
+
+    /// The app's settings dependency container, handed over by `cmuxApp` via
+    /// `AppDelegate.configure(...)` before any main window is created. Late-bound
+    /// (`var` optional), matching the former `AppDelegate.settingsRuntime`.
+    var settingsRuntime: SettingsRuntime?
+
+    /// Update-pill / Sparkle update log store; composition-root owned.
+    let updateLog = UpdateLogStore()
+
+    /// Keyboard-focus diagnostics log store; composition-root owned.
+    let focusLog = FocusLogStore()
+
+    /// Accessibility window-hierarchy cache (CmuxWindowing); composition-root
+    /// owned. The `NSApplication` AX swizzle forwards to it behind
+    /// ``AccessibilityWindowCaching``.
+    /// `nonisolated(unsafe)`: the existential is non-Sendable, but it is only
+    /// touched from the main-actor AX swizzle path (callers hold it on main),
+    /// matching the other non-Sendable composition-root members.
+    nonisolated(unsafe) let accessibilityWindowCache: any AccessibilityWindowCaching = AccessibilityWindowCache()
+
+    #if DEBUG
+    /// Debug-only registry mapping each mounted sidebar's window id to its live
+    /// `SidebarDragState`. Composition-root owned; injected into the sidebar (via
+    /// `\.sidebarDragStateRegistry`) and the `debug.sidebar.simulate_drag` reader.
+    let sidebarDragStateRegistry = SidebarDragStateRegistry()
+
+    /// DEBUG main-run-loop stall probe (CmuxTestSupport); composition-root owned,
+    /// injected behind ``RunLoopStallMonitoring`` to retire the former
+    /// `CmuxMainRunLoopStallMonitor.shared` singleton.
+    let runLoopStallMonitor: any RunLoopStallMonitoring = CmuxMainRunLoopStallMonitor()
+
+    /// DEBUG main-thread turn profiler (CmuxTestSupport); composition-root owned,
+    /// injected behind ``MainThreadTurnProfiling``. Installed as
+    /// `CmuxTypingTiming.turnProfiler` in `applicationDidFinishLaunching` so the
+    /// typing probe's `logDuration` forwards to this instance, retiring the former
+    /// `CmuxMainThreadTurnProfiler.shared` singleton.
+    let mainThreadTurnProfiler: any MainThreadTurnProfiling = CmuxMainThreadTurnProfiler()
+    #endif
+
+    init() {}
+}

--- a/Sources/AppEnvironmentKey.swift
+++ b/Sources/AppEnvironmentKey.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// SwiftUI environment carrier for the process-lifetime ``AppEnvironment`` the
+/// app owns at its composition root (`AppDelegate`).
+///
+/// AppKit hosts each main window's `ContentView` in its own `NSHostingView`,
+/// which does not inherit the App scene's SwiftUI environment. The composition
+/// root injects its owned ``AppEnvironment`` via
+/// `.environment(\.appEnvironment, …)` at the per-window root view so any View
+/// below can read process-lifetime services through `@Environment(\.appEnvironment)`
+/// instead of reaching `AppDelegate.shared`.
+///
+/// The default is `nil`, matching the legacy fallback: `AppDelegate.shared?` was
+/// optional, so a reader with no injected environment short-circuits exactly as
+/// `AppDelegate.shared?.notificationStore` did when the delegate was unavailable
+/// (`appEnvironment?.notificationStore`).
+private struct AppEnvironmentKey: EnvironmentKey {
+    static let defaultValue: AppEnvironment? = nil
+}
+
+extension EnvironmentValues {
+    /// The process-lifetime ``AppEnvironment`` injected from the app composition
+    /// root, or `nil` when none has been injected.
+    var appEnvironment: AppEnvironment? {
+        get { self[AppEnvironmentKey.self] }
+        set { self[AppEnvironmentKey.self] = newValue }
+    }
+}

--- a/Sources/AppleScriptSupport.swift
+++ b/Sources/AppleScriptSupport.swift
@@ -83,7 +83,8 @@ extension NSApplication {
               let appDelegate = AppDelegate.shared else {
             return []
         }
-        return appDelegate.scriptableMainWindows().map { ScriptWindow(windowId: $0.windowId) }
+        return appDelegate.environment.windowRegistry.scriptableMainWindows()
+            .map { ScriptWindow(windowId: $0.windowId) }
     }
 
     @objc(frontWindow)
@@ -96,7 +97,7 @@ extension NSApplication {
         guard isAppleScriptEnabled,
               let windowId = UUID(uuidString: uniqueID),
               let appDelegate = AppDelegate.shared,
-              appDelegate.scriptableMainWindow(windowId: windowId) != nil else {
+              appDelegate.environment.windowRegistry.scriptableMainWindow(windowId: windowId) != nil else {
             return nil
         }
         return ScriptWindow(windowId: windowId)
@@ -109,7 +110,7 @@ extension NSApplication {
             return []
         }
 
-        return appDelegate.scriptableMainWindows()
+        return appDelegate.environment.windowRegistry.scriptableMainWindows()
             .flatMap { state in
                 state.tabManager.tabs.flatMap { workspace in
                     workspace.scriptingTerminalPanels().map {
@@ -127,7 +128,7 @@ extension NSApplication {
             return nil
         }
 
-        for state in appDelegate.scriptableMainWindows() {
+        for state in appDelegate.environment.windowRegistry.scriptableMainWindows() {
             for workspace in state.tabManager.tabs where workspace.terminalPanel(for: terminalId) != nil {
                 return ScriptTerminal(workspaceId: workspace.id, terminalId: terminalId)
             }
@@ -576,7 +577,7 @@ final class ScriptTerminal: NSObject {
         }
 
         if let app = AppDelegate.shared {
-            _ = app.focusScriptableMainWindow(windowId: state.windowId, bringToFront: true)
+            _ = app.environment.mainWindowRouter.focusScriptableWindow(windowId: state.windowId, bringToFront: true)
         }
         state.tabManager.selectWorkspace(workspace)
         workspace.focusPanel(terminalId)

--- a/Sources/ContentView+AuthCommandPalette.swift
+++ b/Sources/ContentView+AuthCommandPalette.swift
@@ -21,7 +21,7 @@ extension ContentView {
 #if DEBUG
             cmuxDebugLog("palette.auth.signIn.invoke")
 #endif
-            guard let auth = AppDelegate.shared?.auth else {
+            guard let auth = appEnvironment?.auth else {
                 NSSound.beep()
                 return
             }
@@ -31,7 +31,7 @@ extension ContentView {
 #if DEBUG
             cmuxDebugLog("palette.auth.signOut.invoke")
 #endif
-            guard let auth = AppDelegate.shared?.auth else {
+            guard let auth = appEnvironment?.auth else {
                 NSSound.beep()
                 return
             }

--- a/Sources/ContentView+MoveTabToNewWorkspace.swift
+++ b/Sources/ContentView+MoveTabToNewWorkspace.swift
@@ -21,7 +21,7 @@ extension ContentView {
 
     func moveFocusedPanelToNewWorkspace() -> Bool {
         guard let panelContext = focusedPanelContext else { return false }
-        return AppDelegate.shared?.moveSurfaceToNewWorkspace(
+        return appEnvironment?.mainWindowRouter.moveSurfaceToNewWorkspace(
             panelId: panelContext.panelId,
             focus: true,
             focusWindow: false
@@ -34,6 +34,7 @@ struct SidebarBonsplitTabNewWorkspaceDropOverlay: NSViewRepresentable {
     @Binding var selectedTabIds: Set<UUID>
     @Binding var lastSidebarSelectionIndex: Int?
     @Binding var dropIndicator: SidebarDropIndicator?
+    @Environment(\.appEnvironment) private var appEnvironment
 
     func makeNSView(context: Context) -> SidebarBonsplitTabNewWorkspaceDropView {
         return SidebarBonsplitTabNewWorkspaceDropView()
@@ -41,20 +42,19 @@ struct SidebarBonsplitTabNewWorkspaceDropOverlay: NSViewRepresentable {
 
     func updateNSView(_ nsView: SidebarBonsplitTabNewWorkspaceDropView, context: Context) {
         nsView.isValidTransfer = { transfer in
-            return AppDelegate.shared?.canMoveBonsplitTabToNewWorkspace(tabId: transfer.tab.id) ?? false
+            appEnvironment?.mainWindowRouter.canMoveBonsplitTabToNewWorkspace(tabId: transfer.tab.id) ?? false
         }
         nsView.setDropActive = { isActive in
             dropIndicator = isActive ? SidebarDropIndicator(tabId: nil, edge: .bottom) : nil
         }
         nsView.performMove = { transfer in
-            guard let app = AppDelegate.shared,
-                  let result = app.moveBonsplitTabToNewWorkspace(
-                    tabId: transfer.tab.id,
-                    destinationManager: tabManager,
-                    focus: true,
-                    focusWindow: true,
-                    placementOverride: .end
-                  ) else {
+            guard let result = appEnvironment?.mainWindowRouter.moveBonsplitTabToNewWorkspace(
+                tabId: transfer.tab.id,
+                destinationManager: tabManager,
+                focus: true,
+                focusWindow: true,
+                placementOverride: .end
+            ) else {
                 return false
             }
 

--- a/Sources/ContentView+RightSidebarCommandPalette.swift
+++ b/Sources/ContentView+RightSidebarCommandPalette.swift
@@ -153,7 +153,7 @@ extension ContentView {
             NSSound.beep()
             return
         }
-        if AppDelegate.shared?.focusRightSidebarInActiveMainWindow(
+        if appEnvironment?.mainWindowRouter.focusRightSidebarInActiveWindow(
             mode: mode,
             focusFirstItem: true,
             preferredWindow: observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -637,7 +637,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
             onSendFeedback: feedbackComposerCoordinator.present,
             onToggleSidebar: { sidebarState.toggle() },
             onNewTab: {
-                AppDelegate.shared?.performNewWorkspaceAction(
+                appEnvironment?.mainWindowRouter.performNewWorkspaceAction(
                     tabManager: tabManager,
                     debugSource: "titlebar.hiddenNewWorkspace"
                 )
@@ -882,7 +882,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
                 #if DEBUG
                 cmuxDebugLog("rightSidebar.closeButton")
                 #endif
-                _ = AppDelegate.shared?.closeRightSidebarInActiveMainWindow(preferredWindow: observedWindow)
+                _ = appEnvironment?.mainWindowRouter.closeRightSidebarInActiveWindow(preferredWindow: observedWindow)
             }
         )
         .frame(width: rightSidebarWidth)
@@ -970,7 +970,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
                 )
             },
             onNewTab: {
-                AppDelegate.shared?.performNewWorkspaceAction(
+                appEnvironment?.mainWindowRouter.performNewWorkspaceAction(
                     tabManager: tabManager,
                     debugSource: "titlebar.fullscreenNewWorkspace"
                 )
@@ -2623,8 +2623,8 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
             windowLabel: nil
         )
 
-        guard let appDelegate = AppDelegate.shared else { return [fallback] }
-        let summaries = appDelegate.listMainWindowSummaries()
+        guard let windowRegistry = appEnvironment?.windowRegistry else { return [fallback] }
+        let summaries = windowRegistry.listMainWindowSummaries()
         guard !summaries.isEmpty else { return [fallback] }
 
         let orderedSummaries = summaries.sorted { lhs, rhs in
@@ -2646,7 +2646,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
         var contexts: [CommandPaletteSwitcherWindowContext] = []
         var seenWindowIds: Set<UUID> = []
         for summary in orderedSummaries {
-            guard let manager = appDelegate.tabManagerFor(windowId: summary.windowId) else { continue }
+            guard let manager = windowRegistry.tabManagerFor(windowId: summary.windowId) else { continue }
             guard seenWindowIds.insert(summary.windowId).inserted else { continue }
             contexts.append(
                 CommandPaletteSwitcherWindowContext(
@@ -2702,7 +2702,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
         // Defer focus mutation one turn so browser omnibar autofocus can run
         // without being blocked by the palette-visibility guard.
         DispatchQueue.main.async {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
             tabManager.focusTab(
                 workspaceId,
                 suppressFlash: true,
@@ -2718,7 +2718,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
         panelId: UUID
     ) {
         DispatchQueue.main.async {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
             tabManager.focusTab(
                 workspaceId,
                 surfaceId: panelId,
@@ -3719,7 +3719,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
 
     private func registerCommandPaletteHandlers(_ registry: inout CommandPaletteHandlerRegistry) {
         registry.register(commandId: "palette.newWorkspace") {
-            AppDelegate.shared?.performNewWorkspaceAction(
+            appEnvironment?.mainWindowRouter.performNewWorkspaceAction(
                 tabManager: tabManager,
                 debugSource: "palette.newWorkspace"
             )
@@ -3728,7 +3728,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
             // Let command-palette dismissal complete first so omnibar focus
             // is not blocked by the palette visibility guard.
             DispatchQueue.main.async {
-                _ = AppDelegate.shared?.performNewBrowserWorkspaceAction(
+                _ = appEnvironment?.mainWindowRouter.performNewBrowserWorkspaceAction(
                     tabManager: tabManager,
                     debugSource: "palette.newBrowserWorkspace"
                 )
@@ -3750,7 +3750,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
         }
         registry.register(commandId: "palette.openFolderInVSCodeInline") {
             DispatchQueue.main.async {
-                AppDelegate.shared?.showOpenFolderInInlineVSCodePanel(tabManager: tabManager)
+                appEnvironment?.mainWindowRouter.showOpenFolderInInlineVSCodePanel(tabManager: tabManager)
             }
         }
         registry.register(commandId: "palette.reopenPreviousSession") {
@@ -3760,7 +3760,8 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
         }
         registry.register(commandId: "palette.newWindow") {
             guard let appDelegate = AppDelegate.shared else { return }
-            appDelegate.openNewMainWindow(preferredWindow: appDelegate.mainWindow(for: windowId))
+            let preferredWindow = appEnvironment?.windowRegistry.mainWindow(for: windowId)
+            appDelegate.openNewMainWindow(preferredWindow: preferredWindow)
         }
         registry.register(commandId: "palette.installCLI") {
             AppDelegate.shared?.installCmuxCLIInPath(nil)
@@ -4144,7 +4145,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
             BrowserHistoryStore.shared.clearHistory()
         }
         registry.register(commandId: "palette.findInDirectory") {
-            _ = AppDelegate.shared?.focusFileSearchInActiveMainWindow(
+            _ = appEnvironment?.mainWindowRouter.focusFileSearchInActiveWindow(
                 preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
             )
         }
@@ -5378,6 +5379,11 @@ struct VerticalTabsSidebar: View {
 #else
     fileprivate static let sidebarDragFailsafeDebugLog: ((_ message: String) -> Void)? = nil
 #endif
+    /// Process-lifetime services (nil-default key, faithful to the legacy
+    /// `AppDelegate.shared?` short-circuit). VerticalTabsSidebar is a plain
+    /// View (not Equatable-gated); the Equatable typing-hot-path row type is
+    /// `TabItemView`, which must never gain this property.
+    @Environment(\.appEnvironment) private var appEnvironment
     var updateViewModel: UpdateStateModel
     @ObservedObject var fileExplorerState: FileExplorerState
     let windowId: UUID
@@ -5696,7 +5702,7 @@ struct VerticalTabsSidebar: View {
         return SidebarEmptyAreaActions(
             selectedTabIsRemoteTmuxMirror: { tabManager.selectedTab?.isRemoteTmuxMirror == true },
             performNewWorkspaceAction: {
-                _ = AppDelegate.shared?.performNewWorkspaceAction(
+                _ = appEnvironment?.mainWindowRouter.performNewWorkspaceAction(
                     tabManager: tabManager,
                     debugSource: "sidebar.emptyArea.remoteTmux"
                 )
@@ -7025,7 +7031,7 @@ struct VerticalTabsSidebar: View {
                 guard let app = AppDelegate.shared else {
                     return false
                 }
-                if let source = app.locateBonsplitSurface(tabId: transfer.tab.id),
+                if let source = app.environment.windowRegistry.locateBonsplitSurface(tabId: transfer.tab.id),
                    source.workspaceId == workspaceId {
                     return true
                 }
@@ -7037,14 +7043,13 @@ struct VerticalTabsSidebar: View {
                 )
             },
             moveToNewWorkspace: { insertionIndex, transfer in
-                guard let app = AppDelegate.shared,
-                      let result = app.moveBonsplitTabToNewWorkspace(
-                        tabId: transfer.tab.id,
-                        destinationManager: tabManager,
-                        focus: true,
-                        focusWindow: true,
-                        insertionIndexOverride: insertionIndex
-                      ) else {
+                guard let result = appEnvironment?.mainWindowRouter.moveBonsplitTabToNewWorkspace(
+                    tabId: transfer.tab.id,
+                    destinationManager: tabManager,
+                    focus: true,
+                    focusWindow: true,
+                    insertionIndexOverride: insertionIndex
+                ) else {
                     return nil
                 }
                 return result.destinationWorkspaceId

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -106,6 +106,11 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
     /// its `SidebarDragState` is wired to the shared registry without reaching
     /// the `AppDelegate.shared` singleton.
     @Environment(\.sidebarWorkspaceDragRegistry) private var sidebarWorkspaceDragRegistry
+    /// Process-lifetime services injected from the app composition root
+    /// (`AppDelegate.environment`); `nil` when no environment was injected,
+    /// matching the legacy `AppDelegate.shared?` optionality. Internal (not
+    /// `private`) so `ContentView` extensions in sibling files can read it.
+    @Environment(\.appEnvironment) var appEnvironment
     @AppStorage("titlebarControlsStyle") private var titlebarControlsStyleRawValue = TitlebarControlsStyle.classic.rawValue
     @AppStorage(RightSidebarWidthSettings.maxWidthKey) private var rightSidebarMaxWidthSetting = RightSidebarWidthSettings.noOverrideValue
     @AppStorage(SessionPersistencePolicy.sidebarMinimumWidthKey) private var sidebarMinimumWidthSetting = SessionPersistencePolicy.defaultMinimumSidebarWidth
@@ -772,7 +777,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
         }
         .padding(.top, effectiveTitlebarPadding)
         .overlay(alignment: .top) {
-            if let guardrail = AppDelegate.shared?.paneMemoryGuardrail {
+            if let guardrail = appEnvironment?.paneMemoryGuardrail {
                 PaneMemoryGuardrailBanner(guardrail: guardrail, tabManager: tabManager)
             }
         }
@@ -2140,7 +2145,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
         windowChrome.nativeTitlebarBackdropCoordinator.removeNativeTitlebarBackdrop(in: window)
 #if DEBUG
         if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
-            AppDelegate.shared?.updateLog.append("ui test window accessor: id=\(windowIdentifier) visible=\(window.isVisible)")
+            appEnvironment?.updateLog.append("ui test window accessor: id=\(windowIdentifier) visible=\(window.isVisible)")
         }
 #endif
         let backdropResult = windowChrome.backdropController.apply(plan: backdropPlan, to: window)
@@ -3156,7 +3161,7 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
         snapshot.setBool(CommandPaletteContextKeys.workspaceMinimalModeEnabled, isMinimalMode)
         snapshot.setBool(CommandPaletteContextKeys.sidebarMatchTerminalBackground, sidebarMatchTerminalBackground)
         snapshot.setBool(CommandPaletteContextKeys.browserDisabled, BrowserAvailabilitySettings.isDisabled())
-        if let auth = AppDelegate.shared?.auth {
+        if let auth = appEnvironment?.auth {
             snapshot.setBool(CommandPaletteContextKeys.authSignedIn, auth.coordinator.isAuthenticated)
             snapshot.setBool(
                 CommandPaletteContextKeys.authWorking,
@@ -5214,14 +5219,14 @@ struct ContentView: View, CommandPaletteWorkspaceSnapshotProviding, CommandPalet
     }
 
     private func stopInlineVSCodeServeWeb() {
-        AppDelegate.shared?.vscodeServeWebController.stop()
+        appEnvironment?.vscodeServeWebController.stop()
     }
 
     private func restartInlineVSCodeServeWeb() -> Bool {
         guard let vscodeApplicationURL = TerminalDirectoryOpenTarget.vscodeInline.applicationURL() else {
             return false
         }
-        AppDelegate.shared?.vscodeServeWebController.restart(vscodeApplicationURL: vscodeApplicationURL) { serveWebURL in
+        appEnvironment?.vscodeServeWebController.restart(vscodeApplicationURL: vscodeApplicationURL) { serveWebURL in
             if serveWebURL == nil {
                 NSSound.beep()
             }

--- a/Sources/DevWindowDisplayDefault.swift
+++ b/Sources/DevWindowDisplayDefault.swift
@@ -75,7 +75,7 @@ enum DevWindowDisplayDefault {
     @MainActor
     static func applyToNewWindow(_ window: NSWindow) {
         guard let app = AppDelegate.shared,
-              let runtime = app.settingsRuntime else { return }
+              let runtime = app.environment.settingsRuntime else { return }
         // Prefer the settings value; fall back to the legacy file so an existing
         // pre-migration default still places the very first window before the
         // async one-time migration has committed to cmux.json.

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -582,7 +582,7 @@ private extension FeedCoordinator {
     ) -> NotificationPolicyContext {
         let appDelegate = AppDelegate.shared
         let workspaceID = event.workspaceId.flatMap(UUID.init(uuidString:))
-        let context = workspaceID.flatMap { appDelegate?.contextContainingTabId($0) }
+        let context = workspaceID.flatMap { appDelegate?.environment.windowRegistry.contextContainingTabId($0) }
             ?? appDelegate?.firstContextWithConfigStore()
         let configStore = context.flatMap { appDelegate?.configStore(for: $0) }
         let workspace = workspaceID.flatMap { id in

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -140,6 +140,7 @@ private struct FeedListView: View {
     let isLoadingOlderItems: Bool
     let onLoadOlderItems: () -> Void
 
+    @Environment(\.appEnvironment) private var appEnvironment
     @State private var focusSnapshot = FeedFocusSnapshot()
     @State private var scrollRequest: FeedScrollRequest?
     @State private var scrollRequestSequence = 0
@@ -437,7 +438,7 @@ private struct FeedListView: View {
         guard let targetId = preferredFocusItemId(in: snapshots) else {
             let window = activeFeedWindow()
             if focusHost {
-                _ = AppDelegate.shared?.focusRightSidebarInActiveMainWindow(
+                _ = appEnvironment?.mainWindowRouter.focusRightSidebarInActiveWindow(
                     mode: .feed,
                     focusFirstItem: false,
                     preferredWindow: window

--- a/Sources/FileExplorerTerminalPathInsertion.swift
+++ b/Sources/FileExplorerTerminalPathInsertion.swift
@@ -80,10 +80,10 @@ enum FileExplorerTerminalPathInsertion {
         }
         if let window,
            let windowId = appDelegate.mainWindowId(from: window),
-           let terminalPanel = appDelegate.tabManagerFor(windowId: windowId)?.selectedWorkspace?.focusedTerminalPanel {
+           let terminalPanel = appDelegate.environment.windowRegistry.tabManagerFor(windowId: windowId)?.selectedWorkspace?.focusedTerminalPanel {
             return terminalPanel
         }
-        return appDelegate.tabManager?.selectedWorkspace?.focusedTerminalPanel
+        return appDelegate.environment.mainWindowRouter.activeTabManager?.selectedWorkspace?.focusedTerminalPanel
     }
 }
 

--- a/Sources/GhosttyNSView+MoveTabToNewWorkspace.swift
+++ b/Sources/GhosttyNSView+MoveTabToNewWorkspace.swift
@@ -68,7 +68,7 @@ extension GhosttyNSView {
               let app = AppDelegate.shared else {
             return []
         }
-        return app.workspaceMoveTargets(forSurface: surfaceId)
+        return app.environment.mainWindowRouter.workspaceMoveTargets(forSurface: surfaceId)
     }
 
     @objc func moveCurrentSurfaceToNewWorkspace(_ sender: Any?) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -886,7 +886,8 @@ class GhosttyApp {
                 // Close requests must be resolved by the callback's workspace/surface IDs only.
                 // If the mapping is already gone (duplicate/stale callback), ignore it.
                 if let callbackTabId,
-                   let manager = app.tabManagerFor(tabId: callbackTabId) ?? app.tabManager,
+                   let manager = app.environment.windowRegistry.tabManagerFor(tabId: callbackTabId)
+                    ?? app.environment.mainWindowRouter.activeTabManager,
                    let workspace = manager.tabs.first(where: { $0.id == callbackTabId }),
                    workspace.panels[callbackSurfaceId] != nil {
                     if needsConfirmClose {
@@ -2122,11 +2123,12 @@ extension GhosttyApp: GhosttyActionHosting {
 
     func dispatchAppDesktopNotification(title: String, body: String) -> Bool {
         performOnMain {
-            guard let tabManager = AppDelegate.shared?.tabManager,
+            guard let app = AppDelegate.shared,
+                  let tabManager = app.tabManager,
                   let tabId = tabManager.selectedTabId else {
                 return false
             }
-            let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? tabManager
+            let owningManager = app.environment.windowRegistry.tabManagerFor(tabId: tabId) ?? tabManager
             let surfaceId = tabManager.focusedSurfaceId(for: tabId)
             if let workspace = owningManager.tabs.first(where: { $0.id == tabId }),
                workspace.suppressesRawTerminalNotification(panelId: surfaceId) {
@@ -2209,7 +2211,8 @@ extension GhosttyApp: GhosttyActionHosting {
             guard let app = AppDelegate.shared else { return }
             if let tabId,
                let surfaceId,
-               let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager,
+               let manager = app.environment.windowRegistry.tabManagerFor(tabId: tabId)
+                ?? app.environment.mainWindowRouter.activeTabManager,
                let workspace = manager.tabs.first(where: { $0.id == tabId }),
                workspace.panels[surfaceId] != nil {
                 manager.closePanelAfterChildExited(tabId: tabId, surfaceId: surfaceId)
@@ -2548,9 +2551,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations, TerminalWordPathHosting
     func applyWindowBackgroundIfActive() {
         guard let window else { return }
         let appDelegate = AppDelegate.shared
-        let owningManager = tabId.flatMap { appDelegate?.tabManagerFor(tabId: $0) }
+        let owningManager = tabId.flatMap { appDelegate?.environment.windowRegistry.tabManagerFor(tabId: $0) }
         let owningSelectedTabId = owningManager?.selectedTabId
-        let activeSelectedTabId = owningManager == nil ? appDelegate?.tabManager?.selectedTabId : nil
+        let activeSelectedTabId = owningManager == nil
+            ? appDelegate?.environment.mainWindowRouter.activeTabManager?.selectedTabId
+            : nil
         guard TerminalWindowBackgroundPolicy.shouldApplyWindowBackground(
             surfaceTabId: tabId,
             owningManagerExists: owningManager != nil,
@@ -5097,7 +5102,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations, TerminalWordPathHosting
         }
         guard let tabId,
               let app = AppDelegate.shared,
-              let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager,
+              let manager = app.environment.windowRegistry.tabManagerFor(tabId: tabId)
+                ?? app.environment.mainWindowRouter.activeTabManager,
               let workspace = manager.tabs.first(where: { $0.id == tabId }) else {
             return false
         }
@@ -5123,7 +5129,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations, TerminalWordPathHosting
         }
         guard let tabId,
               let app = AppDelegate.shared,
-              let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager else {
+              let manager = app.environment.windowRegistry.tabManagerFor(tabId: tabId)
+                ?? app.environment.mainWindowRouter.activeTabManager else {
             return false
         }
         return manager.createSplit(tabId: tabId, surfaceId: surfaceId, direction: direction) != nil
@@ -6956,7 +6963,7 @@ final class GhosttySurfaceScrollView: NSView {
     private func canApplyMountedSearchFieldFocusRequest() -> Bool {
         guard let terminalSurface = surfaceView.terminalSurface,
               let app = AppDelegate.shared,
-              let manager = app.tabManagerFor(tabId: terminalSurface.tabId),
+              let manager = app.environment.windowRegistry.tabManagerFor(tabId: terminalSurface.tabId),
               manager.selectedTabId == terminalSurface.tabId,
               let workspace = manager.tabs.first(where: { $0.id == terminalSurface.tabId }) else {
             return false
@@ -7731,7 +7738,8 @@ final class GhosttySurfaceScrollView: NSView {
         }
 
         guard let delegate = AppDelegate.shared,
-              let tabManager = delegate.tabManagerFor(tabId: tabId) ?? delegate.tabManager,
+              let tabManager = delegate.environment.windowRegistry.tabManagerFor(tabId: tabId)
+                ?? delegate.environment.mainWindowRouter.activeTabManager,
               tabManager.selectedTabId == tabId else {
             scheduleAutomaticFirstResponderApply(reason: "ensureFocus.inactiveTab")
             return
@@ -7796,7 +7804,7 @@ final class GhosttySurfaceScrollView: NSView {
 
         if !window.isKeyWindow {
             guard shouldAllowEnsureFocusWindowActivation(
-                activeTabManager: delegate.tabManager,
+                activeTabManager: delegate.environment.mainWindowRouter.activeTabManager,
                 targetTabManager: tabManager,
                 keyWindow: NSApp.keyWindow,
                 mainWindow: NSApp.mainWindow,
@@ -7835,7 +7843,8 @@ final class GhosttySurfaceScrollView: NSView {
 
     private func matchesCurrentTerminalFocusTarget(tabId: UUID, surfaceId: UUID) -> Bool {
         guard let delegate = AppDelegate.shared,
-              let tabManager = delegate.tabManagerFor(tabId: tabId) ?? delegate.tabManager,
+              let tabManager = delegate.environment.windowRegistry.tabManagerFor(tabId: tabId)
+                ?? delegate.environment.mainWindowRouter.activeTabManager,
               tabManager.selectedTabId == tabId,
               let tab = tabManager.tabs.first(where: { $0.id == tabId }),
               let tabIdForSurface = tab.surfaceIdFromPanelId(surfaceId),
@@ -9248,6 +9257,7 @@ extension GhosttyNSView: NSTextInputClient {
 
 struct GhosttyTerminalView: NSViewRepresentable {
     @Environment(\.paneDropZone) var paneDropZone
+    @Environment(\.appEnvironment) private var appEnvironment
 
     let terminalSurface: TerminalSurface
     let paneId: PaneID
@@ -9425,7 +9435,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
         coordinator.hostedView = hostedView
 #if DEBUG
         if desiredStateChanged {
-            if let snapshot = AppDelegate.shared?.tabManager?.debugCurrentWorkspaceSwitchSnapshot() {
+            if let snapshot = appEnvironment?.mainWindowRouter.activeTabManager?.debugCurrentWorkspaceSwitchSnapshot() {
                 let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
                 cmuxDebugLog(
                     "ws.swiftui.update id=\(snapshot.id) dt=\(String(format: "%.2fms", dtMs)) " +

--- a/Sources/MainWindowRouter.swift
+++ b/Sources/MainWindowRouter.swift
@@ -1,0 +1,1071 @@
+import AppKit
+import Bonsplit
+import CmuxSettings
+import CmuxSidebar
+import CmuxWindowing
+import CmuxWorkspaces
+import Foundation
+
+@MainActor
+struct MainWindowRouterHostSeams {
+    let shortcutRoutingKeyWindow: @MainActor () -> NSWindow?
+    let contextForMainWindow: @MainActor (NSWindow?) -> AppDelegate.RegisteredMainWindow?
+    let registeredMainWindows: @MainActor () -> [AppDelegate.RegisteredMainWindow]
+    let registeredMainWindowForManager: @MainActor (TabManager) -> AppDelegate.RegisteredMainWindow?
+    let resolvedWindow: @MainActor (AppDelegate.RegisteredMainWindow) -> NSWindow?
+    let windowForMainWindowId: @MainActor (UUID) -> NSWindow?
+    let setActiveMainWindow: @MainActor (NSWindow) -> Void
+    let discardOrphanedMainWindowContext: @MainActor (AppDelegate.RegisteredMainWindow) -> Void
+    let focusMainWindow: @MainActor (UUID) -> Bool
+    let closeMainWindow: @MainActor (UUID, Bool) -> Bool
+    let discardMainWindowWithoutClosedHistory: @MainActor (UUID) -> Void
+    let closeWindowContainingTabId: @MainActor (UUID, Bool) -> Void
+    let createMainWindow: @MainActor () -> UUID?
+    let focusForInWindowCommand: @MainActor (NSWindow, MainWindowVisibilityController.Reason) -> Void
+    let setActiveTerminalControlTabManager: @MainActor (TabManager?) -> Void
+    let reassertCrossWindowSurfaceMoveFocus: @MainActor (UUID, UUID, UUID, UUID, TabManager) -> Void
+    let paneSurfaceMoveTargets: @MainActor ([PaneSurfaceMoveWindowSummary], UUID?) -> [AppDelegate.WorkspaceMoveTarget]
+    let bringToFront: @MainActor (NSWindow) -> Void
+    let showMainWindowFromMenuBar: @MainActor () -> NSWindow?
+    let activateMainWindowFromSocket: @MainActor () -> Bool
+    let focusWindowForAppActivation: @MainActor (NSWindow, MainWindowVisibilityController.Reason) -> Bool
+    let preferredWindowForSettingsPresentation: @MainActor () -> NSWindow?
+    let performNewWorkspaceAction: @MainActor (TabManager?, NSEvent?, String) -> Bool
+    let performNewBrowserWorkspaceAction: @MainActor (TabManager?, NSEvent?, String) -> Bool
+    let performCloudVMAction: @MainActor (TabManager?, NSWindow?, String, ((CloudVMActionCompletion) -> Void)?) -> Bool
+    let showNewWorkspaceContextMenu: @MainActor (NSView, NSEvent, String) -> Bool
+    let showOpenFolderInInlineVSCodePanel: @MainActor (TabManager?) -> Void
+    let showFocusHistoryContextMenu: @MainActor (NSView, NSEvent, FocusHistoryMenuDirection, Bool, String) -> Bool
+#if DEBUG
+    // `var` with defaults (set via statement-level `#if DEBUG` at the wiring
+    // site) rather than memberwise-init parameters: `#if` cannot split a
+    // parameter clause, so conditional fields must stay out of the init.
+    var debugManagerToken: @MainActor (TabManager?) -> String = { _ in "nil" }
+    var debugWindowToken: @MainActor (NSWindow?) -> String = { _ in "nil" }
+    var debugContextToken: @MainActor (AppDelegate.RegisteredMainWindow?) -> String = { _ in "nil" }
+    var debugRouteSnapshot: @MainActor (NSEvent?) -> String = { _ in "" }
+#endif
+
+    init(
+        shortcutRoutingKeyWindow: @escaping @MainActor () -> NSWindow? = { nil },
+        contextForMainWindow: @escaping @MainActor (NSWindow?) -> AppDelegate.RegisteredMainWindow? = { _ in nil },
+        registeredMainWindows: @escaping @MainActor () -> [AppDelegate.RegisteredMainWindow] = { [] },
+        registeredMainWindowForManager: @escaping @MainActor (TabManager) -> AppDelegate.RegisteredMainWindow? = { _ in nil },
+        resolvedWindow: @escaping @MainActor (AppDelegate.RegisteredMainWindow) -> NSWindow? = { _ in nil },
+        windowForMainWindowId: @escaping @MainActor (UUID) -> NSWindow? = { _ in nil },
+        setActiveMainWindow: @escaping @MainActor (NSWindow) -> Void = { _ in },
+        discardOrphanedMainWindowContext: @escaping @MainActor (AppDelegate.RegisteredMainWindow) -> Void = { _ in },
+        focusMainWindow: @escaping @MainActor (UUID) -> Bool = { _ in false },
+        closeMainWindow: @escaping @MainActor (UUID, Bool) -> Bool = { _, _ in false },
+        discardMainWindowWithoutClosedHistory: @escaping @MainActor (UUID) -> Void = { _ in },
+        closeWindowContainingTabId: @escaping @MainActor (UUID, Bool) -> Void = { _, _ in },
+        createMainWindow: @escaping @MainActor () -> UUID? = { nil },
+        focusForInWindowCommand: @escaping @MainActor (NSWindow, MainWindowVisibilityController.Reason) -> Void = { _, _ in },
+        setActiveTerminalControlTabManager: @escaping @MainActor (TabManager?) -> Void = { _ in },
+        reassertCrossWindowSurfaceMoveFocus: @escaping @MainActor (UUID, UUID, UUID, UUID, TabManager) -> Void = { _, _, _, _, _ in },
+        paneSurfaceMoveTargets: @escaping @MainActor ([PaneSurfaceMoveWindowSummary], UUID?) -> [AppDelegate.WorkspaceMoveTarget] = { _, _ in [] },
+        bringToFront: @escaping @MainActor (NSWindow) -> Void = { _ in },
+        showMainWindowFromMenuBar: @escaping @MainActor () -> NSWindow? = { nil },
+        activateMainWindowFromSocket: @escaping @MainActor () -> Bool = { false },
+        focusWindowForAppActivation: @escaping @MainActor (NSWindow, MainWindowVisibilityController.Reason) -> Bool = { _, _ in false },
+        preferredWindowForSettingsPresentation: @escaping @MainActor () -> NSWindow? = { nil },
+        performNewWorkspaceAction: @escaping @MainActor (TabManager?, NSEvent?, String) -> Bool = { _, _, _ in false },
+        performNewBrowserWorkspaceAction: @escaping @MainActor (TabManager?, NSEvent?, String) -> Bool = { _, _, _ in false },
+        performCloudVMAction: @escaping @MainActor (TabManager?, NSWindow?, String, ((CloudVMActionCompletion) -> Void)?) -> Bool = { _, _, _, _ in false },
+        showNewWorkspaceContextMenu: @escaping @MainActor (NSView, NSEvent, String) -> Bool = { _, _, _ in false },
+        showOpenFolderInInlineVSCodePanel: @escaping @MainActor (TabManager?) -> Void = { _ in },
+        showFocusHistoryContextMenu: @escaping @MainActor (NSView, NSEvent, FocusHistoryMenuDirection, Bool, String) -> Bool = { _, _, _, _, _ in false }
+    ) {
+        self.shortcutRoutingKeyWindow = shortcutRoutingKeyWindow
+        self.contextForMainWindow = contextForMainWindow
+        self.registeredMainWindows = registeredMainWindows
+        self.registeredMainWindowForManager = registeredMainWindowForManager
+        self.resolvedWindow = resolvedWindow
+        self.windowForMainWindowId = windowForMainWindowId
+        self.setActiveMainWindow = setActiveMainWindow
+        self.discardOrphanedMainWindowContext = discardOrphanedMainWindowContext
+        self.focusMainWindow = focusMainWindow
+        self.closeMainWindow = closeMainWindow
+        self.discardMainWindowWithoutClosedHistory = discardMainWindowWithoutClosedHistory
+        self.closeWindowContainingTabId = closeWindowContainingTabId
+        self.createMainWindow = createMainWindow
+        self.focusForInWindowCommand = focusForInWindowCommand
+        self.setActiveTerminalControlTabManager = setActiveTerminalControlTabManager
+        self.reassertCrossWindowSurfaceMoveFocus = reassertCrossWindowSurfaceMoveFocus
+        self.paneSurfaceMoveTargets = paneSurfaceMoveTargets
+        self.bringToFront = bringToFront
+        self.showMainWindowFromMenuBar = showMainWindowFromMenuBar
+        self.activateMainWindowFromSocket = activateMainWindowFromSocket
+        self.focusWindowForAppActivation = focusWindowForAppActivation
+        self.preferredWindowForSettingsPresentation = preferredWindowForSettingsPresentation
+        self.performNewWorkspaceAction = performNewWorkspaceAction
+        self.performNewBrowserWorkspaceAction = performNewBrowserWorkspaceAction
+        self.performCloudVMAction = performCloudVMAction
+        self.showNewWorkspaceContextMenu = showNewWorkspaceContextMenu
+        self.showOpenFolderInInlineVSCodePanel = showOpenFolderInInlineVSCodePanel
+        self.showFocusHistoryContextMenu = showFocusHistoryContextMenu
+    }
+}
+
+@MainActor
+final class MainWindowRouter {
+    private let windowRegistry: WindowRegistry
+    private var hostSeams = MainWindowRouterHostSeams()
+
+    weak var activeTabManager: TabManager?
+    weak var activeSidebarState: SidebarState?
+    weak var activeSidebarSelectionState: SidebarSelectionState?
+    weak var activeFileExplorerState: FileExplorerState?
+
+    init(windowRegistry: WindowRegistry) {
+        self.windowRegistry = windowRegistry
+    }
+
+    func configureHostSeams(_ seams: MainWindowRouterHostSeams) {
+        hostSeams = seams
+    }
+
+    private var shortcutRoutingKeyWindow: NSWindow? {
+        hostSeams.shortcutRoutingKeyWindow()
+    }
+
+    private var registeredMainWindows: [AppDelegate.RegisteredMainWindow] {
+        hostSeams.registeredMainWindows()
+    }
+
+    private func contextForMainWindow(_ window: NSWindow?) -> AppDelegate.RegisteredMainWindow? {
+        hostSeams.contextForMainWindow(window)
+    }
+
+    private func registeredMainWindow(forManager tabManager: TabManager) -> AppDelegate.RegisteredMainWindow? {
+        hostSeams.registeredMainWindowForManager(tabManager)
+    }
+
+    private func resolvedWindow(for context: AppDelegate.RegisteredMainWindow) -> NSWindow? {
+        hostSeams.resolvedWindow(context)
+    }
+
+    private func windowForMainWindowId(_ windowId: UUID) -> NSWindow? {
+        hostSeams.windowForMainWindowId(windowId)
+    }
+
+    private func sidebarSelectionState(for context: AppDelegate.RegisteredMainWindow) -> SidebarSelectionState {
+        if let wctx = windowRegistry.context(for: WindowID(context.windowId)) {
+            return wctx.sidebarSelectionState
+        }
+        return SidebarSelectionState()
+    }
+
+    private func sidebarState(for context: AppDelegate.RegisteredMainWindow) -> SidebarState {
+        if let wctx = windowRegistry.context(for: WindowID(context.windowId)) {
+            return wctx.sidebarState
+        }
+        return SidebarState()
+    }
+
+    private func fileExplorerState(for context: AppDelegate.RegisteredMainWindow) -> FileExplorerState? {
+        windowRegistry.context(for: WindowID(context.windowId))?.fileExplorerState
+    }
+
+    func preferredRegisteredMainWindowContext(preferredWindow: NSWindow? = nil) -> AppDelegate.RegisteredMainWindow? {
+        if let preferredWindow,
+           let context = contextForMainWindow(preferredWindow) {
+            return context
+        }
+        if let context = contextForMainWindow(shortcutRoutingKeyWindow) {
+            return context
+        }
+        if let context = contextForMainWindow(NSApp.mainWindow) {
+            return context
+        }
+        if let activeManager = activeTabManager,
+           let activeContext = registeredMainWindow(forManager: activeManager) {
+            return activeContext
+        }
+        return registeredMainWindows.first
+    }
+
+    func activeTabManagerForCommands(preferredWindow: NSWindow? = nil) -> TabManager? {
+        if let context = contextForMainWindow(preferredWindow) {
+            return context.tabManager
+        }
+        if let context = contextForMainWindow(shortcutRoutingKeyWindow) {
+            return context.tabManager
+        }
+        if let context = contextForMainWindow(NSApp.mainWindow) {
+            return context.tabManager
+        }
+        if let activeManager = activeTabManager,
+           let activeContext = liveMainWindowContext(for: activeManager) {
+            return activeContext.tabManager
+        }
+        return registeredMainWindows.first { context in
+            resolvedWindow(for: context) != nil
+        }?.tabManager
+    }
+
+    private func liveMainWindowContext(for tabManager: TabManager) -> AppDelegate.RegisteredMainWindow? {
+        for context in Array(registeredMainWindows) where context.tabManager === tabManager {
+            if resolvedWindow(for: context) != nil {
+                return context
+            }
+        }
+        return nil
+    }
+
+    @discardableResult
+    func synchronizeActiveWindowContext(preferredWindow: NSWindow? = nil) -> TabManager? {
+        let (context, source): (AppDelegate.RegisteredMainWindow?, String) = {
+            if let preferredWindow,
+               let context = contextForMainWindow(preferredWindow) {
+                return (context, "preferredWindow")
+            }
+            if let context = contextForMainWindow(shortcutRoutingKeyWindow) {
+                return (context, "keyWindow")
+            }
+            if let context = contextForMainWindow(NSApp.mainWindow) {
+                return (context, "mainWindow")
+            }
+            if let activeManager = activeTabManager,
+               let activeContext = registeredMainWindow(forManager: activeManager) {
+                return (activeContext, "activeManager")
+            }
+            return (registeredMainWindows.first, "firstContextFallback")
+        }()
+
+#if DEBUG
+        let beforeManagerToken = hostSeams.debugManagerToken(activeTabManager)
+        cmuxDebugLog(
+            "shortcut.sync.pre source=\(source) preferred={\(hostSeams.debugWindowToken(preferredWindow))} chosen={\(hostSeams.debugContextToken(context))} \(hostSeams.debugRouteSnapshot(nil))"
+        )
+#endif
+        guard let context else { return activeTabManager }
+        let alreadyActive =
+            activeTabManager === context.tabManager
+            && activeSidebarState === sidebarState(for: context)
+            && activeSidebarSelectionState === sidebarSelectionState(for: context)
+        if alreadyActive {
+#if DEBUG
+            cmuxDebugLog(
+                "shortcut.sync.post source=\(source) beforeMgr=\(beforeManagerToken) afterMgr=\(hostSeams.debugManagerToken(activeTabManager)) chosen={\(hostSeams.debugContextToken(context))} nochange=1 \(hostSeams.debugRouteSnapshot(nil))"
+            )
+#endif
+            return context.tabManager
+        }
+        if let window = context.window ?? windowForMainWindowId(context.windowId) {
+            hostSeams.setActiveMainWindow(window)
+        } else {
+            activeTabManager = context.tabManager
+            activeSidebarState = sidebarState(for: context)
+            activeSidebarSelectionState = sidebarSelectionState(for: context)
+            activeFileExplorerState = fileExplorerState(for: context)
+            hostSeams.setActiveTerminalControlTabManager(context.tabManager)
+        }
+#if DEBUG
+        cmuxDebugLog(
+            "shortcut.sync.post source=\(source) beforeMgr=\(beforeManagerToken) afterMgr=\(hostSeams.debugManagerToken(activeTabManager)) chosen={\(hostSeams.debugContextToken(context))} \(hostSeams.debugRouteSnapshot(nil))"
+        )
+#endif
+        return context.tabManager
+    }
+
+    func repointActiveWindow(to context: AppDelegate.RegisteredMainWindow?) {
+        guard let context else {
+            activeTabManager = nil
+            activeSidebarState = nil
+            activeSidebarSelectionState = nil
+            activeFileExplorerState = nil
+            hostSeams.setActiveTerminalControlTabManager(nil)
+            return
+        }
+        activeTabManager = context.tabManager
+        activeSidebarState = sidebarState(for: context)
+        activeSidebarSelectionState = sidebarSelectionState(for: context)
+        activeFileExplorerState = fileExplorerState(for: context)
+        hostSeams.setActiveTerminalControlTabManager(context.tabManager)
+    }
+
+    func setActiveWindowContext(_ context: AppDelegate.RegisteredMainWindow, keyWindow window: NSWindow) {
+#if DEBUG
+        let beforeManagerToken = hostSeams.debugManagerToken(activeTabManager)
+#endif
+        repointActiveWindow(to: context)
+#if DEBUG
+        cmuxDebugLog(
+            "mainWindow.active window={\(hostSeams.debugWindowToken(window))} context={\(hostSeams.debugContextToken(context))} beforeMgr=\(beforeManagerToken) afterMgr=\(hostSeams.debugManagerToken(activeTabManager)) \(hostSeams.debugRouteSnapshot(nil))"
+        )
+#endif
+    }
+
+    @discardableResult
+    func toggleSidebarInActiveWindow(preferredWindow: NSWindow? = nil) -> Bool {
+        func toggle(_ context: AppDelegate.RegisteredMainWindow) -> Bool {
+            guard let window = resolvedWindow(for: context) else {
+                hostSeams.discardOrphanedMainWindowContext(context)
+                return false
+            }
+            hostSeams.setActiveMainWindow(window)
+            sidebarState(for: context).toggle()
+            return true
+        }
+
+        if let preferredWindow,
+           let preferredContext = contextForMainWindow(preferredWindow),
+           toggle(preferredContext) {
+            return true
+        }
+        if let keyWindow = shortcutRoutingKeyWindow,
+           let keyContext = contextForMainWindow(keyWindow),
+           toggle(keyContext) {
+            return true
+        }
+        if let mainWindow = NSApp.mainWindow,
+           let mainContext = contextForMainWindow(mainWindow),
+           toggle(mainContext) {
+            return true
+        }
+        if let activeManager = activeTabManager,
+           let activeContext = registeredMainWindow(forManager: activeManager),
+           toggle(activeContext) {
+            return true
+        }
+        for fallbackContext in Array(registeredMainWindows) where toggle(fallbackContext) {
+            return true
+        }
+        return false
+    }
+
+    @discardableResult
+    func toggleRightSidebarInActiveWindow(preferredWindow: NSWindow? = nil) -> Bool {
+        guard let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow) else {
+            if let activeFileExplorerState {
+                activeFileExplorerState.toggle()
+                return true
+            }
+            return false
+        }
+
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+        if let window {
+            hostSeams.setActiveMainWindow(window)
+        }
+
+        guard let state = fileExplorerState(for: context) ?? activeFileExplorerState else {
+            return false
+        }
+        let wasVisible = state.isVisible
+        state.toggle()
+        if wasVisible && !state.isVisible {
+            _ = context.keyboardFocusCoordinator.restoreTerminalFocusAfterRightSidebarHiddenIfNeeded()
+        }
+        return true
+    }
+
+    @discardableResult
+    func closeRightSidebarInActiveWindow(preferredWindow: NSWindow? = nil) -> Bool {
+        guard let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow) else {
+            guard let activeFileExplorerState else {
+                return false
+            }
+            activeFileExplorerState.setVisible(false)
+            return true
+        }
+
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+        if let window {
+            hostSeams.setActiveMainWindow(window)
+        }
+
+        guard let state = fileExplorerState(for: context) ?? activeFileExplorerState else {
+            return false
+        }
+        let wasVisible = state.isVisible
+        state.setVisible(false)
+        if wasVisible && !state.isVisible {
+            _ = context.keyboardFocusCoordinator.restoreTerminalFocusAfterRightSidebarHiddenIfNeeded()
+        }
+        return true
+    }
+
+    @discardableResult
+    func focusRightSidebarInActiveWindow(
+        mode requestedMode: RightSidebarMode? = nil,
+        focusFirstItem: Bool = true,
+        preferredWindow: NSWindow? = nil
+    ) -> Bool {
+        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
+
+        guard let context else {
+#if DEBUG
+            dlog(
+                "rs.focus.app.abort reason=noContext preferred={\(hostSeams.debugWindowToken(preferredWindow))} " +
+                "\(hostSeams.debugRouteSnapshot(nil))"
+            )
+#endif
+            return false
+        }
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+#if DEBUG
+        let beforeResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        let beforeState = fileExplorerState(for: context) ?? activeFileExplorerState
+        dlog(
+            "rs.focus.app.begin preferred={\(hostSeams.debugWindowToken(preferredWindow))} " +
+            "context={\(hostSeams.debugContextToken(context))} targetWin={\(hostSeams.debugWindowToken(window))} " +
+            "visible=\((beforeState?.isVisible ?? false) ? 1 : 0) mode=\(beforeState?.mode.rawValue ?? "nil") " +
+            "fr=\(beforeResponder)"
+        )
+#endif
+        if let window {
+            hostSeams.focusForInWindowCommand(window, .rightSidebarFocus)
+        }
+        let result = context.keyboardFocusCoordinator.focusRightSidebar(
+            mode: requestedMode,
+            focusFirstItem: focusFirstItem
+        )
+#if DEBUG
+        let afterResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        dlog(
+            "rs.focus.app.end requested=1 result=\(result ? 1 : 0) " +
+            "mode=\(requestedMode?.rawValue ?? (fileExplorerState(for: context)?.mode.rawValue ?? "nil")) " +
+            "targetWin={\(hostSeams.debugWindowToken(window))} fr=\(afterResponder)"
+        )
+#endif
+        return result
+    }
+
+#if DEBUG
+    func debugRevealRightSidebarInActiveWindow(
+        mode: RightSidebarMode,
+        focusFirstItem: Bool,
+        preferredWindow: NSWindow? = nil
+    ) -> (
+        revealed: Bool,
+        focusApplied: Bool,
+        contextFound: Bool,
+        stateFound: Bool,
+        visible: Bool,
+        activeMode: String?
+    ) {
+        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
+        let window = context.flatMap { $0.window ?? windowForMainWindowId($0.windowId) }
+        if let window {
+            if !window.isKeyWindow {
+                if !NSApp.isActive {
+                    NSRunningApplication.current.activate(options: [.activateAllWindows])
+                }
+                window.makeKeyAndOrderFront(nil)
+            }
+            hostSeams.setActiveMainWindow(window)
+        }
+
+        guard let state = context.flatMap({ fileExplorerState(for: $0) }) ?? activeFileExplorerState else {
+            return (
+                revealed: false,
+                focusApplied: false,
+                contextFound: context != nil,
+                stateFound: false,
+                visible: false,
+                activeMode: nil
+            )
+        }
+
+        if state.mode != mode {
+            state.mode = mode
+        }
+        state.setVisible(true)
+
+        let focusApplied = context?.keyboardFocusCoordinator.focusRightSidebar(
+            mode: mode,
+            focusFirstItem: focusFirstItem
+        ) ?? false
+
+        return (
+            revealed: state.isVisible && state.mode == mode,
+            focusApplied: focusApplied,
+            contextFound: context != nil,
+            stateFound: true,
+            visible: state.isVisible,
+            activeMode: state.mode.rawValue
+        )
+    }
+#endif
+
+    @discardableResult
+    func focusFileSearchInActiveWindow(preferredWindow: NSWindow? = nil) -> Bool {
+        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
+
+        guard let context else {
+#if DEBUG
+            dlog(
+                "file.search.focus.app.abort reason=noContext preferred={\(hostSeams.debugWindowToken(preferredWindow))} " +
+                "\(hostSeams.debugRouteSnapshot(nil))"
+            )
+#endif
+            return false
+        }
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+#if DEBUG
+        let beforeResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        dlog(
+            "file.search.focus.app.begin preferred={\(hostSeams.debugWindowToken(preferredWindow))} " +
+            "context={\(hostSeams.debugContextToken(context))} targetWin={\(hostSeams.debugWindowToken(window))} " +
+            "fr=\(beforeResponder)"
+        )
+#endif
+        if let window {
+            hostSeams.focusForInWindowCommand(window, .fileSearchFocus)
+        }
+        let result = context.keyboardFocusCoordinator.focusFileSearch()
+#if DEBUG
+        let afterResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        dlog(
+            "file.search.focus.app.end result=\(result ? 1 : 0) " +
+            "targetWin={\(hostSeams.debugWindowToken(window))} fr=\(afterResponder)"
+        )
+#endif
+        return result
+    }
+
+    @discardableResult
+    func performFindInActiveWindow(preferredWindow: NSWindow? = nil) -> Bool {
+        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
+
+        guard let context else {
+#if DEBUG
+            dlog(
+                "find.shortcut.app.abort reason=noContext preferred={\(hostSeams.debugWindowToken(preferredWindow))} " +
+                "\(hostSeams.debugRouteSnapshot(nil))"
+            )
+#endif
+            return false
+        }
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+#if DEBUG
+        let beforeResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        dlog(
+            "find.shortcut.app.begin preferred={\(hostSeams.debugWindowToken(preferredWindow))} " +
+            "context={\(hostSeams.debugContextToken(context))} targetWin={\(hostSeams.debugWindowToken(window))} " +
+            "fr=\(beforeResponder)"
+        )
+#endif
+        let target = context.keyboardFocusCoordinator.findShortcutTarget(
+            currentResponder: window?.firstResponder
+        )
+        guard target != .none else {
+#if DEBUG
+            dlog(
+                "find.shortcut.app.end target=\(target) result=0 " +
+                "targetWin={\(hostSeams.debugWindowToken(window))} fr=\(beforeResponder)"
+            )
+#endif
+            return false
+        }
+
+        if let window {
+            hostSeams.focusForInWindowCommand(window, .findShortcut)
+        }
+
+        let result: Bool
+        switch target {
+        case .rightSidebarFileSearch:
+            result = context.keyboardFocusCoordinator.focusFileSearch()
+        case .mainPanelFind:
+            result = context.tabManager.startSearch()
+        case .none:
+            return false
+        }
+#if DEBUG
+        let afterResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        dlog(
+            "find.shortcut.app.end target=\(target) result=\(result ? 1 : 0) " +
+            "targetWin={\(hostSeams.debugWindowToken(window))} fr=\(afterResponder)"
+        )
+#endif
+        return result
+    }
+
+    @discardableResult
+    func toggleRightSidebarKeyboardFocusInActiveWindow(preferredWindow: NSWindow? = nil) -> Bool {
+        let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow)
+
+        guard let context else {
+#if DEBUG
+            dlog(
+                "rs.focus.toggle.abort reason=noContext preferred={\(hostSeams.debugWindowToken(preferredWindow))} " +
+                "\(hostSeams.debugRouteSnapshot(nil))"
+            )
+#endif
+            return false
+        }
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+#if DEBUG
+        let beforeResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        dlog(
+            "rs.focus.toggle.begin preferred={\(hostSeams.debugWindowToken(preferredWindow))} " +
+            "context={\(hostSeams.debugContextToken(context))} targetWin={\(hostSeams.debugWindowToken(window))} " +
+            "fr=\(beforeResponder)"
+        )
+#endif
+        if let window {
+            hostSeams.focusForInWindowCommand(window, .rightSidebarToggle)
+        }
+        let result = context.keyboardFocusCoordinator.toggleRightSidebarOrTerminalFocus()
+#if DEBUG
+        let afterResponder = window?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
+        dlog(
+            "rs.focus.toggle.end result=\(result ? 1 : 0) " +
+            "targetWin={\(hostSeams.debugWindowToken(window))} fr=\(afterResponder)"
+        )
+#endif
+        return result
+    }
+
+    func windowMoveTargets(referenceWindowId: UUID?) -> [AppDelegate.WindowMoveTarget] {
+        let orderedSummaries = orderedMainWindowSummaries(referenceWindowId: referenceWindowId)
+        let labels = windowLabelsById(orderedSummaries: orderedSummaries, referenceWindowId: referenceWindowId)
+        return orderedSummaries.compactMap { summary in
+            guard windowRegistry.tabManagerFor(windowId: summary.windowId) != nil else { return nil }
+            let label = labels[summary.windowId] ?? "Window"
+            return AppDelegate.WindowMoveTarget(
+                windowId: summary.windowId,
+                label: label,
+                isCurrentWindow: summary.windowId == referenceWindowId
+            )
+        }
+    }
+
+    func workspaceMoveTargets(excludingWorkspaceId: UUID? = nil, referenceWindowId: UUID?) -> [AppDelegate.WorkspaceMoveTarget] {
+        let orderedSummaries = orderedMainWindowSummaries(referenceWindowId: referenceWindowId)
+        let labels = windowLabelsById(orderedSummaries: orderedSummaries, referenceWindowId: referenceWindowId)
+
+        let summaries: [PaneSurfaceMoveWindowSummary] = orderedSummaries.compactMap { summary in
+            guard let manager = windowRegistry.tabManagerFor(windowId: summary.windowId) else { return nil }
+            return PaneSurfaceMoveWindowSummary(
+                windowId: summary.windowId,
+                windowLabel: labels[summary.windowId] ?? "Window",
+                isCurrentWindow: summary.windowId == referenceWindowId,
+                workspaces: manager.tabs.map { workspace in
+                    PaneSurfaceMoveWindowSummary.Workspace(
+                        workspaceId: workspace.id,
+                        title: workspaceDisplayName(workspace)
+                    )
+                }
+            )
+        }
+
+        return hostSeams.paneSurfaceMoveTargets(summaries, excludingWorkspaceId)
+    }
+
+    @discardableResult
+    func moveWorkspaceToWindow(workspaceId: UUID, windowId: UUID, atIndex: Int? = nil, focus: Bool = true) -> Bool {
+        guard let sourceManager = windowRegistry.tabManagerFor(tabId: workspaceId),
+              let destinationManager = windowRegistry.tabManagerFor(windowId: windowId) else {
+            return false
+        }
+
+        if sourceManager === destinationManager {
+            if focus {
+                destinationManager.focusTab(workspaceId, suppressFlash: true)
+                _ = hostSeams.focusMainWindow(windowId)
+                hostSeams.setActiveTerminalControlTabManager(destinationManager)
+            }
+            return true
+        }
+
+        guard let workspace = sourceManager.detachWorkspace(tabId: workspaceId) else { return false }
+        destinationManager.attachWorkspace(workspace, at: atIndex, select: focus)
+
+        if focus {
+            _ = hostSeams.focusMainWindow(windowId)
+            hostSeams.setActiveTerminalControlTabManager(destinationManager)
+        }
+        return true
+    }
+
+    @discardableResult
+    func moveWorkspaceToNewWindow(workspaceId: UUID, focus: Bool = true) -> UUID? {
+        guard let windowId = hostSeams.createMainWindow() else { return nil }
+        guard let destinationManager = windowRegistry.tabManagerFor(windowId: windowId) else { return nil }
+        let bootstrapWorkspaceId = destinationManager.tabs.first?.id
+
+        guard moveWorkspaceToWindow(workspaceId: workspaceId, windowId: windowId, focus: focus) else {
+            _ = hostSeams.closeMainWindow(windowId, false)
+            return nil
+        }
+
+        if let bootstrapWorkspaceId,
+           bootstrapWorkspaceId != workspaceId,
+           let bootstrapWorkspace = destinationManager.tabs.first(where: { $0.id == bootstrapWorkspaceId }),
+           destinationManager.tabs.count > 1 {
+            destinationManager.closeWorkspace(bootstrapWorkspace, recordHistory: false)
+        }
+        return windowId
+    }
+
+    @discardableResult
+    func focusScriptableWindow(windowId: UUID, bringToFront shouldBringToFront: Bool) -> Bool {
+        guard let state = windowRegistry.scriptableMainWindow(windowId: windowId),
+              let window = state.window else {
+            return false
+        }
+        hostSeams.setActiveMainWindow(window)
+        if shouldBringToFront {
+            hostSeams.bringToFront(window)
+        }
+        return true
+    }
+
+    func allMainWindowTabManagersForDebug() -> [TabManager] {
+        Array(registeredMainWindows).compactMap { context in
+            resolvedWindow(for: context) == nil ? nil : context.tabManager
+        }
+    }
+
+    func canMoveSurfaceToNewWorkspace(panelId: UUID) -> Bool {
+        guard let source = windowRegistry.locateSurface(surfaceId: panelId),
+              let sourceWorkspace = source.tabManager.tabs.first(where: { $0.id == source.workspaceId }),
+              sourceWorkspace.panels[panelId] != nil else {
+            return false
+        }
+        return sourceWorkspace.panels.count > 1
+    }
+
+    func canMoveBonsplitTabToNewWorkspace(tabId: UUID) -> Bool {
+        guard let located = windowRegistry.locateBonsplitSurface(tabId: tabId) else { return false }
+        return canMoveSurfaceToNewWorkspace(panelId: located.panelId)
+    }
+
+    func canMoveBonsplitTab(tabId: UUID, toWorkspace targetWorkspaceId: UUID) -> Bool {
+        guard let located = windowRegistry.locateBonsplitSurface(tabId: tabId),
+              let sourceWorkspace = located.tabManager.tabs.first(where: { $0.id == located.workspaceId }),
+              sourceWorkspace.panels[located.panelId] != nil,
+              let destinationManager = windowRegistry.tabManagerFor(tabId: targetWorkspaceId),
+              destinationManager.tabs.contains(where: { $0.id == targetWorkspaceId }) else {
+            return false
+        }
+        return true
+    }
+
+    func workspaceMoveTargets(forSurface panelId: UUID) -> [AppDelegate.WorkspaceMoveTarget] {
+        guard let source = windowRegistry.locateSurface(surfaceId: panelId) else { return [] }
+        return workspaceMoveTargets(
+            excludingWorkspaceId: source.workspaceId,
+            referenceWindowId: source.windowId
+        )
+    }
+
+    func workspaceMoveTargets(forBonsplitTab tabId: UUID) -> [AppDelegate.WorkspaceMoveTarget] {
+        guard let located = windowRegistry.locateBonsplitSurface(tabId: tabId) else { return [] }
+        return workspaceMoveTargets(
+            excludingWorkspaceId: located.workspaceId,
+            referenceWindowId: located.windowId
+        )
+    }
+
+    @discardableResult
+    func moveBonsplitTabToNewWorkspace(
+        tabId: UUID,
+        destinationManager: TabManager? = nil,
+        title: String? = nil,
+        focus: Bool = true,
+        focusWindow: Bool = true,
+        placementOverride: WorkspacePlacement? = nil,
+        insertionIndexOverride: Int? = nil
+    ) -> SurfaceNewWorkspaceMoveResult? {
+        guard let located = windowRegistry.locateBonsplitSurface(tabId: tabId) else { return nil }
+        return moveSurfaceToNewWorkspace(
+            panelId: located.panelId,
+            destinationManager: destinationManager,
+            title: title,
+            focus: focus,
+            focusWindow: focusWindow,
+            placementOverride: placementOverride,
+            insertionIndexOverride: insertionIndexOverride
+        )
+    }
+
+    @discardableResult
+    func moveSurfaceToNewWorkspace(
+        panelId: UUID,
+        destinationManager: TabManager? = nil,
+        title: String? = nil,
+        focus: Bool = true,
+        focusWindow: Bool = true,
+        placementOverride: WorkspacePlacement? = nil,
+        insertionIndexOverride: Int? = nil
+    ) -> SurfaceNewWorkspaceMoveResult? {
+        guard let source = windowRegistry.locateSurface(surfaceId: panelId),
+              let sourceWorkspace = source.tabManager.tabs.first(where: { $0.id == source.workspaceId }),
+              let sourcePanel = sourceWorkspace.panels[panelId],
+              sourceWorkspace.panels.count > 1 else {
+            return nil
+        }
+
+        let targetManager = destinationManager ?? source.tabManager
+        let destinationTitle = titleForDetachedWorkspace(
+            explicitTitle: title,
+            workspace: sourceWorkspace,
+            panelId: panelId,
+            panel: sourcePanel
+        )
+        let sourcePane = sourceWorkspace.paneId(forPanelId: panelId)
+        let sourceIndex = sourceWorkspace.indexInPane(forPanelId: panelId)
+        let activationIntent = focusIntentForNewWorkspaceMove(panel: sourcePanel)
+        guard let detached = sourceWorkspace.detachSurface(panelId: panelId) else { return nil }
+
+        guard let destinationWorkspace = targetManager.addWorkspace(
+            fromDetachedSurface: detached,
+            title: destinationTitle,
+            select: false,
+            placementOverride: placementOverride,
+            insertionIndexOverride: insertionIndexOverride,
+            focusIntent: activationIntent
+        ) else {
+            rollbackDetachedSurface(
+                detached,
+                to: sourceWorkspace,
+                sourcePane: sourcePane,
+                sourceIndex: sourceIndex,
+                focus: focus
+            )
+            return nil
+        }
+
+        cleanupEmptySourceWorkspaceAfterSurfaceMove(
+            sourceWorkspace: sourceWorkspace,
+            sourceManager: source.tabManager,
+            sourceWindowId: source.windowId
+        )
+
+        if focus {
+            let destinationWindowId = focusWindow ? windowRegistry.windowId(for: targetManager) : nil
+            if let destinationWindowId {
+                _ = hostSeams.focusMainWindow(destinationWindowId)
+            }
+            targetManager.focusTab(
+                destinationWorkspace.id,
+                surfaceId: panelId,
+                suppressFlash: true,
+                focusIntent: activationIntent
+            )
+            if let destinationWindowId {
+                hostSeams.reassertCrossWindowSurfaceMoveFocus(
+                    destinationWindowId,
+                    source.windowId,
+                    destinationWorkspace.id,
+                    panelId,
+                    targetManager
+                )
+            }
+        }
+
+        return SurfaceNewWorkspaceMoveResult(
+            sourceWindowId: source.windowId,
+            sourceWorkspaceId: source.workspaceId,
+            destinationWindowId: windowRegistry.windowId(for: targetManager),
+            destinationWorkspaceId: destinationWorkspace.id,
+            surfaceId: panelId,
+            paneId: destinationWorkspace.paneId(forPanelId: panelId)?.id
+        )
+    }
+
+    func cleanupEmptySourceWorkspaceAfterSurfaceMove(
+        sourceWorkspace: Workspace,
+        sourceManager: TabManager,
+        sourceWindowId: UUID
+    ) {
+        let outcome = DetachedSourceWorkspaceCleanupPolicy().outcome(
+            sourceWorkspaceIsEmpty: sourceWorkspace.panels.isEmpty,
+            sourceWorkspaceStillInManager: sourceManager.tabs.contains(where: { $0.id == sourceWorkspace.id }),
+            sourceManagerWorkspaceCount: sourceManager.tabs.count
+        )
+        switch outcome {
+        case .none:
+            return
+        case .closeWorkspace:
+            sourceManager.closeWorkspace(sourceWorkspace, recordHistory: false)
+        case .closeWindow:
+            _ = hostSeams.closeMainWindow(sourceWindowId, false)
+        }
+    }
+
+    func rollbackDetachedSurface(
+        _ detached: Workspace.DetachedSurfaceTransfer,
+        to workspace: Workspace,
+        sourcePane: PaneID?,
+        sourceIndex: Int?,
+        focus: Bool
+    ) {
+        let rollbackPane = sourcePane.flatMap { pane in
+            workspace.bonsplitController.allPaneIds.first(where: { $0 == pane })
+        } ?? workspace.bonsplitController.focusedPaneId
+            ?? workspace.bonsplitController.allPaneIds.first
+        guard let rollbackPane else { return }
+        _ = workspace.attachDetachedSurface(
+            detached,
+            inPane: rollbackPane,
+            atIndex: sourceIndex,
+            focus: focus
+        )
+    }
+
+    @discardableResult
+    func moveWindow(windowId: UUID, toDisplayMatching query: String) -> String? {
+        guard let window = windowRegistry.mainWindow(for: windowId),
+              let screen = NSScreen.cmuxScreen(matching: query) else { return nil }
+        window.cmuxRepositionPreservingSize(onto: screen)
+        return screen.localizedName
+    }
+
+    func moveAllWindows(toDisplayMatching query: String) -> (display: String, windowIds: [UUID])? {
+        guard let screen = NSScreen.cmuxScreen(matching: query) else { return nil }
+        var moved: [UUID] = []
+        for summary in windowRegistry.listMainWindowSummaries() {
+            guard let window = windowRegistry.mainWindow(for: summary.windowId) else { continue }
+            window.cmuxRepositionPreservingSize(onto: screen)
+            moved.append(summary.windowId)
+        }
+        return (screen.localizedName, moved)
+    }
+
+    @discardableResult
+    func focusMainWindow(windowId: UUID) -> Bool {
+        hostSeams.focusMainWindow(windowId)
+    }
+
+    @discardableResult
+    func closeMainWindow(windowId: UUID, recordHistory: Bool = true) -> Bool {
+        hostSeams.closeMainWindow(windowId, recordHistory)
+    }
+
+    func discardWindowWithoutHistory(windowId: UUID) {
+        hostSeams.discardMainWindowWithoutClosedHistory(windowId)
+    }
+
+    func closeWindowContaining(tabId: UUID, recordHistory: Bool = true) {
+        hostSeams.closeWindowContainingTabId(tabId, recordHistory)
+    }
+
+    func createMainWindow() -> UUID? {
+        hostSeams.createMainWindow()
+    }
+
+    @discardableResult
+    func showMainWindowFromMenuBar() -> NSWindow? {
+        hostSeams.showMainWindowFromMenuBar()
+    }
+
+    @discardableResult
+    func activateFromSocket() -> Bool {
+        hostSeams.activateMainWindowFromSocket()
+    }
+
+    @discardableResult
+    func focusWindowForAppActivation(
+        _ window: NSWindow,
+        reason: MainWindowVisibilityController.Reason
+    ) -> Bool {
+        hostSeams.focusWindowForAppActivation(window, reason)
+    }
+
+    func preferredWindowForSettingsPresentation() -> NSWindow? {
+        hostSeams.preferredWindowForSettingsPresentation()
+    }
+
+    @discardableResult
+    func performNewWorkspaceAction(
+        tabManager preferredTabManager: TabManager? = nil,
+        event: NSEvent? = nil,
+        debugSource: String = "newWorkspace"
+    ) -> Bool {
+        hostSeams.performNewWorkspaceAction(preferredTabManager, event, debugSource)
+    }
+
+    @discardableResult
+    func performNewBrowserWorkspaceAction(
+        tabManager preferredTabManager: TabManager? = nil,
+        event: NSEvent? = nil,
+        debugSource: String = "newBrowserWorkspace"
+    ) -> Bool {
+        hostSeams.performNewBrowserWorkspaceAction(preferredTabManager, event, debugSource)
+    }
+
+    @discardableResult
+    func performCloudVMAction(
+        tabManager preferredTabManager: TabManager? = nil,
+        preferredWindow: NSWindow? = nil,
+        debugSource: String = "cloudVM",
+        onCompletion: ((CloudVMActionCompletion) -> Void)? = nil
+    ) -> Bool {
+        hostSeams.performCloudVMAction(preferredTabManager, preferredWindow, debugSource, onCompletion)
+    }
+
+    @discardableResult
+    func showNewWorkspaceContextMenu(
+        anchorView: NSView,
+        event: NSEvent,
+        debugSource: String = "titlebar.newWorkspace.contextMenu"
+    ) -> Bool {
+        hostSeams.showNewWorkspaceContextMenu(anchorView, event, debugSource)
+    }
+
+    func showOpenFolderInInlineVSCodePanel(tabManager preferredTabManager: TabManager? = nil) {
+        hostSeams.showOpenFolderInInlineVSCodePanel(preferredTabManager)
+    }
+
+    @discardableResult
+    func showFocusHistoryContextMenu(
+        anchorView: NSView,
+        event: NSEvent,
+        direction: FocusHistoryMenuDirection,
+        showFullHistory: Bool = false,
+        debugSource: String = "titlebar.focusHistory.contextMenu"
+    ) -> Bool {
+        hostSeams.showFocusHistoryContextMenu(anchorView, event, direction, showFullHistory, debugSource)
+    }
+
+    private func orderedMainWindowSummaries(referenceWindowId: UUID?) -> [AppDelegate.MainWindowSummary] {
+        windowRegistry.listMainWindowSummaries().orderedByReference(referenceWindowId: referenceWindowId)
+    }
+
+    private func windowLabelsById(orderedSummaries: [AppDelegate.MainWindowSummary], referenceWindowId: UUID?) -> [UUID: String] {
+        var labels: [UUID: String] = [:]
+        for (index, summary) in orderedSummaries.enumerated() {
+            if summary.windowId == referenceWindowId {
+                labels[summary.windowId] = String(localized: "menu.currentWindow", defaultValue: "Current Window")
+            } else {
+                let number = index + 1
+                labels[summary.windowId] = String(localized: "menu.windowNumber", defaultValue: "Window \(number)")
+            }
+        }
+        return labels
+    }
+
+    private func workspaceDisplayName(_ workspace: Workspace) -> String {
+        let trimmed = workspace.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? String(localized: "workspace.displayName.fallback", defaultValue: "Workspace") : trimmed
+    }
+
+    private func focusIntentForNewWorkspaceMove(panel: any Panel) -> PanelFocusIntent {
+        if panel is BrowserPanel {
+            return .browser(.addressBar)
+        }
+        return panel.preferredFocusIntentForActivation()
+    }
+
+    private func titleForDetachedWorkspace(
+        explicitTitle: String?,
+        workspace: Workspace,
+        panelId: UUID,
+        panel: any Panel
+    ) -> String {
+        DetachedWorkspaceTitlePolicy().title(
+            explicitTitle: explicitTitle,
+            surfaceTitle: workspace.panelTitle(panelId: panelId) ?? panel.displayTitle,
+            localizedFallback: String(
+                localized: "commandPalette.subtitle.tabFallback",
+                defaultValue: "Tab"
+            )
+        )
+    }
+}

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -45,6 +45,7 @@ struct BrowserPanelView: View {
     @Environment(\.cmuxCanvasInlineBrowserHosting) private var canvasInlineBrowserHosting
     @Environment(\.openWindow) private var openWindow
     @Environment(\.paneDropZone) private var paneDropZone
+    @Environment(\.appEnvironment) private var appEnvironment
     /// Held detector instance; the view detects and summarizes installed browsers
     /// through this rather than the former `BrowserInstalledBrowserDetector` static
     /// namespace.
@@ -332,8 +333,7 @@ struct BrowserPanelView: View {
     }
 
     private var owningWorkspace: Workspace? {
-        guard let app = AppDelegate.shared,
-              let manager = app.tabManagerFor(tabId: panel.workspaceId) else {
+        guard let manager = appEnvironment?.windowRegistry.tabManagerFor(tabId: panel.workspaceId) else {
             return nil
         }
         return manager.tabs.first(where: { $0.id == panel.workspaceId })
@@ -1339,6 +1339,7 @@ struct BrowserPanelView: View {
                 WebViewRepresentable(
                     panel: panel,
                     paneId: paneId,
+                    appEnvironment: appEnvironment,
                     shouldAttachWebView: isVisibleInUI && isCurrentPaneOwner && !useLocalInlineDeveloperToolsHosting,
                     useLocalInlineHosting: useLocalInlineDeveloperToolsHosting,
                     shouldFocusWebView: isFocused && !addressBarFocused,
@@ -1522,8 +1523,7 @@ struct BrowserPanelView: View {
     }
 
     private func isPanelFocusedInModel() -> Bool {
-        guard let app = AppDelegate.shared,
-              let manager = app.tabManagerFor(tabId: panel.workspaceId),
+        guard let manager = appEnvironment?.windowRegistry.tabManagerFor(tabId: panel.workspaceId),
               manager.selectedTabId == panel.workspaceId,
               let workspace = manager.tabs.first(where: { $0.id == panel.workspaceId }) else {
             return false
@@ -1588,9 +1588,9 @@ struct BrowserPanelView: View {
             return true
         }
 
-        if let manager = app.tabManagerFor(tabId: panel.workspaceId),
-           let windowId = app.windowId(for: manager),
-           let window = app.mainWindow(for: windowId),
+        if let manager = appEnvironment?.windowRegistry.tabManagerFor(tabId: panel.workspaceId),
+           let windowId = appEnvironment?.windowRegistry.windowId(for: manager),
+           let window = appEnvironment?.windowRegistry.mainWindow(for: windowId),
            app.isCommandPaletteVisible(for: window) {
             return true
         }
@@ -1610,9 +1610,8 @@ struct BrowserPanelView: View {
             return true
         }
 
-        guard let app = AppDelegate.shared,
-              let manager = app.tabManagerFor(tabId: panel.workspaceId),
-              let panelWindowId = app.windowId(for: manager) else {
+        guard let manager = appEnvironment?.windowRegistry.tabManagerFor(tabId: panel.workspaceId),
+              let panelWindowId = appEnvironment?.windowRegistry.windowId(for: manager) else {
             return false
         }
 
@@ -1621,7 +1620,7 @@ struct BrowserPanelView: View {
         }
 
         if let notificationWindow = notification.object as? NSWindow,
-           let panelWindow = app.mainWindow(for: panelWindowId) {
+           let panelWindow = appEnvironment?.windowRegistry.mainWindow(for: panelWindowId) {
             return notificationWindow === panelWindow
         }
         return false
@@ -1955,7 +1954,7 @@ struct BrowserPanelView: View {
         omnibarState.isUserEditing = false
         switch suggestion.kind {
         case .switchToTab(let tabId, let panelId, _, _):
-            AppDelegate.shared?.tabManager?.focusTab(tabId, surfaceId: panelId)
+            appEnvironment?.mainWindowRouter.activeTabManager?.focusTab(tabId, surfaceId: panelId)
         default:
             panel.navigateSmart(suggestion.completion)
         }
@@ -3191,6 +3190,11 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
 struct WebViewRepresentable: NSViewRepresentable {
     let panel: BrowserPanel
     let paneId: PaneID
+    /// Threaded from `BrowserPanelView`'s `@Environment(\.appEnvironment)` at the
+    /// construction site: representable lifecycle callbacks run outside body
+    /// evaluation, so this is a stored dependency rather than an environment read.
+    /// Optional to preserve the legacy `AppDelegate.shared?` nil short-circuit.
+    let appEnvironment: AppEnvironment?
     let shouldAttachWebView: Bool
     let useLocalInlineHosting: Bool
     let shouldFocusWebView: Bool
@@ -5608,8 +5612,7 @@ struct WebViewRepresentable: NSViewRepresentable {
     }
 
     private func currentPaneDropContext() -> BrowserPaneDropContext? {
-        guard let app = AppDelegate.shared,
-              let manager = app.tabManagerFor(tabId: panel.workspaceId),
+        guard let manager = appEnvironment?.windowRegistry.tabManagerFor(tabId: panel.workspaceId),
               let workspace = manager.tabs.first(where: { $0.id == panel.workspaceId }),
               let paneId = workspace.paneId(forPanelId: panel.id) else {
             return nil

--- a/Sources/RemoteTmuxMirrorAttachCoordinator.swift
+++ b/Sources/RemoteTmuxMirrorAttachCoordinator.swift
@@ -136,7 +136,7 @@ final class RemoteTmuxMirrorAttachCoordinator {
         try Task.checkCancellation()
 
         let windowId = appDelegate.createMainWindow(shouldActivate: activateWindow)
-        guard let manager = appDelegate.tabManagerFor(windowId: windowId) else {
+        guard let manager = appDelegate.environment.windowRegistry.tabManagerFor(windowId: windowId) else {
             throw RemoteTmuxError.unreachable("could not create window")
         }
         windowRegistry.bind(host: host, windowId: windowId)

--- a/Sources/RightSidebarPanelModel.swift
+++ b/Sources/RightSidebarPanelModel.swift
@@ -11,8 +11,7 @@ import Observation
 /// view holds this via `@State`; reactive inputs (settings flags, the file
 /// explorer/session stores, the active workspace) stay on the view and are passed
 /// into each method at call time so behavior matches the previous inline reads
-/// exactly. App-side: `AppDelegate.shared` focus routing and `NSApp` key-window
-/// lookup remain here.
+/// exactly. App-side responder checks and `NSApp` key-window lookup remain here.
 @MainActor
 @Observable
 final class RightSidebarPanelModel {
@@ -76,7 +75,8 @@ final class RightSidebarPanelModel {
     func refreshModeAvailabilityAndFocusIfNeeded(
         fileExplorerState: FileExplorerState,
         dockRootDirectory: String?,
-        workspaceId: UUID?
+        workspaceId: UUID?,
+        mainWindowRouter: MainWindowRouter?
     ) {
         let previousMode = fileExplorerState.mode
         fileExplorerState.refreshModeAvailability()
@@ -93,7 +93,7 @@ final class RightSidebarPanelModel {
               fileExplorerState.isVisible,
               let window = NSApp.keyWindow ?? NSApp.mainWindow
         else { return }
-        _ = AppDelegate.shared?.focusRightSidebarInActiveMainWindow(
+        _ = mainWindowRouter?.focusRightSidebarInActiveWindow(
             mode: fileExplorerState.mode,
             focusFirstItem: false,
             preferredWindow: window

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -78,6 +78,7 @@ struct RightSidebarPanelView: View {
     let onOpenAsPane: (RightSidebarMode) -> Void
     let onClose: () -> Void
 
+    @Environment(\.appEnvironment) private var appEnvironment
     @State private var model = RightSidebarPanelModel()
     private let keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
     private let alwaysShowShortcutHints = ShortcutHintDebugSettings().alwaysShowHints
@@ -163,7 +164,8 @@ struct RightSidebarPanelView: View {
         model.refreshModeAvailabilityAndFocusIfNeeded(
             fileExplorerState: fileExplorerState,
             dockRootDirectory: dockRootDirectory,
-            workspaceId: workspaceId
+            workspaceId: workspaceId,
+            mainWindowRouter: appEnvironment?.mainWindowRouter
         )
     }
 
@@ -187,7 +189,7 @@ struct RightSidebarPanelView: View {
                             modifierHoldHintsEnabled: showModifierHoldHints
                         )
                     ) {
-                        if AppDelegate.shared?.focusRightSidebarInActiveMainWindow(
+                        if appEnvironment?.mainWindowRouter.focusRightSidebarInActiveWindow(
                             mode: mode,
                             focusFirstItem: true,
                             preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow

--- a/Sources/Search/AppDelegate+GlobalSearch.swift
+++ b/Sources/Search/AppDelegate+GlobalSearch.swift
@@ -178,7 +178,7 @@ extension AppDelegate {
             return
         }
 
-        _ = focusMainWindow(windowId: windowID)
+        _ = environment.mainWindowRouter.focusMainWindow(windowId: windowID)
         tabManager.selectTab(workspace)
         terminalControl.setActiveTabManager(tabManager)
 

--- a/Sources/Sidebar/SidebarBonsplitTabWorkspaceDropOverlay.swift
+++ b/Sources/Sidebar/SidebarBonsplitTabWorkspaceDropOverlay.swift
@@ -4,6 +4,8 @@ import CmuxFoundation
 import SwiftUI
 
 struct SidebarBonsplitTabWorkspaceDropOverlay: NSViewRepresentable {
+    @Environment(\.appEnvironment) private var appEnvironment
+
     @MainActor
     final class TargetBridge {
         fileprivate weak var view: SidebarBonsplitTabWorkspaceDropView?
@@ -60,18 +62,18 @@ struct SidebarBonsplitTabWorkspaceDropOverlay: NSViewRepresentable {
         targetBridge.view = nsView
         nsView.targetBridge = targetBridge
         nsView.canPerformAction = { action, transfer in
-            guard let app = AppDelegate.shared else {
+            guard let appEnvironment else {
                 return false
             }
             switch action {
             case .existingWorkspace(let workspaceId):
-                if let source = app.locateBonsplitSurface(tabId: transfer.tab.id),
+                if let source = appEnvironment.windowRegistry.locateBonsplitSurface(tabId: transfer.tab.id),
                    source.workspaceId == workspaceId {
                     return true
                 }
-                return app.canMoveBonsplitTab(tabId: transfer.tab.id, toWorkspace: workspaceId)
+                return appEnvironment.mainWindowRouter.canMoveBonsplitTab(tabId: transfer.tab.id, toWorkspace: workspaceId)
             case .newWorkspace:
-                return app.canMoveBonsplitTabToNewWorkspace(tabId: transfer.tab.id)
+                return appEnvironment.mainWindowRouter.canMoveBonsplitTabToNewWorkspace(tabId: transfer.tab.id)
             }
         }
         nsView.updateAutoscroll = updateAutoscroll

--- a/Sources/SidebarTabItemActions.swift
+++ b/Sources/SidebarTabItemActions.swift
@@ -218,13 +218,13 @@ struct SidebarTabItemActions {
     }
 
     func moveWorkspaces(_ workspaceIds: [UUID], toWindow windowId: UUID) {
-        guard let app = AppDelegate.shared else { return }
+        guard let router = tabManager.appEnvironment?.mainWindowRouter else { return }
         let orderedWorkspaceIds = tabManager.tabs.compactMap { workspaceIds.contains($0.id) ? $0.id : nil }
         guard !orderedWorkspaceIds.isEmpty else { return }
 
         for (index, workspaceId) in orderedWorkspaceIds.enumerated() {
             let shouldFocus = index == orderedWorkspaceIds.count - 1
-            _ = app.moveWorkspaceToWindow(workspaceId: workspaceId, windowId: windowId, focus: shouldFocus)
+            _ = router.moveWorkspaceToWindow(workspaceId: workspaceId, windowId: windowId, focus: shouldFocus)
         }
 
         selectedTabIds.subtract(orderedWorkspaceIds)
@@ -232,21 +232,21 @@ struct SidebarTabItemActions {
     }
 
     func moveWorkspacesToNewWindow(_ workspaceIds: [UUID]) {
-        guard let app = AppDelegate.shared else { return }
+        guard let router = tabManager.appEnvironment?.mainWindowRouter else { return }
         let orderedWorkspaceIds = tabManager.tabs.compactMap { workspaceIds.contains($0.id) ? $0.id : nil }
         guard let firstWorkspaceId = orderedWorkspaceIds.first else { return }
 
         let shouldFocusImmediately = orderedWorkspaceIds.count == 1
-        guard let newWindowId = app.moveWorkspaceToNewWindow(workspaceId: firstWorkspaceId, focus: shouldFocusImmediately) else {
+        guard let newWindowId = router.moveWorkspaceToNewWindow(workspaceId: firstWorkspaceId, focus: shouldFocusImmediately) else {
             return
         }
 
         if orderedWorkspaceIds.count > 1 {
             for workspaceId in orderedWorkspaceIds.dropFirst() {
-                _ = app.moveWorkspaceToWindow(workspaceId: workspaceId, windowId: newWindowId, focus: false)
+                _ = router.moveWorkspaceToWindow(workspaceId: workspaceId, windowId: newWindowId, focus: false)
             }
             if let finalWorkspaceId = orderedWorkspaceIds.last {
-                _ = app.moveWorkspaceToWindow(workspaceId: finalWorkspaceId, windowId: newWindowId, focus: true)
+                _ = router.moveWorkspaceToWindow(workspaceId: finalWorkspaceId, windowId: newWindowId, focus: true)
             }
         }
 

--- a/Sources/SidebarTabReorderHost.swift
+++ b/Sources/SidebarTabReorderHost.swift
@@ -3,12 +3,12 @@ import CmuxSidebarUI
 import Foundation
 
 /// App-side adapter conforming the hovered window's `TabManager` plus the
-/// `AppDelegate.shared` cross-window routing to the package
+/// `TabManager` environment cross-window routing to the package
 /// ``SidebarTabReorderHosting`` seam that ``SidebarTabDropDelegate`` (now in
 /// `CmuxSidebarUI`) reads.
 ///
 /// Destination reads/mutations forward to the injected `tabManager`; source and
-/// window-routing operations forward to `AppDelegate.shared.tabManagerFor(tabId:)`
+/// window-routing operations forward to `tabManager.appEnvironment`'s registry
 /// / `moveWorkspaceToWindow(...)`, matching the legacy delegate's direct
 /// `AppDelegate.shared` lookups. Constructed per drop delegate at the sidebar
 /// call sites, so it holds no shared state of its own.
@@ -20,6 +20,8 @@ final class SidebarTabReorderHost: SidebarTabReorderHosting {
     init(tabManager: TabManager) {
         self.tabManager = tabManager
     }
+
+    private var appEnvironment: AppEnvironment? { tabManager.appEnvironment }
 
     var destinationTabIds: [UUID] { tabManager.tabs.map(\.id) }
 
@@ -99,42 +101,45 @@ final class SidebarTabReorderHost: SidebarTabReorderHosting {
     }
 
     func isGroupAnchorInSourceWindow(_ draggedTabId: UUID) -> Bool {
-        guard let sourceManager = AppDelegate.shared?.tabManagerFor(tabId: draggedTabId) else {
+        guard let sourceManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: draggedTabId) else {
             return false
         }
         return sourceManager.workspaceGroups.contains { $0.anchorWorkspaceId == draggedTabId }
     }
 
     func foreignTabIsPinned(_ id: UUID) -> Bool {
-        AppDelegate.shared?
+        appEnvironment?
+            .windowRegistry
             .tabManagerFor(tabId: id)?
             .tabs.first { $0.id == id }?.isPinned ?? false
     }
 
     func destinationWindowId() -> UUID? {
-        AppDelegate.shared?.windowId(for: tabManager)
+        appEnvironment?.windowRegistry.windowId(for: tabManager)
     }
 
     func sourceWindowExists(forTab draggedTabId: UUID) -> Bool {
-        AppDelegate.shared?.tabManagerFor(tabId: draggedTabId) != nil
+        appEnvironment?.windowRegistry.tabManagerFor(tabId: draggedTabId) != nil
     }
 
     func sourceSelectedWorkspaceIds(forTab draggedTabId: UUID) -> Set<UUID> {
-        AppDelegate.shared?.tabManagerFor(tabId: draggedTabId)?.sidebarSelectedWorkspaceIds ?? []
+        appEnvironment?.windowRegistry.tabManagerFor(tabId: draggedTabId)?.sidebarSelectedWorkspaceIds ?? []
     }
 
     func sourceWorkspaceIds(forTab draggedTabId: UUID, matching selection: Set<UUID>) -> [UUID] {
-        AppDelegate.shared?
+        appEnvironment?
+            .windowRegistry
             .tabManagerFor(tabId: draggedTabId)?
             .tabs.filter { selection.contains($0.id) }.map(\.id) ?? []
     }
 
     func sourceGroupAnchorIds(forTab draggedTabId: UUID) -> Set<UUID> {
-        Set(AppDelegate.shared?.tabManagerFor(tabId: draggedTabId)?.workspaceGroups.map(\.anchorWorkspaceId) ?? [])
+        Set(appEnvironment?.windowRegistry.tabManagerFor(tabId: draggedTabId)?.workspaceGroups.map(\.anchorWorkspaceId) ?? [])
     }
 
     func sourceTabIsPinned(forTab draggedTabId: UUID, workspaceId: UUID) -> Bool {
-        AppDelegate.shared?
+        appEnvironment?
+            .windowRegistry
             .tabManagerFor(tabId: draggedTabId)?
             .tabs.first { $0.id == workspaceId }?.isPinned ?? false
     }
@@ -146,7 +151,7 @@ final class SidebarTabReorderHost: SidebarTabReorderHosting {
         atIndex: Int?,
         focus: Bool
     ) -> Bool {
-        AppDelegate.shared?.moveWorkspaceToWindow(
+        appEnvironment?.mainWindowRouter.moveWorkspaceToWindow(
             workspaceId: workspaceId,
             windowId: windowId,
             atIndex: atIndex,
@@ -157,7 +162,7 @@ final class SidebarTabReorderHost: SidebarTabReorderHosting {
 
 /// Bonsplit-tab drop seam: forwards the package
 /// ``SidebarBonsplitTabDropHosting`` reads/mutations to the bonsplit
-/// tab-transfer pasteboard plus `AppDelegate.shared` surface lookup and
+/// tab-transfer pasteboard plus environment surface lookup and
 /// bonsplit-tab move, matching the legacy `SidebarBonsplitTabDropDelegate`'s
 /// direct `AppDelegate.shared`/`BonsplitTabTransferPasteboard` use.
 extension SidebarTabReorderHost: SidebarBonsplitTabDropHosting {
@@ -168,7 +173,7 @@ extension SidebarTabReorderHost: SidebarBonsplitTabDropHosting {
     }
 
     func bonsplitSurfaceWorkspaceId(forTab tabId: UUID) -> UUID? {
-        AppDelegate.shared?.locateBonsplitSurface(tabId: tabId)?.workspaceId
+        appEnvironment?.windowRegistry.locateBonsplitSurface(tabId: tabId)?.workspaceId
     }
 
     @discardableResult

--- a/Sources/TabManager+AgentPIDLivenessSweepHosting.swift
+++ b/Sources/TabManager+AgentPIDLivenessSweepHosting.swift
@@ -42,7 +42,7 @@ extension TabManager: AgentPIDLivenessSweepHosting {
             PortScanner.shared.refreshAgentPorts(workspaceId: tab.id, agentPIDs: remainingAgentPIDs)
             // Also clear stale notifications (e.g. "Doing well, thanks!")
             // left behind when Claude was killed without SessionEnd firing.
-            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: tab.id)
+            appEnvironment?.notificationStore?.clearNotifications(forTabId: tab.id)
         }
     }
 }

--- a/Sources/TabManager+NotificationDismissalHosting.swift
+++ b/Sources/TabManager+NotificationDismissalHosting.swift
@@ -17,7 +17,7 @@ extension TabManager: NotificationDismissalHosting {
     }
 
     var hasNotificationStore: Bool {
-        AppDelegate.shared?.notificationStore != nil
+        appEnvironment?.notificationStore != nil
     }
 
     // focusedPanelId(in:) is already witnessed by the SidebarGitHosting
@@ -37,38 +37,38 @@ extension TabManager: NotificationDismissalHosting {
     }
 
     func storeHasManualUnread(workspaceId: UUID) -> Bool {
-        AppDelegate.shared?.notificationStore?.hasManualUnread(forTabId: workspaceId) ?? false
+        appEnvironment?.notificationStore?.hasManualUnread(forTabId: workspaceId) ?? false
     }
 
     func storeHasRestoredUnreadIndicator(workspaceId: UUID) -> Bool {
-        AppDelegate.shared?.notificationStore?.hasRestoredUnreadIndicator(forTabId: workspaceId) ?? false
+        appEnvironment?.notificationStore?.hasRestoredUnreadIndicator(forTabId: workspaceId) ?? false
     }
 
     func storeHasUnreadNotification(workspaceId: UUID, surfaceId: UUID?) -> Bool {
-        AppDelegate.shared?.notificationStore?.hasUnreadNotification(forTabId: workspaceId, surfaceId: surfaceId) ?? false
+        appEnvironment?.notificationStore?.hasUnreadNotification(forTabId: workspaceId, surfaceId: surfaceId) ?? false
     }
 
     func storeHasVisibleNotificationIndicator(workspaceId: UUID, surfaceId: UUID?) -> Bool {
-        AppDelegate.shared?.notificationStore?
+        appEnvironment?.notificationStore?
             .hasVisibleNotificationIndicator(forTabId: workspaceId, surfaceId: surfaceId) ?? false
     }
 
     func storeMarkRead(workspaceId: UUID, surfaceId: UUID?) {
-        AppDelegate.shared?.notificationStore?.markRead(forTabId: workspaceId, surfaceId: surfaceId)
+        appEnvironment?.notificationStore?.markRead(forTabId: workspaceId, surfaceId: surfaceId)
     }
 
     @discardableResult
     func storeClearManualUnread(workspaceId: UUID) -> Bool {
-        AppDelegate.shared?.notificationStore?.clearManualUnread(forTabId: workspaceId) ?? false
+        appEnvironment?.notificationStore?.clearManualUnread(forTabId: workspaceId) ?? false
     }
 
     @discardableResult
     func storeClearRestoredUnreadIndicator(workspaceId: UUID) -> Bool {
-        AppDelegate.shared?.notificationStore?.clearRestoredUnreadIndicator(forTabId: workspaceId) ?? false
+        appEnvironment?.notificationStore?.clearRestoredUnreadIndicator(forTabId: workspaceId) ?? false
     }
 
     func storeClearFocusedReadIndicator(workspaceId: UUID, surfaceId: UUID?) {
-        AppDelegate.shared?.notificationStore?.clearFocusedReadIndicator(forTabId: workspaceId, surfaceId: surfaceId)
+        appEnvironment?.notificationStore?.clearFocusedReadIndicator(forTabId: workspaceId, surfaceId: surfaceId)
     }
 
     func workspaceClearManualUnread(workspaceId: UUID, panelId: UUID) {

--- a/Sources/TabManager+SessionFingerprintHosting.swift
+++ b/Sources/TabManager+SessionFingerprintHosting.swift
@@ -7,7 +7,7 @@ import Foundation
 /// The deterministic hashing lives in `CmuxWorkspaces.SessionFingerprintService`
 /// over the `Sendable` `SessionWorkspaceFingerprintInput`. This conformance is
 /// the irreducible live-state read seam: it walks the per-window `tabs`,
-/// `workspaceGroups`, the app's `AppDelegate.shared.notificationStore`, and the
+/// `workspaceGroups`, the app environment's notification store, and the
 /// per-panel restorable-agent / surface-resume / text-box / hibernation state
 /// that are all app-target-owned, flattening each into the package value types.
 /// It reproduces the legacy `TabManager.sessionAutosaveFingerprint` read order
@@ -20,7 +20,7 @@ extension TabManager: SessionFingerprintHosting {
         resolveSurfaceResumeBinding: (_ workspaceId: UUID, _ panelId: UUID)
             -> SessionFingerprintSurfaceResumeBindingSnapshot?
     ) -> SessionWorkspaceFingerprintInput {
-        let notificationStore = AppDelegate.shared?.notificationStore
+        let notificationStore = appEnvironment?.notificationStore
 
         let groups = workspaceGroups.map { group in
             SessionFingerprintGroupSnapshot(

--- a/Sources/TabManager+SurfaceSplitHosting.swift
+++ b/Sources/TabManager+SurfaceSplitHosting.swift
@@ -6,7 +6,7 @@ import Foundation
 /// notification-store effects the package ``SurfaceSplitCoordinator`` cannot own.
 ///
 /// `TabManager` owns the tab list, the selected-workspace id, the app-target
-/// Sentry breadcrumb trail, and the `AppDelegate.shared` notification-store —
+/// Sentry breadcrumb trail, and the environment notification-store reach path —
 /// all app-target state. The coordinator keeps the resolution/guard/creation
 /// orchestration; this conformance performs the exact app-coupled effects the
 /// legacy `createSplit`/`closeSurface` bodies inlined.
@@ -29,6 +29,6 @@ extension TabManager: SurfaceSplitHosting {
     }
 
     func clearNotifications(forWorkspaceId workspaceId: UUID, surfaceId: UUID) {
-        AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspaceId, surfaceId: surfaceId)
+        appEnvironment?.notificationStore?.clearNotifications(forTabId: workspaceId, surfaceId: surfaceId)
     }
 }

--- a/Sources/TabManager+WorkspaceCommandHosting.swift
+++ b/Sources/TabManager+WorkspaceCommandHosting.swift
@@ -70,8 +70,8 @@ extension TabManager: WorkspaceCommandHosting {
     // MARK: Cross-window move
 
     func windowMoveTargets() -> [WorkspaceCommandWindowTarget] {
-        let referenceWindowId = AppDelegate.shared?.windowId(for: self)
-        let targets = AppDelegate.shared?.windowMoveTargets(referenceWindowId: referenceWindowId) ?? []
+        let referenceWindowId = appEnvironment?.windowRegistry.windowId(for: self)
+        let targets = appEnvironment?.mainWindowRouter.windowMoveTargets(referenceWindowId: referenceWindowId) ?? []
         return targets.map {
             WorkspaceCommandWindowTarget(
                 windowId: $0.windowId,
@@ -82,11 +82,11 @@ extension TabManager: WorkspaceCommandHosting {
     }
 
     func moveWorkspace(_ workspaceId: UUID, toWindow windowId: UUID) {
-        _ = AppDelegate.shared?.moveWorkspaceToWindow(workspaceId: workspaceId, windowId: windowId, focus: true)
+        _ = appEnvironment?.mainWindowRouter.moveWorkspaceToWindow(workspaceId: workspaceId, windowId: windowId, focus: true)
     }
 
     func moveWorkspaceToNewWindow(_ workspaceId: UUID) {
-        _ = AppDelegate.shared?.moveWorkspaceToNewWindow(workspaceId: workspaceId, focus: true)
+        _ = appEnvironment?.mainWindowRouter.moveWorkspaceToNewWindow(workspaceId: workspaceId, focus: true)
     }
 
     // MARK: Notification store

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -47,6 +47,15 @@ class TabManager {
     /// Stable identifier of the owning macOS window. Used only for opt-in title
     /// templates that expose a WM-matchable per-window token.
     var windowId: UUID?
+    /// Weak reach path back to process-lifetime services while call sites migrate
+    /// away from `AppDelegate.shared`.
+    private(set) weak var appEnvironment: AppEnvironment?
+
+    /// Attaches the composition-root environment. Nil reads through this
+    /// property preserve the optional short-circuit shape of `AppDelegate.shared?`.
+    func attachAppEnvironment(_ environment: AppEnvironment) {
+        appEnvironment = environment
+    }
 
     // Wave-4 sub-model (TabManager decomposition): the workspace list, the
     // sidebar group sections, and the selected-workspace id storage live in
@@ -1409,7 +1418,7 @@ class TabManager {
         // but only when the write landed (an `.auto` write rejected over a
         // user-set title must not desync the remote session name).
         if applied, tabs[index].isRemoteTmuxMirror {
-            AppDelegate.shared?.remoteTmuxController.handleMirrorWorkspaceRenamed(
+            appEnvironment?.remoteTmuxController.handleMirrorWorkspaceRenamed(
                 workspaceId: tabId, title: title
             )
         }
@@ -1870,7 +1879,7 @@ class TabManager {
     }
 
     func killRemoteTmuxMirror(_ tab: Workspace) {
-        AppDelegate.shared?.remoteTmuxController.handleWorkspaceClosed(workspaceId: tab.id)
+        appEnvironment?.remoteTmuxController.handleWorkspaceClosed(workspaceId: tab.id)
     }
 
     func isRestorableInSessionSnapshot(_ tab: Workspace) -> Bool {
@@ -1889,7 +1898,7 @@ class TabManager {
         )
         closedItemHistory.push(.workspace(ClosedWorkspaceHistoryEntry(
             workspaceId: tab.id,
-            windowId: AppDelegate.shared?.windowId(for: self),
+            windowId: appEnvironment?.windowRegistry.windowId(for: self),
             workspaceIndex: index,
             snapshot: snapshot
         )))
@@ -1912,7 +1921,7 @@ class TabManager {
     }
 
     func clearNotifications(workspaceId: UUID) {
-        AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspaceId)
+        appEnvironment?.notificationStore?.clearNotifications(forTabId: workspaceId)
     }
 
     func teardownAllPanels(_ tab: Workspace) {
@@ -1966,8 +1975,8 @@ class TabManager {
     }
 
     func markRemoteTmuxKillOnWindowClose() {
-        guard let windowId = AppDelegate.shared?.windowId(for: self) else { return }
-        AppDelegate.shared?.remoteTmuxController.markKillSessionsOnWindowClose(windowId: windowId)
+        guard let windowId = appEnvironment?.windowRegistry.windowId(for: self) else { return }
+        appEnvironment?.remoteTmuxController.markKillSessionsOnWindowClose(windowId: windowId)
     }
 
     @discardableResult
@@ -1976,8 +1985,8 @@ class TabManager {
             window.performClose(nil)
             return true
         }
-        if AppDelegate.shared != nil {
-            AppDelegate.shared?.closeMainWindowContainingTabId(workspaceId)
+        if let router = appEnvironment?.mainWindowRouter {
+            router.closeWindowContaining(tabId: workspaceId)
             return true
         }
         return false
@@ -2023,9 +2032,9 @@ class TabManager {
 
     @discardableResult
     func closeWindowForLastChildExit(workspaceId: UUID) -> Bool {
-        guard let app = AppDelegate.shared else { return false }
-        app.notificationStore?.clearNotifications(forTabId: workspaceId)
-        app.closeMainWindowContainingTabId(workspaceId, recordHistory: false)
+        guard let appEnvironment else { return false }
+        appEnvironment.notificationStore?.clearNotifications(forTabId: workspaceId)
+        appEnvironment.mainWindowRouter.closeWindowContaining(tabId: workspaceId, recordHistory: false)
         return true
     }
 
@@ -2282,7 +2291,7 @@ class TabManager {
         }
 
         _ = tab.closePanel(surfaceId, force: true)
-        AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: tab.id, surfaceId: surfaceId)
+        appEnvironment?.notificationStore?.clearNotifications(forTabId: tab.id, surfaceId: surfaceId)
     }
 
     /// Runtime close requests from Ghostty without confirmation (e.g. child-exit).
@@ -2309,7 +2318,7 @@ class TabManager {
             "surface=\(surfaceId.uuidString.prefix(5)) closed=\(closed ? 1 : 0) panelsAfter=\(tab.panels.count)"
         )
 #endif
-        AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: tab.id, surfaceId: surfaceId)
+        appEnvironment?.notificationStore?.clearNotifications(forTabId: tab.id, surfaceId: surfaceId)
     }
 
     /// Close a panel because its child process exited (e.g. the user hit Ctrl+D).
@@ -4275,7 +4284,7 @@ extension TabManager {
         // Session restore replaces the bootstrap workspace objects with freshly
         // restored ones. Tear the old graph down after the atomic swap so late
         // panel/socket callbacks cannot keep mutating hidden pre-restore state.
-        AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
+        appEnvironment?.notificationStore?.clearNotifications(forTabId: workspace.id)
         workspace.teardownAllPanels()
         workspace.teardownRemoteConnection()
         workspace.owningTabManager = nil

--- a/Sources/TaskManagerWindowController.swift
+++ b/Sources/TaskManagerWindowController.swift
@@ -196,9 +196,11 @@ final class CmuxTaskManagerModel {
     func viewWorkspace(for row: CmuxTaskManagerRow) {
         guard let workspaceId = row.workspaceId,
               let appDelegate = AppDelegate.shared,
-              let manager = appDelegate.tabManagerFor(tabId: workspaceId) else { return }
-        if let windowId = appDelegate.windowId(for: manager) {
-            _ = appDelegate.focusMainWindow(windowId: windowId)
+              let manager = appDelegate.environment.windowRegistry.tabManagerFor(tabId: workspaceId) else {
+            return
+        }
+        if let windowId = appDelegate.environment.windowRegistry.windowId(for: manager) {
+            _ = appDelegate.environment.mainWindowRouter.focusMainWindow(windowId: windowId)
         }
         manager.focusTab(
             workspaceId,
@@ -206,16 +208,18 @@ final class CmuxTaskManagerModel {
             suppressFlash: true,
             dismissRestoredUnreadOnResume: true
         )
-        flashSelection(workspaceId: workspaceId, surfaceId: row.surfaceId)
+        flashSelection(workspaceId: workspaceId, surfaceId: row.surfaceId, appDelegate: appDelegate)
     }
 
     func viewTerminal(for row: CmuxTaskManagerRow) {
         guard let workspaceId = row.workspaceId,
               let terminalSurfaceId = row.terminalSurfaceId,
               let appDelegate = AppDelegate.shared,
-              let manager = appDelegate.tabManagerFor(tabId: workspaceId) else { return }
-        if let windowId = appDelegate.windowId(for: manager) {
-            _ = appDelegate.focusMainWindow(windowId: windowId)
+              let manager = appDelegate.environment.windowRegistry.tabManagerFor(tabId: workspaceId) else {
+            return
+        }
+        if let windowId = appDelegate.environment.windowRegistry.windowId(for: manager) {
+            _ = appDelegate.environment.mainWindowRouter.focusMainWindow(windowId: windowId)
         }
         manager.focusTab(
             workspaceId,
@@ -223,7 +227,7 @@ final class CmuxTaskManagerModel {
             suppressFlash: true,
             dismissRestoredUnreadOnResume: true
         )
-        flashSelection(workspaceId: workspaceId, surfaceId: terminalSurfaceId)
+        flashSelection(workspaceId: workspaceId, surfaceId: terminalSurfaceId, appDelegate: appDelegate)
     }
 
     func killProcess(for row: CmuxTaskManagerRow) {
@@ -382,8 +386,8 @@ final class CmuxTaskManagerModel {
         return errno == EPERM
     }
 
-    private func flashSelection(workspaceId: UUID, surfaceId: UUID?) {
-        guard let manager = AppDelegate.shared?.tabManagerFor(tabId: workspaceId),
+    private func flashSelection(workspaceId: UUID, surfaceId: UUID?, appDelegate: AppDelegate) {
+        guard let manager = appDelegate.environment.windowRegistry.tabManagerFor(tabId: workspaceId),
               let workspace = manager.tabs.first(where: { $0.id == workspaceId }) else { return }
         let targetSurfaceId = surfaceId ?? workspace.focusedPanelId
         guard let targetSurfaceId,

--- a/Sources/TerminalController+ControlBrowserContext.swift
+++ b/Sources/TerminalController+ControlBrowserContext.swift
@@ -441,7 +441,7 @@ extension TerminalController: ControlBrowserContext {
         }
 
         if let windowId = v2ResolveWindowId(tabManager: tabManager) {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
             setActiveTabManager(tabManager)
         }
         if tabManager.selectedTabId != ws.id {

--- a/Sources/TerminalController+ControlDebugContext.swift
+++ b/Sources/TerminalController+ControlDebugContext.swift
@@ -256,7 +256,7 @@ extension TerminalController: ControlDebugContext {
     ) -> Bool {
         let targetWindow: NSWindow?
         if let windowID {
-            guard let window = AppDelegate.shared?.mainWindow(for: windowID) else {
+            guard let window = appEnvironment?.windowRegistry.mainWindow(for: windowID) else {
                 return false
             }
             targetWindow = window
@@ -306,7 +306,7 @@ extension TerminalController: ControlDebugContext {
     func controlDebugCommandPaletteRenameInputSelection(
         windowID: UUID
     ) -> ControlDebugRenameInputSelectionResolution {
-        guard let window = AppDelegate.shared?.mainWindow(for: windowID) else {
+        guard let window = appEnvironment?.windowRegistry.mainWindow(for: windowID) else {
             return .windowNotFound
         }
         guard let editor = window.firstResponder as? NSTextView, editor.isFieldEditor else {
@@ -378,7 +378,7 @@ extension TerminalController: ControlDebugContext {
         }
         let preferredWindow: NSWindow?
         if let windowID {
-            preferredWindow = AppDelegate.shared?.mainWindow(for: windowID)
+            preferredWindow = appEnvironment?.windowRegistry.mainWindow(for: windowID)
             guard preferredWindow != nil else {
                 return .windowNotFound
             }
@@ -637,8 +637,8 @@ extension TerminalController: ControlDebugContext {
             // scoped to the intended window even when NSApp.keyWindow is stale.
             let targetWindow: NSWindow? = {
                 if let activeTabManager = self.tabManager,
-                   let windowId = AppDelegate.shared?.windowId(for: activeTabManager),
-                   let window = AppDelegate.shared?.mainWindow(for: windowId) {
+                   let windowId = appEnvironment?.windowRegistry.windowId(for: activeTabManager),
+                   let window = appEnvironment?.windowRegistry.mainWindow(for: windowId) {
                     return window
                 }
                 return NSApp.keyWindow
@@ -693,7 +693,7 @@ extension TerminalController: ControlDebugContext {
 
     func activateApp() -> String {
         v2MainSync {
-            _ = AppDelegate.shared?.activateMainWindowFromSocket()
+            _ = appEnvironment?.mainWindowRouter.activateFromSocket()
         }
         return "OK"
     }

--- a/Sources/TerminalController+ControlIdentifyContext.swift
+++ b/Sources/TerminalController+ControlIdentifyContext.swift
@@ -48,7 +48,7 @@ extension TerminalController: ControlIdentifyContext {
         guard let fallbackTabManager = v2ResolveTabManager(params: foundationParams) else {
             return nil
         }
-        let callerTabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceID) ?? fallbackTabManager
+        let callerTabManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID) ?? fallbackTabManager
         guard let ws = callerTabManager.tabs.first(where: { $0.id == workspaceID }) else {
             return nil
         }

--- a/Sources/TerminalController+ControlNotificationContext.swift
+++ b/Sources/TerminalController+ControlNotificationContext.swift
@@ -66,7 +66,7 @@ extension TerminalController: ControlNotificationContext {
         return .delivered(
             workspaceID: ws.id,
             surfaceID: surfaceID,
-            windowID: AppDelegate.shared?.windowId(for: tabManager)
+            windowID: appEnvironment?.windowRegistry.windowId(for: tabManager)
         )
     }
 
@@ -97,7 +97,7 @@ extension TerminalController: ControlNotificationContext {
         return .delivered(
             workspaceID: ws.id,
             surfaceID: surfaceID,
-            windowID: AppDelegate.shared?.windowId(for: tabManager)
+            windowID: appEnvironment?.windowRegistry.windowId(for: tabManager)
         )
     }
 

--- a/Sources/TerminalController+ControlPaneContext.swift
+++ b/Sources/TerminalController+ControlPaneContext.swift
@@ -117,7 +117,7 @@ extension TerminalController: ControlPaneContext {
             return .paneNotFound(paneID)
         }
         if let windowId = v2ResolveWindowId(tabManager: tabManager) {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
             setActiveTabManager(tabManager)
         }
         if tabManager.selectedTabId != ws.id {

--- a/Sources/TerminalController+ControlRemotePTYReading.swift
+++ b/Sources/TerminalController+ControlRemotePTYReading.swift
@@ -133,7 +133,7 @@ extension TerminalController {
             }
             if workspace == nil,
                let fallbackWorkspaceId,
-               let fallbackOwner = AppDelegate.shared?.tabManagerFor(tabId: fallbackWorkspaceId),
+               let fallbackOwner = appEnvironment?.windowRegistry.tabManagerFor(tabId: fallbackWorkspaceId),
                let fallbackWorkspace = fallbackOwner.tabs.first(where: { $0.id == fallbackWorkspaceId }) {
                 owner = fallbackOwner
                 workspace = fallbackWorkspace
@@ -264,9 +264,9 @@ extension TerminalController {
         var targets: [ControlRemotePTYTarget] = []
         v2MainSync {
             v2RefreshKnownRefs()
-            guard let app = AppDelegate.shared else { return }
-            for summary in app.listMainWindowSummaries() {
-                guard let owner = app.tabManagerFor(windowId: summary.windowId) else { continue }
+            guard let windowRegistry = appEnvironment?.windowRegistry else { return }
+            for summary in windowRegistry.listMainWindowSummaries() {
+                guard let owner = windowRegistry.tabManagerFor(windowId: summary.windowId) else { continue }
                 for workspace in owner.tabs where workspace.isRemoteWorkspace {
                     targets.append(
                         ControlRemotePTYTarget(

--- a/Sources/TerminalController+ControlRemoteTmuxReading.swift
+++ b/Sources/TerminalController+ControlRemoteTmuxReading.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// `ControlRemoteTmuxWorker` is in a package that must not import the app
 /// target, where the `remote.tmux.*` commands reach the `@MainActor`
-/// `RemoteTmuxController` (via `AppDelegate.shared`) and the
+/// `RemoteTmuxController` (via `TerminalController.shared.appEnvironment`) and the
 /// `RemoteTmuxController.isEnabled` beta flag. ``ControlRemoteTmuxReading``
 /// inverts that: the package owns the protocol, ``TerminalControllerRemoteTmuxReading``
 /// conforms it, hopping to the main actor inside each member to fetch the
@@ -45,7 +45,7 @@ extension TerminalController {
 
 /// Conforms ``ControlRemoteTmuxReading`` with no live `TerminalController` state:
 /// the bodies reach only `RemoteTmuxController.isEnabled` (a static
-/// UserDefaults read) and `AppDelegate.shared?.remoteTmuxController`, so the
+/// UserDefaults read) and `TerminalController.shared.appEnvironment?.remoteTmuxController`, so the
 /// conformer is a plain `Sendable` value.
 ///
 /// Each member hops to the `@MainActor` to fetch the controller and call its
@@ -59,7 +59,7 @@ struct TerminalControllerRemoteTmuxReading: ControlRemoteTmuxReading {
     }
 
     func listSessions(host: ControlRemoteTmuxHost) async throws -> [ControlRemoteTmuxSession] {
-        guard let controller = await MainActor.run(body: { AppDelegate.shared?.remoteTmuxController }) else {
+        guard let controller = await MainActor.run(body: { TerminalController.shared.appEnvironment?.remoteTmuxController }) else {
             throw RemoteTmuxError.unreachable("app not ready")
         }
         let sessions = try await controller.listSessions(host: Self.host(host))
@@ -79,7 +79,7 @@ struct TerminalControllerRemoteTmuxReading: ControlRemoteTmuxReading {
         sessionName: String,
         createIfMissing: Bool
     ) async throws -> [String]? {
-        guard let controller = await MainActor.run(body: { AppDelegate.shared?.remoteTmuxController }) else {
+        guard let controller = await MainActor.run(body: { TerminalController.shared.appEnvironment?.remoteTmuxController }) else {
             throw RemoteTmuxError.unreachable("app not ready")
         }
         return try await controller.attachControlStreamWhenReady(
@@ -90,7 +90,7 @@ struct TerminalControllerRemoteTmuxReading: ControlRemoteTmuxReading {
     }
 
     func mirrorHost(host: ControlRemoteTmuxHost) async throws {
-        guard let controller = await MainActor.run(body: { AppDelegate.shared?.remoteTmuxController }) else {
+        guard let controller = await MainActor.run(body: { TerminalController.shared.appEnvironment?.remoteTmuxController }) else {
             throw RemoteTmuxError.unreachable("app not ready")
         }
         try await controller.mirrorHost(host: Self.host(host))
@@ -100,7 +100,7 @@ struct TerminalControllerRemoteTmuxReading: ControlRemoteTmuxReading {
         host: ControlRemoteTmuxHost,
         activateWindow: Bool
     ) async throws -> ControlRemoteTmuxAttachOutcome {
-        guard let controller = await MainActor.run(body: { AppDelegate.shared?.remoteTmuxController }) else {
+        guard let controller = await MainActor.run(body: { TerminalController.shared.appEnvironment?.remoteTmuxController }) else {
             throw RemoteTmuxError.unreachable("app not ready")
         }
         let outcome = try await controller.mirrorHostInNewWindow(
@@ -117,7 +117,7 @@ struct TerminalControllerRemoteTmuxReading: ControlRemoteTmuxReading {
 
     func detach(host: ControlRemoteTmuxHost, sessionName: String) async throws {
         try await MainActor.run {
-            guard let controller = AppDelegate.shared?.remoteTmuxController else {
+            guard let controller = TerminalController.shared.appEnvironment?.remoteTmuxController else {
                 throw RemoteTmuxError.unreachable("app not ready")
             }
             controller.detach(host: Self.host(host), sessionName: sessionName)
@@ -129,7 +129,7 @@ struct TerminalControllerRemoteTmuxReading: ControlRemoteTmuxReading {
         sessionName: String
     ) async -> ControlRemoteTmuxStateSnapshot? {
         let snapshot: RemoteTmuxControlConnection.Snapshot? = await MainActor.run {
-            AppDelegate.shared?.remoteTmuxController
+            TerminalController.shared.appEnvironment?.remoteTmuxController
                 .connection(host: Self.host(host), sessionName: sessionName)?
                 .snapshot()
         }

--- a/Sources/TerminalController+ControlSidebarContext2.swift
+++ b/Sources/TerminalController+ControlSidebarContext2.swift
@@ -17,8 +17,8 @@ extension TerminalController {
         branch: String,
         isDirty: Bool?
     ) {
-        TerminalMutationBus.shared.enqueueMainActorMutation {
-            guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceID),
+        TerminalMutationBus.shared.enqueueMainActorMutation { [weak self] in
+            guard let tabManager = self?.appEnvironment?.windowRegistry.tabManagerFor(tabId: scope.workspaceID),
                   let tab = tabManager.tabs.first(where: { $0.id == scope.workspaceID }) else {
                 return
             }
@@ -56,8 +56,8 @@ extension TerminalController {
     }
 
     func controlSidebarScheduleScopedGitBranchClear(scope: ControlSidebarPanelScope) {
-        TerminalMutationBus.shared.enqueueMainActorMutation {
-            guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceID),
+        TerminalMutationBus.shared.enqueueMainActorMutation { [weak self] in
+            guard let tabManager = self?.appEnvironment?.windowRegistry.tabManagerFor(tabId: scope.workspaceID),
                   let tab = tabManager.tabs.first(where: { $0.id == scope.workspaceID }) else {
                 return
             }
@@ -134,13 +134,13 @@ extension TerminalController {
         action: String,
         actionTarget: String?
     ) {
-        controlSidebarSchedulePanelMetadataMutation(target: target) { tab, surfaceId in
+        controlSidebarSchedulePanelMetadataMutation(target: target) { [weak self] tab, surfaceId in
             guard SidebarWorkspaceDetailDefaults.pullRequestPollingEnabled(defaults: .standard) else {
                 tab.clearPanelPullRequest(panelId: surfaceId)
                 return
             }
 
-            guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: tab.id) else { return }
+            guard let tabManager = self?.appEnvironment?.windowRegistry.tabManagerFor(tabId: tab.id) else { return }
             tabManager.handleWorkspacePullRequestCommandHint(
                 tabId: tab.id,
                 surfaceId: surfaceId,
@@ -191,8 +191,8 @@ extension TerminalController {
     }
 
     func controlSidebarScheduleScopedDirectoryUpdate(scope: ControlSidebarPanelScope, directory: String) {
-        TerminalMutationBus.shared.enqueueMainActorMutation {
-            guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceID),
+        TerminalMutationBus.shared.enqueueMainActorMutation { [weak self] in
+            guard let tabManager = self?.appEnvironment?.windowRegistry.tabManagerFor(tabId: scope.workspaceID),
                   let tab = tabManager.tabs.first(where: { $0.id == scope.workspaceID }) else {
                 return
             }
@@ -227,8 +227,8 @@ extension TerminalController {
         ) else {
             return
         }
-        TerminalMutationBus.shared.enqueueMainActorMutation {
-            guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceID) else { return }
+        TerminalMutationBus.shared.enqueueMainActorMutation { [weak self] in
+            guard let tabManager = self?.appEnvironment?.windowRegistry.tabManagerFor(tabId: scope.workspaceID) else { return }
             tabManager.updateSurfaceShellActivity(tabId: scope.workspaceID, surfaceId: scope.panelID, state: state)
         }
     }
@@ -250,8 +250,8 @@ extension TerminalController {
     }
 
     func controlSidebarScheduleScopedTTY(scope: ControlSidebarPanelScope, ttyName: String) {
-        TerminalMutationBus.shared.enqueueMainActorMutation {
-            guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceID),
+        TerminalMutationBus.shared.enqueueMainActorMutation { [weak self] in
+            guard let tabManager = self?.appEnvironment?.windowRegistry.tabManagerFor(tabId: scope.workspaceID),
                   let tab = tabManager.tabs.first(where: { $0.id == scope.workspaceID }) else {
                 return
             }
@@ -290,8 +290,8 @@ extension TerminalController {
             // Unreachable: the coordinator only forwards a value this app produced.
             return
         }
-        TerminalMutationBus.shared.enqueueMainActorMutation {
-            guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceID),
+        TerminalMutationBus.shared.enqueueMainActorMutation { [weak self] in
+            guard let tabManager = self?.appEnvironment?.windowRegistry.tabManagerFor(tabId: scope.workspaceID),
                   let tab = tabManager.tabs.first(where: { $0.id == scope.workspaceID }) else {
                 return
             }

--- a/Sources/TerminalController+ControlSidebarContext3.swift
+++ b/Sources/TerminalController+ControlSidebarContext3.swift
@@ -108,12 +108,12 @@ extension TerminalController {
         // The byte-faithful twin of the file-private `v2RefreshKnownRefs()`
         // (which stays in `TerminalController.swift` for the v2 dispatch
         // pre-pass), minting into the same coordinator-owned registry.
-        guard let app = AppDelegate.shared else { return }
+        guard let windowRegistry = appEnvironment?.windowRegistry else { return }
 
-        let windows = app.listMainWindowSummaries()
+        let windows = windowRegistry.listMainWindowSummaries()
         for item in windows {
             _ = controlCommandCoordinator.ensureRef(kind: .window, uuid: item.windowId)
-            if let tm = app.tabManagerFor(windowId: item.windowId) {
+            if let tm = windowRegistry.tabManagerFor(windowId: item.windowId) {
                 for ws in tm.tabs {
                     _ = controlCommandCoordinator.ensureRef(kind: .workspace, uuid: ws.id)
                     for paneId in ws.bonsplitController.allPaneIds {

--- a/Sources/TerminalController+ControlSidebarContextSupport.swift
+++ b/Sources/TerminalController+ControlSidebarContextSupport.swift
@@ -20,7 +20,7 @@ extension TerminalController {
             }
             // The tab may belong to a different window — search all contexts.
             if let uuid = UUID(uuidString: tabArg.trimmingCharacters(in: .whitespacesAndNewlines)),
-               let otherManager = AppDelegate.shared?.tabManagerFor(tabId: uuid) {
+               let otherManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: uuid) {
                 return otherManager.tabs.first(where: { $0.id == uuid })
             }
             return nil
@@ -58,7 +58,7 @@ extension TerminalController {
         if let tab = tabManager?.tabs.first(where: { $0.id == id }) {
             return tab
         }
-        if let otherManager = AppDelegate.shared?.tabManagerFor(tabId: id) {
+        if let otherManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: id) {
             return otherManager.tabs.first(where: { $0.id == id })
         }
         return nil

--- a/Sources/TerminalController+ControlSidebarSimulateDragReading.swift
+++ b/Sources/TerminalController+ControlSidebarSimulateDragReading.swift
@@ -89,7 +89,7 @@ struct TerminalControllerSidebarSimulateDragReading: ControlSidebarSimulateDragR
             // Scope to the requested window. owner.tabManager is the controller's
             // primary tabManager; in multi-window runs that's the wrong list for
             // a window_id other than the primary.
-            guard let windowTabManager = AppDelegate.shared?.tabManagerFor(windowId: windowId) else {
+            guard let windowTabManager = owner.appEnvironment?.windowRegistry.tabManagerFor(windowId: windowId) else {
                 return .error(
                     code: "not_found",
                     message: "No TabManager for window_id",

--- a/Sources/TerminalController+ControlSurfaceContext.swift
+++ b/Sources/TerminalController+ControlSurfaceContext.swift
@@ -182,7 +182,7 @@ extension TerminalController: ControlSurfaceContext {
             return .workspaceNotFound
         }
         if let windowId = v2ResolveWindowId(tabManager: tabManager) {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
             setActiveTabManager(tabManager)
         }
         if tabManager.selectedTabId != ws.id {

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -222,7 +222,7 @@ extension TerminalController {
             guard let requestedSurfaceId = inputs.requestedSurfaceID else {
                 return .surfaceNotFoundForID(nil)
             }
-            guard let located = AppDelegate.shared?.locateSurface(surfaceId: requestedSurfaceId),
+            guard let located = appEnvironment?.windowRegistry.locateSurface(surfaceId: requestedSurfaceId),
                   let locatedWorkspace = located.tabManager.tabs.first(where: { $0.id == located.workspaceId }) else {
                 return .surfaceNotFoundForID(requestedSurfaceId)
             }

--- a/Sources/TerminalController+ControlSurfaceContext3.swift
+++ b/Sources/TerminalController+ControlSurfaceContext3.swift
@@ -19,8 +19,8 @@ extension TerminalController {
     /// coordinator owns the routing precedence and branch; these witnesses keep
     /// every live window/workspace/pane lookup and Bonsplit mutation app-side.
     func controlSurfaceMoveLocateSource(surfaceID: UUID) -> ControlSurfaceMoveSourceResolution {
-        guard let app = AppDelegate.shared else { return .appUnavailable }
-        guard let source = app.locateSurface(surfaceId: surfaceID),
+        guard let windowRegistry = appEnvironment?.windowRegistry else { return .appUnavailable }
+        guard let source = windowRegistry.locateSurface(surfaceId: surfaceID),
               let sourceWorkspace = source.tabManager.tabs.first(where: { $0.id == source.workspaceId }) else {
             return .surfaceNotFound
         }
@@ -39,8 +39,7 @@ extension TerminalController {
     }
 
     func controlSurfaceMoveLocateAnchor(surfaceID: UUID) -> ControlSurfaceMoveAnchorSnapshot? {
-        guard let app = AppDelegate.shared,
-              let anchor = app.locateSurface(surfaceId: surfaceID),
+        guard let anchor = appEnvironment?.windowRegistry.locateSurface(surfaceId: surfaceID),
               let anchorWorkspace = anchor.tabManager.tabs.first(where: { $0.id == anchor.workspaceId }),
               let anchorPane = anchorWorkspace.paneId(forPanelId: surfaceID),
               let anchorIndex = anchorWorkspace.indexInPane(forPanelId: surfaceID) else {
@@ -64,22 +63,21 @@ extension TerminalController {
     }
 
     func controlSurfaceMoveLocateWorkspace(workspaceID: UUID) -> ControlSurfaceMoveWorkspaceSnapshot? {
-        guard let app = AppDelegate.shared,
-              let tabManager = app.tabManagerFor(tabId: workspaceID),
+        guard let tabManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID),
               let workspace = tabManager.tabs.first(where: { $0.id == workspaceID }) else {
             return nil
         }
         let destinationPane = workspace.bonsplitController.focusedPaneId
             ?? workspace.bonsplitController.allPaneIds.first
         return ControlSurfaceMoveWorkspaceSnapshot(
-            windowID: app.windowId(for: tabManager),
+            windowID: appEnvironment?.windowRegistry.windowId(for: tabManager),
             workspaceID: workspace.id,
             destinationPaneID: destinationPane?.id
         )
     }
 
     func controlSurfaceMoveLocateWindow(windowID: UUID) -> ControlSurfaceMoveWindowResolution {
-        guard let app = AppDelegate.shared, let tabManager = app.tabManagerFor(windowId: windowID) else {
+        guard let tabManager = appEnvironment?.windowRegistry.tabManagerFor(windowId: windowID) else {
             return .windowNotFound
         }
         guard let selectedWorkspaceId = tabManager.selectedTabId,
@@ -99,8 +97,7 @@ extension TerminalController {
         requestedFocus: Bool
     ) -> Bool {
         let focus = v2FocusAllowed(requested: requestedFocus)
-        guard let app = AppDelegate.shared,
-              let tabManager = app.tabManagerFor(tabId: workspaceID),
+        guard let tabManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID),
               let workspace = tabManager.tabs.first(where: { $0.id == workspaceID }),
               let destinationPane = workspace.bonsplitController.allPaneIds.first(where: { $0.id == destinationPaneID }) else {
             return false
@@ -120,10 +117,10 @@ extension TerminalController {
         requestedFocus: Bool
     ) -> ControlSurfaceMoveTransferOutcome {
         let focus = v2FocusAllowed(requested: requestedFocus)
-        guard let app = AppDelegate.shared,
-              let sourceTabManager = app.tabManagerFor(tabId: sourceWorkspaceID),
+        guard let windowRegistry = appEnvironment?.windowRegistry,
+              let sourceTabManager = windowRegistry.tabManagerFor(tabId: sourceWorkspaceID),
               let sourceWorkspace = sourceTabManager.tabs.first(where: { $0.id == sourceWorkspaceID }),
-              let targetTabManager = app.tabManagerFor(tabId: targetWorkspaceID),
+              let targetTabManager = windowRegistry.tabManagerFor(tabId: targetWorkspaceID),
               let targetWorkspace = targetTabManager.tabs.first(where: { $0.id == targetWorkspaceID }),
               let destinationPane = targetWorkspace.bonsplitController.allPaneIds.first(where: { $0.id == destinationPaneID }) else {
             return .detachFailed
@@ -147,7 +144,7 @@ extension TerminalController {
         }
 
         if focus {
-            _ = app.focusMainWindow(windowId: targetWindowID)
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: targetWindowID)
             setActiveTabManager(targetTabManager)
             targetTabManager.selectWorkspace(targetWorkspace)
         }
@@ -163,8 +160,7 @@ extension TerminalController {
         requestedFocus: Bool
     ) -> ControlSurfaceReorderResolution {
         let focus = v2FocusAllowed(requested: requestedFocus)
-        guard let app = AppDelegate.shared,
-              let located = app.locateSurface(surfaceId: surfaceID),
+        guard let located = appEnvironment?.windowRegistry.locateSurface(surfaceId: surfaceID),
               let ws = located.tabManager.tabs.first(where: { $0.id == located.workspaceId }),
               let sourcePane = ws.paneId(forPanelId: surfaceID) else {
             return .surfaceNotFound(surfaceID)
@@ -470,7 +466,7 @@ extension TerminalController {
     /// target rather than moving into the control-plane package. The
     /// table-construction logic now lives in the app-side
     /// `TerminalDebugTableBuilder`; this witness still owns the
-    /// `AppDelegate.shared` guard (so a `nil` payload maps to the legacy
+    /// `appEnvironment` guard (so a `nil` payload maps to the legacy
     /// `unavailable` error when `AppDelegate` is gone), the `v2MainSync`
     /// hop, and the Foundation→`JSONValue` wire bridge. The legacy method
     /// ignored its params, so the seam takes none. The builder receives the two
@@ -479,9 +475,9 @@ extension TerminalController {
         var payload: [String: Any]?
 
         v2MainSync {
-            guard let app = AppDelegate.shared else { return }
+            guard let windowRegistry = appEnvironment?.windowRegistry else { return }
             let builder = TerminalDebugTableBuilder(
-                windows: app.scriptableMainWindows(),
+                windows: windowRegistry.scriptableMainWindows(),
                 surfaces: GhosttyApp.terminalSurfaceRegistry.allTerminalSurfaces(),
                 orderedPanels: { self.orderedPanels(in: $0) },
                 makeRef: { self.v2Ref(kind: $0, uuid: $1) }

--- a/Sources/TerminalController+ControlSurfaceContext4.swift
+++ b/Sources/TerminalController+ControlSurfaceContext4.swift
@@ -43,7 +43,7 @@ extension TerminalController {
                 }
                 return (fallbackTabManager, workspace, explicitSurfaceId)
             }
-            if let located = AppDelegate.shared?.locateSurface(surfaceId: explicitSurfaceId),
+            if let located = appEnvironment?.windowRegistry.locateSurface(surfaceId: explicitSurfaceId),
                let workspace = located.tabManager.tabs.first(where: { $0.id == located.workspaceId }),
                workspace.terminalPanel(for: explicitSurfaceId) != nil {
                 return (located.tabManager, workspace, explicitSurfaceId)
@@ -334,8 +334,8 @@ extension TerminalController {
                 state: state.rawValue
             )
             if shouldPublish {
-                DispatchQueue.main.async {
-                    guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceID) else { return }
+                DispatchQueue.main.async { [weak self] in
+                    guard let tabManager = self?.appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID) else { return }
                     tabManager.updateSurfaceShellActivity(
                         tabId: workspaceID,
                         surfaceId: requestedSurfaceID,
@@ -357,7 +357,7 @@ extension TerminalController {
                 validSurfaceIds: validSurfaceIds
             )
             guard let surfaceId, validSurfaceIds.contains(surfaceId) else { return }
-            guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: tab.id) else { return }
+            guard let tabManager = self.appEnvironment?.windowRegistry.tabManagerFor(tabId: tab.id) else { return }
             tabManager.updateSurfaceShellActivity(tabId: tab.id, surfaceId: surfaceId, state: state)
         }
         return .pending
@@ -409,7 +409,7 @@ extension TerminalController {
         if let tab = tabManager?.tabs.first(where: { $0.id == id }) {
             return tab
         }
-        if let otherManager = AppDelegate.shared?.tabManagerFor(tabId: id) {
+        if let otherManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: id) {
             return otherManager.tabs.first(where: { $0.id == id })
         }
         return nil

--- a/Sources/TerminalController+ControlSurfaceSendNotifyV1.swift
+++ b/Sources/TerminalController+ControlSurfaceSendNotifyV1.swift
@@ -442,7 +442,7 @@ extension TerminalController {
         var success = false
         var error: String?
         v2MainSync {
-            guard let targetManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceId)
+            guard let targetManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceId)
                 ?? (tabManager.tabs.contains(where: { $0.id == workspaceId }) ? tabManager : nil) else {
                 error = "ERROR: Workspace not found"
                 return

--- a/Sources/TerminalController+ControlSystemContext.swift
+++ b/Sources/TerminalController+ControlSystemContext.swift
@@ -30,8 +30,8 @@ extension TerminalController: ControlSystemContext {
         var workspaceFound = (workspaceFilter == nil)
         var windowFound = (requestedWindowID == nil)
 
-        if let app = AppDelegate.shared {
-            let summaries = app.listMainWindowSummaries()
+        if let windowRegistry = appEnvironment?.windowRegistry {
+            let summaries = windowRegistry.listMainWindowSummaries()
             let defaultWindowId = requestedWindowID ?? focusedWindowID ?? summaries.first?.windowId
 
             for (windowIndex, summary) in summaries.enumerated() {
@@ -39,7 +39,7 @@ extension TerminalController: ControlSystemContext {
                     continue
                 }
                 windowFound = true
-                guard let manager = app.tabManagerFor(windowId: summary.windowId) else { continue }
+                guard let manager = windowRegistry.tabManagerFor(windowId: summary.windowId) else { continue }
 
                 if let workspaceFilter {
                     guard let workspaceIndex = manager.tabs.firstIndex(where: { $0.id == workspaceFilter }) else {
@@ -245,10 +245,12 @@ extension TerminalController: ControlSystemContext {
 
     func controlFeedbackOpen(workspaceID: UUID?, windowID: UUID?, requestedActivate: Bool) {
         let shouldActivate = v2FocusAllowed(requested: requestedActivate)
+        let windowRegistry = appEnvironment?.windowRegistry
+        let mainWindowRouter = appEnvironment?.mainWindowRouter
         DispatchQueue.main.async {
             let targetWindow: NSWindow?
-            if let windowID, let app = AppDelegate.shared {
-                targetWindow = app.mainWindow(for: windowID)
+            if let windowID {
+                targetWindow = windowRegistry?.mainWindow(for: windowID)
             } else if let workspaceID, let app = AppDelegate.shared {
                 targetWindow = app.mainWindowContainingWorkspace(workspaceID)
             } else {
@@ -257,7 +259,7 @@ extension TerminalController: ControlSystemContext {
 
             if shouldActivate {
                 if let targetWindow {
-                    _ = AppDelegate.shared?.focusWindowForAppActivation(targetWindow, reason: .feedback)
+                    _ = mainWindowRouter?.focusWindowForAppActivation(targetWindow, reason: .feedback)
                 } else {
                     // The legacy body also passed .activateIgnoringOtherApps; the
                     // option is deprecated and documented as a no-op on macOS 14+
@@ -290,7 +292,7 @@ extension TerminalController: ControlSystemContext {
         }
         return ControlExtensionSidebarSnapshot(
             sequence: sequence,
-            windowID: AppDelegate.shared?.windowId(for: tabManager),
+            windowID: appEnvironment?.windowRegistry.windowId(for: tabManager),
             selectedWorkspaceID: selectedWorkspaceId,
             workspaces: workspaces
         )

--- a/Sources/TerminalController+ControlSystemTopContext.swift
+++ b/Sources/TerminalController+ControlSystemTopContext.swift
@@ -24,9 +24,9 @@ extension TerminalController {
         index: Int,
         selected: Bool
     ) -> ControlSystemTopWorkspaceNode? {
-        guard let app = AppDelegate.shared else { return nil }
-        for summary in app.listMainWindowSummaries() {
-            guard let manager = app.tabManagerFor(windowId: summary.windowId) else { continue }
+        guard let windowRegistry = appEnvironment?.windowRegistry else { return nil }
+        for summary in windowRegistry.listMainWindowSummaries() {
+            guard let manager = windowRegistry.tabManagerFor(windowId: summary.windowId) else { continue }
             if let workspace = manager.tabs.first(where: { $0.id == workspaceID }) {
                 return systemTopWorkspaceNode(workspace: workspace, index: index, selected: selected)
             }

--- a/Sources/TerminalController+ControlWorkspaceContext.swift
+++ b/Sources/TerminalController+ControlWorkspaceContext.swift
@@ -68,7 +68,7 @@ extension TerminalController: ControlWorkspaceContext {
             }
             return ws.controlWorkspaceSummary
         }
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         return .resolved(windowID: windowId, workspaces: summaries, selectedIndex: selectedIndex)
     }
 
@@ -83,7 +83,7 @@ extension TerminalController: ControlWorkspaceContext {
         // still answered .ok with "workspace": null.
         let workspace = tabManager.tabs.first(where: { $0.id == workspaceId })
         let index = tabManager.tabs.firstIndex(where: { $0.id == workspaceId })
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         return .resolved(
             windowID: windowId,
             workspaceID: workspaceId,
@@ -120,9 +120,9 @@ extension TerminalController: ControlWorkspaceContext {
         }
         // If this workspace belongs to another window, bring it forward so focus
         // is visible.
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         if let windowId {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
             setActiveTabManager(tabManager)
         }
         tabManager.selectWorkspace(ws)
@@ -136,7 +136,7 @@ extension TerminalController: ControlWorkspaceContext {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
         }
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         guard let ws = tabManager.tabs.first(where: { $0.id == workspaceID }) else {
             return .notFound
         }
@@ -152,10 +152,10 @@ extension TerminalController: ControlWorkspaceContext {
         windowID: UUID,
         focusRequested: Bool
     ) -> ControlWorkspaceMoveToWindowResolution {
-        guard let srcTM = AppDelegate.shared?.tabManagerFor(tabId: workspaceID) else {
+        guard let srcTM = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID) else {
             return .workspaceNotFound
         }
-        guard let dstTM = AppDelegate.shared?.tabManagerFor(windowId: windowID) else {
+        guard let dstTM = appEnvironment?.windowRegistry.tabManagerFor(windowId: windowID) else {
             return .windowNotFound
         }
         guard let ws = srcTM.detachWorkspace(tabId: workspaceID) else {
@@ -164,7 +164,7 @@ extension TerminalController: ControlWorkspaceContext {
         let focus = v2FocusAllowed(requested: focusRequested)
         dstTM.attachWorkspace(ws, select: focus)
         if focus {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowID)
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowID)
             setActiveTabManager(dstTM)
         }
         return .resolved
@@ -202,7 +202,7 @@ extension TerminalController: ControlWorkspaceContext {
         if !dryRun {
             _ = tabManager.reorderWorkspace(tabId: workspaceID, toIndex: plan.toIndex)
         }
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         return .resolved(
             windowID: windowId,
             plan: ControlWorkspaceReorderPlanItem(
@@ -224,7 +224,7 @@ extension TerminalController: ControlWorkspaceContext {
         let result = tabManager.reorderWorkspaces(orderedWorkspaceIds: workspaceIDs, dryRun: dryRun)
         switch result {
         case .success(let planned):
-            let windowId = AppDelegate.shared?.windowId(for: tabManager)
+            let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
             let plans = planned.map {
                 ControlWorkspaceReorderPlanItem(
                     workspaceID: $0.workspaceId,
@@ -251,7 +251,7 @@ extension TerminalController: ControlWorkspaceContext {
             return resolveTabManager(routing: routing)
         }
         for workspaceId in workspaceIDs {
-            if let owner = AppDelegate.shared?.tabManagerFor(tabId: workspaceId) {
+            if let owner = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceId) {
                 return owner
             }
         }
@@ -265,7 +265,7 @@ extension TerminalController: ControlWorkspaceContext {
         workspaceID: UUID,
         message: String?
     ) -> ControlWorkspacePromptSubmitResolution {
-        guard let tabManager = (AppDelegate.shared?.tabManagerFor(tabId: workspaceID))
+        guard let tabManager = (appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID))
             ?? resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
         }
@@ -278,7 +278,7 @@ extension TerminalController: ControlWorkspaceContext {
             return .notFound
         }
         let preview = tabManager.tabs.first(where: { $0.id == workspaceID })?.latestSubmittedMessage
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         return .resolved(
             windowID: windowId,
             iMessageModeEnabled: iMessageModeEnabled,
@@ -301,7 +301,7 @@ extension TerminalController: ControlWorkspaceContext {
             return .notFound
         }
         tabManager.setCustomTitle(tabId: workspaceID, title: title)
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         return .resolved(windowID: windowId)
     }
 
@@ -312,13 +312,13 @@ extension TerminalController: ControlWorkspaceContext {
             return .tabManagerUnavailable
         }
         guard tabManager.selectedTabId != nil else { return .notFound }
-        if let windowId = AppDelegate.shared?.windowId(for: tabManager) {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+        if let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager) {
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
             setActiveTabManager(tabManager)
         }
         tabManager.selectNextTab()
         guard let workspaceId = tabManager.selectedTabId else { return .notFound }
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         return .resolved(workspaceID: workspaceId, windowID: windowId)
     }
 
@@ -327,13 +327,13 @@ extension TerminalController: ControlWorkspaceContext {
             return .tabManagerUnavailable
         }
         guard tabManager.selectedTabId != nil else { return .notFound }
-        if let windowId = AppDelegate.shared?.windowId(for: tabManager) {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+        if let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager) {
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
             setActiveTabManager(tabManager)
         }
         tabManager.selectPreviousTab()
         guard let workspaceId = tabManager.selectedTabId else { return .notFound }
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         return .resolved(workspaceID: workspaceId, windowID: windowId)
     }
 
@@ -342,13 +342,13 @@ extension TerminalController: ControlWorkspaceContext {
             return .tabManagerUnavailable
         }
         guard let before = tabManager.selectedTabId else { return .notFound }
-        if let windowId = AppDelegate.shared?.windowId(for: tabManager) {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+        if let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager) {
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
             setActiveTabManager(tabManager)
         }
         tabManager.navigateBack()
         guard let after = tabManager.selectedTabId, after != before else { return .notFound }
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         return .resolved(workspaceID: after, windowID: windowId)
     }
 
@@ -488,7 +488,7 @@ extension TerminalController: ControlWorkspaceContext {
         guard let workspace = resolveWorkspace(routing: routing, tabManager: tabManager) else {
             return .notFound
         }
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         return .resolved(
             windowID: windowId,
             workspaceID: workspace.id,
@@ -510,12 +510,12 @@ extension TerminalController: ControlWorkspaceContext {
         workspaceID: UUID,
         clearConfiguration: Bool
     ) -> ControlWorkspaceRemoteResolution {
-        guard let owner = AppDelegate.shared?.tabManagerFor(tabId: workspaceID),
+        guard let owner = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID),
               let workspace = owner.tabs.first(where: { $0.id == workspaceID }) else {
             return .notFound(workspaceID: workspaceID)
         }
         workspace.disconnectRemoteConnection(clearConfiguration: clearConfiguration)
-        let windowId = AppDelegate.shared?.windowId(for: owner)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: owner)
         return .resolved(
             windowID: windowId,
             workspaceID: workspace.id,
@@ -527,7 +527,7 @@ extension TerminalController: ControlWorkspaceContext {
         workspaceID: UUID,
         surfaceID: UUID?
     ) -> ControlWorkspaceRemoteResolution {
-        guard let owner = AppDelegate.shared?.tabManagerFor(tabId: workspaceID),
+        guard let owner = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID),
               let workspace = owner.tabs.first(where: { $0.id == workspaceID }) else {
             return .notFound(workspaceID: workspaceID)
         }
@@ -536,7 +536,7 @@ extension TerminalController: ControlWorkspaceContext {
         }
         workspace.reconnectRemoteConnection(surfaceId: surfaceID)
         notifyRemotePTYControllerAvailabilityChanged()
-        let windowId = AppDelegate.shared?.windowId(for: owner)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: owner)
         return .resolved(
             windowID: windowId,
             workspaceID: workspace.id,
@@ -548,13 +548,13 @@ extension TerminalController: ControlWorkspaceContext {
         workspaceID: UUID,
         foregroundAuthToken: String?
     ) -> ControlWorkspaceRemoteResolution {
-        guard let owner = AppDelegate.shared?.tabManagerFor(tabId: workspaceID),
+        guard let owner = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID),
               let workspace = owner.tabs.first(where: { $0.id == workspaceID }) else {
             return .notFound(workspaceID: workspaceID)
         }
         workspace.notifyRemoteForegroundAuthenticationReady(token: foregroundAuthToken)
         notifyRemotePTYControllerAvailabilityChanged()
-        let windowId = AppDelegate.shared?.windowId(for: owner)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: owner)
         return .resolved(
             windowID: windowId,
             workspaceID: workspace.id,
@@ -563,11 +563,11 @@ extension TerminalController: ControlWorkspaceContext {
     }
 
     func controlWorkspaceRemoteStatus(workspaceID: UUID) -> ControlWorkspaceRemoteResolution {
-        guard let owner = AppDelegate.shared?.tabManagerFor(tabId: workspaceID),
+        guard let owner = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID),
               let workspace = owner.tabs.first(where: { $0.id == workspaceID }) else {
             return .notFound(workspaceID: workspaceID)
         }
-        let windowId = AppDelegate.shared?.windowId(for: owner)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: owner)
         return .resolved(
             windowID: windowId,
             workspaceID: workspace.id,
@@ -645,7 +645,7 @@ extension TerminalController: ControlWorkspaceContext {
         )
 #endif
 
-        guard let owner = AppDelegate.shared?.tabManagerFor(tabId: workspaceId),
+        guard let owner = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceId),
               let workspace = owner.tabs.first(where: { $0.id == workspaceId }) else {
             return .err(code: "not_found", message: "Workspace not found", data: .object([
                 "workspace_id": .string(workspaceId.uuidString),
@@ -656,7 +656,7 @@ extension TerminalController: ControlWorkspaceContext {
         workspace.configureRemoteConnection(config, autoConnect: parsed.autoConnect)
         notifyRemotePTYControllerAvailabilityChanged()
 
-        let windowId = AppDelegate.shared?.windowId(for: owner)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: owner)
         return .ok(.object([
             "window_id": controlCommandCoordinator.windowIDValue(windowId),
             "window_ref": controlCommandCoordinator.windowRefValue(windowId),
@@ -675,14 +675,14 @@ extension TerminalController: ControlWorkspaceContext {
             panelId: surfaceId,
             preferredWorkspaceId: workspaceId
         )
-        let fallbackOwner = AppDelegate.shared?.tabManagerFor(tabId: workspaceId)
+        let fallbackOwner = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceId)
         let fallbackWorkspace = fallbackOwner?.tabs.first(where: { $0.id == workspaceId })
         guard let owner = located?.tabManager ?? fallbackOwner,
               let workspace = located?.workspace ?? fallbackWorkspace else {
             return .notFound
         }
         let outcome = workspace.markRemotePTYAttachEnded(surfaceId: surfaceId, sessionID: sessionID)
-        let windowId = AppDelegate.shared?.windowId(for: owner)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: owner)
         return .resolved(
             windowID: windowId,
             workspaceID: workspace.id,
@@ -697,12 +697,12 @@ extension TerminalController: ControlWorkspaceContext {
         surfaceID surfaceId: UUID,
         relayPort: Int
     ) -> ControlWorkspaceRemoteTerminalSessionEndResolution {
-        guard let owner = AppDelegate.shared?.tabManagerFor(tabId: workspaceId),
+        guard let owner = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceId),
               let workspace = owner.tabs.first(where: { $0.id == workspaceId }) else {
             return .notFound
         }
         workspace.markRemoteTerminalSessionEnded(surfaceId: surfaceId, relayPort: relayPort)
-        let windowId = AppDelegate.shared?.windowId(for: owner)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: owner)
         return .resolved(
             windowID: windowId,
             workspaceID: workspace.id,
@@ -982,11 +982,11 @@ extension TerminalController: ControlWorkspaceContext {
     }
 
     func controlWorkspaceActionMarkRead(workspaceID: UUID) {
-        AppDelegate.shared?.notificationStore?.markRead(forTabId: workspaceID)
+        appEnvironment?.notificationStore?.markRead(forTabId: workspaceID)
     }
 
     func controlWorkspaceActionMarkUnread(workspaceID: UUID) {
-        AppDelegate.shared?.notificationStore?.markUnread(forTabId: workspaceID)
+        appEnvironment?.notificationStore?.markUnread(forTabId: workspaceID)
     }
 
     func controlWorkspaceActionSetTabColor(workspaceID: UUID, hex: String?) {
@@ -1003,7 +1003,7 @@ extension TerminalController: ControlWorkspaceContext {
     private func controlWorkspaceActionResolveWorkspace(
         _ workspaceID: UUID
     ) -> (tabManager: TabManager, workspace: Workspace)? {
-        guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceID),
+        guard let tabManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceID),
               let workspace = tabManager.tabs.first(where: { $0.id == workspaceID }) else {
             return nil
         }

--- a/Sources/TerminalController+ControlWorkspaceGroupContext.swift
+++ b/Sources/TerminalController+ControlWorkspaceGroupContext.swift
@@ -54,7 +54,7 @@ extension TerminalController: ControlWorkspaceGroupContext {
         let groups = tabManager.workspaceGroups.map {
             controlWorkspaceGroupSnapshot($0, tabManager: tabManager)
         }
-        let windowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager)
         return .resolved(windowID: windowId, groups: groups)
     }
 
@@ -345,8 +345,8 @@ extension TerminalController: ControlWorkspaceGroupContext {
               let anchor = tabManager.tabs.first(where: { $0.id == group.anchorWorkspaceId }) else {
             return .notFound
         }
-        if let windowId = AppDelegate.shared?.windowId(for: tabManager) {
-            _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+        if let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager) {
+            _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
             setActiveTabManager(tabManager)
         }
         // Route through selectWorkspace so the explicit-resume notification

--- a/Sources/TerminalController+MobileViewport.swift
+++ b/Sources/TerminalController+MobileViewport.swift
@@ -54,7 +54,7 @@ extension TerminalController {
     #endif
 
     private func terminalPanel(surfaceID: UUID) -> TerminalPanel? {
-        guard let located = AppDelegate.shared?.locateSurface(surfaceId: surfaceID),
+        guard let located = appEnvironment?.windowRegistry.locateSurface(surfaceId: surfaceID),
               let workspace = located.tabManager.tabs.first(where: { $0.id == located.workspaceId }) else {
             return nil
         }

--- a/Sources/TerminalController+MobileWorkspaceList.swift
+++ b/Sources/TerminalController+MobileWorkspaceList.swift
@@ -122,19 +122,23 @@ extension TerminalController: MobileWorkspaceListRPCHost {
     }
 
     var mobileWorkspaceListKeyWindowSelectedWorkspaceID: UUID? {
-        AppDelegate.shared?.currentScriptableMainWindow()?.tabManager.selectedTabId
+        appEnvironment?.windowRegistry.currentScriptableMainWindow()?.tabManager.selectedTabId
     }
 
     var mobileWorkspaceListAppAvailable: Bool {
-        AppDelegate.shared != nil
+        // Keyed on the same source the sibling witnesses read
+        // (mobileWorkspaceListMainWindowSummaries/TabManager/NotificationStore all
+        // resolve through appEnvironment), so the availability gate can never
+        // disagree with the data reads.
+        appEnvironment != nil
     }
 
     func mobileWorkspaceListMainWindowSummaries() -> [MainWindowSummary] {
-        AppDelegate.shared?.listMainWindowSummaries() ?? []
+        appEnvironment?.windowRegistry.listMainWindowSummaries() ?? []
     }
 
     func mobileWorkspaceListTabManager(windowId: UUID) -> TabManager? {
-        AppDelegate.shared?.tabManagerFor(windowId: windowId)
+        appEnvironment?.windowRegistry.tabManagerFor(windowId: windowId)
     }
 
     func mobileWorkspaceListMainSync<T>(_ body: @MainActor () -> T) -> T {
@@ -162,7 +166,7 @@ extension TerminalController: MobileWorkspaceListRPCHost {
     }
 
     var mobileWorkspaceListNotificationStore: TerminalNotificationStore? {
-        AppDelegate.shared?.notificationStore
+        appEnvironment?.notificationStore
     }
 
     var mobileWorkspaceListCloseBlockedMessage: String {

--- a/Sources/TerminalController+MoveTabToNewWorkspace.swift
+++ b/Sources/TerminalController+MoveTabToNewWorkspace.swift
@@ -34,12 +34,12 @@ extension TerminalController {
                 data: nil
             )
         }
-        guard let app = AppDelegate.shared else {
+        guard let mainWindowRouter = appEnvironment?.mainWindowRouter else {
             return .err(code: "unavailable", message: "AppDelegate not available", data: nil)
         }
 
         let focus = v2FocusAllowed(requested: v2Bool(params, "focus") ?? false)
-        guard let result = app.moveSurfaceToNewWorkspace(
+        guard let result = mainWindowRouter.moveSurfaceToNewWorkspace(
             panelId: surfaceId,
             destinationManager: tabManager,
             title: v2String(params, "title"),
@@ -123,11 +123,13 @@ extension TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: SurfaceSplitOffMessage.moveSurfaceFailed, data: nil)
         v2MainSync {
-            guard let app = AppDelegate.shared else {
+            guard let appEnvironment = appEnvironment else {
                 result = .err(code: "unavailable", message: SurfaceSplitOffMessage.appDelegateUnavailable, data: nil)
                 return
             }
-            guard let located = app.locateSurface(surfaceId: surfaceId),
+            let windowRegistry = appEnvironment.windowRegistry
+            let mainWindowRouter = appEnvironment.mainWindowRouter
+            guard let located = windowRegistry.locateSurface(surfaceId: surfaceId),
                   let ws = located.tabManager.tabs.first(where: { $0.id == located.workspaceId }) else {
                 result = .err(code: "not_found", message: SurfaceSplitOffMessage.surfaceNotFound, data: ["surface_id": surfaceId.uuidString])
                 return
@@ -171,7 +173,7 @@ extension TerminalController {
                 return
             }
             if focus {
-                _ = app.focusMainWindow(windowId: located.windowId)
+                _ = mainWindowRouter.focusMainWindow(windowId: located.windowId)
                 setActiveTabManager(located.tabManager)
                 located.tabManager.focusTab(ws.id, surfaceId: surfaceId, suppressFlash: true)
             } else if let previousFocusedPanelId, ws.panels[previousFocusedPanelId] != nil {

--- a/Sources/TerminalController+SystemTopCommandBodies.swift
+++ b/Sources/TerminalController+SystemTopCommandBodies.swift
@@ -28,11 +28,11 @@ extension TerminalController {
         let focused = identifyPayload["focused"] as? [String: Any] ?? [:]
         var windowNodes: [[String: Any]] = []
 
-        if let app = AppDelegate.shared {
-            let summaries = app.listMainWindowSummaries()
+        if let windowRegistry = appEnvironment?.windowRegistry {
+            let summaries = windowRegistry.listMainWindowSummaries()
 
             for (windowIndex, summary) in summaries.enumerated() {
-                guard let manager = app.tabManagerFor(windowId: summary.windowId) else { continue }
+                guard let manager = windowRegistry.tabManagerFor(windowId: summary.windowId) else { continue }
                 let workspaceNodes = manager.tabs.enumerated().map { workspaceIndex, workspace in
                     systemTopWorkspaceNode(
                         workspace: workspace,
@@ -212,8 +212,8 @@ extension TerminalController {
         var workspaceFound = (workspaceFilter == nil)
         var windowFound = (routing.requestedWindowID == nil)
 
-        if let app = AppDelegate.shared {
-            let summaries = app.listMainWindowSummaries()
+        if let windowRegistry = appEnvironment?.windowRegistry {
+            let summaries = windowRegistry.listMainWindowSummaries()
             let defaultWindowId = routing.requestedWindowID ?? routing.focusedWindowID ?? summaries.first?.windowId
 
             for (windowIndex, summary) in summaries.enumerated() {
@@ -221,7 +221,7 @@ extension TerminalController {
                     continue
                 }
                 windowFound = true
-                guard let manager = app.tabManagerFor(windowId: summary.windowId) else { continue }
+                guard let manager = windowRegistry.tabManagerFor(windowId: summary.windowId) else { continue }
 
                 if let workspaceFilter {
                     guard let workspaceIndex = manager.tabs.firstIndex(where: { $0.id == workspaceFilter }) else {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -94,6 +94,16 @@ class TerminalController: MobileViewportSurfaceLimiting {
         compositionRootInstance = instance
     }
 
+    /// Weak reach path back to process-lifetime services while control-context
+    /// call sites migrate away from `AppDelegate.shared`.
+    private(set) weak var appEnvironment: AppEnvironment?
+
+    /// Attaches the composition-root environment. Nil reads through this
+    /// property preserve the optional short-circuit shape of `AppDelegate.shared?`.
+    func attachAppEnvironment(_ environment: AppEnvironment) {
+        appEnvironment = environment
+    }
+
     /// Pure replacement-policy transforms for sidebar status/metadata/git/PR/
     /// port projections plus directory normalization and explicit-socket-scope
     /// parsing. A `Sendable` value type owned by `CmuxSidebar`; the sidebar
@@ -246,7 +256,7 @@ class TerminalController: MobileViewportSurfaceLimiting {
     )
 
     /// The worker-lane `remote.tmux.*` RPC handler (CmuxControlSocket), reaching
-    /// the `@MainActor` `RemoteTmuxController` (via `AppDelegate.shared`) and the
+    /// the `@MainActor` `RemoteTmuxController` (via ``appEnvironment``) and the
     /// `RemoteTmuxController.isEnabled` beta flag strictly through the
     /// ``ControlRemoteTmuxReading`` seam conformed by
     /// ``TerminalControllerRemoteTmuxReading``. The seam conformer holds no live
@@ -499,7 +509,7 @@ class TerminalController: MobileViewportSurfaceLimiting {
     func v2MaybeFocusWindow(for tabManager: TabManager) {
         guard socketCommandAllowsInAppFocusMutations(),
               let windowId = v2ResolveWindowId(tabManager: tabManager) else { return }
-        _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+        _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
         setActiveTabManager(tabManager)
     }
 
@@ -1630,12 +1640,12 @@ class TerminalController: MobileViewportSurfaceLimiting {
     // whose `controlWorkspaceEnv` witness reproduces the legacy `v2WorkspaceEnv`
     // pre-resolution refs refresh and so must reach this member.
     func v2RefreshKnownRefs() {
-        guard let app = AppDelegate.shared else { return }
+        guard let windowRegistry = appEnvironment?.windowRegistry else { return }
 
-        let windows = app.listMainWindowSummaries()
+        let windows = windowRegistry.listMainWindowSummaries()
         for item in windows {
             _ = v2EnsureHandleRef(kind: .window, uuid: item.windowId)
-            if let tm = app.tabManagerFor(windowId: item.windowId) {
+            if let tm = windowRegistry.tabManagerFor(windowId: item.windowId) {
                 for ws in tm.tabs {
                     _ = v2EnsureHandleRef(kind: .workspace, uuid: ws.id)
                     for paneId in ws.bonsplitController.allPaneIds {
@@ -1667,7 +1677,7 @@ class TerminalController: MobileViewportSurfaceLimiting {
         // active window's TabManager.
         if v2HasNonNullParam(params, "window_id") {
             guard let windowId = v2UUID(params, "window_id") else { return nil }
-            return v2MainSync { AppDelegate.shared?.tabManagerFor(windowId: windowId) }
+            return v2MainSync { appEnvironment?.windowRegistry.tabManagerFor(windowId: windowId) }
         }
         if let groupId = v2UUID(params, "group_id") {
             if let tm = v2MainSync({ v2LocateTabManager(forGroupId: groupId) }) {
@@ -1675,14 +1685,14 @@ class TerminalController: MobileViewportSurfaceLimiting {
             }
         }
         if let wsId = v2UUID(params, "workspace_id") {
-            if let tm = v2MainSync({ AppDelegate.shared?.tabManagerFor(tabId: wsId) }) {
+            if let tm = v2MainSync({ appEnvironment?.windowRegistry.tabManagerFor(tabId: wsId) }) {
                 return tm
             }
         }
         if let surfaceId = v2UUID(params, "surface_id")
             ?? v2UUID(params, "terminal_id")
             ?? v2UUID(params, "tab_id") {
-            if let tm = v2MainSync({ AppDelegate.shared?.locateSurface(surfaceId: surfaceId)?.tabManager }) {
+            if let tm = v2MainSync({ appEnvironment?.windowRegistry.locateSurface(surfaceId: surfaceId)?.tabManager }) {
                 return tm
             }
         }
@@ -1691,14 +1701,14 @@ class TerminalController: MobileViewportSurfaceLimiting {
                 return tm
             }
         }
-        return v2MainSync { tabManager ?? AppDelegate.shared?.currentScriptableMainWindow()?.tabManager }
+        return v2MainSync { tabManager ?? appEnvironment?.windowRegistry.currentScriptableMainWindow()?.tabManager }
     }
 
     @MainActor
     private func v2LocateTabManager(forGroupId groupId: UUID) -> TabManager? {
-        guard let app = AppDelegate.shared else { return nil }
-        for summary in app.listMainWindowSummaries() {
-            guard let tm = app.tabManagerFor(windowId: summary.windowId) else { continue }
+        guard let windowRegistry = appEnvironment?.windowRegistry else { return nil }
+        for summary in windowRegistry.listMainWindowSummaries() {
+            guard let tm = windowRegistry.tabManagerFor(windowId: summary.windowId) else { continue }
             if tm.workspaceGroups.contains(where: { $0.id == groupId }) {
                 return tm
             }
@@ -1716,34 +1726,34 @@ class TerminalController: MobileViewportSurfaceLimiting {
     func resolveTabManager(routing: ControlRoutingSelectors) -> TabManager? {
         if routing.hasWindowIDParam {
             guard let windowId = routing.windowID else { return nil }
-            return AppDelegate.shared?.tabManagerFor(windowId: windowId)
+            return appEnvironment?.windowRegistry.tabManagerFor(windowId: windowId)
         }
         if let groupId = routing.groupID,
            let tm = v2LocateTabManager(forGroupId: groupId) {
             return tm
         }
         if let workspaceId = routing.workspaceID,
-           let tm = AppDelegate.shared?.tabManagerFor(tabId: workspaceId) {
+           let tm = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceId) {
             return tm
         }
         if let surfaceId = routing.surfaceID,
-           let tm = AppDelegate.shared?.locateSurface(surfaceId: surfaceId)?.tabManager {
+           let tm = appEnvironment?.windowRegistry.locateSurface(surfaceId: surfaceId)?.tabManager {
             return tm
         }
         if let paneId = routing.paneID,
            let tm = v2LocatePane(paneId)?.tabManager {
             return tm
         }
-        return tabManager ?? AppDelegate.shared?.currentScriptableMainWindow()?.tabManager
+        return tabManager ?? appEnvironment?.windowRegistry.currentScriptableMainWindow()?.tabManager
     }
 
     func v2ResolveWindowId(tabManager: TabManager?) -> UUID? {
         guard let tabManager else { return nil }
-        return v2MainSync { AppDelegate.shared?.windowId(for: tabManager) }
+        return v2MainSync { appEnvironment?.windowRegistry.windowId(for: tabManager) }
     }
 
     private func v2ResolveWorkspaceOwner(_ workspaceId: UUID) -> TabManager? {
-        v2MainSync { AppDelegate.shared?.tabManagerFor(tabId: workspaceId) }
+        v2MainSync { appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceId) }
     }
 
     // MARK: - V2 Surface Methods
@@ -1866,7 +1876,7 @@ class TerminalController: MobileViewportSurfaceLimiting {
         case .userPromptSubmit:
             v2MainSync {
                 guard let workspaceId = v2UUIDAny(rawWorkspaceId) else { return }
-                guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceId) else { return }
+                guard let tabManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceId) else { return }
                 _ = tabManager.handlePromptSubmit(
                     workspaceId: workspaceId,
                     message: event.submittedPromptMessage,
@@ -1878,7 +1888,7 @@ class TerminalController: MobileViewportSurfaceLimiting {
             Task { @MainActor [weak self, rawWorkspaceId, assistantFinalMessage, iMessageModeEnabled] in
                 guard let self,
                       let workspaceId = self.v2UUIDAny(rawWorkspaceId) else { return }
-                guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceId) else { return }
+                guard let tabManager = self.appEnvironment?.windowRegistry.tabManagerFor(tabId: workspaceId) else { return }
                 _ = tabManager.handleAssistantFinalMessage(
                     workspaceId: workspaceId,
                     message: assistantFinalMessage,
@@ -2211,7 +2221,7 @@ class TerminalController: MobileViewportSurfaceLimiting {
             guard webView.url == nil,
                   !webView.isLoading,
                   webView.backForwardList.currentItem == nil else { return false }
-            guard let located = AppDelegate.shared?.locateSurface(surfaceId: surfaceId),
+            guard let located = appEnvironment?.windowRegistry.locateSurface(surfaceId: surfaceId),
                   let workspace = located.tabManager.tabs.first(where: { $0.id == located.workspaceId }),
                   let browserPanel = workspace.browserPanel(for: surfaceId),
                   let blankURL = URL(string: "about:blank") else {
@@ -3462,7 +3472,7 @@ class TerminalController: MobileViewportSurfaceLimiting {
             }
             // The tab may belong to a different window — search all contexts.
             if let uuid = UUID(uuidString: tabArg.trimmingCharacters(in: .whitespacesAndNewlines)),
-               let otherManager = AppDelegate.shared?.tabManagerFor(tabId: uuid) {
+               let otherManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: uuid) {
                 return otherManager.tabs.first(where: { $0.id == uuid })
             }
             return nil
@@ -3507,7 +3517,7 @@ class TerminalController: MobileViewportSurfaceLimiting {
         if let tab = tabManager?.tabs.first(where: { $0.id == id }) {
             return tab
         }
-        if let otherManager = AppDelegate.shared?.tabManagerFor(tabId: id) {
+        if let otherManager = appEnvironment?.windowRegistry.tabManagerFor(tabId: id) {
             return otherManager.tabs.first(where: { $0.id == id })
         }
         return nil

--- a/Sources/TerminalControllerControlCommandContext.swift
+++ b/Sources/TerminalControllerControlCommandContext.swift
@@ -19,7 +19,7 @@ extension TerminalController: ControlCommandContext {}
 /// hop would re-apply the identical thread-local focus-allowance stack — a no-op.
 extension TerminalController: ControlWindowContext {
     func controlWindowSummaries() -> [ControlWindowSummary] {
-        (AppDelegate.shared?.listMainWindowSummaries() ?? []).map { summary in
+        (appEnvironment?.windowRegistry.listMainWindowSummaries() ?? []).map { summary in
             ControlWindowSummary(
                 windowID: summary.windowId,
                 isKeyWindow: summary.isKeyWindow,
@@ -36,28 +36,28 @@ extension TerminalController: ControlWindowContext {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
         }
-        guard let windowId = AppDelegate.shared?.windowId(for: tabManager) else {
+        guard let windowId = appEnvironment?.windowRegistry.windowId(for: tabManager) else {
             return .windowNotFound
         }
         return .resolved(windowId)
     }
 
     func controlFocusWindow(id: UUID) -> Bool {
-        AppDelegate.shared?.focusMainWindow(windowId: id) ?? false
+        appEnvironment?.mainWindowRouter.focusMainWindow(windowId: id) ?? false
     }
 
     func controlCreateWindowAndActivate() -> UUID? {
-        guard let windowId = AppDelegate.shared?.createMainWindow() else { return nil }
+        guard let windowId = appEnvironment?.mainWindowRouter.createMainWindow() else { return nil }
         // The new window should become key, but setActiveTabManager defensively
         // (preserves the legacy v2WindowCreate side effect and ordering).
-        if let tabManager = AppDelegate.shared?.tabManagerFor(windowId: windowId) {
+        if let tabManager = appEnvironment?.windowRegistry.tabManagerFor(windowId: windowId) {
             setActiveTabManager(tabManager)
         }
         return windowId
     }
 
     func controlCloseWindow(id: UUID) -> Bool {
-        AppDelegate.shared?.closeMainWindow(windowId: id) ?? false
+        appEnvironment?.mainWindowRouter.closeMainWindow(windowId: id) ?? false
     }
 
     func controlAvailableDisplays() -> [ControlDisplayInfo] {
@@ -86,11 +86,11 @@ extension TerminalController: ControlWindowContext {
     }
 
     func controlMoveWindow(id: UUID, toDisplayMatching query: String) -> String? {
-        AppDelegate.shared?.moveMainWindow(windowId: id, toDisplayMatching: query)
+        appEnvironment?.mainWindowRouter.moveWindow(windowId: id, toDisplayMatching: query)
     }
 
     func controlMoveAllWindows(toDisplayMatching query: String) -> ControlMoveAllWindowsResult? {
-        guard let result = AppDelegate.shared?.moveAllMainWindows(toDisplayMatching: query) else {
+        guard let result = appEnvironment?.mainWindowRouter.moveAllWindows(toDisplayMatching: query) else {
             return nil
         }
         return ControlMoveAllWindowsResult(display: result.display, windowIDs: result.windowIds)
@@ -114,20 +114,20 @@ extension TerminalController: ControlWindowContext {
         let trimmed = arg.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let windowId = UUID(uuidString: trimmed) else { return "ERROR: Invalid window id" }
 
-        let ok = v2MainSync { AppDelegate.shared?.focusMainWindow(windowId: windowId) ?? false }
+        let ok = v2MainSync { appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId) ?? false }
         guard ok else { return "ERROR: Window not found" }
 
-        if let tm = v2MainSync({ AppDelegate.shared?.tabManagerFor(windowId: windowId) }) {
+        if let tm = v2MainSync({ appEnvironment?.windowRegistry.tabManagerFor(windowId: windowId) }) {
             setActiveTabManager(tm)
         }
         return "OK"
     }
 
     func controlNewWindowV1() -> String {
-        guard let windowId = v2MainSync({ AppDelegate.shared?.createMainWindow() }) else {
+        guard let windowId = v2MainSync({ appEnvironment?.mainWindowRouter.createMainWindow() }) else {
             return "ERROR: Failed to create window"
         }
-        if let tm = v2MainSync({ AppDelegate.shared?.tabManagerFor(windowId: windowId) }) {
+        if let tm = v2MainSync({ appEnvironment?.windowRegistry.tabManagerFor(windowId: windowId) }) {
             setActiveTabManager(tm)
         }
         return "OK \(windowId.uuidString)"
@@ -136,7 +136,7 @@ extension TerminalController: ControlWindowContext {
     func controlCloseWindowV1(arg: String) -> String {
         let trimmed = arg.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let windowId = UUID(uuidString: trimmed) else { return "ERROR: Invalid window id" }
-        let ok = v2MainSync { AppDelegate.shared?.closeMainWindow(windowId: windowId) ?? false }
+        let ok = v2MainSync { appEnvironment?.mainWindowRouter.closeMainWindow(windowId: windowId) ?? false }
         return ok ? "OK" : "ERROR: Window not found"
     }
 
@@ -149,15 +149,15 @@ extension TerminalController: ControlWindowContext {
         var ok = false
         let focus = socketCommandAllowsInAppFocusMutations()
         v2MainSync {
-            guard let srcTM = AppDelegate.shared?.tabManagerFor(tabId: wsId),
-                  let dstTM = AppDelegate.shared?.tabManagerFor(windowId: windowId),
+            guard let srcTM = appEnvironment?.windowRegistry.tabManagerFor(tabId: wsId),
+                  let dstTM = appEnvironment?.windowRegistry.tabManagerFor(windowId: windowId),
                   let ws = srcTM.detachWorkspace(tabId: wsId) else {
                 ok = false
                 return
             }
             dstTM.attachWorkspace(ws, select: focus)
             if focus {
-                _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
+                _ = appEnvironment?.mainWindowRouter.focusMainWindow(windowId: windowId)
                 setActiveTabManager(dstTM)
             }
             ok = true

--- a/Sources/TerminalControllerV2ParamParsingSupport.swift
+++ b/Sources/TerminalControllerV2ParamParsingSupport.swift
@@ -119,10 +119,10 @@ extension TerminalController {
     }
 
     func v2LocatePane(_ paneUUID: UUID) -> (windowId: UUID, tabManager: TabManager, workspace: Workspace, paneId: PaneID)? {
-        guard let app = AppDelegate.shared else { return nil }
-        let windows = app.listMainWindowSummaries()
+        guard let windowRegistry = appEnvironment?.windowRegistry else { return nil }
+        let windows = windowRegistry.listMainWindowSummaries()
         for item in windows {
-            guard let tm = app.tabManagerFor(windowId: item.windowId) else { continue }
+            guard let tm = windowRegistry.tabManagerFor(windowId: item.windowId) else { continue }
             for ws in tm.tabs {
                 if let paneId = ws.bonsplitController.allPaneIds.first(where: { $0.id == paneUUID }) {
                     return (item.windowId, tm, ws, paneId)

--- a/Sources/TerminalNotificationCallerResolver.swift
+++ b/Sources/TerminalNotificationCallerResolver.swift
@@ -38,7 +38,8 @@ extension TerminalController {
             preferredWorkspaceId: preferredWorkspaceID,
             preferredSurfaceId: preferredSurfaceID,
             callerTTY: normalizedTTY,
-            preferTTY: preferTTY
+            preferTTY: preferTTY,
+            appEnvironment: appEnvironment
         ) else {
             return .workspaceNotFound
         }
@@ -57,12 +58,14 @@ extension TerminalController {
         preferredWorkspaceId: UUID?,
         preferredSurfaceId: UUID?,
         callerTTY: String?,
-        preferTTY: Bool
+        preferTTY: Bool,
+        appEnvironment: AppEnvironment?
     ) -> TerminalCallerNotificationTarget? {
         let managers = candidateManagers(
             fallback: fallback,
             preferredWorkspaceId: preferredWorkspaceId,
-            preferredSurfaceId: preferredSurfaceId
+            preferredSurfaceId: preferredSurfaceId,
+            appEnvironment: appEnvironment
         )
         let ttyTarget = callerTTY.flatMap { targetForTTY($0, tabManagers: managers) }
         if preferTTY, let ttyTarget { return ttyTarget }
@@ -93,7 +96,8 @@ extension TerminalController {
     private static func candidateManagers(
         fallback: TabManager,
         preferredWorkspaceId: UUID?,
-        preferredSurfaceId: UUID?
+        preferredSurfaceId: UUID?,
+        appEnvironment: AppEnvironment?
     ) -> [TabManager] {
         var managers: [TabManager] = []
         func append(_ manager: TabManager?) {
@@ -101,11 +105,13 @@ extension TerminalController {
             managers.append(manager)
         }
 
-        let app = AppDelegate.shared
-        if let preferredWorkspaceId { append(app?.tabManagerFor(tabId: preferredWorkspaceId)) }
-        if let preferredSurfaceId { append(app?.locateSurface(surfaceId: preferredSurfaceId)?.tabManager) }
+        let windowRegistry = appEnvironment?.windowRegistry
+        if let preferredWorkspaceId { append(windowRegistry?.tabManagerFor(tabId: preferredWorkspaceId)) }
+        if let preferredSurfaceId { append(windowRegistry?.locateSurface(surfaceId: preferredSurfaceId)?.tabManager) }
         append(fallback)
-        app?.listMainWindowSummaries().forEach { append(app?.tabManagerFor(windowId: $0.windowId)) }
+        windowRegistry?.listMainWindowSummaries().forEach {
+            append(windowRegistry?.tabManagerFor(windowId: $0.windowId))
+        }
         return managers
     }
 

--- a/Sources/TerminalNotificationQueue.swift
+++ b/Sources/TerminalNotificationQueue.swift
@@ -406,7 +406,8 @@ extension TerminalNotificationStore {
     private func shouldDeliverQueuedNotification(_ notification: QueuedTerminalNotification) -> Bool {
         guard let appDelegate = AppDelegate.shared else { return false }
         guard let surfaceId = notification.key.surfaceId else {
-            let tabManager = appDelegate.tabManagerFor(tabId: notification.key.tabId) ?? appDelegate.tabManager
+            let tabManager = appDelegate.environment.windowRegistry.tabManagerFor(tabId: notification.key.tabId)
+                ?? appDelegate.environment.mainWindowRouter.activeTabManager
             return tabManager?.tabs.contains(where: { $0.id == notification.key.tabId }) == true
         }
 

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -503,8 +503,8 @@ final class TerminalNotificationStore: ObservableObject {
 
     private func clearWorkspacePanelUnread(forTabId tabId: UUID) {
         guard let appDelegate = AppDelegate.shared else { return }
-        let workspace = appDelegate.workspaceFor(tabId: tabId) ??
-            appDelegate.tabManager?.tabs.first(where: { $0.id == tabId })
+        let workspace = appDelegate.environment.windowRegistry.workspaceFor(tabId: tabId) ??
+            appDelegate.environment.mainWindowRouter.activeTabManager?.tabs.first(where: { $0.id == tabId })
         workspace?.clearAllPanelUnreadIndicatorsForWorkspaceRead()
     }
 
@@ -736,8 +736,11 @@ final class TerminalNotificationStore: ObservableObject {
         body: String
     ) -> NotificationPolicyContext {
         let appDelegate = AppDelegate.shared
-        let context = appDelegate?.contextContainingTabId(tabId)
-        let tabManager = context?.tabManager ?? appDelegate?.tabManagerFor(tabId: tabId) ?? appDelegate?.tabManager
+        let windowRegistry = appDelegate?.environment.windowRegistry
+        let context = windowRegistry?.contextContainingTabId(tabId)
+        let tabManager = context?.tabManager
+            ?? windowRegistry?.tabManagerFor(tabId: tabId)
+            ?? appDelegate?.environment.mainWindowRouter.activeTabManager
         let cmuxConfigStore = context.flatMap { appDelegate?.configStore(for: $0) }
         let workspace = tabManager?.tabs.first(where: { $0.id == tabId })
         let focusedSurfaceId = tabManager?.focusedSurfaceId(for: tabId)
@@ -951,8 +954,11 @@ final class TerminalNotificationStore: ObservableObject {
 
     private func shouldSuppressExternalDelivery(tabId: UUID, surfaceId: UUID?) -> Bool {
         let appDelegate = AppDelegate.shared
-        let context = appDelegate?.contextContainingTabId(tabId)
-        let tabManager = context?.tabManager ?? appDelegate?.tabManagerFor(tabId: tabId) ?? appDelegate?.tabManager
+        let windowRegistry = appDelegate?.environment.windowRegistry
+        let context = windowRegistry?.contextContainingTabId(tabId)
+        let tabManager = context?.tabManager
+            ?? windowRegistry?.tabManagerFor(tabId: tabId)
+            ?? appDelegate?.environment.mainWindowRouter.activeTabManager
         let focusedSurfaceId = tabManager?.focusedSurfaceId(for: tabId)
         let isActiveTab = tabManager?.selectedTabId == tabId
         let isFocusedSurface = surfaceId == nil || focusedSurfaceId == surfaceId

--- a/Sources/WindowContext.swift
+++ b/Sources/WindowContext.swift
@@ -1,0 +1,86 @@
+import AppKit
+import CmuxWindowing
+
+/// Per-window model + UI state for one main terminal `NSWindow`.
+///
+/// This consolidates the six per-window slices that previously lived in six
+/// parallel `WindowScopedStore<…>` dictionaries on `AppDelegate`
+/// (`windowTabManagers`, `windowFocusControllers`, `windowConfigStores`,
+/// `windowSidebarSelectionStates`, `windowSidebarStates`,
+/// `windowFileExplorerStates`) into one object owned per window. One
+/// `WindowContext` exists per main `NSWindow`: it is built in the
+/// window-registration funnel (`seedNewMainWindowSlices` / the DEBUG
+/// `seedTestingMainWindowSlices`), indexed by ``WindowRegistry`` under the
+/// window's ``WindowID``, held (weakly) by the per-window
+/// `AppDelegate.MainWindowController`, and dropped by `removeWindowModelSlices`
+/// on every window-teardown path.
+///
+/// The registry is the single strong owner of a context (exactly replacing the
+/// dictionaries' strong ownership), so a context's lifetime matches the old
+/// per-slice dictionary entries: it dies when the registry drops it on teardown.
+/// The owning `MainWindowController` references its context weakly, purely to
+/// express the per-window association without extending the context's lifetime.
+///
+/// ## Slice optionality
+///
+/// `tabManager`, `focusController`, `sidebarState`, and `sidebarSelectionState`
+/// are always seeded together when the context is created, matching the old
+/// invariant that a registered window always had those four slices.
+/// `fileExplorerState` and `configStore` are optional by design: the lifted
+/// `MainWindowContext.fileExplorerState` was a lazily-bound `var
+/// FileExplorerState?` (nil until the window's content view seeds it) and the
+/// config store may be absent, so an unset field reads back `nil` rather than a
+/// synthesized empty default.
+///
+/// ## Isolation
+///
+/// `@MainActor` because every slice is a main-actor model mutated alongside
+/// window registration and AppKit teardown, co-located with its callers so no
+/// cross-actor hop is introduced.
+@MainActor
+final class WindowContext {
+    /// The window this context belongs to.
+    let windowId: WindowID
+
+    /// The window's tab/workspace manager. Rebound by `rebindTabManagerSlice`
+    /// during a same-window re-registration; never `nil` for a live context.
+    var tabManager: TabManager
+
+    /// The window's keyboard-focus / right-sidebar-mode controller. Its storage
+    /// lives here, but the keyboard-focus accessor sites stay on `AppDelegate`
+    /// (a `KeyEventRouter` concern for a later wave); they reach this through the
+    /// resolved `RegisteredMainWindow.keyboardFocusCoordinator`.
+    var focusController: MainWindowFocusController
+
+    /// The window's sidebar visibility + persisted width state.
+    var sidebarState: SidebarState
+
+    /// The window's sidebar selection state.
+    var sidebarSelectionState: SidebarSelectionState
+
+    /// The window's right-sidebar (file-explorer) state, or `nil` until the
+    /// content view lazily binds it. Optional by design; never seed an empty
+    /// default (a missing value must read back `nil`).
+    var fileExplorerState: FileExplorerState?
+
+    /// The window's cmux-config store, or `nil` when the window has none.
+    var configStore: CmuxConfigStore?
+
+    init(
+        windowId: WindowID,
+        tabManager: TabManager,
+        focusController: MainWindowFocusController,
+        sidebarState: SidebarState,
+        sidebarSelectionState: SidebarSelectionState,
+        fileExplorerState: FileExplorerState?,
+        configStore: CmuxConfigStore?
+    ) {
+        self.windowId = windowId
+        self.tabManager = tabManager
+        self.focusController = focusController
+        self.sidebarState = sidebarState
+        self.sidebarSelectionState = sidebarSelectionState
+        self.fileExplorerState = fileExplorerState
+        self.configStore = configStore
+    }
+}

--- a/Sources/WindowRegistry.swift
+++ b/Sources/WindowRegistry.swift
@@ -1,0 +1,69 @@
+import CmuxWindowing
+
+/// Cross-window index of per-window ``WindowContext``s, keyed by ``WindowID``.
+///
+/// This replaces the six parallel `WindowScopedStore<…>` dictionaries
+/// `AppDelegate` used to hold (`windowTabManagers`, `windowFocusControllers`,
+/// `windowConfigStores`, `windowSidebarSelectionStates`, `windowSidebarStates`,
+/// `windowFileExplorerStates`). The per-window state now lives in one
+/// ``WindowContext`` per `NSWindow`; this registry is the single
+/// `WindowID`→context index the window-lifecycle seam
+/// (`resolveRegisteredWindow`, `seedNewMainWindowSlices`,
+/// `rebindRegisteredWindowSlices`, `removeWindowModelSlices`, …) and the
+/// per-window config/sidebar/file-explorer accessors resolve through.
+///
+/// The cross-window resolver family (`tabManagerFor`, `locateSurface`,
+/// `workspaceContainingPanel`, `tabTitle`, `scriptableMainWindow`, …) is
+/// unchanged: it iterates `registeredMainWindows` (which funnels through
+/// `resolveRegisteredWindow`, now reading this registry) plus the
+/// `recoverableMainWindowRoutes()` pass, exactly as before.
+///
+/// ## Ownership + teardown
+///
+/// The registry is the single strong owner of each ``WindowContext`` (exactly
+/// replacing the dictionaries' strong ownership), so a context's lifetime
+/// matches the old per-slice dictionary entries. It is a passive index: it does
+/// NOT subscribe to `windowCoordinator.windowClosed` (a single-consumer stream
+/// whose sole consumer is the window-teardown loop). Slice removal is driven by
+/// that loop's single `removeWindowModelSlices` funnel calling
+/// ``removeContext(for:)``.
+///
+/// ## Isolation
+///
+/// `@MainActor` because its mutators run on the main thread alongside window
+/// registration and AppKit teardown. Internally it reuses the package's
+/// ``WindowScopedStore`` (the canonical `WindowID`-keyed per-window store) as
+/// its backing dictionary.
+@MainActor
+final class WindowRegistry {
+    private let store = WindowScopedStore<WindowContext>()
+
+    /// The context registered for `id`, or `nil` if no window has one.
+    func context(for id: WindowID) -> WindowContext? {
+        store.model(for: id)
+    }
+
+    /// Registers `context` for `id`, replacing any prior context for that window.
+    func setContext(_ context: WindowContext, for id: WindowID) {
+        store.setModel(context, for: id)
+    }
+
+    /// Removes and returns the context registered for `id`, if any. Called by the
+    /// window-teardown funnel; idempotent if already gone.
+    @discardableResult
+    func removeContext(for id: WindowID) -> WindowContext? {
+        store.remove(id)
+    }
+
+    /// The ``WindowID`` of every window that currently has a context, in no
+    /// guaranteed order. Backs the coordinator's `registeredWindowIds`.
+    var ids: [WindowID] {
+        store.ids
+    }
+
+    /// Every registered context, in no guaranteed order. Mirrors the legacy
+    /// aggregate-wide sweeps (e.g. reloading every window's config store).
+    var contexts: [WindowContext] {
+        store.models
+    }
+}

--- a/Sources/WindowRegistry.swift
+++ b/Sources/WindowRegistry.swift
@@ -1,4 +1,56 @@
+import AppKit
+import Bonsplit
+import CmuxTerminalCore
+import CmuxTerminal
 import CmuxWindowing
+
+@MainActor
+final class RecoverableMainWindowRoute {
+    let windowId: UUID
+    weak var tabManager: TabManager?
+    weak var window: NSWindow?
+    let order: UInt64
+
+    init(windowId: UUID, tabManager: TabManager, window: NSWindow?, order: UInt64) {
+        self.windowId = windowId
+        self.tabManager = tabManager
+        self.window = window
+        self.order = order
+    }
+}
+
+@MainActor
+struct WindowRegistryHostSeams {
+    let registeredMainWindows: @MainActor () -> [AppDelegate.RegisteredMainWindow]
+    let registeredMainWindowForManager: @MainActor (TabManager) -> AppDelegate.RegisteredMainWindow?
+    let registeredMainWindowForWindowId: @MainActor (UUID) -> AppDelegate.RegisteredMainWindow?
+    let contextForMainTerminalWindow: @MainActor (NSWindow, Bool) -> AppDelegate.RegisteredMainWindow?
+    let mainWindowIdFromWindow: @MainActor (NSWindow) -> UUID?
+    let windowForMainWindowId: @MainActor (UUID) -> NSWindow?
+
+    init(
+        registeredMainWindows: @escaping @MainActor () -> [AppDelegate.RegisteredMainWindow] = { [] },
+        registeredMainWindowForManager: @escaping @MainActor (TabManager) -> AppDelegate.RegisteredMainWindow? = { _ in nil },
+        registeredMainWindowForWindowId: @escaping @MainActor (UUID) -> AppDelegate.RegisteredMainWindow? = { _ in nil },
+        contextForMainTerminalWindow: @escaping @MainActor (NSWindow, Bool) -> AppDelegate.RegisteredMainWindow? = { _, _ in nil },
+        mainWindowIdFromWindow: @escaping @MainActor (NSWindow) -> UUID? = { _ in nil },
+        windowForMainWindowId: @escaping @MainActor (UUID) -> NSWindow? = { _ in nil }
+    ) {
+        self.registeredMainWindows = registeredMainWindows
+        self.registeredMainWindowForManager = registeredMainWindowForManager
+        self.registeredMainWindowForWindowId = registeredMainWindowForWindowId
+        self.contextForMainTerminalWindow = contextForMainTerminalWindow
+        self.mainWindowIdFromWindow = mainWindowIdFromWindow
+        self.windowForMainWindowId = windowForMainWindowId
+    }
+}
+
+@MainActor
+private struct MainWindowRouteSnapshot {
+    let windowId: UUID
+    let tabManager: TabManager
+    let window: NSWindow?
+}
 
 /// Cross-window index of per-window ``WindowContext``s, keyed by ``WindowID``.
 ///
@@ -7,16 +59,17 @@ import CmuxWindowing
 /// `windowConfigStores`, `windowSidebarSelectionStates`, `windowSidebarStates`,
 /// `windowFileExplorerStates`). The per-window state now lives in one
 /// ``WindowContext`` per `NSWindow`; this registry is the single
-/// `WindowID`→context index the window-lifecycle seam
+/// `WindowID`→context index and recoverable-route owner the window-lifecycle seam
 /// (`resolveRegisteredWindow`, `seedNewMainWindowSlices`,
 /// `rebindRegisteredWindowSlices`, `removeWindowModelSlices`, …) and the
 /// per-window config/sidebar/file-explorer accessors resolve through.
 ///
 /// The cross-window resolver family (`tabManagerFor`, `locateSurface`,
-/// `workspaceContainingPanel`, `tabTitle`, `scriptableMainWindow`, …) is
-/// unchanged: it iterates `registeredMainWindows` (which funnels through
-/// `resolveRegisteredWindow`, now reading this registry) plus the
-/// `recoverableMainWindowRoutes()` pass, exactly as before.
+/// `scriptableMainWindow`, …) lives here and is reached through AppDelegate
+/// forwarders during the migration. Host lookups that still belong to
+/// AppDelegate/window lifecycle are injected through ``WindowRegistryHostSeams``;
+/// the resolver order remains live registered windows first, then the
+/// recoverable-route ledger.
 ///
 /// ## Ownership + teardown
 ///
@@ -37,6 +90,17 @@ import CmuxWindowing
 @MainActor
 final class WindowRegistry {
     private let store = WindowScopedStore<WindowContext>()
+    private var hostSeams = WindowRegistryHostSeams()
+
+    /// Ordered ledger of recoverable main-window routes remembered during window
+    /// teardown and replayed after live registered-window resolution.
+    let recoverableRouteLedger = RecoverableWindowRouteLedger<RecoverableMainWindowRoute>()
+
+    /// Wires AppDelegate/window-lifecycle lookups into the registry once at the
+    /// composition root, before main windows are created.
+    func configureHostSeams(_ seams: WindowRegistryHostSeams) {
+        hostSeams = seams
+    }
 
     /// The context registered for `id`, or `nil` if no window has one.
     func context(for id: WindowID) -> WindowContext? {
@@ -65,5 +129,380 @@ final class WindowRegistry {
     /// aggregate-wide sweeps (e.g. reloading every window's config store).
     var contexts: [WindowContext] {
         store.models
+    }
+
+    private var registeredMainWindows: [AppDelegate.RegisteredMainWindow] {
+        hostSeams.registeredMainWindows()
+    }
+
+    private func registeredMainWindow(forManager tabManager: TabManager) -> AppDelegate.RegisteredMainWindow? {
+        hostSeams.registeredMainWindowForManager(tabManager)
+    }
+
+    private func registeredMainWindow(forWindowId windowId: UUID) -> AppDelegate.RegisteredMainWindow? {
+        hostSeams.registeredMainWindowForWindowId(windowId)
+    }
+
+    private func contextForMainTerminalWindow(_ window: NSWindow, reindex: Bool = true) -> AppDelegate.RegisteredMainWindow? {
+        hostSeams.contextForMainTerminalWindow(window, reindex)
+    }
+
+    private func mainWindowId(from window: NSWindow) -> UUID? {
+        hostSeams.mainWindowIdFromWindow(window)
+    }
+
+    private func windowForMainWindowId(_ windowId: UUID) -> NSWindow? {
+        hostSeams.windowForMainWindowId(windowId)
+    }
+
+    private func tabManagerHasRegisteredTerminalSurface(_ manager: TabManager) -> Bool {
+        for workspace in manager.tabs {
+            for panel in workspace.panels.values {
+                guard let terminalPanel = panel as? TerminalPanel else { continue }
+                if GhosttyApp.terminalSurfaceRegistry.surface(id: terminalPanel.id) === terminalPanel.surface {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private func liveRecoverableMainWindow(windowId: UUID, cachedWindow: NSWindow?) -> NSWindow? {
+        cachedWindow ?? windowForMainWindowId(windowId)
+    }
+
+    private func sortedRecoverableMainWindowRoutes() -> [RecoverableMainWindowRoute] {
+        recoverableRouteLedger.sortedByMostRecentFirst()
+    }
+
+    private func recoverableMainWindowRouteSnapshot(windowId: UUID) -> MainWindowRouteSnapshot? {
+        guard let route = recoverableRouteLedger.route(for: WindowID(windowId)),
+              let manager = route.tabManager,
+              let window = liveRecoverableMainWindow(windowId: route.windowId, cachedWindow: route.window) else {
+            return nil
+        }
+        return MainWindowRouteSnapshot(windowId: route.windowId, tabManager: manager, window: window)
+    }
+
+    private func recoverableMainWindowRouteSnapshots() -> [MainWindowRouteSnapshot] {
+        sortedRecoverableMainWindowRoutes().compactMap { route in
+            guard let manager = route.tabManager,
+                  let window = liveRecoverableMainWindow(windowId: route.windowId, cachedWindow: route.window) else {
+                return nil
+            }
+            return MainWindowRouteSnapshot(windowId: route.windowId, tabManager: manager, window: window)
+        }
+    }
+
+    private func liveRegisteredMainWindowRouteSnapshots() -> [MainWindowRouteSnapshot] {
+        registeredMainWindows.compactMap { context in
+            guard let window = context.window ?? windowForMainWindowId(context.windowId) else { return nil }
+            return MainWindowRouteSnapshot(
+                windowId: context.windowId,
+                tabManager: context.tabManager,
+                window: window
+            )
+        }
+    }
+
+    func retireRecoverableMainWindowRoutesWithoutRegisteredTerminalSurfaces(reason: String) {
+        let before = recoverableRouteLedger.count
+        recoverableRouteLedger.retainRoutes { _, route in
+            guard let manager = route.tabManager else { return false }
+            guard let window = liveRecoverableMainWindow(windowId: route.windowId, cachedWindow: route.window) else { return false }
+            route.window = window
+            return tabManagerHasRegisteredTerminalSurface(manager)
+        }
+        let after = recoverableRouteLedger.count
+#if DEBUG
+        if after != before {
+            cmuxDebugLog("recoverableRoute.prune reason=\(reason) removed=\(before - after) remaining=\(after)")
+        }
+#endif
+    }
+
+    func forgetRecoverableMainWindowRoute(windowId: UUID) {
+        if recoverableRouteLedger.remove(WindowID(windowId)) != nil {
+#if DEBUG
+            cmuxDebugLog("recoverableRoute.forget windowId=\(String(windowId.uuidString.prefix(8)))")
+#endif
+        }
+    }
+
+    func rememberRecoverableMainWindowRoute(windowId: UUID, tabManager: TabManager, window: NSWindow?) {
+        guard let window = liveRecoverableMainWindow(windowId: windowId, cachedWindow: window) else { return }
+        guard tabManagerHasRegisteredTerminalSurface(tabManager) else { return }
+        let order = recoverableRouteLedger.issueOrder()
+        recoverableRouteLedger.setRoute(
+            RecoverableMainWindowRoute(
+                windowId: windowId,
+                tabManager: tabManager,
+                window: window,
+                order: order
+            ),
+            order: order,
+            for: WindowID(windowId)
+        )
+#if DEBUG
+        cmuxDebugLog("recoverableRoute.remember windowId=\(String(windowId.uuidString.prefix(8)))")
+#endif
+    }
+
+    func recoverableMainWindowRoute(windowId: UUID) -> RecoverableMainWindowRoute? {
+        guard recoverableMainWindowRouteSnapshot(windowId: windowId) != nil else { return nil }
+        return recoverableRouteLedger.route(for: WindowID(windowId))
+    }
+
+    func recoverableMainWindowRoutes() -> [RecoverableMainWindowRoute] {
+        let validWindowIds = Set(recoverableMainWindowRouteSnapshots().map(\.windowId))
+        return sortedRecoverableMainWindowRoutes().filter { validWindowIds.contains($0.windowId) }
+    }
+
+    private func mainWindowSummary(from snapshot: MainWindowRouteSnapshot) -> MainWindowSummary {
+        MainWindowSummary(
+            windowId: snapshot.windowId,
+            isKeyWindow: snapshot.window?.isKeyWindow ?? false,
+            isVisible: snapshot.window?.isVisible ?? false,
+            workspaceCount: snapshot.tabManager.tabs.count,
+            selectedWorkspaceId: snapshot.tabManager.selectedTabId
+        )
+    }
+
+    func listMainWindowSummaries() -> [MainWindowSummary] {
+        var seen: Set<WindowID> = []
+        var summaries: [MainWindowSummary] = []
+        for snapshot in liveRegisteredMainWindowRouteSnapshots() {
+            seen.insert(WindowID(snapshot.windowId))
+            summaries.append(mainWindowSummary(from: snapshot))
+        }
+        recoverableRouteLedger.appendingDeduplicatedProjections(into: &summaries, seen: &seen) { route in
+            guard let snapshot = recoverableMainWindowRouteSnapshot(windowId: route.windowId) else { return nil }
+            return (id: WindowID(snapshot.windowId), projection: mainWindowSummary(from: snapshot))
+        }
+        return summaries
+    }
+
+    func tabManagerFor(windowId: UUID) -> TabManager? {
+        if let snapshot = liveRegisteredMainWindowRouteSnapshots().first(where: { $0.windowId == windowId }) {
+            return snapshot.tabManager
+        }
+        return recoverableMainWindowRouteSnapshot(windowId: windowId)?.tabManager
+    }
+
+    func windowId(for tabManager: TabManager) -> UUID? {
+        if let windowId = registeredMainWindow(forManager: tabManager)?.windowId {
+            return windowId
+        }
+        return recoverableMainWindowRouteSnapshots().first(where: { $0.tabManager === tabManager })?.windowId
+    }
+
+    func mainWindow(for windowId: UUID) -> NSWindow? {
+        windowForMainWindowId(windowId)
+    }
+
+    func mainWindowContainingWorkspace(_ workspaceId: UUID) -> NSWindow? {
+        for context in registeredMainWindows where context.tabManager.tabs.contains(where: { $0.id == workspaceId }) {
+            if let window = context.window ?? windowForMainWindowId(context.windowId) {
+                return window
+            }
+        }
+        for snapshot in recoverableMainWindowRouteSnapshots() {
+            guard snapshot.tabManager.tabs.contains(where: { $0.id == workspaceId }) else {
+                continue
+            }
+            return snapshot.window
+        }
+        return nil
+    }
+
+    func locateSurface(surfaceId: UUID) -> (windowId: UUID, workspaceId: UUID, tabManager: TabManager)? {
+        for ctx in registeredMainWindows {
+            for ws in ctx.tabManager.tabs {
+                if ws.panels[surfaceId] != nil, ws.surfaceIdFromPanelId(surfaceId) != nil {
+                    return (ctx.windowId, ws.id, ctx.tabManager)
+                }
+            }
+        }
+        for route in recoverableMainWindowRoutes() {
+            guard let manager = route.tabManager else { continue }
+            for ws in manager.tabs {
+                if ws.panels[surfaceId] != nil, ws.surfaceIdFromPanelId(surfaceId) != nil {
+                    return (route.windowId, ws.id, manager)
+                }
+            }
+        }
+        return nil
+    }
+
+    func locateBonsplitSurface(tabId: UUID) -> (windowId: UUID, workspaceId: UUID, panelId: UUID, tabManager: TabManager)? {
+        let bonsplitTabId = TabID(uuid: tabId)
+        for context in registeredMainWindows {
+            for workspace in context.tabManager.tabs {
+                if let panelId = workspace.panelIdFromSurfaceId(bonsplitTabId) {
+                    return (context.windowId, workspace.id, panelId, context.tabManager)
+                }
+            }
+        }
+        for route in recoverableMainWindowRoutes() {
+            guard let manager = route.tabManager else { continue }
+            for workspace in manager.tabs {
+                if let panelId = workspace.panelIdFromSurfaceId(bonsplitTabId) {
+                    return (route.windowId, workspace.id, panelId, manager)
+                }
+            }
+        }
+        return nil
+    }
+
+    func workspaceFor(tabId: UUID) -> Workspace? {
+        tabManagerFor(tabId: tabId)?.tabs.first(where: { $0.id == tabId })
+    }
+
+    private func scriptableMainWindow(for window: NSWindow) -> AppDelegate.ScriptableMainWindowState? {
+        if let context = contextForMainTerminalWindow(window, reindex: false) {
+            return AppDelegate.ScriptableMainWindowState(
+                windowId: context.windowId,
+                tabManager: context.tabManager,
+                window: context.window ?? windowForMainWindowId(context.windowId)
+            )
+        }
+
+        if let windowId = mainWindowId(from: window),
+           let snapshot = recoverableMainWindowRouteSnapshot(windowId: windowId) {
+            return AppDelegate.ScriptableMainWindowState(
+                windowId: snapshot.windowId,
+                tabManager: snapshot.tabManager,
+                window: snapshot.window
+            )
+        }
+
+        let windowNumber = window.windowNumber
+        guard windowNumber >= 0 else { return nil }
+        for snapshot in recoverableMainWindowRouteSnapshots() {
+            guard let routeWindow = snapshot.window,
+                  routeWindow === window || routeWindow.windowNumber == windowNumber else {
+                continue
+            }
+            return AppDelegate.ScriptableMainWindowState(
+                windowId: snapshot.windowId,
+                tabManager: snapshot.tabManager,
+                window: routeWindow
+            )
+        }
+        return nil
+    }
+
+    private func makeOrderedMainWindowResolver() -> OrderedMainWindowResolver {
+        OrderedMainWindowResolver(
+            keyWindow: { NSApp.keyWindow },
+            mainWindow: { NSApp.mainWindow },
+            orderedWindows: { NSApp.orderedWindows }
+        )
+    }
+
+    func currentScriptableMainWindow() -> AppDelegate.ScriptableMainWindowState? {
+        makeOrderedMainWindowResolver().resolve(
+            project: { scriptableMainWindow(for: $0) },
+            fallback: { scriptableMainWindows().first }
+        )
+    }
+
+    func scriptableMainWindows() -> [AppDelegate.ScriptableMainWindowState] {
+        var results: [AppDelegate.ScriptableMainWindowState] = []
+        var seen: Set<WindowID> = []
+
+        for window in NSApp.orderedWindows {
+            guard let state = scriptableMainWindow(for: window) else { continue }
+            guard seen.insert(WindowID(state.windowId)).inserted else { continue }
+            results.append(state)
+        }
+
+        let remaining = liveRegisteredMainWindowRouteSnapshots()
+            .sorted { $0.windowId.uuidString < $1.windowId.uuidString }
+            .filter { seen.insert(WindowID($0.windowId)).inserted }
+
+        for snapshot in remaining {
+            results.append(
+                AppDelegate.ScriptableMainWindowState(
+                    windowId: snapshot.windowId,
+                    tabManager: snapshot.tabManager,
+                    window: snapshot.window
+                )
+            )
+        }
+
+        recoverableRouteLedger.appendingDeduplicatedProjections(into: &results, seen: &seen) { route in
+            guard let snapshot = recoverableMainWindowRouteSnapshot(windowId: route.windowId) else { return nil }
+            return (
+                id: WindowID(snapshot.windowId),
+                projection: AppDelegate.ScriptableMainWindowState(
+                    windowId: snapshot.windowId,
+                    tabManager: snapshot.tabManager,
+                    window: snapshot.window
+                )
+            )
+        }
+
+        return results
+    }
+
+    func scriptableMainWindow(windowId: UUID) -> AppDelegate.ScriptableMainWindowState? {
+        if let context = registeredMainWindow(forWindowId: windowId),
+           let window = context.window ?? windowForMainWindowId(context.windowId) {
+            return AppDelegate.ScriptableMainWindowState(
+                windowId: context.windowId,
+                tabManager: context.tabManager,
+                window: window
+            )
+        }
+        guard let snapshot = recoverableMainWindowRouteSnapshot(windowId: windowId) else { return nil }
+        return AppDelegate.ScriptableMainWindowState(
+            windowId: snapshot.windowId,
+            tabManager: snapshot.tabManager,
+            window: snapshot.window
+        )
+    }
+
+    func scriptableMainWindowForTab(_ tabId: UUID) -> AppDelegate.ScriptableMainWindowState? {
+        if let context = contextContainingTabId(tabId) {
+            guard let window = context.window ?? windowForMainWindowId(context.windowId) else { return nil }
+            return AppDelegate.ScriptableMainWindowState(
+                windowId: context.windowId,
+                tabManager: context.tabManager,
+                window: window
+            )
+        }
+        for snapshot in recoverableMainWindowRouteSnapshots() {
+            guard snapshot.tabManager.tabs.contains(where: { $0.id == tabId }) else {
+                continue
+            }
+            return AppDelegate.ScriptableMainWindowState(
+                windowId: snapshot.windowId,
+                tabManager: snapshot.tabManager,
+                window: snapshot.window
+            )
+        }
+        return nil
+    }
+
+    func contextContainingTabId(_ tabId: UUID) -> AppDelegate.RegisteredMainWindow? {
+        for context in registeredMainWindows {
+            if context.tabManager.tabs.contains(where: { $0.id == tabId }) {
+                return context
+            }
+        }
+        return nil
+    }
+
+    /// Returns the `TabManager` that owns `tabId`, if any.
+    func tabManagerFor(tabId: UUID) -> TabManager? {
+        if let manager = contextContainingTabId(tabId)?.tabManager {
+            return manager
+        }
+        return recoverableMainWindowRoutes()
+            .compactMap(\.tabManager)
+            .first { manager in
+                manager.tabs.contains(where: { $0.id == tabId })
+            }
     }
 }

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -370,7 +370,7 @@ extension Workspace {
             lastTerminalConfigInheritancePanelId = nil
         }
         if clearSurfaceNotifications {
-            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id, surfaceId: panelId)
+            hostEnvironment?.notificationStore?.clearNotifications(forTabId: id, surfaceId: panelId)
         }
 
         if requestTransferredRemoteCleanup, let transferredRemoteCleanupConfiguration {

--- a/Sources/Workspace+WorkspaceContextMenuHosting.swift
+++ b/Sources/Workspace+WorkspaceContextMenuHosting.swift
@@ -102,19 +102,19 @@ extension Workspace: WorkspaceContextMenuHosting {
     // MARK: Cross-workspace move (AppDelegate)
 
     func canMoveSurfaceToNewWorkspace(panelId: UUID) -> Bool {
-        AppDelegate.shared?.canMoveSurfaceToNewWorkspace(panelId: panelId) ?? false
+        hostEnvironment?.environment.mainWindowRouter.canMoveSurfaceToNewWorkspace(panelId: panelId) ?? false
     }
 
     func workspaceMoveTargets(forBonsplitTab tabId: TabID) -> [WorkspaceContextMoveTarget] {
-        guard let app = AppDelegate.shared else { return [] }
-        return app.workspaceMoveTargets(forBonsplitTab: tabId.uuid).map { target in
+        guard let mainWindowRouter = hostEnvironment?.environment.mainWindowRouter else { return [] }
+        return mainWindowRouter.workspaceMoveTargets(forBonsplitTab: tabId.uuid).map { target in
             WorkspaceContextMoveTarget(workspaceId: target.workspaceId, label: target.label)
         }
     }
 
     func moveSurfaceToNewWorkspace(panelId: UUID) -> Bool {
-        guard let app = AppDelegate.shared else { return false }
-        return app.moveSurfaceToNewWorkspace(
+        guard let mainWindowRouter = hostEnvironment?.environment.mainWindowRouter else { return false }
+        return mainWindowRouter.moveSurfaceToNewWorkspace(
             panelId: panelId,
             focus: true,
             focusWindow: false

--- a/Sources/WorkspaceCloseTabsBatching.swift
+++ b/Sources/WorkspaceCloseTabsBatching.swift
@@ -41,8 +41,8 @@ struct CloseOtherTabsConfirmationPrompt: Sendable {
 extension Workspace {
     func closeTabsFromContextMenu(_ tabIds: [TabID], skipPinned: Bool = true) {
         let confirmationManager = owningTabManager
-            ?? AppDelegate.shared?.tabManagerFor(tabId: id)
-            ?? AppDelegate.shared?.tabManager
+            ?? hostEnvironment?.windowRegistry.tabManagerFor(tabId: id)
+            ?? hostEnvironment?.environment.mainWindowRouter.activeTabManager
 
         guard confirmationManager?.workspaceClosing.isCloseConfirmationInFlight != true else { return }
 

--- a/Sources/WorkspaceHostEnvironment.swift
+++ b/Sources/WorkspaceHostEnvironment.swift
@@ -35,6 +35,10 @@ import Foundation
 /// `hostEnvironment` matching a nil `AppDelegate.shared`) is byte-identical.
 @MainActor
 protocol WorkspaceHostEnvironment: AnyObject {
+    /// The process-lifetime app environment, used when a `Workspace` needs to
+    /// reach router-owned active-window operations.
+    var environment: AppEnvironment { get }
+
     /// The app's terminal-notification store (legacy
     /// `AppDelegate.shared?.notificationStore`). Optional because the store is a
     /// `weak` reference on the delegate that is only bound while a notification
@@ -54,6 +58,9 @@ protocol WorkspaceHostEnvironment: AnyObject {
     /// The DEBUG focus log (legacy `AppDelegate.shared?.focusLog`). Non-optional
     /// on the delegate; the optionality lives on the host-environment reference.
     var focusLog: FocusLogStore { get }
+
+    /// The app's window registry, which owns cross-window resolver lookups.
+    var windowRegistry: WindowRegistry { get }
 
     /// Resolves the tab manager owning the given workspace/tab id (legacy
     /// `AppDelegate.shared?.tabManagerFor(tabId:)`).

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -297,7 +297,7 @@ struct cmuxApp: App {
                     )
 #if DEBUG
                     if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
-                        AppDelegate.shared?.updateLog.append("ui test: cmuxApp onAppear")
+                        appDelegate.environment.updateLog.append("ui test: cmuxApp onAppear")
                     }
 #endif
                     bootstrapMainWindowScene()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -240,7 +240,9 @@ struct cmuxApp: App {
         KeyboardShortcutSettings.settingsFileStore.applyDeferredManagedDefaultSideEffects()
         StartupBreadcrumbLog.append("app.init.keyboardShortcuts.sideEffectsApplied")
         StartupBreadcrumbLog.append("app.init.tabManager.begin")
-        _tabManager = State(wrappedValue: TabManager())
+        let initialTabManager = TabManager()
+        initialTabManager.attachAppEnvironment(appDelegate.environment)
+        _tabManager = State(wrappedValue: initialTabManager)
         StartupBreadcrumbLog.append("app.init.tabManager.complete")
         // Normalize the persisted socket mode and (for release builds) migrate the
         // legacy keychain password. Breadcrumb instrumentation stays app-side.
@@ -292,7 +294,7 @@ struct cmuxApp: App {
                             openWindow(id: SettingsWindowPresenter.windowID)
                         },
                         parentWindowProvider: {
-                            AppDelegate.shared?.preferredMainWindowForSettingsPresentation()
+                            appDelegate.environment.mainWindowRouter.preferredWindowForSettingsPresentation()
                         }
                     )
 #if DEBUG
@@ -579,28 +581,17 @@ struct cmuxApp: App {
                 }
 
                 splitCommandButton(title: String(localized: "menu.file.newWorkspace", defaultValue: "New Workspace"), shortcut: menuShortcut(for: .newTab)) {
-                    if let appDelegate = AppDelegate.shared {
-                        appDelegate.performNewWorkspaceAction(
-                            tabManager: activeTabManager,
-                            debugSource: "menu.newWorkspace"
-                        )
-                    } else {
-                        activeTabManager.addWorkspace()
-                    }
+                    appDelegate.environment.mainWindowRouter.performNewWorkspaceAction(
+                        tabManager: activeTabManager,
+                        debugSource: "menu.newWorkspace"
+                    )
                 }
 
                 splitCommandButton(title: String(localized: "menu.file.newBrowserWorkspace", defaultValue: "New Browser Workspace"), shortcut: menuShortcut(for: .newBrowserWorkspace)) {
-                    if let appDelegate = AppDelegate.shared {
-                        appDelegate.performNewBrowserWorkspaceAction(
-                            tabManager: activeTabManager,
-                            debugSource: "menu.newBrowserWorkspace"
-                        )
-                    } else if BrowserAvailabilitySettings.isEnabled() {
-                        // Last-resort fallback for a missing AppDelegate; keep
-                        // the browser-availability gate identical to the
-                        // shared action path.
-                        activeTabManager.addWorkspace(initialSurface: .browser)
-                    }
+                    appDelegate.environment.mainWindowRouter.performNewBrowserWorkspaceAction(
+                        tabManager: activeTabManager,
+                        debugSource: "menu.newBrowserWorkspace"
+                    )
                 }
 
                 splitCommandButton(title: String(localized: "menu.file.openFolder", defaultValue: "Open Folder…"), shortcut: menuShortcut(for: .openFolder)) {
@@ -613,7 +604,7 @@ struct cmuxApp: App {
                         defaultValue: "Open Folder in VS Code (Inline)…"
                     )
                 ) {
-                    AppDelegate.shared?.showOpenFolderInInlineVSCodePanel()
+                    appDelegate.environment.mainWindowRouter.showOpenFolderInInlineVSCodePanel()
                 }
                 .disabled(!TerminalDirectoryOpenTarget.vscodeInline.isAvailable())
             }
@@ -671,13 +662,13 @@ struct cmuxApp: App {
 #if DEBUG
                         cmuxDebugLog("find.menu Cmd+F fired")
 #endif
-                        _ = AppDelegate.shared?.performFindShortcutInActiveMainWindow(
+                        _ = appDelegate.environment.mainWindowRouter.performFindInActiveWindow(
                             preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
                         )
                     }
 
                     splitCommandButton(title: String(localized: "menu.find.findInDirectory", defaultValue: "Find in Directory…"), shortcut: menuShortcut(for: .findInDirectory)) {
-                        _ = AppDelegate.shared?.focusFileSearchInActiveMainWindow(
+                        _ = appDelegate.environment.mainWindowRouter.focusFileSearchInActiveWindow(
                             preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
                         )
                     }
@@ -757,13 +748,13 @@ struct cmuxApp: App {
         historyCommands
         CommandGroup(after: .toolbar) {
             splitCommandButton(title: String(localized: "menu.view.toggleLeftSidebar", defaultValue: "Toggle Left Sidebar"), shortcut: menuShortcut(for: .toggleSidebar)) {
-                if AppDelegate.shared?.toggleSidebarInActiveMainWindow() != true {
+                if appDelegate.environment.mainWindowRouter.toggleSidebarInActiveWindow() != true {
                     sidebarState.toggle()
                 }
             }
 
             splitCommandButton(title: String(localized: "menu.view.toggleRightSidebar", defaultValue: "Toggle Right Sidebar"), shortcut: menuShortcut(for: .toggleRightSidebar)) {
-                if AppDelegate.shared?.toggleRightSidebarInActiveMainWindow(
+                if appDelegate.environment.mainWindowRouter.toggleRightSidebarInActiveWindow(
                     preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
                 ) != true {
                     NSSound.beep()
@@ -771,8 +762,9 @@ struct cmuxApp: App {
             }
 
             splitCommandButton(title: String(localized: "menu.view.focusRightSidebar", defaultValue: "Toggle Right Sidebar Focus"), shortcut: menuShortcut(for: .focusRightSidebar)) {
-                if AppDelegate.shared?.toggleRightSidebarKeyboardFocusInActiveMainWindow() != true {
-                    if AppDelegate.shared?.focusRightSidebarInActiveMainWindow(
+                let mainWindowRouter = appDelegate.environment.mainWindowRouter
+                if mainWindowRouter.toggleRightSidebarKeyboardFocusInActiveWindow() != true {
+                    if mainWindowRouter.focusRightSidebarInActiveWindow(
                         preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
                     ) != true {
                         NSSound.beep()
@@ -999,7 +991,7 @@ struct cmuxApp: App {
     }
 
     var activeTabManager: TabManager {
-        AppDelegate.shared?.activeTabManagerForCommands(
+        appDelegate.environment.mainWindowRouter.activeTabManagerForCommands(
             preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
         ) ?? tabManager
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1055,11 +1055,13 @@
 		A5001900A1B2C3D4E5F60718 /* WindowBackgroundComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001901A1B2C3D4E5F60718 /* WindowBackgroundComposition.swift */; };
 		B7F9A602B7F9A602B7F9A602 /* WindowChromeMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F9A603B7F9A603B7F9A603 /* WindowChromeMetrics.swift */; };
 		A6D1F0200000000000000002 /* WindowCloseObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D1F0200000000000000001 /* WindowCloseObserver.swift */; };
+		2F0C05000000000000000012 /* WindowContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C05000000000000000011 /* WindowContext.swift */; };
 		A5001240 /* WindowDecorationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001241 /* WindowDecorationsController.swift */; };
 		B9000018A1B2C3D4E5F60719 /* WindowDragHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */; };
 		D0B10024A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10025A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift */; };
 		313585583035A1E685010A97 /* WindowKeyDownReplayGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B8CFAF8FCA4231C702D16A /* WindowKeyDownReplayGuard.swift */; };
 		8770D0F2D2BB45359D6BE5E3 /* WindowKeyDownReplayGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79482F1ECA54E98BE5C8953 /* WindowKeyDownReplayGuardTests.swift */; };
+		2F0C05000000000000000022 /* WindowRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C05000000000000000021 /* WindowRegistry.swift */; };
 		6042C0056042C0056042C005 /* WindowScopedShortcutHintModifierMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6042D0056042D0056042D005 /* WindowScopedShortcutHintModifierMonitor.swift */; };
 		606600020000000000000001 /* WindowTerminalHostViewHitTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606600020000000000000002 /* WindowTerminalHostViewHitTesting.swift */; };
 		606600010000000000000001 /* WindowTerminalHostViewTitlebarHitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606600010000000000000002 /* WindowTerminalHostViewTitlebarHitTests.swift */; };
@@ -2211,11 +2213,13 @@
 		A5001901A1B2C3D4E5F60718 /* WindowBackgroundComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowBackgroundComposition.swift; sourceTree = "<group>"; };
 		B7F9A603B7F9A603B7F9A603 /* WindowChromeMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeMetrics.swift; sourceTree = "<group>"; };
 		A6D1F0200000000000000001 /* WindowCloseObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WindowCloseObserver.swift; sourceTree = "<group>"; };
+		2F0C05000000000000000011 /* WindowContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContext.swift; sourceTree = "<group>"; };
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
 		B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandleView.swift; sourceTree = "<group>"; };
 		D0B10025A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowInputRoutingContext.swift; sourceTree = "<group>"; };
 		81B8CFAF8FCA4231C702D16A /* WindowKeyDownReplayGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WindowKeyDownReplayGuard.swift; sourceTree = "<group>"; };
 		B79482F1ECA54E98BE5C8953 /* WindowKeyDownReplayGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowKeyDownReplayGuardTests.swift; sourceTree = "<group>"; };
+		2F0C05000000000000000021 /* WindowRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowRegistry.swift; sourceTree = "<group>"; };
 		6042D0056042D0056042D005 /* WindowScopedShortcutHintModifierMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowScopedShortcutHintModifierMonitor.swift; sourceTree = "<group>"; };
 		606600020000000000000002 /* WindowTerminalHostViewHitTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowTerminalHostViewHitTesting.swift; sourceTree = "<group>"; };
 		606600010000000000000002 /* WindowTerminalHostViewTitlebarHitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowTerminalHostViewTitlebarHitTests.swift; sourceTree = "<group>"; };
@@ -3006,6 +3010,8 @@
 				C10D00020000000000000002 /* CloudVMActionLauncher.swift */,
 				B37A00000000000000000006 /* MainWindowFocusTypes.swift */,
 				2F0C05000000000000000001 /* MainWindowFocusController.swift */,
+				2F0C05000000000000000011 /* WindowContext.swift */,
+				2F0C05000000000000000021 /* WindowRegistry.swift */,
 				A5001091 /* NotificationsPage.swift */,
 				D1F0A00200000000000000B2 /* MacPresenceMonitor.swift */,
 				D1F0A00500000000000000E2 /* MacPresenceDecisionCache.swift */,
@@ -4718,10 +4724,12 @@
 				A5001900A1B2C3D4E5F60718 /* WindowBackgroundComposition.swift in Sources */,
 				B7F9A602B7F9A602B7F9A602 /* WindowChromeMetrics.swift in Sources */,
 				A6D1F0200000000000000002 /* WindowCloseObserver.swift in Sources */,
+				2F0C05000000000000000012 /* WindowContext.swift in Sources */,
 				A5001240 /* WindowDecorationsController.swift in Sources */,
 				B9000018A1B2C3D4E5F60719 /* WindowDragHandleView.swift in Sources */,
 				D0B10024A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift in Sources */,
 				313585583035A1E685010A97 /* WindowKeyDownReplayGuard.swift in Sources */,
+				2F0C05000000000000000022 /* WindowRegistry.swift in Sources */,
 				6042C0056042C0056042C005 /* WindowScopedShortcutHintModifierMonitor.swift in Sources */,
 				606600020000000000000001 /* WindowTerminalHostViewHitTesting.swift in Sources */,
 				604500100000000000000001 /* WindowTitleTemplate.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
 		A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAB000000000000000001 /* AppearanceSettings.swift */; };
 		A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAA000000000000000001 /* AppearanceSettingsTests.swift */; };
+		2F0C05000000000000000014 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C05000000000000000013 /* AppEnvironment.swift */; };
+		2F0C05000000000000000016 /* AppEnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C05000000000000000015 /* AppEnvironmentKey.swift */; };
 		AAFD0001000100010001000A /* AppFileDropTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFD0002000200020002000B /* AppFileDropTarget.swift */; };
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
 		A1C04E00A1C04E00A1C04E01 /* AppIconRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C04E00A1C04E00A1C04E04 /* AppIconRuntime.swift */; };
@@ -1320,6 +1322,8 @@
 		F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
 		A11EAB000000000000000001 /* AppearanceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettings.swift; sourceTree = "<group>"; };
 		A11EAA000000000000000001 /* AppearanceSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsTests.swift; sourceTree = "<group>"; };
+		2F0C05000000000000000013 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
+		2F0C05000000000000000015 /* AppEnvironmentKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironmentKey.swift; sourceTree = "<group>"; };
 		AAFD0002000200020002000B /* AppFileDropTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFileDropTarget.swift; sourceTree = "<group>"; };
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
 		D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockTilePlugin.swift; sourceTree = "<group>"; };
@@ -3012,6 +3016,8 @@
 				2F0C05000000000000000001 /* MainWindowFocusController.swift */,
 				2F0C05000000000000000011 /* WindowContext.swift */,
 				2F0C05000000000000000021 /* WindowRegistry.swift */,
+				2F0C05000000000000000013 /* AppEnvironment.swift */,
+				2F0C05000000000000000015 /* AppEnvironmentKey.swift */,
 				A5001091 /* NotificationsPage.swift */,
 				D1F0A00200000000000000B2 /* MacPresenceMonitor.swift */,
 				D1F0A00500000000000000E2 /* MacPresenceDecisionCache.swift */,
@@ -4127,6 +4133,8 @@
 				FE0DEB01 /* AppDelegateDebugTerminalActionsHosting.swift in Sources */,
 				D10014C2 /* AppDelegateMarkdownPanelSurfaceRouting.swift in Sources */,
 				A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */,
+				2F0C05000000000000000014 /* AppEnvironment.swift in Sources */,
+				2F0C05000000000000000016 /* AppEnvironmentKey.swift in Sources */,
 				AAFD0001000100010001000A /* AppFileDropTarget.swift in Sources */,
 				A1C04E00A1C04E00A1C04E01 /* AppIconRuntime.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -566,6 +566,7 @@
 		2F0C05000000000000000002 /* MainWindowFocusController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C05000000000000000001 /* MainWindowFocusController.swift */; };
 		B37A00000000000000000005 /* MainWindowFocusTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A00000000000000000006 /* MainWindowFocusTypes.swift */; };
 		A5C0FF01 /* MainWindowRegistrationSlices.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C0FF02 /* MainWindowRegistrationSlices.swift */; };
+		2F0C05000000000000000024 /* MainWindowRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C05000000000000000023 /* MainWindowRouter.swift */; };
 		A6D1F0300000000000000002 /* MainWindowVisibilityController+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D1F0300000000000000001 /* MainWindowVisibilityController+Lifecycle.swift */; };
 		2F0C06000000000000000002 /* MainWindowVisibilityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C06000000000000000001 /* MainWindowVisibilityController.swift */; };
 		17C9F5BA0DD14EDC8C3E5001 /* MainWindowVisibilityControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C9F5BA0DD14EDC8C3E5002 /* MainWindowVisibilityControllerTests.swift */; };
@@ -1736,6 +1737,7 @@
 		2F0C05000000000000000001 /* MainWindowFocusController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowFocusController.swift; sourceTree = "<group>"; };
 		B37A00000000000000000006 /* MainWindowFocusTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowFocusTypes.swift; sourceTree = "<group>"; };
 		A5C0FF02 /* MainWindowRegistrationSlices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowRegistrationSlices.swift; sourceTree = "<group>"; };
+		2F0C05000000000000000023 /* MainWindowRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowRouter.swift; sourceTree = "<group>"; };
 		A6D1F0300000000000000001 /* MainWindowVisibilityController+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/MainWindowVisibilityController+Lifecycle.swift"; sourceTree = "<group>"; };
 		2F0C06000000000000000001 /* MainWindowVisibilityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MainWindowVisibilityController.swift; sourceTree = "<group>"; };
 		17C9F5BA0DD14EDC8C3E5002 /* MainWindowVisibilityControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowVisibilityControllerTests.swift; sourceTree = "<group>"; };
@@ -3014,6 +3016,7 @@
 				C10D00020000000000000002 /* CloudVMActionLauncher.swift */,
 				B37A00000000000000000006 /* MainWindowFocusTypes.swift */,
 				2F0C05000000000000000001 /* MainWindowFocusController.swift */,
+				2F0C05000000000000000023 /* MainWindowRouter.swift */,
 				2F0C05000000000000000011 /* WindowContext.swift */,
 				2F0C05000000000000000021 /* WindowRegistry.swift */,
 				2F0C05000000000000000013 /* AppEnvironment.swift */,
@@ -4378,6 +4381,7 @@
 				2F0C05000000000000000002 /* MainWindowFocusController.swift in Sources */,
 				B37A00000000000000000005 /* MainWindowFocusTypes.swift in Sources */,
 				A5C0FF01 /* MainWindowRegistrationSlices.swift in Sources */,
+				2F0C05000000000000000024 /* MainWindowRouter.swift in Sources */,
 				A6D1F0300000000000000002 /* MainWindowVisibilityController+Lifecycle.swift in Sources */,
 				2F0C06000000000000000002 /* MainWindowVisibilityController.swift in Sources */,
 				D5E40A01D5E40A01D5E40A01 /* ManagedDefaultSideEffectApplier.swift in Sources */,


### PR DESCRIPTION
Wave 1-3 checkpoint of the AppDelegate dissolution per docs/refactor/god-dissolution-plan.md.

AppEnvironment now owns the 12 process services. The cross-window resolver family and the recoverable-route ledger moved onto WindowRegistry behind injected host seams. MainWindowRouter owns the four active-window mirrors plus the active-window routing and move families. TerminalController and TabManager gained injected environment reach paths. About 296 call sites migrated off AppDelegate.shared (675 -> 452 reference lines). The first forwarder-deletion sweep landed (6 forwarders removed, survivors verified zero).

Every unit was adversarially reviewed in-place (3 compile blockers caught and fixed pre-merge; swiftc -parse clean on restructured files), but the tree is BUILD-UNVERIFIED since 6cdadc1d29 by owner directive (Jarred in-place model, single reconcile build scheduled at program end) and typing hot paths are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785621963&installation_id=133855650&pr_number=7220&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7220&signature=9b37c92de2d2bfc3e4f9651762ec6ee9a62e980d953b563569f2ff09912edfc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
De-singletonized AppDelegate by introducing a process-wide AppEnvironment, a WindowRegistry for per-window state/lookup, and a MainWindowRouter for active-window routing and cross-window moves. Consolidates six per-window stores into WindowContext and migrates ~296 call sites without changing behavior.

- **Refactors**
  - Added AppEnvironment to own 12 process services (e.g., auth, settingsRuntime, notificationStore), injected into each window’s SwiftUI root.
  - Added WindowRegistry with WindowContext to centralize per-window state and cross-window resolvers (e.g., tabManagerFor, locateSurface, scriptable windows).
  - Added MainWindowRouter to handle active-window queries, focus, right-sidebar focus, and workspace/surface moves.
  - TabManager and TerminalController now accept `attachAppEnvironment`; views access services via `@Environment(\.appEnvironment)`.

- **Migration**
  - Replace `AppDelegate.shared` lookups with `appEnvironment?.windowRegistry` for window/workspace/pane discovery and summaries.
  - Use `appEnvironment?.mainWindowRouter` for focus and cross-window moves (e.g., moveWorkspaceToWindow, moveSurfaceToNewWorkspace, focusRightSidebarInActiveWindow).
  - When constructing controllers, call `attachAppEnvironment`; in SwiftUI, read `@Environment(\.appEnvironment)` instead of reaching the singleton.

<sup>Written for commit 9610068dd30a567fc2c748aef3e6dfcf41f31525. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

