### PR TITLE
Support Arc cookie import

### DIFF
--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
@@ -351,25 +351,19 @@ public struct BrowserInstalledBrowserDetector {
         for child in children {
             guard (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
             let name = child.lastPathComponent
-            let isLikelyProfile =
-                name == "Default" ||
-                name.hasPrefix("Profile ") ||
-                name.hasPrefix("Guest Profile") ||
-                name.hasPrefix("Person ") ||
-                nameMap[name] != nil
-            if isLikelyProfile && looksLikeChromiumProfile(rootURL: child) {
-                profiles.append(
-                    InstalledBrowserProfile(
-                        displayName: Self.chromiumProfileDisplayName(
-                            directoryName: name,
-                            nameMap: nameMap,
-                            isDefault: name == "Default"
-                        ),
-                        rootURL: child,
+            guard name != "Network" else { continue }
+            guard looksLikeChromiumProfile(rootURL: child) else { continue }
+            profiles.append(
+                InstalledBrowserProfile(
+                    displayName: Self.chromiumProfileDisplayName(
+                        directoryName: name,
+                        nameMap: nameMap,
                         isDefault: name == "Default"
-                    )
+                    ),
+                    rootURL: child,
+                    isDefault: name == "Default"
                 )
-            }
+            )
         }
 
         return Self.sortProfiles(Self.dedupedProfiles(profiles))
@@ -470,7 +464,12 @@ public struct BrowserInstalledBrowserDetector {
     private func looksLikeChromiumProfile(rootURL: URL) -> Bool {
         let historyURL = rootURL.appendingPathComponent("History", isDirectory: false)
         let cookiesURL = rootURL.appendingPathComponent("Cookies", isDirectory: false)
-        return fileManager.fileExists(atPath: historyURL.path) || fileManager.fileExists(atPath: cookiesURL.path)
+        let networkCookiesURL = rootURL
+            .appendingPathComponent("Network", isDirectory: true)
+            .appendingPathComponent("Cookies", isDirectory: false)
+        return fileManager.fileExists(atPath: historyURL.path) ||
+            fileManager.fileExists(atPath: cookiesURL.path) ||
+            fileManager.fileExists(atPath: networkCookiesURL.path)
     }
 
     private func looksLikeFirefoxProfile(rootURL: URL) -> Bool {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
@@ -257,7 +257,7 @@ public struct BrowserInstalledBrowserDetector {
         rootURL: URL
     ) -> (family: BrowserImportEngineFamily, profiles: [InstalledBrowserProfile]) {
         let candidates: [(BrowserImportEngineFamily, [InstalledBrowserProfile])] = [
-            (.chromium, chromiumProfiles(rootURL: rootURL)),
+            (.chromium, chromiumProfiles(descriptor: descriptor, rootURL: rootURL)),
             (.firefox, firefoxProfiles(rootURL: rootURL)),
             (.webkit, webKitProfiles(descriptor: descriptor, rootURL: rootURL)),
         ]
@@ -325,10 +325,10 @@ public struct BrowserInstalledBrowserDetector {
         return score
     }
 
-    private func chromiumProfiles(rootURL: URL) -> [InstalledBrowserProfile] {
+    private func chromiumProfiles(descriptor: BrowserImportBrowserDescriptor, rootURL: URL) -> [InstalledBrowserProfile] {
         let nameMap = Self.chromiumProfileNameMap(rootURL: rootURL)
         var profiles: [InstalledBrowserProfile] = []
-        if looksLikeChromiumProfile(rootURL: rootURL) {
+        if looksLikeChromiumProfile(rootURL: rootURL, allowNetworkCookies: false) {
             profiles.append(
                 InstalledBrowserProfile(
                     displayName: Self.chromiumProfileDisplayName(
@@ -352,7 +352,9 @@ public struct BrowserInstalledBrowserDetector {
             guard (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
             let name = child.lastPathComponent
             guard name != "Network" else { continue }
-            guard looksLikeChromiumProfile(rootURL: child) else { continue }
+            guard looksLikeChromiumProfile(rootURL: child, allowNetworkCookies: true) else { continue }
+            guard name == "Default" || name.hasPrefix("Profile ") || name.hasPrefix("Guest Profile") ||
+                name.hasPrefix("Person ") || nameMap[name] != nil || descriptor.id == "arc" else { continue }
             profiles.append(
                 InstalledBrowserProfile(
                     displayName: Self.chromiumProfileDisplayName(
@@ -461,15 +463,12 @@ public struct BrowserInstalledBrowserDetector {
         return sections
     }
 
-    private func looksLikeChromiumProfile(rootURL: URL) -> Bool {
+    private func looksLikeChromiumProfile(rootURL: URL, allowNetworkCookies: Bool) -> Bool {
         let historyURL = rootURL.appendingPathComponent("History", isDirectory: false)
         let cookiesURL = rootURL.appendingPathComponent("Cookies", isDirectory: false)
-        let networkCookiesURL = rootURL
-            .appendingPathComponent("Network", isDirectory: true)
-            .appendingPathComponent("Cookies", isDirectory: false)
-        return fileManager.fileExists(atPath: historyURL.path) ||
-            fileManager.fileExists(atPath: cookiesURL.path) ||
-            fileManager.fileExists(atPath: networkCookiesURL.path)
+        guard !fileManager.fileExists(atPath: historyURL.path), !fileManager.fileExists(atPath: cookiesURL.path) else { return true }
+        let networkCookiesURL = rootURL.appendingPathComponent("Network", isDirectory: true).appendingPathComponent("Cookies", isDirectory: false)
+        return allowNetworkCookies && fileManager.fileExists(atPath: networkCookiesURL.path)
     }
 
     private func looksLikeFirefoxProfile(rootURL: URL) -> Bool {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
@@ -257,7 +257,7 @@ public struct BrowserInstalledBrowserDetector {
         rootURL: URL
     ) -> (family: BrowserImportEngineFamily, profiles: [InstalledBrowserProfile]) {
         let candidates: [(BrowserImportEngineFamily, [InstalledBrowserProfile])] = [
-            (.chromium, chromiumProfiles(descriptor: descriptor, rootURL: rootURL)),
+            (.chromium, chromiumProfiles(rootURL: rootURL)),
             (.firefox, firefoxProfiles(rootURL: rootURL)),
             (.webkit, webKitProfiles(descriptor: descriptor, rootURL: rootURL)),
         ]
@@ -325,7 +325,7 @@ public struct BrowserInstalledBrowserDetector {
         return score
     }
 
-    private func chromiumProfiles(descriptor: BrowserImportBrowserDescriptor, rootURL: URL) -> [InstalledBrowserProfile] {
+    private func chromiumProfiles(rootURL: URL) -> [InstalledBrowserProfile] {
         let nameMap = Self.chromiumProfileNameMap(rootURL: rootURL)
         var profiles: [InstalledBrowserProfile] = []
         if looksLikeChromiumProfile(rootURL: rootURL, allowNetworkCookies: false) {
@@ -353,8 +353,7 @@ public struct BrowserInstalledBrowserDetector {
             let name = child.lastPathComponent
             guard name != "Network" else { continue }
             guard looksLikeChromiumProfile(rootURL: child, allowNetworkCookies: true) else { continue }
-            guard name == "Default" || name.hasPrefix("Profile ") || name.hasPrefix("Guest Profile") ||
-                name.hasPrefix("Person ") || nameMap[name] != nil || descriptor.id == "arc" else { continue }
+            guard name == "Default" || name.hasPrefix("Profile ") || name.hasPrefix("Guest Profile") || name.hasPrefix("Person ") || nameMap[name] != nil else { continue }
             profiles.append(
                 InstalledBrowserProfile(
                     displayName: Self.chromiumProfileDisplayName(

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Values/BrowserImportBrowserDescriptor.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Values/BrowserImportBrowserDescriptor.swift
@@ -110,7 +110,10 @@ public struct BrowserImportBrowserDescriptor: Hashable, Sendable {
             tier: 1,
             bundleIdentifiers: ["company.thebrowser.Browser", "company.thebrowser.arc"],
             appNames: ["Arc.app"],
-            dataRootRelativePaths: ["Library/Application Support/Arc"],
+            dataRootRelativePaths: [
+                "Library/Application Support/Arc/User Data",
+                "Library/Application Support/Arc",
+            ],
             dataArtifactRelativePaths: [],
             supportsDataOnlyDetection: true
         ),

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Import/BrowserInstalledBrowserDetectorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Import/BrowserInstalledBrowserDetectorTests.swift
@@ -84,6 +84,59 @@ struct BrowserInstalledBrowserDetectorTests {
         #expect(dia.profiles.map(\.rootURL.lastPathComponent) == ["Default", "Profile 1"])
     }
 
+    @Test("detects Arc Chromium profiles and Network cookie stores under User Data")
+    func detectsArcProfilesUnderUserData() throws {
+        let home = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let arcUserDataRoot = home
+            .appendingPathComponent("Library/Application Support/Arc/User Data", isDirectory: true)
+        let defaultProfile = arcUserDataRoot.appendingPathComponent("Default", isDirectory: true)
+        let workProfile = arcUserDataRoot.appendingPathComponent("Arc Work", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: defaultProfile.appendingPathComponent("Network", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: workProfile.appendingPathComponent("Network", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: defaultProfile.appendingPathComponent("Network/Cookies"))
+        try Data().write(to: workProfile.appendingPathComponent("Network/Cookies"))
+        try Data(
+            """
+            {
+              "profile": {
+                "info_cache": {
+                  "Default": {
+                    "name": "Personal"
+                  },
+                  "Arc Work": {
+                    "name": "Work"
+                  }
+                }
+              }
+            }
+            """.utf8
+        ).write(to: arcUserDataRoot.appendingPathComponent("Local State"))
+
+        let detector = BrowserInstalledBrowserDetector(
+            homeDirectoryURL: home,
+            bundleLookup: { _ in nil },
+            applicationSearchDirectories: [],
+            fileManager: .default
+        )
+
+        let arc = try #require(detector.detectInstalledBrowsers().first { $0.id == "arc" })
+        #expect(arc.family == .chromium)
+        #expect(arc.dataRootURL == arcUserDataRoot)
+        #expect(arc.profiles.map(\.displayName) == ["Personal", "Work"])
+        #expect(arc.profiles.map(\.rootURL.lastPathComponent) == ["Default", "Arc Work"])
+        #expect(arc.profiles.allSatisfy {
+            FileManager.default.fileExists(atPath: $0.rootURL.appendingPathComponent("Network/Cookies").path)
+        })
+    }
+
     @Test("detects a Firefox browser and reads its profiles.ini name")
     func detectsFirefoxFromINI() throws {
         let home = try makeTempHome()

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Import/BrowserInstalledBrowserDetectorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Import/BrowserInstalledBrowserDetectorTests.swift
@@ -91,6 +91,11 @@ struct BrowserInstalledBrowserDetectorTests {
 
         let arcUserDataRoot = home
             .appendingPathComponent("Library/Application Support/Arc/User Data", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: arcUserDataRoot.appendingPathComponent("Network", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: arcUserDataRoot.appendingPathComponent("Network/Cookies"))
         let defaultProfile = arcUserDataRoot.appendingPathComponent("Default", isDirectory: true)
         let workProfile = arcUserDataRoot.appendingPathComponent("Arc Work", isDirectory: true)
         try FileManager.default.createDirectory(
@@ -132,6 +137,7 @@ struct BrowserInstalledBrowserDetectorTests {
         #expect(arc.dataRootURL == arcUserDataRoot)
         #expect(arc.profiles.map(\.displayName) == ["Personal", "Work"])
         #expect(arc.profiles.map(\.rootURL.lastPathComponent) == ["Default", "Arc Work"])
+        #expect(!arc.profiles.contains { $0.rootURL == arcUserDataRoot })
         #expect(arc.profiles.allSatisfy {
             FileManager.default.fileExists(atPath: $0.rootURL.appendingPathComponent("Network/Cookies").path)
         })

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Import/BrowserInstalledBrowserDetectorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Import/BrowserInstalledBrowserDetectorTests.swift
@@ -106,8 +106,11 @@ struct BrowserInstalledBrowserDetectorTests {
             at: workProfile.appendingPathComponent("Network", isDirectory: true),
             withIntermediateDirectories: true
         )
+        let systemProfile = arcUserDataRoot.appendingPathComponent("System Profile", isDirectory: true)
+        try FileManager.default.createDirectory(at: systemProfile.appendingPathComponent("Network", isDirectory: true), withIntermediateDirectories: true)
         try Data().write(to: defaultProfile.appendingPathComponent("Network/Cookies"))
         try Data().write(to: workProfile.appendingPathComponent("Network/Cookies"))
+        try Data().write(to: systemProfile.appendingPathComponent("Network/Cookies"))
         try Data(
             """
             {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -9734,9 +9734,7 @@ enum BrowserDataImporter {
         var skippedEncryptedCookies = 0
         let decryptor = ChromiumCookieDecryptor(browser: browser)
 
-        let databaseURLs = dedupedCanonicalURLs(
-            sourceProfiles.flatMap { chromiumCookieDatabaseURLs(for: $0) }
-        ).filter { fileManager.fileExists(atPath: $0.path) }
+        let databaseURLs = sourceProfiles.compactMap { profile -> URL? in let networkURL = profile.rootURL.appendingPathComponent("Network", isDirectory: true).appendingPathComponent("Cookies", isDirectory: false); let legacyURL = profile.rootURL.appendingPathComponent("Cookies", isDirectory: false); return fileManager.fileExists(atPath: networkURL.path) ? networkURL : (fileManager.fileExists(atPath: legacyURL.path) ? legacyURL : nil) }
 
         for databaseURL in databaseURLs {
             do {
@@ -9809,15 +9807,6 @@ enum BrowserDataImporter {
         }
         let skippedCount = max(0, dedupedCookies.count - importedCount) + skippedEncryptedCookies
         return CookieImportResult(importedCount: importedCount, skippedCount: skippedCount, warnings: warnings)
-    }
-
-    private static func chromiumCookieDatabaseURLs(for profile: InstalledBrowserProfile) -> [URL] {
-        [
-            profile.rootURL
-                .appendingPathComponent("Network", isDirectory: true)
-                .appendingPathComponent("Cookies", isDirectory: false),
-            profile.rootURL.appendingPathComponent("Cookies", isDirectory: false),
-        ]
     }
 
     private static func importFirefoxHistory(

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -9734,9 +9734,9 @@ enum BrowserDataImporter {
         var skippedEncryptedCookies = 0
         let decryptor = ChromiumCookieDecryptor(browser: browser)
 
-        let databaseURLs = sourceProfiles.map {
-            $0.rootURL.appendingPathComponent("Cookies", isDirectory: false)
-        }.filter { fileManager.fileExists(atPath: $0.path) }
+        let databaseURLs = dedupedCanonicalURLs(
+            sourceProfiles.flatMap { chromiumCookieDatabaseURLs(for: $0) }
+        ).filter { fileManager.fileExists(atPath: $0.path) }
 
         for databaseURL in databaseURLs {
             do {
@@ -9809,6 +9809,15 @@ enum BrowserDataImporter {
         }
         let skippedCount = max(0, dedupedCookies.count - importedCount) + skippedEncryptedCookies
         return CookieImportResult(importedCount: importedCount, skippedCount: skippedCount, warnings: warnings)
+    }
+
+    private static func chromiumCookieDatabaseURLs(for profile: InstalledBrowserProfile) -> [URL] {
+        [
+            profile.rootURL
+                .appendingPathComponent("Network", isDirectory: true)
+                .appendingPathComponent("Cookies", isDirectory: false),
+            profile.rootURL.appendingPathComponent("Cookies", isDirectory: false),
+        ]
     }
 
     private static func importFirefoxHistory(


### PR DESCRIPTION
Fix Arc browser cookie import by detecting Arc's Chromium User Data root and reading modern Chromium Network/Cookies stores.\n\nChanges:\n- Prefer ~/Library/Application Support/Arc/User Data for Arc profile discovery.\n- Treat artifact-backed Chromium profile directories as importable even when their names are not Default or Profile N.\n- Read Chromium cookies from Profile/Network/Cookies with Profile/Cookies as a legacy fallback.\n\nValidation:\n- swift test --package-path Packages/macOS/CmuxBrowser --filter BrowserInstalledBrowserDetector\n- swift test --package-path Packages/macOS/CmuxBrowser\n- ./scripts/reload-cloud.sh --tag arcimp\n- Tagged preflight: CMUX_TAG=arcimp scripts/cmux-debug-cli.sh browser import --non-interactive --from arc --to-profile default --domain cmux.invalid --json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785628238&installation_id=133855650&pr_number=7224&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7224&signature=c5ca4639596f209be20a3610f2449345843a4706a925b0d9672bfba1758df1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to browser import detection and cookie path resolution; no auth or network API changes. Slightly broader Chromium profile heuristics could affect edge-case detection for other browsers.
> 
> **Overview**
> Fixes **Arc cookie import** by aligning profile discovery and cookie DB paths with Arc’s Chromium **User Data** layout and modern **`Network/Cookies`** stores.
> 
> **Detection:** Arc’s descriptor now prefers `Library/Application Support/Arc/User Data` (with the old `Arc` path as fallback). Chromium scanning skips a top-level **`Network`** folder, treats profiles that only have cookies under **`Network/Cookies`** as valid (not the User Data root itself), and still accepts custom folder names when they appear in **`Local State`** `info_cache` (e.g. **Arc Work**).
> 
> **Import:** Chromium cookie import reads **`Profile/Network/Cookies`** when present, otherwise **`Profile/Cookies`**.
> 
> Adds detector coverage for Arc User Data + Network cookie layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bdac229be31bb299e867c2b5f05f744edac45d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Arc cookie import by preferring Arc’s “User Data” root, reading `Network/Cookies` first, and tightening profile detection so we don’t treat the data root or `Network` folder as profiles.

- **Bug Fixes**
  - Prefer `~/Library/Application Support/Arc/User Data` for Arc, with `~/Library/Application Support/Arc` as fallback.
  - Do not consider the data root a profile when only `Network/Cookies` exists; skip the top-level `Network` directory.
  - Detect profiles only if named `Default`, `Profile N`, `Guest Profile`, `Person N`, or listed in `Local State`; accept `Network/Cookies` as the cookie store for child profiles.
  - Read cookies from `Profile/Network/Cookies` first, then `Profile/Cookies`.
  - Add tests for Arc User Data detection, `Network/Cookies` profiles, and ensuring the root isn’t identified as a profile.

<sup>Written for commit 9bdac229be31bb299e867c2b5f05f744edac45d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chromium-based browser profile detection to avoid treating the `Network` directory as a profile root.
  * Enhanced detection of valid profiles when cookie data is stored in `Network/Cookies`, including support for additional Arc data-root locations.
  * Updated Chromium cookie import to prefer `root/Network/Cookies` and fall back to `root/Cookies` when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->