### PR TITLE
Add Safari MCP integration for agents

### DIFF
--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CMUXAgentLaunch
 
 extension CMUXCLI {
     /// The per-invocation Codex hook events the wrapper injects, paired with the
@@ -41,6 +42,12 @@ extension CMUXCLI {
         // inline snippet so the working path can never regress.
         let hooksDir = Self.codexHookScriptsDirectory()
         var args: [String] = ["--enable", "hooks", "--dangerously-bypass-hook-trust"]
+        if let safariDriverPath = SafariMCPServerConfig.resolvedDriverPath() {
+            for override in SafariMCPServerConfig.codexConfigOverrides(driverPath: safariDriverPath) {
+                args.append("-c")
+                args.append(override)
+            }
+        }
         for event in Self.codexWrapperInjectionEvents {
             let ff = Self.codexFireAndForgetAgentHookShellCommand(
                 "cmux hooks codex \(event.cmuxSubcommand)", for: codexDef

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -41,6 +41,8 @@ public enum AgentLaunchEnvironmentPolicy {
         "CLAUDE_CONFIG_DIR",
         "CMUX_CUSTOM_CLAUDE_PATH",
         "CMUX_ROVODEV_SESSIONS_DIR",
+        "CMUX_SAFARI_MCP_DISABLED",
+        "CMUX_SAFARI_MCP_DRIVER_PATH",
         "CODEX_HOME",
         "CODEBUDDY_BASE_URL",
         "CODEBUDDY_CONFIG_DIR",

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SafariMCPServerConfig.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/SafariMCPServerConfig.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Resolves the Safari Technology Preview MCP server command for agent launches.
+public enum SafariMCPServerConfig {
+    /// The MCP server name used in generated agent configuration.
+    public static let serverName = "safari-mcp-stp"
+
+    /// Safari Technology Preview's bundled `safaridriver` path.
+    public static let defaultDriverPath = "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver"
+
+    /// Returns the executable Safari MCP server driver path, or `nil` when unavailable.
+    ///
+    /// - Parameters:
+    ///   - environment: Environment variables used for opt-out and path override.
+    ///   - fileManager: Filesystem dependency used to verify executability.
+    /// - Returns: An executable `safaridriver` path suitable for MCP stdio launch.
+    public static func resolvedDriverPath(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> String? {
+        if environment["CMUX_SAFARI_MCP_DISABLED"] == "1" {
+            return nil
+        }
+
+        let rawPath = environment["CMUX_SAFARI_MCP_DRIVER_PATH"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let path = rawPath?.isEmpty == false ? rawPath! : defaultDriverPath
+        let expanded = (path as NSString).expandingTildeInPath
+        guard fileManager.isExecutableFile(atPath: expanded) else { return nil }
+        return expanded
+    }
+
+    /// Returns Codex `-c` overrides that register Safari's MCP stdio server.
+    ///
+    /// - Parameter driverPath: Executable `safaridriver` path.
+    /// - Returns: TOML assignment strings for Codex's `mcp_servers` config.
+    public static func codexConfigOverrides(driverPath: String) -> [String] {
+        [
+            "mcp_servers.\(serverName).command=\(tomlString(driverPath))",
+            "mcp_servers.\(serverName).args=[\"--mcp\"]",
+        ]
+    }
+
+    private static func tomlString(_ value: String) -> String {
+        var escaped = ""
+        for scalar in value.unicodeScalars {
+            switch scalar.value {
+            case 0x08: escaped += "\\b"
+            case 0x09: escaped += "\\t"
+            case 0x0A: escaped += "\\n"
+            case 0x0C: escaped += "\\f"
+            case 0x0D: escaped += "\\r"
+            case 0x22: escaped += "\\\""
+            case 0x5C: escaped += "\\\\"
+            default:
+                escaped.unicodeScalars.append(scalar)
+            }
+        }
+        return "\"\(escaped)\""
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -19,4 +19,21 @@ struct AgentLaunchEnvironmentPolicyTests {
             "PI_CONFIG_DIR": ".custom-omp",
         ])
     }
+
+    @Test("Preserves Safari MCP path controls without persisting secrets")
+    func preservesSafariMCPPathControlsWithoutPersistingSecrets() {
+        let selected = AgentLaunchEnvironmentPolicy.selectedEnvironment(
+            from: [
+                "CMUX_SAFARI_MCP_DISABLED": "1",
+                "CMUX_SAFARI_MCP_DRIVER_PATH": "/tmp/Safari Technology Preview.app/safaridriver",
+                "SAFARI_MCP_TOKEN": "secret-should-not-persist",
+            ],
+            kind: "codex"
+        )
+
+        #expect(selected == [
+            "CMUX_SAFARI_MCP_DISABLED": "1",
+            "CMUX_SAFARI_MCP_DRIVER_PATH": "/tmp/Safari Technology Preview.app/safaridriver",
+        ])
+    }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/SafariMCPServerConfigTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/SafariMCPServerConfigTests.swift
@@ -1,0 +1,47 @@
+import CMUXAgentLaunch
+import Foundation
+import Testing
+
+@Suite("SafariMCPServerConfig")
+struct SafariMCPServerConfigTests {
+    @Test("Resolves executable override path and emits Codex MCP overrides")
+    func resolvesExecutableOverridePathAndEmitsCodexOverrides() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-safari-mcp-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let driver = root.appendingPathComponent("safaridriver", isDirectory: false)
+        try Data("#!/bin/sh\n".utf8).write(to: driver, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: driver.path)
+
+        let resolved = SafariMCPServerConfig.resolvedDriverPath(
+            environment: ["CMUX_SAFARI_MCP_DRIVER_PATH": driver.path]
+        )
+        #expect(resolved == driver.path)
+        #expect(SafariMCPServerConfig.codexConfigOverrides(driverPath: driver.path) == [
+            "mcp_servers.safari-mcp-stp.command=\"\(driver.path)\"",
+            "mcp_servers.safari-mcp-stp.args=[\"--mcp\"]",
+        ])
+    }
+
+    @Test("Opt-out disables Safari MCP resolution")
+    func optOutDisablesSafariMCPResolution() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-safari-mcp-disabled-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let driver = root.appendingPathComponent("safaridriver", isDirectory: false)
+        try Data("#!/bin/sh\n".utf8).write(to: driver, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: driver.path)
+
+        let resolved = SafariMCPServerConfig.resolvedDriverPath(
+            environment: [
+                "CMUX_SAFARI_MCP_DISABLED": "1",
+                "CMUX_SAFARI_MCP_DRIVER_PATH": driver.path,
+            ]
+        )
+        #expect(resolved == nil)
+    }
+}

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -409,6 +409,58 @@ claude_option_consumes_value() {
     return 1
 }
 
+cmux_safari_mcp_driver_path() {
+    [[ "${CMUX_SAFARI_MCP_DISABLED:-}" == "1" ]] && return 1
+    local driver="${CMUX_SAFARI_MCP_DRIVER_PATH:-/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver}"
+    driver="${driver#"${driver%%[![:space:]]*}"}"
+    driver="${driver%"${driver##*[![:space:]]}"}"
+    if [[ "$driver" == "~/"* ]]; then
+        driver="$HOME/${driver#~/}"
+    fi
+    [[ -n "$driver" && -x "$driver" && ! -d "$driver" ]] || return 1
+    printf '%s' "$driver"
+}
+
+cmux_json_escape() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\r'/\\r}"
+    value="${value//$'\t'/\\t}"
+    printf '%s' "$value"
+}
+
+cmux_safari_mcp_config_json() {
+    local driver
+    driver="$(cmux_safari_mcp_driver_path)" || return 1
+    printf '{"mcpServers":{"safari-mcp-stp":{"command":"%s","args":["--mcp"]}}}' "$(cmux_json_escape "$driver")"
+}
+
+cmux_claude_args_have_mcp_config() {
+    local arg skip_next=false
+    for arg in "$@"; do
+        if [[ "$skip_next" == true ]]; then
+            skip_next=false
+            continue
+        fi
+        case "$arg" in
+            --)
+                return 1
+                ;;
+            --mcp-config|--mcp-config=*)
+                return 0
+                ;;
+            -*)
+                if [[ "$arg" != *=* ]] && claude_option_consumes_value "$arg"; then
+                    skip_next=true
+                fi
+                ;;
+        esac
+    done
+    return 1
+}
+
 claude_remaining_args_have_resume_flag() {
     local arg
     for arg in "$@"; do
@@ -1011,9 +1063,17 @@ process.stdout.write(JSON.stringify(acc));
     unset CMUX_MERGED_SETTINGS cmux_merge_status
 fi
 
+CMUX_SAFARI_MCP_ARGS=()
+if ! cmux_claude_args_have_mcp_config "$@"; then
+    CMUX_SAFARI_MCP_CONFIG="$(cmux_safari_mcp_config_json 2>/dev/null || true)"
+    if [[ -n "$CMUX_SAFARI_MCP_CONFIG" ]]; then
+        CMUX_SAFARI_MCP_ARGS=(--mcp-config "$CMUX_SAFARI_MCP_CONFIG")
+    fi
+fi
+
 if [[ "$SKIP_SESSION_ID" == true ]]; then
-    cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
+    cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" --settings "$HOOKS_JSON" "${CMUX_SAFARI_MCP_ARGS[@]}" "$@"
 else
     SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
-    cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
+    cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "${CMUX_SAFARI_MCP_ARGS[@]}" "$@"
 fi

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -39,6 +39,15 @@ def parse_settings_arg(argv: list[str]) -> dict:
     return json.loads(argv[index + 1])
 
 
+def parse_mcp_config_arg(argv: list[str]) -> dict:
+    if "--mcp-config" not in argv:
+        return {}
+    index = argv.index("--mcp-config")
+    if index + 1 >= len(argv):
+        return {}
+    return json.loads(argv[index + 1])
+
+
 def run_wrapper(
     *,
     socket_state: str,
@@ -46,6 +55,7 @@ def run_wrapper(
     node_options: str | None = None,
     tmpdir: str | None = None,
     hooks_disabled: bool = False,
+    safari_driver: bool = False,
 ) -> tuple[int, list[str], list[str], str, str, str, str, str, str, str]:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-test-") as td:
         tmp = Path(td)
@@ -69,6 +79,7 @@ def run_wrapper(
         hook_cmux_bin_log = tmp / "hook-cmux-bin.log"
         cmux_log = tmp / "cmux.log"
         socket_path = str(tmp / "cmux.sock")
+        safari_driver_path = tmp / "Safari Technology Preview.app" / "Contents" / "MacOS" / "safaridriver"
 
         make_executable(
             real_dir / "claude",
@@ -179,6 +190,12 @@ exit 0
         env["FAKE_CMUX_PING_OK"] = "1" if socket_state == "live" else "0"
         env["CMUX_BUNDLED_CLI_PATH"] = str(bundled_cli_path)
         env["CLAUDECODE"] = "nested-session-sentinel"
+        if safari_driver:
+            safari_driver_path.parent.mkdir(parents=True, exist_ok=True)
+            make_executable(safari_driver_path, "#!/bin/sh\nexit 0\n")
+            env["CMUX_SAFARI_MCP_DRIVER_PATH"] = str(safari_driver_path)
+        else:
+            env.pop("CMUX_SAFARI_MCP_DRIVER_PATH", None)
         if hooks_disabled:
             env["CMUX_CLAUDE_HOOKS_DISABLED"] = "1"
         else:
@@ -633,6 +650,52 @@ def test_live_socket_merges_user_settings_into_hooks(failures: list[str]) -> Non
     expect(
         "-p" in real_argv and "hi" in real_argv,
         f"merge user settings: user args dropped, got {real_argv}",
+        failures,
+    )
+
+
+def test_live_socket_injects_safari_mcp_when_driver_exists(failures: list[str]) -> None:
+    code, real_argv, _cmux_log, stderr, *_ = run_wrapper(
+        socket_state="live",
+        argv=["hi"],
+        safari_driver=True,
+    )
+    expect(code == 0, f"safari mcp: wrapper exited {code}: {stderr}", failures)
+    expect(
+        real_argv.count("--mcp-config") == 1,
+        f"safari mcp: expected one injected --mcp-config, got {real_argv}",
+        failures,
+    )
+    config = parse_mcp_config_arg(real_argv)
+    safari = config.get("mcpServers", {}).get("safari-mcp-stp", {})
+    expect(
+        safari.get("command", "").endswith("Safari Technology Preview.app/Contents/MacOS/safaridriver"),
+        f"safari mcp: expected safaridriver command, got {config}",
+        failures,
+    )
+    expect(
+        safari.get("args") == ["--mcp"],
+        f"safari mcp: expected --mcp args, got {config}",
+        failures,
+    )
+
+
+def test_live_socket_explicit_mcp_config_skips_safari_injection(failures: list[str]) -> None:
+    user_config = '{"mcpServers":{"custom":{"command":"/tmp/custom","args":[]}}}'
+    code, real_argv, _cmux_log, stderr, *_ = run_wrapper(
+        socket_state="live",
+        argv=["--mcp-config", user_config, "hi"],
+        safari_driver=True,
+    )
+    expect(code == 0, f"explicit mcp config: wrapper exited {code}: {stderr}", failures)
+    expect(
+        real_argv.count("--mcp-config") == 1,
+        f"explicit mcp config: expected only user's --mcp-config, got {real_argv}",
+        failures,
+    )
+    expect(
+        parse_mcp_config_arg(real_argv) == {"mcpServers": {"custom": {"command": "/tmp/custom", "args": []}}},
+        f"explicit mcp config: user config should be preserved, got {real_argv}",
         failures,
     )
 
@@ -1858,6 +1921,8 @@ def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
     test_live_socket_merges_user_settings_into_hooks(failures)
+    test_live_socket_injects_safari_mcp_when_driver_exists(failures)
+    test_live_socket_explicit_mcp_config_skips_safari_injection(failures)
     test_live_socket_merges_inline_settings_form(failures)
     test_live_socket_repeated_settings_user_value_wins_conflict(failures)
     test_live_socket_user_nonobject_hooks_does_not_drop_cmux_hooks(failures)


### PR DESCRIPTION
## Summary
- add a shared Safari MCP server config helper for agent launches
- inject Safari Technology Preview `safaridriver --mcp` into Codex and Claude sessions when the driver is executable
- preserve Safari MCP override/disable env controls across agent resume/fork flows

## Testing
- `swift test` in `Packages/macOS/CMUXAgentLaunch`
- `python3 tests/test_claude_wrapper_hooks.py`
- `./scripts/reload-cloud.sh --tag safmcp`
- built tagged CLI preflight with `CMUX_SAFARI_MCP_DRIVER_PATH=<fake executable>` verified Codex emits `mcp_servers.safari-mcp-stp.command` and `args=["--mcp"]`

## Notes
- Safari MCP remains dormant unless Safari Technology Preview's `safaridriver` exists, or `CMUX_SAFARI_MCP_DRIVER_PATH` points at an executable.
- Set `CMUX_SAFARI_MCP_DISABLED=1` to opt out.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785655820&installation_id=133855650&pr_number=7249&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7249&signature=023a34d22b79ca79b8a9b8d67d1bd05b22f00c55ec10f13221a76924d7b83006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default agent launch configuration (Codex `-c` and Claude `--mcp-config`) on macOS when STP is installed, though behavior is gated on an executable driver and can be disabled via env.
> 
> **Overview**
> Adds optional **Safari Technology Preview** browser MCP (`safari-mcp-stp` via `safaridriver --mcp`) to cmux-managed **Codex** and **Claude** launches when an executable driver is present.
> 
> A shared **`SafariMCPServerConfig`** helper resolves the driver (default STP path, `CMUX_SAFARI_MCP_DRIVER_PATH`, or no injection when `CMUX_SAFARI_MCP_DISABLED=1`). **Codex** wrapper args gain extra `-c` `mcp_servers` overrides; the **Claude** wrapper injects `--mcp-config` JSON unless the user already passed `--mcp-config`. **`CMUX_SAFARI_MCP_*`** env vars are allowlisted for resume/fork flows without persisting unrelated secrets.
> 
> Wrapper regression tests cover auto-injection and respecting an explicit user MCP config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd39726e413d274a2e952052fd2c856cc09bfec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Safari MCP integration for agents, auto-registering Safari Technology Preview `safaridriver --mcp` for Codex and Claude when available. Supports opt-out and path overrides that persist across resume/fork flows.

- **New Features**
  - Added `SafariMCPServerConfig` in `CMUXAgentLaunch` to resolve an executable driver (default STP path) and emit Codex `-c` overrides.
  - Codex: injects `mcp_servers.safari-mcp-stp` command and `args=["--mcp"]` when the driver exists.
  - Claude: injects `--mcp-config` JSON for Safari MCP unless the user already passed `--mcp-config`.
  - Preserves `CMUX_SAFARI_MCP_DISABLED` and `CMUX_SAFARI_MCP_DRIVER_PATH` across resume/fork.
  - Added Swift and Python tests for path resolution, opt-out, and injection behavior.

- **Migration**
  - No action needed; Safari MCP is dormant by default.
  - To enable: install Safari Technology Preview or set `CMUX_SAFARI_MCP_DRIVER_PATH` to an executable driver.
  - To disable: set `CMUX_SAFARI_MCP_DISABLED=1`.

<sup>Written for commit 5fd39726e413d274a2e952052fd2c856cc09bfec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Safari Technology Preview MCP setup when a valid driver is available.
  * Support now respects a configurable driver path and an opt-out setting.
  * Wrapper behavior was expanded to include MCP configuration alongside existing launch settings.

* **Bug Fixes**
  * Preserves user-provided MCP configuration instead of overriding it.
  * Improves environment handling so only safe Safari-related controls are retained.
  * Added coverage for driver resolution, disabled mode, and injection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->