### PR TITLE
Pairing: single Copy Address button on Mac, single address box on iOS

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxManualPairingEntry.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxManualPairingEntry.swift
@@ -60,8 +60,10 @@ public struct CmxManualPairingEntry: Equatable, Sendable {
         /// or junk between `]` and the port separator).
         case invalidHost
         /// An explicit port separator is present but the port is not a
-        /// number in `1...65535`.
-        case invalidPort
+        /// number in `1...65535`. Carries the intact host part so host-keyed
+        /// UI (the manual-route trust warning) keeps working while the user
+        /// is mid-typing a port, e.g. on the trailing colon of `10.0.0.5:`.
+        case invalidPort(host: String)
     }
 
     /// Splits a user-entered address into host + port, inverting
@@ -99,7 +101,7 @@ public struct CmxManualPairingEntry: Equatable, Sendable {
                 return .failure(.invalidHost)
             }
             guard let port = validPort(remainder.dropFirst()) else {
-                return .failure(.invalidPort)
+                return .failure(.invalidPort(host: host))
             }
             return .success(CmxManualPairingEntry(host: host, port: port))
         }
@@ -115,7 +117,7 @@ public struct CmxManualPairingEntry: Equatable, Sendable {
                 return .failure(.invalidHost)
             }
             guard let port = validPort(trimmed[trimmed.index(after: separator)...]) else {
-                return .failure(.invalidPort)
+                return .failure(.invalidPort(host: host))
             }
             return .success(CmxManualPairingEntry(host: host, port: port))
         default:

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxManualPairingEntry.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxManualPairingEntry.swift
@@ -1,8 +1,9 @@
 import Darwin
 import Foundation
 
-/// The single `host` + `port` the Mac pairing window offers for manual entry
-/// (the "Copy IP" / "Copy Port" buttons next to the QR code).
+/// The single `host:port` address the Mac pairing window offers for manual
+/// entry (the "Copy Address" button next to the QR code) and the phone's
+/// address box parses back.
 ///
 /// Selection mirrors the QR's trust rules and the phone's manual-entry needs:
 /// only routes a phone can actually dial qualify (loopback never does, by the
