### PR TITLE
Forward right/middle mouse drags to Ghostty (fixes tmux right-click menu)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -7,7 +7,7 @@
 14270	Sources/TerminalController.swift
 13172	Sources/Workspace.swift
 12348	cmuxTests/AppDelegateShortcutRoutingTests.swift
-12212	Sources/GhosttyTerminalView.swift
+12232	Sources/GhosttyTerminalView.swift
 11669	Sources/Panels/BrowserPanel.swift
 9497	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 8032	Sources/Panels/BrowserPanelView.swift

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7357,6 +7357,26 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         ghostty_surface_mouse_pos(surface, eventPoint.x, bounds.height - eventPoint.y, mouseModsFromEvent(event))
     }
 
+    override func rightMouseDragged(with event: NSEvent) {
+        // Forward right-button drags so mouse-reporting apps receive pointer
+        // motion while the right button is held. Without this, tmux's
+        // right-click context menu (press to open, drag to highlight, release
+        // to select) never sees the drag and cannot track hover state. Mirrors
+        // mouseDragged and matches upstream Ghostty, which funnels every drag
+        // variant to the same position-forwarding path.
+        mouseDragged(with: event)
+    }
+
+    override func otherMouseDragged(with event: NSEvent) {
+        // Only the middle button (buttonNumber 2) is forwarded to Ghostty, to
+        // stay consistent with otherMouseDown/otherMouseUp above.
+        guard event.buttonNumber == 2 else {
+            super.otherMouseDragged(with: event)
+            return
+        }
+        mouseDragged(with: event)
+    }
+
 #if DEBUG
     func debugHasPendingLeftMouseReleaseForTesting() -> Bool {
         hasPendingLeftMouseRelease


### PR DESCRIPTION
## What

In real Ghostty, right-click + drag + release drives tmux's right-click context
menu (open on press, highlight on drag, select on release). In cmux the menu
opened but dragging produced no hover highlight and release selected nothing.

## How

cmux overrode `mouseDragged` (left button) but not `rightMouseDragged` or
`otherMouseDragged`, so pointer motion during a right- or middle-button drag was
never forwarded to libghostty via `ghostty_surface_mouse_pos`. Under an app with
mouse reporting on (tmux), the app never saw the drag. Add both overrides,
funneling to `mouseDragged` the same way upstream Ghostty funnels every drag
variant to one position-forwarding path (`rightMouseDragged`/`otherMouseDragged`
-> `mouseMoved`). Middle-button drags are gated on `buttonNumber == 2` to match
the existing `otherMouseDown`/`otherMouseUp`.

## Test

In cmux, `tmux` with `set -g mouse on`, then right-click a pane: the tmux
context menu opens, dragging highlights items (hover), releasing selects the
highlighted item. Previously no highlight/selection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785741262&installation_id=133855650&pr_number=7319&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7319&signature=32104c877691f94316f5ed0b02f2945c9e47b99d90d501ea7a12682a629835f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized input-event forwarding in the terminal view with no auth, data, or API surface changes.
> 
> **Overview**
> **`GhosttyTerminalView`** now forwards **right-button** and **middle-button** drag motion to libghostty the same way left-button drags already did, by adding `rightMouseDragged` and `otherMouseDragged` overrides that call into the existing `mouseDragged` / `ghostty_surface_mouse_pos` path.
> 
> That closes a gap where mouse-reporting programs (notably **tmux** with mouse on) saw press/release but not pointer motion during a right-click menu drag, so hover highlight and release-to-select did not work. Middle-button drags are limited to `buttonNumber == 2`, consistent with the existing `otherMouseDown` / `otherMouseUp` handling.
> 
> The Swift file length budget for **`Sources/GhosttyTerminalView.swift`** is bumped slightly for the new lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6785a84aaba5d8a5f3cc326fb864952319dc4957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward right- and middle-button drag events to Ghostty so mouse-reporting apps (e.g., tmux) receive pointer motion during drags. Fixes tmux right-click menu hover/select and updates the Swift file-length budget for `Sources/GhosttyTerminalView.swift`.

- **Bug Fixes**
  - Override `rightMouseDragged` to delegate to `mouseDragged`.
  - Override `otherMouseDragged` for middle button only (`buttonNumber == 2`), delegating to `mouseDragged`.

<sup>Written for commit 63e0b171a7440475e3b72b2260f17c9d411df799. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse drag handling in the terminal view so right-button drags consistently update the pointer position.
  * Improved middle-button drag behavior (via secondary/other mouse drags) so pointer position updates are more reliable, while non-middle other-button drags retain the default app behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->