### PR TITLE
Seed Claude transcripts before cwd-changing fork

### DIFF
--- a/Sources/AgentResumeScriptStore.swift
+++ b/Sources/AgentResumeScriptStore.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+struct AgentResumeScriptStore {
+    private static let directoryName = "cmux-agent-resume"
+    private static let scriptTTL: TimeInterval = 24 * 60 * 60
+
+    let fileManager: FileManager
+    let temporaryDirectory: URL
+
+    init(
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL = FileManager.default.temporaryDirectory
+    ) {
+        self.fileManager = fileManager
+        self.temporaryDirectory = temporaryDirectory
+    }
+
+    func writeLauncherScript(
+        command: String,
+        kind: RestorableAgentKind,
+        sessionId: String,
+        returnToLoginShell: Bool = false,
+        workingDirectory: String? = nil
+    ) -> URL? {
+        let directoryURL = temporaryDirectory.appendingPathComponent(Self.directoryName, isDirectory: true)
+        do {
+            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directoryURL.path)
+            pruneOldScripts(in: directoryURL)
+
+            let safeSessionPrefix = sessionId
+                .prefix(12)
+                .map { character -> Character in
+                    character.isLetter || character.isNumber || character == "-" ? character : "_"
+                }
+            let scriptURL = directoryURL.appendingPathComponent(
+                "\(kind.rawValue)-\(String(safeSessionPrefix))-\(UUID().uuidString).zsh",
+                isDirectory: false
+            )
+            var lines = [
+                "#!/bin/zsh",
+                "rm -f -- \"$0\" 2>/dev/null || true",
+            ]
+            if returnToLoginShell {
+                lines.append(contentsOf: TerminalStartupReturnShellScript.commandThenReturnLines(
+                    command: command,
+                    workingDirectory: workingDirectory
+                ))
+            } else {
+                lines.append(command)
+            }
+            let contents = lines.joined(separator: "\n") + "\n"
+            try contents.write(to: scriptURL, atomically: true, encoding: .utf8)
+            try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: scriptURL.path)
+            return scriptURL
+        } catch {
+            return nil
+        }
+    }
+
+    private func pruneOldScripts(in directoryURL: URL) {
+        guard let scriptURLs = try? fileManager.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+
+        let cutoff = Date().addingTimeInterval(-Self.scriptTTL)
+        for scriptURL in scriptURLs where scriptURL.pathExtension == "zsh" {
+            let values = try? scriptURL.resourceValues(forKeys: [.contentModificationDateKey])
+            if let modified = values?.contentModificationDate, modified < cutoff {
+                try? fileManager.removeItem(at: scriptURL)
+            }
+        }
+    }
+}

