### PR TITLE
Remove chat shortcut row hard stop

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Composer/ChatAccessoryChipRow.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Composer/ChatAccessoryChipRow.swift
@@ -7,7 +7,6 @@ import UIKit
 
 /// The horizontal shortcut row above the composer field.
 public struct ChatAccessoryChipRow: View {
-    private static let scrollLeadingHardStopWidth: CGFloat = 14
     private static let scrollTrailingFadeWidth: CGFloat = 34
 
     private let agentState: ChatAgentState
@@ -78,7 +77,6 @@ public struct ChatAccessoryChipRow: View {
             .onGeometryChange(for: CGFloat.self, of: { $0.size.width }) { width in
                 scrollContentWidth = width
             }
-            .padding(.leading, usesLeadingHardStop ? Self.scrollLeadingHardStopWidth : 0)
             .padding(.trailing, scrollNeedsTrailingFade ? Self.scrollTrailingFadeWidth : 2)
         }
         .frame(height: 32)
@@ -90,11 +88,6 @@ public struct ChatAccessoryChipRow: View {
         .clipShape(.rect)
         .mask {
             scrollTrailingFadeMask
-        }
-        .overlay(alignment: .leading) {
-            if usesLeadingHardStop {
-                scrollLeadingHardStop
-            }
         }
     }
 
@@ -123,15 +116,7 @@ public struct ChatAccessoryChipRow: View {
     }
 
     private var scrollNeedsTrailingFade: Bool {
-        scrollContentWidth + scrollLeadingInset + 2 > scrollViewportWidth + 1
-    }
-
-    private var usesLeadingHardStop: Bool {
-        !displayedLeadingShortcuts.isEmpty
-    }
-
-    private var scrollLeadingInset: CGFloat {
-        usesLeadingHardStop ? Self.scrollLeadingHardStopWidth : 0
+        scrollContentWidth + 2 > scrollViewportWidth + 1
     }
 
     private var stopShortcut: ChatAccessoryShortcut {
@@ -203,26 +188,6 @@ public struct ChatAccessoryChipRow: View {
         } else {
             Text(shortcut.title)
         }
-    }
-
-    private var scrollLeadingHardStop: some View {
-        Rectangle()
-            .fill(scrollHardStopFill)
-            .frame(width: Self.scrollLeadingHardStopWidth)
-            .overlay(alignment: .trailing) {
-                Rectangle()
-                    .fill(Color.primary.opacity(0.16))
-                    .frame(width: 0.5)
-            }
-            .allowsHitTesting(false)
-    }
-
-    private var scrollHardStopFill: Color {
-        #if os(iOS)
-        Color(uiColor: .systemBackground)
-        #else
-        Color.black
-        #endif
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Remove the fixed leading hard-stop overlay from the iOS agent chat shortcut row.
- Let the shortcut scroll region clip naturally next to the attachment/mic controls, preserving the trailing fade only when content overflows.

## Root cause
The row painted a 14pt `systemBackground` rectangle over the leading edge of the scroll view whenever fixed leading controls were present. On top of the keyboard/composer glass material, that solid fill could render as the black vertical block seen between the controls and shortcut row.

## Validation
- `swift test --package-path Packages/iOS/CmuxAgentChatUI`
- `xcodebuild -scheme CmuxAgentChatUI -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/cmux-ios-shortcut-gap-agentchatui build`
- `git diff --check HEAD~1..HEAD`
- localized-string audit, no user-facing strings added
- `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `./scripts/reload.sh --tag sgap`
- `./ios/scripts/reload.sh --tag sgap --simulator cmux-sgap-se-77315 --no-launch --no-setup`
- `./ios/scripts/reload.sh --tag sgap --simulator cmux-sgap-pro-77315 --no-launch --no-setup`
- `xcodebuild test -workspace ios/cmux.xcworkspace -scheme cmux-ios -destination 'platform=iOS Simulator,id=7EAD0EEE-933A-4D17-8F24-B6DD29DFBD1D' -only-testing:cmuxUITests/cmuxUITests/testAgentChatTranscriptKeepsTopEdgeVisibleWithKeyboardAcrossScrollPositions -derivedDataPath /tmp/cmux-ios-sgap-motion -resultBundlePath out/verify-sgap/fresh-motion/xcresult/pro-keyboard-tap.xcresult`

## Evidence
Rendered proof comment: https://github.com/manaflow-ai/cmux/pull/7241#issuecomment-4877711902

Artifact branch: https://github.com/manaflow-ai/cmux/tree/artifact-pr-7241-shortcut-gap

HTML proof file: https://raw.githubusercontent.com/manaflow-ai/cmux/artifact-pr-7241-shortcut-gap/index.html

Simulator screenshots and XCUITest attachments were captured from commit `d3caf5bab1`. SE and Pro keyboard-up screenshots show the previously bad region without the black block. The passing tap-based UI test captured bottom/middle/top keyboard-up states after real `ChatComposerField` taps, with metrics moving from `keyboardOverlap=0.0` to `keyboardOverlap=301.0` and `presentationGap=0.0`.

Raw proof files:
- https://raw.githubusercontent.com/manaflow-ai/cmux/artifact-pr-7241-shortcut-gap/screenshots/se-keyboard-up.png
- https://raw.githubusercontent.com/manaflow-ai/cmux/artifact-pr-7241-shortcut-gap/screenshots/pro-keyboard-up.png
- https://raw.githubusercontent.com/manaflow-ai/cmux/artifact-pr-7241-shortcut-gap/screenshots/pro-bottom-keyboard.png
- https://raw.githubusercontent.com/manaflow-ai/cmux/artifact-pr-7241-shortcut-gap/screenshots/pro-middle-keyboard.png
- https://raw.githubusercontent.com/manaflow-ai/cmux/artifact-pr-7241-shortcut-gap/screenshots/pro-top-keyboard.png
- https://raw.githubusercontent.com/manaflow-ai/cmux/artifact-pr-7241-shortcut-gap/media/tap-toggle-overlap-contact-sheet.png
- https://raw.githubusercontent.com/manaflow-ai/cmux/artifact-pr-7241-shortcut-gap/metrics/pro-bottom.txt
- https://raw.githubusercontent.com/manaflow-ai/cmux/artifact-pr-7241-shortcut-gap/metrics/pro-middle.txt
- https://raw.githubusercontent.com/manaflow-ai/cmux/artifact-pr-7241-shortcut-gap/metrics/pro-top.txt
