### PR TITLE
Sidebar: hop selectedTabId row delivery to RunLoop.main + guard synchronous row onReceive

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -3,7 +3,7 @@
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 34499	CLI/cmux.swift
 17954	Sources/AppDelegate.swift
-16427	Sources/ContentView.swift
+16434	Sources/ContentView.swift
 14270	Sources/TerminalController.swift
 13172	Sources/Workspace.swift
 12348	cmuxTests/AppDelegateShortcutRoutingTests.swift

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14068,6 +14068,13 @@ struct TabItemView: View, Equatable {
             tabManager.selectedTabIdPublisher
                 .map { $0 == tab.id }
                 .removeDuplicates()
+                // The CurrentValueSubject replays synchronously on subscribe —
+                // which happens while the LazyVStack realizes this row, inside
+                // an in-flight layout transaction — and emits during willSet.
+                // Hop to RunLoop.main so the @State write below never lands in
+                // the transaction being laid out (#2586/#6556 livelock family);
+                // first render is covered by the live selectedTabId fallback.
+                .receive(on: RunLoop.main)
         ) { isSelected in
             updateObservedActiveState(isSelected)
         }

--- a/scripts/check-sidebar-lazy-layout.py
+++ b/scripts/check-sidebar-lazy-layout.py
@@ -139,6 +139,56 @@ ROW_FORBIDDEN_PATTERNS = (
      "inside a row is the #5323 feedback shape)"),
 )
 
