### PR TITLE
Add first-party client config API for flags

### DIFF
--- a/Packages/Shared/CmuxClientConfig/Package.swift
+++ b/Packages/Shared/CmuxClientConfig/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxClientConfig",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxClientConfig",
+            targets: ["CmuxClientConfig"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxClientConfig",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxClientConfigTests",
+            dependencies: ["CmuxClientConfig"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+    ]
+)

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfig.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfig.swift
@@ -40,6 +40,10 @@ public struct ClientConfig: Decodable, Sendable, Equatable {
         guard let payload = featureFlagPayloads[flag.key] else {
             return flag.defaultValue
         }
-        return try payload.decode(Value.self, decoder: decoder)
+        do {
+            return try payload.decode(Value.self, decoder: decoder)
+        } catch is DecodingError {
+            return flag.defaultValue
+        }
     }
 }

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfig.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfig.swift
@@ -1,0 +1,45 @@
+public import Foundation
+
+/// A typed representation of the response returned by `/api/client-config`.
+public struct ClientConfig: Decodable, Sendable, Equatable {
+    /// Feature flag values keyed by PostHog feature flag key.
+    public let featureFlags: [String: ClientConfigFlagValue]
+    /// Feature flag payloads keyed by PostHog feature flag key.
+    public let featureFlagPayloads: [String: ClientConfigJSONValue]
+    /// Whether PostHog reported errors while evaluating flags.
+    public let errorsWhileComputingFlags: Bool
+    /// Optional upstream request id for diagnostics.
+    public let requestId: String?
+
+    /// Creates a client configuration value, primarily for tests and local composition.
+    public init(
+        featureFlags: [String: ClientConfigFlagValue],
+        featureFlagPayloads: [String: ClientConfigJSONValue],
+        errorsWhileComputingFlags: Bool,
+        requestId: String? = nil
+    ) {
+        self.featureFlags = featureFlags
+        self.featureFlagPayloads = featureFlagPayloads
+        self.errorsWhileComputingFlags = errorsWhileComputingFlags
+        self.requestId = requestId
+    }
+
+    /// Reads a declared flag through its typed resolver.
+    public func value<Value>(_ flag: ClientConfigFlag<Value>) -> Value {
+        flag.resolve(
+            featureFlags[flag.key],
+            featureFlagPayloads[flag.key]
+        )
+    }
+
+    /// Decodes a declared payload into the caller's concrete type.
+    public func payload<Value: Decodable & Sendable>(
+        _ flag: ClientConfigPayloadFlag<Value>,
+        decoder: JSONDecoder = JSONDecoder()
+    ) throws -> Value? {
+        guard let payload = featureFlagPayloads[flag.key] else {
+            return flag.defaultValue
+        }
+        return try payload.decode(Value.self, decoder: decoder)
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigError.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigError.swift
@@ -1,0 +1,9 @@
+/// Errors produced by the HTTP client-config loader before response decoding.
+public enum ClientConfigError: Error, Sendable, Equatable {
+    /// The configured API base URL could not form a `/api/client-config` URL.
+    case invalidBaseURL
+    /// The transport returned a non-HTTP response.
+    case invalidResponse
+    /// The web route returned a non-2xx status code.
+    case httpStatus(Int)
+}

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigEvaluationContext.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigEvaluationContext.swift
@@ -1,0 +1,58 @@
+/// Extra evaluation data forwarded to PostHog by `/api/client-config`.
+public struct ClientConfigEvaluationContext: Encodable, Sendable, Equatable {
+    /// Group keys, such as organization id, used for group-level flag evaluation.
+    public let groups: [String: ClientConfigJSONValue]
+    /// Person properties attached to this evaluation request.
+    public let personProperties: [String: ClientConfigJSONValue]
+    /// Group properties attached to this evaluation request.
+    public let groupProperties: [String: ClientConfigJSONValue]
+    /// The anonymous install or browser id, when distinct from the current user id.
+    public let anonDistinctId: String?
+    /// The device id used by the client, when available.
+    public let deviceId: String?
+    /// The IANA timezone name, when available.
+    public let timezone: String?
+    /// PostHog evaluation contexts or environments to include.
+    public let evaluationContexts: [String]
+
+    /// Creates an evaluation context.
+    public init(
+        groups: [String: ClientConfigJSONValue] = [:],
+        personProperties: [String: ClientConfigJSONValue] = [:],
+        groupProperties: [String: ClientConfigJSONValue] = [:],
+        anonDistinctId: String? = nil,
+        deviceId: String? = nil,
+        timezone: String? = nil,
+        evaluationContexts: [String] = []
+    ) {
+        self.groups = groups
+        self.personProperties = personProperties
+        self.groupProperties = groupProperties
+        self.anonDistinctId = anonDistinctId
+        self.deviceId = deviceId
+        self.timezone = timezone
+        self.evaluationContexts = evaluationContexts
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case groups
+        case personProperties
+        case groupProperties
+        case anonDistinctId
+        case deviceId
+        case timezone
+        case evaluationContexts
+    }
+
+    /// Encodes only populated context fields so the web route sees the same sparse shape as browser callers.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if !groups.isEmpty { try container.encode(groups, forKey: .groups) }
+        if !personProperties.isEmpty { try container.encode(personProperties, forKey: .personProperties) }
+        if !groupProperties.isEmpty { try container.encode(groupProperties, forKey: .groupProperties) }
+        try container.encodeIfPresent(anonDistinctId, forKey: .anonDistinctId)
+        try container.encodeIfPresent(deviceId, forKey: .deviceId)
+        try container.encodeIfPresent(timezone, forKey: .timezone)
+        if !evaluationContexts.isEmpty { try container.encode(evaluationContexts, forKey: .evaluationContexts) }
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigFlag.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigFlag.swift
@@ -1,0 +1,51 @@
+/// A declared feature flag with a typed value resolver.
+public struct ClientConfigFlag<Value: Sendable>: Sendable {
+    /// The PostHog feature flag key.
+    public let key: String
+    /// The value returned when the API omits the flag or the value has the wrong shape.
+    public let defaultValue: Value
+    /// Converts the raw flag and payload values into the typed value.
+    public let resolve: @Sendable (ClientConfigFlagValue?, ClientConfigJSONValue?) -> Value
+
+    /// Creates a typed feature flag declaration.
+    public init(
+        key: String,
+        defaultValue: Value,
+        resolve: @escaping @Sendable (ClientConfigFlagValue?, ClientConfigJSONValue?) -> Value
+    ) {
+        self.key = key
+        self.defaultValue = defaultValue
+        self.resolve = resolve
+    }
+}
+
+/// Boolean feature flag declarations.
+public extension ClientConfigFlag where Value == Bool {
+    /// Creates a boolean flag declaration.
+    init(booleanKey key: String, defaultValue: Bool = false) {
+        self.init(key: key, defaultValue: defaultValue) { value, _ in
+            value?.boolValue ?? defaultValue
+        }
+    }
+
+    /// Enables Windows download/sign-up surfaces.
+    static let cmuxForWindows = Self(booleanKey: "cmux-for-windows")
+    /// Enables Linux download/sign-up surfaces.
+    static let cmuxForLinux = Self(booleanKey: "cmux-for-linux")
+    /// Enables Android download/sign-up surfaces.
+    static let cmuxForAndroid = Self(booleanKey: "cmux-for-android")
+    /// Enables the production upgrade UI.
+    static let proUpgradeUIEnabledRelease = Self(booleanKey: "pro-upgrade-ui-enabled-release")
+    /// Enables the production mobile connect button.
+    static let mobileConnectButtonEnabledRelease = Self(booleanKey: "mobile-connect-button-enabled-release")
+}
+
+/// Multivariate feature flag declarations.
+public extension ClientConfigFlag where Value == String? {
+    /// Creates a multivariate flag declaration.
+    init(variantKey key: String, defaultValue: String? = nil) {
+        self.init(key: key, defaultValue: defaultValue) { value, _ in
+            value?.variantValue ?? defaultValue
+        }
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigFlagValue.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigFlagValue.swift
@@ -1,0 +1,40 @@
+/// A PostHog feature-flag value normalized by the cmux client-config API.
+public enum ClientConfigFlagValue: Codable, Sendable, Equatable {
+    /// A boolean flag value.
+    case bool(Bool)
+    /// A multivariate flag value.
+    case variant(String)
+
+    /// Decodes a flag value from either a JSON boolean or string.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else {
+            self = .variant(try container.decode(String.self))
+        }
+    }
+
+    /// Encodes the flag value as the JSON scalar expected by `/api/client-config`.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .bool(let value):
+            try container.encode(value)
+        case .variant(let value):
+            try container.encode(value)
+        }
+    }
+
+    /// The boolean value when this flag is boolean.
+    public var boolValue: Bool? {
+        if case .bool(let value) = self { return value }
+        return nil
+    }
+
+    /// The variant string when this flag is multivariate.
+    public var variantValue: String? {
+        if case .variant(let value) = self { return value }
+        return nil
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigJSONValue.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigJSONValue.swift
@@ -1,0 +1,81 @@
+public import Foundation
+
+/// A JSON value that can safely cross Swift concurrency domains.
+public enum ClientConfigJSONValue: Codable, Sendable, Equatable {
+    /// A JSON null value.
+    case null
+    /// A JSON boolean value.
+    case bool(Bool)
+    /// A JSON number value.
+    case number(Double)
+    /// A JSON string value.
+    case string(String)
+    /// A JSON array value.
+    case array([ClientConfigJSONValue])
+    /// A JSON object value.
+    case object([String: ClientConfigJSONValue])
+
+    /// Decodes a JSON value from a single-value container.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([ClientConfigJSONValue].self) {
+            self = .array(value)
+        } else {
+            self = .object(try container.decode([String: ClientConfigJSONValue].self))
+        }
+    }
+
+    /// Encodes this value into JSON.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case .bool(let value):
+            try container.encode(value)
+        case .number(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        }
+    }
+
+    /// The boolean value when this JSON value is a boolean.
+    public var boolValue: Bool? {
+        if case .bool(let value) = self { return value }
+        return nil
+    }
+
+    /// The string value when this JSON value is a string.
+    public var stringValue: String? {
+        if case .string(let value) = self { return value }
+        return nil
+    }
+
+    /// The object value when this JSON value is an object.
+    public var objectValue: [String: ClientConfigJSONValue]? {
+        if case .object(let value) = self { return value }
+        return nil
+    }
+
+    /// Re-decodes this JSON value into a concrete Decodable type.
+    public func decode<Value: Decodable>(
+        _ type: Value.Type = Value.self,
+        decoder: JSONDecoder = JSONDecoder()
+    ) throws -> Value {
+        let data = try JSONEncoder().encode(self)
+        return try decoder.decode(Value.self, from: data)
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigLoading.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigLoading.swift
@@ -1,0 +1,5 @@
+/// Loads cmux client configuration from an injected backend.
+public protocol ClientConfigLoading: Sendable {
+    /// Fetches and decodes the current feature flags for a request.
+    func load(_ request: ClientConfigRequest) async throws -> ClientConfig
+}

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigPayloadFlag.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigPayloadFlag.swift
@@ -1,0 +1,13 @@
+/// A declared feature-flag payload with a typed decoder target.
+public struct ClientConfigPayloadFlag<Value: Decodable & Sendable>: Sendable {
+    /// The PostHog feature flag key whose payload should be decoded.
+    public let key: String
+    /// The value returned when the API response does not include a payload.
+    public let defaultValue: Value?
+
+    /// Creates a payload declaration.
+    public init(key: String, defaultValue: Value? = nil) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigRequest.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/ClientConfigRequest.swift
@@ -1,0 +1,13 @@
+/// A typed request body for `/api/client-config`.
+public struct ClientConfigRequest: Encodable, Sendable, Equatable {
+    /// The PostHog distinct id for this evaluation.
+    public let distinctId: String
+    /// Optional context forwarded to PostHog by the web route.
+    public let context: ClientConfigEvaluationContext
+
+    /// Creates a request for feature-flag evaluation.
+    public init(distinctId: String, context: ClientConfigEvaluationContext = .init()) {
+        self.distinctId = distinctId
+        self.context = context
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/HTTPClientConfigLoader.swift
+++ b/Packages/Shared/CmuxClientConfig/Sources/CmuxClientConfig/HTTPClientConfigLoader.swift
@@ -1,0 +1,50 @@
+public import Foundation
+
+/// A URLSession-backed loader for the cmux `/api/client-config` route.
+public struct HTTPClientConfigLoader: ClientConfigLoading {
+    private let apiBaseURL: String
+    private let session: URLSession
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    /// Creates an HTTP loader.
+    ///
+    /// - Parameters:
+    ///   - apiBaseURL: The cmux web API origin, with or without a trailing slash.
+    ///   - session: The URLSession used for the request.
+    ///   - encoder: Encoder for the request body.
+    ///   - decoder: Decoder for the response body.
+    public init(
+        apiBaseURL: String,
+        session: sending URLSession = .shared,
+        encoder: sending JSONEncoder = JSONEncoder(),
+        decoder: sending JSONDecoder = JSONDecoder()
+    ) {
+        self.apiBaseURL = apiBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        self.session = session
+        self.encoder = encoder
+        self.decoder = decoder
+    }
+
+    /// POSTs the request to `/api/client-config` and decodes the typed response.
+    public func load(_ request: ClientConfigRequest) async throws -> ClientConfig {
+        guard let url = URL(string: apiBaseURL + "/api/client-config") else {
+            throw ClientConfigError.invalidBaseURL
+        }
+
+        var urlRequest = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.httpBody = try encoder.encode(request)
+
+        let (data, response) = try await session.data(for: urlRequest)
+        guard let http = response as? HTTPURLResponse else {
+            throw ClientConfigError.invalidResponse
+        }
+        guard (200...299).contains(http.statusCode) else {
+            throw ClientConfigError.httpStatus(http.statusCode)
+        }
+        return try decoder.decode(ClientConfig.self, from: data)
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/ClientConfigRequestRecorder.swift
+++ b/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/ClientConfigRequestRecorder.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+final class ClientConfigRequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedRequests: [URLRequest] = []
+
+    var requests: [URLRequest] {
+        lock.withLock { storedRequests }
+    }
+
+    func record(_ request: URLRequest) {
+        lock.withLock {
+            storedRequests.append(request)
+        }
+    }
+
+    func reset() {
+        lock.withLock {
+            storedRequests = []
+        }
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/ClientConfigTests.swift
+++ b/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/ClientConfigTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import CmuxClientConfig
+
+@Suite(.serialized) struct ClientConfigTests {
+    @Test func decodesFlagValuesAndPayloads() throws {
+        let data = Data("""
+        {
+          "featureFlags": {
+            "cmux-for-windows": true,
+            "pricing-copy": "enterprise"
+          },
+          "featureFlagPayloads": {
+            "pricing-copy": {
+              "headline": "Ship faster",
+              "seats": 12,
+              "trial": true
+            }
+          },
+          "errorsWhileComputingFlags": false,
+          "requestId": "req-1"
+        }
+        """.utf8)
+
+        let config = try JSONDecoder().decode(ClientConfig.self, from: data)
+
+        #expect(config.value(.cmuxForWindows) == true)
+        #expect(config.value(ClientConfigFlag<String?>(variantKey: "pricing-copy")) == "enterprise")
+        #expect(config.featureFlagPayloads["pricing-copy"]?.objectValue?["headline"]?.stringValue == "Ship faster")
+    }
+
+    @Test func typedFlagsFallBackOnMissingOrMismatchedValues() {
+        let config = ClientConfig(
+            featureFlags: [
+                "cmux-for-windows": .variant("beta"),
+                "pricing-copy": .bool(true),
+            ],
+            featureFlagPayloads: [:],
+            errorsWhileComputingFlags: false
+        )
+
+        #expect(config.value(.cmuxForWindows) == false)
+        #expect(config.value(ClientConfigFlag<String?>(variantKey: "pricing-copy")) == nil)
+        #expect(config.value(ClientConfigFlag<String?>(variantKey: "missing", defaultValue: "control")) == "control")
+    }
+
+    @Test func decodesTypedPayloads() throws {
+        let config = ClientConfig(
+            featureFlags: [:],
+            featureFlagPayloads: [
+                "pricing-copy": .object([
+                    "headline": .string("Ship faster"),
+                    "seats": .number(12),
+                ]),
+            ],
+            errorsWhileComputingFlags: false
+        )
+
+        let payload = try config.payload(ClientConfigPayloadFlag<PricingPayload>(key: "pricing-copy"))
+        #expect(payload == PricingPayload(headline: "Ship faster", seats: 12))
+    }
+
+    @Test func encodesRequestContextWithoutEmptyBuckets() throws {
+        let request = ClientConfigRequest(
+            distinctId: "user-1",
+            context: ClientConfigEvaluationContext(
+                personProperties: ["platform": .string("ios"), "build": .string("123")],
+                anonDistinctId: "anon-1",
+                evaluationContexts: ["mobile"]
+            )
+        )
+
+        let object = try JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as? [String: Any]
+        let context = object?["context"] as? [String: Any]
+
+        #expect(object?["distinctId"] as? String == "user-1")
+        #expect(context?["personProperties"] != nil)
+        #expect(context?["groups"] == nil)
+        #expect(context?["anonDistinctId"] as? String == "anon-1")
+        #expect(context?["evaluationContexts"] as? [String] == ["mobile"])
+    }
+
+    @Test func httpLoaderPostsToClientConfigRoute() async throws {
+        RecordingClientConfigURLProtocol.recorder.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RecordingClientConfigURLProtocol.self]
+        let loader = HTTPClientConfigLoader(
+            apiBaseURL: "https://cmux.test/",
+            session: URLSession(configuration: configuration)
+        )
+
+        let config = try await loader.load(ClientConfigRequest(distinctId: "user-1"))
+
+        #expect(config.value(.cmuxForWindows) == true)
+        let request = RecordingClientConfigURLProtocol.recorder.requests.first
+        #expect(request?.url?.absoluteString == "https://cmux.test/api/client-config")
+        #expect(request?.httpMethod == "POST")
+        #expect(request?.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        #expect(request?.value(forHTTPHeaderField: "Accept") == "application/json")
+    }
+}

--- a/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/ClientConfigTests.swift
+++ b/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/ClientConfigTests.swift
@@ -60,6 +60,29 @@ import Testing
         #expect(payload == PricingPayload(headline: "Ship faster", seats: 12))
     }
 
+    @Test func typedPayloadsFallBackOnMissingOrMismatchedValues() throws {
+        let fallback = PricingPayload(headline: "Fallback", seats: 1)
+        let config = ClientConfig(
+            featureFlags: [:],
+            featureFlagPayloads: [
+                "pricing-copy": .string("{\"headline\":\"Keep as text\"}"),
+            ],
+            errorsWhileComputingFlags: false
+        )
+
+        let mismatchedPayload = try config.payload(ClientConfigPayloadFlag<PricingPayload>(
+            key: "pricing-copy",
+            defaultValue: fallback
+        ))
+        let missingPayload = try config.payload(ClientConfigPayloadFlag<PricingPayload>(
+            key: "missing",
+            defaultValue: fallback
+        ))
+
+        #expect(mismatchedPayload == fallback)
+        #expect(missingPayload == fallback)
+    }
+
     @Test func encodesRequestContextWithoutEmptyBuckets() throws {
         let request = ClientConfigRequest(
             distinctId: "user-1",

--- a/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/PricingPayload.swift
+++ b/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/PricingPayload.swift
@@ -1,0 +1,4 @@
+struct PricingPayload: Decodable, Equatable, Sendable {
+    let headline: String
+    let seats: Int
+}

--- a/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/RecordingClientConfigURLProtocol.swift
+++ b/Packages/Shared/CmuxClientConfig/Tests/CmuxClientConfigTests/RecordingClientConfigURLProtocol.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+final class RecordingClientConfigURLProtocol: URLProtocol, @unchecked Sendable {
+    static let recorder = ClientConfigRequestRecorder()
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.recorder.record(request)
+        let body = Data("""
+        {
+          "featureFlags": { "cmux-for-windows": true },
+          "featureFlagPayloads": {},
+          "errorsWhileComputingFlags": false
+        }
+        """.utf8)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/cmux.xcworkspace/contents.xcworkspacedata
+++ b/cmux.xcworkspace/contents.xcworkspacedata
@@ -20,6 +20,9 @@
          location = "group:CmuxAuthRuntime">
       </FileRef>
       <FileRef
+         location = "group:CmuxClientConfig">
+      </FileRef>
+      <FileRef
          location = "group:CMUXMobileCore">
       </FileRef>
       <FileRef

--- a/ios/cmuxPackage/Package.resolved
+++ b/ios/cmuxPackage/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cc0a83364cf864c5596b95ee12cb33ace7b9387d0803d9abed381da4e81388eb",
+  "originHash" : "bda8ff0fb423a16b5b03e75a0e5ca59a75a45bb6628f4d3d3ba736865109229c",
   "pins" : [
     {
       "identity" : "swift-asn1",

--- a/ios/cmuxPackage/Package.swift
+++ b/ios/cmuxPackage/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
     dependencies: [
         .package(path: "../../Packages/Shared/CMUXAuthCore"),
         .package(path: "../../Packages/Shared/CmuxAuthRuntime"),
+        .package(path: "../../Packages/Shared/CmuxClientConfig"),
         .package(path: "../../Packages/Shared/CMUXMobileCore"),
         .package(path: "../../Packages/iOS/CmuxMobileAnalytics"),
         .package(path: "../../Packages/iOS/CmuxMobileBrowser"),
@@ -46,6 +47,7 @@ let package = Package(
             dependencies: [
                 "CMUXAuthCore",
                 "CmuxAuthRuntime",
+                "CmuxClientConfig",
                 "CMUXMobileCore",
                 "CmuxMobileAnalytics",
                 "CmuxMobileBrowser",
@@ -74,6 +76,7 @@ let package = Package(
                 "cmuxFeature",
                 "CMUXAuthCore",
                 "CmuxAuthRuntime",
+                "CmuxClientConfig",
                 "CMUXMobileCore",
                 "CmuxMobileAnalytics",
                 "CmuxMobileBrowser",

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAnalyticsComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAnalyticsComposition.swift
@@ -1,5 +1,6 @@
 import CMUXMobileCore
 import CmuxAuthRuntime
+import CmuxClientConfig
 import CmuxMobileAnalytics
 import CmuxMobileShellModel
 import Foundation
@@ -27,6 +28,16 @@ import UIKit
 public struct MobileAnalyticsComposition {
     /// The shared, injected analytics emitter.
     public let emitter: any AnalyticsEmitting
+    /// The typed feature-flag/config loader for Swift callers.
+    public let clientConfig: any ClientConfigLoading
+    /// The per-install anonymous id used for analytics and feature flag evaluation.
+    public let anonymousID: String
+    /// The default mobile evaluation context sent to `/api/client-config`.
+    public let clientConfigContext: ClientConfigEvaluationContext
+    /// A request for anonymous mobile flag evaluation.
+    public var anonymousClientConfigRequest: ClientConfigRequest {
+        ClientConfigRequest(distinctId: anonymousID, context: clientConfigContext)
+    }
     /// The session store + sessionizer the app shell drives on foreground/background.
     public let sessionStore: AnalyticsSessionStore
     /// The 30-minute-window sessionizer used with ``sessionStore``.
@@ -50,10 +61,11 @@ public struct MobileAnalyticsComposition {
         defaults: UserDefaults = .standard,
         session: URLSession? = nil
     ) {
+        let networkSession = session ?? Self.analyticsSession()
         let uploader = HTTPAnalyticsUploader(
             apiBaseURL: apiBaseURL,
             tokenProvider: AnalyticsTokenProviderBridge(tokenProvider: tokenProvider),
-            session: session ?? Self.analyticsSession()
+            session: networkSession
         )
         let consent = UserDefaultsAnalyticsConsentProvider(defaults: defaults)
         // Resolve the per-install id once, here, at the single point that owns
@@ -73,6 +85,13 @@ public struct MobileAnalyticsComposition {
             emitter.capture("ios_app_first_launch", ["client_id": .string(anonymousID)])
         }
         self.emitter = emitter
+        self.clientConfig = HTTPClientConfigLoader(apiBaseURL: apiBaseURL, session: networkSession)
+        self.anonymousID = anonymousID
+        self.clientConfigContext = ClientConfigEvaluationContext(
+            personProperties: Self.clientConfigDeviceProperties(anonymousID: anonymousID),
+            anonDistinctId: anonymousID,
+            evaluationContexts: ["mobile"]
+        )
         self.sessionStore = AnalyticsSessionStore(defaults: defaults)
     }
 
@@ -94,6 +113,27 @@ public struct MobileAnalyticsComposition {
     @MainActor private static func deviceSuperProperties(anonymousID: String) -> [String: AnalyticsValue] {
         let info = Bundle.main.infoDictionary
         var props: [String: AnalyticsValue] = ["client_id": .string(anonymousID)]
+        if let version = info?["CFBundleShortVersionString"] as? String {
+            props["app_version"] = .string(version)
+        }
+        if let build = info?["CFBundleVersion"] as? String {
+            props["build_number"] = .string(build)
+        }
+        #if canImport(UIKit)
+        props["os_version"] = .string(UIDevice.current.systemVersion)
+        props["device_model"] = .string(UIDevice.current.model)
+        #endif
+        return props
+    }
+
+    @MainActor private static func clientConfigDeviceProperties(
+        anonymousID: String
+    ) -> [String: ClientConfigJSONValue] {
+        let info = Bundle.main.infoDictionary
+        var props: [String: ClientConfigJSONValue] = [
+            "client_id": .string(anonymousID),
+            "platform": .string("ios"),
+        ]
         if let version = info?["CFBundleShortVersionString"] as? String {
             props["app_version"] = .string(version)
         }

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,6 +1,7 @@
 RESEND_API_KEY=
 CMUX_FEEDBACK_FROM_EMAIL=
 CMUX_FEEDBACK_RATE_LIMIT_ID=
+CMUX_CLIENT_CONFIG_RATE_LIMIT_ID=
 
 # cmux Founder's Edition welcome email. /api/stripe/founders-welcome verifies the
 # Stripe webhook signature with this endpoint secret, then sends the welcome email

--- a/web/app/[locale]/posthog.tsx
+++ b/web/app/[locale]/posthog.tsx
@@ -8,11 +8,11 @@ import { useEffect, Suspense } from "react";
 if (typeof window !== "undefined") {
   posthog.init("phc_opOVu7oFzR9wD3I6ZahFGOV2h3mqGpl5EHyQvmHciDP", {
     api_host: "https://r.cmux.com",
-    flags_api_host: "https://r.cmux.dev",
     ui_host: "https://us.posthog.com",
     person_profiles: "identified_only",
     capture_pageview: false,
     capture_pageleave: true,
+    advanced_disable_feature_flags: true,
   });
 }
 

--- a/web/app/api/client-config/route.ts
+++ b/web/app/api/client-config/route.ts
@@ -33,6 +33,7 @@ export async function POST(request: Request): Promise<Response> {
       return json({ error: "client_config_unavailable" }, 503);
     } else if (error) {
       console.error("client-config.route.rate_limit_error", error);
+      return json({ error: "client_config_unavailable" }, 503);
     }
   }
 

--- a/web/app/api/client-config/route.ts
+++ b/web/app/api/client-config/route.ts
@@ -1,6 +1,7 @@
 import { checkRateLimit } from "@vercel/firewall";
 import { NextResponse } from "next/server";
 
+import "../../env";
 import { readBoundedJsonObject } from "../../../services/apns/routePolicy";
 import {
   CLIENT_CONFIG_FLAGS_TIMEOUT_MS,

--- a/web/app/api/client-config/route.ts
+++ b/web/app/api/client-config/route.ts
@@ -1,0 +1,79 @@
+import { checkRateLimit } from "@vercel/firewall";
+import { NextResponse } from "next/server";
+
+import { readBoundedJsonObject } from "../../../services/apns/routePolicy";
+import {
+  CLIENT_CONFIG_FLAGS_TIMEOUT_MS,
+  MAX_CLIENT_CONFIG_REQUEST_BYTES,
+  isPostHogFlagsResponseAvailable,
+  normalizeClientConfigEvaluationContext,
+  normalizeDistinctId,
+  normalizePostHogFlagsResponse,
+  postHogFlagsBody,
+  postHogFlagsUrl,
+} from "../../../services/client-config/posthogFlags";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  if (process.env.VERCEL === "1") {
+    const rateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID?.trim();
+    if (!rateLimitId) {
+      console.error("client-config.route.rate_limit_not_configured");
+      return json({ error: "client_config_unavailable" }, 503);
+    }
+
+    const { error, rateLimited } = await checkRateLimit(rateLimitId, { request });
+    if (rateLimited || error === "blocked") {
+      return json({ error: "rate_limited" }, 429);
+    }
+    if (error === "not-found") {
+      console.error("client-config.route.rate_limit_not_found", rateLimitId);
+      return json({ error: "client_config_unavailable" }, 503);
+    } else if (error) {
+      console.error("client-config.route.rate_limit_error", error);
+    }
+  }
+
+  const body = await readBoundedJsonObject(request, MAX_CLIENT_CONFIG_REQUEST_BYTES);
+  if (!body.ok) {
+    return json({ error: body.error }, body.error === "request_too_large" ? 413 : 400);
+  }
+
+  const distinctId = normalizeDistinctId(body.value.distinctId);
+  const context = normalizeClientConfigEvaluationContext(body.value.context);
+  try {
+    const response = await fetch(postHogFlagsUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: postHogFlagsBody(distinctId, context),
+      cache: "no-store",
+      signal: AbortSignal.timeout(CLIENT_CONFIG_FLAGS_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return json({ error: "client_config_unavailable" }, 502);
+    }
+
+    const raw = await response.json() as unknown;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return json({ error: "client_config_invalid" }, 502);
+    }
+    if (!isPostHogFlagsResponseAvailable(raw as Record<string, unknown>)) {
+      return json({ error: "client_config_unavailable" }, 502);
+    }
+
+    return json(normalizePostHogFlagsResponse(raw as Record<string, unknown>));
+  } catch {
+    return json({ error: "client_config_unavailable" }, 502);
+  }
+}
+
+function json(body: Record<string, unknown>, status = 200): Response {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -27,6 +27,7 @@ export const env = createEnv({
     RESEND_API_KEY: z.string().min(1),
     CMUX_FEEDBACK_FROM_EMAIL: z.string().email(),
     CMUX_FEEDBACK_RATE_LIMIT_ID: z.string().min(1),
+    CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: z.string().min(1).optional(),
     STACK_SECRET_SERVER_KEY: z.string().min(1),
     // APNs push (iOS notifications). Optional: the app boots without them; the
     // push route returns a clear "not configured" error until they are set.
@@ -55,6 +56,7 @@ export const env = createEnv({
     RESEND_API_KEY: trimEnv(process.env.RESEND_API_KEY),
     CMUX_FEEDBACK_FROM_EMAIL: trimEnv(process.env.CMUX_FEEDBACK_FROM_EMAIL),
     CMUX_FEEDBACK_RATE_LIMIT_ID: trimEnv(process.env.CMUX_FEEDBACK_RATE_LIMIT_ID),
+    CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: trimEnv(process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID),
     CMUX_APNS_KEY_P8: trimEnv(process.env.CMUX_APNS_KEY_P8),
     CMUX_APNS_KEY_ID: trimEnv(process.env.CMUX_APNS_KEY_ID),
     CMUX_APNS_TEAM_ID: trimEnv(process.env.CMUX_APNS_TEAM_ID),

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -12,6 +12,15 @@ const skipEnvValidation =
   process.env.SKIP_ENV_VALIDATION === "1" ||
   process.env.VERCEL_ENV === "preview";
 const allowPreviewStackPlaceholders = process.env.VERCEL_ENV === "preview";
+const requireVercelNonPreviewValue = (name: string): z.ZodType<string | undefined> =>
+  z.string().min(1).optional().superRefine((value, context) => {
+    if (process.env.VERCEL === "1" && process.env.VERCEL_ENV !== "preview" && !value) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${name} is required for deployed non-preview runtimes`,
+      });
+    }
+  });
 
 const stackEnv = (
   value: string | undefined,
@@ -27,7 +36,7 @@ export const env = createEnv({
     RESEND_API_KEY: z.string().min(1),
     CMUX_FEEDBACK_FROM_EMAIL: z.string().email(),
     CMUX_FEEDBACK_RATE_LIMIT_ID: z.string().min(1),
-    CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: z.string().min(1).optional(),
+    CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: requireVercelNonPreviewValue("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID"),
     STACK_SECRET_SERVER_KEY: z.string().min(1),
     // APNs push (iOS notifications). Optional: the app boots without them; the
     // push route returns a clear "not configured" error until they are set.

--- a/web/app/lib/client-config-flags.ts
+++ b/web/app/lib/client-config-flags.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { getClientConfig, type ClientConfig, type ClientConfigFlagValue } from "./client-config";
+
+export type ClientConfigFlagDefinition<Value> = {
+  readonly key: string;
+  readonly defaultValue: Value;
+  readonly read: (config: ClientConfig) => Value;
+};
+
+export type ClientConfigPayloadDefinition<Value> = {
+  readonly key: string;
+  readonly defaultValue: Value | undefined;
+  readonly read: (config: ClientConfig) => Value | undefined;
+};
+
+export function booleanClientConfigFlag(
+  key: string,
+  defaultValue = false,
+): ClientConfigFlagDefinition<boolean> {
+  return {
+    key,
+    defaultValue,
+    read(config) {
+      const value = config.featureFlags[key];
+      return typeof value === "boolean" ? value : defaultValue;
+    },
+  };
+}
+
+export function variantClientConfigFlag(
+  key: string,
+  defaultValue?: string,
+): ClientConfigFlagDefinition<string | undefined> {
+  return {
+    key,
+    defaultValue,
+    read(config) {
+      const value = config.featureFlags[key];
+      return typeof value === "string" ? value : defaultValue;
+    },
+  };
+}
+
+export function payloadClientConfigFlag<Value>(
+  key: string,
+  decode: (payload: unknown) => Value | undefined,
+  defaultValue?: Value,
+): ClientConfigPayloadDefinition<Value> {
+  return {
+    key,
+    defaultValue,
+    read(config) {
+      const value = decode(config.featureFlagPayloads[key]);
+      return value === undefined ? defaultValue : value;
+    },
+  };
+}
+
+export function getClientConfigValue<Value>(
+  config: ClientConfig,
+  flag: ClientConfigFlagDefinition<Value>,
+): Value {
+  return flag.read(config);
+}
+
+export async function loadClientConfigValue<Value>(
+  flag: ClientConfigFlagDefinition<Value>,
+  options: Parameters<typeof getClientConfig>[0] = {},
+): Promise<Value> {
+  return flag.read(await getClientConfig(options));
+}
+
+export function rawClientConfigFlagValue(
+  config: ClientConfig,
+  key: string,
+): ClientConfigFlagValue | undefined {
+  return config.featureFlags[key];
+}
+
+export const clientConfigFlags = {
+  cmuxForWindows: booleanClientConfigFlag("cmux-for-windows"),
+  cmuxForLinux: booleanClientConfigFlag("cmux-for-linux"),
+  cmuxForAndroid: booleanClientConfigFlag("cmux-for-android"),
+  proUpgradeUIEnabledRelease: booleanClientConfigFlag("pro-upgrade-ui-enabled-release"),
+  mobileConnectButtonEnabledRelease: booleanClientConfigFlag("mobile-connect-button-enabled-release"),
+} as const;

--- a/web/app/lib/client-config.ts
+++ b/web/app/lib/client-config.ts
@@ -1,0 +1,173 @@
+"use client";
+
+import posthog from "posthog-js";
+
+export type ClientConfigFlagValue = boolean | string;
+
+export type ClientConfig = {
+  readonly featureFlags: Record<string, ClientConfigFlagValue>;
+  readonly featureFlagPayloads: Record<string, unknown>;
+  readonly errorsWhileComputingFlags: boolean;
+  readonly requestId?: string;
+};
+
+export type ClientConfigEvaluationContext = {
+  readonly groups?: Record<string, unknown>;
+  readonly personProperties?: Record<string, unknown>;
+  readonly groupProperties?: Record<string, unknown>;
+  readonly anonDistinctId?: string;
+  readonly deviceId?: string;
+  readonly timezone?: string;
+  readonly evaluationContexts?: readonly string[];
+};
+
+type PostHogWithFlagContext = typeof posthog & {
+  readonly config?: {
+    readonly evaluation_contexts?: unknown;
+    readonly evaluation_environments?: unknown;
+  };
+  readonly getAnonymousId?: () => unknown;
+  readonly featureFlags?: {
+    readonly $anon_distinct_id?: unknown;
+  };
+  readonly persistence?: {
+    readonly get_initial_props?: () => unknown;
+  };
+};
+
+export async function getClientConfig(
+  options: { readonly distinctId?: string; readonly context?: ClientConfigEvaluationContext } = {},
+): Promise<ClientConfig> {
+  const response = await fetch("/api/client-config", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      distinctId: options.distinctId ?? getPostHogDistinctId(),
+      context: options.context ?? getPostHogEvaluationContext(),
+    }),
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error("client_config_unavailable");
+  }
+  return await response.json() as ClientConfig;
+}
+
+export function getClientConfigFlag(
+  config: ClientConfig,
+  key: string,
+): ClientConfigFlagValue | undefined {
+  return config.featureFlags[key];
+}
+
+function getPostHogEvaluationContext(): ClientConfigEvaluationContext {
+  return {
+    groups: getPostHogGroups(),
+    personProperties: getPostHogPersonProperties(),
+    groupProperties: getPostHogRecordProperty("$stored_group_properties"),
+    anonDistinctId: getPostHogAnonDistinctId(),
+    deviceId: getPostHogStringProperty("$device_id"),
+    timezone: getBrowserTimezone(),
+    evaluationContexts: getPostHogEvaluationContexts(),
+  };
+}
+
+function getPostHogDistinctId(): string {
+  try {
+    const distinctId = posthog.get_distinct_id();
+    if (typeof distinctId === "string" && distinctId.trim()) return distinctId;
+  } catch {
+    return "anonymous";
+  }
+  return "anonymous";
+}
+
+function getPostHogGroups(): Record<string, unknown> {
+  try {
+    const groups = posthog.getGroups();
+    if (groups && typeof groups === "object" && !Array.isArray(groups)) {
+      return { ...(groups as Record<string, unknown>) };
+    }
+  } catch {
+    return {};
+  }
+  return {};
+}
+
+function getPostHogPersonProperties(): Record<string, unknown> {
+  return {
+    ...getPostHogInitialProps(),
+    ...getPostHogRecordProperty("$stored_person_properties"),
+  };
+}
+
+function getPostHogInitialProps(): Record<string, unknown> {
+  const client = posthog as PostHogWithFlagContext;
+  try {
+    const value = client.persistence?.get_initial_props?.();
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return { ...(value as Record<string, unknown>) };
+    }
+  } catch {
+    return {};
+  }
+  return {};
+}
+
+function getPostHogRecordProperty(key: string): Record<string, unknown> {
+  try {
+    const value = posthog.get_property(key);
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return { ...(value as Record<string, unknown>) };
+    }
+  } catch {
+    return {};
+  }
+  return {};
+}
+
+function getPostHogStringProperty(key: string): string | undefined {
+  try {
+    const value = posthog.get_property(key);
+    return typeof value === "string" && value.trim() ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getPostHogAnonDistinctId(): string | undefined {
+  const client = posthog as PostHogWithFlagContext;
+  try {
+    const value = client.getAnonymousId?.();
+    if (typeof value === "string" && value.trim()) return value;
+  } catch {
+    return getPersistedPostHogAnonDistinctId(client);
+  }
+  return getPersistedPostHogAnonDistinctId(client);
+}
+
+function getPersistedPostHogAnonDistinctId(client: PostHogWithFlagContext): string | undefined {
+  const value = getPostHogStringProperty("anonymous_id") ??
+    getPostHogStringProperty("$anon_distinct_id") ??
+    client.featureFlags?.$anon_distinct_id;
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function getBrowserTimezone(): string | undefined {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+}
+
+function getPostHogEvaluationContexts(): string[] | undefined {
+  const client = posthog as PostHogWithFlagContext;
+  const value = client.config?.evaluation_contexts ?? client.config?.evaluation_environments;
+  if (!Array.isArray(value)) return undefined;
+  const contexts = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return contexts.length ? contexts : undefined;
+}

--- a/web/app/lib/client-config.ts
+++ b/web/app/lib/client-config.ts
@@ -53,13 +53,6 @@ export async function getClientConfig(
   return await response.json() as ClientConfig;
 }
 
-export function getClientConfigFlag(
-  config: ClientConfig,
-  key: string,
-): ClientConfigFlagValue | undefined {
-  return config.featureFlags[key];
-}
-
 function getPostHogEvaluationContext(): ClientConfigEvaluationContext {
   return {
     groups: getPostHogGroups(),

--- a/web/scripts/load-dev-env.sh
+++ b/web/scripts/load-dev-env.sh
@@ -103,6 +103,7 @@ fi
 export RESEND_API_KEY="${RESEND_API_KEY:-cmux-local-dev}"
 export CMUX_FEEDBACK_FROM_EMAIL="${CMUX_FEEDBACK_FROM_EMAIL:-dev@example.invalid}"
 export CMUX_FEEDBACK_RATE_LIMIT_ID="${CMUX_FEEDBACK_RATE_LIMIT_ID:-cmux-feedback-local}"
+export CMUX_CLIENT_CONFIG_RATE_LIMIT_ID="${CMUX_CLIENT_CONFIG_RATE_LIMIT_ID:-cmux-client-config-local}"
 export CMUX_PUSH_RATE_LIMIT_ID="${CMUX_PUSH_RATE_LIMIT_ID:-cmux-push-local}"
 
 export CMUX_WEB_SECRET_ENV_FILE="$cmux_secret_file"

--- a/web/services/client-config/posthogFlags.ts
+++ b/web/services/client-config/posthogFlags.ts
@@ -145,6 +145,8 @@ function normalizeFeatureFlagPayloads(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const payloads: Record<string, unknown> = {};
   for (const [key, payload] of Object.entries(value)) {
+    // Match posthog-js: payload values are already JSON values, and string
+    // payloads remain strings instead of being parsed opportunistically.
     payloads[key] = payload;
   }
   return payloads;
@@ -187,5 +189,7 @@ function payloadFromDetailedFlag(value: unknown, flagValue: ClientConfigFlagValu
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
   const metadata = (value as Record<string, unknown>).metadata;
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return undefined;
+  // posthog-js copies metadata.payload through without JSON.parse; preserve
+  // string payloads so free-text payloads do not change type.
   return (metadata as Record<string, unknown>).payload;
 }

--- a/web/services/client-config/posthogFlags.ts
+++ b/web/services/client-config/posthogFlags.ts
@@ -1,0 +1,176 @@
+import { POSTHOG_PROJECT_KEY } from "../analytics/iosEventPolicy";
+
+export const MAX_CLIENT_CONFIG_REQUEST_BYTES = 16 * 1024;
+export const CLIENT_CONFIG_FLAGS_TIMEOUT_MS = 4_000;
+export const POSTHOG_FLAGS_HOST = (process.env.POSTHOG_FLAGS_HOST ?? "https://us.i.posthog.com").replace(/\/$/, "");
+
+export type ClientConfigFlagValue = boolean | string;
+
+export type ClientConfig = {
+  readonly featureFlags: Record<string, ClientConfigFlagValue>;
+  readonly featureFlagPayloads: Record<string, unknown>;
+  readonly errorsWhileComputingFlags: boolean;
+  readonly requestId?: string;
+};
+
+export type ClientConfigEvaluationContext = {
+  readonly groups?: Record<string, unknown>;
+  readonly personProperties?: Record<string, unknown>;
+  readonly groupProperties?: Record<string, unknown>;
+  readonly anonDistinctId?: string;
+  readonly deviceId?: string;
+  readonly timezone?: string;
+  readonly evaluationContexts?: readonly string[];
+};
+
+export function normalizeDistinctId(value: unknown): string {
+  if (typeof value !== "string") return "anonymous";
+  const trimmed = value.trim();
+  if (!trimmed) return "anonymous";
+  return trimmed.slice(0, 200);
+}
+
+export function postHogFlagsUrl(): string {
+  return `${POSTHOG_FLAGS_HOST}/flags/?v=2&ip=0`;
+}
+
+export function postHogFlagsBody(distinctId: string, context: ClientConfigEvaluationContext = {}): string {
+  const body: Record<string, unknown> = {
+    token: POSTHOG_PROJECT_KEY,
+    distinct_id: distinctId,
+    groups: context.groups ?? {},
+    person_properties: context.personProperties ?? {},
+    group_properties: context.groupProperties ?? {},
+  };
+  if (context.anonDistinctId) body.$anon_distinct_id = context.anonDistinctId;
+  if (context.deviceId) body.$device_id = context.deviceId;
+  if (context.timezone) body.timezone = context.timezone;
+  if (context.evaluationContexts?.length) body.evaluation_contexts = context.evaluationContexts;
+  return JSON.stringify(body);
+}
+
+export function normalizeClientConfigEvaluationContext(value: unknown): ClientConfigEvaluationContext {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const record = value as Record<string, unknown>;
+  return {
+    groups: normalizePayloads(record.groups),
+    personProperties: normalizePayloads(record.personProperties),
+    groupProperties: normalizePayloads(record.groupProperties),
+    anonDistinctId: normalizeOptionalString(record.anonDistinctId),
+    deviceId: normalizeOptionalString(record.deviceId),
+    timezone: normalizeOptionalString(record.timezone),
+    evaluationContexts: normalizeStringArray(record.evaluationContexts),
+  };
+}
+
+export function normalizePostHogFlagsResponse(body: Record<string, unknown>): ClientConfig {
+  const featureFlags: Record<string, ClientConfigFlagValue> = {};
+  const legacyPayloads = normalizeFeatureFlagPayloads(body.featureFlagPayloads);
+  const featureFlagPayloads = { ...legacyPayloads };
+
+  const legacyFeatureFlags = body.featureFlags;
+  if (legacyFeatureFlags && typeof legacyFeatureFlags === "object" && !Array.isArray(legacyFeatureFlags)) {
+    for (const [key, value] of Object.entries(legacyFeatureFlags)) {
+      if (typeof value === "boolean" || typeof value === "string") {
+        featureFlags[key] = value;
+      }
+    }
+  }
+
+  const detailedFlags = body.flags;
+  if (!isFlagsRecord(detailedFlags)) {
+    for (const key of Object.keys(legacyPayloads)) {
+      if (featureFlags[key] === undefined) featureFlags[key] = true;
+    }
+  }
+
+  if (detailedFlags && typeof detailedFlags === "object" && !Array.isArray(detailedFlags)) {
+    for (const [key, value] of Object.entries(detailedFlags)) {
+      if (isFailedDetailedFlag(value)) continue;
+      const normalized = normalizeDetailedFlag(value);
+      if (normalized !== undefined) featureFlags[key] = normalized;
+      const payload = payloadFromDetailedFlag(value, normalized);
+      if (payload !== undefined && featureFlagPayloads[key] === undefined) {
+        featureFlagPayloads[key] = payload;
+      }
+    }
+  }
+
+  const config: ClientConfig = {
+    featureFlags,
+    featureFlagPayloads,
+    errorsWhileComputingFlags: body.errorsWhileComputingFlags === true,
+  };
+  if (typeof body.requestId === "string") {
+    return { ...config, requestId: body.requestId };
+  }
+  return config;
+}
+
+export function isPostHogFlagsResponseAvailable(body: Record<string, unknown>): boolean {
+  if (isFeatureFlagsQuotaLimited(body.quotaLimited)) return false;
+  return isFlagsRecord(body.featureFlags) || isFlagsRecord(body.flags) || isFlagsRecord(body.featureFlagPayloads);
+}
+
+function isFeatureFlagsQuotaLimited(value: unknown): boolean {
+  if (value === true) return true;
+  return Array.isArray(value) && value.includes("feature_flags");
+}
+
+function isFlagsRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function normalizePayloads(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return { ...(value as Record<string, unknown>) };
+}
+
+function normalizeFeatureFlagPayloads(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const payloads: Record<string, unknown> = {};
+  for (const [key, payload] of Object.entries(value)) {
+    payloads[key] = payload;
+  }
+  return payloads;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 500) : undefined;
+}
+
+function normalizeStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 20);
+  return strings.length ? strings : undefined;
+}
+
+function normalizeDetailedFlag(value: unknown): ClientConfigFlagValue | undefined {
+  if (typeof value === "boolean" || typeof value === "string") return value;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+
+  const record = value as Record<string, unknown>;
+  if (record.enabled === false) return false;
+  if (typeof record.variant === "string") return record.variant;
+  if (typeof record.enabled === "boolean") return record.enabled;
+  return undefined;
+}
+
+function isFailedDetailedFlag(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return (value as Record<string, unknown>).failed === true;
+}
+
+function payloadFromDetailedFlag(value: unknown, flagValue: ClientConfigFlagValue | undefined): unknown {
+  if (flagValue === undefined || flagValue === false) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const metadata = (value as Record<string, unknown>).metadata;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return undefined;
+  return (metadata as Record<string, unknown>).payload;
+}

--- a/web/services/client-config/posthogFlags.ts
+++ b/web/services/client-config/posthogFlags.ts
@@ -67,6 +67,7 @@ export function normalizePostHogFlagsResponse(body: Record<string, unknown>): Cl
   const featureFlags: Record<string, ClientConfigFlagValue> = {};
   const legacyPayloads = normalizeFeatureFlagPayloads(body.featureFlagPayloads);
   const featureFlagPayloads = { ...legacyPayloads };
+  const suppressedPayloadKeys = new Set<string>();
 
   const legacyFeatureFlags = body.featureFlags;
   if (legacyFeatureFlags && typeof legacyFeatureFlags === "object" && !Array.isArray(legacyFeatureFlags)) {
@@ -78,21 +79,35 @@ export function normalizePostHogFlagsResponse(body: Record<string, unknown>): Cl
   }
 
   const detailedFlags = body.flags;
-  if (!isFlagsRecord(detailedFlags)) {
-    for (const key of Object.keys(legacyPayloads)) {
-      if (featureFlags[key] === undefined) featureFlags[key] = true;
-    }
-  }
-
   if (detailedFlags && typeof detailedFlags === "object" && !Array.isArray(detailedFlags)) {
     for (const [key, value] of Object.entries(detailedFlags)) {
-      if (isFailedDetailedFlag(value)) continue;
+      if (isFailedDetailedFlag(value)) {
+        delete featureFlags[key];
+        delete featureFlagPayloads[key];
+        suppressedPayloadKeys.add(key);
+        continue;
+      }
       const normalized = normalizeDetailedFlag(value);
-      if (normalized !== undefined) featureFlags[key] = normalized;
+      if (normalized !== undefined) {
+        featureFlags[key] = normalized;
+        if (normalized === false) {
+          delete featureFlagPayloads[key];
+          suppressedPayloadKeys.add(key);
+        }
+      }
       const payload = payloadFromDetailedFlag(value, normalized);
       if (payload !== undefined && featureFlagPayloads[key] === undefined) {
         featureFlagPayloads[key] = payload;
       }
+    }
+  }
+
+  for (const key of Object.keys(legacyPayloads)) {
+    if (featureFlags[key] === undefined && !suppressedPayloadKeys.has(key)) {
+      featureFlags[key] = true;
+    }
+    if (featureFlags[key] === false || suppressedPayloadKeys.has(key)) {
+      delete featureFlagPayloads[key];
     }
   }
 

--- a/web/tests/client-config-flags.test.ts
+++ b/web/tests/client-config-flags.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("posthog-js", () => ({
+  default: {},
+}));
+
+const {
+  booleanClientConfigFlag,
+  clientConfigFlags,
+  getClientConfigValue,
+  payloadClientConfigFlag,
+  rawClientConfigFlagValue,
+  variantClientConfigFlag,
+} = await import("../app/lib/client-config-flags");
+
+import type { ClientConfig } from "../app/lib/client-config";
+
+describe("client-config typed flags", () => {
+  test("reads declared boolean flags with safe fallback on wrong type", () => {
+    const config: ClientConfig = {
+      featureFlags: {
+        "cmux-for-windows": true,
+        "cmux-for-linux": "beta",
+      },
+      featureFlagPayloads: {},
+      errorsWhileComputingFlags: false,
+    };
+
+    expect(getClientConfigValue(config, clientConfigFlags.cmuxForWindows)).toBe(true);
+    expect(getClientConfigValue(config, clientConfigFlags.cmuxForLinux)).toBe(false);
+    expect(getClientConfigValue(config, booleanClientConfigFlag("missing", true))).toBe(true);
+  });
+
+  test("reads declared variant flags with safe fallback on wrong type", () => {
+    const config: ClientConfig = {
+      featureFlags: {
+        "pricing-copy": "enterprise",
+        "pricing-enabled": true,
+      },
+      featureFlagPayloads: {},
+      errorsWhileComputingFlags: false,
+    };
+
+    expect(getClientConfigValue(config, variantClientConfigFlag("pricing-copy"))).toBe("enterprise");
+    expect(getClientConfigValue(config, variantClientConfigFlag("pricing-enabled"))).toBeUndefined();
+    expect(getClientConfigValue(config, variantClientConfigFlag("missing", "control"))).toBe("control");
+  });
+
+  test("decodes payloads through caller-provided parser", () => {
+    const config: ClientConfig = {
+      featureFlags: {},
+      featureFlagPayloads: {
+        "pricing-copy": { headline: "Ship faster", seats: 12 },
+      },
+      errorsWhileComputingFlags: false,
+    };
+    const pricingPayload = payloadClientConfigFlag("pricing-copy", (payload) => {
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+      const record = payload as Record<string, unknown>;
+      if (typeof record.headline !== "string" || typeof record.seats !== "number") return undefined;
+      return { headline: record.headline, seats: record.seats };
+    });
+
+    expect(pricingPayload.read(config)).toEqual({ headline: "Ship faster", seats: 12 });
+  });
+
+  test("preserves explicit null payloads when a default exists", () => {
+    const config: ClientConfig = {
+      featureFlags: {},
+      featureFlagPayloads: {
+        "pricing-copy": null,
+      },
+      errorsWhileComputingFlags: false,
+    };
+    const nullablePayload = payloadClientConfigFlag(
+      "pricing-copy",
+      (payload): string | null | undefined => payload === null ? null : undefined,
+      "control",
+    );
+
+    expect(nullablePayload.read(config)).toBeNull();
+  });
+
+  test("keeps raw access explicitly named for diagnostics", () => {
+    const config: ClientConfig = {
+      featureFlags: { "unknown-flag": "variant" },
+      featureFlagPayloads: {},
+      errorsWhileComputingFlags: false,
+    };
+
+    expect(rawClientConfigFlagValue(config, "unknown-flag")).toBe("variant");
+  });
+});

--- a/web/tests/client-config-helper.test.ts
+++ b/web/tests/client-config-helper.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+const getDistinctId = mock(() => "posthog-distinct-id");
+const getAnonymousId = mock(() => "anon-id");
+const getGroups = mock(() => ({ organization: "org-1" }));
+const getProperty = mock((key: unknown) => {
+  switch (key) {
+    case "$stored_person_properties":
+      return { plan: "pro" };
+    case "$stored_group_properties":
+      return { organization: { tier: "team" } };
+    case "anonymous_id":
+      return "persisted-anon-id";
+    case "$device_id":
+      return "device-id";
+    default:
+      return undefined;
+  }
+});
+
+mock.module("posthog-js", () => ({
+  default: {
+    get_distinct_id: getDistinctId,
+    getAnonymousId,
+    getGroups,
+    get_property: getProperty,
+    featureFlags: {
+      $anon_distinct_id: "internal-anon-id",
+    },
+    config: {
+      evaluation_contexts: ["web"],
+    },
+    persistence: {
+      get_initial_props: () => ({
+        plan: "free",
+        initial_referrer: "https://example.com",
+      }),
+    },
+  },
+}));
+
+const { getClientConfig } = await import("../app/lib/client-config");
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  getDistinctId.mockClear();
+  getAnonymousId.mockClear();
+  getGroups.mockClear();
+  getProperty.mockClear();
+});
+
+describe("getClientConfig", () => {
+  test("uses the PostHog distinct id by default", async () => {
+    const fetchBodies: string[] = [];
+    globalThis.fetch = mock(async (...args: unknown[]) => {
+      const init = args[1] as RequestInit | undefined;
+      if (typeof init?.body === "string") fetchBodies.push(init.body);
+      return new Response(JSON.stringify({
+        errorsWhileComputingFlags: false,
+        featureFlags: {},
+        featureFlagPayloads: {},
+      }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }) as unknown as typeof fetch;
+
+    await getClientConfig();
+
+    expect(fetchBodies).toEqual([JSON.stringify({
+      distinctId: "posthog-distinct-id",
+      context: {
+        groups: { organization: "org-1" },
+        personProperties: {
+          plan: "pro",
+          initial_referrer: "https://example.com",
+        },
+        groupProperties: { organization: { tier: "team" } },
+        anonDistinctId: "anon-id",
+        deviceId: "device-id",
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        evaluationContexts: ["web"],
+      },
+    })]);
+  });
+
+  test("allows callers to pass an explicit distinct id", async () => {
+    const fetchBodies: string[] = [];
+    globalThis.fetch = mock(async (...args: unknown[]) => {
+      const init = args[1] as RequestInit | undefined;
+      if (typeof init?.body === "string") fetchBodies.push(init.body);
+      return new Response(JSON.stringify({
+        errorsWhileComputingFlags: false,
+        featureFlags: {},
+        featureFlagPayloads: {},
+      }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }) as unknown as typeof fetch;
+
+    await getClientConfig({
+      distinctId: "server-authoritative-id",
+      context: { groups: { organization: "org-2" } },
+    });
+
+    expect(fetchBodies).toEqual([JSON.stringify({
+      distinctId: "server-authoritative-id",
+      context: { groups: { organization: "org-2" } },
+    })]);
+    expect(getDistinctId).not.toHaveBeenCalled();
+    expect(getAnonymousId).not.toHaveBeenCalled();
+    expect(getGroups).not.toHaveBeenCalled();
+    expect(getProperty).not.toHaveBeenCalled();
+  });
+});

--- a/web/tests/client-config-route.test.ts
+++ b/web/tests/client-config-route.test.ts
@@ -1,5 +1,8 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 
+const originalSkipEnvValidation = process.env.SKIP_ENV_VALIDATION;
+const originalPostHogProjectKey = process.env.POSTHOG_PROJECT_KEY;
+const originalClientConfigRateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID;
 process.env.SKIP_ENV_VALIDATION = "1";
 process.env.POSTHOG_PROJECT_KEY = "test-project-key";
 process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID = "cmux-client-config-test";
@@ -32,6 +35,12 @@ afterEach(() => {
   } else {
     process.env.VERCEL = originalVercel;
   }
+});
+
+afterAll(() => {
+  restoreEnv("SKIP_ENV_VALIDATION", originalSkipEnvValidation);
+  restoreEnv("POSTHOG_PROJECT_KEY", originalPostHogProjectKey);
+  restoreEnv("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID", originalClientConfigRateLimitId);
 });
 
 describe("client config", () => {
@@ -107,6 +116,50 @@ describe("client config", () => {
       featureFlagPayloads: {
         "pricing-page-copy": { cta: "Start" },
         "pricing-page-payload-only": "{\"plan\":\"team\"}",
+      },
+    });
+  });
+
+  test("lets detailed disabled and failed flags suppress legacy payloads", () => {
+    const config = normalizePostHogFlagsResponse({
+      errorsWhileComputingFlags: false,
+      featureFlags: {
+        "pricing-page-disabled": "checkout-a",
+        "pricing-page-failed": true,
+        "pricing-page-legacy-disabled": false,
+      },
+      featureFlagPayloads: {
+        "pricing-page-disabled": { cta: "Disabled" },
+        "pricing-page-failed": { cta: "Failed" },
+        "pricing-page-payload-only": "{\"plan\":\"team\"}",
+        "pricing-page-legacy-disabled": { cta: "Legacy disabled" },
+        "pricing-page-legacy-payload-only": { cta: "Legacy payload" },
+      },
+      flags: {
+        "pricing-page-disabled": {
+          enabled: false,
+          variant: "checkout-b",
+          metadata: { payload: { cta: "Should not leak" } },
+        },
+        "pricing-page-failed": {
+          enabled: true,
+          failed: true,
+          metadata: { payload: { cta: "Should not leak" } },
+        },
+      },
+    });
+
+    expect(config).toEqual({
+      errorsWhileComputingFlags: false,
+      featureFlags: {
+        "pricing-page-disabled": false,
+        "pricing-page-legacy-disabled": false,
+        "pricing-page-payload-only": true,
+        "pricing-page-legacy-payload-only": true,
+      },
+      featureFlagPayloads: {
+        "pricing-page-payload-only": "{\"plan\":\"team\"}",
+        "pricing-page-legacy-payload-only": { cta: "Legacy payload" },
       },
     });
   });
@@ -269,4 +322,38 @@ describe("client config", () => {
     expect(checkRateLimit).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  test("fails closed on Vercel when the client-config limiter returns an error", async () => {
+    process.env.VERCEL = "1";
+    checkRateLimit.mockResolvedValue({ rateLimited: false, error: "firewall-unavailable" });
+    const consoleError = mock(() => {});
+    console.error = consoleError as unknown as typeof console.error;
+    const fetchMock = mock(async () => {
+      throw new Error("PostHog flags should not be reached after a limiter error");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await POST(new Request("https://cmux.test/api/client-config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ distinctId: "browser-id" }),
+    }));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "client_config_unavailable" });
+    expect(consoleError).toHaveBeenCalledWith(
+      "client-config.route.rate_limit_error",
+      "firewall-unavailable",
+    );
+    expect(checkRateLimit).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (typeof value === "undefined") {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/web/tests/client-config-route.test.ts
+++ b/web/tests/client-config-route.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.POSTHOG_PROJECT_KEY = "test-project-key";
+process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID = "cmux-client-config-test";
+
+const originalVercel = process.env.VERCEL;
+const checkRateLimit = mock(async () => ({ rateLimited: false, error: null }));
+
+mock.module("@vercel/firewall", () => ({
+  checkRateLimit,
+}));
+
+const {
+  normalizePostHogFlagsResponse,
+  postHogFlagsBody,
+  postHogFlagsUrl,
+} = await import("../services/client-config/posthogFlags");
+const { POST } = await import("../app/api/client-config/route");
+
+const originalFetch = globalThis.fetch;
+const originalConsoleError = console.error;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.error = originalConsoleError;
+  process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID = "cmux-client-config-test";
+  checkRateLimit.mockClear();
+  checkRateLimit.mockResolvedValue({ rateLimited: false, error: null });
+  if (typeof originalVercel === "undefined") {
+    delete process.env.VERCEL;
+  } else {
+    process.env.VERCEL = originalVercel;
+  }
+});
+
+describe("client config", () => {
+  test("normalizes detailed PostHog flag responses", () => {
+    const config = normalizePostHogFlagsResponse({
+      errorsWhileComputingFlags: false,
+      requestId: "request-1",
+      flags: {
+        "pricing-page-copy": {
+          enabled: true,
+          variant: "checkout-a",
+          metadata: { payload: { cta: "Start" } },
+        },
+        "pricing-page-string-payload": {
+          enabled: true,
+          variant: "checkout-b",
+          metadata: { payload: "{\"cta\":\"Keep as text\"}" },
+        },
+        "pricing-page-visible": {
+          enabled: false,
+          variant: null,
+          metadata: { payload: null },
+        },
+        "pricing-page-disabled-variant": {
+          enabled: false,
+          variant: "checkout-b",
+          metadata: { payload: "{\"cta\":\"Disabled\"}" },
+        },
+        "pricing-page-failed": {
+          enabled: false,
+          failed: true,
+          metadata: { payload: "{\"cta\":\"Broken\"}" },
+        },
+      },
+    });
+
+    expect(config).toEqual({
+      errorsWhileComputingFlags: false,
+      requestId: "request-1",
+      featureFlags: {
+        "pricing-page-copy": "checkout-a",
+        "pricing-page-string-payload": "checkout-b",
+        "pricing-page-visible": false,
+        "pricing-page-disabled-variant": false,
+      },
+      featureFlagPayloads: {
+        "pricing-page-copy": { cta: "Start" },
+        "pricing-page-string-payload": "{\"cta\":\"Keep as text\"}",
+      },
+    });
+  });
+
+  test("preserves legacy PostHog payload values", () => {
+    const config = normalizePostHogFlagsResponse({
+      errorsWhileComputingFlags: false,
+      featureFlags: {
+        "pricing-page-copy": "checkout-a",
+        "pricing-page-hidden": false,
+      },
+      featureFlagPayloads: {
+        "pricing-page-copy": { cta: "Start" },
+        "pricing-page-payload-only": "{\"plan\":\"team\"}",
+      },
+    });
+
+    expect(config).toEqual({
+      errorsWhileComputingFlags: false,
+      featureFlags: {
+        "pricing-page-copy": "checkout-a",
+        "pricing-page-hidden": false,
+        "pricing-page-payload-only": true,
+      },
+      featureFlagPayloads: {
+        "pricing-page-copy": { cta: "Start" },
+        "pricing-page-payload-only": "{\"plan\":\"team\"}",
+      },
+    });
+  });
+
+  test("forwards route requests to PostHog flags from the server", async () => {
+    const fetchCalls: Array<[RequestInfo | URL, RequestInit | undefined]> = [];
+    const fetchMock = mock(async (...args: unknown[]) => {
+      fetchCalls.push([args[0] as RequestInfo | URL, args[1] as RequestInit | undefined]);
+      return new Response(
+        JSON.stringify({
+          errorsWhileComputingFlags: false,
+          featureFlags: { "pricing-page-visible": true },
+          featureFlagPayloads: { "pricing-page-visible": { plan: "team" } },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await POST(new Request("https://cmux.test/api/client-config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        distinctId: "browser-id",
+        context: {
+          groups: { organization: "org-1" },
+          personProperties: { plan: "pro" },
+          groupProperties: { organization: { tier: "team" } },
+          anonDistinctId: "anon-id",
+          deviceId: "device-id",
+          timezone: "America/Los_Angeles",
+          evaluationContexts: ["web"],
+        },
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      errorsWhileComputingFlags: false,
+      featureFlags: { "pricing-page-visible": true },
+      featureFlagPayloads: { "pricing-page-visible": { plan: "team" } },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const fetchCall = fetchCalls[0];
+    expect(fetchCall?.[0]).toBe(postHogFlagsUrl());
+    const fetchInit = fetchCall?.[1] as RequestInit | undefined;
+    expect(fetchInit).toMatchObject({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: postHogFlagsBody("browser-id", {
+        groups: { organization: "org-1" },
+        personProperties: { plan: "pro" },
+        groupProperties: { organization: { tier: "team" } },
+        anonDistinctId: "anon-id",
+        deviceId: "device-id",
+        timezone: "America/Los_Angeles",
+        evaluationContexts: ["web"],
+      }),
+      cache: "no-store",
+    });
+    expect(fetchInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("treats quota-limited or flagless upstream responses as unavailable", async () => {
+    for (const upstreamBody of [
+      { quotaLimited: true },
+      { flags: {}, quotaLimited: ["feature_flags"] },
+      { requestId: "request-without-flags" },
+    ]) {
+      const fetchMock = mock(async () => new Response(
+        JSON.stringify(upstreamBody),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const response = await POST(new Request("https://cmux.test/api/client-config", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ distinctId: "browser-id" }),
+      }));
+
+      expect(response.status).toBe(502);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(await response.json()).toEqual({ error: "client_config_unavailable" });
+    }
+  });
+
+  test("applies the Vercel limiter before proxying flags", async () => {
+    process.env.VERCEL = "1";
+    process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID = " cmux-client-config-test\n";
+    checkRateLimit.mockResolvedValue({ rateLimited: true, error: null });
+    const fetchMock = mock(async () => {
+      throw new Error("PostHog flags should not be reached after a rate-limit block");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await POST(new Request("https://cmux.test/api/client-config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+    }));
+
+    expect(response.status).toBe(429);
+    expect(await response.json()).toEqual({ error: "rate_limited" });
+    expect(checkRateLimit).toHaveBeenCalledTimes(1);
+    const calls = (checkRateLimit as unknown as {
+      mock: { calls: Array<[string, { request: Request }]> };
+    }).mock.calls;
+    expect(calls[0]?.[0]).toBe("cmux-client-config-test");
+    expect(calls[0]?.[1]?.request.url).toBe("https://cmux.test/api/client-config");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("fails closed on Vercel when the client-config limiter is missing", async () => {
+    process.env.VERCEL = "1";
+    delete process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID;
+    const consoleError = mock(() => {});
+    console.error = consoleError as unknown as typeof console.error;
+    const fetchMock = mock(async () => {
+      throw new Error("PostHog flags should not be reached without a rate-limit rule");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await POST(new Request("https://cmux.test/api/client-config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ distinctId: "browser-id" }),
+    }));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "client_config_unavailable" });
+    expect(consoleError).toHaveBeenCalledWith("client-config.route.rate_limit_not_configured");
+    expect(checkRateLimit).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("fails closed on Vercel when the client-config limiter rule is not found", async () => {
+    process.env.VERCEL = "1";
+    checkRateLimit.mockResolvedValue({ rateLimited: false, error: "not-found" });
+    const consoleError = mock(() => {});
+    console.error = consoleError as unknown as typeof console.error;
+    const fetchMock = mock(async () => {
+      throw new Error("PostHog flags should not be reached without a valid rate-limit rule");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await POST(new Request("https://cmux.test/api/client-config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ distinctId: "browser-id" }),
+    }));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "client_config_unavailable" });
+    expect(consoleError).toHaveBeenCalledWith(
+      "client-config.route.rate_limit_not_found",
+      "cmux-client-config-test",
+    );
+    expect(checkRateLimit).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- disables browser-side PostHog feature flag polling so ad blockers never see `/flags` from cmux.com
- adds a first-party `/api/client-config` route that calls PostHog `/flags` server-side with a 4s abort timeout and `ip=0`
- forwards bounded SDK evaluation context from the browser helper: PostHog distinct ID, groups, initial + stored person properties, stored group properties, anon/device IDs, timezone, and evaluation contexts
- normalizes PostHog legacy and detailed flag responses, including JSON-string payload parsing, enabled-flag payload filtering, and failed detailed flag omission
- adds a client-only `getClientConfig()` helper for future pricing-page flag usage

## Verification
- `bun test tests/client-config-route.test.ts tests/client-config-helper.test.ts`
- `bun run typecheck`
- `bun run lint` (existing warnings only)
- `source scripts/load-dev-env.sh && bun run build`
- local Next server on `CMUX_PORT=4572`: warmed `/`, `/handler/sign-in`, `/handler/after-sign-in` with redirects followed
- local `/api/client-config` context-bearing request returned 200 with `Cache-Control: no-store`
- local browser network check: `POST /api/client-config` returned 200, no `/flags` requests captured, no `r.cmux.*` requests captured

## Notes
`proxy.ts` is left alone because its matcher excludes API routes. The app API route owns this behavior instead of middleware or a Next rewrite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production feature-flag delivery and requires new Vercel rate-limit env on non-preview deploys; misconfiguration fails closed with 503, but wrong normalization could change flag values for users.
> 
> **Overview**
> Introduces a **first-party feature-flag path** so clients call `POST /api/client-config` on cmux instead of PostHog `/flags` in the browser (ad-blocker friendly). **posthog-js** now sets `advanced_disable_feature_flags: true` and drops the separate flags API host; flags are loaded on demand via new **`getClientConfig()`** and typed **`client-config-flags`** helpers that forward PostHog distinct id and evaluation context.
> 
> The **Next.js route** rate-limits on Vercel (`CMUX_CLIENT_CONFIG_RATE_LIMIT_ID`), bounds request size, proxies to PostHog with a 4s timeout and `ip=0`, and **normalizes** legacy and detailed flag shapes (payload suppression, failed flags, quota limits) in **`posthogFlags`**.
> 
> Adds shared Swift package **`CmuxClientConfig`** (typed flags, HTTP loader, evaluation context) and wires **`MobileAnalyticsComposition`** to expose `clientConfig`, anonymous id, and a default mobile evaluation request. Workspace, iOS package deps, dev env defaults, and tests cover route, helpers, and Swift decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4aa87292e2002a989a0804fc3fcbd983660b4e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a client-config endpoint that securely fetches feature flags and related settings from the backend.
  * Client config requests can now include richer evaluation context data for more tailored responses.

* **Bug Fixes**
  * Improved handling for missing, invalid, or unavailable flag responses.
  * Added rate-limit protection and clearer fallback behavior when client-config data can’t be loaded.

* **Tests**
  * Added coverage for response normalization, request forwarding, rate limiting, and client-side request payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->