--- a/Sources/ClaudeTranscriptSeeder.swift
+++ b/Sources/ClaudeTranscriptSeeder.swift
@@ -1,0 +1,223 @@
+import CMUXAgentLaunch
+import Foundation
+
+struct ClaudeTranscriptSeeder {
+    let fileManager: FileManager
+    let homeDirectory: String
+
+    init(fileManager: FileManager = .default, homeDirectory: String = NSHomeDirectory()) {
+        self.fileManager = fileManager
+        self.homeDirectory = homeDirectory
+    }
+
+    @discardableResult
+    func seedTranscriptIfNeeded(
+        sessionId: String,
+        targetWorkingDirectory: String?,
+        sourceWorkingDirectory: String?,
+        environment: [String: String]?
+    ) -> Bool {
+        guard Self.isSafeSessionId(sessionId),
+              let targetWorkingDirectory = Self.normalized(targetWorkingDirectory) else {
+            return false
+        }
+
+        for configRoot in configRoots(environment: environment) {
+            let targetProjectDirectory = projectDirectory(configRoot: configRoot, cwd: targetWorkingDirectory)
+            if transcriptURL(inProjectDirectory: targetProjectDirectory, sessionId: sessionId) != nil {
+                return false
+            }
+            guard let sourceProjectDirectory = sourceProjectDirectory(
+                sessionId: sessionId,
+                configRoot: configRoot,
+                targetProjectDirectory: targetProjectDirectory,
+                sourceWorkingDirectory: sourceWorkingDirectory
+            ),
+                  let sourceTranscript = transcriptURL(
+                      inProjectDirectory: sourceProjectDirectory,
+                      sessionId: sessionId
+                  ) else {
+                continue
+            }
+            return copyTranscript(
+                sourceTranscript: sourceTranscript,
+                sourceProjectDirectory: sourceProjectDirectory,
+                targetProjectDirectory: targetProjectDirectory,
+                sessionId: sessionId
+            )
+        }
+        return false
+    }
+
+    static func encodedProjectDirectoryName(for path: String) -> String {
+        path.replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+    }
+
+    func transcriptURL(inProjectDirectory projectDirectory: URL, sessionId: String) -> URL? {
+        guard Self.isSafeSessionId(sessionId) else { return nil }
+
+        let directURL = projectDirectory.appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+        if regularNonEmptyFileExists(at: directURL) {
+            return directURL
+        }
+
+        let nestedMessagesURL = projectDirectory
+            .appendingPathComponent(sessionId, isDirectory: true)
+            .appendingPathComponent("messages", isDirectory: true)
+            .appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+        if regularNonEmptyFileExists(at: nestedMessagesURL) {
+            return nestedMessagesURL
+        }
+        return nil
+    }
+
+    private func sourceProjectDirectory(
+        sessionId: String,
+        configRoot: URL,
+        targetProjectDirectory: URL,
+        sourceWorkingDirectory: String?
+    ) -> URL? {
+        let targetPath = targetProjectDirectory.standardizedFileURL.path
+        var candidates: [URL] = []
+        var seen: Set<String> = []
+        func appendCandidate(_ candidate: URL) {
+            let path = candidate.standardizedFileURL.path
+            guard path != targetPath, seen.insert(path).inserted else { return }
+            candidates.append(candidate)
+        }
+
+        if let sourceWorkingDirectory = Self.normalized(sourceWorkingDirectory) {
+            appendCandidate(projectDirectory(configRoot: configRoot, cwd: sourceWorkingDirectory))
+        }
+
+        for projectDirectory in projectDirectories(configRoot: configRoot) {
+            appendCandidate(projectDirectory)
+        }
+
+        return candidates.first {
+            transcriptURL(inProjectDirectory: $0, sessionId: sessionId) != nil
+        }
+    }
+
+    private func copyTranscript(
+        sourceTranscript: URL,
+        sourceProjectDirectory: URL,
+        targetProjectDirectory: URL,
+        sessionId: String
+    ) -> Bool {
+        let targetTranscript = targetProjectDirectory.appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+        do {
+            try fileManager.createDirectory(at: targetProjectDirectory, withIntermediateDirectories: true)
+            guard !fileManager.fileExists(atPath: targetTranscript.path) else {
+                return false
+            }
+            try fileManager.copyItem(at: sourceTranscript, to: targetTranscript)
+            copySidecarDirectoryIfNeeded(
+                sourceProjectDirectory: sourceProjectDirectory,
+                targetProjectDirectory: targetProjectDirectory,
+                sessionId: sessionId
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func copySidecarDirectoryIfNeeded(
+        sourceProjectDirectory: URL,
+        targetProjectDirectory: URL,
+        sessionId: String
+    ) {
+        let sourceSidecar = sourceProjectDirectory.appendingPathComponent(sessionId, isDirectory: true)
+        guard directoryExists(at: sourceSidecar) else { return }
+
+        let targetSidecar = targetProjectDirectory.appendingPathComponent(sessionId, isDirectory: true)
+        guard !fileManager.fileExists(atPath: targetSidecar.path) else { return }
+        try? fileManager.copyItem(at: sourceSidecar, to: targetSidecar)
+    }
+
+    private func projectDirectory(configRoot: URL, cwd: String) -> URL {
+        configRoot
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(Self.encodedProjectDirectoryName(for: cwd), isDirectory: true)
+    }
+
+    private func projectDirectories(configRoot: URL) -> [URL] {
+        let projectsRoot = configRoot.appendingPathComponent("projects", isDirectory: true)
+        guard directoryExists(at: projectsRoot),
+              let names = try? fileManager.contentsOfDirectory(atPath: projectsRoot.path) else {
+            return []
+        }
+        return names.sorted().map {
+            projectsRoot.appendingPathComponent($0, isDirectory: true)
+        }
+    }
+
+    private func configRoots(environment: [String: String]?) -> [URL] {
+        if let configured = environment.flatMap({ Self.normalized($0["CLAUDE_CONFIG_DIR"]) }) {
+            return [
+                URL(fileURLWithPath: ClaudeConfigDirectoryPath.preferredPath(
+                    configured,
+                    fileManager: fileManager,
+                    homeDirectory: homeDirectory
+                ), isDirectory: true).standardizedFileURL,
+            ]
+        }
+
+        var roots: [URL] = []
+        var seen: Set<String> = []
+        func appendRoot(_ path: String) {
+            let url = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+            guard seen.insert(url.path).inserted else { return }
+            roots.append(url)
+        }
+
+        let home = (homeDirectory as NSString).expandingTildeInPath
+        let accountRoot = (home as NSString).appendingPathComponent(".codex-accounts/claude")
+        if directoryExists(at: URL(fileURLWithPath: accountRoot, isDirectory: true)),
+           let accountDirs = try? fileManager.contentsOfDirectory(atPath: accountRoot) {
+            for accountDir in accountDirs.sorted() {
+                appendRoot((accountRoot as NSString).appendingPathComponent(accountDir))
+            }
+        }
+        appendRoot((home as NSString).appendingPathComponent(".claude"))
+        appendRoot(ClaudeConfigDirectoryPath.preferredPath(
+            (home as NSString).appendingPathComponent(".subrouter/codex/claude"),
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        ))
+        return roots
+    }
+
+    private func regularNonEmptyFileExists(at url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue,
+              let attrs = try? fileManager.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? NSNumber else {
+            return false
+        }
+        return size.intValue > 0
+    }
+
+    private func directoryExists(at url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    private static func isSafeSessionId(_ sessionId: String) -> Bool {
+        sessionId.range(of: #"[\\/]"#, options: .regularExpression) == nil
+            && !sessionId.isEmpty
+            && sessionId != "."
+            && sessionId != ".."
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let rawValue = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawValue.isEmpty else {
+            return nil
+        }
+        return rawValue
+    }
+}

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -775,13 +775,18 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory
     ) -> String? {
-        guard let command = resumeCommand,
-              let scriptURL = AgentResumeScriptStore.writeLauncherScript(
+        guard let command = resumeCommand else {
+            return nil
+        }
+        seedClaudeTranscriptIfNeeded(fileManager: fileManager)
+        let scriptStore = AgentResumeScriptStore(
+            fileManager: fileManager,
+            temporaryDirectory: temporaryDirectory
+        )
+        guard let scriptURL = scriptStore.writeLauncherScript(
                   command: command,
                   kind: kind,
                   sessionId: sessionId,
-                  fileManager: fileManager,
-                  temporaryDirectory: temporaryDirectory,
                   returnToLoginShell: true,
                   // Match the resume command's own cd: agents with an `.ignore` cwd policy resume from
                   // the current directory (no cd), so the post-exit shell must not force the launch dir.
@@ -815,6 +820,9 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         allowOversizedInlineInput: Bool = false
     ) -> String? {
         guard let command else { return nil }
+        if allowLauncherScript {
+            seedClaudeTranscriptIfNeeded(fileManager: fileManager)
+        }
         let inlineInput = command + "\n"
         guard inlineInput.utf8.count > Self.maxInlineStartupInputBytes else {
             return inlineInput
@@ -823,12 +831,14 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             return inlineInput
         }
         guard allowLauncherScript else { return nil }
-        guard let scriptURL = AgentResumeScriptStore.writeLauncherScript(
-            command: command,
-            kind: kind,
-            sessionId: sessionId,
+        let scriptStore = AgentResumeScriptStore(
             fileManager: fileManager,
             temporaryDirectory: temporaryDirectory
+        )
+        guard let scriptURL = scriptStore.writeLauncherScript(
+            command: command,
+            kind: kind,
+            sessionId: sessionId
         ) else {
             return nil
         }
@@ -845,74 +855,6 @@ extension SessionRestorableAgentSnapshot {
             return name
         }
         return kind.displayName
-    }
-}
-
-private enum AgentResumeScriptStore {
-    private static let directoryName = "cmux-agent-resume"
-    private static let scriptTTL: TimeInterval = 24 * 60 * 60
-
-    static func writeLauncherScript(
-        command: String,
-        kind: RestorableAgentKind,
-        sessionId: String,
-        fileManager: FileManager,
-        temporaryDirectory: URL,
-        returnToLoginShell: Bool = false,
-        workingDirectory: String? = nil
-    ) -> URL? {
-        let directoryURL = temporaryDirectory.appendingPathComponent(directoryName, isDirectory: true)
-        do {
-            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-            try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directoryURL.path)
-            pruneOldScripts(in: directoryURL, fileManager: fileManager)
-
-            let safeSessionPrefix = sessionId
-                .prefix(12)
-                .map { character -> Character in
-                    character.isLetter || character.isNumber || character == "-" ? character : "_"
-                }
-            let scriptURL = directoryURL.appendingPathComponent(
-                "\(kind.rawValue)-\(String(safeSessionPrefix))-\(UUID().uuidString).zsh",
-                isDirectory: false
-            )
-            var lines = [
-                "#!/bin/zsh",
-                "rm -f -- \"$0\" 2>/dev/null || true"
-            ]
-            if returnToLoginShell {
-                lines.append(contentsOf: TerminalStartupReturnShellScript.commandThenReturnLines(
-                    command: command,
-                    workingDirectory: workingDirectory
-                ))
-            } else {
-                lines.append(command)
-            }
-            let contents = lines.joined(separator: "\n") + "\n"
-            try contents.write(to: scriptURL, atomically: true, encoding: .utf8)
-            try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: scriptURL.path)
-            return scriptURL
-        } catch {
-            return nil
-        }
-    }
-
-    private static func pruneOldScripts(in directoryURL: URL, fileManager: FileManager) {
-        guard let scriptURLs = try? fileManager.contentsOfDirectory(
-            at: directoryURL,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return
-        }
-
-        let cutoff = Date().addingTimeInterval(-scriptTTL)
-        for scriptURL in scriptURLs where scriptURL.pathExtension == "zsh" {
-            let values = try? scriptURL.resourceValues(forKeys: [.contentModificationDateKey])
-            if let modified = values?.contentModificationDate, modified < cutoff {
-                try? fileManager.removeItem(at: scriptURL)
-            }
-        }
     }
 }
 
@@ -1553,11 +1495,7 @@ struct RestorableAgentSessionIndex: Sendable {
     }
 
     static func encodeClaudeProjectDir(_ path: String) -> String {
-        // Claude derives a project directory name by replacing both "/" and "." with "-"
-        // (e.g. "/Users/x/repo/.claude" -> "-Users-x-repo--claude"). Missing the "." case
-        // sent dotted paths to the wrong project directory.
-        path.replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: ".", with: "-")
+        ClaudeTranscriptSeeder.encodedProjectDirectoryName(for: path)
     }
 
     private static func claudeProjectDirName(containingTranscriptPath path: String, configRoots: [String]) -> String? {
@@ -1588,19 +1526,9 @@ struct RestorableAgentSessionIndex: Sendable {
             return nil
         }
 
-        let directPath = (projectRoot as NSString).appendingPathComponent("\(sessionId).jsonl")
-        if regularNonEmptyFileExists(atPath: directPath, fileManager: fileManager) {
-            return directPath
-        }
-
-        let nestedMessagesPath = (((projectRoot as NSString)
-            .appendingPathComponent(sessionId) as NSString)
-            .appendingPathComponent("messages") as NSString)
-            .appendingPathComponent("\(sessionId).jsonl")
-        if regularNonEmptyFileExists(atPath: nestedMessagesPath, fileManager: fileManager) {
-            return nestedMessagesPath
-        }
-        return nil
+        return ClaudeTranscriptSeeder(fileManager: fileManager)
+            .transcriptURL(inProjectDirectory: URL(fileURLWithPath: projectRoot, isDirectory: true), sessionId: sessionId)?
+            .path
     }
 
     private final class ClaudeTranscriptLookupCache {

--- a/Sources/SessionRestorableAgentSnapshot+ClaudeTranscriptSeeding.swift
+++ b/Sources/SessionRestorableAgentSnapshot+ClaudeTranscriptSeeding.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension SessionRestorableAgentSnapshot {
+    func seedClaudeTranscriptIfNeeded(fileManager: FileManager = .default) {
+        guard kind == .claude else { return }
+        ClaudeTranscriptSeeder(fileManager: fileManager).seedTranscriptIfNeeded(
+            sessionId: sessionId,
+            targetWorkingDirectory: workingDirectory,
+            sourceWorkingDirectory: launchCommand?.workingDirectory,
+            environment: launchCommand?.environment
+        )
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		A5D41222A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */; };
 		C7A533000000000000000002 /* ClaudeSessionCanonicalizationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A533000000000000000001 /* ClaudeSessionCanonicalizationContext.swift */; };
 		A9F200000000000000000015 /* ClaudeStreamJSONAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000015 /* ClaudeStreamJSONAccumulator.swift */; };
+		A59410000000000000000002 /* ClaudeTranscriptSeedingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59410000000000000000001 /* ClaudeTranscriptSeedingTests.swift */; };
 		CE7000000000000000000001 /* ClaudeWrapperResumeEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7000000000000000000002 /* ClaudeWrapperResumeEnvironmentTests.swift */; };
 		A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */; };
 		CA11E4D0FA017DE500000B101 /* CLICallerWorkspaceDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */; };