+# `.onReceive(` in a row view. Combine delivery into a sidebar row must hop
+# through `.receive(on:)`: the TabManager bridges are `CurrentValueSubject`s
+# that replay the current value SYNCHRONOUSLY at subscribe time -- and a lazy
+# row subscribes while the LazyVStack realizes it, inside an in-flight SwiftUI
+# layout transaction -- and they emit during `willSet`, so a selection change
+# made mid-update delivers mid-update. Either path lets the `onReceive` action
+# write row `@State` inside the transaction being laid out: the same
+# write-during-layout family as the #2586/#6556 livelocks (a row shipped this
+# exact shape in stable v0.64.17 via `selectedTabIdPublisher`, observed
+# livelocked in the wild on 2026-07-02/03). `NotificationCenter` publishers
+# deliver synchronously on the posting thread and need the same hop.
+ONRECEIVE_CALL = re.compile(r"\.onReceive\s*\(")
+
+ROW_SYNC_ONRECEIVE_MESSAGE = (
+    ".onReceive( without .receive(on:) in a row (synchronous publisher "
+    "delivery -- a CurrentValueSubject replays on subscribe while the "
+    "LazyVStack is realizing the row and emits during willSet -- writes row "
+    "@State inside the in-flight layout transaction, the #2586/#6556 "
+    "write-during-layout livelock family; route row subscriptions through "
+    ".receive(on: RunLoop.main))"
+)
+
+
+def find_sync_onreceive(region):
+    """Return True if ``region`` (neutralized Swift) contains an
+    ``.onReceive(`` whose publisher argument lacks a ``.receive(on:`` hop.
+
+    The publisher expression is the balanced-parenthesis argument list of the
+    ``.onReceive(`` call; the action trailing closure sits outside it, so a
+    ``.receive(on:)`` inside the action cannot mask a synchronous publisher.
+    """
+    for match in ONRECEIVE_CALL.finditer(region):
+        i = match.end() - 1  # at the opening '(' of the argument list
+        depth = 0
+        start = i
+        n = len(region)
+        while i < n:
+            ch = region[i]
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        publisher_expr = re.sub(r"\s+", "", region[start:i + 1])
+        if ".receive(on:" not in publisher_expr:
+            return True
+    return False
+
 # Lazy-fill primitives the #6188 fix depends on. Each must remain present in the
 # named function (after comments/strings are stripped).
 REQUIRED_PRIMITIVES = (
@@ -476,6 +526,11 @@ def check_source(
                     "row-wrapper file contains forbidden per-row geometry "
                     "feedback: {0}".format(description)
                 )
+        if find_sync_onreceive(neutralized):
+            violations.append(
+                "row-wrapper file contains forbidden synchronous delivery: "
+                "{0}".format(ROW_SYNC_ONRECEIVE_MESSAGE)
+            )
         for name in sorted(custom_layout_names):
             if re.search(r"\b" + re.escape(name) + r"\b", neutralized):
                 violations.append(
@@ -501,6 +556,12 @@ def check_source(
                     "{0} contains forbidden per-row geometry feedback: "
                     "{1}".format(type_name, description)
                 )
+        if find_sync_onreceive(body):
+            violations.append(
+                "{0} contains forbidden synchronous delivery: {1}".format(
+                    type_name, ROW_SYNC_ONRECEIVE_MESSAGE
+                )
+            )
         for name in sorted(custom_layout_names):
             if re.search(r"\b" + re.escape(name) + r"\b", body):
                 violations.append(

--- a/tests/test_ci_sidebar_lazy_layout_guard.py
+++ b/tests/test_ci_sidebar_lazy_layout_guard.py
@@ -24,6 +24,13 @@ Cases:
       wild on 2026-07-02.
   (l) Per-row `.anchorPreference` (the #5323 virtualization defeat) fails.
   (m) A required row type missing from its file fails loudly (no silent skip).
+  (o) An `.onReceive(` in a row whose publisher lacks a `.receive(on:)` hop
+      fails — a CurrentValueSubject bridge replays synchronously while the
+      LazyVStack realizes the row (and emits during willSet), so the action
+      writes row @State inside the in-flight layout transaction. This exact
+      shape shipped in stable v0.64.17 via `selectedTabIdPublisher`.
+  (p) The same subscription routed through `.receive(on: RunLoop.main)`
+      passes, including when `.receive(on:)` spans multiple lines.
 """
 
 import importlib.util
@@ -311,6 +318,49 @@ def main():
         failures += 0 if expect(
             run_guard(write_fixture(workdir, "AnchorRow.swift", anchor_row)),
             False, "per-row .anchorPreference (#5323 shape) fails",
+        ) else 1
+
+        # (o) An .onReceive( whose publisher chain has no .receive(on:) hop:
+        # the CurrentValueSubject bridge replays synchronously during lazy row
+        # realization and emits during willSet, so the action's @State write
+        # lands inside the in-flight layout transaction (the #2586/#6556
+        # family). This shape shipped in stable v0.64.17 and livelocked in the
+        # wild on 2026-07-02/03. A .receive(on:) inside the ACTION closure
+        # (outside the publisher argument) must not mask the violation.
+        sync_onreceive_row = row_fixture(
+            "        HStack { Text(tab.title) }\n"
+            "            .onReceive(\n"
+            "                tabManager.selectedTabIdPublisher\n"
+            "                    .map { $0 == tab.id }\n"
+            "                    .removeDuplicates()\n"
+            "            ) { isSelected in\n"
+            "                observedIsActive = isSelected\n"
+            "            }"
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "SyncOnReceiveRow.swift", sync_onreceive_row)),
+            False, "row .onReceive without .receive(on:) fails",
+        ) else 1
+
+        # (p) The same subscription with a .receive(on: RunLoop.main) hop in
+        # the publisher chain passes -- also with the hop split across lines,
+        # since the real call sites chain one operator per line.
+        deferred_onreceive_row = row_fixture(
+            "        HStack { Text(tab.title) }\n"
+            "            .onReceive(\n"
+            "                tabManager.selectedTabIdPublisher\n"
+            "                    .map { $0 == tab.id }\n"
+            "                    .removeDuplicates()\n"
+            "                    .receive(\n"
+            "                        on: RunLoop.main\n"
+            "                    )\n"
+            "            ) { isSelected in\n"
+            "                observedIsActive = isSelected\n"
+            "            }"
+        )
+        failures += 0 if expect(
+            run_guard(write_fixture(workdir, "DeferredOnReceiveRow.swift", deferred_onreceive_row)),
+            True, "row .onReceive with .receive(on:) passes",
         ) else 1
 
         # (n) --file on a row-view source (no container functions) must not


### PR DESCRIPTION
## Summary

**Problem.** Stable v0.64.17 livelocks in the wild with the #2586 signature. On my machine (0.64.17 (97), macOS 26.5, ~20–40 workspaces driving per-second tmux title updates) macOS wrote three `.hang` reports in two days — 173 s, 620 s, and one **62-minute** hang force-quit from the Dock. Two live `sample` captures taken 83 s apart during a fourth hang are statistically identical: 6586/6586 and 3178/3178 main-thread samples inside **one never-returning** `NSHostingView.beginTransaction → GraphHost.flushTransactions`, ~90 % under `AG::Subgraph::update` doing `LazySubviewPlacements.placeSubviews → LazyStack.place → ForEachList.applyNodes` over the workspace-list ForEach, plus ~9 % applying `LazyLayoutCacheItem.AllItemsPhaseMutation` — the re-enqueue that keeps the flush from draining. 3–27 `TerminalController.v2MainSync` socket threads sit turnstile-blocked behind the busy main thread, so the CLI and Claude hooks hang in `read()` too. I can attach the .hang files and samples (14–16 MB each) to #2586.

**This is not a re-fix of #7117** — I'm aware #7117 removed the v0.64.17 row-height probes and hover tracker one day after the release was cut, and #7221 added the scale gate. This PR closes the one residual synchronous-delivery channel that survived, and bans the shape in CI:

**Root cause (residual).** `TabItemView`'s `.onReceive(tabManager.selectedTabIdPublisher …)` is the only row subscription without a `.receive(on:)` hop (both sibling publishers at the same call site have one). The publisher is a `CurrentValueSubject` bridge: it **replays synchronously at subscribe time** — and a lazy row subscribes while the LazyVStack realizes it, inside an in-flight layout transaction — and it **emits during `selectedTabId`'s willSet**, so a selection change made mid-update delivers mid-update. Either path writes the row's `@State observedIsActive` inside the transaction being laid out: the same write-during-layout family as #2586/#6556.

**Fix.** Route the chain through `.receive(on: RunLoop.main)`, matching its two siblings. No visual change: first render reads the live fallback (`observedIsActive ?? (tabManager.selectedTabId == tab.id)`), row `onAppear` seeds the same value, and the deferred replay is deduplicated by `updateObservedActiveState`'s equality guard.

**Guard.** `scripts/check-sidebar-lazy-layout.py` now fails on any row-region `.onReceive(` whose publisher argument lacks `.receive(on:` (balanced-paren extraction, so a hop inside the *action* closure can't mask a synchronous publisher). Two new meta-test cases (o)/(p) prove catch + pass, including a multi-line `.receive(\n on:…)`.

**Two-commit red/green** (per repo policy): commit 1 adds the guard + meta-tests only — `check-sidebar-lazy-layout.py` goes red on `TabItemView` (and meta-case (a) with it, by design); commit 2 fixes the call site — everything green.

Refs #2586 (evidence lineage: #5323 → #5764 → #5845 → #6033/#6210 → #6556/#7117/#7221).

## Testing

```
python3 scripts/check-sidebar-lazy-layout.py        # exit 1 at commit 1 (TabItemView flagged); ok at HEAD
python3 tests/test_ci_sidebar_lazy_layout_guard.py  # 22/22 PASS at HEAD
python3 scripts/swift_file_length_budget.py         # budget respected (ContentView 16427 → 16434, +7)
git diff --check                                    # clean
```

Honest scale/build note: I'm an external contributor without Xcode on this machine, so I could not run `reload.sh` or `SidebarLazyLayoutScaleTests` locally — requesting CI as the build/behavior gate. The Swift diff is a single chained operator plus a constraint comment, shape-identical to the sibling subscription at the same call site. Localization audit: no user-facing strings changed.

## Demo Video

Not applicable — no visual behavior change; this hardens delivery timing for a captured live hang (sample excerpts above, full captures available on request). #7117 precedent: this class is "not cleanly unit-testable without an on-device sample".

## Review Trigger

Will post `@codex review / @coderabbitai review / @greptile-apps review / @cubic-dev-ai review` as a comment after the latest commit.

## Checklist

- [x] Tested locally (guard red/green, meta-tests 22/22, budget, whitespace — static; no Xcode available)
- [x] Added/updated tests (guard meta-test cases (o)/(p))
- [ ] Docs/changelog (n/a — changelog regenerated at release)
- [ ] Bot reviews requested (comment after open)
- [ ] All bot + human comments resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785771861&installation_id=133855650&pr_number=7341&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7341&signature=2b1d5857e2dcd44a3477fb52b43de56276cdb42f42992ac48b5136d5a54deb8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a sidebar livelock by deferring row selection updates to RunLoop.main and adds a CI guard to block synchronous onReceive delivery in row views. Prevents hangs caused by `selectedTabIdPublisher` delivering during layout.

- Bug Fixes
  - In `TabItemView`, route `tabManager.selectedTabIdPublisher` through `.receive(on: RunLoop.main)` to avoid synchronous `onReceive` updates during layout. No visual change; first render uses the existing fallback and updates are deduped.
  - Add a CI guard that fails on any row `.onReceive(` whose publisher lacks `.receive(on:)`, plus tests (including multiline `.receive(on:)`) to catch and prevent regressions.

<sup>Written for commit 2d87b4758585d05d4f9b5aaeb42e57fd368457a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar/tab selection updates to behave more reliably during fast UI updates, reducing the risk of layout-related glitches or freezes.
  * Fixed handling of row-based event updates so they are delivered safely on the main thread.

* **Tests**
  * Added coverage for row update scenarios to verify both failing and passing behavior with deferred event delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->