@@ -11,15 +12,22 @@ import Foundation
 /// works even when the phone's DNS is not pointed at the tailnet. Ties fall
 /// back to the Mac's own route priority order.
 public struct CmxManualPairingEntry: Equatable, Sendable {
-    /// The address the user types into the phone's host field.
+    /// The bare host part of the address (no brackets, no port).
     public let host: String
-    /// The port the user types into the phone's port field.
+    /// The port part of the address.
     public let port: Int
+
+    /// The one-string `host:port` form the Mac copies and the phone pastes.
+    /// IPv6 hosts are bracketed (`[fe80::1]:58465`) so the port separator
+    /// stays unambiguous.
+    public var displayString: String {
+        host.contains(":") ? "[\(host)]:\(port)" : "\(host):\(port)"
+    }
 
     /// Creates a manual-entry pair.
     /// - Parameters:
-    ///   - host: The address for the phone's host field.
-    ///   - port: The port for the phone's port field.
+    ///   - host: The bare host part of the address.
+    ///   - port: The port part of the address.
     public init(host: String, port: Int) {
         self.host = host
         self.port = port
@@ -42,6 +50,59 @@ public struct CmxManualPairingEntry: Equatable, Sendable {
         let pick = pool.first { isIPLiteral($0.entry.host) } ?? pool.first
         return pick?.entry
     }
+
+    /// Splits a user-entered address into host + port, inverting
+    /// ``displayString``: accepts `host`, `host:port`, `[v6]`, `[v6]:port`,
+    /// and a bare bracketless IPv6 literal (two or more colons, which can
+    /// never be a `host:port` split, so the whole string is the host).
+    ///
+    /// Only the shape is decided here; host *validity* (no schemes, paths,
+    /// or whitespace) stays with the caller's host policy. Returns `nil`
+    /// when an explicit port separator is present but the port is not a
+    /// number in `1...65535`, or when a bracket form is malformed.
+    /// - Parameters:
+    ///   - input: The raw address string the user typed or pasted.
+    ///   - defaultPort: The port used when `input` has no port suffix.
+    public static func parse(_ input: String, defaultPort: Int) -> CmxManualPairingEntry? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if trimmed.hasPrefix("[") {
+            guard let closing = trimmed.firstIndex(of: "]") else {
+                return nil
+            }
+            let host = String(trimmed[trimmed.index(after: trimmed.startIndex)..<closing])
+            let remainder = trimmed[trimmed.index(after: closing)...]
+            guard !host.isEmpty else {
+                return nil
+            }
+            if remainder.isEmpty {
+                return CmxManualPairingEntry(host: host, port: defaultPort)
+            }
+            guard remainder.hasPrefix(":"), let port = validPort(remainder.dropFirst()) else {
+                return nil
+            }
+            return CmxManualPairingEntry(host: host, port: port)
+        }
+
+        let colonCount = trimmed.filter { $0 == ":" }.count
+        switch colonCount {
+        case 0:
+            return CmxManualPairingEntry(host: trimmed, port: defaultPort)
+        case 1:
+            let separator = trimmed.firstIndex(of: ":")!
+            let host = String(trimmed[..<separator])
+            guard !host.isEmpty, let port = validPort(trimmed[trimmed.index(after: separator)...]) else {
+                return nil
+            }
+            return CmxManualPairingEntry(host: host, port: port)
+        default:
+            // Bracketless IPv6 literal; there is no unambiguous port split.
+            return CmxManualPairingEntry(host: trimmed, port: defaultPort)
+        }
+    }
 }
 private extension CmxManualPairingEntry {
     /// Whether `host` is a strict numeric IP literal (dotted-quad IPv4 or any
@@ -53,5 +114,14 @@ private extension CmxManualPairingEntry {
         }
         var ipv6 = in6_addr()
         return inet_pton(AF_INET6, host, &ipv6) == 1
+    }
+
+    /// Parses a port substring, requiring all digits and the 1...65535 range.
+    static func validPort(_ text: Substring) -> Int? {
+        guard !text.isEmpty, text.allSatisfy({ $0.isASCII && $0.isNumber }), let port = Int(text),
+              (1...65535).contains(port) else {
+            return nil
+        }
+        return port
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxManualPairingEntry.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxManualPairingEntry.swift
@@ -51,56 +51,76 @@ public struct CmxManualPairingEntry: Equatable, Sendable {
         return pick?.entry
     }
 
+    /// Why ``parse(_:defaultPort:)`` rejected an address, so the caller can
+    /// show the host-shaped or port-shaped error instead of guessing (a user
+    /// typing `:58465` has a host problem, not a port problem).
+    public enum ParseError: Error, Equatable, Sendable {
+        /// The host part is missing or the bracket form is malformed
+        /// (empty input, `:port`, `[]`, `[v6` with no closing bracket,
+        /// or junk between `]` and the port separator).
+        case invalidHost
+        /// An explicit port separator is present but the port is not a
+        /// number in `1...65535`.
+        case invalidPort
+    }
+
     /// Splits a user-entered address into host + port, inverting
     /// ``displayString``: accepts `host`, `host:port`, `[v6]`, `[v6]:port`,
     /// and a bare bracketless IPv6 literal (two or more colons, which can
     /// never be a `host:port` split, so the whole string is the host).
     ///
     /// Only the shape is decided here; host *validity* (no schemes, paths,
-    /// or whitespace) stays with the caller's host policy. Returns `nil`
-    /// when an explicit port separator is present but the port is not a
-    /// number in `1...65535`, or when a bracket form is malformed.
+    /// or whitespace) stays with the caller's host policy. Failures carry a
+    /// ``ParseError`` naming the broken part so error messages stay honest.
     /// - Parameters:
     ///   - input: The raw address string the user typed or pasted.
     ///   - defaultPort: The port used when `input` has no port suffix.
-    public static func parse(_ input: String, defaultPort: Int) -> CmxManualPairingEntry? {
+    public static func parse(
+        _ input: String, defaultPort: Int
+    ) -> Result<CmxManualPairingEntry, ParseError> {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
-            return nil
+            return .failure(.invalidHost)
         }
 
         if trimmed.hasPrefix("[") {
             guard let closing = trimmed.firstIndex(of: "]") else {
-                return nil
+                return .failure(.invalidHost)
             }
             let host = String(trimmed[trimmed.index(after: trimmed.startIndex)..<closing])
             let remainder = trimmed[trimmed.index(after: closing)...]
             guard !host.isEmpty else {
-                return nil
+                return .failure(.invalidHost)
             }
             if remainder.isEmpty {
-                return CmxManualPairingEntry(host: host, port: defaultPort)
+                return .success(CmxManualPairingEntry(host: host, port: defaultPort))
             }
-            guard remainder.hasPrefix(":"), let port = validPort(remainder.dropFirst()) else {
-                return nil
+            guard remainder.hasPrefix(":") else {
+                return .failure(.invalidHost)
             }
-            return CmxManualPairingEntry(host: host, port: port)
+            guard let port = validPort(remainder.dropFirst()) else {
+                return .failure(.invalidPort)
+            }
+            return .success(CmxManualPairingEntry(host: host, port: port))
         }
 
         let colonCount = trimmed.filter { $0 == ":" }.count
         switch colonCount {
         case 0:
-            return CmxManualPairingEntry(host: trimmed, port: defaultPort)
+            return .success(CmxManualPairingEntry(host: trimmed, port: defaultPort))
         case 1:
             let separator = trimmed.firstIndex(of: ":")!
             let host = String(trimmed[..<separator])
-            guard !host.isEmpty, let port = validPort(trimmed[trimmed.index(after: separator)...]) else {
-                return nil
+            guard !host.isEmpty else {
+                return .failure(.invalidHost)
             }
-            return CmxManualPairingEntry(host: host, port: port)
+            guard let port = validPort(trimmed[trimmed.index(after: separator)...]) else {
+                return .failure(.invalidPort)
+            }
+            return .success(CmxManualPairingEntry(host: host, port: port))
         default:
             // Bracketless IPv6 literal; there is no unambiguous port split.
-            return CmxManualPairingEntry(host: trimmed, port: defaultPort)
+            return .success(CmxManualPairingEntry(host: trimmed, port: defaultPort))
         }
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxManualPairingEntryTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxManualPairingEntryTests.swift
@@ -4,7 +4,8 @@ import Testing
 @testable import CMUXMobileCore
 
 /// Coverage for the manual-entry route selection behind the pairing window's
-/// "Copy IP" / "Copy Port" buttons.
+/// "Copy Address" button, and for the `host:port` display/parse round trip
+/// shared with the phone's address box.
 @Suite struct CmxManualPairingEntryTests {
     private func route(
         id: String,
@@ -68,5 +69,62 @@ import Testing
 
     @Test func emptyRoutesYieldNothing() {
         #expect(CmxManualPairingEntry.best(in: []) == nil)
+    }
+
+    @Test func displayStringJoinsHostAndPort() {
+        #expect(CmxManualPairingEntry(host: "100.64.0.5", port: 58465).displayString == "100.64.0.5:58465")
+        #expect(CmxManualPairingEntry(host: "mac.tail1234.ts.net", port: 1).displayString == "mac.tail1234.ts.net:1")
+    }
+
+    @Test func displayStringBracketsIPv6Hosts() {
+        #expect(CmxManualPairingEntry(host: "fd7a:115c:a1e0::1", port: 58465).displayString == "[fd7a:115c:a1e0::1]:58465")
+    }
+
+    @Test func parseRoundTripsDisplayString() {
+        let entries = [
+            CmxManualPairingEntry(host: "100.64.0.5", port: 58465),
+            CmxManualPairingEntry(host: "mac.tail1234.ts.net", port: 443),
+            CmxManualPairingEntry(host: "fd7a:115c:a1e0::1", port: 58465),
+        ]
+        for entry in entries {
+            #expect(CmxManualPairingEntry.parse(entry.displayString, defaultPort: 1) == entry)
+        }
+    }
+
+    @Test func parseDefaultsPortWhenAbsent() {
+        #expect(
+            CmxManualPairingEntry.parse("  100.64.0.5  ", defaultPort: 58465)
+                == CmxManualPairingEntry(host: "100.64.0.5", port: 58465)
+        )
+        #expect(
+            CmxManualPairingEntry.parse("[fd7a::1]", defaultPort: 58465)
+                == CmxManualPairingEntry(host: "fd7a::1", port: 58465)
+        )
+    }
+
+    @Test func parseTreatsBracketlessIPv6AsHostOnly() {
+        // Two or more colons can never be a host:port split, so the whole
+        // string is the host and the port falls back to the default.
+        #expect(
+            CmxManualPairingEntry.parse("fd7a:115c:a1e0::1", defaultPort: 58465)
+                == CmxManualPairingEntry(host: "fd7a:115c:a1e0::1", port: 58465)
+        )
+    }
+
+    @Test func parseRejectsBadPorts() {
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:70000", defaultPort: 1) == nil)
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:0", defaultPort: 1) == nil)
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:", defaultPort: 1) == nil)
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:abc", defaultPort: 1) == nil)
+        #expect(CmxManualPairingEntry.parse("[fd7a::1]:99999", defaultPort: 1) == nil)
+    }
+
+    @Test func parseRejectsMalformedShapes() {
+        #expect(CmxManualPairingEntry.parse("", defaultPort: 1) == nil)
+        #expect(CmxManualPairingEntry.parse("   ", defaultPort: 1) == nil)
+        #expect(CmxManualPairingEntry.parse("[fd7a::1", defaultPort: 1) == nil)
+        #expect(CmxManualPairingEntry.parse("[]:58465", defaultPort: 1) == nil)
+        #expect(CmxManualPairingEntry.parse(":58465", defaultPort: 1) == nil)
+        #expect(CmxManualPairingEntry.parse("[fd7a::1]58465", defaultPort: 1) == nil)
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxManualPairingEntryTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxManualPairingEntryTests.swift
@@ -87,18 +87,18 @@ import Testing
             CmxManualPairingEntry(host: "fd7a:115c:a1e0::1", port: 58465),
         ]
         for entry in entries {
-            #expect(CmxManualPairingEntry.parse(entry.displayString, defaultPort: 1) == entry)
+            #expect(CmxManualPairingEntry.parse(entry.displayString, defaultPort: 1) == .success(entry))
         }
     }
 
     @Test func parseDefaultsPortWhenAbsent() {
         #expect(
             CmxManualPairingEntry.parse("  100.64.0.5  ", defaultPort: 58465)
-                == CmxManualPairingEntry(host: "100.64.0.5", port: 58465)
+                == .success(CmxManualPairingEntry(host: "100.64.0.5", port: 58465))
         )
         #expect(
             CmxManualPairingEntry.parse("[fd7a::1]", defaultPort: 58465)
-                == CmxManualPairingEntry(host: "fd7a::1", port: 58465)
+                == .success(CmxManualPairingEntry(host: "fd7a::1", port: 58465))
         )
     }
 
