### PR TITLE
mux: CDP browser panes rendered with kitty graphics, interactive, reusing existing Chrome

### DIFF
--- a/mux/Cargo.lock
+++ b/mux/Cargo.lock
@@ -62,6 +62,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +175,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -179,6 +219,22 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -227,6 +283,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "ghostty-vt"
 version = "0.1.0"
 dependencies = [
@@ -262,6 +339,22 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "ident_case"
@@ -383,6 +476,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mux-cdp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde_json",
+ "tungstenite",
+]
+
+[[package]]
 name = "mux-core"
 version = "0.1.0"
 dependencies = [
@@ -390,9 +492,11 @@ dependencies = [
  "base64",
  "ghostty-vt",
  "libc",
+ "mux-cdp",
  "portable-pty",
  "serde",
  "serde_json",
+ "tungstenite",
 ]
 
 [[package]]
@@ -403,6 +507,7 @@ dependencies = [
  "base64",
  "crossterm",
  "ghostty-vt",
+ "libc",
  "mux-core",
  "ratatui",
  "serde",
@@ -483,6 +588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +622,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -661,6 +805,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +940,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +997,18 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -942,6 +1133,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/ghostty-vt-sys",
     "crates/ghostty-vt",
+    "crates/mux-cdp",
     "crates/mux-core",
     "crates/mux-tui",
 ]
@@ -16,6 +17,7 @@ publish = false
 ghostty-vt-sys = { path = "crates/ghostty-vt-sys" }
 ghostty-vt = { path = "crates/ghostty-vt" }
 mux-core = { path = "crates/mux-core" }
+mux-cdp = { path = "crates/mux-cdp" }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -25,6 +27,7 @@ ratatui = "0.29"
 unicode-width = "0.2"
 base64 = "0.22"
 libc = "0.2"
+tungstenite = { version = "0.24", default-features = false, features = ["handshake"] }
 
 [profile.release]
 lto = "thin"

--- a/mux/README.md
+++ b/mux/README.md
@@ -1,12 +1,13 @@
 # cmux-mux
 
-A decoupled terminal-multiplexer backend for cmux, with a bundled tmux-like TUI. The multiplexer core owns workspaces → screens → split panes → tabs: a workspace holds screens (like tmux windows; the status bar switches between them), each screen is a binary split tree of panes mirroring the cmux app's pane system, and each pane holds one or more tabs (surfaces). Each tab is a real PTY whose output feeds libghostty-vt, the terminal engine extracted from Ghostty and built from this repo's `ghostty/` submodule. Frontends only read render snapshots and send input, so the same session state can be drawn by the Ratatui TUI in any terminal today and attached to real Ghostty surfaces in the cmux app later.
+A decoupled terminal-multiplexer backend for cmux, with a bundled tmux-like TUI. The multiplexer core owns workspaces → screens → split panes → tabs: a workspace holds screens (like tmux windows; the status bar switches between them), each screen is a binary split tree of panes mirroring the cmux app's pane system, and each pane holds one or more tabs (surfaces). A surface can be a real PTY whose output feeds libghostty-vt, or a local Chrome/Chromium page driven over the Chrome DevTools Protocol and rendered in the TUI with kitty graphics. Frontends only read render snapshots and send input, so PTY session state can be drawn by the Ratatui TUI in any terminal today and attached to real Ghostty surfaces in the cmux app later.
 
 ## Layout
 
 - `crates/ghostty-vt-sys` — raw FFI. build.rs compiles `libghostty-vt.a` from `../ghostty` with zig (`-Demit-lib-vt=true`, ReleaseFast) and generates bindings from `include/ghostty/vt.h` with bindgen.
 - `crates/ghostty-vt` — safe wrapper: `Terminal` (vt parsing, modes, callbacks, plain-text dump), `RenderState` (dirty-tracked viewport snapshots), `KeyEncoder` (legacy + kitty keyboard protocol, synced from terminal modes).
-- `crates/mux-core` — the backend: session model (`model.rs`), orchestrator (`mux.rs`), surface runtime (`surface.rs`: portable-pty, one reader thread per surface), layout math shared by frontends (`layout.rs`), and the JSON control socket (`server.rs`).
+- `crates/mux-cdp` — sync CDP transport and Chrome lifecycle for local browser surfaces.
+- `crates/mux-core` — the backend: session model (`model.rs`), orchestrator (`mux.rs`), surface runtimes (`surface.rs` / `browser.rs`), layout math shared by frontends (`layout.rs`), and the JSON control socket (`server.rs`).
 - `crates/mux-tui` — the `cmux-mux` binary: crossterm + Ratatui frontend (`app.rs` event loop, `ui/` drawing, `session/` local-or-remote session abstraction).
 
 ## Build and run
@@ -23,11 +24,30 @@ cargo test                      # unit + integration tests
 
 Detach with prefix-d while attached; the headless session keeps running and `attach` reconnects with full screen state (VT replay + live stream). A local (non-attach) `cmux-mux` ends its session on quit.
 
-Keys (prefix Ctrl-b, tmux-style): `c` new tab in the active pane, `n`/`p`/`1`-`9` switch tab within the pane, `%` split right, `"` split down, `h j k l`/arrows move focus, `x` close tab (a pane collapses with its last tab), `,` rename pane, `$` rename workspace, `Tab` next screen, `S` new screen, `w` next workspace, `W` new workspace, `s` toggle the workspace sidebar, PageUp/PageDown scrollback, `d` quit, `Ctrl-b` twice sends a literal Ctrl-b.
+Keys (prefix Ctrl-b, tmux-style): `c` new PTY tab in the active pane, `B` new browser tab URL prompt, `n`/`p`/`1`-`9` switch tab within the pane, `%` split right, `"` split down, `h j k l`/arrows move focus, `x` close tab (a pane collapses with its last tab), `,` rename pane, `$` rename workspace, `Tab` next screen, `S` new screen, `w` next workspace, `W` new workspace, `s` toggle the workspace sidebar, PageUp/PageDown scrollback, `d` quit, `Ctrl-b` twice sends a literal Ctrl-b.
 
 Every pane draws a border box; the active pane's border is highlighted, the pane under the mouse gets a hover shade, and the box is where flashing notifications will hook in later. The top border doubles as an always-visible tab bar: tabs are numbered (`1`, `2`, ...; the process title follows the number when reported), clicking a title switches, the trailing `+` opens a new tab, and when tabs overflow, `‹`/`›` arrows (or the wheel over the bar) scroll them while the active tab stays visible. Click anywhere in a pane to focus it. The status bar shows the active workspace's screens: click an entry to switch, the trailing `+` for a new screen; it spans only the pane region (not the sidebar), with the session label right-aligned. Right-click a pane for rename pane / new tab / split right / split down / close pane; right-click a workspace in the sidebar for rename/close; right-click a screen in the status bar for rename/close. Context menu items have a one-cell side padding and the hover/selection highlight spans the full row. Renames use a status-line prompt (Enter commits, Esc cancels; empty pane/screen names fall back to defaults). The sidebar reserves two lines per workspace (name, then the active pane's title) under a `workspaces` header with a blank line after it and between entries; click an entry to switch, `+ new workspace` to create one.
 
-Drag to select text; on release the selection is copied to the host clipboard via OSC 52 (works over SSH). The highlight is viewport-anchored and clears on scroll or typing. Wheel scrolls (arrow keys on the alternate screen). The right border doubles as the scrollbar: a `┃` thumb appears whenever the surface has any scrollback (hidden only when no scrolling is possible at all), and the track can be clicked or dragged to jump.
+Drag to select text in PTY panes; on release the selection is copied to the host clipboard via OSC 52 (works over SSH). The highlight is viewport-anchored and clears on scroll or typing. Wheel scrolls PTY scrollback (arrow keys on the alternate screen). The right border doubles as the PTY scrollbar: a `┃` thumb appears whenever the surface has any scrollback (hidden only when no scrolling is possible at all), and the track can be clicked or dragged to jump. Browser panes receive text input, Enter/Backspace/Tab/Esc/navigation keys, left click/drag/release, and wheel scroll through CDP.
+
+## Browser panes
+
+Press prefix-`B` or right-click a pane and choose `New browser tab` to open a URL prompt. Bare domains get `https://` prepended; `about:blank` and explicit schemes pass through unchanged. Browser panes share one local Chrome DevTools Protocol connection per mux session. cmux first uses `CMUX_MUX_CDP_URL`, then `browser.cdp_url`, then probes `127.0.0.1` discovery ports such as 9222, and only then launches its own Chrome/Chromium-family binary in `--headless=new` mode. Launched Chrome uses a persistent cmux profile by default so logins survive restarts; set `browser.ephemeral` to use a temporary profile deleted on shutdown.
+
+Chrome 136 and newer ignore `--remote-debugging-port` for the default user data directory, so everyday Chrome profiles are not attachable. Reuse works with Chrome instances started with a custom `--user-data-dir` and a debugging port, or with other tooling/headless instances that expose `/json/version`. Headful Chrome may throttle screencast frames when its window or tab is hidden or occluded.
+
+Frames stream as `Page.screencastFrame` PNGs into the TUI. The frame is rendered with the kitty graphics protocol after each Ratatui draw; overlapping cmux menus and prompts temporarily delete the image placement so terminal UI stays readable.
+
+Terminal support:
+
+| Terminal | Browser frame rendering |
+| --- | --- |
+| Ghostty | Supported via kitty graphics |
+| kitty | Supported via kitty graphics |
+| WezTerm | Supported when kitty graphics are enabled |
+| Other terminals | TUI remains usable and shows `terminal has no kitty graphics support` |
+
+If no reusable browser is found and no Chrome binary is found, browser tab creation fails in the status line with an error naming `browser.chrome_binary`. Attach clients do not stream browser pixels in v1: remote attach shows a placeholder for browser surfaces, and browser creation over attach returns `browser panes are not supported over attach yet`. `list-workspaces` reports browser tabs with `kind: "browser"` and `browser_source: "external"` or `"launched"`.
 
 ## Configuration
 
@@ -49,9 +69,18 @@ Drag to select text; on release the selection is copied to the host clipboard vi
     "agents": ["claude", "codex", "opencode", "pi"]
   },
   "sidebar": { "width": 22 },
+  "browser": {
+    "chrome_binary": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "cdp_url": "http://127.0.0.1:9222",
+    "discover": true,
+    "discover_ports": [9222],
+    "user_data_dir": "/Users/me/Library/Application Support/cmux-mux/chrome-profile",
+    "ephemeral": false
+  },
   "keys": {
     "prefix": "ctrl+b",
-    "new-tab": "c", "next-tab": "n", "prev-tab": "p",
+    "new-tab": "c", "new_browser_tab": "B",
+    "next-tab": "n", "prev-tab": "p",
     "split-right": "%", "split-down": "\"", "close-tab": "x",
     "rename-pane": ",", "rename-workspace": "$",
     "next-screen": "tab", "new-screen": "S",
@@ -64,7 +93,7 @@ Drag to select text; on release the selection is copied to the host clipboard vi
 }
 ```
 
-Colors are `#rrggbb`, `#rgb`, or an xterm-256 index. The selection colors default to the user's Ghostty config (`selection-background`/`selection-foreground` from `~/.config/ghostty/config`), falling back to a dark grey. Tabs are numbered `1 2 3…` by default; recognized agent programs (the `agents` list) surface after the number, and `show_titles` restores full process titles. Every prefix binding is remappable via `keys` (formats: `"c"`, `"%"`, `"ctrl+b"`, `"alt+enter"`, `"tab"`, `"pageup"`); `1`-`9` stay fixed to tab selection.
+Colors are `#rrggbb`, `#rgb`, or an xterm-256 index. The selection colors default to the user's Ghostty config (`selection-background`/`selection-foreground` from `~/.config/ghostty/config`), falling back to a dark grey. Tabs are numbered `1 2 3…` by default; recognized agent programs (the `agents` list) surface after the number, and `show_titles` restores full process titles. Browser config is optional: `chrome_binary` overrides binary discovery, `cdp_url` accepts `ws://...` or `http://host:port`, `discover` defaults to true, `discover_ports` defaults to `[9222]`, `user_data_dir` overrides the launched profile path, and `ephemeral` restores temporary-profile behavior. When `ephemeral` is true it takes precedence over `user_data_dir`: cmux creates and later deletes a fresh temp profile and never deletes the configured directory. Every prefix binding is remappable via `keys` (formats: `"c"`, `"%"`, `"ctrl+b"`, `"alt+enter"`, `"tab"`, `"pageup"`); `1`-`9` stay fixed to tab selection.
 
 ## Control socket
 
@@ -78,15 +107,17 @@ printf '%s\n' '{"id":3,"cmd":"send","surface":1,"text":"ls\r"}' | nc -U "$SOCK"
 printf '%s\n' '{"id":4,"cmd":"read-screen","surface":1}' | nc -U "$SOCK"
 ```
 
-Commands: `identify`, `list-workspaces` (each workspace carries `screens`, each with its split-tree `layout` plus `panes` with their `tabs`), `send` (text or base64 `bytes`), `read-screen`, `vt-state`, `new-tab` (in a pane), `new-screen` (in a workspace), `new-workspace`, `split` (`dir`: `right`/`down`), `close-surface`, `close-pane`, `close-screen`, `close-workspace`, `rename-pane`, `rename-screen`, `rename-workspace`, `resize-surface`, `focus-pane`, `select-tab` (within a pane), `select-screen`, `select-workspace`, `scroll-surface`, `subscribe`, `attach-surface`.
+Commands: `identify`, `list-workspaces` (each tab includes `kind: "pty" | "browser"` and browser tabs include `browser_source`), `send` (text or base64 `bytes`, PTY only), `read-screen` (PTY only), `vt-state` (PTY only), `new-tab` (PTY tab in a pane), `new-browser-tab` (local browser tab in a pane), `new-screen` (in a workspace), `new-workspace`, `split` (`dir`: `right`/`down`), `close-surface`, `close-pane`, `close-screen`, `close-workspace`, `rename-pane`, `rename-screen`, `rename-workspace`, `resize-surface`, `focus-pane`, `select-tab` (within a pane), `select-screen`, `select-workspace`, `scroll-surface` (PTY only), `subscribe`, `attach-surface` (PTY only).
 
-`subscribe` turns the connection full-duplex: the server pushes `{"event":...}` lines (tree-changed, surface-output, surface-exited, title-changed, bell). `attach-surface` sends a `vt-state` event carrying a base64 VT replay of the surface's complete state (screen, styles, cursor, modes, palette, kitty keyboard state, charsets — produced by ghostty's formatter), then streams every subsequent pty byte as `output` events. Replaying state then stream into a fresh terminal reproduces the surface exactly; the snapshot and stream tap are taken under the same terminal lock, so there is no gap and no duplication. This is the attach surface for the cmux app: a real Ghostty surface can adopt a tab by replaying `vt-state` and following the stream, because both sides speak the same VT engine.
+`subscribe` turns the connection full-duplex: the server pushes `{"event":...}` lines (tree-changed, surface-output, surface-exited, title-changed, bell). `attach-surface` sends a `vt-state` event carrying a base64 VT replay of a PTY surface's complete state (screen, styles, cursor, modes, palette, kitty keyboard state, charsets — produced by ghostty's formatter), then streams every subsequent pty byte as `output` events. Replaying state then stream into a fresh terminal reproduces the surface exactly; the snapshot and stream tap are taken under the same terminal lock, so there is no gap and no duplication. Browser surfaces are local-only in v1; PTY-only socket commands against them return `ok:false` with a clear error.
 
 ## Design notes
 
 - The pty reader thread is the only writer into a surface's `Terminal`; renderers take the terminal lock just long enough to snapshot into their own `RenderState`, so slow frontends never block pty IO.
 - Query responses (DSR, DECRQM, ...) generated during parsing are queued by the write-pty callback and flushed to the pty after each parse batch.
 - Input is encoded with ghostty's key encoder synced from the active surface's terminal modes each keystroke, so cursor-key application mode and the kitty keyboard protocol work end to end.
+- Browser input is sent through CDP `Input.*` commands; CDP screencast frames are acknowledged immediately so Chrome keeps streaming.
+- Browser surfaces share a single CDP browser connection; closing a tab closes only its target, and mux shutdown kills Chrome only when cmux launched it.
 - Exited surfaces are reaped by the mux itself (tab removed, pane/workspace collapsed), so headless sessions and every frontend see the same tree without frontend-side cleanup.
 - Surfaces spawn at their final render size (`new-tab`/`new-workspace`/`split` take optional `cols`/`rows`, and the TUI predicts sizes from its layout): spawning at 80x24 and resizing a frame later makes shells repaint their first prompt, which left zsh's reverse-video `%` partial-line marker on screen.
 - Children get `TERM=xterm-256color` by default; set `--term xterm-ghostty` (or `CMUX_MUX_TERM`) when the ghostty terminfo is installed.
@@ -94,6 +125,8 @@ Commands: `identify`, `list-workspaces` (each workspace carries `screens`, each 
 ## Current limitations
 
 - Scrollback from before an attach is not replayed (the VT replay covers the screen and state, not history); the mirror accumulates its own scrollback from the live stream.
-- No mouse-event forwarding to applications (viewport scroll and alternate-screen arrow fallback only).
-- Kitty graphics state is tracked by the engine but not rendered by the TUI.
+- Browser frame streaming over attach is not implemented; attach clients show a placeholder for browser tabs.
+- Reused headful Chrome instances can pause screencast frames when their windows or tabs are hidden.
+- PTY mouse-event forwarding to applications is not implemented (viewport scroll and alternate-screen arrow fallback only).
+- Kitty graphics generated by PTY applications are tracked by the engine but not rendered by the TUI.
 - Split ratios are fixed at 50% (no interactive divider drag yet).

--- a/mux/crates/mux-cdp/Cargo.toml
+++ b/mux/crates/mux-cdp/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mux-cdp"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Synchronous Chrome DevTools Protocol transport and Chrome lifecycle for cmux-mux"
+
+[dependencies]
+anyhow.workspace = true
+serde_json.workspace = true
+tungstenite.workspace = true

--- a/mux/crates/mux-cdp/src/chrome.rs
+++ b/mux/crates/mux-cdp/src/chrome.rs
@@ -1,0 +1,273 @@
+use std::ffi::OsString;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+static PROFILE_SEQ: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone)]
+pub struct ChromeLaunchOptions {
+    pub binary: Option<String>,
+    pub user_data_dir: Option<PathBuf>,
+    pub ephemeral: bool,
+}
+
+/// A launched Chrome/Chromium process plus its profile dir.
+pub struct Chrome {
+    child: Mutex<Option<Child>>,
+    profile_dir: PathBuf,
+    profile_ephemeral: bool,
+    web_socket_url: String,
+}
+
+impl Chrome {
+    /// Launch Chrome in headless mode and wait for the browser CDP
+    /// endpoint printed on stderr.
+    pub fn launch(explicit_binary: Option<&str>) -> anyhow::Result<Self> {
+        Chrome::launch_with(ChromeLaunchOptions {
+            binary: explicit_binary.map(str::to_string),
+            user_data_dir: None,
+            ephemeral: true,
+        })
+    }
+
+    pub fn launch_with(options: ChromeLaunchOptions) -> anyhow::Result<Self> {
+        let binary = find_chrome_binary(options.binary.as_deref())?;
+        let (profile_dir, profile_ephemeral) = profile_dir_for(&options)?;
+        std::fs::create_dir_all(&profile_dir)?;
+        let mut child = Command::new(&binary)
+            .arg("--headless=new")
+            .arg("--remote-debugging-port=0")
+            .arg("--no-first-run")
+            .arg("--no-default-browser-check")
+            .arg(format!("--user-data-dir={}", profile_dir.display()))
+            .arg("about:blank")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("failed to launch Chrome at {}: {e}", binary.display()))?;
+
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("failed to capture Chrome stderr"))?;
+        let (tx, rx) = mpsc::channel();
+        std::thread::Builder::new().name("mux-cdp-chrome-stderr".into()).spawn(move || {
+            let mut reader = BufReader::new(stderr);
+            let mut line = String::new();
+            let mut sent = false;
+            loop {
+                line.clear();
+                match reader.read_line(&mut line) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {
+                        if !sent {
+                            if let Some(url) = parse_devtools_url(&line) {
+                                let _ = tx.send(url);
+                                sent = true;
+                            }
+                        }
+                    }
+                }
+            }
+        })?;
+
+        let web_socket_url = match rx.recv_timeout(Duration::from_secs(10)) {
+            Ok(url) => url,
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                if profile_ephemeral {
+                    let _ = std::fs::remove_dir_all(&profile_dir);
+                }
+                anyhow::bail!(
+                    "Chrome did not publish a DevTools endpoint within 10s (binary: {})",
+                    binary.display()
+                );
+            }
+        };
+
+        Ok(Chrome {
+            child: Mutex::new(Some(child)),
+            profile_dir,
+            profile_ephemeral,
+            web_socket_url,
+        })
+    }
+
+    pub fn web_socket_url(&self) -> &str {
+        &self.web_socket_url
+    }
+
+    pub fn kill(&self) {
+        if let Some(mut child) = self.child.lock().unwrap().take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+impl Drop for Chrome {
+    fn drop(&mut self) {
+        self.kill();
+        if self.profile_ephemeral {
+            let _ = std::fs::remove_dir_all(&self.profile_dir);
+        }
+    }
+}
+
+/// Locate a Chrome-family binary. The explicit config path wins; then
+/// well-known app locations; then PATH.
+pub fn find_chrome_binary(explicit: Option<&str>) -> anyhow::Result<PathBuf> {
+    if let Some(path) = explicit.filter(|s| !s.trim().is_empty()) {
+        let path = PathBuf::from(path);
+        if is_executable_file(&path) {
+            return Ok(path);
+        }
+        anyhow::bail!(
+            "configured browser.chrome_binary does not point to an executable file: {}",
+            path.display()
+        );
+    }
+
+    for path in known_binary_paths() {
+        if is_executable_file(&path) {
+            return Ok(path);
+        }
+    }
+
+    for name in ["google-chrome", "chromium", "chromium-browser", "brave-browser", "microsoft-edge"]
+    {
+        if let Some(path) = find_on_path(name) {
+            return Ok(path);
+        }
+    }
+
+    anyhow::bail!(
+        "no Chrome/Chromium binary found; set browser.chrome_binary in ~/.config/cmux/mux.json"
+    )
+}
+
+fn known_binary_paths() -> Vec<PathBuf> {
+    vec![
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome".into(),
+        "/Applications/Chromium.app/Contents/MacOS/Chromium".into(),
+        "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser".into(),
+        "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge".into(),
+        "/usr/bin/google-chrome".into(),
+        "/usr/bin/chromium".into(),
+        "/usr/bin/chromium-browser".into(),
+        "/snap/bin/chromium".into(),
+        "/usr/bin/brave-browser".into(),
+        "/usr/bin/microsoft-edge".into(),
+    ]
+}
+
+fn find_on_path(name: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path).map(|dir| dir.join(name)).find(|p| is_executable_file(p))
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else { return false };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn make_profile_dir() -> anyhow::Result<PathBuf> {
+    let seq = PROFILE_SEQ.fetch_add(1, Ordering::Relaxed);
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
+    let mut name = OsString::from("cmux-mux-cdp-");
+    name.push(std::process::id().to_string());
+    name.push("-");
+    name.push(now.to_string());
+    name.push("-");
+    name.push(seq.to_string());
+    let dir = std::env::temp_dir().join(name);
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn profile_dir_for(options: &ChromeLaunchOptions) -> anyhow::Result<(PathBuf, bool)> {
+    if options.ephemeral {
+        return Ok((make_profile_dir()?, true));
+    }
+    if let Some(dir) = options.user_data_dir.clone() {
+        return Ok((dir, false));
+    }
+    Ok((default_user_data_dir()?, false))
+}
+
+pub fn default_user_data_dir() -> anyhow::Result<PathBuf> {
+    if cfg!(target_os = "macos") {
+        let home = std::env::var("HOME")?;
+        return Ok(PathBuf::from(home)
+            .join("Library")
+            .join("Application Support")
+            .join("cmux-mux")
+            .join("chrome-profile"));
+    }
+    if let Some(data_home) = std::env::var_os("XDG_DATA_HOME") {
+        return Ok(PathBuf::from(data_home).join("cmux-mux").join("chrome-profile"));
+    }
+    let home = std::env::var("HOME")?;
+    Ok(PathBuf::from(home).join(".local/share/cmux-mux/chrome-profile"))
+}
+
+fn parse_devtools_url(line: &str) -> Option<String> {
+    let marker = "DevTools listening on ";
+    let idx = line.find(marker)?;
+    Some(line[idx + marker.len()..].trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_devtools_endpoint() {
+        assert_eq!(
+            parse_devtools_url("DevTools listening on ws://127.0.0.1:1/devtools/browser/x\n"),
+            Some("ws://127.0.0.1:1/devtools/browser/x".to_string())
+        );
+        assert_eq!(parse_devtools_url("other"), None);
+    }
+
+    #[test]
+    fn ephemeral_profile_ignores_configured_user_data_dir() {
+        let explicit_dir =
+            std::env::temp_dir().join(format!("cmux-mux-cdp-explicit-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&explicit_dir);
+        std::fs::create_dir_all(&explicit_dir).unwrap();
+        let sentinel = explicit_dir.join("keep");
+        std::fs::write(&sentinel, b"keep").unwrap();
+
+        let options = ChromeLaunchOptions {
+            binary: None,
+            user_data_dir: Some(explicit_dir.clone()),
+            ephemeral: true,
+        };
+        let (selected, ephemeral) = profile_dir_for(&options).unwrap();
+        assert!(ephemeral);
+        assert_ne!(selected, explicit_dir);
+
+        let _ = std::fs::remove_dir_all(&selected);
+        assert!(sentinel.exists());
+        let _ = std::fs::remove_dir_all(&explicit_dir);
+    }
+}

--- a/mux/crates/mux-cdp/src/client.rs
+++ b/mux/crates/mux-cdp/src/client.rs
@@ -1,0 +1,537 @@
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{channel, Sender};
+use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tungstenite::client::IntoClientRequest;
+use tungstenite::{client, Error as WsError, Message, WebSocket};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScreencastFrame {
+    pub session_id: String,
+    pub data_b64: String,
+    pub css_width: u32,
+    pub css_height: u32,
+    pub seq: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetInfo {
+    pub session_id: Option<String>,
+    pub target_id: String,
+    pub title: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CdpEvent {
+    ScreencastFrame(ScreencastFrame),
+    TargetInfoChanged(TargetInfo),
+    Other { method: String, params: Value, session_id: Option<String> },
+    Closed(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CdpKeyEvent<'a> {
+    pub event_type: &'a str,
+    pub key: &'a str,
+    pub code: &'a str,
+    pub windows_virtual_key_code: u32,
+    pub modifiers: u32,
+    pub text: Option<&'a str>,
+}
+
+#[derive(Clone)]
+pub struct CdpClient {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    ws: Mutex<WebSocket<TcpStream>>,
+    pending: Mutex<HashMap<u64, Sender<Result<Value, String>>>>,
+    events: Sender<CdpEvent>,
+    next_id: AtomicU64,
+    closed: AtomicBool,
+    timeout: Duration,
+}
+
+impl CdpClient {
+    pub fn connect(web_socket_url: &str, events: Sender<CdpEvent>) -> anyhow::Result<Self> {
+        let endpoint = WsEndpoint::parse(web_socket_url)?;
+        let mut addrs = (endpoint.host.as_str(), endpoint.port).to_socket_addrs()?;
+        let addr = addrs.next().ok_or_else(|| {
+            anyhow::anyhow!("no socket address for {}:{}", endpoint.host, endpoint.port)
+        })?;
+        let stream = TcpStream::connect_timeout(&addr, Duration::from_secs(5))?;
+        stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+        let request = web_socket_url.into_client_request()?;
+        let (ws, _) = client(request, stream)?;
+        ws.get_ref().set_read_timeout(Some(Duration::from_millis(100)))?;
+        ws.get_ref().set_write_timeout(Some(Duration::from_secs(5)))?;
+        let client = CdpClient {
+            inner: Arc::new(Inner {
+                ws: Mutex::new(ws),
+                pending: Mutex::new(HashMap::new()),
+                events,
+                next_id: AtomicU64::new(1),
+                closed: AtomicBool::new(false),
+                timeout: Duration::from_secs(10),
+            }),
+        };
+        client.spawn_reader()?;
+        Ok(client)
+    }
+
+    fn spawn_reader(&self) -> anyhow::Result<()> {
+        let weak = Arc::downgrade(&self.inner);
+        std::thread::Builder::new().name("mux-cdp-reader".into()).spawn(move || {
+            reader_loop(weak);
+        })?;
+        Ok(())
+    }
+
+    /// JSON-RPC call. Page-scoped commands pass a flat-session
+    /// `session_id`, which is emitted as the top-level CDP `sessionId`.
+    pub fn call(
+        &self,
+        method: &str,
+        params: Value,
+        session_id: Option<&str>,
+    ) -> anyhow::Result<Value> {
+        let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = channel();
+        self.inner.pending.lock().unwrap().insert(id, tx);
+
+        let mut msg = json!({
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        if let Some(session_id) = session_id {
+            msg["sessionId"] = json!(session_id);
+        }
+        if let Err(e) = self.send_value(&msg) {
+            self.inner.pending.lock().unwrap().remove(&id);
+            return Err(e);
+        }
+
+        match rx.recv_timeout(self.inner.timeout) {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(e)) => anyhow::bail!("{e}"),
+            Err(_) => {
+                self.inner.pending.lock().unwrap().remove(&id);
+                anyhow::bail!("CDP call {method} timed out")
+            }
+        }
+    }
+
+    pub fn set_discover_targets(&self, discover: bool) -> anyhow::Result<()> {
+        self.call("Target.setDiscoverTargets", json!({ "discover": discover }), None).map(|_| ())
+    }
+
+    pub fn create_target(&self, url: &str) -> anyhow::Result<String> {
+        let result = self.call("Target.createTarget", json!({ "url": url }), None)?;
+        result
+            .get("targetId")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| anyhow::anyhow!("Target.createTarget response missing targetId"))
+    }
+
+    pub fn attach_to_target(&self, target_id: &str) -> anyhow::Result<String> {
+        let result = self.call(
+            "Target.attachToTarget",
+            json!({ "targetId": target_id, "flatten": true }),
+            None,
+        )?;
+        result
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| anyhow::anyhow!("Target.attachToTarget response missing sessionId"))
+    }
+
+    pub fn close_target(&self, target_id: &str) -> anyhow::Result<()> {
+        self.call("Target.closeTarget", json!({ "targetId": target_id }), None).map(|_| ())
+    }
+
+    pub fn page_enable(&self, session_id: &str) -> anyhow::Result<()> {
+        self.call("Page.enable", json!({}), Some(session_id)).map(|_| ())
+    }
+
+    pub fn start_screencast(
+        &self,
+        session_id: &str,
+        max_width: u32,
+        max_height: u32,
+    ) -> anyhow::Result<()> {
+        self.call(
+            "Page.startScreencast",
+            json!({
+                "format": "png",
+                "maxWidth": max_width,
+                "maxHeight": max_height,
+                "everyNthFrame": 1,
+            }),
+            Some(session_id),
+        )
+        .map(|_| ())
+    }
+
+    pub fn stop_screencast(&self, session_id: &str) -> anyhow::Result<()> {
+        self.call("Page.stopScreencast", json!({}), Some(session_id)).map(|_| ())
+    }
+
+    pub fn navigate(&self, session_id: &str, url: &str) -> anyhow::Result<()> {
+        self.call("Page.navigate", json!({ "url": url }), Some(session_id)).map(|_| ())
+    }
+
+    pub fn set_device_metrics(
+        &self,
+        session_id: &str,
+        width: u32,
+        height: u32,
+    ) -> anyhow::Result<()> {
+        self.call(
+            "Emulation.setDeviceMetricsOverride",
+            json!({
+                "width": width.max(1),
+                "height": height.max(1),
+                "deviceScaleFactor": 1,
+                "mobile": false,
+            }),
+            Some(session_id),
+        )
+        .map(|_| ())
+    }
+
+    pub fn dispatch_mouse_event(
+        &self,
+        session_id: &str,
+        event_type: &str,
+        x: f64,
+        y: f64,
+        button: Option<&str>,
+        click_count: Option<u32>,
+    ) -> anyhow::Result<()> {
+        let mut params = json!({
+            "type": event_type,
+            "x": x,
+            "y": y,
+        });
+        if let Some(button) = button {
+            params["button"] = json!(button);
+        }
+        if let Some(click_count) = click_count {
+            params["clickCount"] = json!(click_count);
+        }
+        self.call("Input.dispatchMouseEvent", params, Some(session_id)).map(|_| ())
+    }
+
+    pub fn dispatch_wheel(
+        &self,
+        session_id: &str,
+        x: f64,
+        y: f64,
+        delta_y: f64,
+    ) -> anyhow::Result<()> {
+        self.call(
+            "Input.dispatchMouseEvent",
+            json!({
+                "type": "mouseWheel",
+                "x": x,
+                "y": y,
+                "deltaX": 0,
+                "deltaY": delta_y,
+            }),
+            Some(session_id),
+        )
+        .map(|_| ())
+    }
+
+    pub fn dispatch_key_event(
+        &self,
+        session_id: &str,
+        event: CdpKeyEvent<'_>,
+    ) -> anyhow::Result<()> {
+        let mut params = json!({
+            "type": event.event_type,
+            "key": event.key,
+            "code": event.code,
+            "windowsVirtualKeyCode": event.windows_virtual_key_code,
+            "nativeVirtualKeyCode": event.windows_virtual_key_code,
+            "modifiers": event.modifiers,
+        });
+        if let Some(text) = event.text {
+            params["text"] = json!(text);
+            params["unmodifiedText"] = json!(text);
+        }
+        self.call("Input.dispatchKeyEvent", params, Some(session_id)).map(|_| ())
+    }
+
+    pub fn insert_text(&self, session_id: &str, text: &str) -> anyhow::Result<()> {
+        self.call("Input.insertText", json!({ "text": text }), Some(session_id)).map(|_| ())
+    }
+
+    fn send_value(&self, value: &Value) -> anyhow::Result<()> {
+        if self.inner.closed.load(Ordering::Acquire) {
+            anyhow::bail!("CDP connection is closed");
+        }
+        let text = serde_json::to_string(value)?;
+        let mut ws = self.inner.ws.lock().unwrap();
+        ws.send(Message::Text(text))?;
+        Ok(())
+    }
+}
+
+pub fn resolve_browser_ws_url(input: &str) -> anyhow::Result<String> {
+    let trimmed = input.trim();
+    if trimmed.starts_with("ws://") {
+        return Ok(trimmed.to_string());
+    }
+    if trimmed.starts_with("http://") {
+        let endpoint = HttpEndpoint::parse(trimmed)?;
+        return fetch_json_version(&endpoint.host, endpoint.port);
+    }
+    anyhow::bail!("CDP URL must start with ws:// or http://, got {input:?}")
+}
+
+pub fn discover_browser_ws_url(ports: &[u16]) -> Option<String> {
+    ports.iter().find_map(|port| fetch_json_version("127.0.0.1", *port).ok())
+}
+
+fn reader_loop(weak: Weak<Inner>) {
+    loop {
+        let Some(inner) = weak.upgrade() else { break };
+        if inner.closed.load(Ordering::Acquire) {
+            break;
+        }
+        let message = {
+            let mut ws = inner.ws.lock().unwrap();
+            ws.read()
+        };
+        match message {
+            Ok(Message::Text(text)) => handle_text(&inner, &text),
+            Ok(Message::Binary(bytes)) => {
+                if let Ok(text) = String::from_utf8(bytes) {
+                    handle_text(&inner, &text);
+                }
+            }
+            Ok(Message::Close(_)) => {
+                close_inner(&inner, "CDP socket closed");
+                break;
+            }
+            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) | Ok(Message::Frame(_)) => {}
+            Err(WsError::Io(e))
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                continue;
+            }
+            Err(e) => {
+                close_inner(&inner, &format!("CDP socket error: {e}"));
+                break;
+            }
+        }
+    }
+}
+
+fn handle_text(inner: &Arc<Inner>, text: &str) {
+    let Ok(value) = serde_json::from_str::<Value>(text) else { return };
+    if let Some(id) = value.get("id").and_then(|v| v.as_u64()) {
+        if let Some(tx) = inner.pending.lock().unwrap().remove(&id) {
+            let response = if let Some(error) = value.get("error") {
+                Err(error.to_string())
+            } else {
+                Ok(value.get("result").cloned().unwrap_or(Value::Null))
+            };
+            let _ = tx.send(response);
+        }
+        return;
+    }
+
+    let Some(method) = value.get("method").and_then(|v| v.as_str()) else { return };
+    let params = value.get("params").cloned().unwrap_or(Value::Null);
+    let session_id = value.get("sessionId").and_then(|v| v.as_str()).map(str::to_string);
+    match method {
+        "Page.screencastFrame" => {
+            if let Some(target_session) = session_id.as_deref() {
+                let Some(frame) = screencast_frame(&params, target_session) else { return };
+                ack_screencast_frame(inner, target_session, frame.seq);
+                let _ = inner.events.send(CdpEvent::ScreencastFrame(frame));
+            }
+        }
+        "Target.targetInfoChanged" => {
+            if let Some(info) = target_info(&params, session_id.as_deref()) {
+                let _ = inner.events.send(CdpEvent::TargetInfoChanged(info));
+            }
+        }
+        _ => {
+            let _ = inner.events.send(CdpEvent::Other {
+                method: method.to_string(),
+                params,
+                session_id,
+            });
+        }
+    }
+}
+
+fn ack_screencast_frame(inner: &Arc<Inner>, target_session: &str, frame_session: u64) {
+    let id = inner.next_id.fetch_add(1, Ordering::Relaxed);
+    let msg = json!({
+        "id": id,
+        "method": "Page.screencastFrameAck",
+        "sessionId": target_session,
+        "params": { "sessionId": frame_session },
+    });
+    let Ok(text) = serde_json::to_string(&msg) else { return };
+    let _ = inner.ws.lock().unwrap().send(Message::Text(text));
+}
+
+fn screencast_frame(params: &Value, session_id: &str) -> Option<ScreencastFrame> {
+    let data_b64 = params.get("data")?.as_str()?.to_string();
+    let seq = params.get("sessionId")?.as_u64()?;
+    let metadata = params.get("metadata").unwrap_or(&Value::Null);
+    let css_width = metadata
+        .get("deviceWidth")
+        .and_then(|v| v.as_u64())
+        .or_else(|| metadata.get("width").and_then(|v| v.as_u64()))
+        .unwrap_or(0) as u32;
+    let css_height = metadata
+        .get("deviceHeight")
+        .and_then(|v| v.as_u64())
+        .or_else(|| metadata.get("height").and_then(|v| v.as_u64()))
+        .unwrap_or(0) as u32;
+    Some(ScreencastFrame {
+        session_id: session_id.to_string(),
+        data_b64,
+        css_width,
+        css_height,
+        seq,
+    })
+}
+
+fn target_info(params: &Value, session_id: Option<&str>) -> Option<TargetInfo> {
+    let info = params.get("targetInfo")?;
+    Some(TargetInfo {
+        session_id: session_id.map(str::to_string),
+        target_id: info.get("targetId")?.as_str()?.to_string(),
+        title: info.get("title").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+        url: info.get("url").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+    })
+}
+
+fn close_inner(inner: &Arc<Inner>, why: &str) {
+    if inner.closed.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    for (_, tx) in inner.pending.lock().unwrap().drain() {
+        let _ = tx.send(Err(why.to_string()));
+    }
+    let _ = inner.events.send(CdpEvent::Closed(why.to_string()));
+}
+
+struct WsEndpoint {
+    host: String,
+    port: u16,
+}
+
+struct HttpEndpoint {
+    host: String,
+    port: u16,
+}
+
+impl HttpEndpoint {
+    fn parse(url: &str) -> anyhow::Result<Self> {
+        let rest = url
+            .strip_prefix("http://")
+            .ok_or_else(|| anyhow::anyhow!("CDP discovery URL must be http://, got {url:?}"))?;
+        let host_port = rest.split('/').next().unwrap_or(rest);
+        let (host, port) = match host_port.rsplit_once(':') {
+            Some((host, port)) => (host, port.parse::<u16>()?),
+            None => (host_port, 80),
+        };
+        Ok(HttpEndpoint { host: host.trim_matches(['[', ']']).to_string(), port })
+    }
+}
+
+fn fetch_json_version(host: &str, port: u16) -> anyhow::Result<String> {
+    let mut addrs = (host, port).to_socket_addrs()?;
+    let addr =
+        addrs.next().ok_or_else(|| anyhow::anyhow!("no socket address for {host}:{port}"))?;
+    let mut stream = TcpStream::connect_timeout(&addr, Duration::from_millis(250))?;
+    stream.set_read_timeout(Some(Duration::from_millis(500)))?;
+    stream.set_write_timeout(Some(Duration::from_millis(500)))?;
+    write!(
+        stream,
+        "GET /json/version HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n"
+    )?;
+    stream.flush()?;
+    let response = read_http_response(&mut stream)?;
+    let body = response
+        .split_once("\r\n\r\n")
+        .map(|(_, body)| body)
+        .ok_or_else(|| anyhow::anyhow!("bad /json/version response from {host}:{port}"))?;
+    let value: Value = serde_json::from_str(body)?;
+    value
+        .get("webSocketDebuggerUrl")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("/json/version missing webSocketDebuggerUrl"))
+}
+
+fn read_http_response(stream: &mut TcpStream) -> anyhow::Result<String> {
+    let mut bytes = Vec::new();
+    let mut buf = [0u8; 1024];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                bytes.extend_from_slice(&buf[..n]);
+                if complete_http_response(&bytes) {
+                    break;
+                }
+            }
+            Err(e) if !bytes.is_empty() && e.kind() == std::io::ErrorKind::ConnectionReset => {
+                break;
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+    Ok(String::from_utf8(bytes)?)
+}
+
+fn complete_http_response(bytes: &[u8]) -> bool {
+    let Some(header_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") else {
+        return false;
+    };
+    let headers = String::from_utf8_lossy(&bytes[..header_end]);
+    let Some(content_len) = headers.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("content-length").then(|| value.trim().parse::<usize>().ok())?
+    }) else {
+        return false;
+    };
+    bytes.len() >= header_end + 4 + content_len
+}
+
+impl WsEndpoint {
+    fn parse(url: &str) -> anyhow::Result<Self> {
+        let rest = url.strip_prefix("ws://").ok_or_else(|| {
+            anyhow::anyhow!("CDP endpoint must be an unencrypted ws:// URL, got {url:?}")
+        })?;
+        let host_port = rest.split('/').next().unwrap_or(rest);
+        let (host, port) = match host_port.rsplit_once(':') {
+            Some((host, port)) => (host, port.parse::<u16>()?),
+            None => (host_port, 80),
+        };
+        Ok(WsEndpoint { host: host.trim_matches(['[', ']']).to_string(), port })
+    }
+}

--- a/mux/crates/mux-cdp/src/client.rs
+++ b/mux/crates/mux-cdp/src/client.rs
@@ -45,6 +45,11 @@ pub struct CdpKeyEvent<'a> {
     pub text: Option<&'a str>,
 }
 
+fn cdp_debug() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("CMUX_MUX_CDP_DEBUG").is_some())
+}
+
 #[derive(Clone)]
 pub struct CdpClient {
     inner: Arc<Inner>,
@@ -80,7 +85,7 @@ impl CdpClient {
                 events,
                 next_id: AtomicU64::new(1),
                 closed: AtomicBool::new(false),
-                timeout: Duration::from_secs(10),
+                timeout: Duration::from_secs(30),
             }),
         };
         client.spawn_reader()?;
@@ -283,6 +288,9 @@ impl CdpClient {
             anyhow::bail!("CDP connection is closed");
         }
         let text = serde_json::to_string(value)?;
+        if cdp_debug() {
+            eprintln!("cdp-> {text}");
+        }
         let mut ws = self.inner.ws.lock().unwrap();
         ws.send(Message::Text(text))?;
         Ok(())
@@ -344,6 +352,9 @@ fn reader_loop(weak: Weak<Inner>) {
 }
 
 fn handle_text(inner: &Arc<Inner>, text: &str) {
+    if cdp_debug() {
+        eprintln!("cdp<- {}", &text[..text.len().min(300)]);
+    }
     let Ok(value) = serde_json::from_str::<Value>(text) else { return };
     if let Some(id) = value.get("id").and_then(|v| v.as_u64()) {
         if let Some(tx) = inner.pending.lock().unwrap().remove(&id) {

--- a/mux/crates/mux-cdp/src/lib.rs
+++ b/mux/crates/mux-cdp/src/lib.rs
@@ -1,0 +1,14 @@
+//! Synchronous Chrome DevTools Protocol support for cmux-mux.
+//!
+//! This crate intentionally stays on `std::thread`, `std::sync::mpsc`,
+//! and blocking sockets. The mux runtime is synchronous, and browser
+//! panes are local-only in v1.
+
+mod chrome;
+mod client;
+
+pub use chrome::{default_user_data_dir, find_chrome_binary, Chrome, ChromeLaunchOptions};
+pub use client::{
+    discover_browser_ws_url, resolve_browser_ws_url, CdpClient, CdpEvent, CdpKeyEvent,
+    ScreencastFrame, TargetInfo,
+};

--- a/mux/crates/mux-cdp/tests/chrome_smoke.rs
+++ b/mux/crates/mux-cdp/tests/chrome_smoke.rs
@@ -1,0 +1,15 @@
+#[test]
+fn chrome_smoke_is_env_gated() {
+    if std::env::var("CMUX_MUX_BROWSER_TEST").ok().as_deref() != Some("1") {
+        eprintln!("skipping Chrome smoke test; set CMUX_MUX_BROWSER_TEST=1 to run it");
+        return;
+    }
+
+    let chrome = mux_cdp::Chrome::launch(None).unwrap();
+    let (tx, _rx) = std::sync::mpsc::channel();
+    let client = mux_cdp::CdpClient::connect(chrome.web_socket_url(), tx).unwrap();
+    client.set_discover_targets(true).unwrap();
+    let target = client.create_target("about:blank").unwrap();
+    let session = client.attach_to_target(&target).unwrap();
+    client.page_enable(&session).unwrap();
+}

--- a/mux/crates/mux-cdp/tests/fake_cdp.rs
+++ b/mux/crates/mux-cdp/tests/fake_cdp.rs
@@ -1,0 +1,180 @@
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+use mux_cdp::{discover_browser_ws_url, resolve_browser_ws_url, CdpClient, CdpEvent};
+use serde_json::{json, Value};
+use tungstenite::{accept, Message};
+
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn read_json(ws: &mut tungstenite::WebSocket<std::net::TcpStream>) -> serde_json::Value {
+    loop {
+        match ws.read().unwrap() {
+            Message::Text(text) => return serde_json::from_str(&text).unwrap(),
+            Message::Binary(bytes) => return serde_json::from_slice(&bytes).unwrap(),
+            _ => {}
+        }
+    }
+}
+
+fn write_json(ws: &mut tungstenite::WebSocket<std::net::TcpStream>, value: Value) {
+    ws.send(Message::Text(value.to_string())).unwrap();
+}
+
+#[test]
+fn fake_cdp_flat_sessions_correlation_events_and_screencast_ack() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut ws = accept(stream).unwrap();
+
+        let create = read_json(&mut ws);
+        assert_eq!(create["method"], "Target.createTarget");
+        assert_eq!(create["params"]["url"], "https://example.test");
+        write_json(&mut ws, json!({"id": create["id"], "result": {"targetId": "target-1"}}));
+
+        let attach = read_json(&mut ws);
+        assert_eq!(attach["method"], "Target.attachToTarget");
+        assert_eq!(attach["params"]["targetId"], "target-1");
+        assert_eq!(attach["params"]["flatten"], true);
+        write_json(&mut ws, json!({"id": attach["id"], "result": {"sessionId": "session-1"}}));
+
+        let first = read_json(&mut ws);
+        let second = read_json(&mut ws);
+        assert_eq!(first["sessionId"], "session-1");
+        assert_eq!(second["sessionId"], "session-1");
+        write_json(&mut ws, json!({"id": second["id"], "result": {"name": second["method"]}}));
+        write_json(&mut ws, json!({"id": first["id"], "result": {"name": first["method"]}}));
+
+        write_json(
+            &mut ws,
+            json!({
+                "method": "Target.targetInfoChanged",
+                "params": {
+                    "targetInfo": {
+                        "targetId": "target-1",
+                        "title": "Example",
+                        "url": "https://example.test/"
+                    }
+                }
+            }),
+        );
+
+        write_json(
+            &mut ws,
+            json!({
+                "method": "Page.screencastFrame",
+                "sessionId": "session-1",
+                "params": {
+                    "data": "iVBORw0KGgo=",
+                    "metadata": {"deviceWidth": 640, "deviceHeight": 480},
+                    "sessionId": 42
+                }
+            }),
+        );
+        let ack = read_json(&mut ws);
+        assert_eq!(ack["method"], "Page.screencastFrameAck");
+        assert_eq!(ack["sessionId"], "session-1");
+        assert_eq!(ack["params"]["sessionId"], 42);
+        write_json(&mut ws, json!({"id": ack["id"], "result": {}}));
+    });
+
+    let (event_tx, event_rx) = std::sync::mpsc::channel();
+    let client =
+        CdpClient::connect(&format!("ws://{addr}/devtools/browser/fake"), event_tx).unwrap();
+    let target_id = client.create_target("https://example.test").unwrap();
+    assert_eq!(target_id, "target-1");
+    let session_id = client.attach_to_target(&target_id).unwrap();
+    assert_eq!(session_id, "session-1");
+
+    let left = {
+        let client = client.clone();
+        let session_id = session_id.clone();
+        thread::spawn(move || client.call("Test.left", json!({}), Some(&session_id)).unwrap())
+    };
+    let right = {
+        let client = client.clone();
+        let session_id = session_id.clone();
+        thread::spawn(move || client.call("Test.right", json!({}), Some(&session_id)).unwrap())
+    };
+    let left = left.join().unwrap();
+    let right = right.join().unwrap();
+    assert_eq!(left["name"], "Test.left");
+    assert_eq!(right["name"], "Test.right");
+
+    let info = event_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    match info {
+        CdpEvent::TargetInfoChanged(info) => {
+            assert_eq!(info.session_id, None);
+            assert_eq!(info.target_id, "target-1");
+            assert_eq!(info.title, "Example");
+            assert_eq!(info.url, "https://example.test/");
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+
+    let frame = event_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    match frame {
+        CdpEvent::ScreencastFrame(frame) => {
+            assert_eq!(frame.session_id, "session-1");
+            assert_eq!(frame.data_b64, "iVBORw0KGgo=");
+            assert_eq!(frame.css_width, 640);
+            assert_eq!(frame.css_height, 480);
+            assert_eq!(frame.seq, 42);
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+
+    server.join().unwrap();
+}
+
+#[test]
+fn resolves_json_version_and_discovers_loopback_port() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    let (port, expected, server) = serve_json_version_once();
+    assert_eq!(resolve_browser_ws_url(&format!("http://127.0.0.1:{port}")).unwrap(), expected);
+    server.join().unwrap();
+
+    let (port, expected, server) = serve_json_version_once();
+    assert_eq!(discover_browser_ws_url(&[port]).unwrap(), expected);
+    server.join().unwrap();
+}
+
+fn serve_json_version_once() -> (u16, String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let expected = format!("ws://127.0.0.1:{port}/devtools/browser/external");
+
+    let server = thread::spawn({
+        let expected = expected.clone();
+        move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request_bytes = Vec::new();
+            let mut buf = [0u8; 1024];
+            while !request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                let n = stream.read(&mut buf).unwrap();
+                if n == 0 {
+                    break;
+                }
+                request_bytes.extend_from_slice(&buf[..n]);
+            }
+            let request = String::from_utf8_lossy(&request_bytes);
+            assert!(request.starts_with("GET /json/version HTTP/1.1\r\n"));
+            let body = json!({ "webSocketDebuggerUrl": expected }).to_string();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        }
+    });
+    (port, expected, server)
+}

--- a/mux/crates/mux-core/Cargo.toml
+++ b/mux/crates/mux-core/Cargo.toml
@@ -8,9 +8,13 @@ description = "Terminal multiplexer core: workspaces, tabs, panes, PTY runtime, 
 
 [dependencies]
 ghostty-vt.workspace = true
+mux-cdp.workspace = true
 portable-pty.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
 base64.workspace = true
 libc.workspace = true
+
+[dev-dependencies]
+tungstenite.workspace = true

--- a/mux/crates/mux-core/src/browser.rs
+++ b/mux/crates/mux-core/src/browser.rs
@@ -206,6 +206,12 @@ fn runtime_endpoint(
         }
     }
 
+    if std::env::var_os("CMUX_MUX_CDP_DEBUG").is_some() {
+        eprintln!(
+            "cdp: no external endpoint (discover={}); launching chrome",
+            opts.browser_discover
+        );
+    }
     let chrome = Chrome::launch_with(ChromeLaunchOptions {
         binary: opts.chrome_binary.clone(),
         user_data_dir: opts.browser_user_data_dir.as_deref().map(PathBuf::from),

--- a/mux/crates/mux-core/src/browser.rs
+++ b/mux/crates/mux-core/src/browser.rs
@@ -1,0 +1,475 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::{Arc, Mutex, Weak};
+
+use mux_cdp::{
+    discover_browser_ws_url, resolve_browser_ws_url, CdpClient, CdpEvent, CdpKeyEvent, Chrome,
+    ChromeLaunchOptions,
+};
+
+use crate::surface::{Surface, SurfaceMeta, SurfaceOptions};
+use crate::{Mux, MuxEvent, SurfaceId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowserSource {
+    External,
+    Launched,
+}
+
+impl BrowserSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BrowserSource::External => "external",
+            BrowserSource::Launched => "launched",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFrame {
+    pub session_id: String,
+    pub data_b64: String,
+    pub css_width: u32,
+    pub css_height: u32,
+    pub seq: u64,
+}
+
+pub struct BrowserRuntime {
+    client: CdpClient,
+    chrome: Option<Chrome>,
+    source: BrowserSource,
+    routes: Mutex<Routes>,
+    closed: AtomicBool,
+}
+
+#[derive(Default)]
+struct Routes {
+    by_session: HashMap<String, Sender<CdpEvent>>,
+    by_target: HashMap<String, Sender<CdpEvent>>,
+}
+
+pub struct BrowserSurface {
+    pub(crate) meta: SurfaceMeta,
+    runtime: Arc<BrowserRuntime>,
+    target_id: String,
+    session_id: String,
+    latest_frame: Mutex<Option<BrowserFrame>>,
+    dirty: AtomicBool,
+    dead: AtomicBool,
+    title: Mutex<String>,
+    url: Mutex<String>,
+    size: Mutex<(u16, u16)>,
+    cell_pixels: Mutex<(u16, u16)>,
+    pixels: Mutex<(u32, u32)>,
+}
+
+impl BrowserRuntime {
+    pub fn connect(opts: &SurfaceOptions) -> anyhow::Result<Arc<Self>> {
+        let (web_socket_url, chrome, source) = runtime_endpoint(opts)?;
+        let (event_tx, event_rx) = std::sync::mpsc::channel();
+        let client = CdpClient::connect(&web_socket_url, event_tx)?;
+        client.set_discover_targets(true)?;
+        let runtime = Arc::new(BrowserRuntime {
+            client,
+            chrome,
+            source,
+            routes: Mutex::new(Routes::default()),
+            closed: AtomicBool::new(false),
+        });
+        start_router(runtime.clone(), event_rx)?;
+        Ok(runtime)
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    pub fn source(&self) -> BrowserSource {
+        self.source
+    }
+
+    pub fn spawn_surface(
+        self: &Arc<Self>,
+        id: SurfaceId,
+        url: String,
+        mux: Weak<Mux>,
+        size: (u16, u16),
+        cell_pixels: (u16, u16),
+    ) -> anyhow::Result<Arc<Surface>> {
+        if self.is_closed() {
+            anyhow::bail!("CDP browser connection is closed");
+        }
+
+        let normalized_url = normalize_url(&url);
+        let target_id = self.client.create_target(&normalized_url)?;
+        let session_id = self.client.attach_to_target(&target_id)?;
+        let (event_tx, event_rx) = std::sync::mpsc::channel();
+        self.register(&target_id, &session_id, event_tx);
+
+        let setup_result = (|| -> anyhow::Result<()> {
+            self.client.page_enable(&session_id)?;
+            let (cols, rows) = (size.0.max(1), size.1.max(1));
+            let (cell_w, cell_h) = (cell_pixels.0.max(1), cell_pixels.1.max(1));
+            let pixel_w = cols as u32 * cell_w as u32;
+            let pixel_h = rows as u32 * cell_h as u32;
+            self.client.set_device_metrics(&session_id, pixel_w, pixel_h)?;
+            self.client.start_screencast(&session_id, pixel_w, pixel_h)?;
+            Ok(())
+        })();
+        if let Err(err) = setup_result {
+            self.unregister(&target_id, &session_id);
+            let _ = self.client.close_target(&target_id);
+            return Err(err);
+        }
+
+        let (cols, rows) = (size.0.max(1), size.1.max(1));
+        let (cell_w, cell_h) = (cell_pixels.0.max(1), cell_pixels.1.max(1));
+        let pixel_w = cols as u32 * cell_w as u32;
+        let pixel_h = rows as u32 * cell_h as u32;
+        let surface = Arc::new(Surface::Browser(BrowserSurface {
+            meta: SurfaceMeta { id },
+            runtime: self.clone(),
+            target_id,
+            session_id,
+            latest_frame: Mutex::new(None),
+            dirty: AtomicBool::new(true),
+            dead: AtomicBool::new(false),
+            title: Mutex::new(normalized_url.clone()),
+            url: Mutex::new(normalized_url),
+            size: Mutex::new((cols, rows)),
+            cell_pixels: Mutex::new((cell_w, cell_h)),
+            pixels: Mutex::new((pixel_w, pixel_h)),
+        }));
+        start_surface_thread(surface.clone(), event_rx, mux)?;
+        Ok(surface)
+    }
+
+    fn register(&self, target_id: &str, session_id: &str, tx: Sender<CdpEvent>) {
+        let mut routes = self.routes.lock().unwrap();
+        routes.by_session.insert(session_id.to_string(), tx.clone());
+        routes.by_target.insert(target_id.to_string(), tx);
+    }
+
+    fn unregister(&self, target_id: &str, session_id: &str) {
+        let mut routes = self.routes.lock().unwrap();
+        routes.by_session.remove(session_id);
+        routes.by_target.remove(target_id);
+    }
+
+    fn close_surface(&self, target_id: &str, session_id: &str) {
+        self.unregister(target_id, session_id);
+        if !self.is_closed() {
+            let _ = self.client.close_target(target_id);
+        }
+    }
+
+    pub fn shutdown(&self) {
+        self.closed.store(true, Ordering::Release);
+        if let Some(chrome) = &self.chrome {
+            chrome.kill();
+        }
+    }
+}
+
+pub(crate) fn spawn(
+    id: SurfaceId,
+    url: String,
+    runtime: Arc<BrowserRuntime>,
+    mux: Weak<Mux>,
+    size: (u16, u16),
+    cell_pixels: (u16, u16),
+) -> anyhow::Result<Arc<Surface>> {
+    runtime.spawn_surface(id, url, mux, size, cell_pixels)
+}
+
+fn runtime_endpoint(
+    opts: &SurfaceOptions,
+) -> anyhow::Result<(String, Option<Chrome>, BrowserSource)> {
+    if let Ok(url) = std::env::var("CMUX_MUX_CDP_URL") {
+        if !url.trim().is_empty() {
+            return Ok((resolve_browser_ws_url(&url)?, None, BrowserSource::External));
+        }
+    }
+    if let Some(url) = opts.cdp_url.as_deref().filter(|url| !url.trim().is_empty()) {
+        return Ok((resolve_browser_ws_url(url)?, None, BrowserSource::External));
+    }
+    if opts.browser_discover {
+        let ports = if opts.browser_discover_ports.is_empty() {
+            &[9222][..]
+        } else {
+            opts.browser_discover_ports.as_slice()
+        };
+        if let Some(url) = discover_browser_ws_url(ports) {
+            return Ok((url, None, BrowserSource::External));
+        }
+    }
+
+    let chrome = Chrome::launch_with(ChromeLaunchOptions {
+        binary: opts.chrome_binary.clone(),
+        user_data_dir: opts.browser_user_data_dir.as_deref().map(PathBuf::from),
+        ephemeral: opts.browser_ephemeral,
+    })?;
+    let web_socket_url = chrome.web_socket_url().to_string();
+    Ok((web_socket_url, Some(chrome), BrowserSource::Launched))
+}
+
+fn start_router(runtime: Arc<BrowserRuntime>, events: Receiver<CdpEvent>) -> anyhow::Result<()> {
+    std::thread::Builder::new().name("browser-runtime-events".into()).spawn(move || {
+        while let Ok(event) = events.recv() {
+            match event {
+                CdpEvent::ScreencastFrame(frame) => {
+                    let tx = {
+                        runtime.routes.lock().unwrap().by_session.get(&frame.session_id).cloned()
+                    };
+                    if let Some(tx) = tx {
+                        let _ = tx.send(CdpEvent::ScreencastFrame(frame));
+                    }
+                }
+                CdpEvent::TargetInfoChanged(info) => {
+                    let tx =
+                        { runtime.routes.lock().unwrap().by_target.get(&info.target_id).cloned() };
+                    if let Some(tx) = tx {
+                        let _ = tx.send(CdpEvent::TargetInfoChanged(info));
+                    }
+                }
+                CdpEvent::Other { method, params, session_id: Some(session_id) } => {
+                    let tx =
+                        { runtime.routes.lock().unwrap().by_session.get(&session_id).cloned() };
+                    if let Some(tx) = tx {
+                        let _ = tx.send(CdpEvent::Other {
+                            method,
+                            params,
+                            session_id: Some(session_id),
+                        });
+                    }
+                }
+                CdpEvent::Closed(reason) => {
+                    runtime.closed.store(true, Ordering::Release);
+                    let senders = {
+                        let mut routes = runtime.routes.lock().unwrap();
+                        let senders = routes.by_session.values().cloned().collect::<Vec<_>>();
+                        routes.by_session.clear();
+                        routes.by_target.clear();
+                        senders
+                    };
+                    for tx in senders {
+                        let _ = tx.send(CdpEvent::Closed(reason.clone()));
+                    }
+                    break;
+                }
+                CdpEvent::Other { .. } => {}
+            }
+        }
+    })?;
+    Ok(())
+}
+
+fn start_surface_thread(
+    surface: Arc<Surface>,
+    events: Receiver<CdpEvent>,
+    mux: Weak<Mux>,
+) -> anyhow::Result<()> {
+    let id = surface.id;
+    std::thread::Builder::new().name(format!("browser-surface-{id}-events")).spawn(move || {
+        while let Ok(event) = events.recv() {
+            let Surface::Browser(browser) = surface.as_ref() else { break };
+            match event {
+                CdpEvent::ScreencastFrame(frame) => {
+                    let frame = BrowserFrame {
+                        session_id: frame.session_id,
+                        data_b64: frame.data_b64,
+                        css_width: frame.css_width,
+                        css_height: frame.css_height,
+                        seq: frame.seq,
+                    };
+                    *browser.latest_frame.lock().unwrap() = Some(frame);
+                    if !browser.dirty.swap(true, Ordering::AcqRel) {
+                        if let Some(mux) = mux.upgrade() {
+                            mux.emit(MuxEvent::SurfaceOutput(id));
+                        }
+                    }
+                }
+                CdpEvent::TargetInfoChanged(info) => {
+                    let title = if info.title.is_empty() { info.url.clone() } else { info.title };
+                    if !info.url.is_empty() {
+                        *browser.url.lock().unwrap() = info.url;
+                    }
+                    let mut current = browser.title.lock().unwrap();
+                    if *current != title {
+                        *current = title;
+                        drop(current);
+                        if let Some(mux) = mux.upgrade() {
+                            mux.emit(MuxEvent::TitleChanged(id));
+                        }
+                    }
+                }
+                CdpEvent::Closed(_) => {
+                    browser.dead.store(true, Ordering::Release);
+                    if let Some(mux) = mux.upgrade() {
+                        mux.surface_exited(id);
+                    }
+                    break;
+                }
+                _ => {}
+            }
+        }
+    })?;
+    Ok(())
+}
+
+impl BrowserSurface {
+    pub fn latest_frame(&self) -> Option<BrowserFrame> {
+        self.latest_frame.lock().unwrap().clone()
+    }
+
+    pub fn title(&self) -> String {
+        self.title.lock().unwrap().clone()
+    }
+
+    pub fn url(&self) -> String {
+        self.url.lock().unwrap().clone()
+    }
+
+    pub fn source(&self) -> BrowserSource {
+        self.runtime.source()
+    }
+
+    pub fn size(&self) -> (u16, u16) {
+        *self.size.lock().unwrap()
+    }
+
+    pub fn is_dead(&self) -> bool {
+        self.dead.load(Ordering::Acquire)
+    }
+
+    pub fn take_dirty(&self) -> bool {
+        self.dirty.swap(false, Ordering::AcqRel)
+    }
+
+    pub fn kill(&self) {
+        if self.dead.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        self.runtime.close_surface(&self.target_id, &self.session_id);
+    }
+
+    pub fn resize(&self, cols: u16, rows: u16) {
+        if let Err(e) = self.try_resize(cols, rows) {
+            eprintln!("cmux-mux: browser resize failed for surface {}: {e}", self.meta.id);
+        }
+    }
+
+    pub fn set_cell_pixel_size(&self, width_px: u16, height_px: u16) {
+        {
+            let mut cell = self.cell_pixels.lock().unwrap();
+            let next = (width_px.max(1), height_px.max(1));
+            if *cell == next {
+                return;
+            }
+            *cell = next;
+        }
+        let (cols, rows) = self.size();
+        self.resize(cols, rows);
+    }
+
+    fn try_resize(&self, cols: u16, rows: u16) -> anyhow::Result<()> {
+        let (cols, rows) = (cols.max(1), rows.max(1));
+        let cell = *self.cell_pixels.lock().unwrap();
+        let pixel_w = cols as u32 * cell.0.max(1) as u32;
+        let pixel_h = rows as u32 * cell.1.max(1) as u32;
+        let unchanged = {
+            let mut size = self.size.lock().unwrap();
+            let mut pixels = self.pixels.lock().unwrap();
+            let unchanged = *size == (cols, rows) && *pixels == (pixel_w, pixel_h);
+            *size = (cols, rows);
+            *pixels = (pixel_w, pixel_h);
+            unchanged
+        };
+        if unchanged {
+            return Ok(());
+        }
+        self.runtime.client.set_device_metrics(&self.session_id, pixel_w, pixel_h)?;
+        let _ = self.runtime.client.stop_screencast(&self.session_id);
+        self.runtime.client.start_screencast(&self.session_id, pixel_w, pixel_h)?;
+        Ok(())
+    }
+
+    pub fn mouse_event(
+        &self,
+        event_type: &str,
+        x: f64,
+        y: f64,
+        button: Option<&str>,
+        click_count: Option<u32>,
+    ) -> anyhow::Result<()> {
+        self.runtime.client.dispatch_mouse_event(
+            &self.session_id,
+            event_type,
+            x,
+            y,
+            button,
+            click_count,
+        )
+    }
+
+    pub fn wheel(&self, x: f64, y: f64, delta_y: f64) -> anyhow::Result<()> {
+        self.runtime.client.dispatch_wheel(&self.session_id, x, y, delta_y)
+    }
+
+    pub fn key_event(
+        &self,
+        event_type: &str,
+        key: &str,
+        code: &str,
+        windows_virtual_key_code: u32,
+        modifiers: u32,
+        text: Option<&str>,
+    ) -> anyhow::Result<()> {
+        self.runtime.client.dispatch_key_event(
+            &self.session_id,
+            CdpKeyEvent { event_type, key, code, windows_virtual_key_code, modifiers, text },
+        )
+    }
+
+    pub fn insert_text(&self, text: &str) -> anyhow::Result<()> {
+        self.runtime.client.insert_text(&self.session_id, text)
+    }
+
+    pub fn navigate(&self, url: &str) -> anyhow::Result<()> {
+        let normalized = normalize_url(url);
+        self.runtime.client.navigate(&self.session_id, &normalized)?;
+        *self.url.lock().unwrap() = normalized.clone();
+        *self.title.lock().unwrap() = normalized;
+        Ok(())
+    }
+}
+
+pub(crate) fn normalize_url(input: &str) -> String {
+    let trimmed = input.trim();
+    if trimmed.contains("://")
+        || trimmed.starts_with("about:")
+        || trimmed.starts_with("file:")
+        || trimmed.starts_with("data:")
+        || trimmed.starts_with("chrome:")
+        || trimmed.starts_with("devtools:")
+    {
+        trimmed.to_string()
+    } else {
+        format!("https://{trimmed}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_url;
+
+    #[test]
+    fn normalizes_browser_urls() {
+        assert_eq!(normalize_url("example.com"), "https://example.com");
+        assert_eq!(normalize_url(" https://example.com "), "https://example.com");
+        assert_eq!(normalize_url("about:blank"), "about:blank");
+        assert_eq!(normalize_url("file:///tmp/test.html"), "file:///tmp/test.html");
+    }
+}

--- a/mux/crates/mux-core/src/lib.rs
+++ b/mux/crates/mux-core/src/lib.rs
@@ -8,6 +8,7 @@
 //! [`MuxEvent`]s and read surface state; they never own terminal state
 //! themselves, which is what makes the backend attachable.
 
+mod browser;
 mod model;
 mod mux;
 mod surface;
@@ -18,7 +19,9 @@ pub mod server;
 pub use layout::{layout_screen, split_sides, LayoutResult, Rect};
 pub use model::{Node, Pane, Screen, State, Workspace};
 pub use mux::{Mux, MuxEvent};
-pub use surface::{AttachStream, Surface, SurfaceOptions};
+pub use surface::{
+    AttachStream, BrowserFrame, BrowserSource, Surface, SurfaceKind, SurfaceOptions,
+};
 
 pub type SurfaceId = u64;
 pub type PaneId = u64;

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 
+use crate::browser::BrowserRuntime;
 use crate::model::{Node, Pane, Screen, State, Workspace};
 use crate::surface::{Surface, SurfaceOptions};
 use crate::{PaneId, ScreenId, SplitDir, SurfaceId, WorkspaceId};
@@ -33,6 +34,8 @@ pub struct Mux {
     subscribers: Mutex<Vec<Sender<MuxEvent>>>,
     next_id: AtomicU64,
     surface_options: SurfaceOptions,
+    browser_runtime: Mutex<Option<Arc<BrowserRuntime>>>,
+    cell_pixels: Mutex<(u16, u16)>,
     pub session: String,
 }
 
@@ -48,6 +51,8 @@ impl Mux {
             subscribers: Mutex::new(Vec::new()),
             next_id: AtomicU64::new(1),
             surface_options,
+            browser_runtime: Mutex::new(None),
+            cell_pixels: Mutex::new((8, 16)),
             session: session.into(),
         })
     }
@@ -89,6 +94,32 @@ impl Mux {
         Ok(surface)
     }
 
+    fn spawn_browser_surface(
+        self: &Arc<Self>,
+        url: String,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<Arc<Surface>> {
+        let id = self.next_id();
+        let opts = self.surface_options.clone();
+        let size = size.unwrap_or((opts.cols, opts.rows));
+        let cell_pixels = *self.cell_pixels.lock().unwrap();
+        let runtime = self.browser_runtime()?;
+        let surface =
+            Surface::spawn_browser(id, url, runtime, Arc::downgrade(self), size, cell_pixels)?;
+        self.state.lock().unwrap().surfaces.insert(id, surface.clone());
+        Ok(surface)
+    }
+
+    fn browser_runtime(&self) -> anyhow::Result<Arc<BrowserRuntime>> {
+        let mut runtime = self.browser_runtime.lock().unwrap();
+        if let Some(existing) = runtime.as_ref().filter(|existing| !existing.is_closed()) {
+            return Ok(existing.clone());
+        }
+        let created = BrowserRuntime::connect(&self.surface_options)?;
+        *runtime = Some(created.clone());
+        Ok(created)
+    }
+
     /// A fresh single-tab pane wrapping `surface`.
     fn make_pane(&self, surface: SurfaceId) -> (PaneId, Pane) {
         let id = self.next_id();
@@ -109,6 +140,31 @@ impl Mux {
 
     pub fn surface_count(&self) -> usize {
         self.state.lock().unwrap().surfaces.len()
+    }
+
+    pub fn shutdown(&self) {
+        let surfaces = self.state.lock().unwrap().surfaces.values().cloned().collect::<Vec<_>>();
+        for surface in surfaces {
+            surface.kill();
+        }
+        if let Some(runtime) = self.browser_runtime.lock().unwrap().take() {
+            runtime.shutdown();
+        }
+    }
+
+    pub fn set_cell_pixel_size(&self, width_px: u16, height_px: u16) {
+        let next = (width_px.max(1), height_px.max(1));
+        {
+            let mut cell = self.cell_pixels.lock().unwrap();
+            if *cell == next {
+                return;
+            }
+            *cell = next;
+        }
+        let surfaces = self.state.lock().unwrap().surfaces.values().cloned().collect::<Vec<_>>();
+        for surface in surfaces {
+            surface.set_cell_pixel_size(next.0, next.1);
+        }
     }
 
     /// Create a workspace with one screen holding one pane with one tab.
@@ -142,6 +198,7 @@ impl Mux {
             state.active_workspace = state.workspaces.len() - 1;
         }
         self.emit(MuxEvent::TreeChanged);
+        self.reap_if_dead(&surface);
         Ok(surface)
     }
 
@@ -199,6 +256,7 @@ impl Mux {
             anyhow::bail!("workspace disappeared while creating screen");
         }
         self.emit(MuxEvent::TreeChanged);
+        self.reap_if_dead(&surface);
         Ok(surface)
     }
 
@@ -252,6 +310,80 @@ impl Mux {
             anyhow::bail!("pane disappeared while creating tab");
         }
         self.emit(MuxEvent::TreeChanged);
+        self.reap_if_dead(&surface);
+        Ok(surface)
+    }
+
+    /// Create a browser tab in a pane (default: the active pane). When
+    /// the session has no workspaces yet, a workspace is created around
+    /// the browser tab.
+    pub fn new_browser_tab(
+        self: &Arc<Self>,
+        url: String,
+        pane: Option<PaneId>,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<Arc<Surface>> {
+        let target = {
+            let state = self.state.lock().unwrap();
+            match pane {
+                Some(id) => {
+                    if !state.panes.contains_key(&id) {
+                        anyhow::bail!("unknown pane {id}");
+                    }
+                    Some(id)
+                }
+                None => state.active_pane(),
+            }
+        };
+        let Some(target) = target else {
+            let surface = self.spawn_browser_surface(url, size)?;
+            let (pane_id, pane) = self.make_pane(surface.id);
+            let screen_id = self.next_id();
+            let ws_id = self.next_id();
+            {
+                let mut state = self.state.lock().unwrap();
+                let name = format!("{}", state.workspaces.len() + 1);
+                state.panes.insert(pane_id, pane);
+                state.workspaces.push(Workspace {
+                    id: ws_id,
+                    name,
+                    screens: vec![Screen {
+                        id: screen_id,
+                        name: None,
+                        root: Node::Leaf(pane_id),
+                        active_pane: pane_id,
+                    }],
+                    active_screen: 0,
+                });
+                state.active_workspace = state.workspaces.len() - 1;
+            }
+            self.emit(MuxEvent::TreeChanged);
+            self.reap_if_dead(&surface);
+            return Ok(surface);
+        };
+
+        let size = size.or_else(|| self.pane_size(target));
+        let surface = self.spawn_browser_surface(url, size)?;
+        let attached = {
+            let mut state = self.state.lock().unwrap();
+            match state.panes.get_mut(&target) {
+                Some(pane) => {
+                    pane.tabs.push(surface.id);
+                    pane.active_tab = pane.tabs.len() - 1;
+                    true
+                }
+                None => {
+                    state.surfaces.remove(&surface.id);
+                    false
+                }
+            }
+        };
+        if !attached {
+            surface.kill();
+            anyhow::bail!("pane disappeared while creating browser tab");
+        }
+        self.emit(MuxEvent::TreeChanged);
+        self.reap_if_dead(&surface);
         Ok(surface)
     }
 
@@ -318,6 +450,7 @@ impl Mux {
             anyhow::bail!("pane {target} not found");
         }
         self.emit(MuxEvent::TreeChanged);
+        self.reap_if_dead(&surface);
         Ok(surface)
     }
 
@@ -328,7 +461,8 @@ impl Mux {
             let mut state = self.state.lock().unwrap();
             (remove_surface(&mut state, target), state.workspaces.is_empty())
         };
-        if removed {
+        if let Some(surface) = removed {
+            surface.kill();
             self.emit(MuxEvent::TreeChanged);
         }
         if empty {
@@ -341,13 +475,18 @@ impl Mux {
     fn close_surfaces(&self, tabs: Vec<SurfaceId>) {
         let (removed, empty) = {
             let mut state = self.state.lock().unwrap();
-            let mut removed = false;
+            let mut removed = Vec::new();
             for surface in tabs {
-                removed |= remove_surface(&mut state, surface);
+                if let Some(surface) = remove_surface(&mut state, surface) {
+                    removed.push(surface);
+                }
             }
             (removed, state.workspaces.is_empty())
         };
-        if removed {
+        if !removed.is_empty() {
+            for surface in removed {
+                surface.kill();
+            }
             self.emit(MuxEvent::TreeChanged);
         }
         if empty {
@@ -453,6 +592,16 @@ impl Mux {
             self.emit(MuxEvent::TreeChanged);
         }
         renamed
+    }
+
+    /// Reap a surface whose child exited before its tree insert completed.
+    /// The exit handler sets the dead flag before calling `surface_exited`,
+    /// whose `close_surface` finds nothing to remove in that window; the
+    /// creator re-checks after the insert (a harmless no-op otherwise).
+    fn reap_if_dead(&self, surface: &Arc<Surface>) {
+        if surface.is_dead() {
+            self.close_surface(surface.id);
+        }
     }
 
     /// Called by a surface's reader thread when its child exits. The mux
@@ -562,16 +711,13 @@ fn screen_tabs(state: &State, screen: &Screen) -> Vec<SurfaceId> {
         .collect()
 }
 
-/// Remove one surface from the state: kill its child, detach it from its
+/// Remove one surface from the state: detach it from its
 /// pane, and collapse emptied panes/screens/workspaces. Returns whether
 /// anything was removed. Runs under the state lock.
-fn remove_surface(state: &mut State, target: SurfaceId) -> bool {
+fn remove_surface(state: &mut State, target: SurfaceId) -> Option<Arc<Surface>> {
     let removed = state.surfaces.remove(&target);
-    if let Some(surface) = &removed {
-        surface.kill();
-    }
     let Some(pane_id) = state.pane_of(target) else {
-        return removed.is_some();
+        return removed;
     };
     let pane = state.panes.get_mut(&pane_id).expect("pane_of returned live id");
     let idx = pane.tabs.iter().position(|id| *id == target).expect("tab in pane");
@@ -580,12 +726,14 @@ fn remove_surface(state: &mut State, target: SurfaceId) -> bool {
         if pane.active_tab >= idx && pane.active_tab > 0 {
             pane.active_tab -= 1;
         }
-        return true;
+        return removed;
     }
 
     // Last tab gone: the pane collapses out of its screen.
     state.panes.remove(&pane_id);
-    let Some((wi, si)) = state.screen_of(pane_id) else { return true };
+    let Some((wi, si)) = state.screen_of(pane_id) else {
+        return removed;
+    };
     let screen = &mut state.workspaces[wi].screens[si];
     match std::mem::replace(&mut screen.root, Node::Leaf(0)).remove_leaf(pane_id) {
         Some(root) => {
@@ -595,7 +743,7 @@ fn remove_surface(state: &mut State, target: SurfaceId) -> bool {
                 screen.root.pane_ids(&mut ids);
                 screen.active_pane = ids[0];
             }
-            return true;
+            return removed;
         }
         None => {
             // Screen emptied: drop it from the workspace.
@@ -603,7 +751,7 @@ fn remove_surface(state: &mut State, target: SurfaceId) -> bool {
             ws.screens.remove(si);
             ws.active_screen = ws.active_screen.min(ws.screens.len().saturating_sub(1));
             if !ws.screens.is_empty() {
-                return true;
+                return removed;
             }
         }
     }
@@ -614,7 +762,7 @@ fn remove_surface(state: &mut State, target: SurfaceId) -> bool {
     state.active_workspace = active_id
         .and_then(|id| state.workspaces.iter().position(|w| w.id == id))
         .unwrap_or_else(|| state.workspaces.len().saturating_sub(1));
-    true
+    removed
 }
 
 #[cfg(test)]

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -30,9 +30,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::model::{Screen, State};
-use crate::{Mux, MuxEvent, Node, PaneId, ScreenId, SplitDir, SurfaceId, WorkspaceId};
+use crate::{Mux, MuxEvent, Node, PaneId, ScreenId, SplitDir, SurfaceId, SurfaceKind, WorkspaceId};
 
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
 
 /// Default socket path for a session: `$TMPDIR/cmux-mux-<uid>/<session>.sock`.
 pub fn default_socket_path(session: &str) -> PathBuf {
@@ -76,6 +76,15 @@ enum Command {
         cwd: Option<String>,
         /// Expected content size in cells (spawn-at-size avoids shell
         /// redraw artifacts).
+        #[serde(default)]
+        cols: Option<u16>,
+        #[serde(default)]
+        rows: Option<u16>,
+    },
+    NewBrowserTab {
+        url: String,
+        #[serde(default)]
+        pane: Option<PaneId>,
         #[serde(default)]
         cols: Option<u16>,
         #[serde(default)]
@@ -291,6 +300,8 @@ fn pane_json(state: &State, id: PaneId) -> Value {
             let surface = state.surfaces.get(sid);
             json!({
                 "surface": sid,
+                "kind": surface.map(|s| s.kind().as_str()).unwrap_or("pty"),
+                "browser_source": surface.and_then(|s| s.browser_source().map(|source| source.as_str())),
                 "title": surface.map(|s| s.title()).unwrap_or_default(),
                 "size": surface.map(|s| {
                     let (c, r) = s.size();
@@ -334,6 +345,14 @@ fn get_surface(mux: &Mux, id: SurfaceId) -> anyhow::Result<Arc<crate::Surface>> 
     mux.surface(id).ok_or_else(|| anyhow::anyhow!("unknown surface {id}"))
 }
 
+fn require_pty(surface: &crate::Surface) -> anyhow::Result<()> {
+    if surface.kind() == SurfaceKind::Pty {
+        Ok(())
+    } else {
+        anyhow::bail!("browser surface does not support PTY/VT socket commands")
+    }
+}
+
 fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::Result<Value> {
     match cmd {
         Command::Identify => Ok(json!({
@@ -346,6 +365,7 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
         Command::ListWorkspaces => Ok(mux.with_state(workspaces_json)),
         Command::Send { surface, text, bytes } => {
             let surface = get_surface(mux, surface)?;
+            require_pty(&surface)?;
             if let Some(text) = text {
                 surface.write_bytes(text.as_bytes())?;
             }
@@ -357,13 +377,16 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
         }
         Command::ReadScreen { surface } => {
             let surface = get_surface(mux, surface)?;
-            let text = surface.with_terminal(|t| t.plain_text())?;
+            require_pty(&surface)?;
+            let text = surface.try_with_terminal(|t| t.plain_text())??;
             Ok(json!({ "text": text }))
         }
         Command::VtState { surface } => {
             let surface = get_surface(mux, surface)?;
-            let (cols, rows, replay) = surface
-                .with_terminal(|t| t.vt_replay().map(|replay| (t.cols(), t.rows(), replay)))?;
+            require_pty(&surface)?;
+            let (cols, rows, replay) = surface.try_with_terminal(|t| {
+                t.vt_replay().map(|replay| (t.cols(), t.rows(), replay))
+            })??;
             Ok(json!({
                 "cols": cols,
                 "rows": rows,
@@ -372,6 +395,10 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
         }
         Command::NewTab { pane, cwd, cols, rows } => {
             let surface = mux.new_tab(pane, cwd, cols.zip(rows))?;
+            Ok(json!({ "surface": surface.id }))
+        }
+        Command::NewBrowserTab { url, pane, cols, rows } => {
+            let surface = mux.new_browser_tab(url, pane, cols.zip(rows))?;
             Ok(json!({ "surface": surface.id }))
         }
         Command::NewWorkspace { name, cols, rows } => {
@@ -458,7 +485,8 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
         }
         Command::ScrollSurface { surface, delta } => {
             let surface = get_surface(mux, surface)?;
-            surface.with_terminal(|t| t.scroll_delta(delta));
+            require_pty(&surface)?;
+            surface.try_with_terminal(|t| t.scroll_delta(delta))?;
             Ok(json!({}))
         }
         Command::Subscribe => {
@@ -489,6 +517,9 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
         }
         Command::AttachSurface { surface: surface_id } => {
             let surface = get_surface(mux, surface_id)?;
+            if surface.kind() == SurfaceKind::Browser {
+                anyhow::bail!("browser panes are not supported over attach yet");
+            }
             let attach = surface.attach_stream()?;
             writer.send(&json!({
                 "event": "vt-state",

--- a/mux/crates/mux-core/src/surface.rs
+++ b/mux/crates/mux-core/src/surface.rs
@@ -1,7 +1,12 @@
-//! Surface runtime: one PTY child plus its ghostty VT state. A surface
-//! is one tab inside a pane.
+//! Surface runtime: one tab inside a pane.
+//!
+//! A surface is either a PTY backed by libghostty-vt state or a local CDP
+//! browser surface. PTY-only methods stay available for existing callers;
+//! browser-aware frontends should branch on [`SurfaceKind`] before using
+//! VT operations.
 
 use std::io::{Read, Write};
+use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 
@@ -9,6 +14,9 @@ use ghostty_vt::{Callbacks, RenderState, Terminal};
 use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtySize};
 
 use crate::{Mux, MuxEvent, SurfaceId};
+
+pub use crate::browser::{BrowserFrame, BrowserSource};
+use crate::browser::{BrowserRuntime, BrowserSurface};
 
 /// How to spawn surface children.
 #[derive(Debug, Clone)]
@@ -24,6 +32,18 @@ pub struct SurfaceOptions {
     pub scrollback: usize,
     /// Extra environment for children (e.g. CMUX_MUX_SOCKET).
     pub extra_env: Vec<(String, String)>,
+    /// Optional Chrome/Chromium binary for browser surfaces.
+    pub chrome_binary: Option<String>,
+    /// Optional existing Chrome CDP endpoint, as ws://... or http://host:port.
+    pub cdp_url: Option<String>,
+    /// Whether browser panes should probe local debuggable Chrome ports.
+    pub browser_discover: bool,
+    /// Local ports to probe for /json/version when discovery is enabled.
+    pub browser_discover_ports: Vec<u16>,
+    /// Optional Chrome user data directory for launched browser runtime.
+    pub browser_user_data_dir: Option<String>,
+    /// Use a temporary launched Chrome profile and delete it on shutdown.
+    pub browser_ephemeral: bool,
 }
 
 impl Default for SurfaceOptions {
@@ -36,13 +56,19 @@ impl Default for SurfaceOptions {
             rows: 24,
             scrollback: 10_000,
             extra_env: Vec::new(),
+            chrome_binary: None,
+            cdp_url: None,
+            browser_discover: true,
+            browser_discover_ports: vec![9222],
+            browser_user_data_dir: None,
+            browser_ephemeral: false,
         }
     }
 }
 
-/// Everything an attaching frontend needs to adopt a surface: its size,
-/// a VT replay of the current state, and a live stream of every pty byte
-/// applied after the replay snapshot.
+/// Everything an attaching frontend needs to adopt a PTY surface: its
+/// size, a VT replay of the current state, and a live stream of every pty
+/// byte applied after the replay snapshot.
 pub struct AttachStream {
     pub cols: u16,
     pub rows: u16,
@@ -50,13 +76,49 @@ pub struct AttachStream {
     pub stream: std::sync::mpsc::Receiver<Vec<u8>>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceKind {
+    Pty,
+    Browser,
+}
+
+impl SurfaceKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SurfaceKind::Pty => "pty",
+            SurfaceKind::Browser => "browser",
+        }
+    }
+}
+
+pub struct SurfaceMeta {
+    pub id: SurfaceId,
+}
+
+/// A pane tab runtime.
+pub enum Surface {
+    Pty(PtySurface),
+    Browser(BrowserSurface),
+}
+
+impl Deref for Surface {
+    type Target = SurfaceMeta;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Surface::Pty(surface) => &surface.meta,
+            Surface::Browser(surface) => &surface.meta,
+        }
+    }
+}
+
 /// A single terminal surface: PTY child plus ghostty VT state.
 ///
 /// The terminal is behind a mutex; the pty reader thread holds it only
 /// while feeding bytes, renderers hold it only while snapshotting into a
 /// [`RenderState`].
-pub struct Surface {
-    pub id: SurfaceId,
+pub struct PtySurface {
+    pub(crate) meta: SurfaceMeta,
     term: Mutex<Terminal>,
     writer: Mutex<Box<dyn Write + Send>>,
     master: Mutex<Box<dyn MasterPty + Send>>,
@@ -78,7 +140,7 @@ pub struct Surface {
 
 impl std::fmt::Debug for Surface {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Surface").field("id", &self.id).finish()
+        f.debug_struct("Surface").field("id", &self.id).field("kind", &self.kind()).finish()
     }
 }
 
@@ -144,8 +206,8 @@ impl Surface {
         };
 
         let term = Terminal::new(opts.cols, opts.rows, opts.scrollback, callbacks)?;
-        let surface = Arc::new(Surface {
-            id,
+        let surface = Arc::new(Surface::Pty(PtySurface {
+            meta: SurfaceMeta { id },
             term: Mutex::new(term),
             writer: Mutex::new(writer),
             master: Mutex::new(pty.master),
@@ -156,9 +218,9 @@ impl Surface {
             pwd: Mutex::new(None),
             size: Mutex::new((opts.cols, opts.rows)),
             taps: Mutex::new(Vec::new()),
-        });
+        }));
 
-        // PTY reader: pty bytes → terminal state → SurfaceOutput events.
+        // PTY reader: pty bytes -> terminal state -> SurfaceOutput events.
         std::thread::Builder::new().name(format!("surface-{id}-reader")).spawn({
             let surface = surface.clone();
             let mux = mux.clone();
@@ -169,37 +231,40 @@ impl Surface {
                         Ok(0) | Err(_) => break,
                         Ok(n) => n,
                     };
+                    let pty = surface.as_pty().expect("surface reader got non-pty surface");
                     {
-                        let mut term = surface.term.lock().unwrap();
+                        let mut term = pty.term.lock().unwrap();
                         term.vt_write(&buf[..n]);
                         {
-                            let mut taps = surface.taps.lock().unwrap();
+                            let mut taps = pty.taps.lock().unwrap();
                             if !taps.is_empty() {
                                 taps.retain(|tap| tap.send(buf[..n].to_vec()).is_ok());
                             }
                         }
                         if title_changed.swap(false, Ordering::Relaxed) {
                             let title = term.title().unwrap_or_default();
-                            *surface.title.lock().unwrap() = title;
+                            *pty.title.lock().unwrap() = title;
                             if let Some(mux) = mux.upgrade() {
                                 mux.emit(MuxEvent::TitleChanged(surface.id));
                             }
                         }
                         if let Some(pwd) = term.pwd() {
-                            *surface.pwd.lock().unwrap() = Some(pwd);
+                            *pty.pwd.lock().unwrap() = Some(pwd);
                         }
                     }
                     let responses = std::mem::take(&mut *pending_responses.lock().unwrap());
                     if !responses.is_empty() {
                         let _ = surface.write_bytes(&responses);
                     }
-                    if !surface.dirty.swap(true, Ordering::AcqRel) {
+                    if !pty.dirty.swap(true, Ordering::AcqRel) {
                         if let Some(mux) = mux.upgrade() {
                             mux.emit(MuxEvent::SurfaceOutput(surface.id));
                         }
                     }
                 }
-                surface.dead.store(true, Ordering::Release);
+                if let Some(pty) = surface.as_pty() {
+                    pty.dead.store(true, Ordering::Release);
+                }
                 if let Some(mux) = mux.upgrade() {
                     mux.surface_exited(surface.id);
                 }
@@ -214,26 +279,214 @@ impl Surface {
         Ok(surface)
     }
 
-    /// Write input bytes to the child.
+    pub(crate) fn spawn_browser(
+        id: SurfaceId,
+        url: String,
+        runtime: Arc<BrowserRuntime>,
+        mux: Weak<Mux>,
+        size: (u16, u16),
+        cell_pixels: (u16, u16),
+    ) -> anyhow::Result<Arc<Surface>> {
+        crate::browser::spawn(id, url, runtime, mux, size, cell_pixels)
+    }
+
+    fn as_pty(&self) -> Option<&PtySurface> {
+        match self {
+            Surface::Pty(surface) => Some(surface),
+            Surface::Browser(_) => None,
+        }
+    }
+
+    fn as_browser(&self) -> Option<&BrowserSurface> {
+        match self {
+            Surface::Pty(_) => None,
+            Surface::Browser(surface) => Some(surface),
+        }
+    }
+
+    pub fn kind(&self) -> SurfaceKind {
+        match self {
+            Surface::Pty(_) => SurfaceKind::Pty,
+            Surface::Browser(_) => SurfaceKind::Browser,
+        }
+    }
+
+    /// Write input bytes to the PTY child.
     pub fn write_bytes(&self, bytes: &[u8]) -> std::io::Result<()> {
-        let mut writer = self.writer.lock().unwrap();
+        let Some(pty) = self.as_pty() else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "browser surface does not accept PTY bytes",
+            ));
+        };
+        let mut writer = pty.writer.lock().unwrap();
         writer.write_all(bytes)?;
         writer.flush()
     }
 
     /// Run `f` with exclusive access to the terminal state.
-    pub fn with_terminal<R>(&self, f: impl FnOnce(&mut Terminal) -> R) -> R {
-        f(&mut self.term.lock().unwrap())
+    ///
+    /// Browser-aware code should call [`Surface::kind`] first. This
+    /// method is kept for existing PTY call sites.
+    pub fn with_terminal<R>(&self, f: impl FnOnce(&mut Terminal) -> R) -> Option<R> {
+        let pty = self.as_pty()?;
+        Some(f(&mut pty.term.lock().unwrap()))
+    }
+
+    pub fn try_with_terminal<R>(&self, f: impl FnOnce(&mut Terminal) -> R) -> anyhow::Result<R> {
+        let Some(pty) = self.as_pty() else {
+            anyhow::bail!("browser surface does not have a VT terminal");
+        };
+        Ok(f(&mut pty.term.lock().unwrap()))
     }
 
     /// Snapshot the terminal into `rs` (holds the terminal lock only for
     /// the duration of the update).
     pub fn snapshot(&self, rs: &mut RenderState) -> ghostty_vt::Result<()> {
-        rs.update(&mut self.term.lock().unwrap())
+        let Some(pty) = self.as_pty() else {
+            return Err(ghostty_vt::Error::InvalidValue);
+        };
+        rs.update(&mut pty.term.lock().unwrap())
     }
 
-    /// Resize both the PTY and the terminal state.
+    /// Resize this surface. PTYs receive cell dimensions; browsers also
+    /// use the last configured cell pixel size for CDP device metrics.
     pub fn resize(&self, cols: u16, rows: u16) {
+        match self {
+            Surface::Pty(pty) => pty.resize(cols, rows),
+            Surface::Browser(browser) => browser.resize(cols, rows),
+        }
+    }
+
+    pub fn set_cell_pixel_size(&self, width_px: u16, height_px: u16) {
+        if let Some(browser) = self.as_browser() {
+            browser.set_cell_pixel_size(width_px, height_px);
+        }
+    }
+
+    pub fn size(&self) -> (u16, u16) {
+        match self {
+            Surface::Pty(pty) => *pty.size.lock().unwrap(),
+            Surface::Browser(browser) => browser.size(),
+        }
+    }
+
+    pub fn title(&self) -> String {
+        match self {
+            Surface::Pty(pty) => pty.title.lock().unwrap().clone(),
+            Surface::Browser(browser) => browser.title(),
+        }
+    }
+
+    pub fn pwd(&self) -> Option<String> {
+        self.as_pty().and_then(|pty| pty.pwd.lock().unwrap().clone())
+    }
+
+    pub fn is_dead(&self) -> bool {
+        match self {
+            Surface::Pty(pty) => pty.dead.load(Ordering::Acquire),
+            Surface::Browser(browser) => browser.is_dead(),
+        }
+    }
+
+    /// Clear the coalesced output flag; returns whether output was pending.
+    pub fn take_dirty(&self) -> bool {
+        match self {
+            Surface::Pty(pty) => pty.dirty.swap(false, Ordering::AcqRel),
+            Surface::Browser(browser) => browser.take_dirty(),
+        }
+    }
+
+    /// Attach to a PTY surface: a VT replay plus a live byte stream.
+    pub fn attach_stream(&self) -> ghostty_vt::Result<AttachStream> {
+        let Some(pty) = self.as_pty() else {
+            return Err(ghostty_vt::Error::InvalidValue);
+        };
+        let mut term = pty.term.lock().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        // Snapshot and tap registration under the same terminal lock:
+        // the reader thread cannot apply bytes between the two.
+        let replay = term.vt_replay()?;
+        let (cols, rows) = (term.cols(), term.rows());
+        pty.taps.lock().unwrap().push(tx);
+        Ok(AttachStream { cols, rows, replay, stream: rx })
+    }
+
+    pub fn kill(&self) {
+        match self {
+            Surface::Pty(pty) => {
+                let _ = pty.killer.lock().unwrap().kill();
+            }
+            Surface::Browser(browser) => browser.kill(),
+        }
+    }
+
+    pub fn browser_frame(&self) -> Option<BrowserFrame> {
+        self.as_browser().and_then(BrowserSurface::latest_frame)
+    }
+
+    pub fn browser_url(&self) -> Option<String> {
+        self.as_browser().map(BrowserSurface::url)
+    }
+
+    pub fn browser_source(&self) -> Option<BrowserSource> {
+        self.as_browser().map(BrowserSurface::source)
+    }
+
+    pub fn browser_insert_text(&self, text: &str) -> anyhow::Result<()> {
+        let Some(browser) = self.as_browser() else {
+            anyhow::bail!("PTY surface is not a browser surface");
+        };
+        browser.insert_text(text)
+    }
+
+    pub fn browser_key_event(
+        &self,
+        event_type: &str,
+        key: &str,
+        code: &str,
+        windows_virtual_key_code: u32,
+        modifiers: u32,
+        text: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let Some(browser) = self.as_browser() else {
+            anyhow::bail!("PTY surface is not a browser surface");
+        };
+        browser.key_event(event_type, key, code, windows_virtual_key_code, modifiers, text)
+    }
+
+    pub fn browser_mouse_event(
+        &self,
+        event_type: &str,
+        x: f64,
+        y: f64,
+        button: Option<&str>,
+        click_count: Option<u32>,
+    ) -> anyhow::Result<()> {
+        let Some(browser) = self.as_browser() else {
+            anyhow::bail!("PTY surface is not a browser surface");
+        };
+        browser.mouse_event(event_type, x, y, button, click_count)
+    }
+
+    pub fn browser_wheel(&self, x: f64, y: f64, delta_y: f64) -> anyhow::Result<()> {
+        let Some(browser) = self.as_browser() else {
+            anyhow::bail!("PTY surface is not a browser surface");
+        };
+        browser.wheel(x, y, delta_y)
+    }
+
+    pub fn browser_navigate(&self, url: &str) -> anyhow::Result<()> {
+        let Some(browser) = self.as_browser() else {
+            anyhow::bail!("PTY surface is not a browser surface");
+        };
+        browser.navigate(url)
+    }
+}
+
+impl PtySurface {
+    /// Resize both the PTY and the terminal state.
+    fn resize(&self, cols: u16, rows: u16) {
         let (cols, rows) = (cols.max(1), rows.max(1));
         {
             let mut size = self.size.lock().unwrap();
@@ -250,46 +503,5 @@ impl Surface {
         });
         // Nominal cell metrics; only pixel size reports observe these.
         let _ = self.term.lock().unwrap().resize(cols, rows, 8, 16);
-    }
-
-    pub fn size(&self) -> (u16, u16) {
-        *self.size.lock().unwrap()
-    }
-
-    pub fn title(&self) -> String {
-        self.title.lock().unwrap().clone()
-    }
-
-    pub fn pwd(&self) -> Option<String> {
-        self.pwd.lock().unwrap().clone()
-    }
-
-    pub fn is_dead(&self) -> bool {
-        self.dead.load(Ordering::Acquire)
-    }
-
-    /// Clear the coalesced output flag; returns whether output was pending.
-    pub fn take_dirty(&self) -> bool {
-        self.dirty.swap(false, Ordering::AcqRel)
-    }
-
-    /// Attach to this surface: a VT replay of the current terminal state
-    /// plus a live stream of every pty byte applied after the snapshot.
-    /// Replaying the first into a fresh terminal of the same size and then
-    /// feeding the stream reproduces the surface exactly — this is how an
-    /// external frontend (e.g. a real Ghostty surface) adopts it.
-    pub fn attach_stream(&self) -> ghostty_vt::Result<AttachStream> {
-        let mut term = self.term.lock().unwrap();
-        let (tx, rx) = std::sync::mpsc::channel();
-        // Snapshot and tap registration under the same terminal lock:
-        // the reader thread cannot apply bytes between the two.
-        let replay = term.vt_replay()?;
-        let (cols, rows) = (term.cols(), term.rows());
-        self.taps.lock().unwrap().push(tx);
-        Ok(AttachStream { cols, rows, replay, stream: rx })
-    }
-
-    pub fn kill(&self) {
-        let _ = self.killer.lock().unwrap().kill();
     }
 }

--- a/mux/crates/mux-core/tests/browser_runtime.rs
+++ b/mux/crates/mux-core/tests/browser_runtime.rs
@@ -1,0 +1,132 @@
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use mux_core::{Mux, SurfaceKind, SurfaceOptions};
+use serde_json::{json, Value};
+use tungstenite::{accept, Message};
+
+fn read_json(ws: &mut tungstenite::WebSocket<std::net::TcpStream>) -> Value {
+    loop {
+        match ws.read().unwrap() {
+            Message::Text(text) => return serde_json::from_str(&text).unwrap(),
+            Message::Binary(bytes) => return serde_json::from_slice(&bytes).unwrap(),
+            _ => {}
+        }
+    }
+}
+
+fn write_json(ws: &mut tungstenite::WebSocket<std::net::TcpStream>, value: Value) {
+    ws.send(Message::Text(value.to_string())).unwrap();
+}
+
+fn wait_for<T>(mut f: impl FnMut() -> Option<T>, timeout: Duration) -> Option<T> {
+    let start = Instant::now();
+    loop {
+        if let Some(value) = f() {
+            return Some(value);
+        }
+        if start.elapsed() > timeout {
+            return None;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn two_browser_surfaces_share_external_runtime_and_demux_frames() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (closed_tx, closed_rx) = mpsc::channel();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut ws = accept(stream).unwrap();
+        let mut next_target = 1u32;
+        let mut closed = 0u8;
+
+        loop {
+            let request = read_json(&mut ws);
+            let id = request["id"].clone();
+            match request["method"].as_str().unwrap() {
+                "Target.setDiscoverTargets" => {
+                    write_json(&mut ws, json!({"id": id, "result": {}}));
+                }
+                "Target.createTarget" => {
+                    let target = format!("target-{next_target}");
+                    next_target += 1;
+                    write_json(&mut ws, json!({"id": id, "result": {"targetId": target}}));
+                }
+                "Target.attachToTarget" => {
+                    let target = request["params"]["targetId"].as_str().unwrap();
+                    let session = target.replace("target", "session");
+                    write_json(&mut ws, json!({"id": id, "result": {"sessionId": session}}));
+                }
+                "Page.enable" | "Emulation.setDeviceMetricsOverride" => {
+                    write_json(&mut ws, json!({"id": id, "result": {}}));
+                }
+                "Page.startScreencast" => {
+                    let session = request["sessionId"].as_str().unwrap().to_string();
+                    let seq = if session == "session-1" { 101 } else { 202 };
+                    write_json(&mut ws, json!({"id": id, "result": {}}));
+                    write_json(
+                        &mut ws,
+                        json!({
+                            "method": "Page.screencastFrame",
+                            "sessionId": session,
+                            "params": {
+                                "data": format!("png-{seq}"),
+                                "metadata": {"deviceWidth": 80, "deviceHeight": 40},
+                                "sessionId": seq
+                            }
+                        }),
+                    );
+                }
+                "Page.screencastFrameAck" => {
+                    write_json(&mut ws, json!({"id": id, "result": {}}));
+                }
+                "Target.closeTarget" => {
+                    let target = request["params"]["targetId"].as_str().unwrap().to_string();
+                    closed_tx.send(target).unwrap();
+                    write_json(&mut ws, json!({"id": id, "result": {"success": true}}));
+                    closed += 1;
+                    if closed == 2 {
+                        break;
+                    }
+                }
+                method => panic!("unexpected CDP method {method}"),
+            }
+        }
+    });
+
+    let opts = SurfaceOptions {
+        cdp_url: Some(format!("ws://{addr}/devtools/browser/fake")),
+        browser_discover: false,
+        ..Default::default()
+    };
+    let mux = Mux::new("browser-runtime-test", opts);
+    let first = mux.new_browser_tab("one.test".to_string(), None, Some((10, 5))).unwrap();
+    let second = mux.new_browser_tab("two.test".to_string(), None, Some((10, 5))).unwrap();
+
+    assert_eq!(first.kind(), SurfaceKind::Browser);
+    assert_eq!(second.kind(), SurfaceKind::Browser);
+    assert_eq!(first.browser_source().unwrap().as_str(), "external");
+    assert_eq!(second.browser_source().unwrap().as_str(), "external");
+
+    let first_frame =
+        wait_for(|| first.browser_frame(), Duration::from_secs(2)).expect("first frame");
+    let second_frame =
+        wait_for(|| second.browser_frame(), Duration::from_secs(2)).expect("second frame");
+    assert_eq!(first_frame.session_id, "session-1");
+    assert_eq!(first_frame.seq, 101);
+    assert_eq!(second_frame.session_id, "session-2");
+    assert_eq!(second_frame.seq, 202);
+
+    mux.close_surface(first.id);
+    assert_eq!(closed_rx.recv_timeout(Duration::from_secs(2)).unwrap(), "target-1");
+    mux.close_surface(second.id);
+    assert_eq!(closed_rx.recv_timeout(Duration::from_secs(2)).unwrap(), "target-2");
+    mux.shutdown();
+    server.join().unwrap();
+}

--- a/mux/crates/mux-core/tests/pty.rs
+++ b/mux/crates/mux-core/tests/pty.rs
@@ -42,7 +42,7 @@ fn surface_runs_command_and_screen_updates() {
     // ...and the ghostty-backed screen contains the marker.
     let text = wait_for(
         || {
-            let text = surface.with_terminal(|t| t.plain_text()).unwrap();
+            let text = surface.with_terminal(|t| t.plain_text()).unwrap().unwrap();
             text.contains("marker-42").then_some(text)
         },
         Duration::from_secs(10),
@@ -201,6 +201,7 @@ fn attach_stream_replays_then_streams_without_duplication() {
         || {
             surface
                 .with_terminal(|t| t.plain_text())
+                .unwrap()
                 .unwrap()
                 .contains("before-attach")
                 .then_some(())

--- a/mux/crates/mux-tui/Cargo.toml
+++ b/mux/crates/mux-tui/Cargo.toml
@@ -20,3 +20,4 @@ unicode-width.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 base64.workspace = true
+libc.workspace = true

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -22,7 +22,8 @@ use crossterm::terminal::{
 use crossterm::ExecutableCommand;
 use ghostty_vt::{KeyEncoder, RenderState, Screen};
 use mux_core::{
-    layout_screen, split_sides, MuxEvent, PaneId, Rect, SplitDir, SurfaceId, WorkspaceId,
+    layout_screen, split_sides, MuxEvent, PaneId, Rect, SplitDir, SurfaceId, SurfaceKind,
+    WorkspaceId,
 };
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal as RatatuiTerminal;
@@ -30,6 +31,7 @@ use ratatui::Terminal as RatatuiTerminal;
 use crate::config::{Action, Config};
 use crate::keys;
 use crate::session::{Session, SurfaceHandle, TreeView};
+use crate::ui::graphics::{GraphicPlacement, GraphicsState};
 
 pub enum AppEvent {
     Mux(MuxEvent),
@@ -99,6 +101,7 @@ pub enum MenuAction {
     CloseScreen(mux_core::ScreenId),
     RenamePane(PaneId),
     NewTab(PaneId),
+    NewBrowserTab(PaneId),
     SplitRight(PaneId),
     SplitDown(PaneId),
     ClosePane(PaneId),
@@ -113,6 +116,7 @@ impl MenuAction {
             MenuAction::CloseScreen(_) => "Close screen",
             MenuAction::RenamePane(_) => "Rename pane",
             MenuAction::NewTab(_) => "New tab",
+            MenuAction::NewBrowserTab(_) => "New browser tab",
             MenuAction::SplitRight(_) => "Split right",
             MenuAction::SplitDown(_) => "Split down",
             MenuAction::ClosePane(_) => "Close pane",
@@ -161,6 +165,7 @@ pub enum PromptTarget {
     Workspace(WorkspaceId),
     Screen(mux_core::ScreenId),
     Pane(PaneId),
+    BrowserTab { pane: Option<PaneId> },
 }
 
 /// Centered rename dialog: a text input with OK/Cancel buttons. The
@@ -236,6 +241,8 @@ impl Selection {
 enum Drag {
     /// Text selection inside a pane's content rect.
     Select { content: Rect },
+    /// Browser mouse drag inside a pane's content rect.
+    Browser { surface: SurfaceId, content: Rect },
     /// Scrollbar thumb drag.
     Scrollbar { surface: SurfaceId, track: Rect },
 }
@@ -245,6 +252,8 @@ pub struct App {
     pub config: Config,
     pub tree: TreeView,
     pub render_states: HashMap<SurfaceId, RenderState>,
+    pub graphics: GraphicsState,
+    pub graphics_supported: bool,
     pub pane_areas: Vec<PaneArea>,
     pub prefix_armed: bool,
     pub session_label: String,
@@ -264,6 +273,8 @@ pub struct App {
     pub menu: Option<ContextMenu>,
     pub prompt: Option<Prompt>,
     pub selection: Option<Selection>,
+    pub status_message: Option<String>,
+    pub cell_pixels: (u16, u16),
     /// Whether the terminal pointer is currently the hand shape (over a
     /// clickable element); tracked to avoid re-emitting OSC 22.
     pointer_shape: bool,
@@ -316,17 +327,6 @@ pub fn run(session: Session, session_label: String) -> anyhow::Result<()> {
     })?;
 
     // Crossterm input → app channel.
-    std::thread::Builder::new().name("input".into()).spawn({
-        let tx = tx.clone();
-        move || {
-            while let Ok(event) = crossterm::event::read() {
-                if tx.send(AppEvent::Input(event)).is_err() {
-                    break;
-                }
-            }
-        }
-    })?;
-
     enable_raw_mode()?;
     if let Err(e) = (|| -> anyhow::Result<()> {
         let mut stdout = std::io::stdout();
@@ -338,6 +338,23 @@ pub fn run(session: Session, session_label: String) -> anyhow::Result<()> {
         let _ = restore_terminal();
         return Err(e);
     }
+
+    let cell_pixels = crate::ui::graphics::detect_cell_pixels(true);
+    session.set_cell_pixel_size(cell_pixels.0, cell_pixels.1);
+    let graphics_supported = crate::ui::graphics::probe_kitty_graphics();
+
+    // Crossterm input → app channel. Start this after startup terminal
+    // probes so DA / window-size responses are not consumed as key input.
+    std::thread::Builder::new().name("input".into()).spawn({
+        let tx = tx.clone();
+        move || {
+            while let Ok(event) = crossterm::event::read() {
+                if tx.send(AppEvent::Input(event)).is_err() {
+                    break;
+                }
+            }
+        }
+    })?;
     // Restore the host terminal even if we panic mid-frame.
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -359,6 +376,8 @@ pub fn run(session: Session, session_label: String) -> anyhow::Result<()> {
         config,
         tree: TreeView::default(),
         render_states: HashMap::new(),
+        graphics: GraphicsState::default(),
+        graphics_supported,
         pane_areas: Vec::new(),
         prefix_armed: false,
         session_label,
@@ -371,6 +390,8 @@ pub fn run(session: Session, session_label: String) -> anyhow::Result<()> {
         menu: None,
         prompt: None,
         selection: None,
+        status_message: None,
+        cell_pixels,
         pointer_shape: false,
         drag: None,
         encoder,
@@ -405,6 +426,7 @@ impl App {
         let size = terminal.size()?;
         self.sync_layout((size.width, size.height));
         terminal.draw(|f| crate::ui::draw(self, f))?;
+        self.emit_graphics()?;
 
         while !self.quit {
             // Block for the first event, then drain whatever queued so a
@@ -431,9 +453,53 @@ impl App {
                 let size = terminal.size()?;
                 self.sync_layout((size.width, size.height));
                 terminal.draw(|f| crate::ui::draw(self, f))?;
+                self.emit_graphics()?;
             }
         }
         Ok(())
+    }
+
+    fn emit_graphics(&mut self) -> anyhow::Result<()> {
+        if !self.graphics_supported {
+            return Ok(());
+        }
+        let mut placements = Vec::new();
+        for area in &self.pane_areas {
+            let Some(surface) = self.session.surface(area.surface) else { continue };
+            if surface.kind() != SurfaceKind::Browser {
+                continue;
+            }
+            if self.browser_graphic_occluded(area.content) {
+                continue;
+            }
+            let Some(frame) = surface.browser_frame() else { continue };
+            placements.push(GraphicPlacement {
+                surface: area.surface,
+                rect: area.content,
+                seq: frame.seq,
+                data_b64: frame.data_b64,
+            });
+        }
+        let bytes = self.graphics.frame_bytes(&placements);
+        if !bytes.is_empty() {
+            let mut stdout = std::io::stdout();
+            stdout.write_all(&bytes)?;
+            stdout.flush()?;
+        }
+        Ok(())
+    }
+
+    fn browser_graphic_occluded(&self, rect: Rect) -> bool {
+        self.menu.as_ref().is_some_and(|menu| rects_intersect(rect, menu.rect))
+            || self.prompt.as_ref().is_some_and(|prompt| rects_intersect(rect, prompt.rect))
+    }
+
+    fn refresh_cell_pixels(&mut self, query_fallback: bool) {
+        let next = crate::ui::graphics::detect_cell_pixels(query_fallback);
+        if self.cell_pixels != next {
+            self.cell_pixels = next;
+            self.session.set_cell_pixel_size(next.0, next.1);
+        }
     }
 
     /// Refresh the tree snapshot, recompute the active screen's layout
@@ -528,7 +594,10 @@ impl App {
                 self.paste(&text);
                 Ok(false)
             }
-            AppEvent::Input(Event::Resize(_, _)) => Ok(true),
+            AppEvent::Input(Event::Resize(_, _)) => {
+                self.refresh_cell_pixels(false);
+                Ok(true)
+            }
             AppEvent::Input(_) => Ok(false),
         }
     }
@@ -579,6 +648,7 @@ impl App {
         if key.kind == KeyEventKind::Release {
             return Ok(false);
         }
+        self.status_message = None;
         if self.prompt.is_some() {
             return self.handle_prompt_key(key);
         }
@@ -611,6 +681,15 @@ impl App {
             // Empty screen/pane names clear back to the default.
             PromptTarget::Screen(id) => self.session.rename_screen(id, prompt.buffer),
             PromptTarget::Pane(id) => self.session.rename_pane(id, prompt.buffer),
+            PromptTarget::BrowserTab { pane } => {
+                if !prompt.buffer.trim().is_empty() {
+                    if let Err(e) = self.create_browser_tab(pane, &prompt.buffer) {
+                        self.status_message = Some(e.to_string());
+                    } else {
+                        self.status_message = None;
+                    }
+                }
+            }
         }
     }
 
@@ -663,6 +742,7 @@ impl App {
                 let action = menu.items[menu.selected];
                 self.menu = None;
                 self.activate_menu(action)?;
+                self.status_message = None;
                 Ok(true)
             }
             _ => Ok(true), // swallow while a menu is open
@@ -695,6 +775,7 @@ impl App {
             Action::NewTab => {
                 self.session.new_tab(pane, None)?;
             }
+            Action::NewBrowserTab => self.open_browser_tab_prompt(pane),
             Action::NextTab => self.session.select_tab(pane, None, Some(1)),
             Action::PrevTab => self.session.select_tab(pane, None, Some(-1)),
             Action::SplitRight => {
@@ -735,6 +816,7 @@ impl App {
                 return Ok(false);
             }
         }
+        self.status_message = None;
         Ok(true)
     }
 
@@ -748,6 +830,36 @@ impl App {
         let Some(ws) = self.tree.active_workspace() else { return };
         self.prompt =
             Some(Prompt::new("Rename workspace", ws.name.clone(), PromptTarget::Workspace(ws.id)));
+    }
+
+    fn open_browser_tab_prompt(&mut self, pane: Option<PaneId>) {
+        self.prompt = Some(Prompt::new(
+            "New browser tab",
+            "https://".to_string(),
+            PromptTarget::BrowserTab { pane },
+        ));
+    }
+
+    fn browser_tab_size_hint(&self, pane: Option<PaneId>) -> Option<(u16, u16)> {
+        match pane {
+            Some(pane) => self
+                .pane_areas
+                .iter()
+                .find(|area| area.pane == pane)
+                .map(|area| (area.content.width.max(1), area.content.height.max(1))),
+            None => self
+                .active_pane()
+                .and_then(|pane| self.browser_tab_size_hint(Some(pane)))
+                .or_else(|| Self::size_of_rect(self.content_area)),
+        }
+    }
+
+    fn create_browser_tab(&mut self, pane: Option<PaneId>, input: &str) -> anyhow::Result<()> {
+        self.session.new_browser_tab(
+            input.trim().to_string(),
+            pane,
+            self.browser_tab_size_hint(pane),
+        )
     }
 
     fn activate_menu(&mut self, action: MenuAction) -> anyhow::Result<()> {
@@ -778,6 +890,7 @@ impl App {
             MenuAction::CloseScreen(id) => self.session.close_screen(id),
             MenuAction::RenamePane(id) => self.open_rename_pane_prompt(Some(id)),
             MenuAction::NewTab(id) => self.session.new_tab(Some(id), None)?,
+            MenuAction::NewBrowserTab(id) => self.open_browser_tab_prompt(Some(id)),
             MenuAction::SplitRight(id) => self.split_pane(id, SplitDir::Right)?,
             MenuAction::SplitDown(id) => self.split_pane(id, SplitDir::Down)?,
             MenuAction::ClosePane(id) => self.session.close_pane(id),
@@ -798,7 +911,10 @@ impl App {
 
     fn scroll_active(&mut self, delta: isize) {
         if let Some(surface) = self.active_surface_handle() {
-            surface.with_terminal(|t| t.scroll_delta(delta));
+            if surface.kind() == SurfaceKind::Browser {
+                return;
+            }
+            let _ = surface.with_terminal(|t| t.scroll_delta(delta));
         }
         if let (Some(sel), Some(active)) = (self.selection, self.active_surface()) {
             if sel.surface == active {
@@ -808,23 +924,57 @@ impl App {
     }
 
     fn forward_key(&mut self, key: &KeyEvent) {
+        if self
+            .active_surface_handle()
+            .is_some_and(|surface| surface.kind() == SurfaceKind::Browser)
+        {
+            self.forward_browser_key(key);
+            return;
+        }
         let Some(input) = keys::key_input_from(key) else { return };
         let Some(surface) = self.active_surface_handle() else { return };
         self.encode_buf.clear();
-        let encoded = surface.with_terminal(|term| {
+        let Some(encoded) = surface.with_terminal(|term| {
             // New input snaps the viewport back to the live screen.
             term.scroll_to_bottom();
             self.encoder.sync_from_terminal(term);
             self.encoder.encode(&input, &mut self.encode_buf)
-        });
+        }) else {
+            return;
+        };
         if encoded.is_ok() && !self.encode_buf.is_empty() {
             surface.write_bytes(&self.encode_buf);
         }
     }
 
+    fn forward_browser_key(&mut self, key: &KeyEvent) {
+        let Some(surface) = self.active_surface_handle() else { return };
+        if let KeyCode::Char(c) = key.code {
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
+            {
+                let _ = surface.browser_insert_text(&c.to_string());
+                return;
+            }
+        }
+        let Some((key_name, code, vk, text)) = browser_key_mapping(key.code) else { return };
+        let modifiers = browser_modifiers(key.modifiers);
+        let _ = surface.browser_key_event("keyDown", key_name, code, vk, modifiers, text);
+        if key.kind == KeyEventKind::Press {
+            let _ = surface.browser_key_event("keyUp", key_name, code, vk, modifiers, None);
+        }
+    }
+
     fn paste(&mut self, text: &str) {
         let Some(surface) = self.active_surface_handle() else { return };
-        let bracketed = surface.with_terminal(|t| t.mode(2004, false));
+        if surface.kind() == SurfaceKind::Browser {
+            let _ = surface.browser_insert_text(text);
+            return;
+        }
+        let Some(bracketed) = surface.with_terminal(|t| t.mode(2004, false)) else {
+            return;
+        };
         if bracketed {
             let mut bytes = Vec::with_capacity(text.len() + 12);
             bytes.extend_from_slice(b"\x1b[200~");
@@ -852,7 +1002,7 @@ impl App {
             MouseEventKind::Drag(MouseButton::Left) => {
                 self.handle_left_drag(mouse.column, mouse.row)
             }
-            MouseEventKind::Up(MouseButton::Left) => self.handle_left_up(),
+            MouseEventKind::Up(MouseButton::Left) => self.handle_left_up(mouse.column, mouse.row),
             MouseEventKind::Down(MouseButton::Right) => {
                 self.open_context_menu(mouse.column, mouse.row);
                 Ok(true)
@@ -971,12 +1121,18 @@ impl App {
         if let Some(area) = self.pane_area_at(x, y).copied() {
             self.session.focus_pane(area.pane);
             if area.content.contains(x, y) {
-                // Begin a text selection; it becomes visible once the
-                // mouse moves to a second cell.
-                let cell = (x - area.content.x, y - area.content.y);
-                self.selection =
-                    Some(Selection { surface: area.surface, anchor: cell, head: cell });
-                self.drag = Some(Drag::Select { content: area.content });
+                if self.surface_kind(area.surface) == SurfaceKind::Browser {
+                    self.send_browser_mouse(area.surface, area.content, x, y, "mousePressed")?;
+                    self.drag =
+                        Some(Drag::Browser { surface: area.surface, content: area.content });
+                } else {
+                    // Begin a text selection; it becomes visible once the
+                    // mouse moves to a second cell.
+                    let cell = (x - area.content.x, y - area.content.y);
+                    self.selection =
+                        Some(Selection { surface: area.surface, anchor: cell, head: cell });
+                    self.drag = Some(Drag::Select { content: area.content });
+                }
             }
             return Ok(true);
         }
@@ -994,6 +1150,13 @@ impl App {
                 }
                 Ok(true)
             }
+            Some(Drag::Browser { surface, content }) => {
+                let (surface, content) = (*surface, *content);
+                let cx = x.clamp(content.x, content.x + content.width.saturating_sub(1));
+                let cy = y.clamp(content.y, content.y + content.height.saturating_sub(1));
+                self.send_browser_mouse(surface, content, cx, cy, "mouseMoved")?;
+                Ok(true)
+            }
             Some(Drag::Scrollbar { surface, track }) => {
                 let (surface, track) = (*surface, *track);
                 self.scroll_to_track_pos(surface, track, y);
@@ -1003,7 +1166,14 @@ impl App {
         }
     }
 
-    fn handle_left_up(&mut self) -> anyhow::Result<bool> {
+    fn handle_left_up(&mut self, x: u16, y: u16) -> anyhow::Result<bool> {
+        if let Some(Drag::Browser { surface, content }) = self.drag {
+            self.drag = None;
+            let cx = x.clamp(content.x, content.x + content.width.saturating_sub(1));
+            let cy = y.clamp(content.y, content.y + content.height.saturating_sub(1));
+            self.send_browser_mouse(surface, content, cx, cy, "mouseReleased")?;
+            return Ok(true);
+        }
         let was_select = matches!(self.drag, Some(Drag::Select { .. }));
         self.drag = None;
         if !was_select {
@@ -1027,7 +1197,9 @@ impl App {
     fn copy_selection(&mut self, sel: Selection) {
         let Some(surface) = self.session.surface(sel.surface) else { return };
         let (start, end) = sel.range();
-        let Some(text) = surface.with_terminal(|t| t.selection_text(start, end)) else { return };
+        let Some(text) = surface.with_terminal(|t| t.selection_text(start, end)).flatten() else {
+            return;
+        };
         if text.is_empty() {
             return;
         }
@@ -1047,7 +1219,7 @@ impl App {
     /// Map a click/drag on a scrollbar track to a viewport position.
     fn scroll_to_track_pos(&mut self, surface: SurfaceId, track: Rect, y: u16) {
         let Some(handle) = self.session.surface(surface) else { return };
-        handle.with_terminal(|t| {
+        let _ = handle.with_terminal(|t| {
             let Some(sb) = t.scrollbar() else { return };
             let denom = track.height.saturating_sub(1).max(1) as f64;
             let frac = (y.saturating_sub(track.y) as f64 / denom).clamp(0.0, 1.0);
@@ -1090,6 +1262,7 @@ impl App {
                 vec![
                     MenuAction::RenamePane(area.pane),
                     MenuAction::NewTab(area.pane),
+                    MenuAction::NewBrowserTab(area.pane),
                     MenuAction::SplitRight(area.pane),
                     MenuAction::SplitDown(area.pane),
                     MenuAction::ClosePane(area.pane),
@@ -1107,7 +1280,16 @@ impl App {
         }
         let (surface_id, _) = (area.surface, area.pane);
         let Some(surface) = self.session.surface(surface_id) else { return Ok(false) };
-        let sent_arrows = surface.with_terminal(|term| {
+        if surface.kind() == SurfaceKind::Browser {
+            if area.content.contains(x, y) {
+                let (px, py) = self.browser_point(area.content, x, y);
+                let delta = if down { 3.0 } else { -3.0 } * f64::from(self.cell_pixels.1);
+                let _ = surface.browser_wheel(px, py, delta);
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+        let Some(sent_arrows) = surface.with_terminal(|term| {
             if term.active_screen() == Screen::Alternate && !term.mouse_tracking() {
                 term.scroll_to_bottom();
                 true
@@ -1115,7 +1297,9 @@ impl App {
                 term.scroll_delta(if down { 3 } else { -3 });
                 false
             }
-        });
+        }) else {
+            return Ok(false);
+        };
         if sent_arrows {
             // Alt-screen apps without mouse support get arrow keys
             // (the usual alternate-scroll behavior).
@@ -1127,5 +1311,74 @@ impl App {
             self.selection = None;
         }
         Ok(true)
+    }
+
+    fn surface_kind(&self, surface: SurfaceId) -> SurfaceKind {
+        self.session.surface(surface).map(|surface| surface.kind()).unwrap_or(SurfaceKind::Pty)
+    }
+
+    fn browser_point(&self, content: Rect, x: u16, y: u16) -> (f64, f64) {
+        let col = x.saturating_sub(content.x) as f64 + 0.5;
+        let row = y.saturating_sub(content.y) as f64 + 0.5;
+        (col * f64::from(self.cell_pixels.0), row * f64::from(self.cell_pixels.1))
+    }
+
+    fn send_browser_mouse(
+        &self,
+        surface_id: SurfaceId,
+        content: Rect,
+        x: u16,
+        y: u16,
+        event_type: &str,
+    ) -> anyhow::Result<()> {
+        let Some(surface) = self.session.surface(surface_id) else { return Ok(()) };
+        let (px, py) = self.browser_point(content, x, y);
+        surface.browser_mouse_event(event_type, px, py, Some("left"), Some(1))
+    }
+}
+
+fn browser_modifiers(modifiers: KeyModifiers) -> u32 {
+    let mut out = 0;
+    if modifiers.contains(KeyModifiers::ALT) {
+        out |= 1;
+    }
+    if modifiers.contains(KeyModifiers::CONTROL) {
+        out |= 2;
+    }
+    if modifiers.contains(KeyModifiers::SUPER) {
+        out |= 4;
+    }
+    if modifiers.contains(KeyModifiers::SHIFT) {
+        out |= 8;
+    }
+    out
+}
+
+fn rects_intersect(a: Rect, b: Rect) -> bool {
+    let ax2 = a.x.saturating_add(a.width);
+    let ay2 = a.y.saturating_add(a.height);
+    let bx2 = b.x.saturating_add(b.width);
+    let by2 = b.y.saturating_add(b.height);
+    a.x < bx2 && ax2 > b.x && a.y < by2 && ay2 > b.y
+}
+
+fn browser_key_mapping(
+    code: KeyCode,
+) -> Option<(&'static str, &'static str, u32, Option<&'static str>)> {
+    match code {
+        KeyCode::Enter => Some(("Enter", "Enter", 13, Some("\r"))),
+        KeyCode::Backspace => Some(("Backspace", "Backspace", 8, None)),
+        KeyCode::Tab | KeyCode::BackTab => Some(("Tab", "Tab", 9, None)),
+        KeyCode::Esc => Some(("Escape", "Escape", 27, None)),
+        KeyCode::Left => Some(("ArrowLeft", "ArrowLeft", 37, None)),
+        KeyCode::Up => Some(("ArrowUp", "ArrowUp", 38, None)),
+        KeyCode::Right => Some(("ArrowRight", "ArrowRight", 39, None)),
+        KeyCode::Down => Some(("ArrowDown", "ArrowDown", 40, None)),
+        KeyCode::Home => Some(("Home", "Home", 36, None)),
+        KeyCode::End => Some(("End", "End", 35, None)),
+        KeyCode::PageUp => Some(("PageUp", "PageUp", 33, None)),
+        KeyCode::PageDown => Some(("PageDown", "PageDown", 34, None)),
+        KeyCode::Delete => Some(("Delete", "Delete", 46, None)),
+        _ => None,
     }
 }

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -19,6 +19,14 @@
 //!   },
 //!   "sidebar": {
 //!     "width": 22
+//!   },
+//!   "browser": {
+//!     "chrome_binary": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+//!     "cdp_url": "http://127.0.0.1:9222",
+//!     "discover": true,
+//!     "discover_ports": [9222],
+//!     "user_data_dir": "/Users/me/Library/Application Support/cmux-mux/chrome-profile",
+//!     "ephemeral": false
 //!   }
 //! }
 //! ```
@@ -45,6 +53,8 @@ struct RawConfig {
     tabs: RawTabs,
     #[serde(default)]
     sidebar: RawSidebar,
+    #[serde(default)]
+    browser: RawBrowser,
     /// Key bindings: `"prefix"` plus one entry per action, e.g.
     /// `{"prefix": "ctrl+b", "new-tab": "c", "split-right": "%"}`.
     #[serde(default)]
@@ -74,6 +84,17 @@ struct RawTabs {
 #[serde(deny_unknown_fields)]
 struct RawSidebar {
     width: Option<u16>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawBrowser {
+    chrome_binary: Option<String>,
+    cdp_url: Option<String>,
+    discover: Option<bool>,
+    discover_ports: Option<Vec<u16>>,
+    user_data_dir: Option<String>,
+    ephemeral: Option<bool>,
 }
 
 /// A color in the config file: "#rrggbb", "#rgb", or an xterm-256 index.
@@ -155,10 +176,34 @@ impl Default for Sidebar {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct Browser {
+    pub chrome_binary: Option<String>,
+    pub cdp_url: Option<String>,
+    pub discover: bool,
+    pub discover_ports: Vec<u16>,
+    pub user_data_dir: Option<String>,
+    pub ephemeral: bool,
+}
+
+impl Default for Browser {
+    fn default() -> Self {
+        Browser {
+            chrome_binary: None,
+            cdp_url: None,
+            discover: true,
+            discover_ports: vec![9222],
+            user_data_dir: None,
+            ephemeral: false,
+        }
+    }
+}
+
 /// Every prefix-key action, so bindings are configurable end to end.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Action {
     NewTab,
+    NewBrowserTab,
     NextTab,
     PrevTab,
     SplitRight,
@@ -184,6 +229,7 @@ impl Action {
     fn config_key(&self) -> &'static str {
         match self {
             Action::NewTab => "new-tab",
+            Action::NewBrowserTab => "new_browser_tab",
             Action::NextTab => "next-tab",
             Action::PrevTab => "prev-tab",
             Action::SplitRight => "split-right",
@@ -242,6 +288,7 @@ impl Default for Keys {
             prefix: Chord { code: KeyCode::Char('b'), mods: KeyModifiers::CONTROL },
             bindings: vec![
                 bind(KeyCode::Char('c'), Action::NewTab),
+                bind(KeyCode::Char('B'), Action::NewBrowserTab),
                 bind(KeyCode::Char('n'), Action::NextTab),
                 bind(KeyCode::Char('p'), Action::PrevTab),
                 bind(KeyCode::Char('%'), Action::SplitRight),
@@ -290,6 +337,7 @@ impl Keys {
             }
             let all = [
                 Action::NewTab,
+                Action::NewBrowserTab,
                 Action::NextTab,
                 Action::PrevTab,
                 Action::SplitRight,
@@ -363,6 +411,7 @@ pub struct Config {
     pub theme: Theme,
     pub tabs: Tabs,
     pub sidebar: Sidebar,
+    pub browser: Browser,
     pub keys: Keys,
 }
 
@@ -409,6 +458,18 @@ pub fn load() -> Config {
     }
     if let Some(w) = raw.sidebar.width {
         config.sidebar.width = w.clamp(10, 60);
+    }
+    config.browser.chrome_binary = raw.browser.chrome_binary.filter(|s| !s.trim().is_empty());
+    config.browser.cdp_url = raw.browser.cdp_url.filter(|s| !s.trim().is_empty());
+    if let Some(discover) = raw.browser.discover {
+        config.browser.discover = discover;
+    }
+    if let Some(ports) = raw.browser.discover_ports {
+        config.browser.discover_ports = ports;
+    }
+    config.browser.user_data_dir = raw.browser.user_data_dir.filter(|s| !s.trim().is_empty());
+    if let Some(ephemeral) = raw.browser.ephemeral {
+        config.browser.ephemeral = ephemeral;
     }
     config.keys.apply(&raw.keys);
     config

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -33,7 +33,8 @@ OPTIONS:
   -h, --help         Show this help.
 
 KEYS (prefix: Ctrl-b)
-  c  new tab in pane   n/p  next/prev tab      1-9  select tab
+  c  new tab in pane   B    new browser tab    n/p  next/prev tab
+  1-9  select tab
   %  split right       \"  split down          x    close tab
   ,  rename pane       $    rename workspace
   Tab  next screen     S    new screen
@@ -110,6 +111,13 @@ fn run_attach(args: Args) -> anyhow::Result<()> {
 
 fn run_server(args: Args) -> anyhow::Result<()> {
     let mut surface_options = SurfaceOptions::default();
+    let config = config::load();
+    surface_options.chrome_binary = config.browser.chrome_binary.clone();
+    surface_options.cdp_url = config.browser.cdp_url.clone();
+    surface_options.browser_discover = config.browser.discover;
+    surface_options.browser_discover_ports = config.browser.discover_ports.clone();
+    surface_options.browser_user_data_dir = config.browser.user_data_dir.clone();
+    surface_options.browser_ephemeral = config.browser.ephemeral;
     if let Some(term) = args.term {
         surface_options.term = term;
     }
@@ -126,6 +134,7 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     } else {
         app::run(Session::Local(mux.clone()), args.session)
     };
+    mux.shutdown();
     mux_core::server::cleanup(&socket_path);
     result
 }

--- a/mux/crates/mux-tui/src/session/mod.rs
+++ b/mux/crates/mux-tui/src/session/mod.rs
@@ -15,7 +15,10 @@ use std::sync::mpsc::Receiver;
 use std::sync::Arc;
 
 use ghostty_vt::{RenderState, Terminal};
-use mux_core::{Mux, MuxEvent, PaneId, ScreenId, SplitDir, Surface, SurfaceId, WorkspaceId};
+use mux_core::{
+    BrowserFrame, Mux, MuxEvent, PaneId, ScreenId, SplitDir, Surface, SurfaceId, SurfaceKind,
+    WorkspaceId,
+};
 use serde_json::json;
 
 pub use remote::{RemoteSession, RemoteSurface};
@@ -39,6 +42,7 @@ fn with_size(mut cmd: serde_json::Value, size: Option<(u16, u16)>) -> serde_json
 pub enum SurfaceHandle {
     Local(Arc<Surface>),
     Remote(Arc<RemoteSurface>, Arc<RemoteSession>),
+    RemoteBrowser,
 }
 
 impl Session {
@@ -83,9 +87,15 @@ impl Session {
     pub fn surface_sized(&self, id: SurfaceId, size: Option<(u16, u16)>) -> Option<SurfaceHandle> {
         match self {
             Session::Local(mux) => mux.surface(id).map(SurfaceHandle::Local),
-            Session::Remote(remote) => remote
-                .ensure_surface(id, size)
-                .map(|surface| SurfaceHandle::Remote(surface, remote.clone())),
+            Session::Remote(remote) => {
+                if remote.surface_kind(id) == SurfaceKind::Browser {
+                    Some(SurfaceHandle::RemoteBrowser)
+                } else {
+                    remote
+                        .ensure_surface(id, size)
+                        .map(|surface| SurfaceHandle::Remote(surface, remote.clone()))
+                }
+            }
         }
     }
 
@@ -95,6 +105,24 @@ impl Session {
             Session::Remote(remote) => {
                 remote.request(with_size(json!({"cmd": "new-tab", "pane": pane}), size)).map(|_| ())
             }
+        }
+    }
+
+    pub fn new_browser_tab(
+        &self,
+        url: String,
+        pane: Option<PaneId>,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<()> {
+        match self {
+            Session::Local(mux) => mux.new_browser_tab(url, pane, size).map(|_| ()),
+            Session::Remote(_) => anyhow::bail!("browser panes are not supported over attach yet"),
+        }
+    }
+
+    pub fn set_cell_pixel_size(&self, width_px: u16, height_px: u16) {
+        if let Session::Local(mux) = self {
+            mux.set_cell_pixel_size(width_px, height_px);
         }
     }
 
@@ -265,6 +293,14 @@ impl Session {
 }
 
 impl SurfaceHandle {
+    pub fn kind(&self) -> SurfaceKind {
+        match self {
+            SurfaceHandle::Local(surface) => surface.kind(),
+            SurfaceHandle::Remote(_, _) => SurfaceKind::Pty,
+            SurfaceHandle::RemoteBrowser => SurfaceKind::Browser,
+        }
+    }
+
     pub fn write_bytes(&self, bytes: &[u8]) {
         match self {
             SurfaceHandle::Local(surface) => {
@@ -273,6 +309,7 @@ impl SurfaceHandle {
             SurfaceHandle::Remote(surface, session) => {
                 session.send_bytes(surface.id, bytes);
             }
+            SurfaceHandle::RemoteBrowser => {}
         }
     }
 
@@ -289,6 +326,7 @@ impl SurfaceHandle {
                     }));
                 }
             }
+            SurfaceHandle::RemoteBrowser => {}
         }
     }
 
@@ -296,6 +334,7 @@ impl SurfaceHandle {
         match self {
             SurfaceHandle::Local(surface) => surface.take_dirty(),
             SurfaceHandle::Remote(surface, _) => surface.dirty.swap(false, Ordering::AcqRel),
+            SurfaceHandle::RemoteBrowser => false,
         }
     }
 
@@ -303,15 +342,91 @@ impl SurfaceHandle {
         match self {
             SurfaceHandle::Local(surface) => surface.snapshot(rs),
             SurfaceHandle::Remote(surface, _) => rs.update(&mut surface.term.lock().unwrap()),
+            SurfaceHandle::RemoteBrowser => Err(ghostty_vt::Error::InvalidValue),
         }
     }
 
     /// Run `f` against the surface's terminal state (the mirror, for
     /// remote surfaces — modes and keyboard state replay there too).
-    pub fn with_terminal<R>(&self, f: impl FnOnce(&mut Terminal) -> R) -> R {
+    pub fn with_terminal<R>(&self, f: impl FnOnce(&mut Terminal) -> R) -> Option<R> {
         match self {
             SurfaceHandle::Local(surface) => surface.with_terminal(f),
-            SurfaceHandle::Remote(surface, _) => f(&mut surface.term.lock().unwrap()),
+            SurfaceHandle::Remote(surface, _) => Some(f(&mut surface.term.lock().unwrap())),
+            SurfaceHandle::RemoteBrowser => None,
+        }
+    }
+
+    pub fn browser_frame(&self) -> Option<BrowserFrame> {
+        match self {
+            SurfaceHandle::Local(surface) => surface.browser_frame(),
+            SurfaceHandle::Remote(_, _) | SurfaceHandle::RemoteBrowser => None,
+        }
+    }
+
+    pub fn browser_url(&self) -> Option<String> {
+        match self {
+            SurfaceHandle::Local(surface) => surface.browser_url(),
+            SurfaceHandle::Remote(_, _) | SurfaceHandle::RemoteBrowser => None,
+        }
+    }
+
+    pub fn browser_insert_text(&self, text: &str) -> anyhow::Result<()> {
+        match self {
+            SurfaceHandle::Local(surface) => surface.browser_insert_text(text),
+            SurfaceHandle::Remote(_, _) | SurfaceHandle::RemoteBrowser => {
+                anyhow::bail!("browser panes are not supported over attach yet")
+            }
+        }
+    }
+
+    pub fn browser_key_event(
+        &self,
+        event_type: &str,
+        key: &str,
+        code: &str,
+        windows_virtual_key_code: u32,
+        modifiers: u32,
+        text: Option<&str>,
+    ) -> anyhow::Result<()> {
+        match self {
+            SurfaceHandle::Local(surface) => surface.browser_key_event(
+                event_type,
+                key,
+                code,
+                windows_virtual_key_code,
+                modifiers,
+                text,
+            ),
+            SurfaceHandle::Remote(_, _) | SurfaceHandle::RemoteBrowser => {
+                anyhow::bail!("browser panes are not supported over attach yet")
+            }
+        }
+    }
+
+    pub fn browser_mouse_event(
+        &self,
+        event_type: &str,
+        x: f64,
+        y: f64,
+        button: Option<&str>,
+        click_count: Option<u32>,
+    ) -> anyhow::Result<()> {
+        match self {
+            SurfaceHandle::Local(surface) => {
+                surface.browser_mouse_event(event_type, x, y, button, click_count)
+            }
+            SurfaceHandle::Remote(_, _) | SurfaceHandle::RemoteBrowser => {
+                anyhow::bail!("browser panes are not supported over attach yet")
+            }
+        }
+    }
+
+    pub fn browser_wheel(&self, x: f64, y: f64, delta_y: f64) -> anyhow::Result<()> {
+        match self {
+            SurfaceHandle::Local(surface) => surface.browser_wheel(x, y, delta_y),
+            SurfaceHandle::Remote(_, _) | SurfaceHandle::RemoteBrowser => {
+                anyhow::bail!("browser panes are not supported over attach yet")
+            }
         }
     }
 }

--- a/mux/crates/mux-tui/src/session/remote.rs
+++ b/mux/crates/mux-tui/src/session/remote.rs
@@ -12,10 +12,12 @@ use std::time::Duration;
 
 use base64::Engine;
 use ghostty_vt::{Callbacks, Terminal};
-use mux_core::{MuxEvent, SurfaceId};
+use mux_core::{MuxEvent, SurfaceId, SurfaceKind};
 use serde_json::{json, Value};
 
 use super::tree::{parse_tree, TreeView};
+
+const SUPPORTED_PROTOCOL_VERSIONS: &[u64] = &[4, 5];
 
 /// A surface mirrored from a remote session.
 pub struct RemoteSurface {
@@ -83,6 +85,12 @@ impl RemoteSession {
         let ident = session.request(json!({"cmd": "identify"}))?;
         if ident.get("app").and_then(|v| v.as_str()) != Some("cmux-mux") {
             anyhow::bail!("socket endpoint is not a cmux-mux session");
+        }
+        let protocol = ident.get("protocol").and_then(|v| v.as_u64()).unwrap_or(0);
+        if !SUPPORTED_PROTOCOL_VERSIONS.contains(&protocol) {
+            anyhow::bail!(
+                "unsupported cmux-mux protocol {protocol}; this client supports protocols 4 and 5"
+            );
         }
         session.request(json!({"cmd": "subscribe"}))?;
         Ok(session)
@@ -231,6 +239,10 @@ impl RemoteSession {
 
     pub fn drop_surface(&self, id: SurfaceId) {
         self.surfaces.lock().unwrap().remove(&id);
+    }
+
+    pub fn surface_kind(&self, id: SurfaceId) -> SurfaceKind {
+        self.tree.lock().unwrap().surface_kind(id)
     }
 
     pub fn tree(&self) -> anyhow::Result<TreeView> {

--- a/mux/crates/mux-tui/src/session/tree.rs
+++ b/mux/crates/mux-tui/src/session/tree.rs
@@ -1,7 +1,7 @@
 //! Read-only tree snapshots shared by the renderer and input handling,
 //! plus the JSON parser for the remote `list-workspaces` shape.
 
-use mux_core::{Node, PaneId, ScreenId, SplitDir, State, SurfaceId, WorkspaceId};
+use mux_core::{Node, PaneId, ScreenId, SplitDir, State, SurfaceId, SurfaceKind, WorkspaceId};
 use serde_json::Value;
 
 #[derive(Clone, Default)]
@@ -42,6 +42,7 @@ pub struct PaneView {
 pub struct TabView {
     pub surface: SurfaceId,
     pub title: String,
+    pub kind: SurfaceKind,
 }
 
 impl TreeView {
@@ -66,6 +67,17 @@ impl TreeView {
     pub fn active_surface(&self) -> Option<SurfaceId> {
         let screen = self.active_screen()?;
         screen.pane(screen.active_pane)?.active_surface()
+    }
+
+    pub fn surface_kind(&self, id: SurfaceId) -> SurfaceKind {
+        self.workspaces
+            .iter()
+            .flat_map(|ws| ws.screens.iter())
+            .flat_map(|screen| screen.panes.iter())
+            .flat_map(|pane| pane.tabs.iter())
+            .find(|tab| tab.surface == id)
+            .map(|tab| tab.kind)
+            .unwrap_or(SurfaceKind::Pty)
     }
 }
 
@@ -122,6 +134,7 @@ pub fn tree_from_state(state: &State) -> TreeView {
                 .map(|sid| TabView {
                     surface: *sid,
                     title: state.surfaces.get(sid).map(|s| s.title()).unwrap_or_default(),
+                    kind: state.surfaces.get(sid).map(|s| s.kind()).unwrap_or(SurfaceKind::Pty),
                 })
                 .collect(),
         })
@@ -193,6 +206,10 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                                 .and_then(|v| v.as_str())
                                 .unwrap_or_default()
                                 .to_string(),
+                            kind: match tab.get("kind").and_then(|v| v.as_str()) {
+                                Some("browser") => SurfaceKind::Browser,
+                                _ => SurfaceKind::Pty,
+                            },
                         })
                     })
                     .collect()

--- a/mux/crates/mux-tui/src/ui/graphics.rs
+++ b/mux/crates/mux-tui/src/ui/graphics.rs
@@ -1,0 +1,212 @@
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+use std::time::{Duration, Instant};
+
+use mux_core::{Rect, SurfaceId};
+
+const ESC: &str = "\x1b";
+const CHUNK: usize = 4096;
+const PLACEMENT_ID: u32 = 1;
+
+#[derive(Debug, Clone)]
+pub struct GraphicPlacement {
+    pub surface: SurfaceId,
+    pub rect: Rect,
+    pub seq: u64,
+    pub data_b64: String,
+}
+
+#[derive(Default)]
+pub struct GraphicsState {
+    transmitted: HashMap<SurfaceId, u64>,
+    visible: HashSet<SurfaceId>,
+}
+
+impl GraphicsState {
+    pub fn frame_bytes(&mut self, placements: &[GraphicPlacement]) -> Vec<u8> {
+        let now_visible = placements.iter().map(|p| p.surface).collect::<HashSet<_>>();
+        let mut out = Vec::new();
+
+        for old in self.visible.difference(&now_visible) {
+            out.extend(delete_image(*old));
+            self.transmitted.remove(old);
+        }
+
+        for placement in placements {
+            let already_sent =
+                self.transmitted.get(&placement.surface).is_some_and(|seq| *seq == placement.seq);
+            if !already_sent {
+                out.extend(transmit_png(placement.surface, &placement.data_b64));
+                self.transmitted.insert(placement.surface, placement.seq);
+            }
+            out.extend(place_image(placement.surface, placement.rect));
+        }
+
+        self.visible = now_visible;
+        out
+    }
+}
+
+pub fn image_id(surface: SurfaceId) -> u32 {
+    ((surface % 2_000_000_000) + 1) as u32
+}
+
+pub fn transmit_png(surface: SurfaceId, data_b64: &str) -> Vec<u8> {
+    let id = image_id(surface);
+    let mut out = Vec::new();
+    let chunks = data_b64.as_bytes().chunks(CHUNK).collect::<Vec<&[u8]>>();
+    for (idx, chunk) in chunks.iter().enumerate() {
+        let more = usize::from(idx + 1 < chunks.len());
+        let header = if idx == 0 {
+            format!("{ESC}_Ga=T,f=100,i={id},q=2,m={more};")
+        } else {
+            format!("{ESC}_Gq=2,m={more};")
+        };
+        out.extend_from_slice(header.as_bytes());
+        out.extend_from_slice(chunk);
+        out.extend_from_slice(format!("{ESC}\\").as_bytes());
+    }
+    out
+}
+
+pub fn place_image(surface: SurfaceId, rect: Rect) -> Vec<u8> {
+    let id = image_id(surface);
+    format!(
+        "{ESC}7{ESC}[{};{}H{ESC}_Ga=p,i={id},p={PLACEMENT_ID},c={},r={},q=2;{ESC}\\{ESC}8",
+        rect.y + 1,
+        rect.x + 1,
+        rect.width.max(1),
+        rect.height.max(1)
+    )
+    .into_bytes()
+}
+
+pub fn delete_image(surface: SurfaceId) -> Vec<u8> {
+    let id = image_id(surface);
+    format!("{ESC}_Ga=d,d=i,i={id},q=2;{ESC}\\").into_bytes()
+}
+
+pub fn probe_kitty_graphics() -> bool {
+    let mut stdout = std::io::stdout();
+    let _ = write!(stdout, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[c");
+    let _ = stdout.flush();
+    let bytes = read_stdin_for(Duration::from_millis(180));
+    let ok = find_bytes(&bytes, b"_Gi=31;OK");
+    let da = find_da1(&bytes);
+    match (ok, da) {
+        (Some(ok), Some(da)) => ok < da,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+pub fn detect_cell_pixels(query_fallback: bool) -> (u16, u16) {
+    if let Some(cell) = ioctl_cell_pixels() {
+        return cell;
+    }
+    if query_fallback {
+        if let Some(cell) = query_cell_pixels() {
+            return cell;
+        }
+    }
+    (8, 16)
+}
+
+fn ioctl_cell_pixels() -> Option<(u16, u16)> {
+    let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+    let ok = unsafe { libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &mut ws) } == 0;
+    if !ok || ws.ws_col == 0 || ws.ws_row == 0 || ws.ws_xpixel == 0 || ws.ws_ypixel == 0 {
+        return None;
+    }
+    let w = (ws.ws_xpixel / ws.ws_col).max(1);
+    let h = (ws.ws_ypixel / ws.ws_row).max(1);
+    Some((w, h))
+}
+
+fn query_cell_pixels() -> Option<(u16, u16)> {
+    let (cols, rows) = crossterm::terminal::size().ok()?;
+    if cols == 0 || rows == 0 {
+        return None;
+    }
+    let mut stdout = std::io::stdout();
+    let _ = write!(stdout, "\x1b[14t");
+    let _ = stdout.flush();
+    let bytes = read_stdin_for(Duration::from_millis(120));
+    let response = String::from_utf8_lossy(&bytes);
+    let start = response.find("\x1b[4;")?;
+    let tail = &response[start + 4..];
+    let end = tail.find('t')?;
+    let mut parts = tail[..end].split(';');
+    let height = parts.next()?.parse::<u32>().ok()?;
+    let width = parts.next()?.parse::<u32>().ok()?;
+    Some((((width / cols as u32).max(1)) as u16, ((height / rows as u32).max(1)) as u16))
+}
+
+fn read_stdin_for(timeout: Duration) -> Vec<u8> {
+    let start = Instant::now();
+    let mut out = Vec::new();
+    while start.elapsed() < timeout {
+        let remaining = timeout.saturating_sub(start.elapsed());
+        let poll_ms = remaining.min(Duration::from_millis(20)).as_millis() as i32;
+        let mut fd = libc::pollfd { fd: libc::STDIN_FILENO, events: libc::POLLIN, revents: 0 };
+        let ready = unsafe { libc::poll(&mut fd, 1, poll_ms) };
+        if ready <= 0 {
+            continue;
+        }
+        let mut buf = [0u8; 1024];
+        let n = unsafe { libc::read(libc::STDIN_FILENO, buf.as_mut_ptr().cast(), buf.len()) };
+        if n <= 0 {
+            break;
+        }
+        out.extend_from_slice(&buf[..n as usize]);
+        if find_da1(&out).is_some() {
+            break;
+        }
+    }
+    out
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|window| window == needle)
+}
+
+fn find_da1(bytes: &[u8]) -> Option<usize> {
+    bytes.iter().enumerate().find_map(|(idx, byte)| {
+        if *byte == b'c' && bytes[..idx].iter().rev().take(16).any(|b| *b == b'[') {
+            Some(idx)
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transmits_png_in_quiet_chunks() {
+        let data = format!("{}{}", "a".repeat(4096), "b".repeat(4));
+        let bytes = String::from_utf8(transmit_png(7, &data)).unwrap();
+        assert_eq!(
+            bytes,
+            format!(
+                "\x1b_Ga=T,f=100,i=8,q=2,m=1;{}\x1b\\\x1b_Gq=2,m=0;bbbb\x1b\\",
+                "a".repeat(4096)
+            )
+        );
+    }
+
+    #[test]
+    fn places_at_cursor_rect_with_save_restore() {
+        let bytes =
+            String::from_utf8(place_image(2, Rect { x: 4, y: 6, width: 80, height: 24 })).unwrap();
+        assert_eq!(bytes, "\x1b7\x1b[7;5H\x1b_Ga=p,i=3,p=1,c=80,r=24,q=2;\x1b\\\x1b8");
+    }
+
+    #[test]
+    fn deletes_by_image_id_quietly() {
+        let bytes = String::from_utf8(delete_image(41)).unwrap();
+        assert_eq!(bytes, "\x1b_Ga=d,d=i,i=42,q=2;\x1b\\");
+    }
+}

--- a/mux/crates/mux-tui/src/ui/mod.rs
+++ b/mux/crates/mux-tui/src/ui/mod.rs
@@ -3,6 +3,7 @@
 //! rename prompt). Every renderer that draws something interactive also
 //! pushes a [`Hit`] so clicks always match what is on screen.
 
+pub mod graphics;
 mod overlay;
 mod pane;
 mod sidebar;
@@ -85,8 +86,13 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     }
     app.hits.extend(hits);
 
-    // Session label, right-aligned (the prefix indicator replaces it).
-    let label = format!("[{}] ", app.session_label);
+    // Session label / status message, right-aligned (the prefix indicator
+    // replaces it).
+    let label = app
+        .status_message
+        .as_ref()
+        .map(|msg| format!(" {} ", truncate(msg, area.width.saturating_sub(x) as usize)))
+        .unwrap_or_else(|| format!("[{}] ", app.session_label));
     let label_w = label.chars().count() as u16;
     if !app.prefix_armed && x + label_w < area.width {
         frame.buffer_mut().set_stringn(
@@ -94,7 +100,11 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
             status_y,
             &label,
             label_w as usize,
-            base.fg(Color::Indexed(244)),
+            if app.status_message.is_some() {
+                base.fg(Color::Red).add_modifier(Modifier::BOLD)
+            } else {
+                base.fg(Color::Indexed(244))
+            },
         );
     }
 

--- a/mux/crates/mux-tui/src/ui/pane.rs
+++ b/mux/crates/mux-tui/src/ui/pane.rs
@@ -7,7 +7,7 @@
 //! where flashing notifications will hook in later.
 
 use ghostty_vt::{Cell as VtCell, RenderState, Scrollbar};
-use mux_core::Rect;
+use mux_core::{Rect, SurfaceKind};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::Frame;
 
@@ -227,6 +227,10 @@ fn draw_content(
     }
     let surface = app.session.surface(area.surface)?;
     surface.take_dirty();
+    if surface.kind() == SurfaceKind::Browser {
+        draw_browser_content(app, frame, area, &surface);
+        return None;
+    }
 
     let rs = app
         .render_states
@@ -287,6 +291,60 @@ fn draw_content(
     None
 }
 
+fn draw_browser_content(
+    app: &mut App,
+    frame: &mut Frame,
+    area: &PaneArea,
+    surface: &crate::session::SurfaceHandle,
+) {
+    let rect = area.content;
+    let screen = frame.area();
+    let max_cols = rect.width.min(screen.width.saturating_sub(rect.x));
+    let max_rows = rect.height.min(screen.height.saturating_sub(rect.y));
+    let buf = frame.buffer_mut();
+    for row in 0..max_rows {
+        for col in 0..max_cols {
+            buf[(rect.x + col, rect.y + row)].set_symbol(" ").set_style(Style::default());
+        }
+    }
+
+    let message = if surface.browser_url().is_none() {
+        Some("browser panes are not supported over attach yet".to_string())
+    } else if !app.graphics_supported {
+        Some("terminal has no kitty graphics support".to_string())
+    } else if surface.browser_frame().is_none() {
+        let url = surface
+            .browser_url()
+            .or_else(|| {
+                app.tree
+                    .active_screen()
+                    .and_then(|screen| screen.pane(area.pane))
+                    .and_then(|pane| pane.tabs.get(pane.active_tab))
+                    .map(|tab| tab.title.clone())
+            })
+            .unwrap_or_else(|| "browser".to_string());
+        Some(format!("loading {}...", truncate(&url, 48)))
+    } else {
+        None
+    };
+
+    let Some(message) = message else { return };
+    if max_cols == 0 || max_rows == 0 {
+        return;
+    }
+    let text = truncate(&message, max_cols as usize);
+    let text_w = text.chars().count() as u16;
+    let x = rect.x + max_cols.saturating_sub(text_w) / 2;
+    let y = rect.y + max_rows / 2;
+    frame.buffer_mut().set_stringn(
+        x,
+        y,
+        &text,
+        max_cols as usize,
+        Style::default().fg(Color::Indexed(244)),
+    );
+}
+
 /// Scrollbar in the right border column. Visible whenever the surface
 /// has any scrollback (total > viewport); hidden only when no scrolling
 /// is possible at all. The thumb overlays the border line; the whole
@@ -297,7 +355,10 @@ fn draw_scrollbar(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bo
         return;
     }
     let Some(surface) = app.session.surface(area.surface) else { return };
-    let Some(sb) = surface.with_terminal(|t| t.scrollbar()) else { return };
+    if surface.kind() == SurfaceKind::Browser {
+        return;
+    }
+    let Some(sb) = surface.with_terminal(|t| t.scrollbar()).flatten() else { return };
     if sb.total <= sb.len {
         return; // nothing to scroll: no scrollbar
     }

--- a/mux/scripts/smoke-tui.py
+++ b/mux/scripts/smoke-tui.py
@@ -53,7 +53,7 @@ drain(1.0)
 
 ident = rpc({"id": 1, "cmd": "identify"})
 assert ident["ok"] and ident["data"]["app"] == "cmux-mux", ident
-assert ident["data"]["protocol"] == 4, ident
+assert ident["data"]["protocol"] in (4, 5), ident
 print("identify ok:", ident["data"])
 
 ws0 = tree()[0]
@@ -78,6 +78,19 @@ text = output.decode("utf-8", "replace")
 assert " 1 " in text, text[-500:]
 assert " + " in text, text[-500:]
 print("always-on tab bar with numbered tab ok")
+
+# Prefix-B opens the browser URL prompt; Esc cancels without requiring
+# Chrome to be installed or creating a tab.
+before_tabs = len(panes[0]["tabs"])
+os.write(fd, b"\x02B")
+drain(0.8)
+text = output.decode("utf-8", "replace")
+assert "New browser tab" in text and "https://" in text, text[-800:]
+os.write(fd, b"\x1b")
+drain(0.5)
+screen0 = active_screen(tree()[0])
+assert len(screen0["panes"][0]["tabs"]) == before_tabs, screen0
+print("prefix-B browser prompt opens and Esc cancels ok")
 
 # Type a command into the shell via the TUI's stdin path (real keystrokes).
 os.write(fd, b"printf 'smoke-marker-%s\\n' ok\r")


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/7180. Adds a browser surface kind to the mux workspace: a Chrome page driven over CDP, rendered as live screencast frames via the kitty graphics protocol in the `cmux-mux` TUI, with mouse/keyboard forwarded to the page.

**How it works.** New `mux-cdp` crate: sync tungstenite WebSocket client (no tokio), flat CDP sessions, Chrome lifecycle, screencast ack loop, typed input wrappers. `Surface` becomes a Pty/Browser enum in mux-core; each `BrowserSurface` is one target + session on a shared per-mux `BrowserRuntime` connection. The TUI passes CDP's base64 PNG frames straight into kitty graphics escapes (no image decoding) after each ratatui draw, probes terminal support at startup, and shows a text placeholder on unsupported terminals. Input maps cell coordinates to page pixels 1:1 via a device-metrics override.

**Reusing an existing Chrome.** Connection order: `CMUX_MUX_CDP_URL` env, `browser.cdp_url` config (ws:// or http://), port discovery on 127.0.0.1 (`/json/version` over a hand-rolled HTTP GET, default port 9222), then launching Chrome with a persistent profile (`browser.ephemeral` opts out; ephemeral always uses a fresh temp dir and never deletes a configured `user_data_dir`). Closing a pane closes only its target; Chrome is killed at shutdown only if we launched it. Note Chrome 136+ refuses debugging on the default user data dir, so everyday Chrome profiles are not attachable by design; `CMUX_MUX_CDP_DEBUG=1` logs all CDP traffic.

**Entry points.** Prefix-`B` URL prompt, pane context menu "New browser tab", `new-browser-tab` socket command (protocol 5; v4 attach clients still work), rebindable via `keys.new_browser_tab`, `browser.*` config keys documented in `mux/README.md`.

**Also fixes** a pre-existing create/exit race where a child exiting before its tree insert left a dead workspace behind (de-flakes `surface_exit_reaps_tree_and_emits_event`).

**Verified.** `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (fake-CDP server tests cover handshake, id correlation, ack round-trip, discovery, external attach, two-surface session demux; no Chrome needed in CI), `smoke-tui.py`, env-gated real-Chrome tests, plus a scripted-pty preflight that answers the kitty probe, creates a browser tab via prefix-B against a freshly launched Chrome, and asserts a kitty transmit escape for a real screencast frame.

**Known limitations.** Browser frames don't stream over remote attach (placeholder shown). Browser tab creation blocks the TUI event thread for the Chrome-launch seconds. SIGTERM without a clean quit can orphan a launched Chrome (no signal handler yet). A user-typed unloadable URL fails slowly (CDP session call timeout) before the status-line error appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785745434&installation_id=133855650&pr_number=7325&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7325&signature=2bdf5e1c7e960129f24fb18f88a25c4df840d13cef8c57f13f4e25b07451134f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new surface kind touching mux orchestration, external Chrome/CDP, and TUI graphics; PTY paths are mostly gated but browser launch and blocking CDP on the UI thread add operational edge cases.
> 
> **Overview**
> Introduces **browser panes** alongside PTY tabs: a new **`mux-cdp`** crate (sync WebSocket CDP client, Chrome launch/discovery, screencast + input), **`Surface` as Pty | Browser** in `mux-core`, and a shared per-session **`BrowserRuntime`** that attaches targets, streams PNG screencasts, and forwards mouse/keyboard.
> 
> The **TUI** opens browser tabs via prefix-`B`, context menu, or `new-browser-tab`; after each draw it emits **kitty graphics** from CDP base64 PNGs (with cell-pixel sizing for CDP metrics), and branches input/rendering by `SurfaceKind`. **Config** adds `browser.*` keys; the control socket bumps to **protocol 5** with `kind` / `browser_source` in listings and PTY-only guards on attach/VT commands.
> 
> Also adds **`reap_if_dead`** after surface creation to fix a race when a child exits before tree insert, **`mux.shutdown()`** to kill launched Chrome, and documents v1 limits (no browser pixels or tab creation over remote attach).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ee1e0c430ea5e6bed3411108f1c477ae514d94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->