### PR TITLE
Fix nightly updater pill install retry

### DIFF
--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
@@ -34,6 +34,10 @@ struct AttemptUpdateCoordinator {
         /// A fresh check was requested. The prompt that was on screen when the user asked may be
         /// stale, so ignore any lingering `.updateAvailable` until the check actually restarts.
         case awaitingCheckRestart
+        /// The stale prompt has been dismissed, but Sparkle has not yet surfaced the fresh
+        /// `.checking` state. Duplicate idle notifications in this window are still part of the
+        /// restart path, not a user cancellation.
+        case awaitingCheckStart
         /// The check has restarted; install the next update it resolves.
         case awaitingResult
     }
@@ -75,13 +79,31 @@ struct AttemptUpdateCoordinator {
                 // Still the pre-request prompt (or a coalesced repeat of it); keep waiting for the
                 // fresh check to actually start before trusting an `.updateAvailable`.
                 return .none
-            case .idle, .checking, .downloading, .extracting, .installing, .permissionRequest:
-                // The check has restarted (or the stale prompt was cleared). Confirm whatever it
-                // resolves next.
+            case .idle:
+                // The stale prompt was cleared. Sparkle can emit another idle notification before
+                // the fresh check starts (#7235), so do not treat idle as cancellation yet.
+                phase = .awaitingCheckStart
+                return .none
+            case .checking, .downloading, .extracting, .installing, .permissionRequest:
+                // The check has restarted. Confirm whatever it resolves next.
                 phase = .awaitingResult
                 return .none
             case .notFound, .error:
                 // The fresh check ended without an update; stop coordinating.
+                phase = .inactive
+                return .none
+            }
+
+        case .awaitingCheckStart:
+            switch state {
+            case .idle, .updateAvailable:
+                // Duplicate idle/stale-available emissions can arrive while Sparkle is tearing
+                // down the dismissed prompt. Keep waiting for the fresh check to begin.
+                return .none
+            case .checking, .downloading, .extracting, .installing, .permissionRequest:
+                phase = .awaitingResult
+                return .none
+            case .notFound, .error:
                 phase = .inactive
                 return .none
             }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
@@ -57,6 +57,23 @@ import Testing
         #expect(!coordinator.isMonitoring)
     }
 
+    /// Regression for #7235: dismissing the stale Sparkle prompt can emit an idle state from
+    /// Sparkle's dismissal callback and then another idle state from cmux's reset path. The second
+    /// idle is still before the fresh check starts, so it must not cancel the install attempt.
+    @Test func duplicateIdleDismissSignalsBeforeFreshCheckDoNotCancelAttempt() {
+        var coordinator = AttemptUpdateCoordinator()
+        _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
+
+        #expect(coordinator.handleStateChange(.idle) == .none)
+        #expect(coordinator.isMonitoring)
+        #expect(coordinator.handleStateChange(.idle) == .none)
+        #expect(coordinator.isMonitoring)
+
+        #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
+        #expect(coordinator.handleStateChange(updateAvailable("0.64.16")) == .confirmInstall)
+        #expect(!coordinator.isMonitoring)
+    }
+
     /// A lingering repeat of the pre-request prompt (before the fresh check actually restarts) must
     /// be ignored, so we never confirm the stale version even if Sparkle re-emits it.
     @Test func ignoresStalePromptUntilCheckRestarts() {


### PR DESCRIPTION
## Summary
- Confirmed the live nightly repro against the updater state machine: `attemptUpdate()` dismisses the stale Sparkle prompt, but two idle notifications can arrive before the fresh check reaches `.checking`; the second idle stopped auto-confirm monitoring.
- Added a focused failing coordinator regression for the double-idle sequence first.
- Kept the install attempt alive until the fresh check actually starts, so the newly resolved update can be confirmed and downloaded.

## Validation
- Not run locally per task instructions; CI is the validation path.
- Cloud/visual repro not used because the provided live logs map directly to a deterministic coordinator state-machine path.

Fixes #7235

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785645423&installation_id=133855650&pr_number=7237&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7237&signature=9935b3253764a672056be96cea4a3761c2579075ab27783c9e297830f2c780f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the nightly updater where duplicate idle signals after dismissing a stale Sparkle prompt canceled auto-confirm. The install attempt now stays active through double idle until the fresh check reaches `.checking`, so the update is confirmed and downloaded. Fixes #7235.

- **Bug Fixes**
  - Added an `awaitingCheckStart` phase in `AttemptUpdateCoordinator` to ignore duplicate `.idle` and stale `.updateAvailable` events until the fresh check starts.
  - Added a regression test for the double-idle sequence to ensure the attempt proceeds to confirm and download the next update.

<sup>Written for commit 3a0b7a97e26870b29daa166a7f96b8121d655f94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update flow reliability during the restart window by better handling stale update prompt signals from Sparkle.
  - Updated the coordination logic so duplicate “idle” (and related) emissions in the interim no longer interrupt an active install attempt.
  - Added safeguards so the coordinator waits for the fresh update check to truly begin before proceeding.
- **Tests**
  - Added a regression test for the duplicate-dismiss-and-recheck scenario to prevent recurrence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->