### PR TITLE
Fix iOS terminal row auto-fit column collapse

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -3589,15 +3589,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // rows so a Mac-constrained grid fills the phone instead of parking a
         // letterbox band above the content.
         autoFitFontToEffectiveRows(
-            renderedRows: naturalSize.rows,
+            renderedSize: naturalSize,
             containerPixelHeight: containerH * scale,
             cellPixelHeight: result.cellPixelSize.height
         )
-        // Report the row CAPACITY at the user's base font, not the rendered
-        // rows: a report derived from the fitted font would ratchet the
-        // negotiated minimum down and the phone could never learn when the
-        // constraining device grew back. Columns stay at the rendered font
-        // (the PTY must never be wider than the rendered grid can show).
+        // Report rows at base-font capacity so fitted fonts never ratchet the
+        // negotiated minimum down. Columns remain the rendered capacity.
         let reportGrid = capacityReportGrid(
             for: naturalSize,
             containerPixelHeight: containerH * scale,
@@ -3639,11 +3636,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Re-derive the rendered font from the effective grid: raise it so a
     /// smaller granted row count fills the container, decay it back toward the
     /// user's base font when the grant returns to (or past) capacity or the
-    /// pin lifts. Floored at the user's base font — the fit only ever
-    /// stretches, and a stale oversized grant during a keyboard transition
-    /// steps to base instead of collapsing the font toward the minimum.
+    /// pin lifts. Floored at the user's base font so stale oversized grants
+    /// during keyboard transitions step back to base instead of shrinking.
     private func autoFitFontToEffectiveRows(
-        renderedRows: Int,
+        renderedSize: TerminalGridSize,
         containerPixelHeight: CGFloat,
         cellPixelHeight: CGFloat
     ) {
@@ -3656,17 +3652,21 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             }
             return
         }
-        guard TerminalRowCapacityFit.shouldRefit(renderedRows: renderedRows, effectiveRows: eff.rows),
+        guard TerminalRowCapacityFit.shouldRefit(renderedRows: renderedSize.rows, effectiveRows: eff.rows),
               let fit = TerminalRowCapacityFit(
                   containerPixelHeight: containerPixelHeight,
                   cellPixelHeight: cellPixelHeight,
                   liveFontSize: liveFontSize
               ),
-              let target = fit.fitFontSize(forEffectiveRows: eff.rows) else { return }
+              let target = fit.fitFontSize(
+                  forEffectiveRows: eff.rows,
+                  baseFontSize: userBaseFontSize,
+                  renderedColumns: renderedSize.columns
+              ) else { return }
         let clamped = min(max(target, userBaseFontSize), MobileTerminalFontPreference.maximumSize)
         guard abs(clamped - liveFontSize) >= 0.25 else { return }
         MobileDebugLog.anchormux(
-            "zoom.autofit eff=\(eff.cols)x\(eff.rows) rendered=\(renderedRows) font \(liveFontSize)->\(clamped)"
+            "zoom.autofit eff=\(eff.cols)x\(eff.rows) rendered=\(renderedSize.rows) font \(liveFontSize)->\(clamped)"
         )
         applyAbsoluteFontSize(clamped)
     }

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalRowCapacityFit.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalRowCapacityFit.swift
@@ -19,14 +19,20 @@ import Foundation
 ///   never escape.
 /// - **Rendered rows** track the effective grid:
 ///   ``fitFontSize(forEffectiveRows:)`` picks the font whose cell height
