### PR TITLE
Add semantic copy for mailto and tel links

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -13,7 +13,6 @@ import SwiftUI
 #elseif os(macOS)
 import AppKit
 #endif
-
 struct WorkspaceDetailView: View {
     let host: String
     let connectionStatus: MobileMacConnectionStatus
@@ -75,12 +74,10 @@ struct WorkspaceDetailView: View {
     private var activeBrowser: BrowserSurfaceState? {
         browserStore.activeBrowser(for: workspace.id.rawValue)
     }
-
     var body: some View {
         let content = Group {
             detailSurfaceContent
         }
-
         #if os(iOS)
         content
             .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }

--- a/Sources/Panels/BrowserSemanticLinkCopyValue.swift
+++ b/Sources/Panels/BrowserSemanticLinkCopyValue.swift
@@ -45,14 +45,29 @@ struct BrowserSemanticLinkCopyValue: Equatable, Sendable {
     }
 
     private static func telephoneNumber(from url: URL) -> String? {
-        guard let decodedPath = decodedPath(from: url),
-              decodedPath.rangeOfCharacter(from: CharacterSet.decimalDigits) != nil
-                || decodedPath.contains("+")
-                || decodedPath.contains("*")
-                || decodedPath.contains("#") else {
+        guard let value = decodedTelephonePath(from: url),
+              value.rangeOfCharacter(from: CharacterSet.decimalDigits) != nil
+                || value.contains("+")
+                || value.contains("*")
+                || value.contains("#") else {
             return nil
         }
-        return decodedPath
+        return value
+    }
+
+    private static func decodedTelephonePath(from url: URL) -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        var value = components.path
+        if components.percentEncodedFragment != nil {
+            value += "#"
+            value += components.fragment ?? ""
+        }
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+        return value
     }
 
     private static func decodedPath(from url: URL) -> String? {

--- a/Sources/Panels/BrowserSemanticLinkCopyValue.swift
+++ b/Sources/Panels/BrowserSemanticLinkCopyValue.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+struct BrowserSemanticLinkCopyValue: Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        case emailAddress
+        case phoneNumber
+    }
+
+    let kind: Kind
+    let string: String
+
+    init?(linkURL url: URL) {
+        _ = url
+        return nil
+    }
+
+    var menuTitle: String {
+        switch kind {
+        case .emailAddress:
+            return String(localized: "browser.contextMenu.copyEmailAddress", defaultValue: "Copy Email Address")
+        case .phoneNumber:
+            return String(localized: "browser.contextMenu.copyPhoneNumber", defaultValue: "Copy Phone Number")
+        }
+    }
+
+    private static func mailtoAddressList(from url: URL) -> String? {
+        guard let decodedPath = decodedPath(from: url) else { return nil }
+        let addresses = decodedPath.split(separator: ",", omittingEmptySubsequences: false)
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+        guard !addresses.isEmpty,
+              addresses.allSatisfy({ !$0.isEmpty && $0.contains("@") }) else {
+            return nil
+        }
+        return addresses.joined(separator: ",")
+    }
+
+    private static func telephoneNumber(from url: URL) -> String? {
+        guard let decodedPath = decodedPath(from: url),
+              decodedPath.rangeOfCharacter(from: CharacterSet.decimalDigits) != nil
+                || decodedPath.contains("+")
+                || decodedPath.contains("*")
+                || decodedPath.contains("#") else {
+            return nil
+        }
+        return decodedPath
+    }
+
+    private static func decodedPath(from url: URL) -> String? {
+        guard let value = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .path
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Sources/Panels/BrowserSemanticLinkCopyValue.swift
+++ b/Sources/Panels/BrowserSemanticLinkCopyValue.swift
@@ -10,8 +10,18 @@ struct BrowserSemanticLinkCopyValue: Equatable, Sendable {
     let string: String
 
     init?(linkURL url: URL) {
-        _ = url
-        return nil
+        switch url.scheme?.lowercased() {
+        case "mailto":
+            guard let addressList = Self.mailtoAddressList(from: url) else { return nil }
+            self.kind = .emailAddress
+            self.string = addressList
+        case "tel":
+            guard let phoneNumber = Self.telephoneNumber(from: url) else { return nil }
+            self.kind = .phoneNumber
+            self.string = phoneNumber
+        default:
+            return nil
+        }
     }
 
     var menuTitle: String {

--- a/Sources/Panels/CmuxWebView+BrowserFocusModeContextMenu.swift
+++ b/Sources/Panels/CmuxWebView+BrowserFocusModeContextMenu.swift
@@ -1,0 +1,42 @@
+import AppKit
+
+extension CmuxWebView {
+    private static let browserFocusModeContextMenuItemIdentifier =
+        NSUserInterfaceItemIdentifier("cmux.browserFocusMode.toggle")
+
+    func appendBrowserFocusModeContextMenuItem(to menu: NSMenu) {
+        let state = AppDelegate.shared?.browserFocusModeContextMenuState(for: self) ?? (isActive: false, canToggle: false)
+        guard state.isActive || state.canToggle else { return }
+
+        let title = state.isActive
+            ? String(localized: "browser.focusMode.context.exit", defaultValue: "Exit Browser Focus Mode")
+            : String(localized: "browser.focusMode.context.enter", defaultValue: "Enter Browser Focus Mode")
+        if let item = menu.items.first(where: { $0.identifier == Self.browserFocusModeContextMenuItemIdentifier }) {
+            item.title = title
+            item.target = self
+            item.action = #selector(contextMenuToggleBrowserFocusMode(_:))
+            item.state = state.isActive ? NSControl.StateValue.on : NSControl.StateValue.off
+            return
+        }
+
+        if menu.items.last?.isSeparatorItem == false {
+            menu.addItem(.separator())
+        }
+        let item = NSMenuItem(
+            title: title,
+            action: #selector(contextMenuToggleBrowserFocusMode(_:)),
+            keyEquivalent: ""
+        )
+        item.identifier = Self.browserFocusModeContextMenuItemIdentifier
+        item.target = self
+        item.state = state.isActive ? NSControl.StateValue.on : NSControl.StateValue.off
+        menu.addItem(item)
+    }
+
+    @objc func contextMenuToggleBrowserFocusMode(_ sender: Any?) {
+        _ = sender
+        if AppDelegate.shared?.toggleBrowserFocusModeFromContextMenu(for: self) != true {
+            NSSound.beep()
+        }
+    }
+}

--- a/Sources/Panels/CmuxWebView+BrowserFocusModeContextMenu.swift
+++ b/Sources/Panels/CmuxWebView+BrowserFocusModeContextMenu.swift
@@ -3,6 +3,9 @@ import AppKit
 extension CmuxWebView {
     private static let browserFocusModeContextMenuItemIdentifier =
         NSUserInterfaceItemIdentifier("cmux.browserFocusMode.toggle")
+    static var contextMenuToggleBrowserFocusModeSelector: Selector {
+        #selector(contextMenuToggleBrowserFocusMode(_:))
+    }
 
     func appendBrowserFocusModeContextMenuItem(to menu: NSMenu) {
         let state = AppDelegate.shared?.browserFocusModeContextMenuState(for: self) ?? (isActive: false, canToggle: false)
@@ -14,7 +17,7 @@ extension CmuxWebView {
         if let item = menu.items.first(where: { $0.identifier == Self.browserFocusModeContextMenuItemIdentifier }) {
             item.title = title
             item.target = self
-            item.action = #selector(contextMenuToggleBrowserFocusMode(_:))
+            item.action = Self.contextMenuToggleBrowserFocusModeSelector
             item.state = state.isActive ? NSControl.StateValue.on : NSControl.StateValue.off
             return
         }
@@ -24,7 +27,7 @@ extension CmuxWebView {
         }
         let item = NSMenuItem(
             title: title,
-            action: #selector(contextMenuToggleBrowserFocusMode(_:)),
+            action: Self.contextMenuToggleBrowserFocusModeSelector,
             keyEquivalent: ""
         )
         item.identifier = Self.browserFocusModeContextMenuItemIdentifier
@@ -33,7 +36,7 @@ extension CmuxWebView {
         menu.addItem(item)
     }
 
-    @objc func contextMenuToggleBrowserFocusMode(_ sender: Any?) {
+    @objc private func contextMenuToggleBrowserFocusMode(_ sender: Any?) {
         _ = sender
         if AppDelegate.shared?.toggleBrowserFocusModeFromContextMenu(for: self) != true {
             NSSound.beep()

--- a/Sources/Panels/CmuxWebView+ContextMenuLinkCapture.swift
+++ b/Sources/Panels/CmuxWebView+ContextMenuLinkCapture.swift
@@ -137,7 +137,7 @@ extension CmuxWebView {
         )
     }
 
-    private func capturedContextMenuLinkURLForCurrentMenu() -> URL? {
+    func capturedContextMenuLinkURLForCurrentMenu() -> URL? {
         guard let captured = contextMenuCapturedLink,
               let menuOpenUptime = lastContextMenuOpenUptime,
               let menuOpenEventTimestamp = lastContextMenuOpenEventTimestamp,

--- a/Sources/Panels/CmuxWebView+SemanticCopy.swift
+++ b/Sources/Panels/CmuxWebView+SemanticCopy.swift
@@ -22,7 +22,7 @@ extension CmuxWebView {
         menu.insertItem(item, at: semanticCopyLinkInsertionIndex(in: menu))
     }
 
-    @objc func contextMenuCopySemanticLinkValue(_ sender: Any?) {
+    @objc private func contextMenuCopySemanticLinkValue(_ sender: Any?) {
         guard let item = sender as? NSMenuItem,
               let value = item.representedObject as? String,
               !value.isEmpty else {

--- a/Sources/Panels/CmuxWebView+SemanticCopy.swift
+++ b/Sources/Panels/CmuxWebView+SemanticCopy.swift
@@ -1,0 +1,45 @@
+import AppKit
+
+extension CmuxWebView {
+    private static let semanticCopyLinkMenuItemIdentifier =
+        NSUserInterfaceItemIdentifier("cmux.browser.semanticCopyLink")
+
+    func insertSemanticCopyLinkContextMenuItemIfNeeded(to menu: NSMenu) {
+        guard let url = capturedContextMenuLinkURLForCurrentMenu(),
+              let copyValue = BrowserSemanticLinkCopyValue(linkURL: url),
+              !menu.items.contains(where: { $0.identifier == Self.semanticCopyLinkMenuItemIdentifier }) else {
+            return
+        }
+
+        let item = NSMenuItem(
+            title: copyValue.menuTitle,
+            action: #selector(contextMenuCopySemanticLinkValue(_:)),
+            keyEquivalent: ""
+        )
+        item.identifier = Self.semanticCopyLinkMenuItemIdentifier
+        item.representedObject = copyValue.string
+        item.target = self
+        menu.insertItem(item, at: semanticCopyLinkInsertionIndex(in: menu))
+    }
+
+    @objc func contextMenuCopySemanticLinkValue(_ sender: Any?) {
+        guard let item = sender as? NSMenuItem,
+              let value = item.representedObject as? String,
+              !value.isEmpty else {
+            return
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(value, forType: .string)
+    }
+
+    private func semanticCopyLinkInsertionIndex(in menu: NSMenu) -> Int {
+        guard let copyLinkIndex = menu.items.firstIndex(where: {
+            $0.identifier?.rawValue == "WKMenuItemIdentifierCopyLink"
+        }) else {
+            return menu.items.count
+        }
+        return min(copyLinkIndex + 1, menu.items.count)
+    }
+}

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -147,8 +147,6 @@ final class CmuxWebView: WKWebView {
     private static var lastMiddleClickIntent: MiddleClickIntent?
     private static let middleClickIntentMaxAge: TimeInterval = 0.8
     private static let pasteAsPlainTextFocusMessageHandlerName = "cmuxPasteAsPlainTextFocus"
-    private static let browserFocusModeContextMenuItemIdentifier =
-        NSUserInterfaceItemIdentifier("cmux.browserFocusMode.toggle")
     private static var pasteAsPlainTextFocusHandlerInstalledKey: UInt8 = 0
     private static let pasteAsPlainTextSharedHelpersScriptSource = """
     const __cmuxPasteAsPlainTextHelpers = (() => {
@@ -1563,35 +1561,6 @@ final class CmuxWebView: WKWebView {
 #endif
     }
 
-    private func appendBrowserFocusModeContextMenuItem(to menu: NSMenu) {
-        let state = AppDelegate.shared?.browserFocusModeContextMenuState(for: self) ?? (isActive: false, canToggle: false)
-        guard state.isActive || state.canToggle else { return }
-
-        let title = state.isActive
-            ? String(localized: "browser.focusMode.context.exit", defaultValue: "Exit Browser Focus Mode")
-            : String(localized: "browser.focusMode.context.enter", defaultValue: "Enter Browser Focus Mode")
-        if let item = menu.items.first(where: { $0.identifier == Self.browserFocusModeContextMenuItemIdentifier }) {
-            item.title = title
-            item.target = self
-            item.action = #selector(contextMenuToggleBrowserFocusMode(_:))
-            item.state = state.isActive ? NSControl.StateValue.on : NSControl.StateValue.off
-            return
-        }
-
-        if menu.items.last?.isSeparatorItem == false {
-            menu.addItem(.separator())
-        }
-        let item = NSMenuItem(
-            title: title,
-            action: #selector(contextMenuToggleBrowserFocusMode(_:)),
-            keyEquivalent: ""
-        )
-        item.identifier = Self.browserFocusModeContextMenuItemIdentifier
-        item.target = self
-        item.state = state.isActive ? NSControl.StateValue.on : NSControl.StateValue.off
-        menu.addItem(item)
-    }
-
     private func runContextMenuFallback(
         action: Selector?,
         target: AnyObject?,
@@ -2188,16 +2157,10 @@ final class CmuxWebView: WKWebView {
             item.target = self
             menu.insertItem(item, at: min(openLinkInsertionIndex, menu.items.count))
         }
+        insertSemanticCopyLinkContextMenuItemIfNeeded(to: menu)
         appendScreenshotContextMenuItems(to: menu)
         appendMoveTabToNewWorkspaceContextMenuItem(to: menu)
         appendBrowserFocusModeContextMenuItem(to: menu)
-    }
-
-    @objc private func contextMenuToggleBrowserFocusMode(_ sender: Any?) {
-        _ = sender
-        if AppDelegate.shared?.toggleBrowserFocusModeFromContextMenu(for: self) != true {
-            NSSound.beep()
-        }
     }
 
     @objc private func contextMenuOpenLinkInDefaultBrowser(_ sender: Any?) {

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -1282,7 +1282,7 @@ final class CmuxWebView: WKWebView {
 
     private func isOurContextMenuAction(target: AnyObject?, action: Selector?) -> Bool {
         guard target === self else { return false }
-        if action == #selector(contextMenuToggleBrowserFocusMode(_:)) {
+        if action == Self.contextMenuToggleBrowserFocusModeSelector {
             return true
         }
         if action == #selector(contextMenuCopyImage(_:)) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -193,6 +193,8 @@
 		4472A0024472A0024472A002 /* BrowserScreenshotPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4472B0024472B0024472B002 /* BrowserScreenshotPipeline.swift */; };
 		4472A0034472A0034472A003 /* BrowserScreenshotSnapshotter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4472B0034472B0034472B003 /* BrowserScreenshotSnapshotter.swift */; };
 		A5008371 /* BrowserSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008370 /* BrowserSearchOverlay.swift */; };
+		C7300C0DE000000000000001 /* BrowserSemanticLinkCopyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7300C0DE000000000000002 /* BrowserSemanticLinkCopyValue.swift */; };
+		C7300C0DE000000000000005 /* BrowserSemanticLinkCopyValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7300C0DE000000000000006 /* BrowserSemanticLinkCopyValueTests.swift */; };
 		C2035A050000000000000001 /* BrowserServerTrustFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A050000000000000002 /* BrowserServerTrustFingerprint.swift */; };
 		C67540050000000000000001 /* BrowserSessionDownloadSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540050000000000000002 /* BrowserSessionDownloadSaver.swift */; };
 		C2035A0B000000000000001 /* BrowserSSLTrustBypassMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A0B000000000000002 /* BrowserSSLTrustBypassMessageHandler.swift */; };
@@ -427,9 +429,11 @@
 		C7A509000000000000000002 /* CmuxTopSnapshotScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */; };
 		CDFEED0300000000CDFEED03 /* CmuxUpdater in Frameworks */ = {isa = PBXBuildFile; productRef = CDFEED0200000000CDFEED02 /* CmuxUpdater */; };
 		CDFEED0600000000CDFEED06 /* CmuxUpdaterUI in Frameworks */ = {isa = PBXBuildFile; productRef = CDFEED0500000000CDFEED05 /* CmuxUpdaterUI */; };
+		C7300C0DE000000000000007 /* CmuxWebView+BrowserFocusModeContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7300C0DE000000000000008 /* CmuxWebView+BrowserFocusModeContextMenu.swift */; };
 		D7C0DE00000000000000A101 /* CmuxWebView+ContextMenuLinkCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C0DE00000000000000A102 /* CmuxWebView+ContextMenuLinkCapture.swift */; };
 		D7AB00000000000000000009 /* CmuxWebView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */; };
 		C6255D010000000000000001 /* CmuxWebView+ScriptedDownloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6255D010000000000000002 /* CmuxWebView+ScriptedDownloads.swift */; };
+		C7300C0DE000000000000003 /* CmuxWebView+SemanticCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7300C0DE000000000000004 /* CmuxWebView+SemanticCopy.swift */; };
 		C67540030000000000000001 /* CmuxWebView+SubframeDownloadIntentScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540030000000000000002 /* CmuxWebView+SubframeDownloadIntentScript.swift */; };
 		A5001500 /* CmuxWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001510 /* CmuxWebView.swift */; };
 		D7C0DE00000000000000A103 /* CmuxWebViewContextMenuLinkCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C0DE00000000000000A104 /* CmuxWebViewContextMenuLinkCaptureTests.swift */; };
@@ -1557,6 +1561,8 @@
 		4472B0024472B0024472B002 /* BrowserScreenshotPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserScreenshotPipeline.swift; sourceTree = "<group>"; };
 		4472B0034472B0034472B003 /* BrowserScreenshotSnapshotter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserScreenshotSnapshotter.swift; sourceTree = "<group>"; };
 		A5008370 /* BrowserSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/BrowserSearchOverlay.swift; sourceTree = "<group>"; };
+		C7300C0DE000000000000002 /* BrowserSemanticLinkCopyValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserSemanticLinkCopyValue.swift; sourceTree = "<group>"; };
+		C7300C0DE000000000000006 /* BrowserSemanticLinkCopyValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserSemanticLinkCopyValueTests.swift; sourceTree = "<group>"; };
 		C2035A050000000000000002 /* BrowserServerTrustFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserServerTrustFingerprint.swift; sourceTree = "<group>"; };
 		C67540050000000000000002 /* BrowserSessionDownloadSaver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserSessionDownloadSaver.swift; sourceTree = "<group>"; };
 		C2035A0B000000000000002 /* BrowserSSLTrustBypassMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserSSLTrustBypassMessageHandler.swift; sourceTree = "<group>"; };
@@ -1742,9 +1748,11 @@
 		C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeCacheTests.swift; sourceTree = "<group>"; };
 		C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeTests.swift; sourceTree = "<group>"; };
 		7E7E6EF344A568AC7FEE3715 /* cmuxUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7300C0DE000000000000008 /* CmuxWebView+BrowserFocusModeContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+BrowserFocusModeContextMenu.swift"; sourceTree = "<group>"; };
 		D7C0DE00000000000000A102 /* CmuxWebView+ContextMenuLinkCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+ContextMenuLinkCapture.swift"; sourceTree = "<group>"; };
 		D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		C6255D010000000000000002 /* CmuxWebView+ScriptedDownloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+ScriptedDownloads.swift"; sourceTree = "<group>"; };
+		C7300C0DE000000000000004 /* CmuxWebView+SemanticCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+SemanticCopy.swift"; sourceTree = "<group>"; };
 		C67540030000000000000002 /* CmuxWebView+SubframeDownloadIntentScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+SubframeDownloadIntentScript.swift"; sourceTree = "<group>"; };
 		A5001510 /* CmuxWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CmuxWebView.swift; sourceTree = "<group>"; };
 		D7C0DE00000000000000A104 /* CmuxWebViewContextMenuLinkCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewContextMenuLinkCaptureTests.swift; sourceTree = "<group>"; };
@@ -3325,6 +3333,7 @@
 				C59240010000000000000002 /* BrowserDownloadFilenameResolver.swift */,
 				C67540020000000000000002 /* BrowserDownloadHTTPStatusDecision.swift */,
 				C67540050000000000000002 /* BrowserSessionDownloadSaver.swift */,
+				C7300C0DE000000000000002 /* BrowserSemanticLinkCopyValue.swift */,
 				C67540010000000000000002 /* BrowserSubframeDownloadIntentTracker.swift */,
 				C6255D010000000000000002 /* CmuxWebView+ScriptedDownloads.swift */,
 				C67540030000000000000002 /* CmuxWebView+SubframeDownloadIntentScript.swift */,
@@ -3453,6 +3462,8 @@
 				C0DE58990000000000000001 /* BrowserWebKitKeyDownDispatch.swift */,
 				D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */,
 				D7C0DE00000000000000A102 /* CmuxWebView+ContextMenuLinkCapture.swift */,
+				C7300C0DE000000000000004 /* CmuxWebView+SemanticCopy.swift */,
+				C7300C0DE000000000000008 /* CmuxWebView+BrowserFocusModeContextMenu.swift */,
 				C57B00080000000000000002 /* CustomSidebarPaneDataContextCache.swift */,
 				C57B00010000000000000002 /* CustomSidebarPanel.swift */,
 				C57B00090000000000000002 /* CustomSidebarPanelView.swift */,
@@ -3795,6 +3806,7 @@
 				BABA25000000000000000004 /* BrowserHTTPBasicAuthPromptTests.swift */,
 				8D828DA0070335773EBAE83F /* BrowserSystemProxyMirrorTests.swift */,
 				C59240010000000000000004 /* BrowserDownloadFilenameResolverTests.swift */,
+				C7300C0DE000000000000006 /* BrowserSemanticLinkCopyValueTests.swift */,
 				C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */,
 				C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */,
 				43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */,
@@ -4570,6 +4582,7 @@
 				4472A0024472A0024472A002 /* BrowserScreenshotPipeline.swift in Sources */,
 				4472A0034472A0034472A003 /* BrowserScreenshotSnapshotter.swift in Sources */,
 				A5008371 /* BrowserSearchOverlay.swift in Sources */,
+				C7300C0DE000000000000001 /* BrowserSemanticLinkCopyValue.swift in Sources */,
 				C2035A050000000000000001 /* BrowserServerTrustFingerprint.swift in Sources */,
 				C67540050000000000000001 /* BrowserSessionDownloadSaver.swift in Sources */,
 				C2035A0B000000000000001 /* BrowserSSLTrustBypassMessageHandler.swift in Sources */,
@@ -4650,9 +4663,11 @@
 				C7A512000000000000000002 /* CmuxTopProcessSnapshotCache.swift in Sources */,
 				C7A501000000000000000002 /* CmuxTopSnapshot.swift in Sources */,
 				C7A508000000000000000002 /* CmuxTopSnapshotScopeCache.swift in Sources */,
+				C7300C0DE000000000000007 /* CmuxWebView+BrowserFocusModeContextMenu.swift in Sources */,
 				D7C0DE00000000000000A101 /* CmuxWebView+ContextMenuLinkCapture.swift in Sources */,
 				D7AB00000000000000000009 /* CmuxWebView+MoveTabToNewWorkspace.swift in Sources */,
 				C6255D010000000000000001 /* CmuxWebView+ScriptedDownloads.swift in Sources */,
+				C7300C0DE000000000000003 /* CmuxWebView+SemanticCopy.swift in Sources */,
 				C67540030000000000000001 /* CmuxWebView+SubframeDownloadIntentScript.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				E30750000000000000000004 /* CmuxWorkspaceDefinition.swift in Sources */,
@@ -5395,6 +5410,7 @@
 				D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */,
 				B65060010000000000000002 /* BrowserPanelSessionRestoreTests.swift in Sources */,
 				1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */,
+				C7300C0DE000000000000005 /* BrowserSemanticLinkCopyValueTests.swift in Sources */,
 				C2035A060000000000000001 /* BrowserSSLTrustBypassStateTests.swift in Sources */,
 				C7B800062D4202A13C962D2D /* BrowserSystemProxyMirrorTests.swift in Sources */,
 				C0DE49870000000000000001 /* BrowserWebContentProcessTests.swift in Sources */,

--- a/cmuxTests/BrowserSemanticLinkCopyValueTests.swift
+++ b/cmuxTests/BrowserSemanticLinkCopyValueTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct BrowserSemanticLinkCopyValueTests {
+    @Test(arguments: [
+        ("mailto:foo@bar.com?subject=Hello&body=World", BrowserSemanticLinkCopyValue.Kind.emailAddress, "foo@bar.com"),
+        ("MAILTO:foo%2Btag@example.com?subject=A%20B", BrowserSemanticLinkCopyValue.Kind.emailAddress, "foo+tag@example.com"),
+        ("mailto:a@x.com,b@y.com?cc=c@y.com", BrowserSemanticLinkCopyValue.Kind.emailAddress, "a@x.com,b@y.com"),
+        ("mailto:a%40x.com,%20b%40y.com?subject=Team", BrowserSemanticLinkCopyValue.Kind.emailAddress, "a@x.com,b@y.com"),
+        ("tel:+1%20555%20123%204567", BrowserSemanticLinkCopyValue.Kind.phoneNumber, "+1 555 123 4567"),
+        ("TEL:%2B81%203%201234%205678?ignored=true", BrowserSemanticLinkCopyValue.Kind.phoneNumber, "+81 3 1234 5678"),
+    ])
+    func extractsSemanticCopyValue(
+        rawURL: String,
+        expectedKind: BrowserSemanticLinkCopyValue.Kind,
+        expectedString: String
+    ) throws {
+        let url = try #require(URL(string: rawURL))
+        let value = try #require(BrowserSemanticLinkCopyValue(linkURL: url))
+
+        #expect(value.kind == expectedKind)
+        #expect(value.string == expectedString)
+    }
+
+    @Test(arguments: [
+        "https://example.com/contact",
+        "mailto:",
+        "mailto:?subject=MissingRecipient",
+        "mailto:not-an-email",
+        "mailto:a@example.com,",
+        "tel:",
+        "tel:not-a-number",
+    ])
+    func ignoresLinksWithoutSemanticCopyValue(rawURL: String) throws {
+        let url = try #require(URL(string: rawURL))
+
+        #expect(BrowserSemanticLinkCopyValue(linkURL: url) == nil)
+    }
+}

--- a/cmuxTests/BrowserSemanticLinkCopyValueTests.swift
+++ b/cmuxTests/BrowserSemanticLinkCopyValueTests.swift
@@ -15,6 +15,7 @@ import Testing
         ("mailto:a%40x.com,%20b%40y.com?subject=Team", BrowserSemanticLinkCopyValue.Kind.emailAddress, "a@x.com,b@y.com"),
         ("tel:+1%20555%20123%204567", BrowserSemanticLinkCopyValue.Kind.phoneNumber, "+1 555 123 4567"),
         ("TEL:%2B81%203%201234%205678?ignored=true", BrowserSemanticLinkCopyValue.Kind.phoneNumber, "+81 3 1234 5678"),
+        ("tel:*67#", BrowserSemanticLinkCopyValue.Kind.phoneNumber, "*67#"),
     ])
     func extractsSemanticCopyValue(
         rawURL: String,


### PR DESCRIPTION
## Summary
- add semantic browser context-menu copy payloads for mailto: and tel: links while keeping WebKit Copy Link
- copy decoded bare email recipients / phone numbers from freshly captured context-menu links
- add localized menu titles and unit coverage for extraction edge cases

Closes #7300

## Validation
- python3 scripts/swift_file_length_budget.py
- scripts/check-pbxproj.sh
- scripts/lint-pbxproj-test-wiring.sh
- python3 -m json.tool Resources/Localizable.xcstrings >/dev/null
- git diff --check
- swiftc -typecheck Sources/Panels/BrowserSemanticLinkCopyValue.swift

Per task instructions, I did not run local xcodebuild tests, XCUITests, reload.sh, or launch the app.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds semantic copy actions to the browser context menu for `mailto:` and `tel:` links so users can copy the decoded email address or phone number directly. Implements #7300 while keeping WebKit “Copy Link” and preserving tel fragment dial characters.

- **New Features**
  - Inserts “Copy Email Address” / “Copy Phone Number” right after WebKit “Copy Link” when a `mailto:` or `tel:` link is selected.
  - Decodes and normalizes values; supports comma-separated emails and tel symbols (+, *, #), including fragments (e.g. *67#).
  - Copies the bare value to the clipboard (no scheme, no query params).
  - Adds localized titles in 20 languages and unit tests for edge cases.

- **Refactors**
  - Extracted browser focus mode context menu code to `CmuxWebView+BrowserFocusModeContextMenu.swift` and shared its selector; exposed captured link helper for extension access.

<sup>Written for commit 2fdf53bf99f53e45868051c09075201366a96a20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added semantic copy options to the browser context menu for email addresses and phone numbers.
  * Added a browser focus mode menu item with updated enter/exit labeling and on/off state.
  * Expanded localized text for the new context menu actions.

* **Bug Fixes**
  * Improved context menu behavior so new actions appear in the right place and only when applicable.
  * Refined copying behavior to use the correct text format for email and phone links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->