### PR TITLE
Cut steady-state sysctl burn from background process snapshots

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -47,7 +47,7 @@
 2085	cmuxTests/ShortcutAndCommandPaletteTests.swift
 2078	Sources/SessionPersistence.swift
 2011	Sources/KeyboardShortcutSettingsFileStore.swift
-1944	Sources/RestorableAgentSession.swift
+1954	Sources/RestorableAgentSession.swift
 1900	cmuxTests/NotificationAndMenuBarTests.swift
 1866	Sources/Panels/BrowserWebAuthnSupport.swift
 1810	Sources/SessionIndexStore.swift

--- a/Sources/CmuxTopSnapshotScopeCache.swift
+++ b/Sources/CmuxTopSnapshotScopeCache.swift
@@ -27,7 +27,8 @@ private nonisolated struct CmuxTopProcessScopeCacheValue {
 // be attributed. A newly spawned process has a new cache key and is probed
 // immediately; this TTL only bounds attribution latency for same-pid execs while
 // collapsing the steady-state re-probe storm for non-cmux processes.
-private nonisolated let cmuxTopNegativeScopeTTLNanoseconds: UInt64 = 60 * 1_000_000_000
+// Internal (not private) so tests can read the TTL via @testable import.
+nonisolated let cmuxTopNegativeScopeTTLNanoseconds: UInt64 = 60 * 1_000_000_000
 
 // Result of probing a single process for its cmux scope. `resolved` means the
 // probe completed (the scope may legitimately be absent) and is safe to cache.
@@ -47,10 +48,6 @@ private nonisolated let cmuxTopScopeCache = OSAllocatedUnfairLock(
 )
 
 nonisolated extension CmuxTopProcessSnapshot {
-    static var scopeCacheNegativeTTLNanoseconds: UInt64 {
-        cmuxTopNegativeScopeTTLNanoseconds
-    }
-
     static func scopeCacheKey(from kinfo: kinfo_proc) -> CmuxTopProcessScopeCacheKey {
         let startTime = kinfo.kp_proc.p_un.__p_starttime
         return CmuxTopProcessScopeCacheKey(

--- a/Sources/CmuxTopSnapshotScopeCache.swift
+++ b/Sources/CmuxTopSnapshotScopeCache.swift
@@ -24,9 +24,10 @@ private nonisolated struct CmuxTopProcessScopeCacheValue {
 // without changing the pid or process start time (the cache key), so a process
 // first sampled in its fork-before-exec window, or one that execs into a
 // `cmux hooks … monitor` later, must be re-probed eventually or it would never
-// be attributed. The TTL bounds that attribution latency while still collapsing
-// the per-poll sysctl storm for the steady-state majority of non-cmux processes.
-private nonisolated let cmuxTopNegativeScopeTTLNanoseconds: UInt64 = 15 * 1_000_000_000
+// be attributed. A newly spawned process has a new cache key and is probed
+// immediately; this TTL only bounds attribution latency for same-pid execs while
+// collapsing the steady-state re-probe storm for non-cmux processes.
+private nonisolated let cmuxTopNegativeScopeTTLNanoseconds: UInt64 = 60 * 1_000_000_000
 
 // Result of probing a single process for its cmux scope. `resolved` means the
 // probe completed (the scope may legitimately be absent) and is safe to cache.
@@ -46,6 +47,10 @@ private nonisolated let cmuxTopScopeCache = OSAllocatedUnfairLock(
 )
 
 nonisolated extension CmuxTopProcessSnapshot {
+    static var scopeCacheNegativeTTLNanoseconds: UInt64 {
+        cmuxTopNegativeScopeTTLNanoseconds
+    }
+
     static func scopeCacheKey(from kinfo: kinfo_proc) -> CmuxTopProcessScopeCacheKey {
         let startTime = kinfo.kp_proc.p_un.__p_starttime
         return CmuxTopProcessScopeCacheKey(
@@ -132,13 +137,15 @@ nonisolated extension CmuxTopProcessSnapshot {
     // The discriminator is liveness: if a procargs read fails but the process is
     // still alive with the same start time, the failure is a permanent denial and
     // resolves to nil; otherwise it raced with exit/reuse and is `.unavailable`.
+    // Callers derive `expectedCacheKey` from a `proc_bsdinfo` snapshot of this pid
+    // in the same enumeration pass, so a pre-read `kinfoProc` check would only
+    // repeat work. The post-read guard still catches pid reuse during the
+    // `KERN_PROCARGS2` probe window.
     static func cmuxScopeProbe(
         for pid: Int,
         expectedCacheKey: CmuxTopProcessScopeCacheKey
     ) -> CmuxTopProcessScopeProbeResult {
-        guard processMatchesKey(pid, expectedCacheKey) else {
-            return .unavailable
-        }
+        guard pid > 0, pid <= Int(Int32.max) else { return .unavailable }
 
         var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, Int32(pid)]
         var size: size_t = 0

--- a/Sources/PaneMemoryGuardrail.swift
+++ b/Sources/PaneMemoryGuardrail.swift
@@ -138,6 +138,12 @@ final class PaneMemoryGuardrail {
         thresholdBytes: Int64,
         includeCMUXScope: Bool = false
     ) -> PaneMemoryGuardrailSampleBatch {
+        // The unscoped maximumAge must stay below pollInterval (4s): serving the
+        // guardrail its own previous tick's snapshot would silently halve its
+        // effective sampling cadence. 3s only allows reuse of a snapshot another
+        // subsystem (autosave, task manager) captured moments earlier; when the
+        // guardrail is the sole sampler it still captures fresh each tick, which
+        // is the cheap no-details tier and the intended freshness floor.
         let snapshot = includeCMUXScope
             ? CmuxTopProcessSnapshot.captureCached(includeCMUXScope: true, maximumAge: 5)
             : CmuxTopProcessSnapshot.captureCached(includeCMUXScope: false, maximumAge: 3)

--- a/Sources/PaneMemoryGuardrail.swift
+++ b/Sources/PaneMemoryGuardrail.swift
@@ -139,8 +139,8 @@ final class PaneMemoryGuardrail {
         includeCMUXScope: Bool = false
     ) -> PaneMemoryGuardrailSampleBatch {
         let snapshot = includeCMUXScope
-            ? CmuxTopProcessSnapshot.capture(includeCMUXScope: true)
-            : CmuxTopProcessSnapshot.captureCached(includeCMUXScope: false, maximumAge: 2)
+            ? CmuxTopProcessSnapshot.captureCached(includeCMUXScope: true, maximumAge: 5)
+            : CmuxTopProcessSnapshot.captureCached(includeCMUXScope: false, maximumAge: 3)
         let samples = computeSamples(
             descriptors: descriptors,
             thresholdBytes: thresholdBytes,

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1898,16 +1898,9 @@ struct ProcessDetectedResumeIndexes: Sendable {
         fileManager: FileManager = .default
     ) async -> ProcessDetectedResumeIndexes {
         await Task.detached(priority: .utility) {
-            // The async path serves the periodic autosave tick and non-terminating
-            // deactivation saves. Those re-run within seconds and self-heal on the
-            // next tick, so they tolerate a snapshot up to 5s old and can reuse
-            // one another subsystem just captured instead of re-scanning the full
-            // process table every 8s.
-            loadSynchronously(
-                homeDirectory: homeDirectory,
-                fileManager: fileManager,
-                maximumSnapshotAge: 5
-            )
+            // Periodic autosave/deactivation saves re-run within seconds and
+            // self-heal, so they tolerate reusing a <=5s-old process snapshot.
+            loadSynchronously(homeDirectory: homeDirectory, fileManager: fileManager, maximumSnapshotAge: 5)
         }.value
     }
 
@@ -1917,20 +1910,13 @@ struct ProcessDetectedResumeIndexes: Sendable {
         maximumSnapshotAge: TimeInterval? = nil
     ) -> ProcessDetectedResumeIndexes {
         let capturedAt = Date().timeIntervalSince1970
-        // Direct synchronous callers are the termination-critical saves (quit,
-        // power-off, update relaunch). The indexes they persist are the last
-        // word on which agent processes were live, and nothing runs afterward
-        // to correct a miss, so they default to a fresh capture; a stale
-        // snapshot could permanently drop an agent that started moments before
-        // quit. Only the periodic async path above opts into cached reuse.
-        let processSnapshot: CmuxTopProcessSnapshot
-        if let maximumSnapshotAge {
-            processSnapshot = CmuxTopProcessSnapshot.captureCached(
-                includeProcessDetails: true,
-                maximumAge: maximumSnapshotAge
-            )
+        // Direct callers are termination-critical saves (quit, power-off, update
+        // relaunch): nothing runs later to correct a stale miss, so nil means a
+        // fresh capture. Only the periodic async path opts into cached reuse.
+        let processSnapshot = if let maximumSnapshotAge {
+            CmuxTopProcessSnapshot.captureCached(includeProcessDetails: true, maximumAge: maximumSnapshotAge)
         } else {
-            processSnapshot = CmuxTopProcessSnapshot.capture(includeProcessDetails: true)
+            CmuxTopProcessSnapshot.capture(includeProcessDetails: true)
         }
         let registry = CmuxVaultAgentRegistry.load(homeDirectory: homeDirectory, fileManager: fileManager)
         let detectedSnapshots = RestorableAgentSessionIndex.processDetectedSnapshots(

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1898,16 +1898,40 @@ struct ProcessDetectedResumeIndexes: Sendable {
         fileManager: FileManager = .default
     ) async -> ProcessDetectedResumeIndexes {
         await Task.detached(priority: .utility) {
-            loadSynchronously(homeDirectory: homeDirectory, fileManager: fileManager)
+            // The async path serves the periodic autosave tick and non-terminating
+            // deactivation saves. Those re-run within seconds and self-heal on the
+            // next tick, so they tolerate a snapshot up to 5s old and can reuse
+            // one another subsystem just captured instead of re-scanning the full
+            // process table every 8s.
+            loadSynchronously(
+                homeDirectory: homeDirectory,
+                fileManager: fileManager,
+                maximumSnapshotAge: 5
+            )
         }.value
     }
 
     static func loadSynchronously(
         homeDirectory: String = NSHomeDirectory(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        maximumSnapshotAge: TimeInterval? = nil
     ) -> ProcessDetectedResumeIndexes {
         let capturedAt = Date().timeIntervalSince1970
-        let processSnapshot = CmuxTopProcessSnapshot.captureCached(includeProcessDetails: true, maximumAge: 5)
+        // Direct synchronous callers are the termination-critical saves (quit,
+        // power-off, update relaunch). The indexes they persist are the last
+        // word on which agent processes were live, and nothing runs afterward
+        // to correct a miss, so they default to a fresh capture; a stale
+        // snapshot could permanently drop an agent that started moments before
+        // quit. Only the periodic async path above opts into cached reuse.
+        let processSnapshot: CmuxTopProcessSnapshot
+        if let maximumSnapshotAge {
+            processSnapshot = CmuxTopProcessSnapshot.captureCached(
+                includeProcessDetails: true,
+                maximumAge: maximumSnapshotAge
+            )
+        } else {
+            processSnapshot = CmuxTopProcessSnapshot.capture(includeProcessDetails: true)
+        }
         let registry = CmuxVaultAgentRegistry.load(homeDirectory: homeDirectory, fileManager: fileManager)
         let detectedSnapshots = RestorableAgentSessionIndex.processDetectedSnapshots(
             registry: registry,

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1907,7 +1907,7 @@ struct ProcessDetectedResumeIndexes: Sendable {
         fileManager: FileManager = .default
     ) -> ProcessDetectedResumeIndexes {
         let capturedAt = Date().timeIntervalSince1970
-        let processSnapshot = CmuxTopProcessSnapshot.capture(includeProcessDetails: true)
+        let processSnapshot = CmuxTopProcessSnapshot.captureCached(includeProcessDetails: true, maximumAge: 5)
         let registry = CmuxVaultAgentRegistry.load(homeDirectory: homeDirectory, fileManager: fileManager)
         let detectedSnapshots = RestorableAgentSessionIndex.processDetectedSnapshots(
             registry: registry,

--- a/cmuxTests/CmuxTopSnapshotScopeCacheTests.swift
+++ b/cmuxTests/CmuxTopSnapshotScopeCacheTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Darwin
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -17,8 +18,9 @@ import Foundation
 struct CmuxTopSnapshotScopeCacheTests {
     // ~1s, well within the negative TTL.
     static let nowNanoseconds: UInt64 = 1_000_000_000
-    // ~1000s later, beyond any sane negative TTL, so the negative entry expires.
-    static let farFutureNanoseconds: UInt64 = 1_000_000_000_000
+    static let afterNegativeTTLNanoseconds = nowNanoseconds
+        + CmuxTopProcessSnapshot.scopeCacheNegativeTTLNanoseconds
+        + 1
 
     // Before the fix, a process with no cmux scope was a permanent cache miss, so
     // every system.top poll re-ran the 3-sysctl probe for every non-cmux process
@@ -68,7 +70,7 @@ struct CmuxTopSnapshotScopeCacheTests {
         let first = CmuxTopProcessSnapshot.cachedCMUXScope(
             for: 901_002, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
         let second = CmuxTopProcessSnapshot.cachedCMUXScope(
-            for: 901_002, cacheKey: cacheKey, nowNanoseconds: Self.farFutureNanoseconds, probe: probe)
+            for: 901_002, cacheKey: cacheKey, nowNanoseconds: Self.afterNegativeTTLNanoseconds, probe: probe)
 
         #expect(first == expected)
         #expect(second == expected)
@@ -150,9 +152,27 @@ struct CmuxTopSnapshotScopeCacheTests {
         // negative entry expires and the next poll re-probes and attributes it.
         resolvedScope = postExecScope
         let afterExpiry = CmuxTopProcessSnapshot.cachedCMUXScope(
-            for: 901_004, cacheKey: cacheKey, nowNanoseconds: Self.farFutureNanoseconds, probe: probe)
+            for: 901_004, cacheKey: cacheKey, nowNanoseconds: Self.afterNegativeTTLNanoseconds, probe: probe)
         #expect(afterExpiry == postExecScope)
         #expect(probeCount == 2, "expired negative entry must be re-probed")
+    }
+
+    @Test func liveProcessScopeProbeResolves() throws {
+        let pid = Int(Darwin.getpid())
+        var info = proc_bsdinfo()
+        let expectedSize = MemoryLayout<proc_bsdinfo>.stride
+        let size = proc_pidinfo(pid_t(pid), PROC_PIDTBSDINFO, 0, &info, Int32(expectedSize))
+        try #require(size == expectedSize)
+        let cacheKey = CmuxTopProcessSnapshot.scopeCacheKey(from: info)
+
+        let result = CmuxTopProcessSnapshot.cmuxScopeProbe(for: pid, expectedCacheKey: cacheKey)
+
+        switch result {
+        case .resolved:
+            break
+        case .unavailable:
+            Issue.record("live process probe should resolve, even when it has no cmux scope")
+        }
     }
 
     // capture() runs concurrently. A slower sample that probed a process before

--- a/cmuxTests/CmuxTopSnapshotScopeCacheTests.swift
+++ b/cmuxTests/CmuxTopSnapshotScopeCacheTests.swift
@@ -19,7 +19,7 @@ struct CmuxTopSnapshotScopeCacheTests {
     // ~1s, well within the negative TTL.
     static let nowNanoseconds: UInt64 = 1_000_000_000
     static let afterNegativeTTLNanoseconds = nowNanoseconds
-        + CmuxTopProcessSnapshot.scopeCacheNegativeTTLNanoseconds
+        + cmuxTopNegativeScopeTTLNanoseconds
         + 1
 
     // Before the fix, a process with no cmux scope was a permanent cache miss, so


### PR DESCRIPTION
An idle cmux burns ~21% of a core continuously in full process-table scans (10s `sample`, 7855 samples: ~1117 in the 8s session-autosave `ProcessDetectedResumeIndexes` capture, ~306 in `PaneMemoryGuardrail.tick`, with the scope-probe sysctl fan-out dominating both). Three changes:

- Route the autosave capture and both guardrail capture paths through `captureCached`. The guardrail's unscoped tick used `maximumAge: 2` at a 4s cadence, so the cache missed every tick; its 15s scoped scan bypassed the cache entirely with a raw `capture`.
- Drop the pre-validation `kinfoProc` sysctl in `cmuxScopeProbe`. Callers derive `expectedCacheKey` from a `proc_bsdinfo` of the same pid in the same enumeration pass, so the pre-check only repeated work; the post-PROCARGS2 recycle guard and both failure-path liveness checks remain, so pid reuse still cannot poison the cache.
- Raise the negative scope TTL from 15s to 60s. A new process has a new (pid, starttime) cache key and is probed immediately regardless of TTL; the TTL only bounds attribution latency for the rare same-pid exec into a cmux scope. At 15s, all ~600 non-cmux PIDs were re-probed (3-4 sysctls plus argv/env parsing each) every 15 seconds forever.

Tests: scope-cache TTL tests now reference the production TTL accessor instead of a magic constant, plus a live self-probe test covering the restructured `cmuxScopeProbe`.

Closes https://github.com/manaflow-ai/cmux/issues/4602

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785795512&installation_id=133855650&pr_number=7349&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7349&signature=f31bc1259a6e7b95ecf9c53da0763b5d997290647a986f09c78660e6a3562dbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process detection for autosave/resume indexes and memory guardrail sampling; termination paths stay on fresh captures, but cached snapshots could briefly miss same-pid exec into cmux scope (bounded by TTL and cache age).
> 
> **Overview**
> Reduces idle CPU from repeated full process-table scans and per-PID scope probes by **sharing and caching** `CmuxTopProcessSnapshot` captures and tightening scope-probe behavior.
> 
> **Snapshot reuse:** Periodic `ProcessDetectedResumeIndexes` autosave now uses `captureCached` (≤5s). `PaneMemoryGuardrail` routes both scoped and unscoped ticks through `captureCached` (5s / 3s max age so unscoped polling stays fresher than the 4s interval). Quit/power-off/update saves still call a **fresh** `capture` when `maximumSnapshotAge` is nil.
> 
> **Scope probe:** `cmuxScopeProbe` drops the upfront `kinfoProc` match check (callers already key from `proc_bsdinfo` in the same pass); post-`KERN_PROCARGS2` liveness checks remain. **Negative** “no cmux scope” cache TTL goes **15s → 60s** (`cmuxTopNegativeScopeTTLNanoseconds` exposed for tests).
> 
> **Tests:** TTL expiry uses the production constant; adds a live `cmuxScopeProbe` self-test on the current process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a96a77a20aa62a4443959433af699cec2eb3eb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts steady-state sysctl work in background process snapshots to reduce idle CPU (~21% core burn). Addresses #4602 by caching more captures, removing a redundant sysctl, and raising the negative scope TTL; termination saves still force a fresh snapshot.

- **Performance**
  - Autosave `ProcessDetectedResumeIndexes` uses `captureCached` (≤5s); synchronous termination saves still use a fresh `capture(includeProcessDetails: true)`.
  - `PaneMemoryGuardrail` uses `captureCached` for both modes: scoped 5s, unscoped 3s (kept under the 4s poll).
  - Drop pre-validation `kinfo_proc` in scope probe; rely on same-pass `proc_bsdinfo` key and post-`KERN_PROCARGS2` liveness guard.
  - Raise negative scope cache TTL 15s → 60s to avoid re-probing non-cmux PIDs; new processes are probed immediately.

- **Tests**
  - Read TTL via `cmuxTopNegativeScopeTTLNanoseconds` with `@testable import`.
  - Add a live self-probe test for `cmuxScopeProbe`.

<sup>Written for commit 9a96a77a20aa62a4443959433af699cec2eb3eb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the cache duration for “no CMUX scope” results to reduce unnecessary reprobes.
  * Improved snapshot/probing behavior so scope outcomes are determined more reliably, and updated caching is used for polling and resume-index preparation with freshness-based reuse.

* **Tests**
  * Enhanced coverage with a live-process scope probe validation.
  * Updated cache-expiry timing expectations and adjusted test setup to support live probing where available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->