### PR TITLE
Honor libghostty mouse-cursor-shape (OSC 22) requests

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -7,7 +7,7 @@
 14270	Sources/TerminalController.swift
 13172	Sources/Workspace.swift
 12348	cmuxTests/AppDelegateShortcutRoutingTests.swift
-12212	Sources/GhosttyTerminalView.swift
+12272	Sources/GhosttyTerminalView.swift
 11669	Sources/Panels/BrowserPanel.swift
 9497	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 8032	Sources/Panels/BrowserPanelView.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -7,7 +7,7 @@
 14270	Sources/TerminalController.swift
 13172	Sources/Workspace.swift
 12348	cmuxTests/AppDelegateShortcutRoutingTests.swift
-12272	Sources/GhosttyTerminalView.swift
+12276	Sources/GhosttyTerminalView.swift
 11669	Sources/Panels/BrowserPanel.swift
 9497	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 8032	Sources/Panels/BrowserPanelView.swift

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3849,6 +3849,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let isAlreadyAttached = surface.isAttached(to: self)
         if !isSameSurface {
             appliedColorScheme = nil
+            // Reset any OSC 22 mouse shape carried over from the previous
+            // surface; the newly-bound surface re-emits its own shape via
+            // GHOSTTY_ACTION_MOUSE_SHAPE if it has one.
+            updateGhosttyMouseShape(GHOSTTY_MOUSE_SHAPE_TEXT)
         }
         terminalSurface = surface
         tabId = surface.tabId

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2818,6 +2818,12 @@ class GhosttyApp {
             }
         case GHOSTTY_ACTION_RENDER:
             return false
+        case GHOSTTY_ACTION_MOUSE_SHAPE:
+            let shape = action.action.mouse_shape
+            DispatchQueue.main.async {
+                surfaceView.updateGhosttyMouseShape(shape)
+            }
+            return true
         case GHOSTTY_ACTION_SCROLLBAR:
             let scrollbar = GhosttyScrollbar(c: action.action.scrollbar)
             surfaceView.enqueueScrollbarUpdate(scrollbar)
@@ -3415,11 +3421,60 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private let _renderedFrameLock = NSLock()
     var cellSize: CGSize = .zero
     private var lastKnownMousePointInView: NSPoint?
+    private var ghosttyMouseShape: ghostty_action_mouse_shape_e = GHOSTTY_MOUSE_SHAPE_TEXT
 
     static func retainRenderedFrameNotifications() -> () -> Void {
         // See GhosttyApp.retainTickNotifications() on the idempotent release.
         let retention = GhosttyApp.renderedFrameNotificationDemand.retain()
         return { retention.release() }
+    }
+
+    private static func ghosttyMouseCursor(for shape: ghostty_action_mouse_shape_e) -> NSCursor {
+        switch shape {
+        case GHOSTTY_MOUSE_SHAPE_DEFAULT:
+            return .arrow
+        case GHOSTTY_MOUSE_SHAPE_TEXT:
+            return .iBeam
+        case GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT:
+            return .iBeamCursorForVerticalLayout
+        case GHOSTTY_MOUSE_SHAPE_POINTER:
+            return .pointingHand
+        case GHOSTTY_MOUSE_SHAPE_CROSSHAIR,
+             GHOSTTY_MOUSE_SHAPE_CELL:
+            return .crosshair
+        case GHOSTTY_MOUSE_SHAPE_GRAB:
+            return .openHand
+        case GHOSTTY_MOUSE_SHAPE_GRABBING,
+             GHOSTTY_MOUSE_SHAPE_MOVE:
+            return .closedHand
+        case GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED,
+             GHOSTTY_MOUSE_SHAPE_NO_DROP:
+            return .operationNotAllowed
+        case GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU:
+            return .contextualMenu
+        case GHOSTTY_MOUSE_SHAPE_COPY:
+            return .dragCopy
+        case GHOSTTY_MOUSE_SHAPE_ALIAS:
+            return .dragLink
+        case GHOSTTY_MOUSE_SHAPE_W_RESIZE,
+             GHOSTTY_MOUSE_SHAPE_E_RESIZE,
+             GHOSTTY_MOUSE_SHAPE_EW_RESIZE,
+             GHOSTTY_MOUSE_SHAPE_COL_RESIZE:
+            return .resizeLeftRight
+        case GHOSTTY_MOUSE_SHAPE_N_RESIZE,
+             GHOSTTY_MOUSE_SHAPE_S_RESIZE,
+             GHOSTTY_MOUSE_SHAPE_NS_RESIZE,
+             GHOSTTY_MOUSE_SHAPE_ROW_RESIZE:
+            return .resizeUpDown
+        default:
+            return .arrow
+        }
+    }
+
+    fileprivate func updateGhosttyMouseShape(_ shape: ghostty_action_mouse_shape_e) {
+        guard ghosttyMouseShape != shape else { return }
+        ghosttyMouseShape = shape
+        window?.invalidateCursorRects(for: self)
     }
 
     /// Coalesce high-frequency scrollbar updates into a single main-thread
