### PR TITLE
Fix iOS chat scroll-to-bottom completion

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -243,7 +243,7 @@
 516	Sources/TerminalImageTransfer.swift
 514	Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
 514	cmuxUITests/UpdatePillUITests.swift
-513	Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
+494	Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
 509	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift
 507	Sources/TerminalControllerTopSupport.swift
 506	Sources/App/MainWindowVisibilityController.swift

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptListView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptListView.swift
@@ -92,7 +92,6 @@ public struct ChatTranscriptListView: View {
             Group {
                 if !isAtBottom {
                     ChatScrollToBottomButton {
-                        isAtBottom = true
                         scrollToBottomRequest += 1
                     }
                     .padding(.trailing, 12)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableConfiguration.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableConfiguration.swift
@@ -1,0 +1,127 @@
+#if os(iOS)
+import CmuxAgentChat
+import SwiftUI
+
+struct ChatTranscriptTableConfiguration {
+    let rows: [ChatTranscriptRow]
+    let expandedIDs: Set<String>
+    let agentState: ChatAgentState
+    let hasMoreHistory: Bool
+    let hasLoadedInitialHistory: Bool
+    let initialLoadFailed: Bool
+    let historyTruncatedAtHead: Bool
+    let actions: ChatRowActions
+    let onReachTop: () -> Void
+    let onRetryInitialLoad: () -> Void
+    let theme: ChatTheme
+    let markdownRenderer: ChatMarkdownRenderer?
+    let contentCache: ChatContentCache?
+
+    func makeItems() -> [ChatTranscriptTableItem] {
+        var items: [ChatTranscriptTableItem] = []
+        if hasMoreHistory {
+            items.append(.loadingMore)
+        } else if historyTruncatedAtHead {
+            items.append(.historyTruncated)
+        }
+        if rows.isEmpty {
+            if initialLoadFailed {
+                items.append(.loadFailed)
+            } else if hasLoadedInitialHistory {
+                items.append(.empty)
+            } else {
+                items.append(.initialLoading)
+            }
+        }
+        items.append(contentsOf: rows.map(ChatTranscriptTableItem.row))
+        if case .working = agentState {
+            items.append(.typing)
+        }
+        items.append(.bottomAnchor)
+        return items
+    }
+
+    @ViewBuilder
+    func view(for item: ChatTranscriptTableItem, tableWidth: CGFloat) -> some View {
+        itemView(for: item)
+            .padding(.horizontal, theme.horizontalMargin)
+            .environment(\.chatTheme, theme)
+            .environment(\.chatMarkdownRenderer, markdownRenderer)
+            .environment(\.chatContentCache, contentCache)
+            .environment(
+                \.chatBubbleMaxWidth,
+                tableWidth > 0 ? tableWidth * theme.bubbleMaxWidthFraction : .infinity
+            )
+    }
+
+    @ViewBuilder
+    private func itemView(for item: ChatTranscriptTableItem) -> some View {
+        switch item {
+        case .loadingMore:
+            ProgressView()
+                .controlSize(.small)
+                .padding(.vertical, 12)
+        case .historyTruncated:
+            Text(
+                String(
+                    localized: "chat.history.truncated",
+                    defaultValue: "Earlier history is on your Mac",
+                    bundle: .module
+                )
+            )
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+            .padding(.vertical, 12)
+        case .loadFailed:
+            VStack(spacing: 12) {
+                Text(
+                    String(
+                        localized: "chat.transcript.load_failed",
+                        defaultValue: "Couldn't load this conversation",
+                        bundle: .module
+                    )
+                )
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                Button(action: onRetryInitialLoad) {
+                    Text(
+                        String(localized: "chat.transcript.retry", defaultValue: "Retry", bundle: .module)
+                    )
+                    .font(.subheadline.weight(.medium))
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("ChatTranscriptRetry")
+            }
+            .padding(.vertical, 48)
+        case .empty:
+            Text(
+                String(
+                    localized: "chat.transcript.empty",
+                    defaultValue: "No messages yet",
+                    bundle: .module
+                )
+            )
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .padding(.vertical, 48)
+        case .initialLoading:
+            ProgressView()
+                .controlSize(.regular)
+                .padding(.vertical, 48)
+        case .row(let row):
+            ChatTranscriptRowView(
+                row: row,
+                isExpanded: expandedIDs.contains(row.id),
+                actions: actions
+            )
+            .equatable()
+        case .typing:
+            ChatTypingIndicatorView(agentState: agentState)
+                .padding(.top, theme.intraGroupSpacing)
+        case .bottomAnchor:
+            Color.clear
+                .frame(height: 9)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableItem.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableItem.swift
@@ -1,0 +1,35 @@
+#if os(iOS)
+import CmuxAgentChat
+
+enum ChatTranscriptTableItem: Equatable {
+    case loadingMore
+    case historyTruncated
+    case loadFailed
+    case empty
+    case initialLoading
+    case row(ChatTranscriptRow)
+    case typing
+    case bottomAnchor
+
+    var id: String {
+        switch self {
+        case .loadingMore:
+            return "loading-more"
+        case .historyTruncated:
+            return "history-truncated"
+        case .loadFailed:
+            return "load-failed"
+        case .empty:
+            return "empty"
+        case .initialLoading:
+            return "initial-loading"
+        case .row(let row):
+            return row.id
+        case .typing:
+            return "typing"
+        case .bottomAnchor:
+            return "bottom-anchor"
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView+ScrollGeometry.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView+ScrollGeometry.swift
@@ -1,0 +1,40 @@
+#if os(iOS)
+import UIKit
+
+extension ChatTranscriptTableView.Coordinator {
+    func userVisibleFinalGlideDistance(in tableView: UITableView) -> CGFloat {
+        max(600, min(1_200, tableView.bounds.height * 1.25))
+    }
+
+    func cancelUserScrollMomentumIfNeeded(in tableView: UITableView) {
+        guard tableView.isTracking || tableView.isDragging || tableView.isDecelerating else { return }
+        tableView.setContentOffset(tableView.contentOffset, animated: false)
+    }
+
+    func distanceFromBottom(in tableView: UITableView) -> CGFloat {
+        guard tableView.bounds.height > 0 else { return 0 }
+        let visibleBottom = visibleBottomY(in: tableView)
+        return max(0, tableView.contentSize.height - visibleBottom)
+    }
+
+    func visibleBottomY(in tableView: UITableView) -> CGFloat {
+        tableView.contentOffset.y
+            + tableView.bounds.height
+            - tableView.adjustedContentInset.bottom
+    }
+
+    func maxOffsetY(in tableView: UITableView) -> CGFloat {
+        max(
+            -tableView.adjustedContentInset.top,
+            tableView.contentSize.height
+                - tableView.bounds.height
+                + tableView.adjustedContentInset.bottom
+        )
+    }
+
+    func clampedOffsetY(_ offsetY: CGFloat, in tableView: UITableView) -> CGFloat {
+        min(max(offsetY, -tableView.adjustedContentInset.top), maxOffsetY(in: tableView))
+    }
+}
+
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
@@ -84,6 +84,9 @@ struct ChatTranscriptTableView: UIViewRepresentable {
         private var isApplyingDataUpdate = false
         private var pendingContentUpdateAnchor: ChatTranscriptTableAnchor?
         private var isExplicitBottomFollowActive = false
+        private var isUserVisibleBottomFollowActive = false
+        private var needsInitialUserVisibleBottomStaging = false
+        private var isUserVisibleBottomAnimationRunning = false
         private var lastObservedScrollContentHeight: CGFloat?
         private var lastObservedScrollOffsetY: CGFloat?
         private weak var tableView: ChatTranscriptUITableView?
@@ -129,6 +132,10 @@ struct ChatTranscriptTableView: UIViewRepresentable {
             lastScrollToBottomRequest = scrollToBottomRequest
             if shouldScrollToBottom {
                 isExplicitBottomFollowActive = true
+                isUserVisibleBottomFollowActive = true
+                needsInitialUserVisibleBottomStaging = true
+                isUserVisibleBottomAnimationRunning = false
+                syncDebugBottomFollowState(in: tableView)
                 recordObservedScrollPosition(in: tableView)
             }
             let wasAtBottom = distanceFromBottom(in: tableView) <= chatTranscriptAtBottomThreshold
@@ -137,7 +144,11 @@ struct ChatTranscriptTableView: UIViewRepresentable {
             guard shouldReload else {
                 if isExplicitBottomFollowActive && (shouldScrollToBottom || !wasAtBottom) {
                     pendingContentUpdateAnchor = nil
-                    scrollToBottom(in: tableView, animated: shouldScrollToBottom)
+                    if shouldScrollToBottom {
+                        scrollToBottomForUserVisibleFollow(in: tableView)
+                    } else {
+                        scrollToBottomForFollow(in: tableView)
+                    }
                 }
                 updateBottomState(from: tableView)
                 return
@@ -154,7 +165,11 @@ struct ChatTranscriptTableView: UIViewRepresentable {
             tableView.layoutIfNeeded()
             if isExplicitBottomFollowActive || (wasAtBottom && !tableView.isUserScrollMomentumActive) {
                 pendingContentUpdateAnchor = nil
-                scrollToBottom(in: tableView, animated: shouldScrollToBottom)
+                if shouldScrollToBottom {
+                    scrollToBottomForUserVisibleFollow(in: tableView)
+                } else {
+                    scrollToBottomForFollow(in: tableView)
+                }
             } else if let anchor, !tableView.isUserScrollMomentumActive {
                 restore(anchor, in: tableView)
                 pendingContentUpdateAnchor = anchor
@@ -199,6 +214,24 @@ struct ChatTranscriptTableView: UIViewRepresentable {
         func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
             pendingContentUpdateAnchor = nil
             isExplicitBottomFollowActive = false
+            isUserVisibleBottomFollowActive = false
+            needsInitialUserVisibleBottomStaging = false
+            isUserVisibleBottomAnimationRunning = false
+            syncDebugBottomFollowState(in: scrollView as? UITableView)
+        }
+
+        func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+            guard let tableView = scrollView as? UITableView else { return }
+            isUserVisibleBottomAnimationRunning = false
+            if isExplicitBottomFollowActive,
+               distanceFromBottom(in: tableView) > chatTranscriptAtBottomThreshold {
+                scrollToBottomForFollow(in: tableView)
+            } else {
+                isUserVisibleBottomFollowActive = false
+                needsInitialUserVisibleBottomStaging = false
+                updateBottomState(from: tableView)
+            }
+            syncDebugBottomFollowState(in: tableView)
         }
 
         private func cancelBottomFollowForStableContentUpwardScroll(in tableView: UITableView) {
@@ -214,6 +247,10 @@ struct ChatTranscriptTableView: UIViewRepresentable {
                 return
             }
             isExplicitBottomFollowActive = false
+            isUserVisibleBottomFollowActive = false
+            needsInitialUserVisibleBottomStaging = false
+            isUserVisibleBottomAnimationRunning = false
+            syncDebugBottomFollowState(in: tableView)
         }
 
         private func recordObservedScrollPosition(in tableView: UITableView) {
@@ -245,7 +282,7 @@ struct ChatTranscriptTableView: UIViewRepresentable {
 
             if tableView.isUserScrollMomentumActive {
                 if isExplicitBottomFollowActive {
-                    scrollToBottom(in: tableView, animated: false)
+                    scrollToBottomForFollow(in: tableView)
                 }
                 pendingContentUpdateAnchor = nil
                 updateBottomState(from: tableView)
@@ -253,7 +290,7 @@ struct ChatTranscriptTableView: UIViewRepresentable {
             }
             if tableView.isViewportInsetsExternallyDriven || isApplyingDataUpdate {
                 if isExplicitBottomFollowActive {
-                    scrollToBottom(in: tableView, animated: false)
+                    scrollToBottomForFollow(in: tableView)
                     return
                 }
                 updateBottomState(from: tableView)
@@ -261,7 +298,7 @@ struct ChatTranscriptTableView: UIViewRepresentable {
             }
 
             if isExplicitBottomFollowActive {
-                scrollToBottom(in: tableView, animated: false)
+                scrollToBottomForFollow(in: tableView)
             } else if boundsChanged, let oldViewport {
                 restoreKeyboardViewport(snapshot: oldViewport, in: tableView)
             } else if contentChanged, let pendingContentUpdateAnchor {
@@ -299,18 +336,82 @@ struct ChatTranscriptTableView: UIViewRepresentable {
             (tableView as? ChatTranscriptUITableView)?.recordCurrentViewport()
         }
 
-        private func scrollToBottom(in tableView: UITableView, animated: Bool) {
+        private func scrollToBottomForUserVisibleFollow(in tableView: UITableView) {
             tableView.layoutIfNeeded()
             cancelUserScrollMomentumIfNeeded(in: tableView)
             let targetY = maxOffsetY(in: tableView)
+            let distance = max(0, targetY - tableView.contentOffset.y)
+            guard distance > chatTranscriptAtBottomThreshold else {
+                guard !isUserVisibleBottomAnimationRunning else {
+                    (tableView as? ChatTranscriptUITableView)?.recordCurrentViewport()
+                    updateBottomState(from: tableView)
+                    return
+                }
+                isUserVisibleBottomFollowActive = false
+                needsInitialUserVisibleBottomStaging = false
+                scrollToBottom(in: tableView, animated: false)
+                return
+            }
+
+            let visibleDistance = userVisibleFinalGlideDistance(in: tableView)
+            if needsInitialUserVisibleBottomStaging, distance > visibleDistance {
+                let stagedOffsetY = clampedOffsetY(targetY - visibleDistance, in: tableView)
+                tableView.setContentOffset(
+                    CGPoint(x: tableView.contentOffset.x, y: stagedOffsetY),
+                    animated: false
+                )
+                #if DEBUG
+                (tableView as? ChatTranscriptUITableView)?.recordBottomUserVisibleStaging()
+                #endif
+                (tableView as? ChatTranscriptUITableView)?.recordCurrentViewport()
+                updateBottomState(from: tableView)
+            }
+            needsInitialUserVisibleBottomStaging = false
+
+            isUserVisibleBottomAnimationRunning = true
+            syncDebugBottomFollowState(in: tableView)
+            if scrollToBottom(in: tableView, animated: true) {
+                #if DEBUG
+                (tableView as? ChatTranscriptUITableView)?.recordBottomScrollRequest(
+                    animated: true,
+                    userVisible: true
+                )
+                #endif
+            } else {
+                isUserVisibleBottomAnimationRunning = false
+                updateBottomState(from: tableView)
+            }
+        }
+
+        private func scrollToBottomForFollow(in tableView: UITableView) {
+            if isUserVisibleBottomFollowActive {
+                scrollToBottomForUserVisibleFollow(in: tableView)
+                return
+            }
+            if scrollToBottom(in: tableView, animated: false) {
+                #if DEBUG
+                (tableView as? ChatTranscriptUITableView)?.recordBottomScrollRequest(
+                    animated: false,
+                    userVisible: false
+                )
+                #endif
+            }
+        }
+
+        @discardableResult
+        private func scrollToBottom(in tableView: UITableView, animated: Bool) -> Bool {
+            tableView.layoutIfNeeded()
+            cancelUserScrollMomentumIfNeeded(in: tableView)
+            let targetY = maxOffsetY(in: tableView)
+            guard abs(tableView.contentOffset.y - targetY) > 0.5 else {
+                (tableView as? ChatTranscriptUITableView)?.recordCurrentViewport()
+                updateBottomState(from: tableView)
+                return false
+            }
             tableView.setContentOffset(CGPoint(x: tableView.contentOffset.x, y: targetY), animated: animated)
             (tableView as? ChatTranscriptUITableView)?.recordCurrentViewport()
             updateBottomState(from: tableView)
-        }
-
-        private func cancelUserScrollMomentumIfNeeded(in tableView: UITableView) {
-            guard tableView.isTracking || tableView.isDragging || tableView.isDecelerating else { return }
-            tableView.setContentOffset(tableView.contentOffset, animated: false)
+            return true
         }
 
         private func requestOlderHistoryIfNeeded(in tableView: UITableView) {
@@ -327,38 +428,28 @@ struct ChatTranscriptTableView: UIViewRepresentable {
         }
 
         private func updateBottomState(from tableView: UITableView) {
-            setAtBottom(distanceFromBottom(in: tableView) <= chatTranscriptAtBottomThreshold)
+            let isBottom = distanceFromBottom(in: tableView) <= chatTranscriptAtBottomThreshold
+            setAtBottom(isBottom)
+            if isBottom, !isUserVisibleBottomAnimationRunning {
+                isUserVisibleBottomFollowActive = false
+                needsInitialUserVisibleBottomStaging = false
+            }
+            syncDebugBottomFollowState(in: tableView)
+        }
+
+        private func syncDebugBottomFollowState(in tableView: UITableView?) {
+            #if DEBUG
+            (tableView as? ChatTranscriptUITableView)?.recordBottomUserVisibleFollow(
+                active: isUserVisibleBottomFollowActive,
+                animationRunning: isUserVisibleBottomAnimationRunning
+            )
+            #endif
         }
 
         private func setAtBottom(_ value: Bool) {
             if isAtBottom.wrappedValue != value {
                 isAtBottom.wrappedValue = value
             }
-        }
-
-        private func distanceFromBottom(in tableView: UITableView) -> CGFloat {
-            guard tableView.bounds.height > 0 else { return 0 }
-            let visibleBottom = visibleBottomY(in: tableView)
-            return max(0, tableView.contentSize.height - visibleBottom)
-        }
-
-        private func visibleBottomY(in tableView: UITableView) -> CGFloat {
-            tableView.contentOffset.y
-                + tableView.bounds.height
-                - tableView.adjustedContentInset.bottom
-        }
-
-        private func maxOffsetY(in tableView: UITableView) -> CGFloat {
-            max(
-                -tableView.adjustedContentInset.top,
-                tableView.contentSize.height
-                    - tableView.bounds.height
-                    + tableView.adjustedContentInset.bottom
-            )
-        }
-
-        private func clampedOffsetY(_ offsetY: CGFloat, in tableView: UITableView) -> CGFloat {
-            min(max(offsetY, -tableView.adjustedContentInset.top), maxOffsetY(in: tableView))
         }
 
         #if DEBUG

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
@@ -83,6 +83,9 @@ struct ChatTranscriptTableView: UIViewRepresentable {
         private var isHandlingLayout = false
         private var isApplyingDataUpdate = false
         private var pendingContentUpdateAnchor: ChatTranscriptTableAnchor?
+        private var isExplicitBottomFollowActive = false
+        private var lastObservedScrollContentHeight: CGFloat?
+        private var lastObservedScrollOffsetY: CGFloat?
         private weak var tableView: ChatTranscriptUITableView?
         private var isAtBottom: Binding<Bool>
         #if DEBUG
@@ -124,13 +127,17 @@ struct ChatTranscriptTableView: UIViewRepresentable {
                 || configuration.agentState != agentState
             let shouldScrollToBottom = scrollToBottomRequest != lastScrollToBottomRequest
             lastScrollToBottomRequest = scrollToBottomRequest
+            if shouldScrollToBottom {
+                isExplicitBottomFollowActive = true
+                recordObservedScrollPosition(in: tableView)
+            }
             let wasAtBottom = distanceFromBottom(in: tableView) <= chatTranscriptAtBottomThreshold
             let anchor = firstVisibleAnchor(in: tableView)
 
             guard shouldReload else {
-                if shouldScrollToBottom {
+                if isExplicitBottomFollowActive && (shouldScrollToBottom || !wasAtBottom) {
                     pendingContentUpdateAnchor = nil
-                    scrollToBottom(in: tableView, animated: true)
+                    scrollToBottom(in: tableView, animated: shouldScrollToBottom)
                 }
                 updateBottomState(from: tableView)
                 return
@@ -145,9 +152,9 @@ struct ChatTranscriptTableView: UIViewRepresentable {
             defer { isApplyingDataUpdate = false }
             tableView.reloadData()
             tableView.layoutIfNeeded()
-            if shouldScrollToBottom || (wasAtBottom && !tableView.isUserScrollMomentumActive) {
+            if isExplicitBottomFollowActive || (wasAtBottom && !tableView.isUserScrollMomentumActive) {
                 pendingContentUpdateAnchor = nil
-                scrollToBottom(in: tableView, animated: false)
+                scrollToBottom(in: tableView, animated: shouldScrollToBottom)
             } else if let anchor, !tableView.isUserScrollMomentumActive {
                 restore(anchor, in: tableView)
                 pendingContentUpdateAnchor = anchor
@@ -180,7 +187,9 @@ struct ChatTranscriptTableView: UIViewRepresentable {
 
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
             guard let tableView = scrollView as? UITableView else { return }
+            cancelBottomFollowForStableContentUpwardScroll(in: tableView)
             updateBottomState(from: tableView)
+            recordObservedScrollPosition(in: tableView)
             #if DEBUG
             (tableView as? ChatTranscriptUITableView)?.updateDebugAccessibilityValue()
             #endif
@@ -189,6 +198,27 @@ struct ChatTranscriptTableView: UIViewRepresentable {
 
         func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
             pendingContentUpdateAnchor = nil
+            isExplicitBottomFollowActive = false
+        }
+
+        private func cancelBottomFollowForStableContentUpwardScroll(in tableView: UITableView) {
+            // Streaming content growth can increase distance from bottom; stable-content upward offsets mean scrolling took over.
+            guard isExplicitBottomFollowActive,
+                  !isHandlingLayout,
+                  !isApplyingDataUpdate,
+                  let lastObservedScrollContentHeight,
+                  let lastObservedScrollOffsetY,
+                  abs(tableView.contentSize.height - lastObservedScrollContentHeight) <= 0.5,
+                  tableView.contentOffset.y < lastObservedScrollOffsetY - 1
+            else {
+                return
+            }
+            isExplicitBottomFollowActive = false
+        }
+
+        private func recordObservedScrollPosition(in tableView: UITableView) {
+            lastObservedScrollContentHeight = tableView.contentSize.height
+            lastObservedScrollOffsetY = tableView.contentOffset.y
         }
 
         private func handleLayoutChange(
@@ -214,16 +244,25 @@ struct ChatTranscriptTableView: UIViewRepresentable {
             defer { isHandlingLayout = false }
 
             if tableView.isUserScrollMomentumActive {
+                if isExplicitBottomFollowActive {
+                    scrollToBottom(in: tableView, animated: false)
+                }
                 pendingContentUpdateAnchor = nil
                 updateBottomState(from: tableView)
                 return
             }
             if tableView.isViewportInsetsExternallyDriven || isApplyingDataUpdate {
+                if isExplicitBottomFollowActive {
+                    scrollToBottom(in: tableView, animated: false)
+                    return
+                }
                 updateBottomState(from: tableView)
                 return
             }
 
-            if boundsChanged, let oldViewport {
+            if isExplicitBottomFollowActive {
+                scrollToBottom(in: tableView, animated: false)
+            } else if boundsChanged, let oldViewport {
                 restoreKeyboardViewport(snapshot: oldViewport, in: tableView)
             } else if contentChanged, let pendingContentUpdateAnchor {
                 restore(pendingContentUpdateAnchor, in: tableView)
@@ -262,10 +301,16 @@ struct ChatTranscriptTableView: UIViewRepresentable {
 
         private func scrollToBottom(in tableView: UITableView, animated: Bool) {
             tableView.layoutIfNeeded()
+            cancelUserScrollMomentumIfNeeded(in: tableView)
             let targetY = maxOffsetY(in: tableView)
             tableView.setContentOffset(CGPoint(x: tableView.contentOffset.x, y: targetY), animated: animated)
             (tableView as? ChatTranscriptUITableView)?.recordCurrentViewport()
-            setAtBottom(true)
+            updateBottomState(from: tableView)
+        }
+
+        private func cancelUserScrollMomentumIfNeeded(in tableView: UITableView) {
+            guard tableView.isTracking || tableView.isDragging || tableView.isDecelerating else { return }
+            tableView.setContentOffset(tableView.contentOffset, animated: false)
         }
 
         private func requestOlderHistoryIfNeeded(in tableView: UITableView) {
@@ -351,161 +396,6 @@ struct ChatTranscriptTableView: UIViewRepresentable {
             )
             (tableView as? ChatTranscriptUITableView)?.recordCurrentViewport()
             setAtBottom(snapshot.wasAtBottom)
-        }
-    }
-}
-
-private struct ChatTranscriptTableConfiguration {
-    let rows: [ChatTranscriptRow]
-    let expandedIDs: Set<String>
-    let agentState: ChatAgentState
-    let hasMoreHistory: Bool
-    let hasLoadedInitialHistory: Bool
-    let initialLoadFailed: Bool
-    let historyTruncatedAtHead: Bool
-    let actions: ChatRowActions
-    let onReachTop: () -> Void
-    let onRetryInitialLoad: () -> Void
-    let theme: ChatTheme
-    let markdownRenderer: ChatMarkdownRenderer?
-    let contentCache: ChatContentCache?
-
-    func makeItems() -> [ChatTranscriptTableItem] {
-        var items: [ChatTranscriptTableItem] = []
-        if hasMoreHistory {
-            items.append(.loadingMore)
-        } else if historyTruncatedAtHead {
-            items.append(.historyTruncated)
-        }
-        if rows.isEmpty {
-            if initialLoadFailed {
-                items.append(.loadFailed)
-            } else if hasLoadedInitialHistory {
-                items.append(.empty)
-            } else {
-                items.append(.initialLoading)
-            }
-        }
-        items.append(contentsOf: rows.map(ChatTranscriptTableItem.row))
-        if case .working = agentState {
-            items.append(.typing)
-        }
-        items.append(.bottomAnchor)
-        return items
-    }
-
-    @ViewBuilder
-    func view(for item: ChatTranscriptTableItem, tableWidth: CGFloat) -> some View {
-        itemView(for: item)
-            .padding(.horizontal, theme.horizontalMargin)
-            .environment(\.chatTheme, theme)
-            .environment(\.chatMarkdownRenderer, markdownRenderer)
-            .environment(\.chatContentCache, contentCache)
-            .environment(
-                \.chatBubbleMaxWidth,
-                tableWidth > 0 ? tableWidth * theme.bubbleMaxWidthFraction : .infinity
-            )
-    }
-
-    @ViewBuilder
-    private func itemView(for item: ChatTranscriptTableItem) -> some View {
-        switch item {
-        case .loadingMore:
-            ProgressView()
-                .controlSize(.small)
-                .padding(.vertical, 12)
-        case .historyTruncated:
-            Text(
-                String(
-                    localized: "chat.history.truncated",
-                    defaultValue: "Earlier history is on your Mac",
-                    bundle: .module
-                )
-            )
-            .font(.caption)
-            .foregroundStyle(.tertiary)
-            .padding(.vertical, 12)
-        case .loadFailed:
-            VStack(spacing: 12) {
-                Text(
-                    String(
-                        localized: "chat.transcript.load_failed",
-                        defaultValue: "Couldn't load this conversation",
-                        bundle: .module
-                    )
-                )
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                Button(action: onRetryInitialLoad) {
-                    Text(
-                        String(localized: "chat.transcript.retry", defaultValue: "Retry", bundle: .module)
-                    )
-                    .font(.subheadline.weight(.medium))
-                }
-                .buttonStyle(.bordered)
-                .accessibilityIdentifier("ChatTranscriptRetry")
-            }
-            .padding(.vertical, 48)
-        case .empty:
-            Text(
-                String(
-                    localized: "chat.transcript.empty",
-                    defaultValue: "No messages yet",
-                    bundle: .module
-                )
-            )
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-            .padding(.vertical, 48)
-        case .initialLoading:
-            ProgressView()
-                .controlSize(.regular)
-                .padding(.vertical, 48)
-        case .row(let row):
-            ChatTranscriptRowView(
-                row: row,
-                isExpanded: expandedIDs.contains(row.id),
-                actions: actions
-            )
-            .equatable()
-        case .typing:
-            ChatTypingIndicatorView(agentState: agentState)
-                .padding(.top, theme.intraGroupSpacing)
-        case .bottomAnchor:
-            Color.clear
-                .frame(height: 9)
-        }
-    }
-}
-
-private enum ChatTranscriptTableItem: Equatable {
-    case loadingMore
-    case historyTruncated
-    case loadFailed
-    case empty
-    case initialLoading
-    case row(ChatTranscriptRow)
-    case typing
-    case bottomAnchor
-
-    var id: String {
-        switch self {
-        case .loadingMore:
-            return "loading-more"
-        case .historyTruncated:
-            return "history-truncated"
-        case .loadFailed:
-            return "load-failed"
-        case .empty:
-            return "empty"
-        case .initialLoading:
-            return "initial-loading"
-        case .row(let row):
-            return row.id
-        case .typing:
-            return "typing"
-        case .bottomAnchor:
-            return "bottom-anchor"
         }
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptUITableView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptUITableView.swift
@@ -41,6 +41,11 @@ final class ChatTranscriptUITableView: UITableView {
     private var debugBottomEdgeEffectSoft = false
     private var debugTopContentScrollViewRegistered = false
     private var debugBottomEdgeElementContainerRegistered = false
+    private var debugBottomUserVisibleAnimationCount = 0
+    private var debugBottomUserVisibleStagingCount = 0
+    private var debugBottomInternalNonanimatedFollowCount = 0
+    private var debugBottomUserVisibleFollowActive = false
+    private var debugBottomUserVisibleAnimationRunning = false
     #endif
 
     #if DEBUG
@@ -234,6 +239,26 @@ final class ChatTranscriptUITableView: UITableView {
         super.accessibilityValue = debugAccessibilityValue()
     }
 
+    func recordBottomUserVisibleFollow(active: Bool, animationRunning: Bool) {
+        debugBottomUserVisibleFollowActive = active
+        debugBottomUserVisibleAnimationRunning = animationRunning
+        updateDebugAccessibilityValue()
+    }
+
+    func recordBottomScrollRequest(animated: Bool, userVisible: Bool) {
+        if userVisible, animated {
+            debugBottomUserVisibleAnimationCount += 1
+        } else if !userVisible, !animated {
+            debugBottomInternalNonanimatedFollowCount += 1
+        }
+        updateDebugAccessibilityValue()
+    }
+
+    func recordBottomUserVisibleStaging() {
+        debugBottomUserVisibleStagingCount += 1
+        updateDebugAccessibilityValue()
+    }
+
     private func debugAccessibilityValue() -> String {
         let frameInWindow = window.map { convert(bounds, to: $0) } ?? frame
         let presentationFrameMaxY: CGFloat
@@ -252,7 +277,7 @@ final class ChatTranscriptUITableView: UITableView {
         let presentationGap = composerPresentationMinY - presentationFrameMaxY
         recordKeyboardAnimationGap(presentationGap)
         return String(
-            format: "frameMinY=%.2f;frameMaxY=%.2f;frameHeight=%.2f;presentationFrameMaxY=%.2f;boundsHeight=%.2f;offsetY=%.2f;adjustedTopInset=%.2f;adjustedBottomInset=%.2f;visibleTopY=%.2f;visibleBottomY=%.2f;contentHeight=%.2f;distanceFromBottom=%.2f;keyboardEvents=%d;keyboardOverlap=%.2f;keyboardTargetOverlap=%.2f;keyboardGuideOverlap=%.2f;keyboardBottomConstraint=%.2f;composerMinY=%.2f;composerPresentationMinY=%.2f;presentationGap=%.2f;topChromeOverlayInset=%.2f;composerOverlayBottomInset=%.2f;keyboardAnimationActive=%d;keyboardAnimationProgress=%.2f;keyboardTransitionDuration=%.3f;maxAnimationPresentationGap=%.2f;keyboardAnimationSamples=%d;topEdgeEffectSoft=%d;bottomEdgeEffectSoft=%d;topContentScrollViewRegistered=%d;bottomEdgeElementContainerRegistered=%d;scrollTracking=%d;scrollDragging=%d;scrollDecelerating=%d",
+            format: "frameMinY=%.2f;frameMaxY=%.2f;frameHeight=%.2f;presentationFrameMaxY=%.2f;boundsHeight=%.2f;offsetY=%.2f;adjustedTopInset=%.2f;adjustedBottomInset=%.2f;visibleTopY=%.2f;visibleBottomY=%.2f;contentHeight=%.2f;distanceFromBottom=%.2f;keyboardEvents=%d;keyboardOverlap=%.2f;keyboardTargetOverlap=%.2f;keyboardGuideOverlap=%.2f;keyboardBottomConstraint=%.2f;composerMinY=%.2f;composerPresentationMinY=%.2f;presentationGap=%.2f;topChromeOverlayInset=%.2f;composerOverlayBottomInset=%.2f;keyboardAnimationActive=%d;keyboardAnimationProgress=%.2f;keyboardTransitionDuration=%.3f;maxAnimationPresentationGap=%.2f;keyboardAnimationSamples=%d;topEdgeEffectSoft=%d;bottomEdgeEffectSoft=%d;topContentScrollViewRegistered=%d;bottomEdgeElementContainerRegistered=%d;scrollTracking=%d;scrollDragging=%d;scrollDecelerating=%d;bottomUserVisibleAnimationCount=%d;bottomUserVisibleStagingCount=%d;bottomInternalNonanimatedFollowCount=%d;bottomUserVisibleFollowActive=%d;bottomUserVisibleAnimationRunning=%d",
             locale: Locale(identifier: "en_US_POSIX"),
             frameInWindow.minY,
             frameInWindow.maxY,
@@ -287,7 +312,12 @@ final class ChatTranscriptUITableView: UITableView {
             debugBottomEdgeElementContainerRegistered ? 1 : 0,
             isTracking ? 1 : 0,
             isDragging ? 1 : 0,
-            isDecelerating ? 1 : 0
+            isDecelerating ? 1 : 0,
+            debugBottomUserVisibleAnimationCount,
+            debugBottomUserVisibleStagingCount,
+            debugBottomInternalNonanimatedFollowCount,
+            debugBottomUserVisibleFollowActive ? 1 : 0,
+            debugBottomUserVisibleAnimationRunning ? 1 : 0
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
@@ -29,7 +29,7 @@ struct AgentChatDemoScreen: View {
                     ProgressView()
                         .task {
                             var (messages, descriptor) = ChatFixtureConversation().make()
-                            messages = repeatedUITestMessagesIfNeeded(messages)
+                            messages = uiTestMessagesIfNeeded(messages)
                             let source = FixtureChatEventSource(backlog: messages, replyToSends: true)
                             stack = DemoStack(
                                 store: ChatConversationStore(descriptor: descriptor, source: source)
@@ -186,6 +186,24 @@ struct AgentChatDemoScreen: View {
         default:
             break
         }
+    }
+
+    private func uiTestMessagesIfNeeded(_ messages: [ChatMessage]) -> [ChatMessage] {
+        let limitedMessages = limitedUITestMessagesIfNeeded(messages)
+        return repeatedUITestMessagesIfNeeded(limitedMessages)
+    }
+
+    private func limitedUITestMessagesIfNeeded(_ messages: [ChatMessage]) -> [ChatMessage] {
+        let env = ProcessInfo.processInfo.environment
+        guard let rawMessageCount = env["CMUX_UITEST_AGENT_CHAT_FIXTURE_MESSAGE_COUNT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              let messageCount = Int(rawMessageCount),
+              messageCount > 0,
+              messageCount < messages.count
+        else {
+            return messages
+        }
+        return Array(messages.prefix(messageCount))
     }
 
     private func repeatedUITestMessagesIfNeeded(_ messages: [ChatMessage]) -> [ChatMessage] {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
@@ -28,7 +28,8 @@ struct AgentChatDemoScreen: View {
                 } else {
                     ProgressView()
                         .task {
-                            let (messages, descriptor) = ChatFixtureConversation().make()
+                            var (messages, descriptor) = ChatFixtureConversation().make()
+                            messages = repeatedUITestMessagesIfNeeded(messages)
                             let source = FixtureChatEventSource(backlog: messages, replyToSends: true)
                             stack = DemoStack(
                                 store: ChatConversationStore(descriptor: descriptor, source: source)
@@ -185,6 +186,33 @@ struct AgentChatDemoScreen: View {
         default:
             break
         }
+    }
+
+    private func repeatedUITestMessagesIfNeeded(_ messages: [ChatMessage]) -> [ChatMessage] {
+        let env = ProcessInfo.processInfo.environment
+        guard let rawRepeatCount = env["CMUX_UITEST_AGENT_CHAT_FIXTURE_REPEAT_COUNT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              let repeatCount = Int(rawRepeatCount),
+              repeatCount > 1
+        else {
+            return messages
+        }
+        var repeatedMessages: [ChatMessage] = []
+        repeatedMessages.reserveCapacity(messages.count * repeatCount)
+        for repeatIndex in 0..<repeatCount {
+            for message in messages {
+                repeatedMessages.append(
+                    ChatMessage(
+                        id: "\(message.id)-repeat-\(repeatIndex)",
+                        seq: repeatedMessages.count,
+                        role: message.role,
+                        timestamp: message.timestamp.addingTimeInterval(TimeInterval(repeatIndex * messages.count)),
+                        kind: message.kind
+                    )
+                )
+            }
+        }
+        return repeatedMessages
     }
 
     private var inlineWorkspaceTitle: String? {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/StreamingChatPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/StreamingChatPreviewView.swift
@@ -29,19 +29,10 @@ struct StreamingChatPreviewView: View {
     @MainActor
     private func start() async {
         guard model == nil else { return }
-        let descriptor = ChatSessionDescriptor(
-            id: "streaming-preview",
-            agentKind: .claude,
-            title: "Streaming preview"
-        )
-        let prompt = ChatMessage(
-            id: "preview-user-0",
-            seq: 0,
-            role: .user,
-            timestamp: Date(),
-            kind: .prose(ChatProse(text: "Reply with three short sentences about the color blue."))
-        )
-        let source = FixtureChatEventSource(backlog: [prompt])
+        let (messages, descriptor) = StreamingPreviewSeedConversation(
+            environment: ProcessInfo.processInfo.environment
+        ).make()
+        let source = FixtureChatEventSource(backlog: messages)
         let store = ChatConversationStore(descriptor: descriptor, source: source)
         let model = Model(store: store, source: source)
         model.runTask = Task { await store.run() }
@@ -103,4 +94,5 @@ struct StreamingChatPreviewView: View {
         }
     }
 }
+
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/StreamingPreviewSeedConversation.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/StreamingPreviewSeedConversation.swift
@@ -1,0 +1,55 @@
+#if canImport(UIKit) && DEBUG
+import CmuxAgentChat
+import CmuxAgentChatUI
+import Foundation
+
+struct StreamingPreviewSeedConversation {
+    let environment: [String: String]
+
+    func make() -> ([ChatMessage], ChatSessionDescriptor) {
+        if let repeatCount = uiTestFixtureRepeatCount(), repeatCount > 1 {
+            let (messages, descriptor) = ChatFixtureConversation().make()
+            return (repeatedMessages(messages, repeatCount: repeatCount), descriptor)
+        }
+
+        let descriptor = ChatSessionDescriptor(
+            id: "streaming-preview",
+            agentKind: .claude,
+            title: "Streaming preview"
+        )
+        let prompt = ChatMessage(
+            id: "preview-user-0",
+            seq: 0,
+            role: .user,
+            timestamp: Date(),
+            kind: .prose(ChatProse(text: "Reply with three short sentences about the color blue."))
+        )
+        return ([prompt], descriptor)
+    }
+
+    private func uiTestFixtureRepeatCount() -> Int? {
+        let rawValue = environment["CMUX_UITEST_AGENT_CHAT_FIXTURE_REPEAT_COUNT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return rawValue.flatMap(Int.init)
+    }
+
+    private func repeatedMessages(_ messages: [ChatMessage], repeatCount: Int) -> [ChatMessage] {
+        var repeatedMessages: [ChatMessage] = []
+        repeatedMessages.reserveCapacity(messages.count * repeatCount)
+        for repeatIndex in 0..<repeatCount {
+            for message in messages {
+                repeatedMessages.append(
+                    ChatMessage(
+                        id: "\(message.id)-repeat-\(repeatIndex)",
+                        seq: repeatedMessages.count,
+                        role: message.role,
+                        timestamp: message.timestamp.addingTimeInterval(TimeInterval(repeatIndex * messages.count)),
+                        kind: message.kind
+                    )
+                )
+            }
+        }
+        return repeatedMessages
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/StreamingPreviewSeedConversation.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/StreamingPreviewSeedConversation.swift
@@ -9,7 +9,7 @@ struct StreamingPreviewSeedConversation {
     func make() -> ([ChatMessage], ChatSessionDescriptor) {
         if let repeatCount = uiTestFixtureRepeatCount(), repeatCount > 1 {
             let (messages, descriptor) = ChatFixtureConversation().make()
-            return (repeatedMessages(messages, repeatCount: repeatCount), descriptor)
+            return (repeatedMessages(limitedMessages(messages), repeatCount: repeatCount), descriptor)
         }
 
         let descriptor = ChatSessionDescriptor(
@@ -25,6 +25,18 @@ struct StreamingPreviewSeedConversation {
             kind: .prose(ChatProse(text: "Reply with three short sentences about the color blue."))
         )
         return ([prompt], descriptor)
+    }
+
+    private func limitedMessages(_ messages: [ChatMessage]) -> [ChatMessage] {
+        guard let rawValue = environment["CMUX_UITEST_AGENT_CHAT_FIXTURE_MESSAGE_COUNT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              let messageCount = Int(rawValue),
+              messageCount > 0,
+              messageCount < messages.count
+        else {
+            return messages
+        }
+        return Array(messages.prefix(messageCount))
     }
 
     private func uiTestFixtureRepeatCount() -> Int? {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1391,6 +1391,88 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
+    func testAgentChatScrollToBottomButtonReturnsDuringStreamingLayoutChurn() throws {
+        let app = launchStreamingChatPreviewApp(environment: [
+            "CMUX_UITEST_AGENT_CHAT_FIXTURE_REPEAT_COUNT": "6",
+            "CMUX_UITEST_CHAT_INITIAL_SCROLL": "middle",
+        ])
+        defer { app.terminate() }
+        let table = app.tables["ChatTranscriptTableView"]
+        let loadedAwayFromBottom = try waitForTranscriptMetrics(table, timeout: 8) {
+            $0.contentHeight > $0.boundsHeight * 4
+                && $0.distanceFromBottom > max(1_000, $0.contentHeight * 0.25)
+                && self.isTranscriptScrollIdle($0)
+        }
+        let streamingGrowth = try waitForStreamingTranscriptContentGrowth(
+            table,
+            from: loadedAwayFromBottom,
+            timeout: 8
+        )
+        let button = app.buttons["ChatScrollToBottomButton"]
+        XCTAssertTrue(
+            button.waitForExistence(timeout: 4),
+            "The scroll-to-bottom button must appear while streaming continues away from bottom. metrics=\(streamingGrowth)"
+        )
+        XCTAssertTrue(button.isHittable)
+        button.tap()
+
+        assertScrollToBottomButtonVisibleUntilBottom(
+            button,
+            table: table,
+            startDescription: "streaming middle",
+            beforeTap: streamingGrowth
+        )
+        let afterTap = try waitForTranscriptMetrics(table, timeout: 6) {
+            $0.distanceFromBottom <= 40 && self.isTranscriptScrollIdle($0)
+        }
+        XCTAssertFalse(
+            button.exists,
+            "The scroll-to-bottom button must disappear after streaming churn settles at bottom. metrics=\(afterTap)"
+        )
+    }
+
+    @MainActor
+    func testAgentChatScrollToBottomButtonCancelsActiveScrollMomentum() throws {
+        let app = launchAgentChatInlinePreviewApp(environment: [
+            "CMUX_UITEST_AGENT_CHAT_FIXTURE_REPEAT_COUNT": "6",
+        ])
+        defer { app.terminate() }
+        let table = app.tables["ChatTranscriptTableView"]
+        let initialMetrics = try waitForTranscriptMetrics(table, timeout: 8) {
+            $0.distanceFromBottom <= 40
+                && $0.contentHeight > $0.boundsHeight * 4
+                && self.isTranscriptScrollIdle($0)
+        }
+        let button = app.buttons["ChatScrollToBottomButton"]
+        XCTAssertFalse(
+            button.exists,
+            "The scroll-to-bottom button must start hidden while the transcript is at bottom. metrics=\(initialMetrics)"
+        )
+
+        table.swipeDown(velocity: .fast)
+        let beforeTap = try waitForScrollToBottomButtonAfterFastSwipe(
+            button,
+            table: table,
+            timeout: 2
+        )
+        button.tap()
+
+        assertScrollToBottomButtonVisibleUntilBottom(
+            button,
+            table: table,
+            startDescription: "active scroll momentum",
+            beforeTap: beforeTap
+        )
+        let afterTap = try waitForTranscriptMetrics(table, timeout: 5) {
+            $0.distanceFromBottom <= 40 && self.isTranscriptScrollIdle($0)
+        }
+        XCTAssertFalse(
+            button.exists,
+            "The scroll-to-bottom button must disappear after the fast-swipe tap actually reaches bottom. beforeTap=\(beforeTap), afterTap=\(afterTap)"
+        )
+    }
+
+    @MainActor
     func testAgentChatTranscriptFastSwipeEvidence() throws {
         let app = launchAgentChatInlinePreviewApp(environment: [
             "CMUX_UITEST_CHAT_INITIAL_SCROLL": "middle",
@@ -1918,6 +2000,24 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(
             settleChatPreviewKeyboardDown(in: app, table: table),
             "Chat preview must start keyboard-down before keyboard evidence is collected. metrics=\(String(describing: transcriptMetrics(from: table)))"
+        )
+        return app
+    }
+
+    @MainActor
+    private func launchStreamingChatPreviewApp(environment: [String: String] = [:]) -> XCUIApplication {
+        var launchEnvironment = [
+            "CMUX_UITEST_STREAMING_CHAT_PREVIEW": "1",
+        ]
+        for (key, value) in environment {
+            launchEnvironment[key] = value
+        }
+        let app = launchApp(mockData: false, environment: launchEnvironment)
+        let table = app.tables["ChatTranscriptTableView"]
+        XCTAssertTrue(table.waitForExistence(timeout: 8))
+        XCTAssertTrue(
+            settleChatPreviewKeyboardDown(in: app, table: table),
+            "Streaming chat preview must start keyboard-down before scroll evidence is collected. metrics=\(String(describing: transcriptMetrics(from: table)))"
         )
         return app
     }
@@ -3333,6 +3433,12 @@ final class cmuxUITests: XCTestCase {
         case down
     }
 
+    private func isTranscriptScrollIdle(_ metrics: ChatTranscriptMetrics) -> Bool {
+        !metrics.scrollTracking
+            && !metrics.scrollDragging
+            && !metrics.scrollDecelerating
+    }
+
     @MainActor
     @discardableResult
     private func scrollTranscript(
@@ -3375,6 +3481,93 @@ final class cmuxUITests: XCTestCase {
             line: line
         )
         return lastMetrics
+    }
+
+    @MainActor
+    private func waitForStreamingTranscriptContentGrowth(
+        _ table: XCUIElement,
+        from baseline: ChatTranscriptMetrics,
+        timeout: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> ChatTranscriptMetrics {
+        try waitForTranscriptMetrics(
+            table,
+            timeout: timeout,
+            matching: {
+                $0.contentHeight > baseline.contentHeight + 2
+                    && $0.distanceFromBottom > max(1_000, $0.contentHeight * 0.25)
+                    && self.isTranscriptScrollIdle($0)
+            },
+            file: file,
+            line: line
+        )
+    }
+
+    @MainActor
+    private func waitForScrollToBottomButtonAfterFastSwipe(
+        _ button: XCUIElement,
+        table: XCUIElement,
+        timeout: TimeInterval,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> ChatTranscriptMetrics {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastMetrics: ChatTranscriptMetrics?
+        while Date() < deadline {
+            if let metrics = transcriptMetrics(from: table) {
+                lastMetrics = metrics
+                if metrics.distanceFromBottom > 180,
+                   button.exists,
+                   button.isHittable {
+                    return metrics
+                }
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        let message = "Timed out waiting for scroll-to-bottom button after a fast swipe. Last metrics: \(String(describing: transcriptMetrics(from: table) ?? lastMetrics))"
+        XCTFail(message, file: file, line: line)
+        throw TranscriptMetricsWaitError(description: message)
+    }
+
+    @MainActor
+    private func assertScrollToBottomButtonVisibleUntilBottom(
+        _ button: XCUIElement,
+        table: XCUIElement,
+        startDescription: String,
+        beforeTap: ChatTranscriptMetrics,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(1.0)
+        var lastMetrics: ChatTranscriptMetrics?
+        while Date() < deadline {
+            guard let metrics = transcriptMetrics(from: table) else {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+                continue
+            }
+            lastMetrics = metrics
+            if metrics.distanceFromBottom <= 40 {
+                return
+            }
+            if !button.exists {
+                XCTFail(
+                    "The scroll-to-bottom button hid before the transcript reached bottom. start=\(startDescription), beforeTap=\(beforeTap), metrics=\(metrics)",
+                    file: file,
+                    line: line
+                )
+                return
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        if let lastMetrics, lastMetrics.distanceFromBottom > 40 {
+            XCTAssertTrue(
+                button.exists,
+                "The scroll-to-bottom button must remain visible while the transcript is still away from bottom. start=\(startDescription), beforeTap=\(beforeTap), metrics=\(lastMetrics)",
+                file: file,
+                line: line
+            )
+        }
     }
 
     @MainActor

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1391,6 +1391,117 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
+    func testAgentChatScrollToBottomButtonVisibleGlideAcrossHistoryLengths() throws {
+        do {
+            let app = launchAgentChatInlinePreviewApp(environment: [
+                "CMUX_UITEST_AGENT_CHAT_FIXTURE_MESSAGE_COUNT": "1",
+            ])
+            defer { app.terminate() }
+            let table = app.tables["ChatTranscriptTableView"]
+            let metrics = try waitForTranscriptMetrics(table, timeout: 8) {
+                $0.contentHeight < $0.boundsHeight
+                    && $0.distanceFromBottom <= 40
+                    && self.isTranscriptScrollIdle($0)
+            }
+            XCTAssertFalse(
+                app.buttons["ChatScrollToBottomButton"].exists,
+                "A transcript shorter than the viewport must not show a useless scroll-to-bottom button. metrics=\(metrics)"
+            )
+        }
+
+        for fixtureCase in [
+            ChatScrollToBottomFixtureCase(
+                name: "little-longer",
+                environment: ["CMUX_UITEST_AGENT_CHAT_FIXTURE_MESSAGE_COUNT": "8"],
+                loaded: {
+                    $0.contentHeight > $0.boundsHeight + 80
+                        && $0.contentHeight < $0.boundsHeight * 3
+                        && !$0.scrollTracking
+                        && !$0.scrollDragging
+                        && !$0.scrollDecelerating
+                },
+                awayFromBottom: { $0.distanceFromBottom > 60 }
+            ),
+            ChatScrollToBottomFixtureCase(
+                name: "much-longer",
+                environment: [
+                    "CMUX_UITEST_AGENT_CHAT_FIXTURE_REPEAT_COUNT": "6",
+                    "CMUX_UITEST_CHAT_INITIAL_SCROLL": "middle",
+                ],
+                loaded: {
+                    $0.contentHeight > $0.boundsHeight * 4
+                        && $0.distanceFromBottom > max(1_000, $0.contentHeight * 0.25)
+                        && !$0.scrollTracking
+                        && !$0.scrollDragging
+                        && !$0.scrollDecelerating
+                },
+                awayFromBottom: { $0.distanceFromBottom > 1_000 }
+            ),
+            ChatScrollToBottomFixtureCase(
+                name: "huge",
+                environment: [
+                    "CMUX_UITEST_AGENT_CHAT_FIXTURE_REPEAT_COUNT": "24",
+                    "CMUX_UITEST_CHAT_INITIAL_SCROLL": "middle",
+                ],
+                loaded: {
+                    $0.contentHeight > $0.boundsHeight * 12
+                        && $0.distanceFromBottom > 3_000
+                        && !$0.scrollTracking
+                        && !$0.scrollDragging
+                        && !$0.scrollDecelerating
+                },
+                awayFromBottom: { $0.distanceFromBottom > 3_000 }
+            ),
+        ] {
+            let app = launchAgentChatInlinePreviewApp(environment: fixtureCase.environment)
+            defer { app.terminate() }
+            let table = app.tables["ChatTranscriptTableView"]
+            let loaded = try waitForTranscriptMetrics(table, timeout: 10, matching: fixtureCase.loaded)
+            let beforeTap: ChatTranscriptMetrics
+            if fixtureCase.awayFromBottom(loaded) {
+                beforeTap = loaded
+            } else {
+                beforeTap = try scrollTranscript(table, direction: .down, timeout: 6, until: fixtureCase.awayFromBottom)
+                    ?? loaded
+            }
+
+            let button = app.buttons["ChatScrollToBottomButton"]
+            XCTAssertTrue(
+                button.waitForExistence(timeout: 4),
+                "The scroll-to-bottom button must show when \(fixtureCase.name) is away from bottom. metrics=\(beforeTap)"
+            )
+            XCTAssertTrue(button.isHittable)
+            let visibleDistance = max(600, min(1_200, beforeTap.boundsHeight * 1.25))
+            button.tap()
+            let afterTap = try waitForTranscriptMetrics(table, timeout: 5) {
+                $0.distanceFromBottom <= 40 && self.isTranscriptScrollIdle($0)
+            }
+            XCTAssertGreaterThan(
+                afterTap.bottomUserVisibleAnimationCount,
+                beforeTap.bottomUserVisibleAnimationCount,
+                "\(fixtureCase.name) scroll-to-bottom tap must enter user-visible animated follow, not only nonanimated bottom pinning. before=\(beforeTap), after=\(afterTap)"
+            )
+            if beforeTap.distanceFromBottom > visibleDistance {
+                XCTAssertGreaterThan(
+                    afterTap.bottomUserVisibleStagingCount,
+                    beforeTap.bottomUserVisibleStagingCount,
+                    "\(fixtureCase.name) should privately stage once before the visible final glide. visibleDistance=\(visibleDistance), before=\(beforeTap), after=\(afterTap)"
+                )
+            } else {
+                XCTAssertEqual(
+                    afterTap.bottomUserVisibleStagingCount,
+                    beforeTap.bottomUserVisibleStagingCount,
+                    "\(fixtureCase.name) should not use hidden staging for a short visible-distance scroll. visibleDistance=\(visibleDistance), before=\(beforeTap), after=\(afterTap)"
+                )
+            }
+            XCTAssertFalse(
+                button.exists,
+                "The scroll-to-bottom button must disappear only after \(fixtureCase.name) reaches bottom. before=\(beforeTap), after=\(afterTap)"
+            )
+        }
+    }
+
+    @MainActor
     func testAgentChatScrollToBottomButtonReturnsDuringStreamingLayoutChurn() throws {
         let app = launchStreamingChatPreviewApp(environment: [
             "CMUX_UITEST_AGENT_CHAT_FIXTURE_REPEAT_COUNT": "6",
@@ -2773,9 +2884,14 @@ final class cmuxUITests: XCTestCase {
         let scrollTracking: Bool
         let scrollDragging: Bool
         let scrollDecelerating: Bool
+        let bottomUserVisibleAnimationCount: Int
+        let bottomUserVisibleStagingCount: Int
+        let bottomInternalNonanimatedFollowCount: Int
+        let bottomUserVisibleFollowActive: Bool
+        let bottomUserVisibleAnimationRunning: Bool
 
         var description: String {
-            "frameMinY=\(frameMinY), frameMaxY=\(frameMaxY), frameHeight=\(frameHeight), presentationFrameMaxY=\(presentationFrameMaxY), boundsHeight=\(boundsHeight), offsetY=\(offsetY), adjustedTopInset=\(adjustedTopInset), adjustedBottomInset=\(adjustedBottomInset), visibleTopY=\(visibleTopY), visibleBottomY=\(visibleBottomY), contentHeight=\(contentHeight), distanceFromBottom=\(distanceFromBottom), keyboardEvents=\(keyboardEvents), keyboardOverlap=\(keyboardOverlap), keyboardTargetOverlap=\(keyboardTargetOverlap), composerMinY=\(composerMinY), composerPresentationMinY=\(composerPresentationMinY), presentationGap=\(presentationGap), topChromeOverlayInset=\(topChromeOverlayInset), composerOverlayBottomInset=\(composerOverlayBottomInset), keyboardAnimationActive=\(keyboardAnimationActive), keyboardAnimationProgress=\(keyboardAnimationProgress), keyboardTransitionDuration=\(keyboardTransitionDuration), maxAnimationPresentationGap=\(maxAnimationPresentationGap), keyboardAnimationSamples=\(keyboardAnimationSamples), topEdgeEffectSoft=\(topEdgeEffectSoft), bottomEdgeEffectSoft=\(bottomEdgeEffectSoft), topContentScrollViewRegistered=\(topContentScrollViewRegistered), bottomEdgeElementContainerRegistered=\(bottomEdgeElementContainerRegistered), scrollTracking=\(scrollTracking), scrollDragging=\(scrollDragging), scrollDecelerating=\(scrollDecelerating)"
+            "frameMinY=\(frameMinY), frameMaxY=\(frameMaxY), frameHeight=\(frameHeight), presentationFrameMaxY=\(presentationFrameMaxY), boundsHeight=\(boundsHeight), offsetY=\(offsetY), adjustedTopInset=\(adjustedTopInset), adjustedBottomInset=\(adjustedBottomInset), visibleTopY=\(visibleTopY), visibleBottomY=\(visibleBottomY), contentHeight=\(contentHeight), distanceFromBottom=\(distanceFromBottom), keyboardEvents=\(keyboardEvents), keyboardOverlap=\(keyboardOverlap), keyboardTargetOverlap=\(keyboardTargetOverlap), composerMinY=\(composerMinY), composerPresentationMinY=\(composerPresentationMinY), presentationGap=\(presentationGap), topChromeOverlayInset=\(topChromeOverlayInset), composerOverlayBottomInset=\(composerOverlayBottomInset), keyboardAnimationActive=\(keyboardAnimationActive), keyboardAnimationProgress=\(keyboardAnimationProgress), keyboardTransitionDuration=\(keyboardTransitionDuration), maxAnimationPresentationGap=\(maxAnimationPresentationGap), keyboardAnimationSamples=\(keyboardAnimationSamples), topEdgeEffectSoft=\(topEdgeEffectSoft), bottomEdgeEffectSoft=\(bottomEdgeEffectSoft), topContentScrollViewRegistered=\(topContentScrollViewRegistered), bottomEdgeElementContainerRegistered=\(bottomEdgeElementContainerRegistered), scrollTracking=\(scrollTracking), scrollDragging=\(scrollDragging), scrollDecelerating=\(scrollDecelerating), bottomUserVisibleAnimationCount=\(bottomUserVisibleAnimationCount), bottomUserVisibleStagingCount=\(bottomUserVisibleStagingCount), bottomInternalNonanimatedFollowCount=\(bottomInternalNonanimatedFollowCount), bottomUserVisibleFollowActive=\(bottomUserVisibleFollowActive), bottomUserVisibleAnimationRunning=\(bottomUserVisibleAnimationRunning)"
         }
 
         var effectiveFrameMaxY: CGFloat {
@@ -2837,6 +2953,11 @@ final class cmuxUITests: XCTestCase {
             self.scrollTracking = (values["scrollTracking"] ?? 0) >= 0.5
             self.scrollDragging = (values["scrollDragging"] ?? 0) >= 0.5
             self.scrollDecelerating = (values["scrollDecelerating"] ?? 0) >= 0.5
+            self.bottomUserVisibleAnimationCount = Int(values["bottomUserVisibleAnimationCount"] ?? 0)
+            self.bottomUserVisibleStagingCount = Int(values["bottomUserVisibleStagingCount"] ?? 0)
+            self.bottomInternalNonanimatedFollowCount = Int(values["bottomInternalNonanimatedFollowCount"] ?? 0)
+            self.bottomUserVisibleFollowActive = (values["bottomUserVisibleFollowActive"] ?? 0) >= 0.5
+            self.bottomUserVisibleAnimationRunning = (values["bottomUserVisibleAnimationRunning"] ?? 0) >= 0.5
         }
     }
 
@@ -2852,6 +2973,13 @@ final class cmuxUITests: XCTestCase {
         var description: String {
             "elapsed=\(elapsed), metrics={\(metrics)}, composerFrame=\(String(describing: composerFrame)), visiblePresentationGap=\(String(describing: visiblePresentationGap))"
         }
+    }
+
+    private struct ChatScrollToBottomFixtureCase {
+        let name: String
+        let environment: [String: String]
+        let loaded: (ChatTranscriptMetrics) -> Bool
+        let awayFromBottom: (ChatTranscriptMetrics) -> Bool
     }
 
     private struct TimedKeyboardAction {


### PR DESCRIPTION
## Summary
- Keep an explicit bottom-follow request active until the transcript reaches the measured bottom or the user takes scrolling back over.
- Stop hiding the scroll-to-bottom button optimistically on tap.
- Add long streaming fixture coverage for the partial-scroll regression and active momentum case.

## Fix mechanism
The table coordinator now treats a scroll-to-bottom tap as an explicit bottom-follow state. Layout reloads, content-height growth, and cell size churn re-pin to the real bottom while that state is active. User dragging, or stable-content upward movement, cancels the follow. Normal no-reload SwiftUI updates at the bottom avoid repeated no-op scroll work.

This is a principled fix because scroll ownership is modeled from measured table geometry instead of timing or a one-shot offset write.

## Repro
Before the fix, `testAgentChatScrollToBottomButtonReturnsDuringStreamingLayoutChurn` failed with the transcript still far from bottom after tapping the button:

- result bundle: `/tmp/cmux-ios-fixscroll-streaming-red.xcresult`
- observed distance from bottom: `5290.33`

## Verification
- Focused local UI tests: `/tmp/cmux-ios-fixscroll-focused-final3.xcresult`, 3 passed, 0 failed.
- Independent verifier: approved rebased HEAD `483dd4e4b53314f1f5a591bd08e137c194d90291` based on identical touched Swift/UI-test content and `/tmp/cmux-ios-fixscroll-verifier-57a388.xcresult`, 3 passed, 0 failed.
- Video/frame evidence: `/tmp/cmux-assets/fix-ios-scroll-bottom/scroll-bottom-streaming-tap/contact-sheet.png`.
- Autoreview: clean against `origin/main`, no accepted/actionable findings, no cmux-policy findings.

Residual risk: the passing UI-test result bundles still contain pre-existing SwiftUI runtime warnings about modifying state during view update. This PR does not introduce or fix that warning class.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785708877&installation_id=133855650&pr_number=7287&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7287&signature=918f0405bcf72b15ad56b5991a7375d3d9d99df5f20d78e97b984ec6dfcaafe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS chat scroll-to-bottom so a tap reliably reaches the true bottom with a visible final glide, even during streaming churn and fast-swipe momentum. The button stays visible until the transcript is actually at bottom.

- **Bug Fixes**
  - Treats a tap as an explicit bottom-follow with a user-visible final glide; stages near-bottom when far away and re-pins during content growth until completion.
  - Cancels active scroll momentum before following; cancels follow on user drag or stable-content upward scroll.
  - Derives bottom state from measured table geometry only; removes optimistic `isAtBottom` writes.
  - Adds regression UI tests across short/long/huge histories and streaming preview; verifies staging/glide behavior; introduces `StreamingPreviewSeedConversation` and supports `CMUX_UITEST_AGENT_CHAT_FIXTURE_MESSAGE_COUNT` and `CMUX_UITEST_AGENT_CHAT_FIXTURE_REPEAT_COUNT`.

- **Refactors**
  - Moves `ChatTranscriptTableConfiguration`, `ChatTranscriptTableItem`, and scroll geometry helpers into dedicated files to simplify the table view.

<sup>Written for commit 2f34f80f87d39091832c64b83df1b277c02eb4f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced chat transcript UI states (loading/truncated/empty/typing) with improved retry and initial-load rendering.
  * Demo/preview chat seeding can now repeat fixture conversations to create richer preview scenarios.
* **Bug Fixes**
  * Improved the chat “scroll to bottom” button reliability, keeping it stable during streaming updates and respecting active user scrolling/momentum before following bottom.
* **Tests**
  * Expanded UI coverage for the “scroll to bottom” button across multiple transcript lengths, streaming churn, and active scroll momentum scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->