@@ -1613,6 +1614,7 @@
 		A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeNotificationStatusLifecycleTests.swift; sourceTree = "<group>"; };
 		C7A533000000000000000001 /* ClaudeSessionCanonicalizationContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ClaudeSessionCanonicalizationContext.swift"; sourceTree = "<group>"; };
 		A9F100000000000000000015 /* ClaudeStreamJSONAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ClaudeStreamJSONAccumulator.swift; sourceTree = "<group>"; };
+		A59410000000000000000001 /* ClaudeTranscriptSeedingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeTranscriptSeedingTests.swift; sourceTree = "<group>"; };
 		CE7000000000000000000002 /* ClaudeWrapperResumeEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeWrapperResumeEnvironmentTests.swift; sourceTree = "<group>"; };
 		A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAuthAliasTests.swift; sourceTree = "<group>"; };
 		CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICallerWorkspaceDefaultTests.swift; sourceTree = "<group>"; };
@@ -3752,6 +3754,7 @@
 				F5410005A1B2C3D4E5F60718 /* RestorableAgentHookProviderHermesTests.swift */,
 				F5410003A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift */,
 				F54100B1A1B2C3D4E5F60718 /* RestorableCodexForkTagTests.swift */,
+				A59410000000000000000001 /* ClaudeTranscriptSeedingTests.swift */,
 				F5410007A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift */,
 				F54100A1A1B2C3D4E5F60718 /* RestorableAgentSessionStalePIDTests.swift */,
 				F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */,
