### PR TITLE
Remote __tmux-compat: support respawn-pane / respawnp (forward to surface.respawn)

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -1352,6 +1352,55 @@ func tmuxShellCommandText(positional []string, cwd string) string {
 	return strings.Join(pieces, " && ") + "\r"
 }
 
+// tmuxShellInvokedStartCommand mirrors CMUXCLI.tmuxShellInvokedStartCommand
+// (CLI/CMUXCLI+TmuxCompatSupport.swift): a pane start-command handed to
+// surface.respawn is exec'd by the surface as a single executable, but tmux
+// shell-commands are arbitrary shell expressions (`cd <dir> && env … claude …`),
+// so every command is run through `/bin/sh -c '<command>'`. See issue #6447
+// and the Swift doc comment for the full rationale.
+func tmuxShellInvokedStartCommand(command string) string {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return command
+	}
+	return "/bin/sh -c " + tmuxShellQuote(trimmed)
+}
+
+// tmuxRespawnStartCommand mirrors CMUXCLI.tmuxRespawnStartCommand: like
+// tmuxShellInvokedStartCommand, but first exports prependEnv inside the
+// wrapping shell so the respawned process inherits those variables. With an
+// empty prependEnv it is byte-for-byte identical to
+// tmuxShellInvokedStartCommand.
+func tmuxRespawnStartCommand(command string, prependEnv [][2]string) string {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return command
+	}
+	if len(prependEnv) == 0 {
+		return tmuxShellInvokedStartCommand(trimmed)
+	}
+	exports := make([]string, 0, len(prependEnv))
+	for _, pair := range prependEnv {
+		exports = append(exports, "export "+pair[0]+"="+tmuxShellQuote(pair[1]))
+	}
+	return tmuxShellInvokedStartCommand(strings.Join(exports, "; ") + "; " + trimmed)
+}
+
+// tmuxClaudeTeamsRespawnEnvironment mirrors
+// CMUXCLI.tmuxClaudeTeamsRespawnEnvironment: teammate panes are respawned by
+// cmux's surface layer, so they do not inherit the launcher environment, and
+// a teammate that hits Claude Code's interactive trust prompt hangs forever
+// (issue #6447). CLAUDE_CODE_SANDBOXED=1 is re-supplied only when the
+// claude-teams launcher recorded the user's explicit
+// --dangerously-skip-permissions opt-in in CMUX_CLAUDE_TEAMS_SANDBOXED; see
+// the Swift doc comment for the safety rationale.
+func tmuxClaudeTeamsRespawnEnvironment() [][2]string {
+	if os.Getenv("CMUX_CLAUDE_TEAMS_SANDBOXED") != "1" {
+		return nil
+	}
+	return [][2]string{{"CLAUDE_CODE_SANDBOXED", "1"}}
+}
+
 // --- Wait-for (filesystem-based signaling) ---
 
 func tmuxWaitForSignalPath(name string) string {
@@ -1389,6 +1438,8 @@ func dispatchTmuxCommand(rc *rpcContext, command string, args []string) error {
 		return tmuxKillWindow(rc, args)
 	case "kill-pane", "killp":
 		return tmuxKillPane(rc, args)
+	case "respawn-pane", "respawnp":
+		return tmuxRespawnPane(rc, args)
 	case "send-keys", "send":
 		return tmuxSendKeys(rc, args)
 	case "capture-pane", "capturep":
@@ -1645,6 +1696,68 @@ func tmuxKillPane(rc *rpcContext, args []string) error {
 	// Re-equalize after removal
 	rc.call("workspace.equalize_splits", map[string]any{"workspace_id": wsId, "orientation": "vertical"})
 	return nil
+}
+
+// tmuxRespawnPane mirrors the Swift CLI's respawn-pane/respawnp handling
+// (CLI/cmux.swift): resolve the target surface and forward to the existing
+// surface.respawn RPC. Claude Code >= 2.1.183 starts agent-team teammate
+// panes with `split-window … cat` followed by `respawn-pane -k …`, so this
+// must work over the remote daemon too (issue #7014).
+func tmuxRespawnPane(rc *rpcContext, args []string) error {
+	p := parseTmuxArgs(args, []string{"-c", "-t"}, []string{"-k"})
+	if !p.hasFlag("-k") {
+		return fmt.Errorf("respawn-pane requires -k in cmux tmux compatibility mode")
+	}
+	wsId, _, surfId, err := tmuxResolveSurfaceTarget(rc, p.value("-t"))
+	if err != nil {
+		return err
+	}
+	commandText := strings.TrimSpace(strings.Join(p.positional, " "))
+	if commandText == "" {
+		commandText = tmuxStoredStartCommand(rc, wsId, surfId)
+	}
+	if commandText == "" {
+		commandText = "exec ${SHELL:-/bin/sh} -l"
+	}
+	params := map[string]any{
+		"workspace_id": wsId,
+		"surface_id":   surfId,
+		// The pane process command is shell-invoked (issue #6447) while the
+		// raw command is kept as display/persistence metadata.
+		"command":            tmuxRespawnStartCommand(commandText, tmuxClaudeTeamsRespawnEnvironment()),
+		"tmux_start_command": commandText,
+	}
+	if cwd := tmuxNormalizePath(p.value("-c")); cwd != "" {
+		params["working_directory"] = cwd
+	}
+	_, err = rc.call("surface.respawn", params)
+	return err
+}
+
+// tmuxStoredStartCommand mirrors CMUXCLI.tmuxStoredStartCommand: the start
+// command the surface was launched with, as recorded by the app.
+func tmuxStoredStartCommand(rc *rpcContext, workspaceId string, surfaceId string) string {
+	payload, err := rc.call("surface.list", map[string]any{"workspace_id": workspaceId})
+	if err != nil {
+		return ""
+	}
+	surfaces, _ := payload["surfaces"].([]any)
+	for _, s := range surfaces {
+		surface, _ := s.(map[string]any)
+		if surface == nil {
+			continue
+		}
+		if id, _ := surface["id"].(string); id != surfaceId {
+			continue
+		}
+		for _, key := range []string{"tmux_start_command", "pane_start_command", "initial_command"} {
+			if value, _ := surface[key].(string); strings.TrimSpace(value) != "" {
+				return strings.TrimSpace(value)
+			}
+		}
+		return ""
+	}
+	return ""
 }
 
 func tmuxSendKeys(rc *rpcContext, args []string) error {

--- a/daemon/remote/cmd/cmuxd-remote/tmux_respawn_pane_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_respawn_pane_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Regression coverage for https://github.com/manaflow-ai/cmux/issues/7014:
+// the remote tmux-compat dispatcher must support respawn-pane/respawnp the
+// same way the local Swift CLI does (resolve the target surface, forward to
+// the surface.respawn RPC). Claude Code >= 2.1.183 launches agent-team
+// teammate panes with `split-window … cat` followed by `respawn-pane -k …`,
+// so a dispatcher without respawn-pane breaks teammate panes over SSH.
+// Expected semantics mirror CLI/cmux.swift ("respawn-pane", "respawnp") and
+// are pinned app-side by tests/test_cli_omo_tmux_respawn_pane.py.
+
+const (
+	tmuxRespawnWorkspaceId       = "11111111-1111-4111-8111-111111111111"
+	tmuxRespawnLeaderPaneId      = "33333333-3333-4333-8333-333333333333"
+	tmuxRespawnLeaderSurfaceId   = "44444444-4444-4444-8444-444444444444"
+	tmuxRespawnTeammatePaneId    = "66666666-6666-4666-8666-666666666666"
+	tmuxRespawnTeammateSurfaceId = "77777777-7777-4777-8777-777777777777"
+)
+
+type tmuxRespawnCallLog struct {
+	mu    sync.Mutex
+	calls []map[string]any
+}
+
+func (l *tmuxRespawnCallLog) append(params map[string]any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	copied := make(map[string]any, len(params))
+	for key, value := range params {
+		copied[key] = value
+	}
+	l.calls = append(l.calls, copied)
+}
+
+func (l *tmuxRespawnCallLog) snapshot() []map[string]any {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]map[string]any(nil), l.calls...)
+}
+
+// startTmuxRespawnRecordingSocket serves the minimal RPC surface needed to
+// resolve a pane target (workspace.list, pane.list, pane.surfaces,
+// surface.list) and records every surface.respawn call it receives.
+// teammateStartCommand, when non-empty, is exposed as the teammate surface's
+// tmux_start_command so the stored-start-command fallback can be exercised.
+func startTmuxRespawnRecordingSocket(t *testing.T, teammateStartCommand string) (string, *tmuxRespawnCallLog) {
+	t.Helper()
+	sockPath := makeShortUnixSocketPath(t)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	log := &tmuxRespawnCallLog{}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				reader := bufio.NewReader(conn)
+				line, err := reader.ReadBytes('\n')
+				if err != nil {
+					return
+				}
+
+				var req map[string]any
+				if err := json.Unmarshal(line, &req); err != nil {
+					_, _ = conn.Write([]byte(`{"ok":false,"error":{"code":"parse","message":"bad json"}}` + "\n"))
+					return
+				}
+
+				method, _ := req["method"].(string)
+				params, _ := req["params"].(map[string]any)
+				resp := map[string]any{
+					"id": req["id"],
+					"ok": true,
+				}
+
+				switch method {
+				case "workspace.list":
+					resp["result"] = map[string]any{
+						"workspaces": []map[string]any{{
+							"id":     tmuxRespawnWorkspaceId,
+							"ref":    "workspace:1",
+							"index":  1,
+							"title":  "demo",
+							"active": true,
+						}},
+					}
+				case "pane.list":
+					resp["result"] = map[string]any{
+						"panes": []map[string]any{
+							{"id": tmuxRespawnLeaderPaneId, "ref": "pane:1", "index": 1, "focused": "1"},
+							{"id": tmuxRespawnTeammatePaneId, "ref": "pane:2", "index": 2, "focused": "0"},
+						},
+					}
+				case "pane.surfaces":
+					paneId, _ := params["pane_id"].(string)
+					surface := map[string]any{
+						"id":       tmuxRespawnLeaderSurfaceId,
+						"ref":      "surface:1",
+						"selected": "1",
+					}
+					if paneId == tmuxRespawnTeammatePaneId {
+						surface = map[string]any{
+							"id":       tmuxRespawnTeammateSurfaceId,
+							"ref":      "surface:2",
+							"selected": "1",
+						}
+					}
+					resp["result"] = map[string]any{"surfaces": []map[string]any{surface}}
+				case "surface.list":
+					teammate := map[string]any{
+						"id":      tmuxRespawnTeammateSurfaceId,
+						"ref":     "surface:2",
+						"pane_id": tmuxRespawnTeammatePaneId,
+					}
+					if teammateStartCommand != "" {
+						teammate["tmux_start_command"] = teammateStartCommand
+					}
+					resp["result"] = map[string]any{
+						"surfaces": []map[string]any{
+							{
+								"id":      tmuxRespawnLeaderSurfaceId,
+								"ref":     "surface:1",
+								"pane_id": tmuxRespawnLeaderPaneId,
+							},
+							teammate,
+						},
+					}
+				case "surface.respawn":
+					log.append(params)
+					resp["result"] = map[string]any{}
+				default:
+					resp["ok"] = false
+					resp["error"] = map[string]any{
+						"code":    "unsupported",
+						"message": method,
+					}
+				}
+
+				payload, _ := json.Marshal(resp)
+				_, _ = conn.Write(append(payload, '\n'))
+			}(conn)
+		}
+	}()
+
+	return sockPath, log
+}
+
+func setTmuxRespawnCallerEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	t.Setenv("CMUX_SURFACE_ID", "surface:1")
+	t.Setenv("TMUX_PANE", "%"+tmuxStableNumericId(tmuxRespawnLeaderPaneId))
+	// Never inherit an ambient claude-teams sandbox opt-in from the host
+	// running the tests; the opt-in case sets this explicitly.
+	t.Setenv("CMUX_CLAUDE_TEAMS_SANDBOXED", "")
+}
+
+func tmuxRespawnTeammateTarget() string {
+	return "%" + tmuxStableNumericId(tmuxRespawnTeammatePaneId)
+}
+
+func singleRespawnCall(t *testing.T, log *tmuxRespawnCallLog) map[string]any {
+	t.Helper()
+	calls := log.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("surface.respawn calls = %d, want 1 (calls: %v)", len(calls), calls)
+	}
+	return calls[0]
+}
+
+func TestTmuxRespawnPaneForwardsToSurfaceRespawn(t *testing.T) {
+	for _, command := range []string{"respawn-pane", "respawnp"} {
+		t.Run(command, func(t *testing.T) {
+			setTmuxRespawnCallerEnv(t)
+			sockPath, log := startTmuxRespawnRecordingSocket(t, "")
+			rc := &rpcContext{socketPath: sockPath}
+
+			err := dispatchTmuxCommand(rc, command, []string{
+				"-k", "-t", tmuxRespawnTeammateTarget(), "--", "echo", "hi",
+			})
+			if err != nil {
+				t.Fatalf("%s: %v", command, err)
+			}
+
+			params := singleRespawnCall(t, log)
+			if got, _ := params["workspace_id"].(string); got != tmuxRespawnWorkspaceId {
+				t.Errorf("workspace_id = %q, want %q", got, tmuxRespawnWorkspaceId)
+			}
+			if got, _ := params["surface_id"].(string); got != tmuxRespawnTeammateSurfaceId {
+				t.Errorf("surface_id = %q, want %q", got, tmuxRespawnTeammateSurfaceId)
+			}
+			// The pane process command is shell-invoked (issue #6447) while the
+			// tmux_start_command metadata stays raw for display/persistence.
+			if got, _ := params["command"].(string); got != "/bin/sh -c 'echo hi'" {
+				t.Errorf("command = %q, want %q", got, "/bin/sh -c 'echo hi'")
+			}
+			if got, _ := params["tmux_start_command"].(string); got != "echo hi" {
+				t.Errorf("tmux_start_command = %q, want %q", got, "echo hi")
+			}
+			if cwd, ok := params["working_directory"]; ok {
+				t.Errorf("working_directory should be absent without -c, got %v", cwd)
+			}
+		})
+	}
+}
+
+func TestTmuxRespawnPaneRequiresKillFlag(t *testing.T) {
+	setTmuxRespawnCallerEnv(t)
+	sockPath, log := startTmuxRespawnRecordingSocket(t, "")
+	rc := &rpcContext{socketPath: sockPath}
+
+	err := dispatchTmuxCommand(rc, "respawn-pane", []string{
+		"-t", tmuxRespawnTeammateTarget(), "--", "echo", "hi",
+	})
+	if err == nil {
+		t.Fatal("respawn-pane without -k should fail")
+	}
+	if !strings.Contains(err.Error(), "requires -k") {
+		t.Fatalf("error = %q, want it to mention the required -k flag", err.Error())
+	}
+	if calls := log.snapshot(); len(calls) != 0 {
+		t.Fatalf("surface.respawn must not be called without -k, got %v", calls)
+	}
+}
+
+func TestTmuxRespawnPaneWithoutCommandReusesStoredStartCommand(t *testing.T) {
+	const stored = `/bin/sh -c "opencode attach http://127.0.0.1:4096 --session subagent-session"`
+	setTmuxRespawnCallerEnv(t)
+	sockPath, log := startTmuxRespawnRecordingSocket(t, stored)
+	rc := &rpcContext{socketPath: sockPath}
+
+	err := dispatchTmuxCommand(rc, "respawn-pane", []string{
+		"-k", "-t", tmuxRespawnTeammateTarget(),
+	})
+	if err != nil {
+		t.Fatalf("respawn-pane: %v", err)
+	}
+
+	params := singleRespawnCall(t, log)
+	if got, _ := params["surface_id"].(string); got != tmuxRespawnTeammateSurfaceId {
+		t.Errorf("surface_id = %q, want %q", got, tmuxRespawnTeammateSurfaceId)
+	}
+	if got, _ := params["command"].(string); got != "/bin/sh -c '"+stored+"'" {
+		t.Errorf("command = %q, want stored start command shell-invoked", got)
+	}
+	if got, _ := params["tmux_start_command"].(string); got != stored {
+		t.Errorf("tmux_start_command = %q, want stored start command %q", got, stored)
+	}
+}
+
+func TestTmuxRespawnPaneWithoutCommandFallsBackToLoginShell(t *testing.T) {
+	setTmuxRespawnCallerEnv(t)
+	sockPath, log := startTmuxRespawnRecordingSocket(t, "")
+	rc := &rpcContext{socketPath: sockPath}
+
+	err := dispatchTmuxCommand(rc, "respawn-pane", []string{
+		"-k", "-t", tmuxRespawnTeammateTarget(),
+	})
+	if err != nil {
+		t.Fatalf("respawn-pane: %v", err)
+	}
+
+	params := singleRespawnCall(t, log)
+	if got, _ := params["command"].(string); got != `/bin/sh -c 'exec ${SHELL:-/bin/sh} -l'` {
+		t.Errorf("command = %q, want login shell fallback", got)
+	}
+	if got, _ := params["tmux_start_command"].(string); got != `exec ${SHELL:-/bin/sh} -l` {
+		t.Errorf("tmux_start_command = %q, want login shell fallback", got)
+	}
+}
+
+func TestTmuxRespawnPaneHonorsCwdAndClaudeTeamsSandboxOptIn(t *testing.T) {
+	setTmuxRespawnCallerEnv(t)
+	t.Setenv("CMUX_CLAUDE_TEAMS_SANDBOXED", "1")
+	cwd := t.TempDir()
+	sockPath, log := startTmuxRespawnRecordingSocket(t, "")
+	rc := &rpcContext{socketPath: sockPath}
+
+	err := dispatchTmuxCommand(rc, "respawn-pane", []string{
+		"-k", "-c", cwd, "-t", tmuxRespawnTeammateTarget(), "--", "echo", "hi",
+	})
+	if err != nil {
+		t.Fatalf("respawn-pane: %v", err)
+	}
+
+	params := singleRespawnCall(t, log)
+	if got, _ := params["working_directory"].(string); got != cwd {
+		t.Errorf("working_directory = %q, want %q", got, cwd)
+	}
+	// The sandbox opt-in recorded by the claude-teams launcher is re-exported
+	// inside the wrapping shell (see tmuxClaudeTeamsRespawnEnvironment in
+	// CLI/CMUXCLI+TmuxCompatSupport.swift) but never baked into the raw
+	// tmux_start_command metadata.
+	want := `/bin/sh -c 'export CLAUDE_CODE_SANDBOXED='"'"'1'"'"'; echo hi'`
+	if got, _ := params["command"].(string); got != want {
+		t.Errorf("command = %q, want %q", got, want)
+	}
+	if got, _ := params["tmux_start_command"].(string); got != "echo hi" {
+		t.Errorf("tmux_start_command = %q, want raw command without sandbox export", got)
+	}
+}