-///   makes exactly the granted rows fill the container, and the columns
-///   re-report at that rendered font (columns must never exceed what the
-///   rendered font can actually show).
+///   makes exactly the granted rows fill the container, but callers can cap
+///   that fit with ``fitFontSize(forEffectiveRows:baseFontSize:renderedColumns:minimumColumnRatio:)``
+///   so a short remote grid cannot turn a phone-width terminal into a tiny
+///   preview-width grid.
 public struct TerminalRowCapacityFit {
     /// Rows past which a mismatch between the rendered grid and the effective
     /// grid triggers a re-fit. One row of slack is inherent to cell flooring;
     /// two rows means a visible band (or clipping) worth a font adjustment.
     public static let refitThresholdRows = 2
+    /// Minimum fraction of the base-font column capacity preserved by the
+    /// row auto-fit. Vertical stretching is opportunistic; once it would cost
+    /// more than a quarter of the phone-width columns, the remaining mismatch
+    /// is left as a bottom-pinned letterbox instead of inflating the font.
+    public static let minimumColumnRatio: CGFloat = 0.75
 
     /// The grid container height in device pixels.
     public let containerPixelHeight: CGFloat
@@ -75,5 +81,31 @@ public struct TerminalRowCapacityFit {
         let targetCellHeight = containerPixelHeight / (CGFloat(effectiveRows) + 0.25)
         let ratio = targetCellHeight / cellPixelHeight
         return liveFontSize * Float32(ratio)
+    }
+
+    /// The row-fill font capped so the rendered grid keeps a minimum share of
+    /// the base-font column capacity.
+    ///
+    /// - Parameters:
+    ///   - effectiveRows: The daemon-granted row count to stretch toward.
+    ///   - baseFontSize: The user's explicit font size.
+    ///   - renderedColumns: The measured columns at ``liveFontSize``.
+    ///   - minimumColumnRatio: The minimum share of base-font columns to keep.
+    /// - Returns: A font size no larger than the full row-fill target.
+    public func fitFontSize(
+        forEffectiveRows effectiveRows: Int,
+        baseFontSize: Float32,
+        renderedColumns: Int,
+        minimumColumnRatio: CGFloat = Self.minimumColumnRatio
+    ) -> Float32? {
+        guard let rowFillFontSize = fitFontSize(forEffectiveRows: effectiveRows) else { return nil }
+        guard baseFontSize > 0, renderedColumns > 0, minimumColumnRatio > 0 else {
+            return rowFillFontSize
+        }
+        let baseColumns = CGFloat(renderedColumns) * CGFloat(liveFontSize) / CGFloat(baseFontSize)
+        guard baseColumns > 0 else { return rowFillFontSize }
+        let minimumColumns = max(1, (baseColumns * min(minimumColumnRatio, 1)).rounded(.up))
+        let maximumFontSize = CGFloat(baseFontSize) * baseColumns / minimumColumns
+        return Float32(min(CGFloat(rowFillFontSize), maximumFontSize))
     }
 }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalRowCapacityFitTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalRowCapacityFitTests.swift
@@ -47,6 +47,20 @@ struct TerminalRowCapacityFitTests {
         #expect(Int((1902 / fittedCell).rounded(.down)) == 54)
     }
 