@@ -3918,6 +3973,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         super.viewDidEndLiveResize()
         updateSurfaceSize(bypassLiveResizeCoalescing: true)
         invalidateTextInputCoordinates()
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        addCursorRect(bounds, cursor: Self.ghosttyMouseCursor(for: ghosttyMouseShape))
     }
 
     override var isOpaque: Bool { false }


### PR DESCRIPTION
## What

cmux's action dispatch dropped `GHOSTTY_ACTION_MOUSE_SHAPE`, so the terminal
showed a static arrow and never reflected the mouse-cursor shape libghostty
requests: `OSC 22` (`\e]22;<shape>` from apps), the pointer over OSC-8 links,
the crosshair during rectangle select, or even the default text/iBeam over the
grid.

## How

`GhosttyNSView` now stores the requested shape (defaulting to `text`/iBeam),
maps it to a public `NSCursor`, and drives the terminal's base cursor rect from
it via `resetCursorRects()`. The `GHOSTTY_ACTION_MOUSE_SHAPE` case hops to main,
updates the shape (guarded against redundant same-shape events to avoid
cursor-rect thrash), and invalidates the cursor rects. The existing Cmd-hover
`pointingHand` push/pop overlays on top and reverts to the base shape on
release. No ghostty/submodule change (the C API was already present); public
`NSCursor` APIs only.

## Test

Hover the terminal grid -> iBeam (was arrow). `printf '\e]22;pointer\e\\'` ->
pointer; `\e]22;crosshair\e\\` -> crosshair; `\e]22;wait\e\\` -> arrow fallback;
`\e]22;\e\\` -> back to iBeam. Cmd-hover a real filename -> pointingHand, revert
to iBeam on release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785741260&installation_id=133855650&pr_number=7318&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7318&signature=02b254123ba250c902e8cf390fdfd7cc9bc05142597834fca1fab2159e06d025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AppKit cursor-rect behavior with no auth, data, or protocol changes beyond handling an existing Ghostty action.
> 
> **Overview**
> The terminal view no longer ignores **`GHOSTTY_ACTION_MOUSE_SHAPE`** from libghostty, so the pointer can follow OSC 22, link hover, selection, and grid text states instead of staying a static arrow.
> 
> **`GhosttyNSView`** keeps the latest requested shape (default **text**/iBeam), maps each **`ghostty_action_mouse_shape_e`** to a public **`NSCursor`**, and applies it in **`resetCursorRects()`**. The action handler dispatches to the main thread, updates the shape only when it changes, and invalidates cursor rects. Existing Cmd-hover **`pointingHand`** push/pop still overlays on top and pops back to the base shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e80e00429d65dd2fcb879ff4b44ea99b872b6ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore dynamic mouse cursor by honoring `OSC 22` from `libghostty`. The terminal now shows the correct shape (iBeam, pointer, crosshair, etc.) instead of a static arrow.

- **Bug Fixes**
  - Process `GHOSTTY_ACTION_MOUSE_SHAPE`; dispatch to main and update `GhosttyNSView`.
  - Map shapes to `NSCursor` and set the base cursor via `resetCursorRects()`.
  - Deduplicate same-shape events; keep Cmd-hover pointer overlay.
  - Reset OSC 22 mouse shape on surface swap to avoid stale cursors.

- **Refactors**
  - Refresh Swift file-length budget for `Sources/GhosttyTerminalView.swift`.

<sup>Written for commit ab1288cf552da0824c1a3f5609a585f314318c90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating the terminal mouse cursor shape in response to app-driven actions.
  * Cursor appearance now updates automatically based on the most recent Ghostty-provided mouse shape while moving within the terminal.

* **Bug Fixes**
  * Cursor shape state is now cleared when a new terminal surface is attached, preventing stale cursor behavior.
  * Cursor regions are now properly registered when the terminal view resets its cursor rectangles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->