### PR TITLE
Keep remote workspace ports across transient empty scans

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -162,7 +162,7 @@
 664	Sources/CmuxTopSnapshot.swift
 663	Sources/PortScanner.swift
 660	Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridInputCatchUpTests.swift
-655	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+658	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
@@ -192,7 +192,7 @@
 590	Sources/Panels/BrowserNavigationDelegate.swift
 589	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
 588	cmuxTests/CommandPaletteShortcutCustomizationTests.swift
-586	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+PortScan.swift
+621	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+PortScan.swift
 586	Sources/JSONCParser.swift
 585	Sources/Cloud/VMClient.swift
 583	cmuxTests/GhosttyTerminalStartupEnvironmentTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -162,7 +162,7 @@
 664	Sources/CmuxTopSnapshot.swift
 663	Sources/PortScanner.swift
 660	Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridInputCatchUpTests.swift
-658	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+666	Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+PortScan.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+PortScan.swift
@@ -11,6 +11,15 @@ public import Foundation
 extension RemoteSessionCoordinator {
     static let remotePortScanCoalesceDelayMilliseconds = 200
 
+    /// How many consecutive empty scans a panel's last-known ports survive
+    /// before they are cleared. The TTY-scoped scan attributes ports through
+    /// the emitting process's controlling TTY, which races under load and can
+    /// momentarily report no port for a still-listening server; retaining the
+    /// last-known ports across a few such misses stops the sidebar port badge
+    /// from flickering, while a port that stays gone past the limit still
+    /// clears.
+    static let remotePortScanEmptyRetentionLimit = 2
+
     /// Replaces the tracked panel-to-TTY map (from shell integration) on the
     /// coordinator queue; panels whose TTY changed lose their scanned ports.
     public func updateRemotePortScanTTYs(_ ttyNames: [UUID: String]) {
@@ -80,6 +89,7 @@ extension RemoteSessionCoordinator {
         cancelBootstrapRemoteTTYRetryLocked()
         bootstrapRemoteTTYRetryCount = 0
         remoteScannedPortsByPanel.removeAll()
+        remotePortScanEmptyMissByPanel.removeAll()
         stopRemotePortPollingLocked()
         polledRemotePorts = []
         remotePortPollBaselinePorts = nil
@@ -215,19 +225,44 @@ extension RemoteSessionCoordinator {
         let ttyNamesByPanel = remotePortScanTTYNames
         guard !ttyNamesByPanel.isEmpty else {
             remoteScannedPortsByPanel.removeAll()
+            remotePortScanEmptyMissByPanel.removeAll()
             keepPolledRemotePortsUntilTTYScan = false
             publishPortsSnapshotLocked()
             return
         }
 
         do {
-            remoteScannedPortsByPanel = try scanRemotePortsByPanelLocked(ttyNamesByPanel: ttyNamesByPanel)
+            let scanned = try scanRemotePortsByPanelLocked(ttyNamesByPanel: ttyNamesByPanel)
+            remoteScannedPortsByPanel = retainingTransientEmptyScansLocked(scanned)
             keepPolledRemotePortsUntilTTYScan = false
             polledRemotePorts = []
             publishPortsSnapshotLocked()
         } catch {
             debugLog("remote.ports.scan.failed error=\(error.localizedDescription) \(debugConfigSummary())")
         }
+    }
+
+    /// Reconciles a fresh scan against the last-known ports so the best-effort
+    /// TTY attribution's transient misses don't drop a still-listening port. A
+    /// panel that scans non-empty adopts the fresh ports; a panel that scans
+    /// empty keeps its previous ports until it has been empty more than
+    /// `remotePortScanEmptyRetentionLimit` scans in a row, then clears.
+    private func retainingTransientEmptyScansLocked(_ scanned: [UUID: [Int]]) -> [UUID: [Int]] {
+        var reconciled: [UUID: [Int]] = [:]
+        var misses: [UUID: Int] = [:]
+        for (panelId, ports) in scanned {
+            if !ports.isEmpty {
+                reconciled[panelId] = ports
+                continue
+            }
+            let previous = remoteScannedPortsByPanel[panelId] ?? []
+            let missCount = (remotePortScanEmptyMissByPanel[panelId] ?? 0) + 1
+            guard !previous.isEmpty, missCount <= Self.remotePortScanEmptyRetentionLimit else { continue }
+            reconciled[panelId] = previous
+            misses[panelId] = missCount
+        }
+        remotePortScanEmptyMissByPanel = misses
+        return reconciled
     }
 
     private func scanRemotePortsByPanelLocked(ttyNamesByPanel: [UUID: String]) throws -> [UUID: [Int]] {

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -83,9 +83,15 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
     var reverseRelayControlMasterForwardSpec: String?
     var cliRelayServer: RemoteCLIRelayServer?
     var remotePortScanTTYNames: [UUID: String] = [:]
+    /// Last-known listening ports per panel. To absorb the TTY attribution's
+    /// transient misses (`retainingTransientEmptyScansLocked`) this may lag the
+    /// most recent physical scan by up to `remotePortScanEmptyRetentionLimit`
+    /// scans, so it is not always a faithful view of the last scan. Kept in sync
+    /// with `remotePortScanEmptyMissByPanel`: every site that clears one clears
+    /// the other.
     var remoteScannedPortsByPanel: [UUID: [Int]] = [:]
-    /// Consecutive empty-scan count per panel, used to retain a panel's
-    /// last-known ports across the TTY attribution's transient misses.
+    /// Consecutive empty-scan count per panel backing the retention above.
+    /// Cleared wherever `remoteScannedPortsByPanel` is cleared.
     var remotePortScanEmptyMissByPanel: [UUID: Int] = [:]
     var remotePortScanBurstActive = false
     var remotePortScanActiveReason: PortScanKickReason?
@@ -259,6 +265,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
         remotePortScanPendingReason = nil
         remotePortScanTTYNames.removeAll()
         remoteScannedPortsByPanel.removeAll()
+        remotePortScanEmptyMissByPanel.removeAll()
         stopRemotePortPollingLocked()
         polledRemotePorts = []
         remotePortPollBaselinePorts = nil
@@ -456,6 +463,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             remotePortScanPendingReason = nil
             cancelRemotePortScanCoalesceLocked()
             remoteScannedPortsByPanel.removeAll()
+            remotePortScanEmptyMissByPanel.removeAll()
             stopRemotePortPollingLocked()
             polledRemotePorts = []
             keepPolledRemotePortsUntilTTYScan = false

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -84,6 +84,9 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
     var cliRelayServer: RemoteCLIRelayServer?
     var remotePortScanTTYNames: [UUID: String] = [:]
     var remoteScannedPortsByPanel: [UUID: [Int]] = [:]
+    /// Consecutive empty-scan count per panel, used to retain a panel's
+    /// last-known ports across the TTY attribution's transient misses.
+    var remotePortScanEmptyMissByPanel: [UUID: Int] = [:]
     var remotePortScanBurstActive = false
     var remotePortScanActiveReason: PortScanKickReason?
     var remotePortScanPendingReason: PortScanKickReason?

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemotePortScanRetentionTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemotePortScanRetentionTests.swift
@@ -70,6 +70,28 @@ struct RemotePortScanRetentionTests {
         coordinator.stop()
     }
 
+    @Test("Teardown clears the retained ports and the miss counter together")
+    func teardownClearsRetentionState() {
+        let runner = ScriptedProcessRunner(stdouts: ["ttys010\t3001\n", ""])
+        let host = RecordingRemoteSessionHost()
+        let coordinator = Self.makeCoordinator(runner: runner, host: host)
+        let panelId = UUID()
+
+        coordinator.queue.sync {
+            coordinator.daemonReady = true
+            coordinator.remotePortScanTTYNames = [panelId: "ttys010"]
+            coordinator.performRemotePortScanLocked()
+            coordinator.performRemotePortScanLocked()
+            #expect(coordinator.remotePortScanEmptyMissByPanel.isEmpty == false)
+
+            coordinator.stopAllLocked()
+            #expect(coordinator.remoteScannedPortsByPanel.isEmpty)
+            #expect(coordinator.remotePortScanEmptyMissByPanel.isEmpty)
+        }
+
+        coordinator.stop()
+    }
+
     private static func makeCoordinator(
         runner: RemoteSessionProcessRunning,
         host: RemoteSessionHosting

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemotePortScanRetentionTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemotePortScanRetentionTests.swift
@@ -1,0 +1,220 @@
+import Foundation
+import Testing
+import CmuxCore
+import CmuxRemoteDaemon
+import CmuxRemoteWorkspace
+@testable import CmuxRemoteSession
+
+// A TTY-scoped port scan attributes a listening port to a panel through the
+// remote process's controlling TTY (`/proc/<pid>/fd/0`). That attribution is
+// best-effort and races under load, so a scan can succeed yet report no port
+// for a panel whose server is still listening. The coordinator used to treat
+// such an empty-but-successful scan as authoritative and drop the port, which
+// made the sidebar port badge flicker and shift the surrounding rows. These
+// tests drive the queue-confined scan directly through a scripted process
+// runner (no wall-clock waits) and assert a transient empty scan keeps the
+// last-known port while a sustained absence still clears it.
+@Suite("Remote port scan retention")
+struct RemotePortScanRetentionTests {
+    @Test("A transient empty scan keeps a still-listening port")
+    func transientEmptyScanKeepsPort() {
+        let runner = ScriptedProcessRunner(stdouts: ["ttys010\t3001\n", ""])
+        let host = RecordingRemoteSessionHost()
+        let coordinator = Self.makeCoordinator(runner: runner, host: host)
+        let panelId = UUID()
+
+        coordinator.queue.sync {
+            coordinator.daemonReady = true
+            coordinator.remotePortScanTTYNames = [panelId: "ttys010"]
+            coordinator.performRemotePortScanLocked()
+        }
+        #expect(host.lastDetected == [3001])
+
+        coordinator.queue.sync {
+            coordinator.performRemotePortScanLocked()
+        }
+        #expect(
+            host.lastDetected == [3001],
+            "a single empty scan must not drop a still-listening port"
+        )
+
+        coordinator.stop()
+    }
+
+    @Test("A port absent past the retention limit is dropped")
+    func sustainedEmptyScanDropsPort() {
+        let emptyScans = [String](
+            repeating: "",
+            count: RemoteSessionCoordinator.remotePortScanEmptyRetentionLimit + 1
+        )
+        let runner = ScriptedProcessRunner(stdouts: ["ttys010\t3001\n"] + emptyScans)
+        let host = RecordingRemoteSessionHost()
+        let coordinator = Self.makeCoordinator(runner: runner, host: host)
+        let panelId = UUID()
+
+        coordinator.queue.sync {
+            coordinator.daemonReady = true
+            coordinator.remotePortScanTTYNames = [panelId: "ttys010"]
+            coordinator.performRemotePortScanLocked()
+        }
+        #expect(host.lastDetected == [3001])
+
+        for _ in emptyScans {
+            coordinator.queue.sync { coordinator.performRemotePortScanLocked() }
+        }
+        #expect(
+            host.lastDetected == [],
+            "a port that stays gone past the retention limit must clear"
+        )
+
+        coordinator.stop()
+    }
+
+    private static func makeCoordinator(
+        runner: RemoteSessionProcessRunning,
+        host: RemoteSessionHosting
+    ) -> RemoteSessionCoordinator {
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "user@example.test",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: nil,
+            relayID: nil,
+            relayToken: nil,
+            localSocketPath: nil,
+            terminalStartupCommand: nil,
+            preserveAfterTerminalExit: false,
+            persistentDaemonSlot: nil
+        )
+        return RemoteSessionCoordinator(
+            host: host,
+            configuration: configuration,
+            proxyBroker: UnusedRemoteProxyBroker(),
+            manifestRepository: RemoteDaemonManifestRepository(
+                homeDirectory: FileManager.default.temporaryDirectory
+            ),
+            processRunner: runner,
+            reachabilityProbe: NoopReachabilityProbe(),
+            relayCommandRewriter: PassthroughRelayCommandRewriter(),
+            buildInfo: StubBuildInfo(),
+            daemonStrings: RemoteDaemonStrings(
+                missingPersistentPTYCapability: "",
+                missingRequiredFunctionality: ""
+            ),
+            strings: RemoteSessionStrings(
+                connectedVMNoProxyFormat: "%@",
+                suspendedDetailFormat: "%@"
+            )
+        )
+    }
+}
+
+// MARK: - Stubs
+
+/// Returns a scripted stdout per invocation (holding the last entry once the
+/// script is exhausted), so a test can sequence "port found" then "empty scan"
+/// deterministically without touching ssh.
+private final class ScriptedProcessRunner: RemoteSessionProcessRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private let stdouts: [String]
+    private var index = 0
+
+    init(stdouts: [String]) {
+        self.stdouts = stdouts
+    }
+
+    func run(
+        _ request: RemoteProcessRequest,
+        operation: (any RemoteTransferCancelling)?
+    ) throws -> RemoteCommandResult {
+        lock.withLock {
+            let stdout = stdouts[min(index, stdouts.count - 1)]
+            index += 1
+            return RemoteCommandResult(status: 0, stdout: stdout, stderr: "")
+        }
+    }
+}
+
+/// Captures the most recent published port snapshot so tests can assert what
+/// the sidebar would render.
+private final class RecordingRemoteSessionHost: RemoteSessionHosting, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _lastDetected: [Int] = []
+
+    var lastDetected: [Int] { lock.withLock { _lastDetected } }
+
+    func publishConnectionState(_ state: WorkspaceRemoteConnectionState, detail: String?) {}
+    func publishDaemonStatus(_ status: WorkspaceRemoteDaemonStatus) {}
+    func publishProxyEndpoint(_ endpoint: BrowserProxyEndpoint?) {}
+    func publishPortsSnapshot(detectedByPanel: [UUID: [Int]], detected: [Int]) {
+        lock.withLock { _lastDetected = detected }
+    }
+    func publishHeartbeat(count: Int, lastSeenAt: Date?) {}
+    func publishBootstrapRemoteTTY(_ ttyName: String) {}
+}
+
+/// The port-scan path never acquires a proxy lease or touches PTY sessions, so
+/// the unreachable members trap if a future change starts exercising them.
+private final class UnusedRemoteProxyBroker: RemoteProxyBrokering, @unchecked Sendable {
+    func acquire(
+        configuration: WorkspaceRemoteConfiguration,
+        remotePath: String,
+        onUpdate: @escaping @Sendable (RemoteProxyBrokerUpdate) -> Void
+    ) -> RemoteProxyLease {
+        fatalError("UnusedRemoteProxyBroker.acquire is not exercised by port-scan retention tests")
+    }
+
+    func listPTY(configuration: WorkspaceRemoteConfiguration) throws -> [[String: Any]] { [] }
+    func closePTY(configuration: WorkspaceRemoteConfiguration, sessionID: String) throws {}
+    func resizePTY(
+        configuration: WorkspaceRemoteConfiguration,
+        sessionID: String,
+        attachmentID: String,
+        attachmentToken: String,
+        cols: Int,
+        rows: Int
+    ) throws {}
+    func detachPTY(
+        configuration: WorkspaceRemoteConfiguration,
+        sessionID: String,
+        attachmentID: String,
+        attachmentToken: String
+    ) throws {}
+    func startPTYBridge(
+        configuration: WorkspaceRemoteConfiguration,
+        sessionID: String,
+        attachmentID: String,
+        command: String?,
+        requireExisting: Bool
+    ) throws -> RemotePTYBridgeServer.Endpoint {
+        fatalError("UnusedRemoteProxyBroker.startPTYBridge is not exercised by port-scan retention tests")
+    }
+}
+
+private struct NoopReachabilityProbe: RemoteHostReachabilityProbing {
+    func probe(
+        destination: String,
+        port: Int?,
+        identityFile: String?,
+        sshOptions: [String],
+        completion: @escaping @Sendable (RemoteHostProbeOutcome) -> Void
+    ) {}
+}
+
+private struct PassthroughRelayCommandRewriter: RemoteRelayCommandRewriting {
+    func rewriteRemoteRelayCommandLine(
+        _ commandLine: Data,
+        workspaceAliases: [UUID: UUID],
+        surfaceAliases: [UUID: UUID]
+    ) -> Data {
+        commandLine
+    }
+}
+
+private struct StubBuildInfo: RemoteSessionBuildInfoProviding {
+    func appVersion() -> String? { nil }
+    func embeddedDaemonManifest() -> WorkspaceRemoteDaemonManifest? { nil }
+    func executableDirectoryURL() -> URL? { nil }
+}