+    @Test("row fit cap preserves base-font column share")
+    func rowFitCapPreservesBaseFontColumnShare() throws {
+        let uncapped = try #require(TerminalRowCapacityFit(
+            containerPixelHeight: 2412, cellPixelHeight: 35, liveFontSize: 10
+        )?.fitFontSize(forEffectiveRows: 22))
+        let capped = try #require(TerminalRowCapacityFit(
+            containerPixelHeight: 2412, cellPixelHeight: 35, liveFontSize: 10
+        )?.fitFontSize(forEffectiveRows: 22, baseFontSize: 10, renderedColumns: 66))
+        #expect(uncapped > 28)
+        #expect(capped < uncapped)
+        let preservedColumns = Int((CGFloat(66) * 10 / CGFloat(capped)).rounded(.down))
+        #expect(preservedColumns >= 49)
+    }
+
     @Test("hysteresis ignores one-row mismatches and acts on two")
     func refitHysteresis() {
         #expect(!TerminalRowCapacityFit.shouldRefit(renderedRows: 45, effectiveRows: 45))

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalViewportColumnFitTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalViewportColumnFitTests.swift
@@ -1,0 +1,140 @@
+#if canImport(UIKit)
+import CMUXMobileCore
+import Foundation
+import Testing
+import UIKit
+
+@testable import CmuxMobileTerminal
+
+/// Regression coverage for #7275: row auto-fit must not turn a phone-width
+/// terminal into a preview-width grid by inflating the rendered font until only
+/// ~26-28 columns fit across the whole phone.
+@MainActor
+private final class ViewportColumnFitDelegate: NSObject, GhosttySurfaceViewDelegate {
+    private(set) var reports: [TerminalGridSize] = []
+    private(set) var reportIDs: [TerminalGridSize: UInt64] = [:]
+    var autoEchoMacGrid: (cols: Int, rows: Int)?
+
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {}
+
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize, reportID: UInt64) {
+        reports.append(size)
+        reportIDs[size] = reportID
+        if let mac = autoEchoMacGrid {
+            surfaceView.markViewportReportConfirmed()
+            surfaceView.applyConfirmedViewSize(
+                cols: min(size.columns, mac.cols),
+                rows: min(size.rows, mac.rows),
+                reportID: reportID
+            )
+        }
+    }
+}
+
+@MainActor
+private final class ViewportColumnFitHarness {
+    let window: UIWindow
+    let view: GhosttySurfaceView
+    let delegate: ViewportColumnFitDelegate
+
+    init() throws {
+        let runtime = try GhosttyRuntime.shared()
+        let delegate = ViewportColumnFitDelegate()
+        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
+        view.autoFocusOnWindowAttach = false
+        view.isRenderDispatchSuppressed = true
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
+        view.frame = window.bounds
+        window.addSubview(view)
+        window.isHidden = false
+        self.window = window
+        self.view = view
+        self.delegate = delegate
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+    }
+
+    func tearDown() {
+        view.prepareForDismantle()
+        view.removeFromSuperview()
+        window.isHidden = true
+    }
+
+    var snapshot: GhosttySurfaceView.DebugGeometrySnapshot {
+        view.debugGeometrySnapshotForTesting()
+    }
+
+    @discardableResult
+    func pump(timeout: TimeInterval = 5, until condition: () -> Bool) async -> Bool {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        return condition()
+    }
+
+    func waitForReport(after count: Int, timeout: TimeInterval = 5) async -> TerminalGridSize? {
+        guard await pump(timeout: timeout, until: { self.delegate.reports.count > count }) else { return nil }
+        return delegate.reports.last
+    }
+
+    func settle(_ interval: TimeInterval = 0.6) async {
+        let deadline = Date(timeIntervalSinceNow: interval)
+        while Date() < deadline {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+
+    func echo(_ report: TerminalGridSize, macColumns: Int = .max, macRows: Int = .max) {
+        view.markViewportReportConfirmed()
+        view.applyConfirmedViewSize(
+            cols: min(report.columns, macColumns),
+            rows: min(report.rows, macRows),
+            reportID: delegate.reportIDs[report] ?? 0
+        )
+    }
+}
+
+@MainActor
+@Suite("Terminal viewport column fit", .serialized)
+struct TerminalViewportColumnFitTests {
+    @Test("row auto-fit preserves phone-width columns")
+    func rowAutoFitDoesNotCollapsePhoneWidthColumns() async throws {
+        let harness = try ViewportColumnFitHarness()
+        defer { harness.tearDown() }
+
+        let initial = try #require(
+            await harness.waitForReport(after: 0),
+            "view never reported its natural grid"
+        )
+        #expect(initial.columns >= 40)
+        #expect(initial.rows >= 20)
+        harness.echo(initial)
+
+        let minimumPhoneWidthColumns = max(1, Int((Double(initial.columns) * 0.75).rounded(.down)))
+        let rowConstrainedGrid = max(6, initial.rows / 3)
+        harness.delegate.autoEchoMacGrid = (cols: initial.columns, rows: rowConstrainedGrid)
+        await harness.view.applyViewSizeAndWait(cols: initial.columns, rows: rowConstrainedGrid)
+        await harness.settle()
+
+        let settled = await harness.pump(timeout: 8) {
+            let snapshot = harness.snapshot
+            return snapshot.effectiveGrid?.rows == rowConstrainedGrid
+                && snapshot.renderedSize?.columns != nil
+        }
+        #expect(settled, "row-constrained grid did not settle")
+
+        let snapshot = harness.snapshot
+        let renderedColumns = try #require(snapshot.renderedSize?.columns)
+        #expect(
+            renderedColumns >= minimumPhoneWidthColumns,
+            """
+            row auto-fit collapsed the phone grid from \(initial.columns) to \(renderedColumns) columns \
+            (minimum \(minimumPhoneWidthColumns), live font \(snapshot.liveFontSize), \
+            base \(snapshot.baseFontSize), effective \(snapshot.effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil"))
+            """
+        )
+    }
+}
+#endif

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalViewportColumnFitTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalViewportColumnFitTests.swift
@@ -79,13 +79,6 @@ private final class ViewportColumnFitHarness {
         return delegate.reports.last
     }
 
