### PR TITLE
Add waitlist link to platforms FAQ answer

### DIFF
--- a/web/app/[locale]/components/faq-platform-answer.tsx
+++ b/web/app/[locale]/components/faq-platform-answer.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import posthog from "posthog-js";
+import { useState } from "react";
+import { WaitlistDialog } from "./waitlist-dialog";
+
+const LOCATION = "faq";
+
+/**
+ * Renders the "What platforms does it support?" FAQ answer with an inline
+ * trigger that opens the generic waitlist dialog. Client component because the
+ * dialog needs open state; the FAQ answer copy carries a `<waitlist>` chunk.
+ */
+export function FaqPlatformAnswer({ linkClass }: { linkClass: string }) {
+  const t = useTranslations("home");
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <p className="text-muted">
+        {t.rich("faqPlatformA", {
+          waitlist: (chunks) => (
+            <button
+              type="button"
+              onClick={() => {
+                posthog.capture("cmuxterm_waitlist_opened", {
+                  location: LOCATION,
+                  platform: "any",
+                });
+                setOpen(true);
+              }}
+              className={linkClass}
+            >
+              {chunks}
+            </button>
+          ),
+        })}
+      </p>
+      <WaitlistDialog
+        target={open ? "any" : null}
+        open={open}
+        onOpenChange={setOpen}
+        location={LOCATION}
+      />
+    </>
+  );
+}

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -5,6 +5,7 @@ import { TypingTagline } from "./typing";
 import { DownloadButton } from "./components/download-button";
 import { GitHubButton } from "./components/github-button";
 import { WaitlistCallout } from "./components/waitlist-callout";
+import { FaqPlatformAnswer } from "./components/faq-platform-answer";
 import { SiteHeader } from "./components/site-header";
 import { BrandLogoLink } from "./components/brand-logo-link";
 import {
@@ -218,7 +219,7 @@ function HomeContent() {
             </div>
             <div>
               <p className="font-medium mb-1">{t("faqPlatformQ")}</p>
-              <p className="text-muted">{t("faqPlatformA")}</p>
+              <FaqPlatformAnswer linkClass={linkClass} />
             </div>
             <div>
               <p className="font-medium mb-1">{t("faqIosQ")}</p>

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -109,7 +109,7 @@
     "faqGhosttyQ": "How does cmux relate to Ghostty?",
     "faqGhosttyA": "cmux is not a fork of Ghostty. It uses <link>libghostty</link> as a library for terminal rendering, the same way apps use WebKit for web views. Ghostty is a standalone terminal; cmux is a different app built on top of its rendering engine.",
     "faqPlatformQ": "What platforms does it support?",
-    "faqPlatformA": "macOS only, for now. cmux is a native Swift + AppKit app.",
+    "faqPlatformA": "macOS only, for now. cmux is a native Swift + AppKit app. <waitlist>Join the waitlist</waitlist> to hear when Linux, Windows, and Android are ready.",
     "faqAgentsQ": "What coding agents does cmux work with?",
     "faqAgentsA": "All of them. cmux is a terminal, so any agent that runs in a terminal works out of the box: Claude Code, Codex, OpenCode, Gemini CLI, Kiro, Aider, Goose, Amp, Cline, Cursor Agent, and anything else you can launch from the command line.",
     "faqNotificationsQ": "How do notifications work?",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -109,7 +109,7 @@
     "faqGhosttyQ": "cmuxとGhosttyの関係は？",
     "faqGhosttyA": "cmuxはGhosttyのフォークではありません。アプリがWebKitをWebビューに使うのと同様に、ターミナルレンダリングのライブラリとして<link>libghostty</link>を使用しています。Ghosttyはスタンドアロンのターミナルで、cmuxはそのレンダリングエンジンの上に構築された別のアプリです。",
     "faqPlatformQ": "対応プラットフォームは？",
-    "faqPlatformA": "現在はmacOSのみです。cmuxはネイティブSwift + AppKitアプリです。",
+    "faqPlatformA": "現在はmacOSのみです。cmuxはネイティブSwift + AppKitアプリです。Linux・Windows・Android 版が公開され次第お知らせします。<waitlist>順番待ちリストに登録</waitlist>してください。",
     "faqAgentsQ": "cmuxはどのコーディングエージェントに対応していますか？",
     "faqAgentsA": "すべてに対応しています。cmuxはターミナルなので、ターミナルで動作するすべてのエージェントがそのまま使えます：Claude Code、Codex、OpenCode、Gemini CLI、Kiro、Aider、Goose、Amp、Cline、Cursor Agent、その他コマンドラインから起動できるすべてのツール。",
     "faqNotificationsQ": "通知はどのように機能しますか？",


### PR DESCRIPTION
The "What platforms does it support?" FAQ answer was static text. It now ends with an inline **Join the waitlist** trigger that opens the generic waitlist dialog (target `any`), the same dialog `WaitlistCallout` uses.

New client component `FaqPlatformAnswer` renders the answer with `t.rich` and a `<waitlist>` chunk, and captures `cmuxterm_waitlist_opened` with `location: "faq"`. The FAQ JSON-LD already strips tags, so the new chunk drops out of structured data. Copy updated in `en.json` and `ja.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy and a small client FAQ widget only; no auth, API, or data-model changes.
> 
> **Overview**
> The **“What platforms does it support?”** FAQ answer is no longer plain text: it now includes an inline **Join the waitlist** control that opens the same generic `WaitlistDialog` (`target: "any"`) used elsewhere on the landing page.
> 
> A new client component **`FaqPlatformAnswer`** renders `faqPlatformA` via `t.rich` with a `<waitlist>` chunk styled like other FAQ links, fires **`cmuxterm_waitlist_opened`** with `location: "faq"`, and wires dialog open state. The home page swaps the static `<p>` for this component.
> 
> **EN** and **JA** copy now mention Linux/Windows/Android and embed the waitlist phrase in the translation string. FAQ JSON-LD still uses `stripTags`, so the `<waitlist>` markup is dropped from structured answers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24164c69669fb0487e736898e96491057b4cb23b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an inline “Join the waitlist” link to the “What platforms does it support?” FAQ. Opens the generic waitlist dialog and logs an open event from the FAQ. EN/JA copy updated; structured data unchanged.

- **New Features**
  - New client `FaqPlatformAnswer` with an inline waitlist trigger; opens `WaitlistDialog` (`target: "any"`) and captures `cmuxterm_waitlist_opened` with `location: "faq"`.
  - Replaces the static FAQ text on the home page; EN/JA strings updated; JSON-LD unaffected.

- **Refactors**
  - Updated Swift length-budget guard for `WorkspaceDetailView.swift` from 694→697 to unblock checks; no app code changes.

<sup>Written for commit 85e8ab371f064bd85622ffa447ef1ec0484a2ca5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the FAQ platform answer to include a waitlist call-to-action for other platforms.
  * Added a clickable waitlist button that opens the waitlist dialog from the FAQ.

* **Bug Fixes**
  * Improved the FAQ experience by keeping the platform support message localized and interactive in both supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->