@@ -5423,6 +5426,7 @@
 				C7A534000000000000000002 /* ClaudeHookFeedTelemetrySwiftTests.swift in Sources */,
 				A5D41220A1B2C3D4E5F60718 /* ClaudeHookSurfaceResolutionSwiftTests.swift in Sources */,
 				A5D41222A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift in Sources */,
+					A59410000000000000000002 /* ClaudeTranscriptSeedingTests.swift in Sources */,
 				CE7000000000000000000001 /* ClaudeWrapperResumeEnvironmentTests.swift in Sources */,
 				A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */,
 					CA11E4D0FA017DE500000B101 /* CLICallerWorkspaceDefaultTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		A5D41234A1B2C3D4E5F60718 /* AgentNotificationGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41235A1B2C3D4E5F60718 /* AgentNotificationGate.swift */; };
 		A5D41230A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */; };
 		C3744E030000000000000001 /* AgentPIDProcessIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E040000000000000001 /* AgentPIDProcessIdentity.swift */; };
+		A5941000000000000000106 /* AgentResumeScriptStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5941000000000000000105 /* AgentResumeScriptStore.swift */; };
 		D3610B010000000000000001 /* AgentSessionAutoResumeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */; };
 		D3610B020000000000000001 /* AgentSessionAutoResumeSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */; };
 		A9E020000000000000000008 /* AgentSessionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000008 /* AgentSessionBridge.swift */; };
