### PR TITLE
Exclude agent-owned sandbox proxy listeners from workspace port badges

### DIFF
--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -226,6 +226,49 @@ final class PortScanner: @unchecked Sendable {
         let pidToPorts = runLsof(pidsCsv: pidsCsv)
 
         // 3. Join: PID→TTY + PID→ports → TTY→ports
+        let join = Self.joinScanResults(
+            pidToPorts: pidToPorts,
+            pidToTTY: pidToTTY,
+            agentPidToWorkspaces: agentPidToWorkspaces,
+            agentRootPIDs: Self.agentRootPIDs(in: agentPIDsByWorkspace)
+        )
+
+        // 4. Map to per-panel port lists.
+        var results: [(PanelKey, [Int])] = []
+        for (key, tty) in panelSnapshot {
+            let ports = join.portsByTTY[tty].map { Array($0).sorted() } ?? []
+            results.append((key, ports))
+        }
+
+        deliverResults(
+            results,
+            workspaceIds: workspaceIds,
+            agentPortsByWorkspace: join.agentPortsByWorkspace,
+            agentRevisions: agentRevisions
+        )
+    }
+
+    /// Output of ``joinScanResults(pidToPorts:pidToTTY:agentPidToWorkspaces:agentRootPIDs:)``.
+    struct ScanJoinResult {
+        /// Listening ports grouped by the TTY of the owning process.
+        let portsByTTY: [String: Set<Int>]
+        /// Listening ports grouped by the workspaces tracking the owning agent process tree.
+        let agentPortsByWorkspace: [UUID: Set<Int>]
+    }
+
+    /// Joins per-PID listening ports onto panel TTYs and agent workspaces.
+    ///
+    /// Ports owned by an agent *root* process (a PID in `agentRootPIDs`) are
+    /// excluded from both groupings: agent binaries like Claude Code hold
+    /// loopback sandbox-proxy listeners in their own process, which are noise
+    /// on the workspace card. Real dev servers an agent launches run as child
+    /// processes and keep their badges.
+    static func joinScanResults(
+        pidToPorts: [Int: Set<Int>],
+        pidToTTY: [Int: String],
+        agentPidToWorkspaces: [Int: Set<UUID>],
+        agentRootPIDs: Set<Int>
+    ) -> ScanJoinResult {
         var portsByTTY: [String: Set<Int>] = [:]
         for (pid, ports) in pidToPorts {
             guard let tty = pidToTTY[pid] else { continue }
@@ -240,19 +283,12 @@ final class PortScanner: @unchecked Sendable {
             }
         }
 
-        // 4. Map to per-panel port lists.
-        var results: [(PanelKey, [Int])] = []
-        for (key, tty) in panelSnapshot {
-            let ports = portsByTTY[tty].map { Array($0).sorted() } ?? []
-            results.append((key, ports))
-        }
+        return ScanJoinResult(portsByTTY: portsByTTY, agentPortsByWorkspace: agentPortsByWorkspace)
+    }
 