### PR DESCRIPTION
Fixes #7014

## Problem

The Go remote daemon's tmux-compat dispatcher (`daemon/remote/cmd/cmuxd-remote/tmux_compat.go`) had no `respawn-pane` / `respawnp` case, so it fell through to the default branch:

```
cmux __tmux-compat: unsupported tmux command: respawn-pane   (exit 1)
```

Claude Code >= 2.1.183 launches agent-team teammate panes with `split-window … cat` followed by `respawn-pane -k …` (#6447 / #6499). Over `cmux ssh`, the `cmux claude-teams` / OMO flows route the tmux shim through the Go relay, so the teammate pane never started. The local Swift CLI already implements this (#5465, #6499); the remote path was missing it.

## Fix

Add the `respawn-pane`/`respawnp` case, mirroring the Swift CLI semantics (`CLI/cmux.swift`, pinned app-side by `tests/test_cli_omo_tmux_respawn_pane.py`):

- require `-k` (same guard and message as the Swift CLI)
- resolve the `-t` target to its surface via the existing `tmuxResolveSurfaceTarget` path (same as `kill-pane`)
- forward to the **existing** `surface.respawn` RPC — forwarding-only, no new daemon backend
- the trailing command (after `--`) is shell-invoked via `/bin/sh -c '…'` for the pane process (#6447) and kept raw in `tmux_start_command` metadata
- with no command: fall back to the surface's stored start command (`tmux_start_command` / `pane_start_command` / `initial_command`), then `exec ${SHELL:-/bin/sh} -l`
- `-c <dir>` → `working_directory` (normalized like the Swift `resolvePath`)
- re-export the claude-teams sandbox opt-in (`CMUX_CLAUDE_TEAMS_SANDBOXED=1` → `export CLAUDE_CODE_SANDBOXED='1'`) inside the wrapping shell, mirroring `tmuxClaudeTeamsRespawnEnvironment`

Independent of #6309 (Swift-side `surface.respawn` env-propagation rework); broader agent-env parity can follow there.

## Commit structure (regression test policy)

1. **a5234da875** — failing tests only (dispatcher recognizes `respawn-pane`/`respawnp`; parses `-k`, `-t`, trailing command after `--`; stored-command and login-shell fallbacks; `-c`; sandbox opt-in). CI red expected on this commit.
2. **83eafda693** — the fix. CI green.

## Verification

- `cd daemon/remote && go test ./...` → ok (full suite)
- New tests fail on commit 1 with `unsupported tmux command: respawn-pane` and pass on commit 2
- `gofmt -l` clean, `go vet ./...` clean
- Repro from the issue, after fix (scrubbed env, dead socket — recognized and proceeds to surface resolution exactly like `split-window`):

```
$ /tmp/cmuxd-remote __tmux-compat respawn-pane -k -t %1 -- echo hi
cmux __tmux-compat: no workspace selected: failed to connect to /tmp/nonexistent-7014.sock: …

$ /tmp/cmuxd-remote __tmux-compat respawn-pane -t %1 -- echo hi
cmux __tmux-compat: respawn-pane requires -k in cmux tmux compatibility mode
```

## Localization audit

Go-only change. The one new user-facing string is a remote-daemon stderr error ("respawn-pane requires -k in cmux tmux compatibility mode"), consistent with the daemon's existing unlocalized plain-English CLI errors (e.g. "unsupported tmux command"); the Go daemon has no localization catalog. No Swift UI strings, docs, or web message catalogs changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785796201&installation_id=133855650&pr_number=7353&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7353&signature=c2c8be52108966cfcbd8417af2d1cde8859d5c19f3cface0026ebceed16975f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds remote tmux-compat support for `respawn-pane`/`respawnp` by forwarding to `surface.respawn` and requiring `-k`, fixing teammate panes over SSH with Claude Code >= 2.1.183. Fixes #7014 and includes regression tests.

- **New Features**
  - Resolve `-t` to the target surface and forward to `surface.respawn`.
  - Shell-invoke the trailing command via `/bin/sh -c`; keep it raw in `tmux_start_command`.
  - If no command: use the stored start command; if none, `exec ${SHELL:-/bin/sh} -l`.
  - Map `-c` to `working_directory`.
  - Re-export `CLAUDE_CODE_SANDBOXED=1` when `CMUX_CLAUDE_TEAMS_SANDBOXED=1`.

<sup>Written for commit 38e77f338ed4eaa45f80b91f23c3b02abe554c23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for respawning tmux panes from the remote interface.
  * Preserves the original command context when restarting a pane, including working directory support.
  * Supports an optional sandboxed launch mode for Claude Teams environments.

* **Bug Fixes**
  * Improved fallback behavior when a pane’s start command is missing.
  * Added validation to prevent respawn requests from running without the required confirmation flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->