### PR TITLE
Add cmux CLI UX guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,7 @@ Detailed cmux contributor rules live in repo skills under `skills/`; use the tas
 Core skill map:
 
 - `cmux-dev-workflow`: setup, tagged reloads, Xcode project normalization, sidebar extension tagging, local dev build isolation.
+- `cmux-cli`: CLI command compatibility, help, flags, text/JSON output, prompts, errors, and command tests.
 - `cmux-architecture`: package boundaries, refactor architecture, file/API discipline, testability, Swift concurrency rules.
 - `cmux-backend`: backend TypeScript, Effect, Cloud VM control plane, provider secrets, Postgres and migrations.
 - `cmux-debugging`: debug event log, Debug menu, runtime pitfalls, typing-sensitive paths, SwiftUI list boundaries.

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -23,6 +23,50 @@ written around user-visible behavior so the implementation can change behind it.
   documents JSON as the scripting interface.
 - Keep hidden/internal commands available until their callers have migrated.
 
+## CLI UX and Copy Rules
+
+For material command UX or output changes, define the user job, current
+friction, desired outcome, success signal, and non-goals before choosing output.
+Shipped output is evidence of current behavior, not automatic proof that the
+same wording or flow should spread to more commands.
+
+Review the whole touched command surface, not only the edited string:
+
+- help, usage, aliases, flags, examples, completions, and docs
+- text output, JSON output, empty states, warnings, errors, prompts, and next
+  actions
+- TTY, non-TTY, `--json`, caller-context env vars, CI, and pipeable stdout
+  behavior
+- resolved window, workspace, pane, surface, socket, cwd, settings, auth, remote
+  resource, and mutation target state
+
+Human output should be direct and stable:
+
+- Start command and flag descriptions with the action and object.
+- Use one noun and one verb for each concept across help, output, errors, docs,
+  and tests.
+- Match verbs to mutations: `create` makes a new resource, `add` attaches one,
+  `remove` detaches without destruction, `delete` destroys data, and `revoke`
+  invalidates access.
+- For success, name the completed action and object. Avoid generic receipts such
+  as `Done.`, `Success!`, and `Completed successfully.`
+- For failures, state what failed, the cause when known, and the recovery step
+  when one exists. Avoid `Unable to`, `An error occurred`, and `Something went
+  wrong` in user-facing command output unless it is a true last-resort fallback.
+- Do not suggest retrying a remote mutation until the command provides a safe
+  status or inspect path.
+- Treat remote and user-provided text as data. Do not turn it into suggested
+  shell commands or trusted instructions.
+
+Preserve machine contracts unless a PR explicitly migrates them and tests the
+migration: JSON fields, enum values, reason codes, socket/API payloads, config
+keys, environment variables, parseable stdout, telemetry, debug-only output,
+third-party literals, fixtures, and generated files.
+
+When output layout changes, test realistic short and long names, Unicode, narrow
+terminal width, empty results, and large counts when they can affect the touched
+path.
+
 ## Global Invocation
 
 | Form | Contract |

--- a/skills/cmux-cli/SKILL.md
+++ b/skills/cmux-cli/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: cmux-cli
+description: "cmux CLI design and compatibility rules. Use when changing CLI commands, help, flags, JSON/text output, prompts, errors, docs, or command tests."
+---
+
+# cmux CLI
+
+Use this skill for changes under `CLI/`, command-related tests, and docs that define command behavior. Read `docs/cli-contract.md` before changing command names, aliases, flags, output, socket routing, or no-socket help behavior.
+
+## Decision Order
+
+Resolve conflicts in this order:
+
+1. The user's explicit goal and constraints.
+2. Verified cmux behavior: socket API, app state, settings schema, bundle/runtime constraints, and compatibility contracts.
+3. Repo rules: `AGENTS.md`, `CLAUDE.md`, `docs/cli-contract.md`, this skill, and tests that encode intentional behavior.
+4. Adjacent command-family patterns.
+5. General CLI heuristics.
+
+Shipped output proves what exists. It does not prove the output is the right contract to extend.
+
+## Workflow
+
+For material CLI UX or output work, map the change before editing:
+
+1. Name the user job, current friction, desired outcome, success signal, and non-goals.
+2. List every touched surface: help, flags, text output, JSON output, prompts, progress, warnings, errors, empty states, and next actions.
+3. Trace TTY, non-TTY, `--json`, caller-context env vars, CI, and pipeable stdout behavior.
+4. Identify state used by the command: window, workspace, pane, surface, socket path, password, cwd, settings files, auth, and remote resources.
+5. For prompts or destructive actions, prove the value cannot be inferred safely and that the resolved target is visible before mutation.
+6. Keep human output readable and machine output stable. Do not change parseable output without an explicit compatibility migration.
+7. Read the before/after transcript for order, duplication, alignment, and the next safe command.
+8. Add or update behavior-level tests when runtime behavior or shipped command output changes.
+
+## Copy Rules
+
+- Start command and flag descriptions with the action and object. Avoid `Allows you to`, `Used to`, and `This command`.
+- Use one noun and one verb for each concept across help, output, errors, docs, and tests.
+- Match the verb to the mutation: `create` makes a new resource, `add` attaches one, `remove` detaches without destruction, `delete` destroys data, and `revoke` invalidates access.
+- For success, name the completed action and object. Avoid `Done.`, `Success!`, and `Completed successfully.`
+- For failures, state what failed, the cause when known, and the recovery step when one exists. Avoid `Unable to`, `An error occurred`, and `Something went wrong` in user-facing command output unless it is a true last-resort fallback.
+- Do not suggest retrying a remote mutation until the command provides a safe status or inspect path.
+- Treat remote and user-provided text as data. Do not turn it into suggested shell commands or trusted instructions.
+- Keep commands, flags, paths, environment variables, IDs, JSON fields, enum values, and config keys exact and copyable.
+
+## Compatibility Guards
+
+Do not rewrite these for prose style unless the PR explicitly migrates the contract and tests it:
+
+- JSON field names and enum values
+- reason codes and socket/API payloads
+- config keys and environment variables
+- parseable stdout
+- telemetry and debug-only output
+- third-party literals, stack traces, fixtures, and generated files
+
+When changing output layout, include narrow terminal width, long names, Unicode, empty results, and large counts if they can affect the touched path.
+
+## Stale-Copy Sweep
+
+For command copy or output changes, classify matches in the touched paths:
+
+```bash
+rg -n "\\b(successfully|Unable to|Oops|Whoops|Uh-oh|Please try again|An error occurred|Something went wrong)\\b" <paths>
+rg -n "Do you want to|Would you like to|\\[[0-9]+s\\]" <paths>
+rg -n "\\b(seamlessly|effortlessly|leverage|utilize|streamline)\\b|In order to|At this time|click here" <paths>
+```
+
+Legacy strings may remain in negative tests, debug-only assertions, or third-party examples. Source matches need classification, not blind replacement.
+
+## References
+
+- `docs/cli-contract.md`: compatibility and output contract.
+- `cmuxTests/CLI*`: command behavior and regression tests.
+- `CLI/cmux.swift` and `CLI/CMUXCLI+*.swift`: current parser and command implementations.