### PR DESCRIPTION
Fixes #7244.

## Summary

- **What:** A remote SSH workspace's sidebar port badge (e.g. `:3001`) flickers — it disappears and reappears every few seconds — and because the ports row only occupies height when the port set is non-empty, every disappearance collapses the row and shifts the sibling rows down/up.
- **Why:** The TTY-scoped port scan treats an empty-but-successful scan as authoritative "no ports" and immediately drops the port, even though the server is still listening. This keeps the last-known ports across a bounded number of consecutive empty scans so a transient miss no longer collapses the row, while a port that has genuinely stopped still clears.

## The bug

With a remote SSH workspace running a dev server (a listening port under the session shell), the sidebar port badge flickers: `:3001` shows, vanishes, shows again, repeatedly. The ports row is only laid out when the port list is non-empty (`Sources/ContentView.swift`, the `// Ports row` block gated on `!listeningPorts.isEmpty`), so each flicker removes and re-adds the row and its spacing, visibly shifting every row beneath it. The flicker is worst while the workspace is actively working (the agent is spawning subprocesses) and settles when activity calms.

## Root cause

`RemoteSessionCoordinator` discovers listening ports per panel by attributing each listening socket to a tracked TTY through the emitting process's controlling terminal (`readlink /proc/<pid>/fd/0`, with an `lsof` fallback keyed by `ps -t`) — see `remotePortScanScript` in `RemoteSessionCoordinator+PortScan.swift`. That attribution is best-effort and races: a dev server frequently listens from a child process whose `fd/0` is not the shell's TTY (redirected, detached, or reparented), and `ss`'s `pid=` visibility and the process tree churn under load. So a scan can **succeed** yet report **no port** for a panel whose server is still listening.

