### PR TITLE
Fix iOS chat keyboard bottom underlap

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatKeyboardTrackingViewController.swift
@@ -331,10 +331,7 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
             bottomSafeAreaUnderlap: safeAreaUnderlap
         )
         let adjustedBottomInset = overlayBottomInset + keyboardOverlap
-        let clipBottomConstant = transcriptClipBottomConstant(
-            composerHeight: composerHeight,
-            bottomSafeAreaUnderlap: safeAreaUnderlap
-        )
+        let clipBottomConstant = transcriptClipBottomConstant(bottomSafeAreaUnderlap: safeAreaUnderlap)
         let fullTranscriptHeight = max(0, layoutHeight)
         updateConstraint(composerHeightConstraint, to: composerHeight)
         updateConstraint(transcriptClipTopConstraint, to: 0)
@@ -393,14 +390,15 @@ final class ChatKeyboardTrackingViewController<Transcript: View, Composer: View>
         return max(0, ceil(visibleComposerHeight + bottomSafeAreaUnderlap))
     }
 
-    private func transcriptClipBottomConstant(
-        composerHeight: CGFloat,
-        bottomSafeAreaUnderlap: CGFloat
-    ) -> CGFloat {
+    private func transcriptClipBottomConstant(bottomSafeAreaUnderlap: CGFloat) -> CGFloat {
         guard keyboardOverlap > 0.5 else {
             return max(0, ceil(bottomSafeAreaUnderlap))
         }
-        return -max(0, ceil(keyboardOverlap + composerHeight))
+        // The composer follows the full keyboard reservation. The transcript
+        // clip stops at the visual keyboard chrome so bottom chrome can overlay
+        // live rows without letting rows enter the key plane.
+        let visualKeyboardChromeOverlap = max(0, keyboardOverlap - bottomSafeAreaUnderlap)
+        return -ceil(visualKeyboardChromeOverlap)
     }
 
     private func updateConstraint(_ constraint: NSLayoutConstraint?, to constant: CGFloat) {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -979,9 +979,14 @@ final class cmuxUITests: XCTestCase {
         )
         XCTAssertEqual(
             keyboardUp.presentationFrameMaxY,
-            keyboardUp.composerPresentationMinY,
+            keyboardUp.effectiveFrameMaxY,
             accuracy: 4,
-            "Video evidence setup must have the visible transcript bottom flush to the visible composer top with the keyboard up. \(keyboardUp)"
+            "Video evidence setup must clip the visible transcript bottom to the keyboard top with the keyboard up. \(keyboardUp)"
+        )
+        XCTAssertGreaterThan(
+            keyboardUp.presentationFrameMaxY,
+            keyboardUp.composerPresentationMinY + 24,
+            "Video evidence setup must have visible transcript content underneath the composer chrome with the keyboard up. \(keyboardUp)"
         )
         XCTAssertEqual(
             keyboardUp.visibleBottomY,
@@ -1460,11 +1465,18 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(table.waitForExistence(timeout: 8))
         let composerBar = app.otherElements["ChatComposerBar"]
         XCTAssertTrue(composerBar.waitForExistence(timeout: 8))
+        let composerField = chatComposerField(in: app)
+        XCTAssertTrue(composerField.waitForExistence(timeout: 8))
+        dismissChatKeyboard(in: app, table: table)
 
         let metrics = try waitForTranscriptMetrics(table, timeout: 8) {
             $0.frameHeight > 240
                 && $0.contentHeight > $0.boundsHeight * 1.6
                 && $0.composerOverlayBottomInset > 40
+                && self.isKeyboardDownClipSettled($0)
+                && !$0.scrollTracking
+                && !$0.scrollDragging
+                && !$0.scrollDecelerating
         }
         let windowFrame = app.windows.firstMatch.frame
         XCTAssertGreaterThanOrEqual(
@@ -1493,6 +1505,69 @@ final class cmuxUITests: XCTestCase {
             metrics.composerOverlayBottomInset,
             accuracy: 4,
             "The adjusted transcript inset must equal the physical composer clearance. A larger value double-counts the device bottom safe area. metrics=\(metrics) composer=\(composerBar.frame)"
+        )
+
+        let richMetrics = try scrollToRichAgentChatFixtureRegion(table: table, app: app)
+        let animationSamples = focusTextInputAndSampleTranscriptAnimation(
+            composerField,
+            table: table,
+            composerBar: composerBar,
+            in: app,
+            frameCapturePrefix: "bottom-edge-rich-keyboard"
+        )
+        assertChatKeyboardAnimationStayedAttached(
+            animationSamples,
+            scrollPosition: "bottom edge rich transcript"
+        )
+        let afterKeyboard = try waitForTranscriptMetrics(table, timeout: 6) {
+            $0.keyboardOverlap > 120
+                && $0.bottomEdgeEffectSoft
+                && $0.bottomEdgeElementContainerRegistered
+                && $0.topContentScrollViewRegistered
+                && self.isKeyboardUpClipSettled($0)
+        }
+        guard let keyboardSnapshot = softwareKeyboardSnapshotAfterFocus(
+            in: app,
+            overlap: afterKeyboard.keyboardOverlap
+        ) else {
+            return
+        }
+        let keyboardFrame = keyboardSnapshot.frame
+        let underlapCellFrame = try waitForTranscriptCellUnderlappingBottomChrome(
+            table: table,
+            composerBar: composerBar,
+            keyboardFrame: keyboardFrame
+        )
+        let keyboardUpAttachment = XCTAttachment(
+            string: "rich=\(richMetrics)\nafter=\(afterKeyboard)\nkeyboard=\(keyboardSnapshot)\nunderlapCellFrame=\(underlapCellFrame)\nsamples=\(animationSamples)"
+        )
+        keyboardUpAttachment.name = "bottom-edge-rich-keyboard-up-metrics"
+        keyboardUpAttachment.lifetime = .keepAlways
+        add(keyboardUpAttachment)
+        let screenshotAttachment = XCTAttachment(screenshot: app.screenshot())
+        screenshotAttachment.name = "bottom-edge-rich-keyboard-up-screenshot"
+        screenshotAttachment.lifetime = .keepAlways
+        add(screenshotAttachment)
+        XCTAssertLessThanOrEqual(
+            afterKeyboard.presentationFrameMaxY,
+            keyboardFrame.minY + 2,
+            "Keyboard-up bottom scroll-edge verification must not let transcript rows render under the keyboard key plane. after=\(afterKeyboard) keyboard=\(keyboardFrame) underlapCell=\(underlapCellFrame)"
+        )
+        XCTAssertGreaterThanOrEqual(
+            afterKeyboard.presentationFrameMaxY,
+            keyboardFrame.minY - 16,
+            "Keyboard-up bottom scroll-edge verification must keep transcript clipping visually adjacent to the keyboard so live rows continue underneath the shortcut/composer chrome instead of ending at a hard composer-top edge. after=\(afterKeyboard) keyboard=\(keyboardFrame) underlapCell=\(underlapCellFrame)"
+        )
+        XCTAssertGreaterThan(
+            afterKeyboard.presentationFrameMaxY,
+            afterKeyboard.composerPresentationMinY + 24,
+            "Keyboard-up transcript clipping must extend below the composer top. Clipping flush to the composer recreates the hard horizontal edge above bottom chrome. after=\(afterKeyboard) keyboard=\(keyboardFrame) underlapCell=\(underlapCellFrame)"
+        )
+        XCTAssertEqual(
+            afterKeyboard.adjustedBottomInset,
+            afterKeyboard.composerOverlayBottomInset + afterKeyboard.keyboardOverlap,
+            accuracy: 6,
+            "Keyboard-up transcript inset must equal composer overlay plus real keyboard overlap. after=\(afterKeyboard)"
         )
     }
 
@@ -1557,6 +1632,7 @@ final class cmuxUITests: XCTestCase {
         let afterKeyboard = try waitForTranscriptMetrics(table, timeout: 6) {
             $0.keyboardOverlap > 120
                 && $0.presentationFrameMaxY < beforeKeyboard.presentationFrameMaxY - 120
+                && self.isKeyboardUpClipSettled($0)
         }
         let metricsAttachment = XCTAttachment(
             string: "scrollPosition=\(scrollPosition)\nbefore=\(beforeKeyboard)\nafter=\(afterKeyboard)"
@@ -1632,8 +1708,15 @@ final class cmuxUITests: XCTestCase {
         )
         XCTAssertLessThanOrEqual(
             afterKeyboard.presentationFrameMaxY,
-            keyboardFrame.minY - 44,
-            "Transcript table effective visible bottom should sit above the composer and keyboard from \(scrollPosition), not behind the keyboard. after=\(afterKeyboard) keyboard=\(keyboardFrame)",
+            keyboardFrame.minY + 8,
+            "Transcript clipping should stop at the keyboard top from \(scrollPosition), not at the composer top or below the keyboard. after=\(afterKeyboard) keyboard=\(keyboardFrame)",
+            file: file,
+            line: line
+        )
+        XCTAssertGreaterThanOrEqual(
+            afterKeyboard.presentationFrameMaxY,
+            keyboardFrame.minY - 8,
+            "Transcript clipping should reach the keyboard-adjacent region from \(scrollPosition) so bottom chrome overlays live transcript content. after=\(afterKeyboard) keyboard=\(keyboardFrame)",
             file: file,
             line: line
         )
@@ -1644,11 +1727,10 @@ final class cmuxUITests: XCTestCase {
             file: file,
             line: line
         )
-        XCTAssertEqual(
+        XCTAssertGreaterThan(
             afterKeyboard.presentationFrameMaxY,
-            afterKeyboard.composerPresentationMinY,
-            accuracy: 4,
-            "Transcript table effective visible bottom must stay flush with the visible composer host top from \(scrollPosition), with no blank band between the table content and input host. after=\(afterKeyboard) composer=\(composerBarFrame) keyboard=\(keyboardFrame)",
+            afterKeyboard.composerPresentationMinY + 24,
+            "Transcript table effective visible bottom must extend underneath the visible composer host from \(scrollPosition). Stopping flush at the composer top leaves the hard horizontal cut line. after=\(afterKeyboard) composer=\(composerBarFrame) keyboard=\(keyboardFrame)",
             file: file,
             line: line
         )
@@ -1699,21 +1781,38 @@ final class cmuxUITests: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> CGRect {
-        let keyboard = app.keyboards.firstMatch
-        if keyboard.waitForExistence(timeout: 1) {
-            return keyboard.frame
-        }
-        let windowFrame = app.windows.firstMatch.frame
-        guard overlap > 0, !windowFrame.isNull, !windowFrame.isEmpty else {
-            XCTFail("Expected a keyboard element or positive keyboard overlap. overlap=\(overlap) window=\(windowFrame)", file: file, line: line)
+        guard let snapshot = softwareKeyboardSnapshotAfterFocus(
+            in: app,
+            overlap: overlap,
+            file: file,
+            line: line
+        ) else {
             return .zero
         }
-        return CGRect(
-            x: windowFrame.minX,
-            y: windowFrame.maxY - overlap,
-            width: windowFrame.width,
-            height: overlap
-        )
+        return snapshot.frame
+    }
+
+    @MainActor
+    private func softwareKeyboardSnapshotAfterFocus(
+        in app: XCUIApplication,
+        overlap: CGFloat,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> SoftwareKeyboardSnapshot? {
+        guard overlap > 120 else {
+            XCTFail("Expected positive keyboard overlap before accepting keyboard-up evidence. overlap=\(overlap)", file: file, line: line)
+            return nil
+        }
+        guard let snapshot = waitForSoftwareKeyboardKeyPlane(
+            in: app,
+            minimumOverlap: 120,
+            timeout: 2,
+            file: file,
+            line: line
+        ) else {
+            return nil
+        }
+        return snapshot
     }
 
     /// Tapping a text field opens the system keyboard; the floating Pair
@@ -2580,7 +2679,10 @@ final class cmuxUITests: XCTestCase {
         }
 
         var effectiveFrameMaxY: CGFloat {
-            composerPresentationMinY
+            if keyboardOverlap > 0.5 {
+                return frameMaxY - keyboardOverlap
+            }
+            return frameMaxY
         }
 
         init?(_ rawValue: String) {
@@ -2655,6 +2757,17 @@ final class cmuxUITests: XCTestCase {
     private struct TimedKeyboardAction {
         let delay: TimeInterval
         let action: @MainActor () -> Void
+    }
+
+    private struct SoftwareKeyboardSnapshot: CustomStringConvertible {
+        let frame: CGRect
+        let overlap: CGFloat
+        let keyCount: Int
+        let sampleLabels: [String]
+
+        var description: String {
+            "frame=\(frame), overlap=\(overlap), keyCount=\(keyCount), sampleLabels=\(sampleLabels)"
+        }
     }
 
     @MainActor
@@ -3001,7 +3114,8 @@ final class cmuxUITests: XCTestCase {
 
     private func isKeyboardUpClipSettled(_ metrics: ChatTranscriptMetrics) -> Bool {
         metrics.keyboardOverlap > 120
-            && abs(metrics.presentationFrameMaxY - metrics.effectiveFrameMaxY) < 4
+            && metrics.presentationFrameMaxY < metrics.frameMaxY - 80
+            && metrics.presentationFrameMaxY > metrics.composerPresentationMinY + 24
     }
 
     private func isKeyboardDownClipSettled(_ metrics: ChatTranscriptMetrics) -> Bool {
@@ -3065,6 +3179,153 @@ final class cmuxUITests: XCTestCase {
             return nil
         }
         return frame
+    }
+
+    @MainActor
+    private func scrollToRichAgentChatFixtureRegion(
+        table: XCUIElement,
+        app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> ChatTranscriptMetrics {
+        let imageAttachment = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label CONTAINS %@", "ci-failure.png"))
+            .firstMatch
+        let cardElements = [
+            app.buttons["ChatQuestionOption0"],
+            app.buttons["ChatPermissionApprove"],
+            app.buttons["ChatToolUseToggle-msg-fixture-4"],
+            app.buttons["ChatTerminalToggle-msg-fixture-6"],
+        ]
+        let deadline = Date().addingTimeInterval(10)
+        var lastMetrics: ChatTranscriptMetrics?
+
+        while Date() < deadline {
+            if let metrics = transcriptMetrics(from: table) {
+                lastMetrics = metrics
+            }
+            if imageAttachment.exists,
+               cardElements.contains(where: { $0.exists }),
+               let metrics = lastMetrics,
+               metrics.contentHeight > metrics.boundsHeight * 1.6 {
+                let attachment = XCTAttachment(screenshot: app.screenshot())
+                attachment.name = "rich-agent-chat-fixture-region"
+                attachment.lifetime = .keepAlways
+                add(attachment)
+                return metrics
+            }
+            table.swipeDown(velocity: .slow)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.12))
+        }
+
+        let message = "Timed out scrolling to rich agent-chat fixture content. imageExists=\(imageAttachment.exists), cardExists=\(cardElements.contains(where: { $0.exists })), lastMetrics=\(String(describing: lastMetrics))"
+        XCTFail(message, file: file, line: line)
+        throw TranscriptMetricsWaitError(description: message)
+    }
+
+    @MainActor
+    private func waitForTranscriptCellUnderlappingBottomChrome(
+        table: XCUIElement,
+        composerBar: XCUIElement,
+        keyboardFrame: CGRect,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> CGRect {
+        let deadline = Date().addingTimeInterval(14)
+        var lastCellFrames: [CGRect] = []
+        while Date() < deadline {
+            guard let composerFrame = usableFrameNow(of: composerBar) else {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+                continue
+            }
+            let underlapRegion = composerFrame.intersection(CGRect(
+                x: composerFrame.minX,
+                y: composerFrame.minY,
+                width: composerFrame.width,
+                height: max(0, keyboardFrame.minY - composerFrame.minY)
+            ))
+            let cells = table.cells.allElementsBoundByIndex
+            lastCellFrames = cells.suffix(10).compactMap { cell in
+                usableFrameNow(of: cell)
+            }
+            if let frame = lastCellFrames.first(where: { cellFrame in
+                let overlap = cellFrame.intersection(underlapRegion)
+                return !overlap.isNull
+                    && !overlap.isEmpty
+                    && overlap.height >= 12
+                    && overlap.width >= min(80, underlapRegion.width * 0.25)
+            }) {
+                return frame
+            }
+            table.swipeDown(velocity: .slow)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.12))
+        }
+
+        let message = "Expected a real transcript cell to underlap the keyboard-up shortcut/composer chrome. keyboard=\(keyboardFrame), composer=\(String(describing: usableFrameNow(of: composerBar))), lastCellFrames=\(lastCellFrames)"
+        XCTFail(message, file: file, line: line)
+        throw TranscriptMetricsWaitError(description: message)
+    }
+
+    @MainActor
+    private func waitForSoftwareKeyboardKeyPlane(
+        in app: XCUIApplication,
+        minimumOverlap: CGFloat,
+        timeout: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> SoftwareKeyboardSnapshot? {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastSnapshot: SoftwareKeyboardSnapshot?
+        while Date() < deadline {
+            if let snapshot = softwareKeyboardSnapshot(in: app) {
+                lastSnapshot = snapshot
+                if snapshot.overlap >= minimumOverlap,
+                   snapshot.frame.height > 120,
+                   snapshot.keyCount >= 10 {
+                    return snapshot
+                }
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        XCTFail(
+            "Expected a visible software keyboard key plane. minimumOverlap=\(minimumOverlap), lastSnapshot=\(String(describing: lastSnapshot)), keyboard=\(app.keyboards.firstMatch.debugDescription)",
+            file: file,
+            line: line
+        )
+        return nil
+    }
+
+    @MainActor
+    private func softwareKeyboardSnapshot(in app: XCUIApplication) -> SoftwareKeyboardSnapshot? {
+        let keyboard = app.keyboards.firstMatch
+        guard keyboard.exists,
+              let keyboardFrame = usableFrameNow(of: keyboard) else {
+            return nil
+        }
+        let windowFrame = app.windows.firstMatch.frame
+        guard !windowFrame.isNull,
+              !windowFrame.isEmpty,
+              !windowFrame.origin.x.isNaN,
+              !windowFrame.origin.y.isNaN,
+              !windowFrame.width.isNaN,
+              !windowFrame.height.isNaN else {
+            return nil
+        }
+        let visibleKeys = keyboard.keys.allElementsBoundByIndex.filter { key in
+            guard key.exists,
+                  let keyFrame = usableFrameNow(of: key) else {
+                return false
+            }
+            return keyFrame.intersects(keyboardFrame)
+        }
+        let sampleLabels = visibleKeys.prefix(8).map(\.label).filter { !$0.isEmpty }
+        return SoftwareKeyboardSnapshot(
+            frame: keyboardFrame,
+            overlap: max(0, windowFrame.maxY - keyboardFrame.minY),
+            keyCount: visibleKeys.count,
+            sampleLabels: sampleLabels
+        )
     }
 
     private enum TranscriptScrollDirection {


### PR DESCRIPTION
## Summary
- clip the iOS agent chat transcript to the visual keyboard boundary while keeping inset space for the composer overlay
- expand the keyboard-up UI regression to require a real chat row under the shortcut/composer chrome without entering the keyboard key plane

## Verification
- `NSUnbufferedIO=YES xcodebuild test -workspace ios/cmux.xcworkspace -scheme cmux-ios -destination id=34B7BA42-0219-4BFA-A6A2-3DA1EC4B7DBA -derivedDataPath /tmp/cmux-ios-hardedge-7200f2-dd -only-testing:cmuxUITests/cmuxUITests/testAgentChatBottomScrollEdgeUnderlapsDeviceBottom -resultBundlePath cmux-assets/task-ios-toolbar-regression/verify-implementation-hard-edge/focused-test-pass3.xcresult`
- `$verify-implementation` approved by final verifier Zeno with artifact page at `cmux-assets/task-ios-toolbar-regression/verify-implementation-hard-edge/index.html`

## Dogfood
- mac tag: `edge3`
- iOS simulator tag: `edge3`
- physical iPhone reload unavailable because `devicectl` reported device tunnel unavailable`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785644262&installation_id=133855650&pr_number=7233&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7233&signature=f9dd0dcdcd5de56e2c02997b192d1a9e1a56be3f23f2b0c4016c5c54555f0043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS chat transcript underlap with the software keyboard. The transcript now clips to the keyboard’s visual top while preserving the composer overlay inset, removing the hard edge and keeping live rows under the bottom chrome.

- **Bug Fixes**
  - In `CmuxAgentChatUI`’s `ChatKeyboardTrackingViewController`, base the transcript bottom clip on `keyboardOverlap - bottomSafeAreaUnderlap` (drop composer height) so rows never enter the key plane. Keep the adjusted bottom inset equal to composer overlay inset + `keyboardOverlap` to avoid safe-area double counting.
  - Strengthen `cmuxUITests`: detect and snapshot the real software keyboard key plane, treat `effectiveFrameMaxY` as the keyboard-top bound, verify clipping stays near the keyboard top and at least 24px below the composer top, require a real transcript cell under the shortcuts/composer chrome, and assert the transcript stays attached during keyboard show/hide.

<sup>Written for commit 28b8fab97c99a19d429f5a12ddff579ce0742523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced chat keyboard tracking so transcript clipping and underlap behave more consistently as the keyboard animates.

* **Bug Fixes**
  * Refined transcript clipping/geometry calculations and improved “settled” behavior during keyboard transitions.
  * Improved bottom scroll-edge alignment by tightening inset/clipping assertions relative to keyboard and composer overlap.

* **Tests**
  * Strengthened iOS UI regression coverage with stricter keyboard-settling predicates, tighter clipping bounds, and richer screenshot/metrics evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->