### PR TITLE
Reduce workspace switch portal hide work

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/Workspace/WorkspacePortalRenderingChange.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/Workspace/WorkspacePortalRenderingChange.swift
@@ -1,0 +1,19 @@
+public import Foundation
+
+/// A desired portal-rendering transition for a workspace.
+public struct WorkspacePortalRenderingChange: Equatable {
+    /// The workspace whose portal-rendering state should be updated.
+    public let workspaceId: UUID
+    /// Whether portal rendering should be enabled for the workspace.
+    public let isEnabled: Bool
+
+    /// Creates a portal-rendering state change.
+    ///
+    /// - Parameters:
+    ///   - workspaceId: The workspace whose state should change.
+    ///   - isEnabled: Whether portal rendering should be enabled.
+    public init(workspaceId: UUID, isEnabled: Bool) {
+        self.workspaceId = workspaceId
+        self.isEnabled = isEnabled
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/Workspace/WorkspacePortalRenderingPlan.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/Workspace/WorkspacePortalRenderingPlan.swift
@@ -1,0 +1,65 @@
+public import Foundation
+
+/// Value object deciding which workspace portal-rendering transitions need to run.
+///
+/// `WorkspaceMountPlan` decides which workspaces should stay mounted. This type
+/// compares that desired mounted set with the last portal-rendering state already
+/// applied to each workspace so callers can avoid repeating expensive portal hide
+/// work for workspaces that are already disabled.
+public struct WorkspacePortalRenderingPlan: Equatable {
+    private let previousStatesByWorkspaceId: [UUID: Bool]
+    private let mountedWorkspaceIds: Set<UUID>
+    private let orderedWorkspaceIds: [UUID]
+
+    /// Creates a portal-rendering reconciliation plan.
+    ///
+    /// - Parameters:
+    ///   - previousStatesByWorkspaceId: The last portal-rendering state applied by
+    ///     the caller, keyed by workspace id.
+    ///   - mountedWorkspaceIds: Workspaces that should have portal rendering enabled.
+    ///   - orderedWorkspaceIds: Existing workspaces in stable application order.
+    public init(
+        previousStatesByWorkspaceId: [UUID: Bool],
+        mountedWorkspaceIds: Set<UUID>,
+        orderedWorkspaceIds: [UUID]
+    ) {
+        self.previousStatesByWorkspaceId = previousStatesByWorkspaceId
+        self.mountedWorkspaceIds = mountedWorkspaceIds
+        self.orderedWorkspaceIds = orderedWorkspaceIds
+    }
+
+    /// The workspace portal-rendering transitions that should be applied.
+    public var changes: [WorkspacePortalRenderingChange] {
+        var seenWorkspaceIds = Set<UUID>()
+        return orderedWorkspaceIds.compactMap { workspaceId -> WorkspacePortalRenderingChange? in
+            guard seenWorkspaceIds.insert(workspaceId).inserted else {
+                return nil
+            }
+            let desiredState = mountedWorkspaceIds.contains(workspaceId)
+            guard previousStatesByWorkspaceId[workspaceId] != desiredState else {
+                return nil
+            }
+            return WorkspacePortalRenderingChange(workspaceId: workspaceId, isEnabled: desiredState)
+        }
+    }
+
+    /// The state snapshot to persist after applying ``changes``.
+    public var nextStatesByWorkspaceId: [UUID: Bool] {
+        Dictionary(orderedWorkspaceIds.map { workspaceId in
+            (workspaceId, mountedWorkspaceIds.contains(workspaceId))
+        }, uniquingKeysWith: { first, _ in first })
+    }
+
+    /// Applies this plan to the caller's previous state snapshot.
+    ///
+    /// - Parameters:
+    ///   - previousStatesByWorkspaceId: The caller's state snapshot. This value is
+    ///     replaced with ``nextStatesByWorkspaceId``.
+    /// - Returns: The portal-rendering transitions that should be applied.
+    public func applying(
+        to previousStatesByWorkspaceId: inout [UUID: Bool]
+    ) -> [WorkspacePortalRenderingChange] {
+        previousStatesByWorkspaceId = nextStatesByWorkspaceId
+        return changes
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/WorkspacePortalRenderingPlanTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/WorkspacePortalRenderingPlanTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+import CmuxFoundation
+
+@Suite("Workspace portal-rendering plan")
+struct WorkspacePortalRenderingPlanTests {
+    @Test("new unmounted workspaces are disabled once")
+    func disablesNewUnmountedWorkspacesOnce() {
+        let mounted = UUID()
+        let unmounted = UUID()
+
+        let initial = WorkspacePortalRenderingPlan(
+            previousStatesByWorkspaceId: [:],
+            mountedWorkspaceIds: [mounted],
+            orderedWorkspaceIds: [mounted, unmounted]
+        )
+
+        #expect(
+            initial.changes == [
+                WorkspacePortalRenderingChange(workspaceId: mounted, isEnabled: true),
+                WorkspacePortalRenderingChange(workspaceId: unmounted, isEnabled: false),
+            ]
+        )
+
+        let repeated = WorkspacePortalRenderingPlan(
+            previousStatesByWorkspaceId: initial.nextStatesByWorkspaceId,
+            mountedWorkspaceIds: [mounted],
+            orderedWorkspaceIds: [mounted, unmounted]
+        )
+
+        #expect(
+            repeated.changes.isEmpty,
+            "Already-disabled workspaces must not repeat portal hide work on every workspace switch"
+        )
+    }
+
+    @Test("only mount transitions are reported")
+    func reportsMountTransitionsOnly() {
+        let previous = UUID()
+        let selected = UUID()
+        let stale = UUID()
+
+        let plan = WorkspacePortalRenderingPlan(
+            previousStatesByWorkspaceId: [
+                previous: true,
+                selected: false,
+                stale: false,
+            ],
+            mountedWorkspaceIds: [selected],
+            orderedWorkspaceIds: [previous, selected]
+        )
+
+        #expect(
+            plan.changes == [
+                WorkspacePortalRenderingChange(workspaceId: previous, isEnabled: false),
+                WorkspacePortalRenderingChange(workspaceId: selected, isEnabled: true),
+            ]
+        )
+        #expect(plan.nextStatesByWorkspaceId[previous] == false)
+        #expect(plan.nextStatesByWorkspaceId[selected] == true)
+        #expect(plan.nextStatesByWorkspaceId[stale] == nil)
+    }
+
+    @Test("applying advances the previous state snapshot")
+    func applyingAdvancesPreviousStateSnapshot() {
+        let mounted = UUID()
+        let unmounted = UUID()
+        var previousStates: [UUID: Bool] = [:]
+
+        let changes = WorkspacePortalRenderingPlan(
+            previousStatesByWorkspaceId: previousStates,
+            mountedWorkspaceIds: [mounted],
+            orderedWorkspaceIds: [mounted, unmounted]
+        ).applying(to: &previousStates)
+
+        #expect(
+            changes == [
+                WorkspacePortalRenderingChange(workspaceId: mounted, isEnabled: true),
+                WorkspacePortalRenderingChange(workspaceId: unmounted, isEnabled: false),
+            ]
+        )
+        #expect(previousStates[mounted] == true)
+        #expect(previousStates[unmounted] == false)
+    }
+
+    @Test("duplicate ordered workspace ids are tolerated")
+    func duplicateOrderedWorkspaceIdsAreTolerated() {
+        let repeated = UUID()
+        let mounted = UUID()
+
+        let plan = WorkspacePortalRenderingPlan(
+            previousStatesByWorkspaceId: [:],
+            mountedWorkspaceIds: [mounted],
+            orderedWorkspaceIds: [repeated, repeated, mounted]
+        )
+
+        #expect(
+            plan.changes == [
+                WorkspacePortalRenderingChange(workspaceId: repeated, isEnabled: false),
+                WorkspacePortalRenderingChange(workspaceId: mounted, isEnabled: true),
+            ]
+        )
+        #expect(plan.nextStatesByWorkspaceId[repeated] == false)
+        #expect(plan.nextStatesByWorkspaceId[mounted] == true)
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -986,6 +986,7 @@ struct ContentView: View {
     @State private var sidebarDragStartWidth: CGFloat?
     @State private var selectedTabIds: Set<UUID> = []
     @State private var mountedWorkspaceIds: [UUID] = []
+    @State private var lastReconciledPortalRenderingStatesByWorkspaceId: [UUID: Bool] = [:]
     @State private var lastSidebarSelectionIndex: Int? = nil
     @State private var titlebarText: String = ""
     @State private var isFullScreen: Bool = false
@@ -3269,12 +3270,13 @@ struct ContentView: View {
             maxMounted: maxMounted
         ).mountedWorkspaceIds
         let removedIds = previousMountedIds.filter { !mountedWorkspaceIds.contains($0) }
-        let mountedIdSet = Set(mountedWorkspaceIds)
-        for workspace in currentTabs {
-            workspace.setPortalRenderingEnabled(
-                mountedIdSet.contains(workspace.id),
-                reason: "workspaceMount"
-            )
+        let portalRenderingChanges = WorkspacePortalRenderingPlan(
+            previousStatesByWorkspaceId: lastReconciledPortalRenderingStatesByWorkspaceId,
+            mountedWorkspaceIds: Set(mountedWorkspaceIds), orderedWorkspaceIds: orderedTabIds
+        ).applying(to: &lastReconciledPortalRenderingStatesByWorkspaceId)
+        let workspacesById = Dictionary(currentTabs.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        for change in portalRenderingChanges {
+            workspacesById[change.workspaceId]?.setPortalRenderingEnabled(change.isEnabled, reason: "workspaceMount")
         }
 #if DEBUG
         if mountedWorkspaceIds != previousMountedIds {
@@ -3388,13 +3390,11 @@ struct ContentView: View {
         workspaceHandoffFallbackTask = nil
         let retiring = retiringWorkspaceId
 
-        // Disable portal rendering for the retiring workspace BEFORE clearing
-        // retiringWorkspaceId. Once cleared, reconcileMountedWorkspaceIds unmounts
-        // the workspace — but dismantleNSView intentionally doesn't hide portal views
-        // during transient rebuilds. Disabling here also cancels stale layout follow-up
-        // loops that could re-show an old terminal above the newly selected workspace.
+        // Disable before clearing retiringWorkspaceId: unmount teardown does not
+        // hide portals during transient rebuilds or cancel stale layout follow-ups.
         if let retiring, let workspace = tabManager.tabs.first(where: { $0.id == retiring }) {
             workspace.setPortalRenderingEnabled(false, reason: "workspaceHandoff")
+            lastReconciledPortalRenderingStatesByWorkspaceId[workspace.id] = false
         }
 
         retiringWorkspaceId = nil


### PR DESCRIPTION
## Summary

- Avoid reapplying portal-rendering state to every workspace on each workspace-switch mount reconciliation.
- Track the last portal-rendering state reconciled by `ContentView` and only call `setPortalRenderingEnabled` for workspaces whose desired state changed.
- Add focused coverage for the new reconciliation planner so already-disabled workspaces do not repeat portal-hide work on later switches.

## Evidence

Reproduced against the already-running `/Applications/cmux.app` without building a dev app.

Fixture:
- `workspace:205`: 1 terminal surface.
- `workspace:207`: 12 terminal surfaces.
- Repeated `cmux select-workspace --window window:1` between the two already-open workspaces.

Observed pre-fix CLI wall time:
- Switching from 12 terminal surfaces to the one-surface workspace: median `752.521 ms`, mean `767.426 ms`, p90 `818.444 ms`.
- Switching from the one-surface workspace back to 12 terminal surfaces: median `204.406 ms`, mean `197.117 ms`, p90 `238.931 ms`.

The local direction differs from the issue wording: the cost showed up while retiring/unmounting the many-surface workspace. The product effect is the same repeated toggle latency involving already-open large workspaces.

Source inspection mapped that repeated cost to `ContentView.reconcileMountedWorkspaceIds`, which called `setPortalRenderingEnabled(false)` for every unmounted workspace every reconciliation. That method clears layout follow-up and hides every terminal/browser portal for the workspace even if it was already disabled, so the work repeats with the number of portal-backed surfaces.

A `sample` capture was attempted during switching, but the release app produced an empty call graph after thread-state sampling failures, so it is not used as hotspot proof.

## Validation

- `git diff --check`
- Not run: local tests or builds, per task instruction. CI should run the added unit coverage.

## Notes

A true failing-first UI/performance regression test was not practical without adding a test seam around AppKit portal side effects. The added unit tests cover the new bounded reconciliation policy rather than pretending to measure UI latency in unit tests.

No user-facing strings were added or changed, so no localization files were updated.

Closes #7226

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785644090&installation_id=133855650&pr_number=7231&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7231&signature=50c67167d406d2479856ece4386f8d99e0ab01f2b4e6dd323eb1a6deeb233ac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates repeated portal hide/show during workspace switches by tracking per-workspace portal state and applying only deltas in stable tab order. Persists the state across handoff to cut switch latency, addressing #7226.

- **Bug Fixes**
  - Added `WorkspacePortalRenderingPlan` and `WorkspacePortalRenderingChange` to compute enable/disable deltas and the next-state snapshot.
  - Updated `ContentView` to use `WorkspacePortalRenderingPlan(...).applying(to:)`, apply only returned changes in `orderedTabIds` order, and persist `lastReconciledPortalRenderingStatesByWorkspaceId` (set to `false` during handoff for the retiring workspace).
  - Added tests for one-time disable on initial unmount, reporting only mount transitions, advancing the previous-state snapshot, and tolerating duplicate ordered workspace IDs.

<sup>Written for commit c8d79156ca3e88bdc528728798ab413a2183a53d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workspace portal-rendering reconciliation plan that applies only required enable/disable updates.
  * Persist the last reconciled portal-rendering enabled state per workspace to maintain consistent behavior across mount/unmount cycles.
* **Bug Fixes**
  * Avoids repeated hide/show actions when a workspace’s portal-rendering state hasn’t changed.
  * Improves mount/selection transitions and prevents stale workspaces from being reported for updates.
* **Tests**
  * Added unit tests validating change computation and snapshot reconciliation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->