### PR TITLE
Suppress codex's blocking startup update prompt on cmux-driven resumes

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20317,7 +20317,7 @@ struct CMUXCLI {
             "--remote",
             appServerURL,
             threadId
-        ]
+        ] + AgentResumeArgv.codexUpdateCheckSuppressionOverride
         return parts
             .map { codexTeamsShellQuote($0) }
             .joined(separator: " ")

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -78,6 +78,38 @@ public struct AgentResumeArgv: Sendable, Equatable {
     public static let codexWrapperShellExecutableToken =
         "\"$([ -x \"${CMUX_CODEX_WRAPPER_SHIM:-}\" ] && printf '%s' \"$CMUX_CODEX_WRAPPER_SHIM\" || printf codex)\""
 
+    /// Per-invocation config override appended to every cmux-generated codex resume argv.
+    ///
+    /// codex's TUI shows a blocking "Update available!" picker at startup whenever no
+    /// initial prompt is passed — exactly the shape of `codex resume <id>` — so a cmux
+    /// relaunch that auto-restores codex sessions lands every pane on the update prompt
+    /// instead of the restored conversation, and the session appears "not restarted".
+    /// `-c key=value` is codex's per-process config override (a clap-global flag, valid
+    /// after subcommands), so this suppresses the startup update check for the restored
+    /// process only; `~/.codex/config.toml` and the user's own manual codex launches are
+    /// untouched. Injection is skipped when the captured launch arguments already set
+    /// `check_for_update_on_startup` (see ``codexResumeConfigOverrides(preserved:)``):
+    /// that keeps an explicit user choice authoritative and keeps restore-of-a-restore
+    /// idempotent, since the codex sanitizer policy preserves `-c key=value` pairs.
+    public static let codexUpdateCheckSuppressionOverride = ["-c", "check_for_update_on_startup=false"]
+
+    /// The override tokens to inject between `resume <id>` and the preserved launch
+    /// arguments: ``codexUpdateCheckSuppressionOverride`` unless `preserved` already
+    /// sets `check_for_update_on_startup` (either value).
+    static func codexResumeConfigOverrides(preserved: [String]) -> [String] {
+        for (index, argument) in preserved.enumerated() {
+            if argument == "-c" || argument == "--config",
+               index + 1 < preserved.count,
+               preserved[index + 1].hasPrefix("check_for_update_on_startup=") {
+                return []
+            }
+            if argument.hasPrefix("--config=check_for_update_on_startup=") {
+                return []
+            }
+        }
+        return codexUpdateCheckSuppressionOverride
+    }
+
     /// Wraps a rendered claude resume/fork command so it parses in any login shell.
     ///
     /// ``claudeWrapperShellExecutableToken`` is POSIX-only syntax, but the rendered
@@ -236,7 +268,10 @@ public struct AgentResumeArgv: Sendable, Equatable {
             guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "codex-fork-restore", args: tail) else {
                 return .resolved(nil)
             }
-            return .resolved([parts.executable, "codex-teams", "resume", sessionId] + preserved)
+            return .resolved(
+                [parts.executable, "codex-teams", "resume", sessionId]
+                    + Self.codexResumeConfigOverrides(preserved: preserved) + preserved
+            )
         case "omo":
             let parts = commandParts(executablePath: executablePath, arguments: arguments, fallbackExecutable: "cmux")
             var tail = parts.tail
@@ -272,7 +307,8 @@ public struct AgentResumeArgv: Sendable, Equatable {
         case "codex":
             let parts = commandParts(executablePath: executablePath, arguments: arguments, fallbackExecutable: "codex")
             guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "codex-fork-restore", args: parts.tail) else { return nil }
-            return [parts.executable, "resume", sessionId] + preserved
+            return [parts.executable, "resume", sessionId]
+                + Self.codexResumeConfigOverrides(preserved: preserved) + preserved
         case "grok":
             return withOption("grok", executable: "grok", option: "-r", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
         case "pi":

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -96,12 +96,12 @@ public struct AgentResumeArgv: Sendable, Equatable {
     /// The override tokens to inject between `resume <id>` and the preserved launch
     /// arguments: ``codexUpdateCheckSuppressionOverride`` unless `preserved` already
     /// sets `check_for_update_on_startup` (either value).
-    static func codexResumeConfigOverrides(preserved: [String]) -> [String] {
+    func codexResumeConfigOverrides(preserved: [String]) -> [String] {
         hasExplicitCheckForUpdateOnStartupOverride(in: preserved) ? [] : codexUpdateCheckSuppressionOverride
     }
 
     /// Returns true when an argv already carries an explicit codex startup update-check setting.
-    public static func hasExplicitCheckForUpdateOnStartupOverride(in arguments: [String]) -> Bool {
+    public func hasExplicitCheckForUpdateOnStartupOverride(in arguments: [String]) -> Bool {
         for (index, argument) in arguments.enumerated() {
             if argument == "-c" || argument == "--config",
                index + 1 < arguments.count,
@@ -275,7 +275,7 @@ public struct AgentResumeArgv: Sendable, Equatable {
             }
             return .resolved(
                 [parts.executable, "codex-teams", "resume", sessionId]
-                    + Self.codexResumeConfigOverrides(preserved: preserved) + preserved
+                    + codexResumeConfigOverrides(preserved: preserved) + preserved
             )
         case "omo":
             let parts = commandParts(executablePath: executablePath, arguments: arguments, fallbackExecutable: "cmux")
@@ -313,7 +313,7 @@ public struct AgentResumeArgv: Sendable, Equatable {
             let parts = commandParts(executablePath: executablePath, arguments: arguments, fallbackExecutable: "codex")
             guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "codex-fork-restore", args: parts.tail) else { return nil }
             return [parts.executable, "resume", sessionId]
-                + Self.codexResumeConfigOverrides(preserved: preserved) + preserved
+                + codexResumeConfigOverrides(preserved: preserved) + preserved
         case "grok":
             return withOption("grok", executable: "grok", option: "-r", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
         case "pi":

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -97,7 +97,7 @@ public struct AgentResumeArgv: Sendable, Equatable {
     /// arguments: ``codexUpdateCheckSuppressionOverride`` unless `preserved` already
     /// sets `check_for_update_on_startup` (either value).
     func codexResumeConfigOverrides(preserved: [String]) -> [String] {
-        hasExplicitCheckForUpdateOnStartupOverride(in: preserved) ? [] : codexUpdateCheckSuppressionOverride
+        hasExplicitCheckForUpdateOnStartupOverride(in: preserved) ? [] : Self.codexUpdateCheckSuppressionOverride
     }
 
     /// Returns true when an argv already carries an explicit codex startup update-check setting.

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -97,17 +97,22 @@ public struct AgentResumeArgv: Sendable, Equatable {
     /// arguments: ``codexUpdateCheckSuppressionOverride`` unless `preserved` already
     /// sets `check_for_update_on_startup` (either value).
     static func codexResumeConfigOverrides(preserved: [String]) -> [String] {
-        for (index, argument) in preserved.enumerated() {
+        hasExplicitCheckForUpdateOnStartupOverride(in: preserved) ? [] : codexUpdateCheckSuppressionOverride
+    }
+
+    /// Returns true when an argv already carries an explicit codex startup update-check setting.
+    public static func hasExplicitCheckForUpdateOnStartupOverride(in arguments: [String]) -> Bool {
+        for (index, argument) in arguments.enumerated() {
             if argument == "-c" || argument == "--config",
-               index + 1 < preserved.count,
-               preserved[index + 1].hasPrefix("check_for_update_on_startup=") {
-                return []
+               index + 1 < arguments.count,
+               arguments[index + 1].hasPrefix("check_for_update_on_startup=") {
+                return true
             }
             if argument.hasPrefix("--config=check_for_update_on_startup=") {
-                return []
+                return true
             }
         }
-        return codexUpdateCheckSuppressionOverride
+        return false
     }
 
     /// Wraps a rendered claude resume/fork command so it parses in any login shell.

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -108,6 +108,9 @@ public struct AgentResumeArgv: Sendable, Equatable {
                arguments[index + 1].hasPrefix("check_for_update_on_startup=") {
                 return true
             }
+            if argument.hasPrefix("-c=check_for_update_on_startup=") {
+                return true
+            }
             if argument.hasPrefix("--config=check_for_update_on_startup=") {
                 return true
             }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -148,6 +148,37 @@ struct AgentResumeArgvTests {
         )
     }
 
+    @Test("Codex resume respects an explicit captured check_for_update_on_startup setting")
+    func codexResumeRespectsExplicitUpdateCheckSetting() {
+        // The codex sanitizer policy preserves `-c key=value` pairs, so a captured
+        // explicit setting must stay authoritative (no injected override) and a
+        // restore-of-a-restore must not stack duplicate overrides.
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "codex",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["codex", "-c", "check_for_update_on_startup=true"]
+            ) == ["codex", "resume", "SID", "-c", "check_for_update_on_startup=true"]
+        )
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "codex",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["codex", "-c", "check_for_update_on_startup=false"]
+            ) == ["codex", "resume", "SID", "-c", "check_for_update_on_startup=false"]
+        )
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codexTeams",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["cmux", "codex-teams", "-c", "check_for_update_on_startup=true"]
+            ) == .resolved(["cmux", "codex-teams", "resume", "SID", "-c", "check_for_update_on_startup=true"])
+        )
+    }
+
     @Test("cmux wrapper launchers resolve before per-kind verbs")
     func launcherWrappers() {
         #expect(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -28,7 +28,7 @@ struct AgentResumeArgvTests {
     func builtInSpecialShapes() {
         #expect(
             AgentResumeArgv().builtInKind(kind: "codex", sessionId: "SID", executablePath: nil, arguments: ["codex"])
-                == ["codex", "resume", "SID"]
+                == ["codex", "resume", "SID", "-c", "check_for_update_on_startup=false"]
         )
         #expect(
             AgentResumeArgv().builtInKind(kind: "amp", sessionId: "SID", executablePath: nil, arguments: ["amp"])
@@ -117,7 +117,34 @@ struct AgentResumeArgvTests {
                 sessionId: "SID",
                 executablePath: "/opt/bin/codex",
                 arguments: ["/opt/bin/codex"]
-            ) == ["/opt/bin/codex", "resume", "SID"]
+            ) == ["/opt/bin/codex", "resume", "SID", "-c", "check_for_update_on_startup=false"]
+        )
+    }
+
+    @Test("Codex resume suppresses codex's blocking startup update prompt per-invocation")
+    func codexResumeSuppressesStartupUpdatePrompt() {
+        // `codex resume <id>` passes no initial prompt, so codex's TUI shows a blocking
+        // "Update available!" picker before restoring the session — a cmux relaunch that
+        // auto-restores codex panes lands them on that prompt instead of the conversation.
+        // The per-invocation `-c` override keeps cmux-driven restores non-interactive
+        // without mutating the user's ~/.codex/config.toml, and it precedes the preserved
+        // launch arguments so a user-captured explicit override still wins.
+        let overrides = ["-c", "check_for_update_on_startup=false"]
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "codex",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["codex", "--model", "gpt-5.4"]
+            ) == ["codex", "resume", "SID"] + overrides + ["--model", "gpt-5.4"]
+        )
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "codexTeams",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["cmux", "codex-teams", "--model", "gpt-5.4"]
+            ) == .resolved(["cmux", "codex-teams", "resume", "SID"] + overrides + ["--model", "gpt-5.4"])
         )
     }
 
