### PR TITLE
Fix surface tab-bar shortcut hint showing stale modifier

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12357,6 +12357,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func installShortcutDefaultsObserver() {
         guard shortcutDefaultsObserver == nil else { return }
+        // Seed the bonsplit tab-bar hint mirror with the resolved surface-number
+        // shortcut before any tab bar renders, then keep it in sync on change.
+        KeyboardShortcutSettings.syncSurfaceNumberShortcutMirrorForTabBarHint()
         shortcutDefaultsObserver = NotificationCenter.default.addObserver(
             forName: KeyboardShortcutSettings.didChangeNotification,
             object: nil,
@@ -12378,6 +12381,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         clearConfiguredShortcutChordState()
         scheduleReloadConfigurationMenuItemRefresh()
         scheduleSplitButtonTooltipRefreshAcrossWorkspaces()
+        // Keep the bonsplit surface tab-bar shortcut hint in step with the
+        // resolved surface-number shortcut (cmux.json / Settings recorder both
+        // persist outside the UserDefaults key the tab bar reads).
+        KeyboardShortcutSettings.syncSurfaceNumberShortcutMirrorForTabBarHint()
     }
 
     private func currentConfiguredShortcutChordActions() -> [KeyboardShortcutSettings.Action] {

--- a/Sources/KeyboardShortcutSettingsLookup.swift
+++ b/Sources/KeyboardShortcutSettingsLookup.swift
@@ -98,10 +98,30 @@ extension KeyboardShortcutSettings {
     /// is a no-op for the pure-UserDefaults path (it already holds it) and, for
     /// the file-managed path, leaves ``shortcutIfBound(for:)`` unchanged because
     /// the settings-file override still wins at a higher priority.
-    static func syncSurfaceNumberShortcutMirrorForTabBarHint(defaults: UserDefaults = .standard) {
+    ///
+    /// bonsplit is a standalone SwiftPM package that cmux depends on (its
+    /// `Package.swift` has no dependencies), so it cannot call
+    /// ``shortcutIfBound(for:)`` directly — a proper root fix would have to add a
+    /// resolved-shortcut input to the bonsplit tab controller and is out of scope
+    /// here. Until then this mirror is the seam, and its invariant
+    /// ("mirrored key == resolved shortcut") holds because every path that
+    /// changes the resolved surface shortcut posts
+    /// ``KeyboardShortcutSettings/didChangeNotification``: `setShortcut`,
+    /// `reset*`, the `settingsFileStore` replacement (its `didSet`), and
+    /// `KeyboardShortcutSettingsFileStore.reload()` (on-disk edits). The sole
+    /// caller re-runs this from that notification (plus once at launch), so a new
+    /// change path only needs to keep firing that notification — which it must
+    /// already do for the rest of the shortcut system to react.
+    ///
+    /// Always reads/writes `UserDefaults.standard` because the value it mirrors —
+    /// ``shortcut(for:)`` — and the key bonsplit reads are both bound to
+    /// `.standard`; a suite parameter here would be dead surface that cannot
+    /// actually isolate either side.
+    static func syncSurfaceNumberShortcutMirrorForTabBarHint() {
         let action = Action.selectSurfaceByNumber
         let resolved = shortcut(for: action)
         guard let data = try? JSONEncoder().encode(resolved) else { return }
+        let defaults = UserDefaults.standard
         if defaults.data(forKey: action.defaultsKey) != data {
             defaults.set(data, forKey: action.defaultsKey)
         }

--- a/Sources/KeyboardShortcutSettingsLookup.swift
+++ b/Sources/KeyboardShortcutSettingsLookup.swift
@@ -83,4 +83,28 @@ extension KeyboardShortcutSettings {
         return String(localized: "settings.shortcuts.managedByFile", defaultValue: "Managed in cmux.json")
     }
 
+    /// The bonsplit surface tab bar renders its Cmd/Ctrl-hold shortcut hint
+    /// (`⌘1`, `⌃2`, …) by reading the surface-number shortcut straight from
+    /// `UserDefaults.standard` under `selectSurfaceByNumber.defaultsKey` (see
+    /// `TabControlShortcutSettings` in vendor/bonsplit). That raw read bypasses
+    /// cmux's canonical resolution in ``shortcutIfBound(for:)`` — a `cmux.json`
+    /// override or the in-app Settings recorder both persist to the settings
+    /// file, not to that UserDefaults key — so after the user rebinds the
+    /// surface shortcut (e.g. from `⌥` to `⌘`) the tab-bar hint keeps showing
+    /// the stale modifier while the actual keystroke already uses the new one.
+    ///
+    /// Mirror the fully-resolved shortcut into that key so the hint always
+    /// matches the shortcut cmux actually dispatches. Writing the resolved value
+    /// is a no-op for the pure-UserDefaults path (it already holds it) and, for
+    /// the file-managed path, leaves ``shortcutIfBound(for:)`` unchanged because
+    /// the settings-file override still wins at a higher priority.
+    static func syncSurfaceNumberShortcutMirrorForTabBarHint(defaults: UserDefaults = .standard) {
+        let action = Action.selectSurfaceByNumber
+        let resolved = shortcut(for: action)
+        guard let data = try? JSONEncoder().encode(resolved) else { return }
+        if defaults.data(forKey: action.defaultsKey) != data {
+            defaults.set(data, forKey: action.defaultsKey)
+        }
+    }
+
 }

--- a/cmuxTests/GlobalSearchShortcutSettingsTests.swift
+++ b/cmuxTests/GlobalSearchShortcutSettingsTests.swift
@@ -292,4 +292,55 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
 
         XCTAssertNil(store.override(for: .globalSearch))
     }
+
+    func testTabBarHintMirrorReflectsSettingsFileManagedSurfaceShortcut() throws {
+        // The bonsplit surface tab bar renders its Cmd/Ctrl-hold shortcut hint
+        // by reading the surface-number shortcut straight from UserDefaults under
+        // `selectSurfaceByNumber.defaultsKey`. Rebindings made in the in-app
+        // Settings recorder (and in cmux.json) persist to the settings file, not
+        // that key, so the hint kept showing the stale modifier after the user
+        // switched the surface shortcut from ⌥ to ⌘. The mirror keeps that key in
+        // step with cmux's resolved shortcut.
+        let defaults = UserDefaults.standard
+        let key = KeyboardShortcutSettings.Action.selectSurfaceByNumber.defaultsKey
+
+        // A stale ⌥ value left in the key the tab bar reads (e.g. from an earlier
+        // rebinding written before the surface shortcut became file-managed).
+        let staleOption = StoredShortcut(key: "1", command: false, shift: false, option: true, control: false)
+        defaults.set(try JSONEncoder().encode(staleOption), forKey: key)
+
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-surface-hint-mirror-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try """
+        {
+          "shortcuts": {
+            "bindings": {
+              "selectSurfaceByNumber": "cmd+1"
+            }
+          }
+        }
+        """.write(to: settingsFileURL, atomically: true, encoding: .utf8)
+
+        KeyboardShortcutSettings.settingsFileStore = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            additionalFallbackPaths: [],
+            startWatching: false
+        )
+
+        // Precondition: cmux resolves the surface shortcut to ⌘ via the override.
+        XCTAssertTrue(KeyboardShortcutSettings.shortcut(for: .selectSurfaceByNumber).command)
+        XCTAssertFalse(KeyboardShortcutSettings.shortcut(for: .selectSurfaceByNumber).option)
+
+        KeyboardShortcutSettings.syncSurfaceNumberShortcutMirrorForTabBarHint()
+
+        let mirroredData = try XCTUnwrap(defaults.data(forKey: key))
+        let mirrored = try JSONDecoder().decode(StoredShortcut.self, from: mirroredData)
+        XCTAssertTrue(mirrored.command, "Tab-bar hint mirror should reflect the ⌘ surface shortcut")
+        XCTAssertFalse(mirrored.option, "Stale ⌥ modifier must not survive in the tab-bar hint mirror")
+    }
 }


### PR DESCRIPTION
## Problem

After changing the **surface** number shortcut (e.g. from `⌥`+digit to `⌘`+digit), the surface tab bar's modifier-hold hint animation keeps showing the **old** modifier — the shortcut itself dispatches correctly, but the tab-bar overlay still animates the stale glyph.

## Root cause

The surface tab bar (`vendor/bonsplit`, `TabControlShortcutSettings` in `TabBarView.swift`) renders its Cmd/Ctrl-hold hint by reading the surface-number shortcut **straight from** `UserDefaults.standard["shortcut.selectSurfaceByNumber"]`.

That raw read bypasses cmux's canonical resolution in `shortcutIfBound(for:)`, whose priority is:

1. settings-file override (`cmux.json` / the in-app Settings recorder)
2. `UserDefaults["shortcut.<action>"]`
3. built-in default

Rebindings made through the in-app Settings recorder — and via `cmux.json` — persist to the **settings file** (`KeyboardShortcutSettingsFileStore.override`), not to that UserDefaults key. So the tab bar never sees the file-managed value and keeps animating whatever stale/default modifier still sits in the raw key.

## Fix

Add `KeyboardShortcutSettings.syncSurfaceNumberShortcutMirrorForTabBarHint()`, which mirrors the fully-resolved surface-number shortcut into the key the tab bar reads. It runs:

- once at launch (in `installShortcutDefaultsObserver()`), before any tab bar renders, and
- on every `keyboardShortcutSettingsDidChange` notification (in `handleShortcutDefaultsDidChange()`).

Properties:

- **Plain-UserDefaults path:** the key already holds the value — idempotent no-op.
- **File-managed path:** `shortcutIfBound(for:)` is unchanged because the settings-file override still wins at higher priority; only the mirrored key catches up so the hint matches.
- **Settings UI:** its own default/reset detection reads `override ?? defaultShortcut` (settings-file based), so it is unaffected by the mirrored key.

## Test

`GlobalSearchShortcutSettingsTests.testTabBarHintMirrorReflectsSettingsFileManagedSurfaceShortcut` seeds a stale `⌥` value in the tab-bar key, points the store at a `cmux.json` that binds `selectSurfaceByNumber` to `⌘`, runs the mirror, and asserts the key now decodes to `⌘` (not `⌥`).

## Validation note

This was prepared in a Linux environment with no macOS/Xcode toolchain, so I could not build the app or run the test target locally — the change relies on CI to validate compilation and the new test. The fix uses only existing, verified symbols, and the test mirrors the established patterns in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785777039&installation_id=133855650&pr_number=7342&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7342&signature=f83e77b59695d741258c42e9b829c72c155341eda06b4006b87f21d8e02934c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the surface tab-bar hint showing the wrong modifier after rebinding the surface-number shortcut. We mirror the resolved shortcut into the key the `bonsplit` tab bar reads so the hint always matches the actual binding.

- Bug Fixes
  - Added `KeyboardShortcutSettings.syncSurfaceNumberShortcutMirrorForTabBarHint()`, run at launch and on shortcut changes.
  - Keeps the `bonsplit` tab-bar hint in sync with the resolved shortcut; no change to shortcut resolution or Settings UI.
  - Mirror now writes to `UserDefaults.standard` directly and documents the mirror invariant.
  - Added a test that updates a stale ⌥ hint to ⌘ when managed via `cmux.json`.

<sup>Written for commit 9be93c8bd6d29342d32f21c30b14a8892a650369. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the bonsplit tab-bar surface-number shortcut hint mirror stays synchronized with the resolved active surface shortcut during startup and updates.
  * Fixed scenarios where the hint could reflect stale or incorrectly resolved key bindings (including cmux-managed overrides).
* **Tests**
  * Added coverage verifying the tab-bar hint mirror reflects the cmux-resolved surface-number shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->