### PR TITLE
Honor a `claude` defined as a shell function via custom launch commands (#7035)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,7 +641,9 @@ jobs:
           python3 tests/test_claude_wrapper_hooks.py
           python3 tests/test_claude_wrapper_mutual_shim_loop.py
           python3 tests/test_claude_wrapper_user_binary_resolution.py
+          python3 tests/test_claude_wrapper_custom_command.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_claude_teams_fallback_path.py
+          CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_claude_teams_custom_command.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_claude_teams_env.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_claude_teams_trust_optin.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_omo_fallback_path.py

--- a/CLI/CMUXCLI+AutoNamingDispatch.swift
+++ b/CLI/CMUXCLI+AutoNamingDispatch.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Foundation
 
 import CmuxSettings
@@ -43,6 +44,12 @@ extension CMUXCLI {
             if !customPath.isEmpty,
                FileManager.default.isExecutableFile(atPath: customPath),
                !isCmuxClaudeWrapper(at: customPath) {
+                return true
+            }
+            // A configured launch command (issue #7035) can run claude too.
+            if configuredClaudeLaunchCommand(
+                configuredCandidates: [customPath], environment: env
+            ) != nil {
                 return true
             }
             return resolveClaudeExecutable(searchPath: env["PATH"]) != nil
@@ -109,6 +116,32 @@ extension CMUXCLI {
         let policy = AutoNamingEnvironmentPolicy()
         let customPath = env["CMUX_CUSTOM_CLAUDE_PATH"]?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let summarizerArguments = [
+            "-p",
+            "--model", policy.claudeModel(from: env),
+            "--tools", "",
+            "--disable-slash-commands",
+            "--no-session-persistence",
+            "--strict-mcp-config",
+            "--mcp-config", "{}"
+        ]
+        // A configured launch command (issue #7035) runs the summarizer
+        // through /bin/sh with the arguments forwarded via "$@".
+        if let launchCommand = configuredClaudeLaunchCommand(
+            configuredCandidates: [customPath], environment: env
+        ) {
+            var environment = policy.summarizerEnvironment(from: env)
+            environment[ClaudeCustomLaunchValue.commandActiveGuardEnvironmentKey] = "1"
+            let argv = ClaudeCustomLaunchValue().shellCommandArgv(
+                command: launchCommand, arguments: summarizerArguments)
+            return runAutoNamingSummarizer(
+                executable: argv[0],
+                arguments: Array(argv.dropFirst()),
+                prompt: prompt,
+                environment: environment,
+                timeout: timeout
+            )
+        }
         let executable: String? = {
             var isDirectory = ObjCBool(false)
             if !customPath.isEmpty,
@@ -123,15 +156,7 @@ extension CMUXCLI {
         guard let executable else { return nil }
         return runAutoNamingSummarizer(
             executable: executable,
-            arguments: [
-                "-p",
-                "--model", policy.claudeModel(from: env),
-                "--tools", "",
-                "--disable-slash-commands",
-                "--no-session-persistence",
-                "--strict-mcp-config",
-                "--mcp-config", "{}"
-            ],
+            arguments: summarizerArguments,
             prompt: prompt,
             environment: policy.summarizerEnvironment(from: env),
             timeout: timeout

--- a/CLI/CMUXCLI+ExecutableResolution.swift
+++ b/CLI/CMUXCLI+ExecutableResolution.swift
@@ -8,7 +8,16 @@ extension CMUXCLI {
             localized: "agentSession.error.missingProviderExecutable",
             defaultValue: "%@ was not found. Install it and make sure \"%@\" is available on PATH."
         )
-        return String(format: format, displayName, executableName)
+        let message = String(format: format, displayName, executableName)
+        guard executableName == "claude" else { return message }
+        // https://github.com/manaflow-ai/cmux/issues/7035: a `claude` defined
+        // as a shell function/alias in the user's rc is invisible to cmux.
+        let hint = String(
+            localized: "agentSession.error.missingProviderExecutable.claudeShellFunctionHint",
+            defaultValue:
+                "If claude is a shell function or alias in your shell profile, cmux cannot see it. Set Settings › Automation › Claude Binary Path to the real binary, or to a launch command containing \"$@\" to forward the arguments."
+        )
+        return message + " " + hint
     }
 
     func isBundledProviderExecutable(at path: String) -> Bool {
@@ -81,6 +90,46 @@ extension CMUXCLI {
             guard !isBundledProviderExecutable(at: candidate) else { continue }
             if let skip, skip(candidate) { continue }
             return candidate
+        }
+        return nil
+    }
+
+    /// The configured Claude launch *command*, when the custom value classifies
+    /// as a `/bin/sh` command (contains the literal `$@` argument reference and
+    /// is not an existing executable file) rather than a binary path.
+    /// https://github.com/manaflow-ai/cmux/issues/7035 — mirrors
+    /// `AgentExecutableResolver.configuredShellCommand` in the app target.
+    ///
+    /// Returns nil when the guard env var is already active (non-empty), so a
+    /// command whose descendants re-enter cmux resolve via PATH instead of
+    /// re-applying the command. Candidates are considered in order; the first
+    /// one that classifies as either a binary path (binary mode wins — handled
+    /// by `resolveClaudeExecutable`) or a command decides.
+    func configuredClaudeLaunchCommand(
+        configuredCandidates: [String?],
+        environment: [String: String]
+    ) -> String? {
+        guard (environment[ClaudeCustomLaunchValue.commandActiveGuardEnvironmentKey] ?? "").isEmpty else {
+            return nil
+        }
+        let launch = ClaudeCustomLaunchValue()
+        for raw in configuredCandidates {
+            switch launch.classify(
+                configuredValue: raw,
+                isExecutableFile: { path in
+                    var isDirectory = ObjCBool(false)
+                    return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+                        && !isDirectory.boolValue
+                        && FileManager.default.isExecutableFile(atPath: path)
+                }
+            ) {
+            case .executablePath:
+                return nil
+            case .shellCommand(let command):
+                return command
+            case .pathFallback:
+                continue
+            }
         }
         return nil
     }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19339,17 +19339,29 @@ struct CMUXCLI {
         )
         // Check custom path from Settings > Automation > Claude Code first.
         // Never fall back to a cmux-bundled provider binary.
-        guard let claudeExecutablePath = resolveClaudeExecutable(
-            configuredCandidates: [
-                launcherEnvironment["CMUX_CUSTOM_CLAUDE_PATH"],
-                UserDefaults.standard.string(forKey: "claudeCodeCustomClaudePath"),
-            ],
-            searchPath: launcherEnvironment["PATH"]
-        ) else {
-            throw CLIError(message: missingProviderExecutableMessage(
-                displayName: "Claude Code",
-                executableName: "claude"
-            ))
+        let configuredClaudeCandidates = [
+            launcherEnvironment["CMUX_CUSTOM_CLAUDE_PATH"],
+            UserDefaults.standard.string(forKey: "claudeCodeCustomClaudePath"),
+        ]
+        // https://github.com/manaflow-ai/cmux/issues/7035: the configured value
+        // may also be a /bin/sh launch command forwarding the arguments via
+        // "$@" (so a `claude` shell function/wrapper can be reached).
+        let claudeLaunchCommand = configuredClaudeLaunchCommand(
+            configuredCandidates: configuredClaudeCandidates,
+            environment: launcherEnvironment
+        )
+        var claudeExecutablePath: String?
+        if claudeLaunchCommand == nil {
+            claudeExecutablePath = resolveClaudeExecutable(
+                configuredCandidates: configuredClaudeCandidates,
+                searchPath: launcherEnvironment["PATH"]
+            )
+            guard claudeExecutablePath != nil else {
+                throw CLIError(message: missingProviderExecutableMessage(
+                    displayName: "Claude Code",
+                    executableName: "claude"
+                ))
+            }
         }
         launcherEnvironment["PATH"] = providerExecutableSearchPath(
             searchPath: launcherEnvironment["PATH"],
@@ -19364,7 +19376,6 @@ struct CMUXCLI {
             focusedContext: focusedContext, commandArgs: commandArgs
         )
 
-        let launchPath = claudeExecutablePath
         let launchArguments = claudeTeamsLaunchArguments(commandArgs: commandArgs)
         exportAgentLaunchCommandEnvironment(
             launcher: "claudeTeams",
@@ -19372,7 +19383,23 @@ struct CMUXCLI {
             arguments: [executablePath, "claude-teams"] + launchArguments,
             workingDirectory: launcherEnvironment["PWD"]
         )
-        var argv = ([launchPath] + claudeTeamsExecArguments(commandArgs: commandArgs)).map { strdup($0) }
+        let execArgv: [String]
+        if let claudeLaunchCommand {
+            // One-shot guard: descendant `claude` invocations resolve via PATH
+            // instead of re-applying the custom command (loop protection).
+            setenv(ClaudeCustomLaunchValue.commandActiveGuardEnvironmentKey, "1", 1)
+            execArgv = ClaudeCustomLaunchValue().shellCommandArgv(
+                command: claudeLaunchCommand,
+                arguments: claudeTeamsExecArguments(commandArgs: commandArgs)
+            )
+        } else {
+            // claudeExecutablePath is non-nil here: the nil-command branch
+            // above either resolved it or threw.
+            execArgv = [claudeExecutablePath ?? "claude"]
+                + claudeTeamsExecArguments(commandArgs: commandArgs)
+        }
+        let launchPath = execArgv[0]
+        var argv = execArgv.map { strdup($0) }
         defer {
             for item in argv {
                 free(item)

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeCustomLaunchValue.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeCustomLaunchValue.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Classifies the user-configured "Claude Binary Path" setting value
+/// (Settings › Automation › Claude Binary Path, `CMUX_CUSTOM_CLAUDE_PATH`).
+///
+/// A `claude` defined as a shell function/wrapper in the user's rc file is
+/// invisible to cmux's non-interactive launch paths, so the setting also
+/// accepts a launch *command*: a `/bin/sh` snippet that receives the agent
+/// arguments as `"$@"` (with `$0` set to `claude`), e.g.
+/// `/bin/zsh -lic 'claude "$@"' claude "$@"`.
+/// https://github.com/manaflow-ai/cmux/issues/7035
+///
+/// Classification rules (must stay in sync with the bash mirror
+/// `cmux_claude_custom_launch_command` in `Resources/bin/cmux-claude-wrapper`):
+/// 1. An existing executable file keeps binary mode. This check runs first so
+///    plain binary paths — including paths containing spaces — behave exactly
+///    as before.
+/// 2. Otherwise a value containing the literal `$@` argument reference is a
+///    launch command. The marker is required, never inferred: a working
+///    command must forward the agent arguments via `"$@"` anyway, and
+///    inferring command mode from whitespace/metacharacters would turn a
+///    stale spaced path into a hard exec failure and silently drop every
+///    argument from a value like `$HOME/bin/claude`.
+/// 3. Anything else (e.g. a stale path to a deleted binary) keeps the
+///    historical silent fallback to PATH resolution.
+///
+/// The type is a stateless value; construct one at the call site
+/// (`ClaudeCustomLaunchValue()`) rather than reaching through a static
+/// namespace, per the package design discipline.
+public struct ClaudeCustomLaunchValue: Sendable, Equatable {
+    /// How a configured Claude Binary Path value should be launched.
+    public enum Classification: Sendable, Equatable {
+        /// The value is an existing executable file; exec it directly.
+        case executablePath(String)
+        /// The value is a `/bin/sh` command receiving the agent arguments as `"$@"`.
+        case shellCommand(String)
+        /// The value is empty or unusable; fall back to PATH resolution.
+        case pathFallback
+    }
+
+    /// Environment variable exported for the duration of a custom launch
+    /// command, so a command whose inner `claude` re-enters cmux's shim or
+    /// wrapper falls back to normal PATH resolution instead of looping.
+    ///
+    /// The variable intentionally leaks into the launched Claude process (the
+    /// wrapper cannot observe the boundary where the user's command hands off
+    /// to the real binary), so descendant `claude` invocations inside that
+    /// session resolve through PATH rather than the custom command.
+    public static let commandActiveGuardEnvironmentKey = "CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE"
+
+    /// Creates a classifier. The type holds no state.
+    public init() {}
+
+    /// Classifies `configuredValue`, probing the filesystem through
+    /// `isExecutableFile` (which must be true only for existing,
+    /// non-directory, executable files).
+    public func classify(
+        configuredValue: String?,
+        isExecutableFile: (String) -> Bool
+    ) -> Classification {
+        guard
+            let trimmed = configuredValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !trimmed.isEmpty
+        else {
+            return .pathFallback
+        }
+        if isExecutableFile(trimmed) {
+            return .executablePath(trimmed)
+        }
+        if trimmed.contains("$@") {
+            return .shellCommand(trimmed)
+        }
+        return .pathFallback
+    }
+
+    /// The argv that runs a ``Classification/shellCommand(_:)`` value:
+    /// `/bin/sh -c <command> claude <arguments…>`, so the command sees the
+    /// agent arguments as `"$@"` and `$0` as `claude`.
+    public func shellCommandArgv(command: String, arguments: [String]) -> [String] {
+        ["/bin/sh", "-c", command, "claude"] + arguments
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeCustomLaunchValueTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeCustomLaunchValueTests.swift
@@ -1,0 +1,98 @@
+import CMUXAgentLaunch
+import Foundation
+import Testing
+
+struct ClaudeCustomLaunchValueTests {
+    private let launch = ClaudeCustomLaunchValue()
+
+    @Test
+    func executableFileKeepsBinaryModeEvenWithSpaces() {
+        let path = "/Users/someone/dir with space/claude"
+        let classification = launch.classify(
+            configuredValue: path,
+            isExecutableFile: { $0 == path }
+        )
+        #expect(classification == .executablePath(path))
+    }
+
+    @Test
+    func commandReferencingArgumentsClassifiesAsShellCommand() {
+        let command = #"/bin/zsh -lic 'claude "$@"' claude "$@""#
+        let classification = launch.classify(
+            configuredValue: command,
+            isExecutableFile: { _ in false }
+        )
+        #expect(classification == .shellCommand(command))
+    }
+
+    // Command mode requires the literal $@ marker: a stale path containing
+    // spaces must keep the historical silent PATH fallback rather than
+    // hard-failing through /bin/sh.
+    @Test
+    func staleSpacedPathWithoutArgumentsReferenceFallsBack() {
+        let classification = launch.classify(
+            configuredValue: "/Users/someone/dir with space/claude",
+            isExecutableFile: { _ in false }
+        )
+        #expect(classification == .pathFallback)
+    }
+
+    // An unexpanded shell-variable path must not become a command that would
+    // run the binary while silently dropping every argument.
+    @Test
+    func unexpandedHomeVariablePathFallsBack() {
+        let classification = launch.classify(
+            configuredValue: "$HOME/bin/claude",
+            isExecutableFile: { _ in false }
+        )
+        #expect(classification == .pathFallback)
+    }
+
+    @Test
+    func commandWithoutArgumentsReferenceFallsBack() {
+        let classification = launch.classify(
+            configuredValue: "zsh -lic claude",
+            isExecutableFile: { _ in false }
+        )
+        #expect(classification == .pathFallback)
+    }
+
+    @Test
+    func trimsSurroundingWhitespaceBeforeClassifying() {
+        let classification = launch.classify(
+            configuredValue: "  my-wrapper \"$@\"\n",
+            isExecutableFile: { _ in false }
+        )
+        #expect(classification == .shellCommand("my-wrapper \"$@\""))
+    }
+
+    @Test
+    func stalePlainPathFallsBackToPathResolution() {
+        let classification = launch.classify(
+            configuredValue: "/opt/deleted/claude",
+            isExecutableFile: { _ in false }
+        )
+        #expect(classification == .pathFallback)
+    }
+
+    @Test
+    func emptyAndNilValuesFallBack() {
+        #expect(launch.classify(configuredValue: nil, isExecutableFile: { _ in true }) == .pathFallback)
+        #expect(launch.classify(configuredValue: "   ", isExecutableFile: { _ in true }) == .pathFallback)
+    }
+
+    @Test
+    func shellCommandArgvAppendsAgentArgumentsAfterArgvZero() {
+        let argv = launch.shellCommandArgv(
+            command: #"my-wrapper "$@""#,
+            arguments: ["--resume", "abc"]
+        )
+        #expect(argv == ["/bin/sh", "-c", #"my-wrapper "$@""#, "claude", "--resume", "abc"])
+    }
+
+    @Test
+    func guardEnvironmentKeyIsStable() {
+        // The bash mirror in Resources/bin/cmux-claude-wrapper hardcodes this name.
+        #expect(ClaudeCustomLaunchValue.commandActiveGuardEnvironmentKey == "CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE")
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AutomationSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AutomationSection.swift
@@ -271,10 +271,10 @@ public struct AutomationSection: View {
             SettingsCardRow(
                 configurationReview: .json("automation.claudeBinaryPath"),
                 String(localized: "settings.automation.claudeCode.customPath", defaultValue: "Claude Binary Path"),
-                subtitle: String(localized: "settings.automation.claudeCode.customPath.subtitle", defaultValue: "Custom path to the claude binary. Leave empty to use PATH.")
+                subtitle: String(localized: "settings.automation.claudeCode.customPath.subtitle", defaultValue: "Custom path to the claude binary, or a launch command containing \"$@\" to forward the arguments. Leave empty to use PATH.")
             ) {
                 TextField(
-                    String(localized: "settings.automation.claudeCode.customPath.placeholder", defaultValue: "e.g. /usr/local/bin/claude"),
+                    String(localized: "settings.automation.claudeCode.customPath.placeholder", defaultValue: "e.g. /usr/local/bin/claude or zsh -lic 'claude \"$@\"' claude \"$@\""),
                     text: Binding(get: { claudePathModel.current }, set: { claudePathModel.set($0) })
                 )
                 .textFieldStyle(.roundedBorder)

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -183,6 +183,81 @@ cmux_claude_wrapper_exec_resolved_claude() {
 
 cmux_claude_wrapper_init_reexec_guard
 
+# Custom launch *command* support: https://github.com/manaflow-ai/cmux/issues/7035
+# A `claude` defined as a shell function/wrapper in the user's rc is invisible
+# to cmux's non-interactive launch paths, so CMUX_CUSTOM_CLAUDE_PATH (Settings >
+# Automation > Claude Binary Path) also accepts a /bin/sh launch command that
+# receives the agent arguments as "$@" (with $0 set to `claude`), e.g.:
+#   /bin/zsh -lic 'claude "$@"' claude "$@"
+# Classification must stay in sync with the Swift classifier
+# `ClaudeCustomLaunchValue` in Packages/macOS/CMUXAgentLaunch:
+#   1. an existing executable file keeps binary mode (find_real_claude);
+#   2. otherwise a value containing the literal $@ argument reference is a
+#      launch command (the marker is required — a working command must forward
+#      the arguments via "$@" anyway, and inferring command mode from
+#      whitespace would hard-fail stale spaced paths and silently drop the
+#      arguments of values like $HOME/bin/claude);
+#   3. anything else keeps the historical PATH fallback.
+# CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE is exported while the command runs so a
+# command whose inner `claude` re-enters cmux's shim/wrapper falls back to
+# normal PATH resolution instead of looping. It intentionally stays exported
+# into the launched claude process (the wrapper cannot observe where the user's
+# command hands off to the real binary).
+cmux_claude_custom_launch_command() {
+    [[ -z "${CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE:-}" ]] || return 1
+    local custom="${CMUX_CUSTOM_CLAUDE_PATH:-}"
+    custom="${custom#"${custom%%[![:space:]]*}"}"  # trim leading whitespace
+    custom="${custom%"${custom##*[![:space:]]}"}"  # trim trailing whitespace
+    [[ -n "$custom" ]] || return 1
+    if [[ -f "$custom" && -x "$custom" ]]; then
+        return 1
+    fi
+    if [[ "$custom" == *'$@'* ]]; then
+        printf '%s' "$custom"
+        return 0
+    fi
+    return 1
+}
+
+cmux_claude_wrapper_exec_custom_command() {
+    local launch_command="$1"
+    shift
+    export CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE=1
+    exec /bin/sh -c "$launch_command" claude "$@"
+}
+
+cmux_custom_launch_command_value=""
+if cmux_custom_launch_candidate="$(cmux_claude_custom_launch_command)"; then
+    cmux_custom_launch_command_value="$cmux_custom_launch_candidate"
+fi
+unset cmux_custom_launch_candidate
+
+cmux_claude_wrapper_fail_not_found() {
+    if [[ -n "${CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE:-}" ]]; then
+        # Nested invocation inside a custom-launch-command session: the
+        # configured command is deliberately not re-applied here (that is the
+        # loop guard), so pointing the user back at the setting they already
+        # set would be a dead end.
+        cat >&2 <<'EOF'
+Error: claude not found in PATH
+This `claude` was invoked from inside a custom launch command session
+(CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE is set). Nested invocations resolve via
+PATH by design — the configured launch command is not re-applied — so a real
+claude binary must be reachable on PATH for nested use.
+EOF
+        exit 127
+    fi
+    cat >&2 <<'EOF'
+Error: claude not found in PATH
+If your `claude` is a shell function or alias defined in your shell profile,
+cmux cannot see it from non-interactive launches. Set Settings > Automation >
+Claude Binary Path (CMUX_CUSTOM_CLAUDE_PATH) to the real claude binary, or to
+a launch command that forwards the arguments via "$@", e.g.:
+  /bin/zsh -lic 'claude "$@"' claude "$@"
+EOF
+    exit 127
+}
+
 # Find the real claude binary, skipping cmux's wrapper and temp shell shims.
 find_real_claude() {
     # Honor custom path from Settings > Automation > Claude Code > Claude Binary Path.
@@ -590,6 +665,23 @@ exec_real_claude_passthrough() {
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" "$@"
 }
 
+# Passthrough twin of exec_real_claude_passthrough for custom launch commands:
+# same cmux env cleanup, then the command-mode exec (which re-exports the
+# one-shot CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE guard after the CMUX_* sweep).
+exec_custom_launch_command_passthrough() {
+    local launch_command="$1"
+    shift
+    if [[ "$IN_CMUX" == "1" ]]; then
+        clear_inherited_claude_session_env
+        local cmux_key
+        for cmux_key in "${!CMUX_@}"; do
+            unset "$cmux_key"
+        done
+        unset TERMINFO
+    fi
+    cmux_claude_wrapper_exec_custom_command "$launch_command" "$@"
+}
+
 if [[ "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]]; then
     # User-managed hooks need the original cmux terminal environment.
     if [[ "$IN_CMUX" == "1" ]]; then
@@ -599,7 +691,10 @@ if [[ "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]]; then
     if [[ "$IN_CMUX" == "1" ]]; then
         reconcile_claude_config_dir_for_resume "$(extract_claude_resume_session_id "$@")"
     fi
-    REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
+    if [[ -n "$cmux_custom_launch_command_value" ]]; then
+        cmux_claude_wrapper_exec_custom_command "$cmux_custom_launch_command_value" "$@"
+    fi
+    REAL_CLAUDE="$(find_real_claude)" || cmux_claude_wrapper_fail_not_found
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" "$@"
 fi
 
@@ -613,12 +708,21 @@ if [[ "$IN_CMUX" == "0" ]] || ! cmux_socket_available; then
     if [[ "$IN_CMUX" == "1" ]]; then
         reconcile_claude_config_dir_for_resume "$(extract_claude_resume_session_id "$@")"
     fi
-    REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
+    if [[ -n "$cmux_custom_launch_command_value" ]]; then
+        exec_custom_launch_command_passthrough "$cmux_custom_launch_command_value" "$@"
+    fi
+    REAL_CLAUDE="$(find_real_claude)" || cmux_claude_wrapper_fail_not_found
     exec_real_claude_passthrough "$@"
 fi
 
-# Find real claude.
-REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
+# Find real claude. In command mode there may be no claude binary anywhere;
+# the bare name keeps launch captures (CMUX_AGENT_LAUNCH_EXECUTABLE / argv)
+# canonical instead of persisting /bin/sh or the command string.
+if [[ -n "$cmux_custom_launch_command_value" ]]; then
+    REAL_CLAUDE="claude"
+else
+    REAL_CLAUDE="$(find_real_claude)" || cmux_claude_wrapper_fail_not_found
+fi
 
 ensure_node_options_restore_module() {
     local guard_dir="${TMPDIR:-/tmp}"
@@ -838,6 +942,9 @@ if (( cmux_claude_wrapper_reexec_hops > 0 )); then
     export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CLAUDE"
     export CMUX_AGENT_LAUNCH_CWD="$PWD"
     install_cmux_node_options
+    if [[ -n "$cmux_custom_launch_command_value" ]]; then
+        cmux_claude_wrapper_exec_custom_command "$cmux_custom_launch_command_value" "$@"
+    fi
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" "$@"
 fi
 
@@ -845,6 +952,9 @@ fi
 # pass through so Claude subcommands do not receive session/hook flags.
 if ! should_inject_claude_hooks "$@"; then
     clear_inherited_claude_auth_selection_env
+    if [[ -n "$cmux_custom_launch_command_value" ]]; then
+        exec_custom_launch_command_passthrough "$cmux_custom_launch_command_value" "$@"
+    fi
     exec_real_claude_passthrough "$@"
 fi
 
@@ -1012,8 +1122,14 @@ process.stdout.write(JSON.stringify(acc));
 fi
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
+    if [[ -n "$cmux_custom_launch_command_value" ]]; then
+        cmux_claude_wrapper_exec_custom_command "$cmux_custom_launch_command_value" --settings "$HOOKS_JSON" "$@"
+    fi
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
 else
     SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    if [[ -n "$cmux_custom_launch_command_value" ]]; then
+        cmux_claude_wrapper_exec_custom_command "$cmux_custom_launch_command_value" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
+    fi
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
 fi

--- a/Sources/AgentExecutableResolver.swift
+++ b/Sources/AgentExecutableResolver.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import CmuxSettings
 import Foundation
 
@@ -30,6 +31,10 @@ struct AgentExecutableResolver {
         let searchDirectories = resolvedSearchDirectories()
         if let configuredURL = resolvedConfiguredExecutableURL(for: provider) {
             return launchPlan(provider: provider, executableURL: configuredURL, searchDirectories: searchDirectories)
+        }
+        if let command = configuredShellCommand(for: provider) {
+            return shellCommandLaunchPlan(
+                provider: provider, command: command, searchDirectories: searchDirectories)
         }
 
         for directory in searchDirectories {
@@ -166,6 +171,53 @@ struct AgentExecutableResolver {
             provider: provider,
             executableURL: executableURL,
             arguments: provider.launchArguments,
+            environment: launchEnvironment
+        )
+    }
+
+    // https://github.com/manaflow-ai/cmux/issues/7035: the configured Claude
+    // Binary Path may be a /bin/sh launch command (receiving the agent
+    // arguments as "$@") so a `claude` defined as a shell function in the
+    // user's rc can be reached. Skipped when the one-shot guard is already in
+    // the environment, so a command whose inner `claude` re-enters cmux falls
+    // back to PATH resolution instead of looping.
+    private func configuredShellCommand(for provider: AgentSessionProviderID) -> String? {
+        // Guard is active iff non-empty, matching the bash mirror's `-z` check.
+        guard provider == .claude,
+              (environment[ClaudeCustomLaunchValue.commandActiveGuardEnvironmentKey] ?? "").isEmpty,
+              case .shellCommand(let command) = ClaudeCustomLaunchValue().classify(
+                  configuredValue: configuredExecutablePaths[provider],
+                  isExecutableFile: isExecutableNonDirectoryFile(atPath:)
+              )
+        else {
+            return nil
+        }
+        return command
+    }
+
+    private func isExecutableNonDirectoryFile(atPath path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: path, isDirectory: &isDirectory)
+            && !isDirectory.boolValue
+            && fileManager.isExecutableFile(atPath: path)
+    }
+
+    private func shellCommandLaunchPlan(
+        provider: AgentSessionProviderID,
+        command: String,
+        searchDirectories: [String]
+    ) -> AgentSessionLaunchPlan {
+        var launchEnvironment = environment
+        launchEnvironment["PATH"] = searchDirectories
+            .filter { !shouldSkipSearchDirectory($0) }
+            .joined(separator: ":")
+        launchEnvironment[ClaudeCustomLaunchValue.commandActiveGuardEnvironmentKey] = "1"
+        let launch = ClaudeCustomLaunchValue()
+        let argv = launch.shellCommandArgv(command: command, arguments: provider.launchArguments)
+        return AgentSessionLaunchPlan(
+            provider: provider,
+            executableURL: URL(fileURLWithPath: argv[0], isDirectory: false),
+            arguments: Array(argv.dropFirst()),
             environment: launchEnvironment
         )
     }

--- a/Sources/AgentExecutableResolverError.swift
+++ b/Sources/AgentExecutableResolverError.swift
@@ -10,7 +10,17 @@ enum AgentExecutableResolverError: LocalizedError, Equatable {
                 localized: "agentSession.error.missingProviderExecutable",
                 defaultValue: "%@ was not found. Install it and make sure \"%@\" is available on PATH."
             )
-            return String(format: format, displayName, executableName)
+            let message = String(format: format, displayName, executableName)
+            guard executableName == "claude" else { return message }
+            // https://github.com/manaflow-ai/cmux/issues/7035: a `claude`
+            // defined as a shell function/alias in the user's rc is invisible
+            // to cmux; point at the setting that can reach it.
+            let hint = String(
+                localized: "agentSession.error.missingProviderExecutable.claudeShellFunctionHint",
+                defaultValue:
+                    "If claude is a shell function or alias in your shell profile, cmux cannot see it. Set Settings › Automation › Claude Binary Path to the real binary, or to a launch command containing \"$@\" to forward the arguments."
+            )
+            return message + " " + hint
         }
     }
 

--- a/cmuxTests/AgentExecutableResolverTests.swift
+++ b/cmuxTests/AgentExecutableResolverTests.swift
@@ -514,6 +514,137 @@ struct AgentExecutableResolverTests {
         expectFalse(AgentSessionProviderID.claude.shouldAutoStartSession)
     }
 
+    // https://github.com/manaflow-ai/cmux/issues/7035: the configured Claude
+    // launch value may be a shell command (receiving the agent arguments as
+    // "$@"), not just a binary path, so a `claude` defined as a shell function
+    // in the user's rc can be reached.
+    @Test
+    func testConfiguredClaudeCommandStringResolvesToShellLaunchPlan() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "AgentExecutableResolverTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let command = #"/bin/zsh -lic 'claude "$@"' claude "$@""#
+        let resolver = AgentExecutableResolver(
+            environment: ["PATH": root.path, "HOME": root.path],
+            bundleResourceURL: root.appendingPathComponent("Resources", isDirectory: true),
+            includeStandardSearchDirectories: false,
+            configuredExecutablePaths: [.claude: command]
+        )
+
+        let plan = try resolver.resolve(.claude)
+        expectEqual(plan.executableURL.path, "/bin/sh")
+        expectEqual(
+            plan.arguments,
+            ["-c", command, "claude"] + AgentSessionProviderID.claude.launchArguments)
+        expectEqual(plan.environment["CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE"], "1")
+    }
+
+    @Test
+    func testConfiguredClaudeCommandIgnoredWhenGuardAlreadyActive() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "AgentExecutableResolverTests-\(UUID().uuidString)", isDirectory: true)
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let executable = bin.appendingPathComponent("claude")
+        try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolver = AgentExecutableResolver(
+            environment: [
+                "PATH": bin.path,
+                "HOME": root.path,
+                "CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE": "1",
+            ],
+            bundleResourceURL: root.appendingPathComponent("Resources", isDirectory: true),
+            includeStandardSearchDirectories: false,
+            configuredExecutablePaths: [.claude: #"/bin/zsh -lic 'claude "$@"' claude "$@""#]
+        )
+
+        let plan = try resolver.resolve(.claude)
+        expectEqual(plan.executableURL.path, executable.standardizedFileURL.path)
+    }
+
+    // The guard is active iff non-empty (matching the wrapper's `-z` check):
+    // an empty inherited value must not disable command mode.
+    @Test
+    func testConfiguredClaudeCommandAppliesWhenGuardEnvValueIsEmpty() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "AgentExecutableResolverTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let command = #"my-wrapper "$@""#
+        let resolver = AgentExecutableResolver(
+            environment: [
+                "PATH": root.path,
+                "HOME": root.path,
+                "CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE": "",
+            ],
+            bundleResourceURL: root.appendingPathComponent("Resources", isDirectory: true),
+            includeStandardSearchDirectories: false,
+            configuredExecutablePaths: [.claude: command]
+        )
+
+        let plan = try resolver.resolve(.claude)
+        expectEqual(plan.executableURL.path, "/bin/sh")
+    }
+
+    // A stale spaced path (no "$@") must keep the silent PATH fallback, not
+    // become a hard-failing /bin/sh command.
+    @Test
+    func testConfiguredStaleSpacedPathFallsBackToPathSearch() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "AgentExecutableResolverTests-\(UUID().uuidString)", isDirectory: true)
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let executable = bin.appendingPathComponent("claude")
+        try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let staleSpacedPath = root.appendingPathComponent("dir with space/claude").path
+        let resolver = AgentExecutableResolver(
+            environment: ["PATH": bin.path, "HOME": root.path],
+            bundleResourceURL: root.appendingPathComponent("Resources", isDirectory: true),
+            includeStandardSearchDirectories: false,
+            configuredExecutablePaths: [.claude: staleSpacedPath]
+        )
+
+        let plan = try resolver.resolve(.claude)
+        expectEqual(plan.executableURL.path, executable.standardizedFileURL.path)
+    }
+
+    @Test
+    func testConfiguredStalePlainPathStillFallsBackToPathSearch() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "AgentExecutableResolverTests-\(UUID().uuidString)", isDirectory: true)
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let executable = bin.appendingPathComponent("claude")
+        try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let stalePath = root.appendingPathComponent("missing/claude").path
+        let resolver = AgentExecutableResolver(
+            environment: ["PATH": bin.path, "HOME": root.path],
+            bundleResourceURL: root.appendingPathComponent("Resources", isDirectory: true),
+            includeStandardSearchDirectories: false,
+            configuredExecutablePaths: [.claude: stalePath]
+        )
+
+        let plan = try resolver.resolve(.claude)
+        expectEqual(plan.executableURL.path, executable.standardizedFileURL.path)
+    }
+
     @Test
     func testSearchesBunBinUnderHome() throws {
         let root = FileManager.default.temporaryDirectory

--- a/skills/cmux-settings/references/all-keys.md
+++ b/skills/cmux-settings/references/all-keys.md
@@ -108,7 +108,7 @@ Socket control and automation settings from Settings > Automation.
 | `automation.socketControlMode` | `"off"` or `"cmuxOnly"` or `"automation"` or `"password"` or `"allowAll"` or `"openAccess"` or `"fullOpenAccess"` or `"notifications"` or `"full"` | `"cmuxOnly"` | Socket control mode. Legacy aliases are accepted and normalized. |
 | `automation.socketPassword` | string or null | `""` | Password for password-mode socket access. Use null or an empty string to clear it. |
 | `automation.claudeCodeIntegration` | boolean | `true` | Enable cmux integration hooks for Claude Code. |
-| `automation.claudeBinaryPath` | string | `""` | Custom path to the claude binary. |
+| `automation.claudeBinaryPath` | string | `""` | Custom path to the claude binary, or a launch command containing `"$@"` to forward the arguments. |
 | `automation.cursorIntegration` | boolean | `true` | Enable cmux integration hooks for Cursor. |
 | `automation.geminiIntegration` | boolean | `true` | Enable cmux integration hooks for Gemini. |
 | `automation.portBase` | integer | `9100` | Starting value for workspace CMUX_PORT assignments. |

--- a/tests/test_claude_wrapper_custom_command.py
+++ b/tests/test_claude_wrapper_custom_command.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Regression tests for https://github.com/manaflow-ai/cmux/issues/7035.
+
+A `claude` defined as a shell function/wrapper in the user's rc file is
+invisible to cmux's non-interactive launch paths. The Claude Binary Path
+setting (CMUX_CUSTOM_CLAUDE_PATH) must accept a launch *command* (a /bin/sh
+snippet receiving the agent arguments as "$@"), not just a binary path, so
+users can route cmux's claude launches through their own shell function.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
+
+
+def minimal_env(path: str, tmpdir: Path | None = None) -> dict[str, str]:
+    env = {
+        "HOME": os.environ.get("HOME", str(ROOT)),
+        "PATH": path,
+    }
+    if tmpdir is not None:
+        env["TMPDIR"] = str(tmpdir)
+    return env
+
+
+def write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def run_wrapper(argv: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def install_wrapper(bundle_bin: Path) -> Path:
+    bundle_bin.mkdir(parents=True, exist_ok=True)
+    wrapper = bundle_bin / "cmux-claude-wrapper"
+    wrapper.write_bytes(WRAPPER.read_bytes())
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def test_command_mode_runs_custom_command(failures: list[str]) -> None:
+    """A command-string CMUX_CUSTOM_CLAUDE_PATH runs with the args as "$@"."""
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-custom-command-") as td:
+        root = Path(td)
+        wrapper = install_wrapper(root / "cmux.app" / "Contents" / "Resources" / "bin")
+        log = root / "argv.log"
+        logger = root / "log-args.sh"
+        write_executable(
+            logger,
+            f"""#!/bin/sh
+printf '%s\\n' "custom-claude $*" > "{log}"
+""",
+        )
+
+        # No claude binary anywhere on PATH: the command is the only way to launch.
+        env = minimal_env("/usr/bin:/bin")
+        env["CMUX_CUSTOM_CLAUDE_PATH"] = f'"{logger}" "$@"'
+
+        result = run_wrapper([str(wrapper), "--version", "hello world"], env)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            failures.append(f"command mode exited {result.returncode}: {output}")
+        if not log.exists():
+            failures.append(f"custom command never ran (wrapper output: {output!r})")
+        elif log.read_text(encoding="utf-8").strip() != "custom-claude --version hello world":
+            failures.append(f"custom command got wrong argv: {log.read_text(encoding='utf-8').strip()!r}")
+
+
+def test_command_mode_reaches_zsh_shell_function(failures: list[str]) -> None:
+    """The issue #7035 repro: claude defined only as a zsh function in ~/.zshrc."""
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-zsh-function-") as td:
+        root = Path(td)
+        wrapper = install_wrapper(root / "cmux.app" / "Contents" / "Resources" / "bin")
+        zdot = root / "zdot"
+        zdot.mkdir(parents=True, exist_ok=True)
+        marker = root / "marker"
+        (zdot / ".zshrc").write_text(
+            f"""claude() {{ printf '%s\\n' "function-claude $*" > "{marker}"; }}
+""",
+            encoding="utf-8",
+        )
+
+        env = minimal_env("/usr/bin:/bin")
+        env["ZDOTDIR"] = str(zdot)
+        env["CMUX_CUSTOM_CLAUDE_PATH"] = '/bin/zsh -lic \'claude "$@"\' claude "$@"'
+
+        result = run_wrapper([str(wrapper), "--resume", "session-123"], env)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            failures.append(f"zsh function launch exited {result.returncode}: {output}")
+        if not marker.exists():
+            failures.append(f"zsh claude function never ran (wrapper output: {output!r})")
+        elif marker.read_text(encoding="utf-8").strip() != "function-claude --resume session-123":
+            failures.append(
+                f"zsh claude function got wrong argv: {marker.read_text(encoding='utf-8').strip()!r}"
+            )
+
+
+def test_command_mode_in_cmux_stale_socket_passthrough(failures: list[str]) -> None:
+    """Inside a cmux terminal with a stale/missing socket the command still runs."""
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-custom-command-in-cmux-") as td:
+        root = Path(td)
+        wrapper = install_wrapper(root / "cmux.app" / "Contents" / "Resources" / "bin")
+        log = root / "argv.log"
+        logger = root / "log-args.sh"
+        write_executable(
+            logger,
+            f"""#!/bin/sh
+printf '%s\\n' "custom-claude $*" > "{log}"
+""",
+        )
+
+        env = minimal_env("/usr/bin:/bin")
+        env["CMUX_SURFACE_ID"] = "surface-custom-command"
+        env["CMUX_CUSTOM_CLAUDE_PATH"] = f'"{logger}" "$@"'
+
+        result = run_wrapper([str(wrapper), "--version"], env)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            failures.append(f"in-cmux command mode exited {result.returncode}: {output}")
+        if not log.exists():
+            failures.append(f"in-cmux custom command never ran (wrapper output: {output!r})")
+        elif log.read_text(encoding="utf-8").strip() != "custom-claude --version":
+            failures.append(
+                f"in-cmux custom command got wrong argv: {log.read_text(encoding='utf-8').strip()!r}"
+            )
+
+
+def test_command_mode_reentry_falls_back_without_looping(failures: list[str]) -> None:
+    """A custom command whose inner `claude` re-enters the cmux shim must not loop.
+
+    The re-entry (guard env var already exported) has to fall back to normal
+    PATH resolution, skipping both the shim and command mode.
+    """
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-custom-command-loop-") as td:
+        root = Path(td)
+        bundle_bin = root / "cmux.app" / "Contents" / "Resources" / "bin"
+        wrapper = install_wrapper(bundle_bin)
+        shim_bin = root / "shim-bin"
+        real_bin = root / "real-bin"
+        for directory in (shim_bin, real_bin):
+            directory.mkdir(parents=True, exist_ok=True)
+
+        shim = shim_bin / "claude"
+        write_executable(
+            shim,
+            f"""#!/bin/sh
+export CMUX_CLAUDE_WRAPPER_SHIM="{shim}"
+export CMUX_CLAUDE_WRAPPER_SHIM_ROOT="{shim_bin}"
+exec "{wrapper}" "$@"
+""",
+        )
+        write_executable(
+            real_bin / "claude",
+            """#!/bin/sh
+echo real-claude "$@"
+""",
+        )
+
+        log = root / "custom.log"
+        env = minimal_env(f"{shim_bin}:{real_bin}:/usr/bin:/bin")
+        env["CMUX_CLAUDE_WRAPPER_SHIM"] = str(shim)
+        env["CMUX_CLAUDE_WRAPPER_SHIM_ROOT"] = str(shim_bin)
+        # The custom command notes that it ran, then resolves `claude` through
+        # PATH again — which hits the cmux shim and re-enters the wrapper.
+        env["CMUX_CUSTOM_CLAUDE_PATH"] = f'echo custom-ran >> "{log}"; exec "{shim}" "$@"'
+
+        result = run_wrapper([str(shim), "--version"], env)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            failures.append(f"re-entrant command mode exited {result.returncode}: {output}")
+        if not log.exists():
+            failures.append(f"re-entrant custom command never ran (wrapper output: {output!r})")
+        elif log.read_text(encoding="utf-8").strip() != "custom-ran":
+            failures.append(
+                "custom command must run exactly once on re-entry, got "
+                f"{log.read_text(encoding='utf-8').strip()!r}"
+            )
+        if log.exists() and output != "real-claude --version":
+            failures.append(f"re-entry expected real claude fallback, got {output!r}")
+
+
+def test_binary_mode_with_space_in_path_still_execs_directly(failures: list[str]) -> None:
+    """An existing executable-file value keeps binary mode, even with spaces."""
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-custom-binary-space-") as td:
+        root = Path(td)
+        wrapper = install_wrapper(root / "cmux.app" / "Contents" / "Resources" / "bin")
+        custom_bin = root / "dir with space"
+        custom_bin.mkdir(parents=True, exist_ok=True)
+        custom_claude = custom_bin / "claude"
+        write_executable(
+            custom_claude,
+            """#!/bin/sh
+echo custom-binary-claude "$@"
+""",
+        )
+
+        env = minimal_env("/usr/bin:/bin")
+        env["CMUX_CUSTOM_CLAUDE_PATH"] = str(custom_claude)
+
+        result = run_wrapper([str(wrapper), "--version"], env)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            failures.append(f"binary mode exited {result.returncode}: {output}")
+        if output != "custom-binary-claude --version":
+            failures.append(f"expected direct exec of custom binary, got {output!r}")
+
+
+def _expect_path_fallback(
+    failures: list[str],
+    label: str,
+    custom_value_for: "callable",
+) -> None:
+    """The configured value must keep the silent PATH fallback: the PATH claude
+    runs and receives the full argv."""
+    with tempfile.TemporaryDirectory(prefix=f"cmux-claude-custom-fallback-{label}-") as td:
+        root = Path(td)
+        wrapper = install_wrapper(root / "cmux.app" / "Contents" / "Resources" / "bin")
+        real_bin = root / "real-bin"
+        real_bin.mkdir(parents=True, exist_ok=True)
+        write_executable(
+            real_bin / "claude",
+            """#!/bin/sh
+echo real-claude "$@"
+""",
+        )
+
+        env = minimal_env(f"{real_bin}:/usr/bin:/bin")
+        env["CMUX_CUSTOM_CLAUDE_PATH"] = custom_value_for(root)
+
+        result = run_wrapper([str(wrapper), "--resume", "session-123"], env)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            failures.append(f"{label}: fallback exited {result.returncode}: {output}")
+        elif output != "real-claude --resume session-123":
+            failures.append(
+                f"{label}: expected PATH fallback with args intact, got {output!r}"
+            )
+
+
+def test_values_without_args_reference_keep_path_fallback(failures: list[str]) -> None:
+    """No-regression: values without a literal "$@" never enter command mode.
+
+    A stale spaced path used to fall back silently and must keep doing so
+    (not hard-fail through /bin/sh); an unexpanded $HOME-style value must not
+    become a command that silently drops the arguments; a spaced command
+    without "$@" could never forward the args, so it falls back too.
+    """
+    _expect_path_fallback(
+        failures, "stale-spaced-path", lambda root: str(root / "dir with space" / "claude")
+    )
+    _expect_path_fallback(
+        failures, "unexpanded-home-path", lambda root: "$HOME/bin/claude"
+    )
+    _expect_path_fallback(
+        failures, "command-without-args-token", lambda root: "zsh -lic claude"
+    )
+
+
+def main() -> int:
+    failures: list[str] = []
+    test_command_mode_runs_custom_command(failures)
+    test_command_mode_reaches_zsh_shell_function(failures)
+    test_command_mode_in_cmux_stale_socket_passthrough(failures)
+    test_command_mode_reentry_falls_back_without_looping(failures)
+    test_binary_mode_with_space_in_path_still_execs_directly(failures)
+    test_values_without_args_reference_keep_path_fallback(failures)
+    if failures:
+        print("FAIL: claude wrapper custom launch command checks failed")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("PASS: claude wrapper honors custom launch commands (issue #7035)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_claude_teams_custom_command.py
+++ b/tests/test_cli_claude_teams_custom_command.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Regression test for https://github.com/manaflow-ai/cmux/issues/7035.
+
+`cmux claude-teams` must honor a Claude Binary Path configured as a launch
+*command* (a /bin/sh snippet forwarding the arguments via "$@") — e.g. a
+`claude` that only exists as a shell function — instead of failing with
+"Claude Code was not found" when no claude binary is on PATH.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from claude_teams_test_utils import resolve_cmux_cli
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def main() -> int:
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-teams-custom-command-") as td:
+        tmp = Path(td)
+        home = tmp / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        log = tmp / "argv.log"
+        logger = tmp / "log-args.sh"
+        make_executable(
+            logger,
+            f"""#!/bin/sh
+printf '%s\\n' "custom-claude $*" > "{log}"
+""",
+        )
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        # No claude binary anywhere: the launch command is the only way in.
+        env["PATH"] = "/usr/bin:/bin"
+        env["CMUX_CUSTOM_CLAUDE_PATH"] = f'"{logger}" "$@"'
+        env.pop("CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE", None)
+
+        proc = subprocess.run(
+            [cli_path, "claude-teams", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=30,
+        )
+
+        if proc.returncode != 0:
+            print("FAIL: `cmux claude-teams --version` failed with a custom launch command")
+            print(f"exit={proc.returncode}")
+            print(f"stdout={proc.stdout.strip()}")
+            print(f"stderr={proc.stderr.strip()}")
+            return 1
+
+        if not log.exists():
+            print("FAIL: the configured launch command never ran")
+            print(f"stdout={proc.stdout.strip()}")
+            print(f"stderr={proc.stderr.strip()}")
+            return 1
+
+        recorded = log.read_text(encoding="utf-8").strip()
+        if "--version" not in recorded:
+            print(f"FAIL: launch command lost the claude-teams arguments: {recorded!r}")
+            return 1
+
+    print("PASS: cmux claude-teams honors a custom claude launch command (issue #7035)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1054,7 +1054,7 @@
         "claudeBinaryPath": {
           "type": "string",
           "default": "",
-          "description": "Custom path to the claude binary."
+          "description": "Custom path to the claude binary, or a launch command containing \"$@\" to forward the agent arguments."
         },
         "workspaceAutoNaming": {
           "type": "boolean",


### PR DESCRIPTION
Fixes #7035.

## Problem

A `claude` defined as a **shell function/wrapper** in the user's rc (`~/.zshrc`) is invisible to cmux: every launch path runs non-interactively, so the rc is never sourced and cmux execs a PATH binary (or its own shim) instead — workspace initial commands go to Ghostty as `/bin/bash --noprofile --norc -c`, resume routes through the wrapper shim to a PATH binary, and the Agent session panel execs a resolved binary directly with no shell at all.

## Fix

The **Claude Binary Path** setting (`CMUX_CUSTOM_CLAUDE_PATH` / `automation.claudeBinaryPath`) now also accepts a **launch command** — a `/bin/sh` snippet receiving the agent arguments as `"$@"`, e.g.:

```
/bin/zsh -lic 'claude "$@"' claude "$@"
```

Classification (shared between the new `ClaudeCustomLaunchValue` in `CMUXAgentLaunch` and its bash mirror in `cmux-claude-wrapper`) is deliberately conservative:

- existing executable file → binary mode, byte-for-byte unchanged (including paths with spaces);
- value containing the literal `$@` → command mode;
- anything else → the historical silent PATH fallback (stale/deleted paths keep behaving exactly as before).

Honored at every seam launches funnel through, per the shared-behavior policy:

- **`Resources/bin/cmux-claude-wrapper`** — covers workspace initial commands, resume, dock-split, and manually typed `claude` (all reach it via the PATH shim or `${CMUX_CLAUDE_WRAPPER_SHIM:-claude}`). Hook injection (`--session-id`/`--settings`) still applies in command mode; launch captures record the bare name `claude`, never `/bin/sh`. A one-shot `CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE` guard makes a command whose inner `claude` re-enters cmux fall back to PATH resolution instead of looping (and the exit-127 message in that state explains nested resolution instead of re-advertising the setting).
- **`AgentExecutableResolver`** — the Agent session panel gets a `/bin/sh -c` launch plan. (`ClaudeStreamJSONAccumulator` already drops non-JSON lines, so rc noise cannot corrupt the stream-json transport.)
- **CLI** — `cmux claude-teams` and workspace auto-naming honor command mode via the shared `configuredClaudeLaunchCommand` helper.
- The wrapper's exit-127 and the panel/CLI missing-executable errors now explain that shell functions/aliases are not visible to cmux and point at the setting.

## Commit structure (regression-test policy)

1. `Add failing tests…` — tests only; **CI is red on this commit by design**, proving the tests catch the bug (includes a real zsh-function repro through `zsh -lic`, wrapper loop-safety, stale-spaced-path / `$HOME`-style / no-`$@` fallback no-regression guards, resolver plan tests, and a `claude-teams` CLI test).
2. `Honor a claude defined as a shell function…` — the fix; everything green.

## Verification

- `python3 tests/test_claude_wrapper_custom_command.py` and `tests/test_cli_claude_teams_custom_command.py` (new, CI-wired) plus all four pre-existing wrapper suites: pass.
- `swift test --package-path Packages/macOS/CMUXAgentLaunch`: 178/178 (7 new classifier tests).
- Focused `cmux-unit` `AgentExecutableResolverTests`: 24/24.
- An independent adversarial review pass refuted the first classification rule (whitespace/metachars would have broken stale spaced paths and silently dropped args for `$HOME/...` values); the final `$@` rule and three further findings are fixed and pinned by tests. Binary-path mode verified unchanged against the old wrapper.
- Localization audit: `settings.automation.claudeCode.customPath.subtitle`/`.placeholder` and the new `agentSession.error.missingProviderExecutable.claudeShellFunctionHint` carry real en/ja/ko translations in `Resources/Localizable.xcstrings`; `web/data/cmux.schema.json` and `skills/cmux-settings/references/all-keys.md` updated (English-only surfaces); no `web/messages/*` catalog references this setting.

Scoped out: codex has no equivalent custom-path setting (no parity work); nested `claude` calls inside a command-mode session intentionally resolve via PATH (guarded, documented in the error text); the per-surface shim script's no-wrapper fallback stays binary-only (the wrapper is always bundled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785799507&installation_id=133855650&pr_number=7358&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7358&signature=4682b01e35087a77f66c0539af179a5e4b11291acfc125315cb8ae9200d4341d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users who define `claude` as a shell function or alias run it through cmux by allowing “Claude Binary Path” to accept a launch command that forwards arguments via "$@". This is honored across the wrapper, Agent session panel, CLI, and auto-naming, with loop protection and clearer errors.

- New Features
  - `automation.claudeBinaryPath` / `CMUX_CUSTOM_CLAUDE_PATH` now support a `/bin/sh` launch command that includes the literal "$@" to forward args.
  - Shared classifier in `CMUXAgentLaunch` (`ClaudeCustomLaunchValue`) and the wrapper:
    - Existing executable file → exec directly.
    - Value containing "$@" → command mode.
    - Anything else → fall back to PATH.
  - Command mode is supported by the wrapper (`Resources/bin/cmux-claude-wrapper`), `AgentExecutableResolver` (shell plan), CLI `cmux claude-teams`, and the auto-naming summarizer.
  - One-shot guard `CMUX_CLAUDE_CUSTOM_COMMAND_ACTIVE` prevents re-entry loops; nested `claude` resolves via PATH.
  - Error messages now explain that shell functions/aliases aren’t visible to cmux and point to the setting; localized (en/ja/ko). Settings UI copy, `web/data/cmux.schema.json`, and docs updated.
  - Added tests for command mode, loop safety, stale-path fallbacks, resolver launch plans, and CLI behavior.

- Migration
  - If `claude` is a shell function/alias, set Settings › Automation › Claude Binary Path (`CMUX_CUSTOM_CLAUDE_PATH`) to a command that forwards args via "$@", for example: /bin/zsh -lic 'claude "$@"' claude "$@".

<sup>Written for commit 3f92a59e477affdfedbb22493138db4a37b63abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude automation can now use a custom launch command, not just a direct binary path.
  * Launch commands can forward arguments, improving support for shell functions and aliases.

* **Bug Fixes**
  * Improved handling when Claude is configured through a wrapper or custom command, reducing launch failures and looped re-entry.
  * Added clearer guidance when Claude isn’t found, including how to point to the real binary or a launch command.

* **Documentation**
  * Updated settings text and error messages to explain the new Claude configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->