@@ -245,6 +246,7 @@
 		A5D41222A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */; };
 		C7A533000000000000000002 /* ClaudeSessionCanonicalizationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A533000000000000000001 /* ClaudeSessionCanonicalizationContext.swift */; };
 		A9F200000000000000000015 /* ClaudeStreamJSONAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000015 /* ClaudeStreamJSONAccumulator.swift */; };
+		A5941000000000000000102 /* ClaudeTranscriptSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5941000000000000000101 /* ClaudeTranscriptSeeder.swift */; };
 		A59410000000000000000002 /* ClaudeTranscriptSeedingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59410000000000000000001 /* ClaudeTranscriptSeedingTests.swift */; };
 		CE7000000000000000000001 /* ClaudeWrapperResumeEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7000000000000000000002 /* ClaudeWrapperResumeEnvironmentTests.swift */; };
 		A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */; };
@@ -929,6 +931,7 @@
 		F6572002A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6572003A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift */; };
 		F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 		E30780000000000000000014 /* SessionRemoteWorkspaceSnapshot+Restore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30780000000000000000013 /* SessionRemoteWorkspaceSnapshot+Restore.swift */; };
+		A5941000000000000000104 /* SessionRestorableAgentSnapshot+ClaudeTranscriptSeeding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5941000000000000000103 /* SessionRestorableAgentSnapshot+ClaudeTranscriptSeeding.swift */; };
 		A5001670 /* SessionRestoredTerminalCommandStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001671 /* SessionRestoredTerminalCommandStore.swift */; };
 		A50016B1A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50016B0A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift */; };
 		F5320002A1B2C3D4E5F60718 /* SessionTranscriptTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320003A1B2C3D4E5F60718 /* SessionTranscriptTypes.swift */; };
@@ -1413,6 +1416,7 @@
 		A5D41235A1B2C3D4E5F60718 /* AgentNotificationGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationGate.swift; sourceTree = "<group>"; };
 		A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationGateTests.swift; sourceTree = "<group>"; };
 		C3744E040000000000000001 /* AgentPIDProcessIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPIDProcessIdentity.swift; sourceTree = "<group>"; };
+		A5941000000000000000105 /* AgentResumeScriptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentResumeScriptStore.swift; sourceTree = "<group>"; };
 		D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionAutoResumeSettingsTests.swift; sourceTree = "<group>"; };
 		D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionAutoResumeSwiftTests.swift; sourceTree = "<group>"; };
 		A9E010000000000000000008 /* AgentSessionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentSessionBridge.swift; sourceTree = "<group>"; };
@@ -1614,6 +1618,7 @@
 		A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeNotificationStatusLifecycleTests.swift; sourceTree = "<group>"; };
 		C7A533000000000000000001 /* ClaudeSessionCanonicalizationContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ClaudeSessionCanonicalizationContext.swift"; sourceTree = "<group>"; };
 		A9F100000000000000000015 /* ClaudeStreamJSONAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ClaudeStreamJSONAccumulator.swift; sourceTree = "<group>"; };
+		A5941000000000000000101 /* ClaudeTranscriptSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeTranscriptSeeder.swift; sourceTree = "<group>"; };
 		A59410000000000000000001 /* ClaudeTranscriptSeedingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeTranscriptSeedingTests.swift; sourceTree = "<group>"; };
 		CE7000000000000000000002 /* ClaudeWrapperResumeEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeWrapperResumeEnvironmentTests.swift; sourceTree = "<group>"; };
 		A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAuthAliasTests.swift; sourceTree = "<group>"; };
@@ -2237,6 +2242,7 @@
 		F6572003A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceResumeBindingTests.swift; sourceTree = "<group>"; };
 		F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
 		E30780000000000000000013 /* SessionRemoteWorkspaceSnapshot+Restore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionRemoteWorkspaceSnapshot+Restore.swift"; sourceTree = "<group>"; };
+		A5941000000000000000103 /* SessionRestorableAgentSnapshot+ClaudeTranscriptSeeding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionRestorableAgentSnapshot+ClaudeTranscriptSeeding.swift"; sourceTree = "<group>"; };
 		A5001671 /* SessionRestoredTerminalCommandStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestoredTerminalCommandStore.swift; sourceTree = "<group>"; };
 		A50016B0A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SessionSnapshotDebugBenchmark.swift; sourceTree = "<group>"; };
 		F5320003A1B2C3D4E5F60718 /* SessionTranscriptTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTranscriptTypes.swift; sourceTree = "<group>"; };
@@ -3524,8 +3530,11 @@
 				92CA6F2F239631988B2FB0C8 /* WorkspaceRemoteTmuxNonInteractiveCloseRoute.swift */,
 				5E55400000000000000000D2 /* FocusStealingResponderConformances.swift */,
 				A5001671 /* SessionRestoredTerminalCommandStore.swift */,