@@ -155,7 +182,7 @@ struct AgentResumeArgvTests {
         #expect(
             AgentResumeArgv().launcherResolution(
                 launcher: "codexTeams", sessionId: "SID", executablePath: nil, arguments: ["cmux", "codex-teams"]
-            ) == .resolved(["cmux", "codex-teams", "resume", "SID"])
+            ) == .resolved(["cmux", "codex-teams", "resume", "SID", "-c", "check_for_update_on_startup=false"])
         )
         #expect(
             AgentResumeArgv().launcherResolution(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -170,6 +170,14 @@ struct AgentResumeArgvTests {
             ) == ["codex", "resume", "SID", "-c", "check_for_update_on_startup=false"]
         )
         #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "codex",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["codex", "-c=check_for_update_on_startup=true"]
+            ) == ["codex", "resume", "SID", "-c=check_for_update_on_startup=true"]
+        )
+        #expect(
             AgentResumeArgv().launcherResolution(
                 launcher: "codexTeams",
                 sessionId: "SID",

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexForkSanitizerTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CodexForkSanitizerTests.swift
@@ -164,7 +164,7 @@ struct CodexForkSanitizerTests {
                 sessionId: "CHILD",
                 executablePath: "/opt/bin/codex",
                 arguments: capturedArguments
-            ) == ["/opt/bin/codex", "resume", "CHILD", "--sandbox", "danger-full-access"]
+            ) == ["/opt/bin/codex", "resume", "CHILD", "-c", "check_for_update_on_startup=false", "--sandbox", "danger-full-access"]
         )
     }
 