@@ -107,24 +107,28 @@ import Testing
         // string is the host and the port falls back to the default.
         #expect(
             CmxManualPairingEntry.parse("fd7a:115c:a1e0::1", defaultPort: 58465)
-                == CmxManualPairingEntry(host: "fd7a:115c:a1e0::1", port: 58465)
+                == .success(CmxManualPairingEntry(host: "fd7a:115c:a1e0::1", port: 58465))
         )
     }
 
-    @Test func parseRejectsBadPorts() {
-        #expect(CmxManualPairingEntry.parse("100.64.0.5:70000", defaultPort: 1) == nil)
-        #expect(CmxManualPairingEntry.parse("100.64.0.5:0", defaultPort: 1) == nil)
-        #expect(CmxManualPairingEntry.parse("100.64.0.5:", defaultPort: 1) == nil)
-        #expect(CmxManualPairingEntry.parse("100.64.0.5:abc", defaultPort: 1) == nil)
-        #expect(CmxManualPairingEntry.parse("[fd7a::1]:99999", defaultPort: 1) == nil)
+    @Test func parseRejectsBadPortsAsPortFailures() {
+        // A well-shaped host with a broken port suffix must blame the port,
+        // so the phone shows the port error, not the host error.
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:70000", defaultPort: 1) == .failure(.invalidPort))
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:0", defaultPort: 1) == .failure(.invalidPort))
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:", defaultPort: 1) == .failure(.invalidPort))
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:abc", defaultPort: 1) == .failure(.invalidPort))
+        #expect(CmxManualPairingEntry.parse("[fd7a::1]:99999", defaultPort: 1) == .failure(.invalidPort))
     }
 
-    @Test func parseRejectsMalformedShapes() {
-        #expect(CmxManualPairingEntry.parse("", defaultPort: 1) == nil)
-        #expect(CmxManualPairingEntry.parse("   ", defaultPort: 1) == nil)
-        #expect(CmxManualPairingEntry.parse("[fd7a::1", defaultPort: 1) == nil)
-        #expect(CmxManualPairingEntry.parse("[]:58465", defaultPort: 1) == nil)
-        #expect(CmxManualPairingEntry.parse(":58465", defaultPort: 1) == nil)
-        #expect(CmxManualPairingEntry.parse("[fd7a::1]58465", defaultPort: 1) == nil)
+    @Test func parseRejectsMalformedShapesAsHostFailures() {
+        // A missing host or broken bracket shape must blame the host even
+        // when the port digits are valid (`:58465` is a host problem).
+        #expect(CmxManualPairingEntry.parse("", defaultPort: 1) == .failure(.invalidHost))
+        #expect(CmxManualPairingEntry.parse("   ", defaultPort: 1) == .failure(.invalidHost))
+        #expect(CmxManualPairingEntry.parse("[fd7a::1", defaultPort: 1) == .failure(.invalidHost))
+        #expect(CmxManualPairingEntry.parse("[]:58465", defaultPort: 1) == .failure(.invalidHost))
+        #expect(CmxManualPairingEntry.parse(":58465", defaultPort: 1) == .failure(.invalidHost))
+        #expect(CmxManualPairingEntry.parse("[fd7a::1]58465", defaultPort: 1) == .failure(.invalidHost))
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxManualPairingEntryTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxManualPairingEntryTests.swift
@@ -112,13 +112,14 @@ import Testing
     }
 
     @Test func parseRejectsBadPortsAsPortFailures() {
-        // A well-shaped host with a broken port suffix must blame the port,
-        // so the phone shows the port error, not the host error.
-        #expect(CmxManualPairingEntry.parse("100.64.0.5:70000", defaultPort: 1) == .failure(.invalidPort))
-        #expect(CmxManualPairingEntry.parse("100.64.0.5:0", defaultPort: 1) == .failure(.invalidPort))
-        #expect(CmxManualPairingEntry.parse("100.64.0.5:", defaultPort: 1) == .failure(.invalidPort))
-        #expect(CmxManualPairingEntry.parse("100.64.0.5:abc", defaultPort: 1) == .failure(.invalidPort))
-        #expect(CmxManualPairingEntry.parse("[fd7a::1]:99999", defaultPort: 1) == .failure(.invalidPort))
+        // A well-shaped host with a broken port suffix must blame the port
+        // (so the phone shows the port error, not the host error) and carry
+        // the intact host so host-keyed UI keeps working mid-typing.
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:70000", defaultPort: 1) == .failure(.invalidPort(host: "100.64.0.5")))
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:0", defaultPort: 1) == .failure(.invalidPort(host: "100.64.0.5")))
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:", defaultPort: 1) == .failure(.invalidPort(host: "100.64.0.5")))
+        #expect(CmxManualPairingEntry.parse("100.64.0.5:abc", defaultPort: 1) == .failure(.invalidPort(host: "100.64.0.5")))
+        #expect(CmxManualPairingEntry.parse("[fd7a::1]:99999", defaultPort: 1) == .failure(.invalidPort(host: "fd7a::1")))
     }
 
     @Test func parseRejectsMalformedShapesAsHostFailures() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PairingView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PairingView.swift
@@ -28,8 +28,7 @@ struct PairingView: View {
     @State private var isShowingScanner = false
     @State private var deviceName = UITestConfig.addDeviceName
         ?? L10n.string("mobile.addDevice.namePlaceholder", defaultValue: "Work Mac")
-    @State private var host = UITestConfig.addDeviceHost ?? ""
-    @State private var port = UITestConfig.addDevicePort ?? "\(CmxMobileDefaults.defaultHostPort)"
+    @State private var address = UITestConfig.addDeviceAddress ?? ""
     @Environment(AuthCoordinator.self) private var authManager
     @Environment(\.analytics) private var analytics
     @Environment(\.tailscaleStatusMonitor) private var tailscaleStatusMonitor
@@ -61,26 +60,17 @@ struct PairingView: View {
                     .accessibilityIdentifier("MobileAddDeviceNameField")
 
                     TextField(
-                        L10n.string("mobile.addDevice.hostPlaceholder", defaultValue: "your-mac.tailnet.ts.net"),
-                        text: $host
+                        L10n.string("mobile.addDevice.addressPlaceholder", defaultValue: "your-mac.tailnet.ts.net:58465"),
+                        text: $address
                     )
-                    .focused($focusedField, equals: .host)
-                    .submitLabel(.next)
-                    .addDeviceInputBehavior(.url)
-                    .accessibilityIdentifier("MobileAddDeviceHostField")
-
-                    TextField(
-                        L10n.string("mobile.addDevice.portPlaceholder", defaultValue: "58465"),
-                        text: $port
-                    )
-                    .focused($focusedField, equals: .port)
+                    .focused($focusedField, equals: .address)
                     .submitLabel(.done)
-                    .addDeviceInputBehavior(.number)
-                    .accessibilityIdentifier("MobileAddDevicePortField")
+                    .addDeviceInputBehavior(.url)
+                    .accessibilityIdentifier("MobileAddDeviceAddressField")
                 } header: {
                     Text(L10n.string("mobile.addDevice.title", defaultValue: "Add Computer"))
                 } footer: {
-                    Text(L10n.string("mobile.addDevice.help", defaultValue: "Enter a Tailscale, LAN, or local host and port. QR/link pairing from that computer is still the safest setup path."))
+                    Text(L10n.string("mobile.addDevice.help", defaultValue: "Paste the address from the Mac's pairing window (Copy Address). The port is optional. QR/link pairing from that computer is still the safest setup path."))
                 }
                 .overlay(alignment: .topLeading) {
                     #if DEBUG
@@ -211,7 +201,7 @@ struct PairingView: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
                 .tint(.blue)
-                .disabled(isPairing || host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .disabled(isPairing || address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 .accessibilityIdentifier("MobilePairButton")
                 .padding(.horizontal)
                 .padding(.bottom, 8)
@@ -277,10 +267,11 @@ struct PairingView: View {
     }
 
     private var manualRouteWarningText: String? {
-        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedHost.isEmpty,
-              !CmxPairingURLScheme.hasPairingScheme(trimmedHost),
-              MobileShellRouteAuthPolicy.manualHostNeedsTrustWarning(trimmedHost) else {
+        let trimmedAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedAddress.isEmpty,
+              !CmxPairingURLScheme.hasPairingScheme(trimmedAddress),
+              let entry = CmxManualPairingEntry.parse(trimmedAddress, defaultPort: CmxMobileDefaults.defaultHostPort),
+              MobileShellRouteAuthPolicy.manualHostNeedsTrustWarning(entry.host) else {
             return nil
         }
         return L10n.string(
@@ -312,30 +303,31 @@ struct PairingView: View {
 
     private func pair() {
         validationError = nil
-        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedHost.isEmpty else {
+        let trimmedAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedAddress.isEmpty else {
             validationError = L10n.string("mobile.addDevice.invalidHost", defaultValue: "Enter a host or IP address, without spaces or URL paths.")
             return
         }
-        if CmxPairingURLScheme.hasPairingScheme(trimmedHost) {
-            pairingCode = trimmedHost
+        if CmxPairingURLScheme.hasPairingScheme(trimmedAddress) {
+            pairingCode = trimmedAddress
             startPairingTask {
                 await connectPairingCode()
             }
             return
         }
-        guard MobileShellRouteAuthPolicy.normalizedManualHost(trimmedHost) != nil else {
-            validationError = L10n.string("mobile.addDevice.invalidHost", defaultValue: "Enter a host or IP address, without spaces or URL paths.")
+        guard let entry = CmxManualPairingEntry.parse(trimmedAddress, defaultPort: CmxMobileDefaults.defaultHostPort) else {
+            // The only parse failures are a bad port suffix or malformed
+            // brackets; a bare host always parses with the default port.
+            validationError = L10n.string("mobile.addDevice.invalidPort", defaultValue: "Enter a port from 1 to 65535.")
             return
         }
-        guard let parsedPort = Int(port.trimmingCharacters(in: .whitespacesAndNewlines)),
-              (1...65535).contains(parsedPort) else {
-            validationError = L10n.string("mobile.addDevice.invalidPort", defaultValue: "Enter a port from 1 to 65535.")
+        guard let normalizedHost = MobileShellRouteAuthPolicy.normalizedManualHost(entry.host) else {
+            validationError = L10n.string("mobile.addDevice.invalidHost", defaultValue: "Enter a host or IP address, without spaces or URL paths.")
             return
         }
 
         startPairingTask {
-            await connectManualHost(deviceName, trimmedHost, parsedPort)
+            await connectManualHost(deviceName, normalizedHost, entry.port)
         }
     }
 
@@ -360,6 +352,5 @@ struct PairingView: View {
 
 private enum AddDeviceField: Hashable {
     case name
-    case host
-    case port
+    case address
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PairingView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PairingView.swift
@@ -269,9 +269,22 @@ struct PairingView: View {
     private var manualRouteWarningText: String? {
         let trimmedAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedAddress.isEmpty,
-              !CmxPairingURLScheme.hasPairingScheme(trimmedAddress),
-              case .success(let entry) = CmxManualPairingEntry.parse(trimmedAddress, defaultPort: CmxMobileDefaults.defaultHostPort),
-              MobileShellRouteAuthPolicy.manualHostNeedsTrustWarning(entry.host) else {
+              !CmxPairingURLScheme.hasPairingScheme(trimmedAddress) else {
+            return nil
+        }
+        // The warning is about the host, so a broken port suffix (common
+        // mid-typing: the trailing colon of `10.0.0.5:`) must not blink the
+        // warning off; `.invalidPort` carries the intact host for this.
+        let host: String
+        switch CmxManualPairingEntry.parse(trimmedAddress, defaultPort: CmxMobileDefaults.defaultHostPort) {
+        case .success(let entry):
+            host = entry.host
+        case .failure(.invalidPort(let hostPart)):
+            host = hostPart
+        case .failure(.invalidHost):
+            return nil
+        }
+        guard MobileShellRouteAuthPolicy.manualHostNeedsTrustWarning(host) else {
             return nil
         }
         return L10n.string(
@@ -322,7 +335,7 @@ struct PairingView: View {
         case .failure(.invalidHost):
             validationError = L10n.string("mobile.addDevice.invalidHost", defaultValue: "Enter a host or IP address, without spaces or URL paths.")
             return
-        case .failure(.invalidPort):
+        case .failure(.invalidPort(host: _)):
             validationError = L10n.string("mobile.addDevice.invalidPort", defaultValue: "Enter a port from 1 to 65535.")
             return
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PairingView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PairingView.swift
@@ -270,7 +270,7 @@ struct PairingView: View {
         let trimmedAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedAddress.isEmpty,
               !CmxPairingURLScheme.hasPairingScheme(trimmedAddress),
-              let entry = CmxManualPairingEntry.parse(trimmedAddress, defaultPort: CmxMobileDefaults.defaultHostPort),
+              case .success(let entry) = CmxManualPairingEntry.parse(trimmedAddress, defaultPort: CmxMobileDefaults.defaultHostPort),
               MobileShellRouteAuthPolicy.manualHostNeedsTrustWarning(entry.host) else {
             return nil
         }
@@ -315,9 +315,14 @@ struct PairingView: View {
             }
             return
         }
-        guard let entry = CmxManualPairingEntry.parse(trimmedAddress, defaultPort: CmxMobileDefaults.defaultHostPort) else {
-            // The only parse failures are a bad port suffix or malformed
-            // brackets; a bare host always parses with the default port.
+        let entry: CmxManualPairingEntry
+        switch CmxManualPairingEntry.parse(trimmedAddress, defaultPort: CmxMobileDefaults.defaultHostPort) {
+        case .success(let parsed):
+            entry = parsed
+        case .failure(.invalidHost):
+            validationError = L10n.string("mobile.addDevice.invalidHost", defaultValue: "Enter a host or IP address, without spaces or URL paths.")
+            return
+        case .failure(.invalidPort):
             validationError = L10n.string("mobile.addDevice.invalidPort", defaultValue: "Enter a port from 1 to 65535.")
             return
         }

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -19,14 +19,9 @@ public struct UITestConfig {
         value(for: "CMUX_UITEST_ADD_DEVICE_NAME")
     }
 
-    /// The host to prefill on the Add Device form, if injected.
-    public static var addDeviceHost: String? {
-        value(for: "CMUX_UITEST_ADD_DEVICE_HOST")
-    }
-
-    /// The port to prefill on the Add Device form, if injected.
-    public static var addDevicePort: String? {
-        value(for: "CMUX_UITEST_ADD_DEVICE_PORT")
+    /// The `host[:port]` address to prefill on the Add Device form, if injected.
+    public static var addDeviceAddress: String? {
+        value(for: "CMUX_UITEST_ADD_DEVICE_ADDRESS")
     }
 
     /// The attach URL to auto-open, if injected.

--- a/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/UITestConfigTests.swift
+++ b/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/UITestConfigTests.swift
@@ -56,9 +56,9 @@ import Testing
     @Test func valueIsNilWhenBlank() {
         let env = [
             "CMUX_UITEST_MOCK_DATA": "1",
-            "CMUX_UITEST_ADD_DEVICE_HOST": "   ",
+            "CMUX_UITEST_ADD_DEVICE_ADDRESS": "   ",
         ]
-        #expect(UITestConfig.value(for: "CMUX_UITEST_ADD_DEVICE_HOST", env: env) == nil)
+        #expect(UITestConfig.value(for: "CMUX_UITEST_ADD_DEVICE_ADDRESS", env: env) == nil)
     }
 
     // MARK: - dogfoodAttachURL (NOT mock-gated)

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -45,8 +45,8 @@ final class MobilePairingModel {
         /// Reachable Tailscale `host:port` routes. Empty when Tailscale is not
         /// detected, in which case a real iPhone cannot reach this Mac.
         let tailscaleLines: [String]
-        /// The best route for manual phone entry, behind the "Copy IP" and
-        /// "Copy Port" buttons. `nil` when no phone-dialable route exists.
+        /// The best route for manual phone entry, behind the "Copy Address"
+        /// button. `nil` when no phone-dialable route exists.
         let manualEntry: CmxManualPairingEntry?
 
         /// Whether at least one Tailscale route resolved.

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -12,9 +12,9 @@ import SwiftUI
 /// same-account check; Tailscale is what gives the iPhone a route to this Mac.
 struct MobilePairingView: View {
     @State private var model = MobilePairingModel()
-    /// The manual-entry value that was just copied (the host or the port
-    /// string), so only the matching button shows the brief "Copied" flash.
-    /// The two values can never collide: one is a host, the other a port.
+    /// The address string that was just copied, so the Copy Address button's
+    /// brief "Copied" flash only shows while the button still offers that
+    /// exact value (a route refresh that changes the address drops the flash).
     @State private var copiedValue: String?
     /// Bumped per copy so an older flash's dismissal can't clear a newer one.
     @State private var copiedValueGeneration = 0

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -275,8 +275,8 @@ struct MobilePairingView: View {
 
     @ViewBuilder
     private func readyContent(_ ready: MobilePairingModel.Ready) -> some View {
-        // Manual entry sits above the QR so Copy IP / Copy Port are reachable
-        // without scrolling (they used to sit below the steps, below the fold).
+        // Manual entry sits above the QR so Copy Address is reachable
+        // without scrolling (it used to sit below the steps, below the fold).
         if ready.reachableViaTailscale {
             manualFallback(ready)
         }
@@ -380,16 +380,10 @@ struct MobilePairingView: View {
                     .foregroundStyle(.secondary)
             }
             if let entry = ready.manualEntry {
-                HStack(spacing: 8) {
-                    copyButton(
-                        label: String(localized: "mobile.pairing.manual.copyIP", defaultValue: "Copy IP"),
-                        value: entry.host
-                    )
-                    copyButton(
-                        label: String(localized: "mobile.pairing.manual.copyPort", defaultValue: "Copy Port"),
-                        value: String(entry.port)
-                    )
-                }
+                copyButton(
+                    label: String(localized: "mobile.pairing.manual.copyAddress", defaultValue: "Copy Address"),
+                    value: entry.displayString
+                )
                 .padding(.top, 2)
             }
         }
@@ -398,8 +392,8 @@ struct MobilePairingView: View {
         .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
     }
 
-    /// One of the two manual-entry copy controls. Copies `value` to the
-    /// general pasteboard and briefly swaps its label to a "Copied" check.
+    /// The manual-entry copy control. Copies `value` to the general
+    /// pasteboard and briefly swaps its label to a "Copied" check.
     private func copyButton(label: String, value: String) -> some View {
         Button {
             let pasteboard = NSPasteboard.general

--- a/Sources/Mobile/Pairing/MobilePairingWindowController.swift
+++ b/Sources/Mobile/Pairing/MobilePairingWindowController.swift
@@ -56,7 +56,7 @@ final class MobilePairingWindowController: ReleasingWindowController {
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         // Tall enough that the title, the manual-entry block, and the whole QR
         // are visible without scrolling out of the box; the 540x720 default
-        // clipped the heading and pushed Copy IP/Port below the fold in
+        // clipped the heading and pushed Copy Address below the fold in
         // dogfood. The minimum keeps the QR plus the manual block usable on
         // small screens.
         window.setContentSize(NSSize(width: 560, height: 800))

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -460,23 +460,6 @@
         }
       }
     },
-    "mobile.addDevice.hostLabel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HOST"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ホスト"
-          }
-        }
-      }
-    },
     "mobile.addDevice.invalidHost": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -392,6 +392,23 @@
         }
       }
     },
+    "mobile.addDevice.addressPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "your-mac.tailnet.ts.net:58465"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "your-mac.tailnet.ts.net:58465"
+          }
+        }
+      }
+    },
     "mobile.addDevice.another": {
       "extractionState": "manual",
       "localizations": {
@@ -432,13 +449,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Enter a Tailscale, LAN, or local host and port. QR/link pairing from that computer is still the safest setup path."
+            "value": "Paste the address from the Mac's pairing window (Copy Address). The port is optional. QR/link pairing from that computer is still the safest setup path."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tailscale、LAN、またはローカルのホストとポートを入力してください。そのコンピュータからの QR/リンクでのペアリングが最も安全な設定方法です。"
+            "value": "Mac のペアリングウィンドウの「アドレスをコピー」からアドレスを貼り付けてください。ポートは省略できます。その Mac からの QR/リンクペアリングが最も安全なセットアップ方法です。"
           }
         }
       }
@@ -456,23 +473,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "ホスト"
-          }
-        }
-      }
-    },
-    "mobile.addDevice.hostPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "your-mac.tailnet.ts.net"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "your-mac.tailnet.ts.net"
           }
         }
       }
@@ -609,23 +609,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "ポート"
-          }
-        }
-      }
-    },
-    "mobile.addDevice.portPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "58465"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "58465"
           }
         }
       }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -29,13 +29,12 @@ final class cmuxUITests: XCTestCase {
     @MainActor
     func testAddDeviceManualHostValidationUsesStableIdentifiers() throws {
         let invalidHostApp = launchAddDeviceApp(environment: [
-            "CMUX_UITEST_ADD_DEVICE_HOST": "dev/path.local"
+            "CMUX_UITEST_ADD_DEVICE_ADDRESS": "dev/path.local"
         ])
 
         XCTAssertTrue(invalidHostApp.otherElements["MobileAddDeviceForm"].waitForExistence(timeout: 8))
         XCTAssertTrue(invalidHostApp.textFields["MobileAddDeviceNameField"].exists)
-        XCTAssertTrue(invalidHostApp.textFields["MobileAddDeviceHostField"].exists)
-        XCTAssertTrue(invalidHostApp.textFields["MobileAddDevicePortField"].exists)
+        XCTAssertTrue(invalidHostApp.textFields["MobileAddDeviceAddressField"].exists)
         XCTAssertTrue(invalidHostApp.staticTexts["MobileAddDeviceSignedInAccount"].exists)
         XCTAssertTrue(invalidHostApp.staticTexts["MobileAddDeviceSignedInAccount"].label.contains("uitest@cmux.local"))
         XCTAssertTrue(invalidHostApp.buttons["MobileScanQRCodeButton"].exists)
@@ -49,8 +48,7 @@ final class cmuxUITests: XCTestCase {
         invalidHostApp.terminate()
 
         let invalidPortApp = launchAddDeviceApp(environment: [
-            "CMUX_UITEST_ADD_DEVICE_HOST": "127.0.0.1",
-            "CMUX_UITEST_ADD_DEVICE_PORT": "70000",
+            "CMUX_UITEST_ADD_DEVICE_ADDRESS": "127.0.0.1:70000",
         ])
         defer { invalidPortApp.terminate() }
         let invalidPortPairButton = invalidPortApp.buttons["MobilePairButton"]
@@ -1727,14 +1725,14 @@ final class cmuxUITests: XCTestCase {
     func testAddDevicePairButtonStaysVisibleWhenKeyboardOpens() throws {
         let app = launchAddDeviceApp()
 
-        let hostField = app.textFields["MobileAddDeviceHostField"]
-        XCTAssertTrue(hostField.waitForExistence(timeout: 4))
+        let addressField = app.textFields["MobileAddDeviceAddressField"]
+        XCTAssertTrue(addressField.waitForExistence(timeout: 4))
         let pairButton = app.buttons["MobilePairButton"]
         XCTAssertTrue(pairButton.waitForExistence(timeout: 4))
 
-        hostField.tap()
+        addressField.tap()
         XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 4),
-                      "Tapping the host field should bring up the keyboard")
+                      "Tapping the address field should bring up the keyboard")
 
         // The pair button stays in the hierarchy when the keyboard is up,
         // proving the .safeAreaInset placement survives keyboard avoidance.


### PR DESCRIPTION
Manual pairing took two copy/paste round trips: the Mac pairing window had separate Copy IP and Copy Port buttons, and the iOS Add Computer form had separate host and port textboxes. This makes it one `host:port` string end to end.

`CmxManualPairingEntry` (shared package) now owns the one-string form: `displayString` emits `host:port` with IPv6 bracketing (`[fd7a::1]:58465`), and `parse(_:defaultPort:)` inverts it, accepting `host`, `host:port`, `[v6]`, `[v6]:port`, and bare bracketless IPv6 (2+ colons can never be a host:port split, so the whole string is the host with the default port). Round-trip and rejection tests added in `CmxManualPairingEntryTests`.

Mac: the manual fallback shows one "Copy Address" button copying `displayString`. iOS: one address textbox; pasted `cmux-ios://` links still route to link pairing, parse failures (bad port suffix, malformed brackets) show the existing invalid-port message, and host-policy failures show the existing invalid-host message. The trust-warning check parses the same way.

UI tests inject `CMUX_UITEST_ADD_DEVICE_ADDRESS` and assert `MobileAddDeviceAddressField`; `UITestConfig` drops the host/port accessors for `addDeviceAddress`. Both string catalogs updated with en+ja: `mobile.pairing.manual.copyAddress` and `mobile.addDevice.addressPlaceholder` added, `copyIP`/`copyPort`/`hostPlaceholder`/`portPlaceholder` removed, `mobile.addDevice.help` rewritten for the paste flow.

Verified: `swift test` for CMUXMobileCore (144 tests) and CmuxMobileSupport (68 tests) pass; `CmuxMobileShellUI` compiles for `arm64-apple-ios18.0-simulator`; both `.xcstrings` catalogs parse and diffs are key-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785753688&installation_id=133855650&pr_number=7335&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7335&signature=771c4aa149089d33e95b4827641db7d95171da358e3a28d530f14aff74f8e480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pairing UX and input parsing only; behavior is covered by new parse tests and updated UI tests, with no changes to auth or attach ticket minting.
> 
> **Overview**
> Manual pairing is now one **`host:port`** string end to end instead of separate Mac copy buttons and iOS host/port fields.
> 
> **Shared (`CmxManualPairingEntry`)** adds **`displayString`** (IPv6 bracketing) and **`parse(_:defaultPort:)`** with **`ParseError`** (`invalidHost` vs **`invalidPort(host:)`**) so callers can show the right validation message and keep trust warnings stable while the port is mid-edit.
> 
> **Mac** pairing shows a single **Copy Address** button copying **`displayString`**. **iOS Add Computer** uses one address field: **`cmux-ios://`** still routes to link pairing; shape errors map to existing host/port copy; host policy runs on the parsed host.
> 
> **Tests & tooling:** new unit tests for display/parse; UI tests use **`CMUX_UITEST_ADD_DEVICE_ADDRESS`** and **`MobileAddDeviceAddressField`**. **en/ja** strings swap copy/help/placeholder keys for the paste flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a6cf44994727ac2840d48bc96c2cee67a18bb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make manual pairing a single step: one Copy Address button on Mac and one address field on iOS, using a `host:port` string with IPv6-safe bracketing. Keeps the trust warning stable while typing by carrying the host through port parse errors.

- New Features
  - `CmxManualPairingEntry`: `displayString` emits `host:port` with IPv6 brackets; `parse(_:defaultPort:)` returns `Result` with `ParseError` (`invalidHost` or `invalidPort(host:)`), accepting `host`, `host:port`, `[v6]`, `[v6]:port`, and bare IPv6 (defaults port).
  - Mac pairing window: single “Copy Address” that copies `displayString`.
  - iOS Add Computer: single address field; `cmux-ios://` links still go to link pairing; explicit port mistakes show the existing invalid-port message; missing host or malformed brackets show the existing invalid-host message; the trust warning stays visible while a port suffix is mid-typing (e.g. `10.0.0.5:`) by using the host from `.invalidPort`.
  - Tests: round-trip and typed parse-error coverage; UI tests updated to the new field/env var.
  - Localizations (en/ja): add `mobile.pairing.manual.copyAddress` and `mobile.addDevice.addressPlaceholder`; remove `copyIP`, `copyPort`, `hostPlaceholder`, `portPlaceholder`, and the unused `hostLabel`; help text updated for paste flow.
  - Cleanup: updated the copied-value comment for the single Copy Address button.

- Migration
  - UITest env var: use `CMUX_UITEST_ADD_DEVICE_ADDRESS` (replaces `..._HOST` and `..._PORT`).
  - Accessibility: use `MobileAddDeviceAddressField` (replaces host/port field identifiers).

<sup>Written for commit 22a6cf44994727ac2840d48bc96c2cee67a18bb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

