### PR TITLE
Fix iOS terminal picker refresh scroll reset

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailDelayedTerminalPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailDelayedTerminalPreviewView.swift
@@ -2,6 +2,8 @@ import CmuxAgentChat
 import CmuxMobileBrowser
 import CmuxMobileShell
 import CmuxMobileShellModel
+import CmuxMobileSupport
+import Foundation
 import SwiftUI
 
 #if os(iOS) && DEBUG
@@ -15,16 +17,10 @@ struct WorkspaceDetailDelayedTerminalPreviewView: View {
         isSignedIn: true,
         connectionState: .connected,
         connectedHostName: "UI Test Mac",
-        workspaces: [
-            MobileWorkspacePreview(
-                id: workspaceID,
-                name: workspaceTitle,
-                terminals: []
-            ),
-        ]
+        workspaces: initialWorkspaces
     )
     @State private var browserStore = BrowserSurfaceStore()
-    @State private var didInjectTerminal = false
+    @State private var didStartFixture = false
 
     var body: some View {
         WorkspaceShellView(
@@ -34,9 +30,20 @@ struct WorkspaceDetailDelayedTerminalPreviewView: View {
         )
         .environment(browserStore)
         .task {
-            guard !didInjectTerminal else { return }
-            didInjectTerminal = true
+            guard !didStartFixture else { return }
+            didStartFixture = true
             store.selectedWorkspaceID = Self.workspaceID
+            if Self.usesRefreshingTerminalMenu {
+                store.selectedTerminalID = Self.refreshingTerminalID(0)
+                for generation in 1...80 {
+                    try? await ContinuousClock().sleep(for: .milliseconds(250))
+                    guard !Task.isCancelled else { return }
+                    store.replaceForegroundWorkspaceState([Self.refreshingWorkspace(generation: generation)])
+                    store.selectedWorkspaceID = Self.workspaceID
+                }
+                return
+            }
+
             try? await ContinuousClock().sleep(for: .milliseconds(1_500))
             guard !Task.isCancelled else { return }
             let workspace = MobileWorkspacePreview(
@@ -76,12 +83,47 @@ struct WorkspaceDetailDelayedTerminalPreviewView: View {
         ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_DETAIL_CHAT_TOGGLE"] == "1"
     }
 
+    private static var usesRefreshingTerminalMenu: Bool {
+        UITestConfig.workspaceDetailRefreshingTerminalMenuPreviewEnabled
+    }
+
     private static var workspaceTitle: String {
         usesLongTitle ? longWorkspaceTitle : "New Workspace"
     }
 
     private static var terminalTitle: String {
         usesLongTitle ? longTerminalTitle : "Terminal 1"
+    }
+
+    private static var initialWorkspaces: [MobileWorkspacePreview] {
+        if usesRefreshingTerminalMenu {
+            return [refreshingWorkspace(generation: 0)]
+        }
+        return [
+            MobileWorkspacePreview(
+                id: workspaceID,
+                name: workspaceTitle,
+                terminals: []
+            ),
+        ]
+    }
+
+    private static func refreshingWorkspace(generation: Int) -> MobileWorkspacePreview {
+        MobileWorkspacePreview(
+            id: workspaceID,
+            name: "Terminal refresh fixture",
+            terminals: (0...24).map { index in
+                let baseName = index == 0 ? "Build" : String(format: "Terminal %02d", index)
+                return MobileTerminalPreview(
+                    id: refreshingTerminalID(index),
+                    name: "\(baseName) refresh \(generation)"
+                )
+            }
+        )
+    }
+
+    private static func refreshingTerminalID(_ index: Int) -> MobileTerminalPreview.ID {
+        index == 0 ? "terminal-build" : MobileTerminalPreview.ID(rawValue: "terminal-extra-\(index)")
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+MenuState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+MenuState.swift
@@ -10,6 +10,15 @@ struct TerminalPickerMenuRow: Identifiable, Equatable {
     }
 }
 
+/// Structural change token for the native menu; title churn must not rebuild an open picker.
+struct TerminalPickerMenuMembership: Equatable {
+    let ids: [MobileTerminalPreview.ID]
+
+    init(_ rows: [TerminalPickerMenuRow]) {
+        ids = rows.map(\.id)
+    }
+}
+
 extension Collection where Element == TerminalPickerMenuRow {
     func resolvedTerminalPickerSelection(
         selectedID: MobileTerminalPreview.ID?
@@ -26,6 +35,10 @@ extension Collection where Element == TerminalPickerMenuRow {
 extension WorkspaceDetailView {
     var terminalPickerLiveRows: [TerminalPickerMenuRow] {
         workspace.terminals.map(TerminalPickerMenuRow.init)
+    }
+
+    var terminalPickerLiveMembership: TerminalPickerMenuMembership {
+        TerminalPickerMenuMembership(terminalPickerLiveRows)
     }
 
     var hasTitleMenuActions: Bool {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+MenuState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+MenuState.swift
@@ -41,6 +41,19 @@ extension WorkspaceDetailView {
         TerminalPickerMenuMembership(terminalPickerLiveRows)
     }
 
+    func syncTerminalPickerRows(includeTitleChanges: Bool = false) {
+        let rows = terminalPickerLiveRows
+        if includeTitleChanges {
+            guard terminalPickerRows != rows else { return }
+            terminalPickerRows = rows
+            return
+        }
+        guard terminalPickerRows.isEmpty
+            || TerminalPickerMenuMembership(terminalPickerRows) != TerminalPickerMenuMembership(rows)
+        else { return }
+        terminalPickerRows = rows
+    }
+
     var hasTitleMenuActions: Bool {
         workspace.actionCapabilities.supportsWorkspaceActions
             || workspace.actionCapabilities.supportsReadStateActions

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -50,7 +50,7 @@ struct WorkspaceDetailView: View {
     @State private var contentWidth: CGFloat = 0
     /// Terminal captured for the current "View as Text" sheet presentation.
     @State private var textSheetSurfaceID: String?
-    @State private var terminalPickerRows: [TerminalPickerMenuRow] = []
+    @State var terminalPickerRows: [TerminalPickerMenuRow] = []
     /// Chat-mode toggle for inline agent chat in place of the terminal.
     @State var isChatMode = false
     /// The session chat mode was entered on, pinned so a newer session
@@ -93,6 +93,7 @@ struct WorkspaceDetailView: View {
             }
             .onChange(of: selectedTerminalID) { _, _ in
                 refreshCachedChatToggleAnchor()
+                syncTerminalPickerRows(includeTitleChanges: true)
             }
             .closeWorkspaceConfirmation(
                 isPresented: $isConfirmingClose,
@@ -350,16 +351,14 @@ struct WorkspaceDetailView: View {
     // Native menu keeps press-drag-release selection and routes through
     // `selectTerminalFromPicker`; keyboard-dismiss-on-open is unavailable.
     var terminalPickerToolbarButton: some View {
-        let liveRows = terminalPickerLiveRows
-        let rows = terminalPickerRows.isEmpty ? liveRows : terminalPickerRows
+        let rows = terminalPickerRows.isEmpty ? terminalPickerLiveRows : terminalPickerRows
         let selection = rows.resolvedTerminalPickerSelection(selectedID: store.selectedTerminalID)
-        let liveSelection = liveRows.resolvedTerminalPickerSelection(selectedID: store.selectedTerminalID)
 
         return Menu {
             terminalPickerMenuContent(rows: rows, selectedID: selection?.id)
         } label: {
             Label(
-                liveSelection?.name ?? selection?.name ?? L10n.string("mobile.terminal.select", defaultValue: "Terminal"),
+                selection?.name ?? L10n.string("mobile.terminal.select", defaultValue: "Terminal"),
                 systemImage: "rectangle.stack"
             )
             .labelStyle(.iconOnly)
@@ -367,9 +366,9 @@ struct WorkspaceDetailView: View {
         .foregroundStyle(TerminalPalette.foreground)
         .accessibilityLabel(L10n.string("mobile.terminal.picker.title", defaultValue: "Terminals"))
         .accessibilityIdentifier("MobileTerminalDropdown")
-        .accessibilityValue(liveSelection?.name ?? selection?.name ?? "")
-        .simultaneousGesture(TapGesture().onEnded { syncTerminalPickerRows() })
-        .onAppear(perform: syncTerminalPickerRows)
+        .accessibilityValue(selection?.name ?? "")
+        .simultaneousGesture(TapGesture().onEnded { syncTerminalPickerRows(includeTitleChanges: true) })
+        .onAppear { syncTerminalPickerRows(includeTitleChanges: true) }
         .onChange(of: terminalPickerLiveMembership) { _, _ in syncTerminalPickerRows() }
     }
 
@@ -445,12 +444,6 @@ struct WorkspaceDetailView: View {
             .accessibilityIdentifier("MobileSendFeedbackMenuItem")
         }
         #endif
-    }
-
-    private func syncTerminalPickerRows() {
-        let rows = terminalPickerLiveRows
-        guard terminalPickerRows != rows else { return }
-        terminalPickerRows = rows
     }
 
     #if canImport(UIKit)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -353,12 +353,13 @@ struct WorkspaceDetailView: View {
         let liveRows = terminalPickerLiveRows
         let rows = terminalPickerRows.isEmpty ? liveRows : terminalPickerRows
         let selection = rows.resolvedTerminalPickerSelection(selectedID: store.selectedTerminalID)
+        let liveSelection = liveRows.resolvedTerminalPickerSelection(selectedID: store.selectedTerminalID)
 
         return Menu {
             terminalPickerMenuContent(rows: rows, selectedID: selection?.id)
         } label: {
             Label(
-                selection?.name ?? L10n.string("mobile.terminal.select", defaultValue: "Terminal"),
+                liveSelection?.name ?? selection?.name ?? L10n.string("mobile.terminal.select", defaultValue: "Terminal"),
                 systemImage: "rectangle.stack"
             )
             .labelStyle(.iconOnly)
@@ -366,9 +367,10 @@ struct WorkspaceDetailView: View {
         .foregroundStyle(TerminalPalette.foreground)
         .accessibilityLabel(L10n.string("mobile.terminal.picker.title", defaultValue: "Terminals"))
         .accessibilityIdentifier("MobileTerminalDropdown")
-        .accessibilityValue(selection?.name ?? "")
+        .accessibilityValue(liveSelection?.name ?? selection?.name ?? "")
+        .simultaneousGesture(TapGesture().onEnded { syncTerminalPickerRows() })
         .onAppear(perform: syncTerminalPickerRows)
-        .onChange(of: liveRows) { _, _ in syncTerminalPickerRows() }
+        .onChange(of: terminalPickerLiveMembership) { _, _ in syncTerminalPickerRows() }
     }
 
     @ViewBuilder

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -352,7 +352,7 @@ struct WorkspaceDetailView: View {
     // `selectTerminalFromPicker`; keyboard-dismiss-on-open is unavailable.
     var terminalPickerToolbarButton: some View {
         let rows = terminalPickerRows.isEmpty ? terminalPickerLiveRows : terminalPickerRows
-        let selection = rows.resolvedTerminalPickerSelection(selectedID: store.selectedTerminalID)
+        let selection = terminalPickerLiveRows.resolvedTerminalPickerSelection(selectedID: store.selectedTerminalID)
 
         return Menu {
             terminalPickerMenuContent(rows: rows, selectedID: selection?.id)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -51,6 +51,8 @@ public struct WorkspaceListLayoutPreviewView: View {
     public var body: some View {
         if UITestConfig.workspaceDetailCreateDelayedTerminalPreviewEnabled {
             WorkspaceDetailCreateDelayedTerminalPreviewView()
+        } else if UITestConfig.workspaceDetailRefreshingTerminalMenuPreviewEnabled {
+            WorkspaceDetailDelayedTerminalPreviewView()
         } else if UITestConfig.workspaceDetailDelayedTerminalPreviewEnabled {
             WorkspaceDetailDelayedTerminalPreviewView()
         } else {

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/Debug/UITestConfig+RefreshingTerminalMenuPreview.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/Debug/UITestConfig+RefreshingTerminalMenuPreview.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Debug-only UI-test preview flags isolated from the production config surface.
+public extension UITestConfig {
+    /// Whether the workspace detail terminal-picker refresh preview is enabled.
+    ///
+    /// When `CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU=1`, the root
+    /// view renders a connected workspace shell already opened to a workspace
+    /// with many terminals, then repeatedly refreshes terminal titles without
+    /// changing terminal identity or order. DEBUG-only.
+    static var workspaceDetailRefreshingTerminalMenuPreviewEnabled: Bool {
+        workspaceDetailRefreshingTerminalMenuPreviewEnabled(from: ProcessInfo.processInfo.environment)
+    }
+
+    static func workspaceDetailRefreshingTerminalMenuPreviewEnabled(from env: [String: String]) -> Bool {
+        #if DEBUG
+        return env["CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU"] == "1"
+        #else
+        return false
+        #endif
+    }
+}

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/Debug/UITestConfig+RefreshingTerminalMenuPreview.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/Debug/UITestConfig+RefreshingTerminalMenuPreview.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 /// Debug-only UI-test preview flags isolated from the production config surface.
-public extension UITestConfig {
+extension UITestConfig {
     /// Whether the workspace detail terminal-picker refresh preview is enabled.
     ///
     /// When `CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU=1`, the root
     /// view renders a connected workspace shell already opened to a workspace
     /// with many terminals, then repeatedly refreshes terminal titles without
     /// changing terminal identity or order. DEBUG-only.
-    static var workspaceDetailRefreshingTerminalMenuPreviewEnabled: Bool {
+    public static var workspaceDetailRefreshingTerminalMenuPreviewEnabled: Bool {
         workspaceDetailRefreshingTerminalMenuPreviewEnabled(from: ProcessInfo.processInfo.environment)
     }
 

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -90,6 +90,7 @@ public struct UITestConfig {
         return ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW"] == "1"
             || workspaceDetailDelayedTerminalPreviewEnabled
             || workspaceDetailCreateDelayedTerminalPreviewEnabled
+            || workspaceDetailRefreshingTerminalMenuPreviewEnabled
             || ProcessInfo.processInfo.arguments.contains("CMUX_UITEST_WORKSPACE_LIST_PREVIEW=1")
         #else
         return false
@@ -119,6 +120,24 @@ public struct UITestConfig {
     public static var workspaceDetailCreateDelayedTerminalPreviewEnabled: Bool {
         #if DEBUG
         return ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_DETAIL_CREATE_DELAYED_TERMINAL"] == "1"
+        #else
+        return false
+        #endif
+    }
+
+    /// Whether the workspace detail terminal-picker refresh preview is enabled.
+    ///
+    /// When `CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU=1`, the root
+    /// view renders a connected workspace shell already opened to a workspace
+    /// with many terminals, then repeatedly refreshes terminal titles without
+    /// changing terminal identity or order. DEBUG-only.
+    public static var workspaceDetailRefreshingTerminalMenuPreviewEnabled: Bool {
+        workspaceDetailRefreshingTerminalMenuPreviewEnabled(from: ProcessInfo.processInfo.environment)
+    }
+
+    public static func workspaceDetailRefreshingTerminalMenuPreviewEnabled(from env: [String: String]) -> Bool {
+        #if DEBUG
+        return env["CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU"] == "1"
         #else
         return false
         #endif

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -125,24 +125,6 @@ public struct UITestConfig {
         #endif
     }
 
-    /// Whether the workspace detail terminal-picker refresh preview is enabled.
-    ///
-    /// When `CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU=1`, the root
-    /// view renders a connected workspace shell already opened to a workspace
-    /// with many terminals, then repeatedly refreshes terminal titles without
-    /// changing terminal identity or order. DEBUG-only.
-    public static var workspaceDetailRefreshingTerminalMenuPreviewEnabled: Bool {
-        workspaceDetailRefreshingTerminalMenuPreviewEnabled(from: ProcessInfo.processInfo.environment)
-    }
-
-    public static func workspaceDetailRefreshingTerminalMenuPreviewEnabled(from env: [String: String]) -> Bool {
-        #if DEBUG
-        return env["CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU"] == "1"
-        #else
-        return false
-        #endif
-    }
-
     /// Whether the standalone streaming-chat preview is enabled.
     ///
     /// When `CMUX_UITEST_STREAMING_CHAT_PREVIEW=1`, the root view renders a

--- a/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/UITestConfigTests.swift
+++ b/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/UITestConfigTests.swift
@@ -112,6 +112,22 @@ import Testing
         #expect(UITestConfig.dogfoodAttachURL(from: env) == nil)
     }
 
+    @Test func workspaceDetailRefreshingTerminalMenuFlagIsDebugOnly() {
+        let env = ["CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU": "1"]
+        #if DEBUG
+        #expect(UITestConfig.workspaceDetailRefreshingTerminalMenuPreviewEnabled(from: env) == true)
+        #else
+        #expect(UITestConfig.workspaceDetailRefreshingTerminalMenuPreviewEnabled(from: env) == false)
+        #endif
+    }
+
+    @Test func workspaceDetailRefreshingTerminalMenuFlagRequiresOne() {
+        #expect(UITestConfig.workspaceDetailRefreshingTerminalMenuPreviewEnabled(from: [:]) == false)
+        #expect(UITestConfig.workspaceDetailRefreshingTerminalMenuPreviewEnabled(
+            from: ["CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU": "0"]
+        ) == false)
+    }
+
     @Test func agentChatPreviewFlagIsDebugOnly() {
         let env = ["CMUX_UITEST_AGENT_CHAT_PREVIEW": "1"]
         let config = UITestEnvironmentConfig(environment: env)

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -532,13 +532,15 @@ final class cmuxUITests: XCTestCase {
         let target = scrollTerminalMenuToItem("terminal-extra-24", in: app)
         XCTAssertTrue(target.isHittable, "Bottom terminal must be visible before refresh pulses start.")
 
-        RunLoop.current.run(until: Date().addingTimeInterval(3.0))
         let refreshedTarget = app.buttons["MobileTerminalMenuItem-terminal-extra-24"]
-
-        XCTAssertTrue(
-            refreshedTarget.exists && refreshedTarget.isHittable,
-            "Bottom terminal must stay visible and hittable while workspace refreshes update terminal titles."
-        )
+        let deadline = Date().addingTimeInterval(3.0)
+        while Date() < deadline {
+            XCTAssertTrue(
+                refreshedTarget.exists && refreshedTarget.isHittable,
+                "Bottom terminal must stay visible and hittable while workspace refreshes update terminal titles."
+            )
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
         tapMenuItem(refreshedTarget, in: app)
         let selectedValue = app.buttons["MobileTerminalDropdown"].value as? String ?? ""
         XCTAssertTrue(

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -524,6 +524,30 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
+    func testTerminalDropdownKeepsBottomScrollDuringWorkspaceRefresh() throws {
+        let app = launchWorkspaceDetailRefreshingTerminalMenuPreviewApp()
+
+        tap(app.buttons["MobileTerminalDropdown"], in: app)
+        assertTerminalMenuItemExists("terminal-build", in: app)
+        let target = scrollTerminalMenuToItem("terminal-extra-24", in: app)
+        XCTAssertTrue(target.isHittable, "Bottom terminal must be visible before refresh pulses start.")
+
+        RunLoop.current.run(until: Date().addingTimeInterval(3.0))
+        let refreshedTarget = app.buttons["MobileTerminalMenuItem-terminal-extra-24"]
+
+        XCTAssertTrue(
+            refreshedTarget.exists && refreshedTarget.isHittable,
+            "Bottom terminal must stay visible and hittable while workspace refreshes update terminal titles."
+        )
+        tapMenuItem(refreshedTarget, in: app)
+        let selectedValue = app.buttons["MobileTerminalDropdown"].value as? String ?? ""
+        XCTAssertTrue(
+            selectedValue.contains("Terminal 24"),
+            "Selecting the bottom terminal should update the picker value. value=\(selectedValue)"
+        )
+    }
+
+    @MainActor
     func testTerminalDropdownSwitchesToAlternateScreenSnapshot() async throws {
         let server = try MobileSyncMockHostServer()
         let port = try await server.start()
@@ -1933,6 +1957,17 @@ final class cmuxUITests: XCTestCase {
         }
         let app = launchApp(mockData: false, environment: launchEnvironment)
         XCTAssertTrue(workspaceTitleElement(in: app).waitForExistence(timeout: 8))
+        return app
+    }
+
+    @MainActor
+    private func launchWorkspaceDetailRefreshingTerminalMenuPreviewApp() -> XCUIApplication {
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU": "1",
+            "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
+        ])
+        XCTAssertTrue(workspaceTitleElement(in: app).waitForExistence(timeout: 8))
+        XCTAssertTrue(app.buttons["MobileTerminalDropdown"].waitForExistence(timeout: 8))
         return app
     }
 


### PR DESCRIPTION
## Summary
- Snapshot iOS terminal picker menu rows and refresh them only when terminal membership changes.
- Keep the toolbar label and accessibility value live so selected terminal title changes still show outside the open menu.
- Add a DEBUG UI-test fixture with 25 terminals and repeated title-only workspace refreshes, plus a regression UI test that keeps the menu scrolled to the bottom for 3 seconds and selects Terminal 24.

## Verification
- `xcodebuild test -quiet -workspace ios/cmux.xcworkspace -scheme cmux-ios -destination 'platform=iOS Simulator,id=00A65572-5C75-4805-9DB1-D3F2D689A4BA' -derivedDataPath /tmp/cmux-ios-menu-refresh-tests -only-testing:cmuxUITests/cmuxUITests/testTerminalDropdownKeepsBottomScrollDuringWorkspaceRefresh`
- `swift test --package-path Packages/iOS/CmuxMobileSupport`
- `git diff --check`
- Reproduced the provided video behavior from `/Users/abdulazizalbahar/Downloads/iCloud Photos from Farhan Khan/Continuous menu terminal reload.mp4`: the bottom of the terminal menu snaps back to the top while still open.
- Recorded fixed behavior at `cmux-assets/fix-ios-terminal-menu-refresh/after/menu-refresh-fixed.mp4`: the menu stays at Terminal 24 during repeated title refreshes, then selects Terminal 24.
- Tagged macOS reload: `./scripts/reload.sh --tag tmenu` succeeded.
- Tagged iOS simulator reload: `ios/scripts/reload.sh --tag tmenu --simulator cmux-menu-refresh-78934` succeeded on simulator `00A65572-5C75-4805-9DB1-D3F2D689A4BA`.

## Notes
- `./scripts/reload-cloud.sh --tag tmenu` could not start because this checkout is missing `scripts/lib/maclease-heartbeat.sh`; used local tagged fallback.
- `xctrace` Time Profiler attempts against the iOS simulator hung while finalizing traces with simulator dylib-overlap warnings, so profiling evidence is not attached.
- The simulator app installed and launched, but the live dogfood session stayed on the sign-in screen even after `scripts/mobile-dev-launch.sh --tag tmenu --simulator-id 00A65572-5C75-4805-9DB1-D3F2D689A4BA --ensure-mac --detach`. The stored dogfood credentials verify directly with Stack. The local web server could only be started with a placeholder Stack server key because no valid `STACK_SECRET_SERVER_KEY` was present locally; `/api/devices` returned 500 with invalid server-key errors, so this is a dogfood setup blocker rather than part of the menu refresh fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS terminal picker jumping to the top during title-only refreshes. The menu now preserves scroll and selection, and the toolbar label/accessibility value stay live.

- **Bug Fixes**
  - Snapshot menu rows using `TerminalPickerMenuMembership` (IDs only); rebuild only when membership changes, not on title churn.
  - Refresh cached rows on tap, on appear, and when selection changes; resolve selection from live rows so the toolbar value stays current.
  - Add DEBUG preview gated by `CMUX_UITEST_WORKSPACE_DETAIL_REFRESHING_TERMINAL_MENU=1` that pulses titles with stable IDs; include a regression UI test that keeps bottom scroll for 3s and selects Terminal 24, plus unit tests for the flag.

<sup>Written for commit 830791cf49060d257ddc3d2182b20b0e88607950. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug preview mode for the workspace detail “refreshing terminal menu” scenario.
  * Improved terminal picker/menu selection syncing to update rows more selectively as terminal data changes.
* **Bug Fixes**
  * Fixed terminal dropdown refresh behavior so bottom items remain visible/hittable and the selection persists after refresh.
* **Tests**
  * Added a UI regression test ensuring scroll and selection persistence during workspace refresh.
  * Expanded test coverage for the refreshing-terminal-menu preview enablement logic (environment/build based).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->