-    func settle(_ interval: TimeInterval = 0.6) async {
-        let deadline = Date(timeIntervalSinceNow: interval)
-        while Date() < deadline {
-            try? await Task.sleep(nanoseconds: 20_000_000)
-        }
-    }
-
     func echo(_ report: TerminalGridSize, macColumns: Int = .max, macRows: Int = .max) {
         view.markViewportReportConfirmed()
         view.applyConfirmedViewSize(
@@ -115,13 +108,18 @@ struct TerminalViewportColumnFitTests {
         let minimumPhoneWidthColumns = max(1, Int((Double(initial.columns) * 0.75).rounded(.down)))
         let rowConstrainedGrid = max(6, initial.rows / 3)
         harness.delegate.autoEchoMacGrid = (cols: initial.columns, rows: rowConstrainedGrid)
+        let beforeConstraintReports = harness.delegate.reports.count
         await harness.view.applyViewSizeAndWait(cols: initial.columns, rows: rowConstrainedGrid)
-        await harness.settle()
+        let postFitReport = try #require(
+            await harness.waitForReport(after: beforeConstraintReports, timeout: 8),
+            "row-constrained grid never re-reported after auto-fit"
+        )
 
         let settled = await harness.pump(timeout: 8) {
             let snapshot = harness.snapshot
             return snapshot.effectiveGrid?.rows == rowConstrainedGrid
-                && snapshot.renderedSize?.columns != nil
+                && snapshot.renderedSize?.columns == postFitReport.columns
+                && snapshot.liveFontSize > snapshot.baseFontSize + 0.25
         }
         #expect(settled, "row-constrained grid did not settle")
 


### PR DESCRIPTION
## Summary
- Cap iOS terminal row auto-fit by base-font column capacity so a short remote row grant cannot inflate the rendered font until the phone-width grid collapses.
- Add a real `GhosttySurfaceView` simulator regression for the #7275 screenshot shape and focused math coverage for the cap.

## Root cause
`GhosttySurfaceView.autoFitFontToEffectiveRows` chose the live rendered font from the daemon-granted row count alone. With a severe row-constrained grid, a 10pt phone terminal could jump to the 28pt maximum to fill height. Because viewport reports keep columns at the rendered font, the follow-up report fed a ~23-column phone grid back into the remote grid negotiation, producing the huge-font/narrow-terminal layout from the issue.

## Reproduction validated
- The test-only commit fails on the unpatched code with `TerminalViewportColumnFitTests.rowAutoFitDoesNotCollapsePhoneWidthColumns`: an iPhone-sized surface reports 66 initial columns, row auto-fit raises the font to 28pt, and the rendered grid collapses to 23 columns.
- After the fix, the focused simulator run passes: `TerminalViewportColumnFitTests`, `TerminalRowCapacityFitTests`, and `TerminalViewportSpacingTests` pass together on `iPhone 17, OS 26.5`.
- `TerminalViewportReportSchedulerTests` also passes, and `python3 scripts/swift_file_length_budget.py` passes after rebasing onto current `origin/main`.

## Regression invariant
`TerminalViewportColumnFitTests.rowAutoFitDoesNotCollapsePhoneWidthColumns` mounts a real `GhosttySurfaceView` in a 402x874 iPhone-sized `UIWindow`, constrains the effective rows to one third of the phone natural grid, waits for auto-fit and viewport-report settle, and asserts rendered columns stay at least 75% of the initial phone-width columns.

Fixes #7275

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785702848&installation_id=133855650&pr_number=7280&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7280&signature=bdb8063081d0b43b23d343e2210ca61908f6d59f41fef0d2435ac7dc18d7a7a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the iOS terminal from inflating the font on short remote row grants, which collapsed phone-width columns to a narrow grid, fixing #7275. Auto-fit now preserves at least 75% of base-font column capacity to keep the terminal wide.

- **Bug Fixes**
  - `GhosttySurfaceView`: report rows at base-font capacity and keep columns at rendered capacity; pass rendered size into auto-fit and cap the target font to avoid column collapse and ratcheting.
  - `TerminalRowCapacityFit`: added `fitFontSize(forEffectiveRows:baseFontSize:renderedColumns:minimumColumnRatio:)` (default 0.75) to cap row-based font increases; added `TerminalViewportColumnFitTests` (now event-driven, no fixed waits) and a unit test to ensure the column share is preserved.

<sup>Written for commit b3271907f3c0630f7431d804a9fb58996da70c9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