--- a/Sources/SessionIndexModels.swift
+++ b/Sources/SessionIndexModels.swift
@@ -349,6 +349,7 @@ struct SessionEntry: Identifiable, Hashable {
             // wrapped in `/bin/sh -c '…'`; the `cd` guard stays outside in
             // `resumeCommandWithCwd`. https://github.com/manaflow-ai/cmux/issues/5639
             var parts = ["\(AgentResumeArgv.codexWrapperShellExecutableToken) resume \(sessionId)"]
+            parts.append(AgentResumeArgv.codexUpdateCheckSuppressionOverride.joined(separator: " "))
             if let model, !model.isEmpty {
                 parts.append("-m \(Self.shellQuote(model))")
             }

--- a/Sources/SessionIndexModels.swift
+++ b/Sources/SessionIndexModels.swift
@@ -348,8 +348,7 @@ struct SessionEntry: Identifiable, Hashable {
             // user's own shell (fish/csh included), so the rendered command is
             // wrapped in `/bin/sh -c '…'`; the `cd` guard stays outside in
             // `resumeCommandWithCwd`. https://github.com/manaflow-ai/cmux/issues/5639
-            var parts = ["\(AgentResumeArgv.codexWrapperShellExecutableToken) resume \(sessionId)"]
-            parts.append(AgentResumeArgv.codexUpdateCheckSuppressionOverride.joined(separator: " "))
+            var parts = ["\(AgentResumeArgv.codexWrapperShellExecutableToken) resume \(sessionId)", AgentResumeArgv.codexUpdateCheckSuppressionOverride.joined(separator: " ")]
             if let model, !model.isEmpty {
                 parts.append("-m \(Self.shellQuote(model))")
             }

--- a/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
@@ -11,31 +11,66 @@ extension SurfaceResumeCommandCanonicalizer {
     /// codex's blocking "Update available!" startup picker used to swallow the
     /// restored session. Normalizing at replay time (not persistence) upgrades
     /// stale bindings without a migration. The override is inserted directly
-    /// after the parsed `resume <session-id>` words; commands that already
-    /// mention `check_for_update_on_startup` (either value) and shapes that
-    /// don't parse to a codex resume argv (e.g. `/bin/sh -c '…'` wrapper forms)
-    /// are returned unchanged — those self-heal on the next agent-hook persist.
+    /// after the parsed `resume <session-id>` words; commands that already set
+    /// `check_for_update_on_startup` through a parsed codex config flag (either
+    /// value) and shapes that don't parse to a codex resume argv are returned
+    /// unchanged.
     static func insertingCodexUpdateCheckSuppression(
         in command: String,
         kind: String?
     ) -> String {
-        guard kind?.trimmingCharacters(in: .whitespacesAndNewlines) == "codex",
-              !command.contains("check_for_update_on_startup") else {
+        let normalizedKind = kind?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedKind == nil || normalizedKind == "codex" else {
             return command
         }
         let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
         guard let executableIndex = commandExecutableWordIndex(in: words, command: command) else {
             return command
         }
-        var resumeIndex = executableIndex + 1
-        if resumeIndex < words.count, words[resumeIndex].value == "codex-teams" {
-            resumeIndex += 1
+        if let updated = insertingCodexUpdateCheckSuppression(
+            in: command,
+            words: words,
+            executableIndex: executableIndex,
+            normalizedKind: normalizedKind
+        ) {
+            return updated
         }
+        if let updated = insertingCodexUpdateCheckSuppressionIntoShellWrapper(
+            in: command,
+            words: words,
+            executableIndex: executableIndex,
+            normalizedKind: normalizedKind
+        ) {
+            return updated
+        }
+        return command
+    }
+
+    private static func insertingCodexUpdateCheckSuppression(
+        in command: String,
+        words: [TerminalStartupWorkingDirectoryPrefix.ShellWordRange],
+        executableIndex: Int,
+        normalizedKind: String?
+    ) -> String? {
+        let executable = words[executableIndex].value
+        let executableBasename = (executable as NSString).lastPathComponent
+        let commandWordIndex = executableIndex + 1
+        let isCodexExecutable = executableBasename == "codex"
+        let isCodexTeamsCommand = commandWordIndex < words.count && words[commandWordIndex].value == "codex-teams"
+        guard normalizedKind == "codex" || isCodexExecutable || isCodexTeamsCommand else {
+            return nil
+        }
+
+        let resumeIndex = isCodexTeamsCommand ? commandWordIndex + 1 : commandWordIndex
         let sessionIndex = resumeIndex + 1
         guard sessionIndex < words.count,
               words[resumeIndex].value == "resume",
               !words[sessionIndex].value.hasPrefix("-") else {
-            return command
+            return nil
+        }
+        let parsedArguments = words[(executableIndex + 1)...].map(\.value)
+        guard !codexResumeConfigOverrideAlreadyPresent(in: parsedArguments) else {
+            return nil
         }
         let overrideText = AgentResumeArgv.codexUpdateCheckSuppressionOverride
             .map(shellQuoted)
@@ -43,5 +78,91 @@ extension SurfaceResumeCommandCanonicalizer {
         var updated = command
         updated.insert(contentsOf: " " + overrideText, at: words[sessionIndex].range.upperBound)
         return updated
+    }
+
+    private static func insertingCodexUpdateCheckSuppressionIntoShellWrapper(
+        in command: String,
+        words: [TerminalStartupWorkingDirectoryPrefix.ShellWordRange],
+        executableIndex: Int,
+        normalizedKind: String?
+    ) -> String? {
+        let executableBasename = (words[executableIndex].value as NSString).lastPathComponent
+        guard executableBasename == "sh" || executableBasename == "zsh" || executableBasename == "bash" else {
+            return nil
+        }
+        let optionIndex = executableIndex + 1
+        let commandIndex = executableIndex + 2
+        guard commandIndex < words.count,
+              words[optionIndex].value == "-c" || words[optionIndex].value == "-lc" else {
+            return nil
+        }
+        let innerCommand = words[commandIndex].value
+        guard let updatedInner = insertingCodexUpdateCheckSuppressionInShellWrapperBody(
+            innerCommand,
+            normalizedKind: normalizedKind
+        ), updatedInner != innerCommand else {
+            return nil
+        }
+        var updated = command
+        updated.replaceSubrange(words[commandIndex].range, with: shellQuoted(updatedInner))
+        return updated
+    }
+
+    private static func insertingCodexUpdateCheckSuppressionInShellWrapperBody(
+        _ command: String,
+        normalizedKind: String?
+    ) -> String? {
+        let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
+        if let executableIndex = commandExecutableWordIndex(in: words, command: command),
+           let updated = insertingCodexUpdateCheckSuppression(
+            in: command,
+            words: words,
+            executableIndex: executableIndex,
+            normalizedKind: normalizedKind
+           ) {
+            return updated
+        }
+        let wrapperToken = AgentResumeArgv.codexWrapperShellExecutableToken
+        guard command.hasPrefix(wrapperToken) else {
+            return nil
+        }
+        let tailStart = command.index(command.startIndex, offsetBy: wrapperToken.count)
+        let tail = String(command[tailStart...])
+        let tailWords = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(tail)
+        let resumeIndex = 0
+        let sessionIndex = 1
+        guard sessionIndex < tailWords.count,
+              tailWords[resumeIndex].value == "resume",
+              !tailWords[sessionIndex].value.hasPrefix("-") else {
+            return nil
+        }
+        guard !codexResumeConfigOverrideAlreadyPresent(in: tailWords.map(\.value)) else {
+            return nil
+        }
+        let overrideText = AgentResumeArgv.codexUpdateCheckSuppressionOverride
+            .map(shellQuoted)
+            .joined(separator: " ")
+        let insertionOffset = tail.distance(
+            from: tail.startIndex,
+            to: tailWords[sessionIndex].range.upperBound
+        )
+        let insertionIndex = command.index(tailStart, offsetBy: insertionOffset)
+        var updated = command
+        updated.insert(contentsOf: " " + overrideText, at: insertionIndex)
+        return updated
+    }
+
+    private static func codexResumeConfigOverrideAlreadyPresent(in arguments: [String]) -> Bool {
+        for (index, argument) in arguments.enumerated() {
+            if argument == "-c" || argument == "--config",
+               index + 1 < arguments.count,
+               arguments[index + 1].hasPrefix("check_for_update_on_startup=") {
+                return true
+            }
+            if argument.hasPrefix("--config=check_for_update_on_startup=") {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
@@ -183,16 +183,6 @@ extension SurfaceResumeCommandCanonicalizer {
     }
 
     private static func codexResumeConfigOverrideAlreadyPresent(in arguments: [String]) -> Bool {
-        for (index, argument) in arguments.enumerated() {
-            if argument == "-c" || argument == "--config",
-               index + 1 < arguments.count,
-               arguments[index + 1].hasPrefix("check_for_update_on_startup=") {
-                return true
-            }
-            if argument.hasPrefix("--config=check_for_update_on_startup=") {
-                return true
-            }
-        }
-        return false
+        AgentResumeArgv.hasExplicitCheckForUpdateOnStartupOverride(in: arguments)
     }
 }

--- a/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
@@ -183,6 +183,6 @@ extension SurfaceResumeCommandCanonicalizer {
     }
 
     private static func codexResumeConfigOverrideAlreadyPresent(in arguments: [String]) -> Bool {
-        AgentResumeArgv.hasExplicitCheckForUpdateOnStartupOverride(in: arguments)
+        AgentResumeArgv().hasExplicitCheckForUpdateOnStartupOverride(in: arguments)
     }
 }

--- a/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
@@ -64,19 +64,36 @@ extension SurfaceResumeCommandCanonicalizer {
         let resumeIndex = isCodexTeamsCommand ? commandWordIndex + 1 : commandWordIndex
         let sessionIndex = resumeIndex + 1
         guard sessionIndex < words.count,
-              words[resumeIndex].value == "resume",
-              !words[sessionIndex].value.hasPrefix("-") else {
+              words[resumeIndex].value == "resume" else {
             return nil
         }
         let parsedArguments = words[(executableIndex + 1)...].map(\.value)
         guard !codexResumeConfigOverrideAlreadyPresent(in: parsedArguments) else {
             return nil
         }
+        if words[sessionIndex].value == "--remote" {
+            let threadIndex = resumeIndex + 3
+            guard threadIndex < words.count,
+                  !words[threadIndex].value.hasPrefix("-") else {
+                return nil
+            }
+            return insertingOverride(in: command, after: words[threadIndex])
+        }
+        guard !words[sessionIndex].value.hasPrefix("-") else {
+            return nil
+        }
+        return insertingOverride(in: command, after: words[sessionIndex])
+    }
+
+    private static func insertingOverride(
+        in command: String,
+        after word: TerminalStartupWorkingDirectoryPrefix.ShellWordRange
+    ) -> String {
         let overrideText = AgentResumeArgv.codexUpdateCheckSuppressionOverride
             .map(shellQuoted)
             .joined(separator: " ")
         var updated = command
-        updated.insert(contentsOf: " " + overrideText, at: words[sessionIndex].range.upperBound)
+        updated.insert(contentsOf: " " + overrideText, at: word.range.upperBound)
         return updated
     }
 
@@ -132,19 +149,32 @@ extension SurfaceResumeCommandCanonicalizer {
         let resumeIndex = 0
         let sessionIndex = 1
         guard sessionIndex < tailWords.count,
-              tailWords[resumeIndex].value == "resume",
-              !tailWords[sessionIndex].value.hasPrefix("-") else {
+              tailWords[resumeIndex].value == "resume" else {
             return nil
         }
         guard !codexResumeConfigOverrideAlreadyPresent(in: tailWords.map(\.value)) else {
             return nil
+        }
+        let insertionWord: TerminalStartupWorkingDirectoryPrefix.ShellWordRange
+        if tailWords[sessionIndex].value == "--remote" {
+            let threadIndex = resumeIndex + 3
+            guard threadIndex < tailWords.count,
+                  !tailWords[threadIndex].value.hasPrefix("-") else {
+                return nil
+            }
+            insertionWord = tailWords[threadIndex]
+        } else {
+            guard !tailWords[sessionIndex].value.hasPrefix("-") else {
+                return nil
+            }
+            insertionWord = tailWords[sessionIndex]
         }
         let overrideText = AgentResumeArgv.codexUpdateCheckSuppressionOverride
             .map(shellQuoted)
             .joined(separator: " ")
         let insertionOffset = tail.distance(
             from: tail.startIndex,
-            to: tailWords[sessionIndex].range.upperBound
+            to: insertionWord.range.upperBound
         )
         let insertionIndex = command.index(tailStart, offsetBy: insertionOffset)
         var updated = command

--- a/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
@@ -1,0 +1,47 @@
+import CMUXAgentLaunch
+import Foundation
+
+extension SurfaceResumeCommandCanonicalizer {
+    /// Inserts codex's per-invocation update-check suppression override into a
+    /// persisted codex resume binding command that predates the override.
+    ///
+    /// Agent-hook resume bindings are persisted as rendered shell strings, so a
+    /// binding saved by a cmux build without the override replays verbatim on
+    /// the first relaunch after updating cmux — exactly the restart where
+    /// codex's blocking "Update available!" startup picker used to swallow the
+    /// restored session. Normalizing at replay time (not persistence) upgrades
+    /// stale bindings without a migration. The override is inserted directly
+    /// after the parsed `resume <session-id>` words; commands that already
+    /// mention `check_for_update_on_startup` (either value) and shapes that
+    /// don't parse to a codex resume argv (e.g. `/bin/sh -c '…'` wrapper forms)
+    /// are returned unchanged — those self-heal on the next agent-hook persist.
+    static func insertingCodexUpdateCheckSuppression(
+        in command: String,
+        kind: String?
+    ) -> String {
+        guard kind?.trimmingCharacters(in: .whitespacesAndNewlines) == "codex",
+              !command.contains("check_for_update_on_startup") else {
+            return command
+        }
+        let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
+        guard let executableIndex = commandExecutableWordIndex(in: words, command: command) else {
+            return command
+        }
+        var resumeIndex = executableIndex + 1
+        if resumeIndex < words.count, words[resumeIndex].value == "codex-teams" {
+            resumeIndex += 1
+        }
+        let sessionIndex = resumeIndex + 1
+        guard sessionIndex < words.count,
+              words[resumeIndex].value == "resume",
+              !words[sessionIndex].value.hasPrefix("-") else {
+            return command
+        }
+        let overrideText = AgentResumeArgv.codexUpdateCheckSuppressionOverride
+            .map(shellQuoted)
+            .joined(separator: " ")
+        var updated = command
+        updated.insert(contentsOf: " " + overrideText, at: words[sessionIndex].range.upperBound)
+        return updated
+    }
+}

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -88,16 +88,19 @@ extension SurfaceResumeBindingSnapshot {
     }
 
     private func resolvedStartupCommand(repairPortableAgentExecutable: Bool) -> String {
-        guard repairPortableAgentExecutable, isAgentHookBinding else {
+        guard isAgentHookBinding else {
             return startupCommand
         }
-        // Suppression insertion runs before executable repair: repair can wrap a
-        // stale-executable command in `/bin/sh -c '…'`, whose single-word body no
-        // longer parses as a codex resume argv.
         let suppressed = SurfaceResumeCommandCanonicalizer.insertingCodexUpdateCheckSuppression(
             in: startupCommand,
             kind: kind
         )
+        guard repairPortableAgentExecutable else {
+            return suppressed
+        }
+        // Suppression insertion runs before executable repair: repair can wrap a
+        // stale-executable command in `/bin/sh -c '…'`, whose single-word body no
+        // longer parses as a codex resume argv.
         return SurfaceResumeCommandCanonicalizer.replacingPortableAgentExecutable(
             in: suppressed,
             kind: kind

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -91,8 +91,15 @@ extension SurfaceResumeBindingSnapshot {
         guard repairPortableAgentExecutable, isAgentHookBinding else {
             return startupCommand
         }
-        return SurfaceResumeCommandCanonicalizer.replacingPortableAgentExecutable(
+        // Suppression insertion runs before executable repair: repair can wrap a
+        // stale-executable command in `/bin/sh -c '…'`, whose single-word body no
+        // longer parses as a codex resume argv.
+        let suppressed = SurfaceResumeCommandCanonicalizer.insertingCodexUpdateCheckSuppression(
             in: startupCommand,
+            kind: kind
+        )
+        return SurfaceResumeCommandCanonicalizer.replacingPortableAgentExecutable(
+            in: suppressed,
             kind: kind
         )
     }
@@ -402,7 +409,7 @@ extension SurfaceResumeCommandCanonicalizer {
         return false
     }
 
-    private static func commandExecutableWordIndex(
+    static func commandExecutableWordIndex(
         in words: [TerminalStartupWorkingDirectoryPrefix.ShellWordRange],
         command: String
     ) -> Int? {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1025,6 +1025,8 @@
 		D35B71010000000000000001 /* StartupBreadcrumbLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B71010000000000000002 /* StartupBreadcrumbLog.swift */; };
 		C0DE70530000000000000002 /* submit-cmux-profile in Copy CLI */ = {isa = PBXBuildFile; fileRef = C0DE70530000000000000001 /* submit-cmux-profile */; };
 		D7AB00000000000000B041 /* SupersededPhoneDismissBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000B040 /* SupersededPhoneDismissBuffer.swift */; };
+		F6572012A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6572013A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift */; };
+		F6572010A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6572011A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift */; };
 		F6572000A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6572001A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift */; };
 		A5001303 /* SurfaceSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001301 /* SurfaceSearchOverlay.swift */; };
 		C7B0FACE000000000000000C /* SystemCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0FACE000000000000000D /* SystemCommandRunner.swift */; };
@@ -2293,6 +2295,8 @@
 		D35B71010000000000000002 /* StartupBreadcrumbLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/StartupBreadcrumbLog.swift; sourceTree = "<group>"; };
 		C0DE70530000000000000001 /* submit-cmux-profile */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/submit-cmux-profile"; sourceTree = SOURCE_ROOT; };
 		D7AB00000000000000B040 /* SupersededPhoneDismissBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupersededPhoneDismissBuffer.swift; sourceTree = "<group>"; };
+		F6572013A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeBindingCodexUpdateCheckTests.swift; sourceTree = "<group>"; };
+		F6572011A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift"; sourceTree = "<group>"; };
 		F6572001A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift"; sourceTree = "<group>"; };
 		A5001301 /* SurfaceSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/SurfaceSearchOverlay.swift; sourceTree = "<group>"; };
 		C7B0FACE000000000000000D /* SystemCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemCommandRunner.swift; sourceTree = "<group>"; };
@@ -3391,6 +3395,7 @@
 				A5001222 /* WindowAccessor.swift */,
 				CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */,
 				F6572001A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift */,
+				F6572011A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift */,
 				A5001611 /* SessionPersistence.swift */,
 				C65930020000000000000001 /* SessionPersistencePolicy+CrashStorage.swift */,
 				E292DDF62C863C3553F4C9E7 /* RemoteTmuxWindowMirrorView.swift */,
@@ -3636,6 +3641,7 @@
 				F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */,
 					F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */,
 					F6572003A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift */,
+					F6572013A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift */,
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
 				B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
 				CDFE000000000000000000C2 /* AgentChatProseStreamerTests.swift */,
@@ -4944,6 +4950,7 @@
 				E30780000000000000000012 /* SSHPTYAttachStartupCommandBuilder.swift in Sources */,
 				D35B71010000000000000001 /* StartupBreadcrumbLog.swift in Sources */,
 				D7AB00000000000000B041 /* SupersededPhoneDismissBuffer.swift in Sources */,
+				F6572010A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift in Sources */,
 				F6572000A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift in Sources */,
 				A5001303 /* SurfaceSearchOverlay.swift in Sources */,
 				C7B0FACE000000000000000C /* SystemCommandRunner.swift in Sources */,
@@ -5507,6 +5514,7 @@
 						E60610300000000000000003 /* SSHPTYAttachReconnectInputFilterState.swift in Sources */,
 						B6285B71BA6F82AF8F945E00 /* SSHPTYAttachReconnectInputFilterTests.swift in Sources */,
 				F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */,
+				F6572012A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift in Sources */,
 				FBE660ABA1854983B84368C6 /* SystemWideHotkeyShortcutPolicyTests.swift in Sources */,
 				C0DE64160000000000000001 /* TabManagerNotificationFocusRegressionTests.swift in Sources */,
 				2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -7899,7 +7899,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(request["auto_resume"] as? Bool, true)
         XCTAssertEqual(
             request["command"] as? String,
-            "cd -- '\(root.path)' 2>/dev/null || [ ! -d '\(root.path)' ] && '/usr/local/bin/cmux' 'codex-teams' 'resume' '\(sessionId)' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access'"
+            "cd -- '\(root.path)' 2>/dev/null || [ ! -d '\(root.path)' ] && '/usr/local/bin/cmux' 'codex-teams' 'resume' '\(sessionId)' '-c' 'check_for_update_on_startup=false' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access'"
         )
     }
 

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -168,7 +168,7 @@ final class SessionIndexViewTests: XCTestCase {
         XCTAssertTrue(inner.hasPrefix(AgentResumeArgv.codexWrapperShellExecutableToken), inner)
         XCTAssertEqual(
             inner,
-            "\(AgentResumeArgv.codexWrapperShellExecutableToken) resume codex-session-123 -m gpt-5.5 --dangerously-bypass-approvals-and-sandbox -c model_reasoning_effort=high"
+            "\(AgentResumeArgv.codexWrapperShellExecutableToken) resume codex-session-123 -c check_for_update_on_startup=false -m gpt-5.5 --dangerously-bypass-approvals-and-sandbox -c model_reasoning_effort=high"
         )
         XCTAssertFalse(
             inner.contains("-s disabled"),
@@ -199,7 +199,7 @@ final class SessionIndexViewTests: XCTestCase {
         let inner = Self.unwrapPortableShellCommand(command)
         XCTAssertEqual(
             inner,
-            "\(AgentResumeArgv.codexWrapperShellExecutableToken) resume codex-session-managed -a on-request"
+            "\(AgentResumeArgv.codexWrapperShellExecutableToken) resume codex-session-managed -c check_for_update_on_startup=false -a on-request"
         )
         XCTAssertFalse(
             inner.contains("-s managed"),
@@ -224,7 +224,7 @@ final class SessionIndexViewTests: XCTestCase {
         )
         XCTAssertEqual(
             Self.unwrapPortableShellCommand(readOnly.resumeCommand ?? ""),
-            "\(AgentResumeArgv.codexWrapperShellExecutableToken) resume codex-ro -a untrusted -s read-only"
+            "\(AgentResumeArgv.codexWrapperShellExecutableToken) resume codex-ro -c check_for_update_on_startup=false -a untrusted -s read-only"
         )
 
         let dangerFullAccess = makeEntry(
@@ -240,7 +240,7 @@ final class SessionIndexViewTests: XCTestCase {
         )
         XCTAssertEqual(
             Self.unwrapPortableShellCommand(dangerFullAccess.resumeCommand ?? ""),
-            "\(AgentResumeArgv.codexWrapperShellExecutableToken) resume codex-dfa -m gpt-5.5 -a never -s danger-full-access"
+            "\(AgentResumeArgv.codexWrapperShellExecutableToken) resume codex-dfa -c check_for_update_on_startup=false -m gpt-5.5 -a never -s danger-full-access"
         )
     }
 

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -471,7 +471,7 @@ import Testing
         #expect(process.terminationStatus == 0, "\(errorText)")
 
         let output = try String(contentsOf: outputURL, encoding: .utf8)
-        #expect(output == "\(cwd.path)|resume session-moved-cli --yolo\n")
+        #expect(output == "\(cwd.path)|resume session-moved-cli -c check_for_update_on_startup=false --yolo\n")
         #expect(!startupInput.contains(movedExecutable.path), "\(startupInput)")
     }
 

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -4424,7 +4424,10 @@ extension SessionPersistenceTests {
         XCTAssertEqual(process.terminationStatus, 0, errorText)
 
         let output = try String(contentsOf: outputURL, encoding: .utf8)
-        XCTAssertTrue(output.contains("resume session-duplicate-turn --yolo"), output)
+        XCTAssertTrue(
+            output.contains("resume session-duplicate-turn -c check_for_update_on_startup=false --yolo"),
+            output
+        )
         XCTAssertFalse(output.hasPrefix("\(deletedCwd.path)|"), output)
     }
 
@@ -5592,7 +5595,10 @@ extension SessionPersistenceTests {
             let startupPayload = try restoredStartupPayload(for: restoredPanel)
 
             XCTAssertNil(restoredPanel.requestedWorkingDirectory)
-            XCTAssertTrue(startupPayload.contains("codex resume session-duplicate-turn --yolo"), startupPayload)
+            XCTAssertTrue(
+                startupPayload.contains("codex resume session-duplicate-turn -c check_for_update_on_startup=false --yolo"),
+                startupPayload
+            )
             // The guard is the fish-safe, brace-free form (https://github.com/manaflow-ai/cmux/issues/6285):
             // `cd -- '<dir>' 2>/dev/null || [ ! -d '<dir>' ] && <cmd>`.
             XCTAssertFalse(startupPayload.contains("{ cd -- "), startupPayload)

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -4424,10 +4424,7 @@ extension SessionPersistenceTests {
         XCTAssertEqual(process.terminationStatus, 0, errorText)
 
         let output = try String(contentsOf: outputURL, encoding: .utf8)
-        XCTAssertTrue(
-            output.contains("resume session-duplicate-turn -c check_for_update_on_startup=false --yolo"),
-            output
-        )
+        XCTAssertTrue(output.contains("resume session-duplicate-turn -c check_for_update_on_startup=false --yolo"), output)
         XCTAssertFalse(output.hasPrefix("\(deletedCwd.path)|"), output)
     }
 
@@ -5595,10 +5592,7 @@ extension SessionPersistenceTests {
             let startupPayload = try restoredStartupPayload(for: restoredPanel)
 
             XCTAssertNil(restoredPanel.requestedWorkingDirectory)
-            XCTAssertTrue(
-                startupPayload.contains("codex resume session-duplicate-turn -c check_for_update_on_startup=false --yolo"),
-                startupPayload
-            )
+            XCTAssertTrue(startupPayload.contains("codex resume session-duplicate-turn -c check_for_update_on_startup=false --yolo"), startupPayload)
             // The guard is the fish-safe, brace-free form (https://github.com/manaflow-ai/cmux/issues/6285):
             // `cd -- '<dir>' 2>/dev/null || [ ! -d '<dir>' ] && <cmd>`.
             XCTAssertFalse(startupPayload.contains("{ cd -- "), startupPayload)

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -2703,7 +2703,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
 
         XCTAssertEqual(
             snapshot.resumeCommand,
-            "cd -- '/Users/example/repo' 2>/dev/null || [ ! -d '/Users/example/repo' ] && 'env' 'CODEX_HOME=/tmp/codex home' '/Users/example/.bun/bin/codex' 'resume' '019dad34-d218-7943-b81a-eddac5c87951' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access' '--ask-for-approval' 'never' '--search'"
+            "cd -- '/Users/example/repo' 2>/dev/null || [ ! -d '/Users/example/repo' ] && 'env' 'CODEX_HOME=/tmp/codex home' '/Users/example/.bun/bin/codex' 'resume' '019dad34-d218-7943-b81a-eddac5c87951' '-c' 'check_for_update_on_startup=false' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access' '--ask-for-approval' 'never' '--search'"
         )
     }
 
@@ -2734,7 +2734,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
 
         XCTAssertEqual(
             snapshot.resumeCommand,
-            "cd -- '/Users/lawrence/fun/cmuxterm-hq' 2>/dev/null || [ ! -d '/Users/lawrence/fun/cmuxterm-hq' ] && '/Users/lawrence/.bun/bin/codex' 'resume' '019e2bb9-5544-7201-a517-d77bb00d724f' '--yolo' '--model' 'gpt-5.4'"
+            "cd -- '/Users/lawrence/fun/cmuxterm-hq' 2>/dev/null || [ ! -d '/Users/lawrence/fun/cmuxterm-hq' ] && '/Users/lawrence/.bun/bin/codex' 'resume' '019e2bb9-5544-7201-a517-d77bb00d724f' '-c' 'check_for_update_on_startup=false' '--yolo' '--model' 'gpt-5.4'"
         )
     }
 
@@ -2766,7 +2766,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
 
         XCTAssertEqual(
             snapshot.resumeCommand,
-            "cd -- '/Users/example/repo' 2>/dev/null || [ ! -d '/Users/example/repo' ] && 'env' 'CODEX_HOME=/tmp/codex home' '/usr/local/bin/cmux' 'codex-teams' 'resume' '019dad34-d218-7943-b81a-eddac5c87951' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access'"
+            "cd -- '/Users/example/repo' 2>/dev/null || [ ! -d '/Users/example/repo' ] && 'env' 'CODEX_HOME=/tmp/codex home' '/usr/local/bin/cmux' 'codex-teams' 'resume' '019dad34-d218-7943-b81a-eddac5c87951' '-c' 'check_for_update_on_startup=false' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access'"
         )
     }
 
@@ -2798,7 +2798,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
 
         XCTAssertEqual(
             snapshot.resumeCommand,
-            "cd -- '/Users/example/repo' 2>/dev/null || [ ! -d '/Users/example/repo' ] && 'env' 'CODEX_HOME=/tmp/codex home' '/usr/local/bin/cmux' 'codex-teams' 'resume' '019dad34-d218-7943-b81a-eddac5c87952' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access'"
+            "cd -- '/Users/example/repo' 2>/dev/null || [ ! -d '/Users/example/repo' ] && 'env' 'CODEX_HOME=/tmp/codex home' '/usr/local/bin/cmux' 'codex-teams' 'resume' '019dad34-d218-7943-b81a-eddac5c87952' '-c' 'check_for_update_on_startup=false' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access'"
         )
     }
 
@@ -3968,7 +3968,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         XCTAssertEqual(snapshot.launchCommand?.arguments.first, "/usr/local/bin/codex")
         XCTAssertEqual(
             snapshot.resumeCommand,
-            "cd -- '/tmp/repo' 2>/dev/null || [ ! -d '/tmp/repo' ] && 'env' 'CODEX_HOME=/tmp/codex' '/usr/local/bin/codex' 'resume' 'codex-session-123' '--model' 'gpt-5.4' '--search'"
+            "cd -- '/tmp/repo' 2>/dev/null || [ ! -d '/tmp/repo' ] && 'env' 'CODEX_HOME=/tmp/codex' '/usr/local/bin/codex' 'resume' 'codex-session-123' '-c' 'check_for_update_on_startup=false' '--model' 'gpt-5.4' '--search'"
         )
     }
 

--- a/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
+++ b/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Persisted agent-hook resume bindings are rendered shell strings, so bindings
+/// saved by a cmux build that predates the codex update-check suppression would
+/// replay verbatim on the first relaunch after updating cmux — the exact restart
+/// where codex's blocking "Update available!" picker used to swallow the
+/// restored session. Replay must normalize those stale codex bindings.
+@Suite struct SurfaceResumeBindingCodexUpdateCheckTests {
+    @Test func staleCodexBindingGainsUpdateCheckSuppressionOnReplay() throws {
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "cd -- '/tmp/repo' 2>/dev/null || [ ! -d '/tmp/repo' ] && 'env' 'CODEX_HOME=/tmp/codex' '/opt/company/bin/codex' 'resume' 'session-stale-binding' '--model' 'gpt-5.4'",
+            cwd: "/tmp/repo",
+            checkpointId: "session-stale-binding",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(
+            startupInput.contains("'resume' 'session-stale-binding' -c check_for_update_on_startup=false '--model'"),
+            "\(startupInput)"
+        )
+    }
+
+    @Test func staleCodexTeamsBindingGainsUpdateCheckSuppressionOnReplay() throws {
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "'/usr/local/bin/cmux' 'codex-teams' 'resume' 'team-stale-binding' '--model' 'gpt-5.4'",
+            checkpointId: "team-stale-binding",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(
+            startupInput.contains("'codex-teams' 'resume' 'team-stale-binding' -c check_for_update_on_startup=false '--model'"),
+            "\(startupInput)"
+        )
+    }
+
+    @Test func codexBindingWithExistingUpdateCheckSettingReplaysUnchanged() throws {
+        let command = "'/opt/company/bin/codex' 'resume' 'session-explicit' '-c' 'check_for_update_on_startup=true'"
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: command,
+            checkpointId: "session-explicit",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(startupInput.contains(command), "\(startupInput)")
+        #expect(!startupInput.contains("check_for_update_on_startup=false"), "\(startupInput)")
+    }
+
+    @Test func claudeBindingReplaysWithoutCodexUpdateCheckSuppression() throws {
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "claude",
+            command: "'/opt/company/bin/claude' '--resume' 'claude-session'",
+            checkpointId: "claude-session",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(!startupInput.contains("check_for_update_on_startup"), "\(startupInput)")
+    }
+
+    @Test func codexBindingWithRemoteResumeReplaysUnchanged() throws {
+        // Codex Teams subagent bindings resume by thread through the app-server
+        // (`resume --remote <url> <thread>`); the option word after `resume` must
+        // not be mistaken for a session id.
+        let command = "'/usr/local/bin/codex' 'resume' '--remote' 'ws://127.0.0.1:4500' 'thread-1'"
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: command,
+            checkpointId: "thread-1",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(startupInput.contains(command), "\(startupInput)")
+        #expect(!startupInput.contains("check_for_update_on_startup"), "\(startupInput)")
+    }
+}

--- a/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
+++ b/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
@@ -65,6 +65,22 @@ import Testing
         #expect(!startupInput.contains("check_for_update_on_startup=false"), "\(startupInput)")
     }
 
+    @Test func codexBindingWithShortEqualsUpdateCheckSettingReplaysUnchanged() throws {
+        let command = "'/opt/company/bin/codex' 'resume' 'session-explicit-short' '-c=check_for_update_on_startup=true'"
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: command,
+            checkpointId: "session-explicit-short",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(startupInput.contains(command), "\(startupInput)")
+        #expect(!startupInput.contains("check_for_update_on_startup=false"), "\(startupInput)")
+    }
+
     @Test func claudeBindingReplaysWithoutCodexUpdateCheckSuppression() throws {
         let binding = SurfaceResumeBindingSnapshot(
             kind: "claude",

--- a/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
+++ b/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
@@ -79,14 +79,13 @@ import Testing
         #expect(!startupInput.contains("check_for_update_on_startup"), "\(startupInput)")
     }
 
-    @Test func codexBindingWithRemoteResumeReplaysUnchanged() throws {
+    @Test func codexBindingWithRemoteResumeGainsUpdateCheckSuppressionOnReplay() throws {
         // Codex Teams subagent bindings resume by thread through the app-server
-        // (`resume --remote <url> <thread>`); the option word after `resume` must
-        // not be mistaken for a session id.
-        let command = "'/usr/local/bin/codex' 'resume' '--remote' 'ws://127.0.0.1:4500' 'thread-1'"
+        // (`resume --remote <url> <thread>`); the override belongs after the
+        // thread id, not after the `--remote` option.
         let binding = SurfaceResumeBindingSnapshot(
             kind: "codex",
-            command: command,
+            command: "'/usr/local/bin/codex' 'resume' '--remote' 'ws://127.0.0.1:4500' 'thread-1'",
             checkpointId: "thread-1",
             source: "agent-hook",
             autoResume: true
@@ -94,8 +93,10 @@ import Testing
 
         let startupInput = try #require(binding.startupInput)
 
-        #expect(startupInput.contains(command), "\(startupInput)")
-        #expect(!startupInput.contains("check_for_update_on_startup"), "\(startupInput)")
+        #expect(
+            startupInput.contains("'--remote' 'ws://127.0.0.1:4500' 'thread-1' -c check_for_update_on_startup=false"),
+            "\(startupInput)"
+        )
     }
 
     @Test func legacyCodexBindingWithoutKindGainsUpdateCheckSuppressionOnReplay() throws {

--- a/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
+++ b/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Foundation
 import Testing
 
@@ -95,5 +96,76 @@ import Testing
 
         #expect(startupInput.contains(command), "\(startupInput)")
         #expect(!startupInput.contains("check_for_update_on_startup"), "\(startupInput)")
+    }
+
+    @Test func legacyCodexBindingWithoutKindGainsUpdateCheckSuppressionOnReplay() throws {
+        let binding = SurfaceResumeBindingSnapshot(
+            command: "'/opt/company/bin/codex' 'resume' 'legacy-kindless-session' '--model' 'gpt-5.4'",
+            checkpointId: "legacy-kindless-session",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(
+            startupInput.contains("'resume' 'legacy-kindless-session' -c check_for_update_on_startup=false '--model'"),
+            "\(startupInput)"
+        )
+    }
+
+    @Test func remoteLauncherScriptCodexBindingGainsUpdateCheckSuppressionOnReplay() throws {
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "'/opt/company/bin/codex' 'resume' 'remote-startup-session' '--model' 'gpt-5.4'",
+            checkpointId: "remote-startup-session",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.remoteStartupInputWithLauncherScript())
+
+        #expect(
+            startupInput.contains("'resume' 'remote-startup-session' -c check_for_update_on_startup=false '--model'"),
+            "\(startupInput)"
+        )
+    }
+
+    @Test func codexBindingWithUnrelatedUpdateCheckTextStillGainsSuppression() throws {
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "'/opt/company/bin/codex' 'resume' 'session-with-text' '--model' 'check_for_update_on_startup-not-config'",
+            checkpointId: "session-with-text",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(
+            startupInput.contains("'resume' 'session-with-text' -c check_for_update_on_startup=false '--model'"),
+            "\(startupInput)"
+        )
+    }
+
+    @Test func wrappedCodexBindingGainsUpdateCheckSuppressionOnReplay() throws {
+        let wrapped = AgentResumeArgv.portableCodexResumeShellCommand(
+            posixCommand: "\(AgentResumeArgv.codexWrapperShellExecutableToken) resume wrapped-session --model gpt-5.4"
+        )
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "cd -- '/tmp/repo' 2>/dev/null || [ ! -d '/tmp/repo' ] && \(wrapped)",
+            cwd: "/tmp/repo",
+            checkpointId: "wrapped-session",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(
+            startupInput.contains("resume wrapped-session -c check_for_update_on_startup=false --model"),
+            "\(startupInput)"
+        )
     }
 }


### PR DESCRIPTION
After a cmux update restarts the app, auto-restored codex sessions can land on codex's blocking "Update available!" startup picker instead of the restored conversation, so the pane looks like the session never restarted. codex shows that picker whenever a new release is cached and no initial prompt is passed (openai/codex `codex-rs/tui/src/lib.rs`, `run_update_prompt_if_needed`), which is exactly the shape of every cmux-generated `codex resume <id>`.

Fix: inject codex's per-invocation config override `-c check_for_update_on_startup=false` into every cmux-generated codex resume command: the shared resume argv builder in `AgentResumeArgv` (covers close-and-reopen auto-restore and the cmux-cli surface-restore publisher), the `codexTeams` launcher resolution, and the sessions-panel resume command in `SessionIndexModels`. `-c key=value` is a clap-global flag in codex, so it is valid after the `resume` subcommand and overrides config for that process only; `~/.codex/config.toml` and the user's own manual codex launches keep their update checks. Injection is skipped when the captured launch arguments already set `check_for_update_on_startup`, so an explicit user choice stays authoritative and restore-of-a-restore does not stack duplicate overrides (the codex sanitizer policy preserves `-c key=value` pairs).

Two-commit structure: the first commit updates/adds the resume-command expectations only (red), the second adds the fix (green).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785624194&installation_id=133855650&pr_number=7222&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7222&signature=e2d665290e1f2d69acb726f9856f781c726e0b711fa08f2885690ae3065b862c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted argv/shell-string changes for codex resume only, with broad tests and no changes to user `~/.codex/config.toml` or non-codex agents.
> 
> **Overview**
> **Fixes auto-restored codex panes landing on codex’s blocking “Update available!” picker** instead of the conversation after cmux relaunch (typical when `codex resume <id>` has no initial prompt).
> 
> Every **new** cmux-generated codex resume path now appends a **per-process** `-c check_for_update_on_startup=false` via shared `AgentResumeArgv` (`codex`, `codex-teams`, CLI codex-teams shell quoting, and sessions-panel resume commands). Injection is **skipped** when captured args already set `check_for_update_on_startup` via `-c`/`--config`, so user choice stays authoritative and restore-of-restore stays idempotent.
> 
> **Stale persisted agent-hook bindings** are upgraded at **replay** (no migration): `SurfaceResumeCommandCanonicalizer+CodexUpdateCheck` parses shell strings and inserts the override after `resume <id>` (or after the thread id for `resume --remote`), including `/bin/sh -c` and codex wrapper-token bodies; this runs before portable-executable repair on hook bindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0697cf1355ba0daa53a9cf9f2e8e3a36c6237c54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `codex`’s blocking update prompt on `cmux`-driven resumes so panes return to the conversation after updates. Adds a per-process `-c check_for_update_on_startup=false` to all `codex` resume paths without changing user config.

- **Bug Fixes**
  - Injects the override into all cmux-generated `codex` resumes: `codex resume <id>`, `codex-teams resume <id>`, and `codex resume --remote <url> <thread>` (shared `AgentResumeArgv`, sessions panel, CLI `codex-teams` launcher). Skips when args already set `check_for_update_on_startup` via `-c`, `--config`, or short equals forms (`-c=…`, `--config=…`) to honor user choice and avoid duplicates.
  - Upgrades stale persisted `codex` bindings at replay by inserting the override after `resume <id>` (or after the thread id for `--remote`); handles `/bin/sh -c` and wrapper-token forms, and runs before portable-executable repair.

<sup>Written for commit 589af22e7424b9bf686b50b3286c96aa15a9564b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Improvements**
  * Codex and Codex Teams resume flows now automatically inject a per-invocation startup update-check suppression flag to avoid the “Update available!” picker, including session replay/restore.
  * The flag is inserted at the correct location for both direct and wrapped command forms, and it won’t be duplicated when `check_for_update_on_startup` is explicitly set.

* **Tests**
  * Updated and expanded unit/integration/sanitizer expectations for argv and shell command ordering, plus added coverage for normalization during persisted binding replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->