+				A5941000000000000000105 /* AgentResumeScriptStore.swift */,
 				B35751000000000000000001 /* TmuxResumeParser.swift */,
+				A5941000000000000000101 /* ClaudeTranscriptSeeder.swift */,
 				A5001661 /* RestorableAgentSession.swift */,
+				A5941000000000000000103 /* SessionRestorableAgentSnapshot+ClaudeTranscriptSeeding.swift */,
 				C0DEF0C10000000000000002 /* AgentForkSupport.swift */,
 				C0DEF0C20000000000000002 /* SemanticVersion.swift */,
 				A5001642 /* RemoteInteractiveShellBootstrapBuilder.swift */,
@@ -4484,6 +4493,7 @@
 				D36A00030000000000000001 /* AgentHibernationLifecycleState.swift in Sources */,
 				A5D41234A1B2C3D4E5F60718 /* AgentNotificationGate.swift in Sources */,
 				C3744E030000000000000001 /* AgentPIDProcessIdentity.swift in Sources */,
+				A5941000000000000000106 /* AgentResumeScriptStore.swift in Sources */,
 				A9E020000000000000000008 /* AgentSessionBridge.swift in Sources */,
 				A9F20000000000000000000B /* AgentSessionBridgeError.swift in Sources */,
 				A9F20000000000000000000C /* AgentSessionBridgeRequest.swift in Sources */,
@@ -4624,6 +4634,7 @@
 				CA52B0070000000000000000 /* CanvasPaneContent.swift in Sources */,
 				C7A533000000000000000002 /* ClaudeSessionCanonicalizationContext.swift in Sources */,
 				A9F200000000000000000015 /* ClaudeStreamJSONAccumulator.swift in Sources */,
+				A5941000000000000000102 /* ClaudeTranscriptSeeder.swift in Sources */,
 				C46790000000000000000003 /* CLIForwardingLaunchRouter.swift in Sources */,
 				C10D51700000000000000002 /* ClosedItemHistory.swift in Sources */,
 				C10D00010000000000000001 /* CloudVMActionLauncher.swift in Sources */,
@@ -4993,6 +5004,7 @@
 				A5001610 /* SessionPersistence.swift in Sources */,
 				C65930020000000000000002 /* SessionPersistencePolicy+CrashStorage.swift in Sources */,
 				E30780000000000000000014 /* SessionRemoteWorkspaceSnapshot+Restore.swift in Sources */,
+				A5941000000000000000104 /* SessionRestorableAgentSnapshot+ClaudeTranscriptSeeding.swift in Sources */,
 				A5001670 /* SessionRestoredTerminalCommandStore.swift in Sources */,
 				A50016B1A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift in Sources */,
 				F5320002A1B2C3D4E5F60718 /* SessionTranscriptTypes.swift in Sources */,