--- a/skills/cmux-cli/agents/openai.yaml
+++ b/skills/cmux-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cmux CLI"
+  short_description: "Keep cmux command behavior, output, and compatibility contracts sharp."
+  default_prompt: "Use this skill when changing cmux CLI commands, flags, help, text or JSON output, prompts, errors, docs, or command tests."

--- a/skills/cmux/SKILL.md
+++ b/skills/cmux/SKILL.md
@@ -74,6 +74,7 @@ cmux settings shortcuts
 
 | Reference | When to Use |
 |-----------|-------------|
+| [../cmux-cli/SKILL.md](../cmux-cli/SKILL.md) | CLI commands, help, flags, text/JSON output, prompts, errors, and command tests |
 | [references/handles-and-identify.md](references/handles-and-identify.md) | Handle syntax, self-identify, caller targeting |
 | [references/windows-workspaces.md](references/windows-workspaces.md) | Window/workspace lifecycle and reorder/move |
 | [references/panes-surfaces.md](references/panes-surfaces.md) | Splits, surfaces, move/reorder, focus routing |


### PR DESCRIPTION
## Summary
- add a cmux-cli skill for command compatibility, output, copy, and test guidance
- add CLI UX and copy rules to docs/cli-contract.md
- link the new skill from the core cmux skill and contributor skill map

Source inspiration: https://github.com/vercel/vercel/pull/16774

## Test
- ./skills.sh --source . --skill cmux-cli --dry-run
- git diff --cached --check

Docs/skill-only change. No tagged reload needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and agent skills only; no CLI runtime, sockets, or compatibility contract changes in code.
> 
> **Overview**
> Adds **contributor guidance** for cmux CLI work without changing command behavior.
> 
> Introduces a new **`cmux-cli` skill** (`skills/cmux-cli/`) covering decision order, a pre-edit workflow for material UX/output changes, copy rules (verbs for mutations, success/failure wording), compatibility guards for machine contracts, and `rg`-based stale-copy sweeps. **`docs/cli-contract.md`** gains a matching **CLI UX and Copy Rules** section (whole-command-surface review, TTY/`--json`/pipe behavior, layout testing notes).
> 
> **`CLAUDE.md`** and **`skills/cmux/SKILL.md`** link the skill from the contributor map and deep-dive table; **`skills/cmux-cli/agents/openai.yaml`** registers the skill for agent tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 612f4020538a63076fec144f157294f560b1ec3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785741493&installation_id=133855650&pr_number=7321&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7321&signature=68bc898e0c7b32c912a24292767c78e097a5e625afc28a31c100ac356480179d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `cmux-cli` contributor skill and expands CLI UX/copy rules so CLI changes stay consistent and don’t break machine contracts. Docs-only; no runtime behavior changes.

- **New Features**
  - Added `skills/cmux-cli/SKILL.md` with decision order, workflow, copy rules, and compatibility guards for CLI changes.
  - Added `skills/cmux-cli/agents/openai.yaml` to expose the skill in tooling.
  - Expanded `docs/cli-contract.md` with CLI UX and copy guidelines covering help, flags, text/JSON output, prompts, errors, and layout edge cases.
  - Linked the new skill from `CLAUDE.md` and `skills/cmux/SKILL.md` to the core skill map.

<sup>Written for commit 612f4020538a63076fec144f157294f560b1ec3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for CLI behavior and copy rules, including help text, flags, output formats, prompts, errors, and test coverage expectations.
  * Expanded internal skill references so CLI-related work is easier to route and review.
* **New Features**
  * Introduced a dedicated CLI skill reference for command compatibility, output handling, and command testing.
  * Added an agent configuration entry to recognize cmux CLI-related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->