`performRemotePortScanLocked` then replaces the per-panel port map wholesale with that scan result:

```swift
remoteScannedPortsByPanel = try scanRemotePortsByPanelLocked(ttyNamesByPanel: ttyNamesByPanel)
polledRemotePorts = []
publishPortsSnapshotLocked()
```

`publishPortsSnapshotLocked` publishes the union of `remoteScannedPortsByPanel` and `polledRemotePorts`, so when the scan comes back empty the published set is empty and the badge disappears until the next scan re-attributes the port. Notably, only an **ssh failure** (the `catch`) preserves the previous ports; an empty **success** clears them. The scan bursts on shell activity and polls every few seconds, so any single empty pass is republished immediately as a flicker.

## The fix

Reconcile a fresh scan against the last-known ports instead of overwriting: a panel that scans non-empty adopts the fresh ports; a panel that scans empty keeps its previous ports until it has been empty more than `remotePortScanEmptyRetentionLimit` (2) scans in a row, then clears. This absorbs the attribution's transient misses (no flicker) while a port that stays gone past the limit still clears within a couple of scan cycles. The retention counter is cleared alongside the existing port teardown (scanner suspend and the empty-TTY branch), so a disabled or re-armed scanner starts clean.

The change is confined to the TTY-scoped scan path; the host-wide/delta poll modes, the settings gating (#6136), and connection-establishing ssh are untouched.

## Testing

`swift test --package-path Packages/macOS/CmuxRemoteSession` — 42 tests pass.

New `RemotePortScanRetentionTests` drives the queue-confined `performRemotePortScanLocked` through a scripted process runner (scripts the ssh scan stdout: `"ttys010\t3001\n"`, then `""`) and a recording host that captures the published port snapshot — fully deterministic, no wall-clock waits:
- a scan that finds `3001` followed by one empty scan keeps `3001` (the flicker regression);
- a scan followed by empty scans past the retention limit clears the port (a genuinely stopped server still drops).

The same regression test fails before the reconciliation and passes after it:

**Before** (wholesale replace — one empty scan drops the still-listening port):

```
✘ Test "A transient empty scan keeps a still-listening port": Expectation failed: (host.lastDetected → []) == [3001]
± removed [3001]
↳ a single empty scan must not drop a still-listening port
✘ Test run with 2 tests in 1 suite failed with 1 issue.
```

**After** (reconcile retains the port across the transient empty scan):

```
✔ Test "A transient empty scan keeps a still-listening port" passed.
✔ Test "A port absent past the retention limit is dropped" passed.
✔ Test run with 2 tests in 1 suite passed.
```

A demo video isn't included because the flicker is a timing-dependent detection race on a remote host rather than a deterministic UI action; the two tests reproduce the drop and its fix deterministically instead.

## Scope notes

- `remotePortScanEmptyRetentionLimit = 2` trades up to ~2 extra scan cycles of a stale badge after a server genuinely stops for the elimination of the flicker. It is a named constant so the trade-off is easy to tune.
- I deliberately did not reserve space / hold last ports at the view layer: the sidebar intentionally applies row changes in one discrete layout pass (no value animation), and masking the collapse there wouldn't fix the port disappearing from the published snapshot.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally (`swift test --package-path Packages/macOS/CmuxRemoteSession`, 42 tests)
- [x] I added or updated tests for behavior changes (`RemotePortScanRetentionTests`)
- [x] I updated docs/changelog if needed (refreshed `swift-file-length-budget.tsv` for the two touched files)
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785648785&installation_id=133855650&pr_number=7245&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7245&signature=2d2e769002ff4f9a845bf5d79d8b58652c81f78e88da855d7f7a8efe7739c318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the sidebar port badge from flickering in remote SSH workspaces by keeping last-known ports across transient empty TTY scans. Ports that are truly gone still clear after a short threshold.

- **Bug Fixes**
  - Reconcile TTY-scoped scan results with previous state instead of replacing them.
  - Retain last-known ports across up to 2 consecutive empty scans; clear after the limit.
  - Clear miss counters on all teardown paths and when no TTYs are tracked; keep counters in sync with the port map.
  - Scope limited to TTY-based scans; polling and host-wide paths are unchanged.
  - Expanded `RemotePortScanRetentionTests` to cover teardown clearing and transient-miss retention.

<sup>Written for commit a18ee88140ea26e417eac1ed68ea40075b7d3951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote port tracking by retaining previously detected listening ports through short-lived “empty/missed” scan gaps.
  * Ports are now cleared only after exceeding a consecutive-empty retention threshold, and retained tracking is properly reset on session shutdown or error.

* **Tests**
  * Added automated coverage to ensure single-miss retention, eventual cleanup after repeated empty scans, and correct state clearing on teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->