--- a/cmuxTests/ClaudeTranscriptSeedingTests.swift
+++ b/cmuxTests/ClaudeTranscriptSeedingTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+struct ClaudeTranscriptSeedingTests {
+    @Test func forkStartupInputSeedsClaudeTranscriptIntoTargetCwdProjectDir() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-claude-transcript-seed-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let sourceCwd = root.appendingPathComponent("cmuxterm-hq", isDirectory: true)
+        let targetCwd = root
+            .appendingPathComponent("worktrees", isDirectory: true)
+            .appendingPathComponent("feat-monaco-settings", isDirectory: true)
+        try fileManager.createDirectory(at: sourceCwd, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: targetCwd, withIntermediateDirectories: true)
+
+        let sessionId = "39c1eb84-1111-2222-3333-444444444444"
+        let sourceProjectDir = projectDirectory(configDir: configDir, cwd: sourceCwd)
+        let targetProjectDir = projectDirectory(configDir: configDir, cwd: targetCwd)
+        try fileManager.createDirectory(at: sourceProjectDir, withIntermediateDirectories: true)
+        let sourceTranscript = sourceProjectDir.appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+        let sourceTranscriptContents = """
+        {"type":"user","sessionId":"\(sessionId)","cwd":"\(sourceCwd.path)"}
+
+        """
+        try sourceTranscriptContents.write(to: sourceTranscript, atomically: true, encoding: .utf8)
+
+        let sourceSidecarDir = sourceProjectDir.appendingPathComponent(sessionId, isDirectory: true)
+        try fileManager.createDirectory(at: sourceSidecarDir, withIntermediateDirectories: true)
+        let sourceSidecar = sourceSidecarDir.appendingPathComponent("metadata.json", isDirectory: false)
+        try #"{"sidecar":true}"#.write(to: sourceSidecar, atomically: true, encoding: .utf8)
+
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: sessionId,
+            workingDirectory: targetCwd.path,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/usr/local/bin/claude",
+                arguments: ["/usr/local/bin/claude"],
+                workingDirectory: sourceCwd.path,
+                environment: ["CLAUDE_CONFIG_DIR": configDir.path],
+                capturedAt: 123,
+                source: "test"
+            )
+        )
+
+        #expect(snapshot.forkStartupInput(fileManager: fileManager, temporaryDirectory: root) != nil)
+
+        let targetTranscript = targetProjectDir.appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+        let copiedTranscript = try String(contentsOf: targetTranscript, encoding: .utf8)
+        #expect(copiedTranscript == sourceTranscriptContents)
+
+        let copiedSidecar = targetProjectDir
+            .appendingPathComponent(sessionId, isDirectory: true)
+            .appendingPathComponent("metadata.json", isDirectory: false)
+        let copiedSidecarContents = try String(contentsOf: copiedSidecar, encoding: .utf8)
+        #expect(copiedSidecarContents == #"{"sidecar":true}"#)
+
+        let sourceInode = try inodeNumber(at: sourceTranscript)
+        let targetInode = try inodeNumber(at: targetTranscript)
+        #expect(sourceInode != targetInode, "Transcript seeding must copy, not hardlink, the JSONL file.")
+    }
+
+    private func projectDirectory(configDir: URL, cwd: URL) -> URL {
+        configDir
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(expectedClaudeProjectDirName(cwd.path), isDirectory: true)
+    }
+
+    private func expectedClaudeProjectDirName(_ path: String) -> String {
+        path.replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+    }
+
+    private func inodeNumber(at url: URL) throws -> UInt64 {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let value = try #require(attributes[.systemFileNumber] as? NSNumber)
+        return value.uint64Value
+    }
+}