-        deliverResults(
-            results,
-            workspaceIds: workspaceIds,
-            agentPortsByWorkspace: agentPortsByWorkspace,
-            agentRevisions: agentRevisions
-        )
+    /// The union of tracked agent root PIDs across all scanned workspaces.
+    static func agentRootPIDs(in agentPIDsByWorkspace: [UUID: Set<Int>]) -> Set<Int> {
+        agentPIDsByWorkspace.values.reduce(into: Set<Int>()) { $0.formUnion($1) }
     }
 
     private func refreshAgentPortsLocked(workspaceId: UUID, agentPIDs: Set<Int>) {
@@ -370,17 +406,16 @@ final class PortScanner: @unchecked Sendable {
 
         let pidsCsv = agentPidToWorkspaces.keys.sorted().map(String.init).joined(separator: ",")
         let pidToPorts = runLsof(pidsCsv: pidsCsv)
-        var agentPortsByWorkspace: [UUID: Set<Int>] = [:]
-        for (pid, ports) in pidToPorts {
-            guard let workspaceIdsForPid = agentPidToWorkspaces[pid] else { continue }
-            for targetWorkspaceId in workspaceIdsForPid {
-                agentPortsByWorkspace[targetWorkspaceId, default: []].formUnion(ports)
-            }
-        }
+        let join = Self.joinScanResults(
+            pidToPorts: pidToPorts,
+            pidToTTY: [:],
+            agentPidToWorkspaces: agentPidToWorkspaces,
+            agentRootPIDs: Self.agentRootPIDs(in: agentPIDsByWorkspace)
+        )
 
         deliverAgentResults(
             workspaceIds: workspaceIds,
-            agentPortsByWorkspace: agentPortsByWorkspace,
+            agentPortsByWorkspace: join.agentPortsByWorkspace,
             agentRevisions: agentRevisions
         )
     }

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -271,13 +271,14 @@ final class PortScanner: @unchecked Sendable {
     ) -> ScanJoinResult {
         var portsByTTY: [String: Set<Int>] = [:]
         for (pid, ports) in pidToPorts {
-            guard let tty = pidToTTY[pid] else { continue }
+            guard !agentRootPIDs.contains(pid), let tty = pidToTTY[pid] else { continue }
             portsByTTY[tty, default: []].formUnion(ports)
         }
 
         var agentPortsByWorkspace: [UUID: Set<Int>] = [:]
         for (pid, ports) in pidToPorts {
-            guard let workspaceIdsForPid = agentPidToWorkspaces[pid] else { continue }
+            guard !agentRootPIDs.contains(pid),
+                  let workspaceIdsForPid = agentPidToWorkspaces[pid] else { continue }
             for workspaceId in workspaceIdsForPid {
                 agentPortsByWorkspace[workspaceId, default: []].formUnion(ports)
             }

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1,3 +1,4 @@
+import Testing
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -5,6 +6,57 @@ import XCTest
 #elseif canImport(cmux)
 @testable import cmux
 #endif
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux port-badge noise:
+/// Claude Code's sandbox network proxies listen from the agent binary's own
+/// PID, so ports owned by agent *root* processes must not badge the card,
+/// while dev servers launched as agent children must keep theirs.
+@Suite struct PortScannerScanJoinTests {
+    private let workspaceId = UUID()
+    private let agentRootPID = 100
+    private let devServerPID = 200
+    private let tty = "ttys004"
+
+    private func join(agentRootPIDs: Set<Int>) -> PortScanner.ScanJoinResult {
+        PortScanner.joinScanResults(
+            pidToPorts: [
+                agentRootPID: [55936, 55937],
+                devServerPID: [5173],
+            ],
+            pidToTTY: [
+                agentRootPID: tty,
+                devServerPID: tty,
+            ],
+            agentPidToWorkspaces: [
+                agentRootPID: [workspaceId],
+                devServerPID: [workspaceId],
+            ],
+            agentRootPIDs: agentRootPIDs
+        )
+    }
+
+    @Test func agentRootProxyPortsAreExcludedFromPanelPorts() {
+        let result = join(agentRootPIDs: [agentRootPID])
+        #expect(result.portsByTTY[tty] == [5173])
+    }
+
+    @Test func agentRootProxyPortsAreExcludedFromWorkspaceAgentPorts() {
+        let result = join(agentRootPIDs: [agentRootPID])
+        #expect(result.agentPortsByWorkspace[workspaceId] == [5173])
+    }
+
+    @Test func nonAgentScansKeepAllPorts() {
+        let result = join(agentRootPIDs: [])
+        #expect(result.portsByTTY[tty] == [5173, 55936, 55937])
+        #expect(result.agentPortsByWorkspace[workspaceId] == [5173, 55936, 55937])
+    }
+
+    @Test func agentRootPIDsUnionsAcrossWorkspaces() {
+        let other = UUID()
+        let roots = PortScanner.agentRootPIDs(in: [workspaceId: [100, 101], other: [200]])
+        #expect(roots == [100, 101, 200])
+    }
+}
 
 final class PortScannerProcessCaptureTests: XCTestCase {
     private func openFDCount() -> Int? {


### PR DESCRIPTION
## Problem

Workspace cards badge every TCP listener owned by processes on a panel's TTY or a tracked agent's process tree. Claude Code runs a loopback HTTP/SOCKS network-filter proxy pair **inside the agent process itself** for its Bash sandbox, so every Claude session shows two meaningless ephemeral port badges (e.g. `:55936 :55937`) that also go stale when the proxy rotates.

## Fix

`PortScanner` now excludes listeners owned by agent **root** PIDs (already tracked via `workspace.agentPIDs`, reported by `set_status --pid`) in both the panel-TTY path and the tracked-agent-tree path. Dev servers launched by an agent are child PIDs and keep their badges. No process-name matching (claude retitles its process to its version string).

## Commits (red/green per regression policy)

1. Extract the scan join into pure `PortScanner.joinScanResults` + failing Swift Testing suite — **CI red**
2. Honor `agentRootPIDs` — **CI green**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785692209&installation_id=133855650&pr_number=7266&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7266&signature=5e5b284035ae65a1f091ee74e36104be1feecca738cfa458ab4d6d127e8ce647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing agent-owned sandbox proxy ports on workspace cards. Only child process ports (like dev servers) are badged now.

- **Bug Fixes**
  - Ignore listeners owned by agent root PIDs in both panel TTY and tracked-agent scans.
  - Removes noisy, rotating proxy badges like :55936/:55937 from Claude Code’s sandbox.

- **Refactors**
  - Extracted `PortScanner.joinScanResults` and `agentRootPIDs(...)` to isolate join logic.
  - Added tests to cover agent-root exclusion and PID union across workspaces.

<sup>Written for commit 11d8d12e4cc49bf00bf8a43c822e29589405a618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how scanned ports are grouped so ports from agent root processes are no longer included in panel or workspace results.
  * Made agent port results consistent across scan paths, reducing cases where ports could appear in the wrong workspace or card.
* **Tests**
  * Added regression coverage for port grouping and agent-root exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->