### PR TITLE
Raise link contrast in dark mode

### DIFF
--- a/web/app/[locale]/community/page.tsx
+++ b/web/app/[locale]/community/page.tsx
@@ -72,7 +72,7 @@ export default function CommunityPage() {
             href={awesomeCmuxSourceUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="font-medium underline underline-offset-2 decoration-border transition-colors hover:decoration-foreground"
+            className="font-medium underline underline-offset-2 decoration-link-underline transition-colors hover:decoration-foreground"
           >
             {t("sourceAction")}
           </a>

--- a/web/app/[locale]/components/download-confirmation.tsx
+++ b/web/app/[locale]/components/download-confirmation.tsx
@@ -79,7 +79,7 @@ export function DownloadConfirmation() {
               // auto-download useEffect won't run if the bundle never hydrates).
               <a
                 href={DOWNLOAD_URL}
-                className="underline underline-offset-2 decoration-border hover:decoration-foreground transition-colors"
+                className="underline underline-offset-2 decoration-link-underline hover:decoration-foreground transition-colors"
               >
                 {chunks}
               </a>

--- a/web/app/[locale]/components/waitlist-callout.tsx
+++ b/web/app/[locale]/components/waitlist-callout.tsx
@@ -33,7 +33,7 @@ export function WaitlistCallout({
             });
             setOpen(true);
           }}
-          className="text-foreground underline underline-offset-2 decoration-border transition-colors hover:decoration-foreground"
+          className="text-foreground underline underline-offset-2 decoration-link-underline transition-colors hover:decoration-foreground"
         >
           {t("join")}
         </button>

--- a/web/app/[locale]/deeplink/[kind]/page.tsx
+++ b/web/app/[locale]/deeplink/[kind]/page.tsx
@@ -386,7 +386,7 @@ export default async function DeeplinkPage({
           {t("examplePrefix")}{" "}
           <a
             href={definition.exampleHref}
-            className="underline underline-offset-2 decoration-border hover:decoration-foreground"
+            className="underline underline-offset-2 decoration-link-underline hover:decoration-foreground"
           >
             {t("exampleLink")}
           </a>

--- a/web/app/[locale]/docs/ios/page.tsx
+++ b/web/app/[locale]/docs/ios/page.tsx
@@ -5,6 +5,7 @@ import { buildAlternates } from "../../../../i18n/seo";
 import { DocsSchema } from "../docs-schema";
 import { Callout } from "../../components/callout";
 import { DocsHeading } from "../../components/docs-heading";
+import { LINK_CLASS as linkClass } from "@/app/lib/link";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
@@ -16,8 +17,6 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   };
 }
 
-const linkClass =
-  "underline underline-offset-2 decoration-border hover:decoration-foreground transition-colors";
 
 export default function IosPage() {
   const t = useTranslations("docs.ios");

--- a/web/app/[locale]/ios/page.tsx
+++ b/web/app/[locale]/ios/page.tsx
@@ -7,6 +7,7 @@ import { SiteHeader } from "../components/site-header";
 import { BrandLogoLink } from "../components/brand-logo-link";
 import { GitHubButton } from "../components/github-button";
 import { AppleMark } from "../components/apple-mark";
+import { LINK_CLASS as linkClass } from "@/app/lib/link";
 import {
   ctaButtonBase,
   ctaButtonDefaultSize,
@@ -39,8 +40,6 @@ export async function generateMetadata({
 export default function IosLanding() {
   const t = useTranslations("ios");
 
-  const linkClass =
-    "underline underline-offset-2 decoration-border hover:decoration-foreground transition-colors";
 
   const features = [
     ["realtimeSync", "realtimeSyncDesc"],

--- a/web/app/[locale]/nightly/page.tsx
+++ b/web/app/[locale]/nightly/page.tsx
@@ -2,6 +2,7 @@ import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { buildAlternates } from "../../../i18n/seo";
 import { SiteHeader } from "../components/site-header";
+import { LINK_CLASS as linkClass } from "@/app/lib/link";
 
 export async function generateMetadata({
   params,
@@ -17,8 +18,6 @@ export async function generateMetadata({
   };
 }
 
-const linkClass =
-  "underline underline-offset-2 decoration-border hover:decoration-foreground transition-colors";
 
 export default function NightlyPage() {
   const t = useTranslations("nightly");

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -14,6 +14,7 @@ import {
   getTestimonialTranslation,
 } from "./testimonials";
 import { Link } from "../../i18n/navigation";
+import { LINK_CLASS as linkClass } from "@/app/lib/link";
 
 export default function Home() {
   return <HomeContent />;
@@ -25,9 +26,6 @@ function HomeContent() {
   const tt = useTranslations("testimonials");
   const tst = useTranslations("testimonialSubtitles");
   const locale = useLocale();
-
-  const linkClass =
-    "underline underline-offset-2 decoration-border hover:decoration-foreground transition-colors";
 
   // FAQPage structured data, built from the same FAQ copy rendered below so the
   // Q&As are eligible for Google rich results and AI answer engines.
@@ -544,13 +542,13 @@ function HomeContent() {
         <div className="flex justify-center gap-4 mt-6">
           <Link
             href="/docs"
-            className="text-sm text-muted hover:text-foreground transition-colors underline underline-offset-2 decoration-border hover:decoration-foreground"
+            className="text-sm text-muted hover:text-foreground transition-colors underline underline-offset-2 decoration-link-underline hover:decoration-foreground"
           >
             {tc("readTheDocs")}
           </Link>
           <Link
             href="/docs/changelog"
-            className="text-sm text-muted hover:text-foreground transition-colors underline underline-offset-2 decoration-border hover:decoration-foreground"
+            className="text-sm text-muted hover:text-foreground transition-colors underline underline-offset-2 decoration-link-underline hover:decoration-foreground"
           >
             {tc("viewChangelog")}
           </Link>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -8,6 +8,10 @@
   --muted: #737373;
   --border: #e5e5e5;
   --code-bg: #f5f5f5;
+  /* Link underline color, kept separate from --border (which is far too low
+     contrast for a line the eye must follow). ~4.8:1 on --background, above
+     the WCAG 1.4.11 non-text 3:1 floor with margin. */
+  --link-underline: #6f6f6f;
 }
 
 .dark {
@@ -16,6 +20,9 @@
   --muted: #a3a3a3;
   --border: #262626;
   --code-bg: #171717;
+  /* ~6.1:1 on --background: clearly visible in dark mode, still softer than
+     the near-white link text so it reads as an underline, not a box. */
+  --link-underline: #8f8f8f;
 }
 
 @theme inline {
@@ -23,6 +30,7 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-border: var(--border);
+  --color-link-underline: var(--link-underline);
   --color-code-bg: var(--code-bg);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
@@ -299,7 +307,7 @@ body {
     text-decoration-skip-ink: none;
     text-underline-offset: 3px;
     text-decoration-thickness: 1px;
-    text-decoration-color: var(--border);
+    text-decoration-color: var(--link-underline);
   }
 
   .docs-content a:not([class]):hover {

--- a/web/app/lib/link.ts
+++ b/web/app/lib/link.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared class for inline text links across the marketing and docs pages.
+ * Foreground text (near-white in dark mode) with a dedicated, higher-contrast
+ * underline that meets WCAG 1.4.11 (>=3:1) with margin; the underline brightens
+ * to full foreground on hover.
+ */
+export const LINK_CLASS =
+  "text-foreground underline underline-offset-2 decoration-link-underline hover:decoration-foreground transition-colors";


### PR DESCRIPTION
Dark-mode links were low contrast: content links inherited muted text, and every link drew its underline in `--border` (`#262626`), about **1.3:1** on the `#0a0a0a` background, below the WCAG 1.4.11 non-text **3:1** floor and nearly invisible.

Changes:
- New `--link-underline` token, kept separate from `--border`: `#6f6f6f` light (~4.8:1) / `#8f8f8f` dark (~6.1:1), both above 3:1 with margin. Exposed to Tailwind as `decoration-link-underline`.
- Inline content links now use foreground (near-white in dark) text via a single shared `LINK_CLASS` (`web/app/lib/link.ts`) that replaces four duplicated copies of the same string.
- Docs prose links (`.docs-content a`) and the remaining inline links (`waitlist-callout`, `download-confirmation`, `community`, `deeplink`, footer) use the same token.
- Hover still brightens the underline to full foreground.

Muted footer/utility links keep their muted text (already ~7.9:1) but get the higher-contrast underline.

Verified locally: the generated `.decoration-link-underline` rule resolves to `var(--link-underline)`, and the dark token compiles to `#8f8f8f`. `web-typecheck` passes, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785756790&installation_id=133855650&pr_number=7339&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7339&signature=51b41cc0bded18c37f8aea98ca0db21106a797b866f97e6b3bf3c42b05f77ec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS token and Tailwind class changes only; no auth, data, or routing logic.
> 
> **Overview**
> Improves **link visibility** (especially dark mode) by replacing `--border`-colored underlines with a dedicated **`--link-underline`** token (`#6f6f6f` / `#8f8f8f`), wired into Tailwind as `decoration-link-underline` and used for docs prose (`.docs-content a`) plus scattered inline anchors.
> 
> **`LINK_CLASS`** in `web/app/lib/link.ts` centralizes the shared inline link styling; docs/ios, ios, nightly, and home pages import it instead of duplicating the same class string. Community, deeplink, download confirmation, waitlist callout, and home footer links switch to the new underline token (hover still moves decoration to foreground).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 715c29be9519e35b065bb8abfb48d30163fee650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised link contrast in dark mode by adding a dedicated underline color and switching inline links to foreground text. Links now meet WCAG 1.4.11 (>=3:1) and are clearly visible across docs and marketing pages.

- Bug Fixes
  - Added `--link-underline` (light `#6f6f6f`, dark `#8f8f8f`) exposed as `decoration-link-underline`; hover still brightens to foreground.
  - Replaced low-contrast `decoration-border` on docs prose and inline links (community, waitlist, download, deeplink, home/footer).

- Refactors
  - Introduced shared `LINK_CLASS` in `web/app/lib/link.ts` and removed duplicated link class strings.

<sup>Written for commit 715c29be9519e35b065bb8abfb48d30163fee650. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