--- a/cmuxTests/ClaudeTranscriptSeedingTests.swift
+++ b/cmuxTests/ClaudeTranscriptSeedingTests.swift
@@ -9,12 +9,57 @@ import Testing
 
 @Suite(.serialized)
 struct ClaudeTranscriptSeedingTests {
+    @Test func encodedProjectDirectoryNameMatchesClaudeCwdRule() {
+        #expect(
+            ClaudeTranscriptSeeder.encodedProjectDirectoryName(for: "/Users/lawrence/fun/cmuxterm-hq/.claude")
+                == "-Users-lawrence-fun-cmuxterm-hq--claude"
+        )
+    }
+
+    @Test func helperCopiesTranscriptAndSidecarIntoTargetCwdProjectDir() throws {
+        let fileManager = FileManager.default
+        let fixture = try makeFixture(fileManager: fileManager)
+        defer { try? fileManager.removeItem(at: fixture.root) }
+
+        let didSeed = ClaudeTranscriptSeeder(fileManager: fileManager).seedTranscriptIfNeeded(
+            sessionId: fixture.sessionId,
+            targetWorkingDirectory: fixture.targetCwd.path,
+            sourceWorkingDirectory: fixture.sourceCwd.path,
+            environment: ["CLAUDE_CONFIG_DIR": fixture.configDir.path]
+        )
+
+        #expect(didSeed)
+        try assertSeededFixture(fixture, fileManager: fileManager)
+    }
+
     @Test func forkStartupInputSeedsClaudeTranscriptIntoTargetCwdProjectDir() throws {
         let fileManager = FileManager.default
+        let fixture = try makeFixture(fileManager: fileManager)
+        defer { try? fileManager.removeItem(at: fixture.root) }
+
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: fixture.sessionId,
+            workingDirectory: fixture.targetCwd.path,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/usr/local/bin/claude",
+                arguments: ["/usr/local/bin/claude"],
+                workingDirectory: fixture.sourceCwd.path,
+                environment: ["CLAUDE_CONFIG_DIR": fixture.configDir.path],
+                capturedAt: 123,
+                source: "test"
+            )
+        )
+
+        #expect(snapshot.forkStartupInput(fileManager: fileManager, temporaryDirectory: fixture.root) != nil)
+
+        try assertSeededFixture(fixture, fileManager: fileManager)
+    }
+
+    private func makeFixture(fileManager: FileManager) throws -> ClaudeTranscriptSeedFixture {
         let root = fileManager.temporaryDirectory
             .appendingPathComponent("cmux-claude-transcript-seed-\(UUID().uuidString)", isDirectory: true)
-        defer { try? fileManager.removeItem(at: root) }
-
         let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
         let sourceCwd = root.appendingPathComponent("cmuxterm-hq", isDirectory: true)
         let targetCwd = root
@@ -39,34 +84,34 @@ struct ClaudeTranscriptSeedingTests {
         let sourceSidecar = sourceSidecarDir.appendingPathComponent("metadata.json", isDirectory: false)
         try #"{"sidecar":true}"#.write(to: sourceSidecar, atomically: true, encoding: .utf8)
 
-        let snapshot = SessionRestorableAgentSnapshot(
-            kind: .claude,
+        return ClaudeTranscriptSeedFixture(
+            root: root,
+            configDir: configDir,
+            sourceCwd: sourceCwd,
+            targetCwd: targetCwd,
             sessionId: sessionId,
-            workingDirectory: targetCwd.path,
-            launchCommand: AgentLaunchCommandSnapshot(
-                launcher: "claude",
-                executablePath: "/usr/local/bin/claude",
-                arguments: ["/usr/local/bin/claude"],
-                workingDirectory: sourceCwd.path,
-                environment: ["CLAUDE_CONFIG_DIR": configDir.path],
-                capturedAt: 123,
-                source: "test"
-            )
+            sourceTranscript: sourceTranscript,
+            targetProjectDir: targetProjectDir,
+            sourceTranscriptContents: sourceTranscriptContents
         )
+    }
 
-        #expect(snapshot.forkStartupInput(fileManager: fileManager, temporaryDirectory: root) != nil)
-
-        let targetTranscript = targetProjectDir.appendingPathComponent("\(sessionId).jsonl", isDirectory: false)
+    private func assertSeededFixture(
+        _ fixture: ClaudeTranscriptSeedFixture,
+        fileManager: FileManager
+    ) throws {
+        let targetTranscript = fixture.targetProjectDir
+            .appendingPathComponent("\(fixture.sessionId).jsonl", isDirectory: false)
         let copiedTranscript = try String(contentsOf: targetTranscript, encoding: .utf8)
-        #expect(copiedTranscript == sourceTranscriptContents)
+        #expect(copiedTranscript == fixture.sourceTranscriptContents)
 
-        let copiedSidecar = targetProjectDir
-            .appendingPathComponent(sessionId, isDirectory: true)
+        let copiedSidecar = fixture.targetProjectDir
+            .appendingPathComponent(fixture.sessionId, isDirectory: true)
             .appendingPathComponent("metadata.json", isDirectory: false)
         let copiedSidecarContents = try String(contentsOf: copiedSidecar, encoding: .utf8)
         #expect(copiedSidecarContents == #"{"sidecar":true}"#)
 
-        let sourceInode = try inodeNumber(at: sourceTranscript)
+        let sourceInode = try inodeNumber(at: fixture.sourceTranscript)
         let targetInode = try inodeNumber(at: targetTranscript)
         #expect(sourceInode != targetInode, "Transcript seeding must copy, not hardlink, the JSONL file.")
     }
@@ -87,4 +132,15 @@ struct ClaudeTranscriptSeedingTests {
         let value = try #require(attributes[.systemFileNumber] as? NSNumber)
         return value.uint64Value
     }
+}
+
+private struct ClaudeTranscriptSeedFixture {
+    var root: URL
+    var configDir: URL
+    var sourceCwd: URL
+    var targetCwd: URL
+    var sessionId: String
+    var sourceTranscript: URL
+    var targetProjectDir: URL
+    var sourceTranscriptContents: String
 }


### PR DESCRIPTION
Closes #5941

## Summary
- Add a Claude transcript seeding helper that uses Claude's cwd project-dir encoding and copies the JSONL transcript plus optional sidecar directory into the target cwd project dir before resume/fork launch.
- Invoke seeding from the shared `SessionRestorableAgentSnapshot` startup paths so fork-to-tab, fork-to-workspace, and session restore use the same behavior.
- Keep availability probes side-effect-free when launcher scripts are disabled.

## Tests / validation
- Added `ClaudeTranscriptSeedingTests` in a first failing-test-only commit, then the fix commit.
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/swift_file_length_budget.py`
- `git diff --check`

No build or xcodebuild run per task instruction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Claude sessions keep their transcript when forking to a different working directory by seeding the JSONL and sidecar into the target project dir before launch. Applies to fork-to-tab, fork-to-workspace, and session restore; closes #5941.

- Bug Fixes
  - Seed the session JSONL and optional sidecar from the source project dir into the target cwd project dir before launch.
  - Only seed for Claude and when launcher scripts are enabled, keeping availability probes side‑effect free.
  - Added `ClaudeTranscriptSeedingTests` to cover seeding and cwd encoding.

- Refactors
  - Extracted `AgentResumeScriptStore` and reused it across launch paths.
  - Centralized Claude project-dir encoding and transcript lookup in `ClaudeTranscriptSeeder`; removed duplicated logic from `RestorableAgentSession`.

<sup>Written for commit 8a1b302553ac8944d36036c6ce1d52fd73aacba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

