### PR TITLE
Fix cmux ssh against hosts configured with RemoteCommand/RequestTTY

### DIFF
--- a/CLI/CMUXCLI+SSHCommandSupport.swift
+++ b/CLI/CMUXCLI+SSHCommandSupport.swift
@@ -1,6 +1,21 @@
+import CmuxFoundation
 import Foundation
 
 extension CMUXCLI {
+    /// Inserts `-o RemoteCommand=none` right after the `ssh` executable so a
+    /// host-configured (or caller-supplied) `RemoteCommand` cannot conflict
+    /// with the command-line remote command this invocation appends — OpenSSH
+    /// aborts on that combination ("Cannot execute command-line and remote
+    /// command.", issue #7246) and honors the first value per option. Only
+    /// for invocations that pass their own command; the interactive session
+    /// hop keeps its explicit `-o RemoteCommand=<bootstrap>`.
+    internal func sshArgumentsOverridingHostRemoteCommand(_ arguments: [String]) -> [String] {
+        guard arguments.first == "ssh" else {
+            return SSHHostConfiguredRemoteCommand.overrideArguments + arguments
+        }
+        return [arguments[0]] + SSHHostConfiguredRemoteCommand.overrideArguments + arguments.dropFirst()
+    }
+
     internal func openSSHLocalCommandValue(shellScript: String?) -> String? {
         guard let shellScript else { return nil }
         let trimmed = shellScript.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/CLI/CMUXCLI+SSHCommandSupport.swift
+++ b/CLI/CMUXCLI+SSHCommandSupport.swift
@@ -11,9 +11,9 @@ extension CMUXCLI {
     /// hop keeps its explicit `-o RemoteCommand=<bootstrap>`.
     internal func sshArgumentsOverridingHostRemoteCommand(_ arguments: [String]) -> [String] {
         guard arguments.first == "ssh" else {
-            return SSHHostConfiguredRemoteCommand.overrideArguments + arguments
+            return SSHHostConfiguredRemoteCommand().overrideArguments + arguments
         }
-        return [arguments[0]] + SSHHostConfiguredRemoteCommand.overrideArguments + arguments.dropFirst()
+        return [arguments[0]] + SSHHostConfiguredRemoteCommand().overrideArguments + arguments.dropFirst()
     }
 
     internal func openSSHLocalCommandValue(shellScript: String?) -> String? {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9068,7 +9068,7 @@ struct CMUXCLI {
             }
             parts.append(options.destination)
         } else {
-            parts.append(options.destination)
+            parts = sshArgumentsOverridingHostRemoteCommand(parts) + [options.destination]
             parts.append(contentsOf: options.extraArguments)
         }
         return parts
@@ -9124,7 +9124,7 @@ struct CMUXCLI {
         localCommandScript: String? = nil
     ) -> String {
         let encodedBootstrapScript = Data(remoteBootstrapScript.utf8).base64EncodedString()
-        let installSSHPrefix = baseSSHArguments(options, localCommandScript: localCommandScript).map(shellQuote).joined(separator: " ")
+        let installSSHPrefix = sshArgumentsOverridingHostRemoteCommand(baseSSHArguments(options, localCommandScript: localCommandScript)).map(shellQuote).joined(separator: " ")
         let sessionSSHPrefix = baseSSHArguments(options).map(shellQuote).joined(separator: " ")
         let remoteCommandTemplate = openSSHRemoteCommandValue(
             shellScript: stagedRemoteBootstrapCommandShell(
@@ -9704,7 +9704,7 @@ struct CMUXCLI {
         localCommandScript: String?,
         controlPathPreflightShellFunction: String?
     ) -> String {
-        var authArguments = baseSSHArguments(options, localCommandScript: localCommandScript)
+        var authArguments = sshArgumentsOverridingHostRemoteCommand(baseSSHArguments(options, localCommandScript: localCommandScript))
         authArguments += ["-T", options.destination, "true"]
         let authCommand = authArguments.map(shellQuote).joined(separator: " ")
         let attachScript = buildSSHPTYAttachScriptBody(

--- a/Packages/macOS/CmuxCore/Sources/CmuxCore/Remote/WorkspaceRemoteConfiguration+SSHBatchCommands.swift
+++ b/Packages/macOS/CmuxCore/Sources/CmuxCore/Remote/WorkspaceRemoteConfiguration+SSHBatchCommands.swift
@@ -16,6 +16,10 @@ extension WorkspaceRemoteConfiguration {
     /// `--persistent --slot <slot>` when a persistent daemon slot is
     /// configured) on the destination for the stdio daemon transport.
     /// Argument text is wire/process behavior; do not alter.
+    ///
+    /// The positional command conflicts with a host-configured
+    /// `RemoteCommand` unless overridden (issue #7246); the override leads
+    /// so it also wins (first value per option) over configured options.
     public func daemonTransportArguments(remotePath: String) -> [String] {
         var serveArguments = ["serve", "--stdio"]
         if let slot = persistentDaemonSlot?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -28,6 +32,7 @@ extension WorkspaceRemoteConfiguration {
         let script = "exec \(daemonCommand)"
         let command = "sh -c \(script.shellSingleQuoted)"
         return ["-T"]
+            + SSHHostConfiguredRemoteCommand.overrideArguments
             + batchSSHArguments()
             + ["-o", "RequestTTY=no", destination, command]
     }

--- a/Packages/macOS/CmuxCore/Sources/CmuxCore/Remote/WorkspaceRemoteConfiguration+SSHBatchCommands.swift
+++ b/Packages/macOS/CmuxCore/Sources/CmuxCore/Remote/WorkspaceRemoteConfiguration+SSHBatchCommands.swift
@@ -32,7 +32,7 @@ extension WorkspaceRemoteConfiguration {
         let script = "exec \(daemonCommand)"
         let command = "sh -c \(script.shellSingleQuoted)"
         return ["-T"]
-            + SSHHostConfiguredRemoteCommand.overrideArguments
+            + SSHHostConfiguredRemoteCommand().overrideArguments
             + batchSSHArguments()
             + ["-o", "RequestTTY=no", destination, command]
     }

--- a/Packages/macOS/CmuxCore/Tests/CmuxCoreTests/WorkspaceRemoteConfigurationSSHBatchCommandsTests.swift
+++ b/Packages/macOS/CmuxCore/Tests/CmuxCoreTests/WorkspaceRemoteConfigurationSSHBatchCommandsTests.swift
@@ -50,7 +50,7 @@ struct WorkspaceRemoteConfigurationSSHBatchCommandsTests {
         let arguments = configuration().daemonTransportArguments(remotePath: "/remote/cmuxd-remote")
         let expectedCommand = #"sh -c 'exec '"'"'/remote/cmuxd-remote'"'"' '"'"'serve'"'"' '"'"'--stdio'"'"''"#
         #expect(
-            arguments == ["-T"]
+            arguments == ["-T", "-o", "RemoteCommand=none"]
                 + expectedBatchArguments
                 + ["-o", "RequestTTY=no", "cmux-macmini", expectedCommand]
         )
@@ -64,7 +64,7 @@ struct WorkspaceRemoteConfigurationSSHBatchCommandsTests {
         ).daemonTransportArguments(remotePath: "/remote/cmuxd-remote")
         let expectedCommand = #"sh -c 'exec '"'"'/remote/cmuxd-remote'"'"' '"'"'serve'"'"' '"'"'--stdio'"'"' '"'"'--persistent'"'"' '"'"'--slot'"'"' '"'"'ws-1'"'"''"#
         #expect(
-            arguments == ["-T"]
+            arguments == ["-T", "-o", "RemoteCommand=none"]
                 + expectedBatchArguments
                 + ["-o", "RequestTTY=no", "cmux-macmini", expectedCommand]
         )
@@ -83,6 +83,7 @@ struct WorkspaceRemoteConfigurationSSHBatchCommandsTests {
         #expect(
             arguments == [
                 "-T",
+                "-o", "RemoteCommand=none",
                 "-o", "ConnectTimeout=6",
                 "-o", "ServerAliveInterval=20",
                 "-o", "ServerAliveCountMax=2",

--- a/Packages/macOS/CmuxCore/Tests/CmuxCoreTests/WorkspaceRemoteConfigurationSSHBatchCommandsTests.swift
+++ b/Packages/macOS/CmuxCore/Tests/CmuxCoreTests/WorkspaceRemoteConfigurationSSHBatchCommandsTests.swift
@@ -99,6 +99,24 @@ struct WorkspaceRemoteConfigurationSSHBatchCommandsTests {
         )
     }
 
+    /// The stdio daemon transport appends its own positional remote command,
+    /// which OpenSSH refuses while a host ssh_config `RemoteCommand` is in
+    /// effect ("Cannot execute command-line and remote command.", issue
+    /// #7246) — the argv must override it before the destination.
+    @Test("daemonTransportArguments override a host-configured RemoteCommand")
+    func daemonTransportArgumentsOverrideHostConfiguredRemoteCommand() {
+        let arguments = configuration().daemonTransportArguments(remotePath: "/remote/cmuxd-remote")
+        let overrideIndex = arguments.indices.dropLast().first {
+            arguments[$0] == "-o" && arguments[$0 + 1] == "RemoteCommand=none"
+        }
+        let destinationIndex = arguments.firstIndex(of: "cmux-macmini")
+        #expect(overrideIndex != nil)
+        #expect(destinationIndex != nil)
+        if let overrideIndex, let destinationIndex {
+            #expect(overrideIndex < destinationIndex)
+        }
+    }
+
     @Test("daemonSocketForwardArguments shape")
     func daemonSocketForwardArguments() {
         let arguments = configuration().daemonSocketForwardArguments(

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHHostConfiguredRemoteCommand.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHHostConfiguredRemoteCommand.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Neutralizes a host-configured OpenSSH `RemoteCommand` for cmux-controlled
+/// invocations that supply their own remote command.
+///
+/// A host alias configured for interactive logins, e.g.
+///
+///     Host dev-host
+///       RequestTTY yes
+///       RemoteCommand sudo su -
+///
+/// makes OpenSSH abort any `ssh dev-host <command>` with "Cannot execute
+/// command-line and remote command." (exit 255), because a command-line
+/// command and a configured `RemoteCommand` are mutually exclusive
+/// (https://github.com/manaflow-ai/cmux/issues/7246). Every cmux-built ssh
+/// argv that appends its own command — auth probes, bootstrap installers,
+/// the cmuxd stdio transport, port scans, tmux mirror commands, cleanup
+/// hops — must therefore override the configured value with
+/// `RemoteCommand=none` (supported since OpenSSH 7.6; macOS has shipped
+/// newer clients since 10.13.2).
+///
+/// OpenSSH uses the first obtained value per option, so insert the override
+/// ahead of caller-supplied `-o` options where the builder allows: an
+/// earlier `none` then also wins over a stray user-provided `RemoteCommand`
+/// option, which would break cmux plumbing the same way. Session
+/// invocations that intentionally carry cmux's own
+/// `-o RemoteCommand=<bootstrap>` — or run no remote command at all — must
+/// not apply this override.
+public enum SSHHostConfiguredRemoteCommand {
+    /// `RemoteCommand=none` — the option text for string-composed ssh
+    /// command lines.
+    public static let overrideOption = "RemoteCommand=none"
+
+    /// `-o RemoteCommand=none` as an argv fragment, inserted before the
+    /// destination.
+    public static let overrideArguments: [String] = ["-o", overrideOption]
+}

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHHostConfiguredRemoteCommand.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHHostConfiguredRemoteCommand.swift
@@ -26,12 +26,14 @@ import Foundation
 /// invocations that intentionally carry cmux's own
 /// `-o RemoteCommand=<bootstrap>` — or run no remote command at all — must
 /// not apply this override.
-public enum SSHHostConfiguredRemoteCommand {
+public struct SSHHostConfiguredRemoteCommand: Sendable {
     /// `RemoteCommand=none` — the option text for string-composed ssh
     /// command lines.
-    public static let overrideOption = "RemoteCommand=none"
+    public let overrideOption = "RemoteCommand=none"
 
     /// `-o RemoteCommand=none` as an argv fragment, inserted before the
     /// destination.
-    public static let overrideArguments: [String] = ["-o", overrideOption]
+    public var overrideArguments: [String] { ["-o", overrideOption] }
+
+    public init() {}
 }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SSHArguments.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SSHArguments.swift
@@ -32,7 +32,7 @@ extension RemoteSessionCoordinator {
             // force` cannot CRLF-corrupt parsed pipes. Placed before the
             // configuration's options: OpenSSH honors the first value per
             // option, so these also win over caller-supplied conflicts.
-            args += SSHHostConfiguredRemoteCommand.overrideArguments
+            args += SSHHostConfiguredRemoteCommand().overrideArguments
             args += ["-o", "RequestTTY=no"]
         }
         if let port = configuration.port {

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SSHArguments.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SSHArguments.swift
@@ -1,10 +1,12 @@
+internal import CmuxFoundation
 internal import Foundation
 
 // Per-exec SSH argument composition and subprocess error-line selection.
-// Faithful lift; argument text is wire/process behavior, do not alter. (The
-// configuration's own batch builders in CmuxCore cover the daemon-transport
-// argv; these compose the coordinator's general exec argv, including the
-// non-batch and drop-ControlPath variants the batch builders do not have.)
+// Faithful lift; argument text is wire/process behavior, do not alter
+// without a pinned-behavior reason. (The configuration's own batch builders
+// in CmuxCore cover the daemon-transport argv; these compose the
+// coordinator's general exec argv, including the non-batch and
+// drop-ControlPath variants the batch builders do not have.)
 extension RemoteSessionCoordinator {
     func sshCommonArguments(batchMode: Bool, dropControlPath: Bool = false) -> [String] {
         let effectiveSSHOptions: [String] = {
@@ -24,6 +26,14 @@ extension RemoteSessionCoordinator {
         if batchMode {
             args += ["-o", "BatchMode=yes"]
             args += ["-o", "ControlMaster=no"]
+            // Batch execs append their own positional remote command, which
+            // OpenSSH refuses while a host-configured RemoteCommand is in
+            // effect (issue #7246); pin RequestTTY=no so a host `RequestTTY
+            // force` cannot CRLF-corrupt parsed pipes. Placed before the
+            // configuration's options: OpenSSH honors the first value per
+            // option, so these also win over caller-supplied conflicts.
+            args += SSHHostConfiguredRemoteCommand.overrideArguments
+            args += ["-o", "RequestTTY=no"]
         }
         if let port = configuration.port {
             args += ["-p", String(port)]

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionSSHRemoteCommandOverrideTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionSSHRemoteCommandOverrideTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import Testing
+import CmuxCore
+import CmuxRemoteDaemon
+import CmuxRemoteWorkspace
+@testable import CmuxRemoteSession
+
+// A host ssh_config with `RemoteCommand …` (often paired with `RequestTTY
+// yes`) must not break the coordinator's non-interactive ssh plumbing
+// (https://github.com/manaflow-ai/cmux/issues/7246): every batch exec —
+// bootstrap probes, installer hops, port scans, upload cleanup, relay
+// metadata — appends its own positional remote command, which OpenSSH
+// refuses while a configured RemoteCommand is in effect ("Cannot execute
+// command-line and remote command.", exit 255). Batch plumbing must also pin
+// `RequestTTY=no` so a host `RequestTTY force` cannot corrupt parsed pipes
+// with a remote PTY's CRLF conversion.
+@Suite("Coordinator batch ssh argv overrides a host-configured RemoteCommand")
+struct RemoteSessionSSHRemoteCommandOverrideTests {
+    @Test("Port-scan exec overrides RemoteCommand and disables TTY allocation")
+    func portScanExecOverridesHostConfiguredRemoteCommand() {
+        let runner = RecordingProcessRunner()
+        let coordinator = Self.makeCoordinator(runner: runner)
+        let panelId = UUID()
+
+        coordinator.queue.sync {
+            coordinator.daemonReady = true
+            coordinator.updateRemotePortScanTTYsLocked([panelId: "ttys010"])
+            coordinator.performRemotePortScanLocked()
+        }
+        defer { coordinator.stop() }
+
+        let requests = runner.requests
+        #expect(requests.count == 1)
+        guard let request = requests.first else { return }
+        #expect(request.executable == "/usr/bin/ssh")
+        #expect(Self.consecutive(request.arguments, "-o", "RemoteCommand=none"))
+        #expect(Self.consecutive(request.arguments, "-o", "RequestTTY=no"))
+
+        let overrideIndex = Self.pairIndex(request.arguments, "-o", "RemoteCommand=none")
+        let destinationIndex = request.arguments.firstIndex(of: "user@example.test")
+        #expect(overrideIndex != nil)
+        #expect(destinationIndex != nil)
+        if let overrideIndex, let destinationIndex {
+            #expect(overrideIndex < destinationIndex)
+        }
+    }
+
+    @Test("Batch args place the override ahead of caller-configured ssh options")
+    func batchArgumentsPlaceOverrideBeforeConfiguredOptions() {
+        // OpenSSH uses the first obtained value per option, so the override
+        // must precede the configuration's own -o options to also win over a
+        // caller-supplied RemoteCommand, not only over ssh_config.
+        let runner = RecordingProcessRunner()
+        let coordinator = Self.makeCoordinator(
+            runner: runner,
+            sshOptions: ["RemoteCommand=sudo su -", "RequestTTY=yes"]
+        )
+        defer { coordinator.stop() }
+
+        let arguments = coordinator.sshCommonArguments(batchMode: true)
+        let overrideIndex = Self.pairIndex(arguments, "-o", "RemoteCommand=none")
+        let configuredIndex = Self.pairIndex(arguments, "-o", "RemoteCommand=sudo su -")
+        #expect(overrideIndex != nil)
+        #expect(configuredIndex != nil)
+        if let overrideIndex, let configuredIndex {
+            #expect(overrideIndex < configuredIndex)
+        }
+        let ttyIndex = Self.pairIndex(arguments, "-o", "RequestTTY=no")
+        let configuredTTYIndex = Self.pairIndex(arguments, "-o", "RequestTTY=yes")
+        #expect(ttyIndex != nil)
+        #expect(configuredTTYIndex != nil)
+        if let ttyIndex, let configuredTTYIndex {
+            #expect(ttyIndex < configuredTTYIndex)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func consecutive(_ args: [String], _ a: String, _ b: String) -> Bool {
+        pairIndex(args, a, b) != nil
+    }
+
+    private static func pairIndex(_ args: [String], _ a: String, _ b: String) -> Int? {
+        for i in args.indices.dropLast() where args[i] == a && args[i + 1] == b {
+            return i
+        }
+        return nil
+    }
+
+    // MARK: - Harness
+
+    private static func makeCoordinator(
+        runner: RecordingProcessRunner,
+        sshOptions: [String] = []
+    ) -> RemoteSessionCoordinator {
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "user@example.test",
+            port: nil,
+            identityFile: nil,
+            sshOptions: sshOptions,
+            localProxyPort: nil,
+            relayPort: nil,
+            relayID: nil,
+            relayToken: nil,
+            localSocketPath: nil,
+            terminalStartupCommand: nil,
+            preserveAfterTerminalExit: false,
+            persistentDaemonSlot: nil
+        )
+        return RemoteSessionCoordinator(
+            host: NoopRemoteSessionHost(),
+            configuration: configuration,
+            proxyBroker: UnusedRemoteProxyBroker(),
+            manifestRepository: RemoteDaemonManifestRepository(
+                homeDirectory: FileManager.default.temporaryDirectory
+            ),
+            processRunner: runner,
+            reachabilityProbe: NoopReachabilityProbe(),
+            relayCommandRewriter: PassthroughRelayCommandRewriter(),
+            buildInfo: StubBuildInfo(),
+            daemonStrings: RemoteDaemonStrings(
+                missingPersistentPTYCapability: "",
+                missingRequiredFunctionality: ""
+            ),
+            strings: RemoteSessionStrings(
+                connectedVMNoProxyFormat: "%@",
+                suspendedDetailFormat: "%@"
+            )
+        )
+    }
+}
+
+// MARK: - Stubs
+
+/// Records every subprocess request the coordinator issues and returns a
+/// canned successful result, so the argv can be asserted without touching ssh.
+private final class RecordingProcessRunner: RemoteSessionProcessRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _requests: [RemoteProcessRequest] = []
+
+    var requests: [RemoteProcessRequest] { lock.withLock { _requests } }
+
+    func run(
+        _ request: RemoteProcessRequest,
+        operation: (any RemoteTransferCancelling)?
+    ) throws -> RemoteCommandResult {
+        lock.withLock { _requests.append(request) }
+        return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+    }
+}
+
+private struct NoopRemoteSessionHost: RemoteSessionHosting {
+    func publishConnectionState(_ state: WorkspaceRemoteConnectionState, detail: String?) {}
+    func publishDaemonStatus(_ status: WorkspaceRemoteDaemonStatus) {}
+    func publishProxyEndpoint(_ endpoint: BrowserProxyEndpoint?) {}
+    func publishPortsSnapshot(detectedByPanel: [UUID: [Int]], detected: [Int]) {}
+    func publishHeartbeat(count: Int, lastSeenAt: Date?) {}
+    func publishBootstrapRemoteTTY(_ ttyName: String) {}
+}
+
+private final class UnusedRemoteProxyBroker: RemoteProxyBrokering, @unchecked Sendable {
+    func acquire(
+        configuration: WorkspaceRemoteConfiguration,
+        remotePath: String,
+        onUpdate: @escaping @Sendable (RemoteProxyBrokerUpdate) -> Void
+    ) -> RemoteProxyLease {
+        fatalError("UnusedRemoteProxyBroker.acquire is not exercised by these tests")
+    }
+
+    func listPTY(configuration: WorkspaceRemoteConfiguration) throws -> [[String: Any]] { [] }
+    func closePTY(configuration: WorkspaceRemoteConfiguration, sessionID: String) throws {}
+    func resizePTY(
+        configuration: WorkspaceRemoteConfiguration,
+        sessionID: String,
+        attachmentID: String,
+        attachmentToken: String,
+        cols: Int,
+        rows: Int
+    ) throws {}
+    func detachPTY(
+        configuration: WorkspaceRemoteConfiguration,
+        sessionID: String,
+        attachmentID: String,
+        attachmentToken: String
+    ) throws {}
+    func startPTYBridge(
+        configuration: WorkspaceRemoteConfiguration,
+        sessionID: String,
+        attachmentID: String,
+        command: String?,
+        requireExisting: Bool
+    ) throws -> RemotePTYBridgeServer.Endpoint {
+        fatalError("UnusedRemoteProxyBroker.startPTYBridge is not exercised by these tests")
+    }
+}
+
+private struct NoopReachabilityProbe: RemoteHostReachabilityProbing {
+    func probe(
+        destination: String,
+        port: Int?,
+        identityFile: String?,
+        sshOptions: [String],
+        completion: @escaping @Sendable (RemoteHostProbeOutcome) -> Void
+    ) {}
+}
+
+private struct PassthroughRelayCommandRewriter: RemoteRelayCommandRewriting {
+    func rewriteRemoteRelayCommandLine(
+        _ commandLine: Data,
+        workspaceAliases: [UUID: UUID],
+        surfaceAliases: [UUID: UUID]
+    ) -> Data {
+        commandLine
+    }
+}
+
+private struct StubBuildInfo: RemoteSessionBuildInfoProviding {
+    func appVersion() -> String? { nil }
+    func embeddedDaemonManifest() -> WorkspaceRemoteDaemonManifest? { nil }
+    func executableDirectoryURL() -> URL? { nil }
+}

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -654,7 +654,7 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
     }
 
     private static func sshArguments(connection: SSHFileExplorerConnection, command: String) -> [String] {
-        var args: [String] = []
+        var args: [String] = SSHHostConfiguredRemoteCommand.overrideArguments
         if let port = connection.port {
             args += ["-p", String(port)]
         }

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -654,7 +654,7 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
     }
 
     private static func sshArguments(connection: SSHFileExplorerConnection, command: String) -> [String] {
-        var args: [String] = SSHHostConfiguredRemoteCommand.overrideArguments
+        var args: [String] = SSHHostConfiguredRemoteCommand().overrideArguments
         if let port = connection.port {
             args += ["-p", String(port)]
         }

--- a/Sources/GitStatusProvider.swift
+++ b/Sources/GitStatusProvider.swift
@@ -178,7 +178,7 @@ struct GitStatusProvider: Sendable {
         process.executableURL = sshExecutableURL
         // The positional command conflicts with a host-configured
         // RemoteCommand unless overridden (issue #7246).
-        var args: [String] = SSHHostConfiguredRemoteCommand.overrideArguments
+        var args: [String] = SSHHostConfiguredRemoteCommand().overrideArguments
         if let port { args += ["-p", String(port)] }
         if let identityFile { args += ["-i", identityFile] }
         for option in sshOptions { args += ["-o", option] }

--- a/Sources/GitStatusProvider.swift
+++ b/Sources/GitStatusProvider.swift
@@ -176,7 +176,9 @@ struct GitStatusProvider: Sendable {
     ) -> String? {
         let process = Process()
         process.executableURL = sshExecutableURL
-        var args: [String] = []
+        // The positional command conflicts with a host-configured
+        // RemoteCommand unless overridden (issue #7246).
+        var args: [String] = SSHHostConfiguredRemoteCommand.overrideArguments
         if let port { args += ["-p", String(port)] }
         if let identityFile { args += ["-i", identityFile] }
         for option in sshOptions { args += ["-o", option] }

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -1,3 +1,4 @@
+import CmuxFoundation
 import Foundation
 
 /// Identifies a remote host whose tmux server cmux mirrors over SSH.
@@ -181,7 +182,11 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
     ///   `tmux -CC` control client; interactive prompts are handled only by
     ///   ``interactiveAuthInvocation()`` running in the user's terminal.
     func sshControlArguments(controlPersistSeconds: Int, batchMode: Bool) -> [String] {
-        var args = [
+        // Every ssh-tmux invocation supplies its own remote command (`true`,
+        // `tmux -CC …`, one-shot discovery), which OpenSSH refuses while a
+        // host-configured RemoteCommand is in effect (issue #7246).
+        var args = SSHHostConfiguredRemoteCommand.overrideArguments
+        args += [
             "-o", "ControlMaster=auto",
             "-o", "ControlPath=\(controlSocketPath)",
             "-o", "ControlPersist=\(controlPersistSeconds)",

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -185,7 +185,7 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
         // Every ssh-tmux invocation supplies its own remote command (`true`,
         // `tmux -CC …`, one-shot discovery), which OpenSSH refuses while a
         // host-configured RemoteCommand is in effect (issue #7246).
-        var args = SSHHostConfiguredRemoteCommand.overrideArguments
+        var args = SSHHostConfiguredRemoteCommand().overrideArguments
         args += [
             "-o", "ControlMaster=auto",
             "-o", "ControlPath=\(controlSocketPath)",

--- a/Sources/SSHPTYAttachStartupCommandBuilder.swift
+++ b/Sources/SSHPTYAttachStartupCommandBuilder.swift
@@ -107,6 +107,9 @@ nonisolated enum SSHPTYAttachStartupCommandBuilder {
         for option in options {
             arguments += ["-o", option]
         }
+        // The command-line `true` below conflicts with a host-configured
+        // RemoteCommand unless overridden (issue #7246).
+        arguments += SSHHostConfiguredRemoteCommand.overrideArguments
         arguments += ["-T", auth.destination, "true"]
         return arguments.map(shellQuote).joined(separator: " ")
     }

--- a/Sources/SSHPTYAttachStartupCommandBuilder.swift
+++ b/Sources/SSHPTYAttachStartupCommandBuilder.swift
@@ -109,7 +109,7 @@ nonisolated enum SSHPTYAttachStartupCommandBuilder {
         }
         // The command-line `true` below conflicts with a host-configured
         // RemoteCommand unless overridden (issue #7246).
-        arguments += SSHHostConfiguredRemoteCommand.overrideArguments
+        arguments += SSHHostConfiguredRemoteCommand().overrideArguments
         arguments += ["-T", auth.destination, "true"]
         return arguments.map(shellQuote).joined(separator: " ")
     }

--- a/Sources/TerminalSSHSessionDetector.swift
+++ b/Sources/TerminalSSHSessionDetector.swift
@@ -178,8 +178,8 @@ struct DetectedSSHSession: Equatable {
     }
 
     private func sshArguments(command: String) -> [String] {
-        var args: [String] = [
-            "-T",
+        var args: [String] = ["-T"] + SSHHostConfiguredRemoteCommand.overrideArguments
+        args += [
             "-o", "ConnectTimeout=6",
             "-o", "ServerAliveInterval=20",
             "-o", "ServerAliveCountMax=2",

--- a/Sources/TerminalSSHSessionDetector.swift
+++ b/Sources/TerminalSSHSessionDetector.swift
@@ -178,7 +178,7 @@ struct DetectedSSHSession: Equatable {
     }
 
     private func sshArguments(command: String) -> [String] {
-        var args: [String] = ["-T"] + SSHHostConfiguredRemoteCommand.overrideArguments
+        var args: [String] = ["-T"] + SSHHostConfiguredRemoteCommand().overrideArguments
         args += [
             "-o", "ConnectTimeout=6",
             "-o", "ServerAliveInterval=20",

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -838,6 +838,7 @@
 		B0555301B0555301B0555301 /* RemoteTmuxControlStreamParserBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0555302B0555302B0555302 /* RemoteTmuxControlStreamParserBudgetTests.swift */; };
 		2FAA10BC0D7B50DE57F507A4 /* RemoteTmuxError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF44822DC080B2110CFECF88 /* RemoteTmuxError.swift */; };
 		240EDE51707EB251790C8985 /* RemoteTmuxHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B8A9858C9804AC9C37D7B4 /* RemoteTmuxHost.swift */; };
+		F6724602A1B2C3D4E5F67246 /* RemoteTmuxHostRemoteCommandOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6724603A1B2C3D4E5F67246 /* RemoteTmuxHostRemoteCommandOverrideTests.swift */; };
 		00B223273DE0DBED98437C7A /* RemoteTmuxLayoutContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1B00F615F44EA3BA234483 /* RemoteTmuxLayoutContainer.swift */; };
 		B12E809B546C64DC359C54E3 /* RemoteTmuxLayoutContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7A830D507D913809EB02B0 /* RemoteTmuxLayoutContent.swift */; };
 		E54DED0FDC24F51BF1470A1A /* RemoteTmuxLayoutNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5717357D55291686F99625 /* RemoteTmuxLayoutNode.swift */; };
@@ -1035,6 +1036,7 @@
 		F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 		C510C1E00000000000000002 /* SocketOperationTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C510C1E00000000000000001 /* SocketOperationTelemetry.swift */; };
 		A5001230 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A5001231 /* Sparkle */; };
+		F6724600A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6724601A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift */; };
 			6E8B6A69A468EF938B9AD8C2 /* SSHPTYAttachReconnectInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4DB33FA55F1B13C60EFFC8 /* SSHPTYAttachReconnectInputFilter.swift */; };
 			B816E948EC5E42AF967648AC /* SSHPTYAttachReconnectInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4DB33FA55F1B13C60EFFC8 /* SSHPTYAttachReconnectInputFilter.swift */; };
 			E60610200000000000000002 /* SSHPTYAttachReconnectInputFilterControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60610200000000000000001 /* SSHPTYAttachReconnectInputFilterControl.swift */; };
@@ -2149,6 +2151,7 @@
 		B0555302B0555302B0555302 /* RemoteTmuxControlStreamParserBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxControlStreamParserBudgetTests.swift; sourceTree = "<group>"; };
 		AF44822DC080B2110CFECF88 /* RemoteTmuxError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxError.swift; sourceTree = "<group>"; };
 		02B8A9858C9804AC9C37D7B4 /* RemoteTmuxHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxHost.swift; sourceTree = "<group>"; };
+		F6724603A1B2C3D4E5F67246 /* RemoteTmuxHostRemoteCommandOverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxHostRemoteCommandOverrideTests.swift; sourceTree = "<group>"; };
 		3A1B00F615F44EA3BA234483 /* RemoteTmuxLayoutContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxLayoutContainer.swift; sourceTree = "<group>"; };
 		4B7A830D507D913809EB02B0 /* RemoteTmuxLayoutContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxLayoutContent.swift; sourceTree = "<group>"; };
 		8A5717357D55291686F99625 /* RemoteTmuxLayoutNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxLayoutNode.swift; sourceTree = "<group>"; };
@@ -2341,6 +2344,7 @@
 		A5001225 /* SocketControlMode+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SocketControlMode+Display.swift"; sourceTree = "<group>"; };
 		F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
 			C510C1E00000000000000001 /* SocketOperationTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketOperationTelemetry.swift; sourceTree = "<group>"; };
+		F6724601A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHConfiguredRemoteCommandHostTests.swift; sourceTree = "<group>"; };
 			1E4DB33FA55F1B13C60EFFC8 /* SSHPTYAttachReconnectInputFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachReconnectInputFilter.swift; sourceTree = "<group>"; };
 			E60610200000000000000001 /* SSHPTYAttachReconnectInputFilterControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachReconnectInputFilterControl.swift; sourceTree = "<group>"; };
 			E60610100000000000000001 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachReconnectInputFilterSequenceMatch.swift; sourceTree = "<group>"; };
@@ -3778,6 +3782,8 @@
 				F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */,
 				F6357301A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift */,
 				0C4AD348F196FBBEE52D53A7 /* SSHPTYAttachReconnectInputFilterTests.swift */,
+				F6724603A1B2C3D4E5F67246 /* RemoteTmuxHostRemoteCommandOverrideTests.swift */,
+				F6724601A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift */,
 				F6355601A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift */,
 				F6120001A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift */,
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
@@ -5573,6 +5579,7 @@
 				5F5553CA5553CA5553CA0001 /* RemoteTmuxCapabilitiesTests.swift in Sources */,
 				B2FDE62450514C4C27FBD8F1 /* RemoteTmuxControlParserTests.swift in Sources */,
 				B0555301B0555301B0555301 /* RemoteTmuxControlStreamParserBudgetTests.swift in Sources */,
+				F6724602A1B2C3D4E5F67246 /* RemoteTmuxHostRemoteCommandOverrideTests.swift in Sources */,
 				6732BEEF6732BEEF6732B002 /* RemoteTmuxMasterReadinessTests.swift in Sources */,
 				F11ED7AB0001000100010001 /* RemoteTmuxMirrorNewTabPlacementTests.swift in Sources */,
 				D4F8A2E61C5B39707A8E6F12 /* RemoteTmuxMirrorSplitRoutingTests.swift in Sources */,
@@ -5630,6 +5637,7 @@
 					62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */,
 				5830CA11BAC0000000000002 /* SocketCallbackAwaiterMainThreadTests.swift in Sources */,
 						F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
+				F6724600A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift in Sources */,
 						6E8B6A69A468EF938B9AD8C2 /* SSHPTYAttachReconnectInputFilter.swift in Sources */,
 						E60610200000000000000003 /* SSHPTYAttachReconnectInputFilterControl.swift in Sources */,
 						E60610100000000000000003 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift in Sources */,

--- a/cmuxTests/CLIRemoteShellStartupPerformanceTests.swift
+++ b/cmuxTests/CLIRemoteShellStartupPerformanceTests.swift
@@ -204,16 +204,32 @@ struct CLIRemoteShellStartupPerformanceTests {
     }
 
     private var fakeSSHScript: String {
+        // Mirrors OpenSSH RemoteCommand semantics: the first obtained value
+        // wins and `none` clears it (so the bootstrap install hop's
+        // `-o RemoteCommand=none` guard for issue #7246 falls through to the
+        // positional installer command, exactly like real ssh).
         """
         #!/bin/sh
         remote_command=
+        remote_command_seen=
         last=
         while [ "$#" -gt 0 ]; do
           if [ "$1" = "-o" ] && [ "$#" -gt 1 ]; then
             shift
-            case "$1" in RemoteCommand=*) remote_command="${1#RemoteCommand=}" ;; esac
+            case "$1" in
+              RemoteCommand=*)
+                if [ -z "$remote_command_seen" ]; then
+                  remote_command_seen=1
+                  remote_command="${1#RemoteCommand=}"
+                  [ "$remote_command" = none ] && remote_command=
+                fi ;;
+            esac
           elif [ "${1#RemoteCommand=}" != "$1" ]; then
-            remote_command="${1#RemoteCommand=}"
+            if [ -z "$remote_command_seen" ]; then
+              remote_command_seen=1
+              remote_command="${1#RemoteCommand=}"
+              [ "$remote_command" = none ] && remote_command=
+            fi
           fi
           last="$1"
           shift

--- a/cmuxTests/FileExplorerGitStatusProviderTests.swift
+++ b/cmuxTests/FileExplorerGitStatusProviderTests.swift
@@ -162,6 +162,57 @@ struct FileExplorerGitStatusProviderTests {
         )
     }
 
+    @Test
+    func sshStatusQueryOverridesHostConfiguredRemoteCommand() throws {
+        // The remote git status runs as an ssh command-line command, which
+        // OpenSSH refuses while a host-configured RemoteCommand is in effect
+        // (issue #7246) — the argv must carry `-o RemoteCommand=none` before
+        // the destination.
+        let repoURL = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: repoURL) }
+
+        let argvLog = repoURL.appendingPathComponent("ssh-argv.txt")
+        let fakeSSHURL = try Self.writeExecutableScript(
+            #"""
+            #!/bin/sh
+            for arg in "$@"; do printf '%s\n' "$arg"; done > "$CMUX_TEST_SSH_ARGV_LOG"
+            printf '%s\n---GIT_STATUS---\n M remote.txt\0' "$CMUX_TEST_REPO_ROOT"
+            """#,
+            named: "fake-ssh",
+            in: repoURL
+        )
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_TEST_REPO_ROOT"] = repoURL.path
+        environment["CMUX_TEST_SSH_ARGV_LOG"] = argvLog.path
+
+        let status = GitStatusProvider(
+            sshExecutableURL: fakeSSHURL,
+            environment: environment
+        ).fetchStatusSSH(
+            directory: repoURL.path,
+            destination: "example.invalid",
+            port: nil,
+            identityFile: nil,
+            sshOptions: []
+        )
+
+        #expect(
+            status[repoURL.appendingPathComponent("remote.txt").path] == .some(.modified)
+        )
+        let argv = try String(contentsOf: argvLog, encoding: .utf8)
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        let overrideIndex = argv.indices.dropLast().first {
+            argv[$0] == "-o" && argv[$0 + 1] == "RemoteCommand=none"
+        }
+        let destinationIndex = argv.firstIndex(of: "example.invalid")
+        #expect(overrideIndex != nil, "\(argv)")
+        #expect(destinationIndex != nil, "\(argv)")
+        if let overrideIndex, let destinationIndex {
+            #expect(overrideIndex < destinationIndex)
+        }
+    }
+
     private static func makeTemporaryDirectory() throws -> URL {
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-file-explorer-git-status-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/RemoteTmuxHostRemoteCommandOverrideTests.swift
+++ b/cmuxTests/RemoteTmuxHostRemoteCommandOverrideTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Every ssh-tmux invocation supplies its own remote command (`true` for
+/// interactive auth, `tmux -CC …` for the mirror, one-shot discovery
+/// commands), so a host ssh_config `RemoteCommand` would abort them all with
+/// OpenSSH's "Cannot execute command-line and remote command." (exit 255,
+/// https://github.com/manaflow-ai/cmux/issues/7246) — the shared control
+/// args must clear it with `-o RemoteCommand=none`.
+@Suite struct RemoteTmuxHostRemoteCommandOverrideTests {
+    @Test(arguments: [true, false])
+    func controlArgsOverrideHostConfiguredRemoteCommand(batchMode: Bool) {
+        let host = RemoteTmuxHost(destination: "user@host")
+        let args = host.sshControlArguments(controlPersistSeconds: 180, batchMode: batchMode)
+        #expect(consecutive(args, "-o", "RemoteCommand=none"))
+    }
+
+    @Test func controlModeArgumentsOverrideHostRemoteCommandAndKeepForcedTTY() {
+        let host = RemoteTmuxHost(destination: "user@host")
+        let args = host.controlModeArguments(sessionName: "work", createIfMissing: false)
+        #expect(consecutive(args, "-o", "RemoteCommand=none"))
+        // The remote `tmux attach` still needs its forced PTY.
+        #expect(args.first == "-tt")
+    }
+
+    @Test func interactiveAuthInvocationOverridesHostConfiguredRemoteCommand() {
+        let host = RemoteTmuxHost(destination: "user@host")
+        #expect(consecutive(host.interactiveAuthInvocation(), "-o", "RemoteCommand=none"))
+    }
+
+    /// True when `a` is immediately followed by `b` in `args` — i.e. an ssh
+    /// `-o KEY=VALUE` pair is adjacent, as ssh requires.
+    private func consecutive(_ args: [String], _ a: String, _ b: String) -> Bool {
+        for i in args.indices.dropLast() where args[i] == a && args[i + 1] == b {
+            return true
+        }
+        return false
+    }
+}

--- a/cmuxTests/SSHConfiguredRemoteCommandHostTests.swift
+++ b/cmuxTests/SSHConfiguredRemoteCommandHostTests.swift
@@ -261,6 +261,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
             startupResult.stderr.contains("Cannot execute command-line and remote command."),
             "The bootstrap installer hop must override a host-configured RemoteCommand; stderr: \(startupResult.stderr)"
         )
+        XCTAssertFalse(
+            startupResult.stderr.contains("[cmux] ssh exited with status"),
+            startupResult.stderr
+        )
         XCTAssertEqual(startupResult.status, 0, startupResult.stderr)
 
         let events = harness.recordedSSHEvents()

--- a/cmuxTests/SSHConfiguredRemoteCommandHostTests.swift
+++ b/cmuxTests/SSHConfiguredRemoteCommandHostTests.swift
@@ -1,0 +1,429 @@
+import Darwin
+import Foundation
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+// Regression coverage for https://github.com/manaflow-ai/cmux/issues/7246:
+// `cmux ssh` against a host whose ~/.ssh/config sets `RequestTTY yes` and
+// `RemoteCommand sudo su -` fails with OpenSSH's
+// "Cannot execute command-line and remote command." (exit 255) and loops the
+// reconnect banner. Every cmux-controlled ssh invocation that supplies its own
+// remote command must override the host-configured RemoteCommand (e.g.
+// `-o RemoteCommand=none`), while the session hop that intentionally carries
+// cmux's own `-o RemoteCommand=<bootstrap>` keeps doing so.
+//
+// The fake `ssh` below mirrors OpenSSH's actual rule: a positional remote
+// command is fatal iff no `-o RemoteCommand=...` override appears on the argv
+// (the first RemoteCommand option wins, like OpenSSH's first-obtained-value
+// semantics). It records one `invocation kind=<...> override=<...>` event per
+// spawn so assertions can distinguish config dumps, control operations,
+// interactive sessions, and command-carrying invocations.
+extension CLINotifyProcessIntegrationRegressionTests {
+    /// `cmux ssh` default flow (ControlMaster/ControlPath defaults →
+    /// foreground auth + persistent SSH PTY attach): the foreground auth hop
+    /// runs `ssh ... <dest> true`, which a host-configured RemoteCommand used
+    /// to break before the attach could ever start.
+    func testSSHStartupConnectsWhenHostConfigSetsRemoteCommandAndRequestTTY() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("ssh-rc-host")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let workspaceID = "11111111-1111-1111-1111-111111111111"
+        let surfaceID = "22222222-2222-2222-2222-222222222222"
+        let sessionID = "ssh-\(workspaceID)-\(surfaceID)"
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        // Phase 1: capture the generated startup command from the CLI.
+        let captureState = MockSocketServerState()
+        let captureHandled = startMockServer(listenerFD: listenerFD, state: captureState) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+            switch method {
+            case "workspace.create":
+                return self.v2Response(id: id, ok: true, result: [
+                    "workspace_id": workspaceID,
+                    "surface_id": surfaceID,
+                ])
+            case "workspace.remote.configure":
+                return self.v2Response(id: id, ok: true, result: [
+                    "workspace_id": workspaceID,
+                    "workspace_ref": "workspace:9",
+                    "remote": ["enabled": true, "state": "connecting"],
+                ])
+            default:
+                return self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected", "message": "Unexpected method \(method)"]
+                )
+            }
+        }
+
+        var captureEnvironment = ProcessInfo.processInfo.environment
+        captureEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        captureEnvironment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        captureEnvironment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+
+        let captureResult = runProcess(
+            executablePath: cliPath,
+            arguments: ["ssh", "--no-focus", "cmux-remotecommand-host"],
+            environment: captureEnvironment,
+            timeout: 5
+        )
+        wait(for: [captureHandled], timeout: 5)
+        XCTAssertFalse(captureResult.timedOut, captureResult.stderr)
+        XCTAssertEqual(captureResult.status, 0, captureResult.stderr)
+
+        let requests = captureState.commands.compactMap(jsonObject)
+        let createParams = try XCTUnwrap(
+            requests.first { $0["method"] as? String == "workspace.create" }?["params"] as? [String: Any]
+        )
+        let startupCommand = try XCTUnwrap(createParams["initial_command"] as? String)
+
+        // Phase 2: the attach leg of the startup script connects back for the
+        // remote PTY bridge once foreground auth has succeeded.
+        let bridge = try bindLoopbackTCP()
+        defer { Darwin.close(bridge.fd) }
+        let bridgeInput = MockBridgeInputCapture()
+        let bridgeHandled = startBridgeReadyCapturingInputUntilEOF(listenerFD: bridge.fd, capture: bridgeInput)
+        let attachState = MockSocketServerState()
+        let attachHandled = startMockServer(listenerFD: listenerFD, state: attachState) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+            switch method {
+            case "workspace.remote.pty_bridge":
+                return self.v2Response(id: id, ok: true, result: [
+                    "host": "127.0.0.1",
+                    "port": bridge.port,
+                    "token": "bridge-token",
+                    "session_id": sessionID,
+                    "attachment_id": surfaceID,
+                ])
+            case "workspace.remote.pty_sessions":
+                return self.v2Response(id: id, ok: true, result: ["sessions": []])
+            case "workspace.remote.pty_attach_end":
+                return self.v2Response(id: id, ok: true, result: [
+                    "workspace_id": workspaceID,
+                    "surface_id": surfaceID,
+                    "session_id": sessionID,
+                    "cleared_remote_pty_session": true,
+                ])
+            default:
+                return self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected", "message": "Unexpected method \(method)"]
+                )
+            }
+        }
+
+        let harness = try makeRemoteCommandHostHarness(prefix: "cmux-ssh-rc-default")
+        defer { harness.cleanup() }
+
+        let startupResult = runProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", startupCommand],
+            environment: harness.startupEnvironment(
+                socketPath: socketPath,
+                workspaceID: workspaceID,
+                surfaceID: surfaceID
+            ),
+            timeout: 10
+        )
+
+        XCTAssertFalse(startupResult.timedOut, startupResult.stderr)
+        XCTAssertFalse(
+            startupResult.stderr.contains("Cannot execute command-line and remote command."),
+            "cmux-controlled ssh invocations must override a host-configured RemoteCommand; stderr: \(startupResult.stderr)"
+        )
+        XCTAssertFalse(
+            startupResult.stderr.contains("[cmux] ssh exited with status"),
+            startupResult.stderr
+        )
+
+        let events = harness.recordedSSHEvents()
+        XCTAssertTrue(
+            events.contains("invocation kind=command override=none"),
+            "The foreground auth hop must pass -o RemoteCommand=none so a host-configured RemoteCommand cannot conflict with its command-line command; events: \(events)"
+        )
+        XCTAssertFalse(
+            events.contains("invocation kind=command override=absent"),
+            "A cmux-supplied command-line remote command reached ssh without a RemoteCommand override; events: \(events)"
+        )
+
+        wait(for: [attachHandled], timeout: 5)
+        XCTAssertTrue(bridgeHandled.wait(timeout: .now() + 5) == .success)
+        let attachMethods = attachState.commands.compactMap { self.jsonObject($0)?["method"] as? String }
+        XCTAssertTrue(
+            attachMethods.contains("workspace.remote.pty_bridge"),
+            "Foreground auth should succeed and hand off to ssh-pty-attach; observed methods: \(attachMethods)"
+        )
+    }
+
+    /// `cmux ssh` bootstrap-install flow (ControlMaster disabled → staged
+    /// installer hop + interactive session hop): the installer hop pipes the
+    /// bootstrap into `ssh ... <dest> <install command>` and used to hit the
+    /// same fatal; the session hop must keep carrying cmux's own
+    /// `-o RemoteCommand=<bootstrap>` rather than having it cleared.
+    func testSSHBootstrapStartupConnectsWhenHostConfigSetsRemoteCommand() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("ssh-rc-boot")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let workspaceID = "11111111-1111-1111-1111-111111111111"
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let captureState = MockSocketServerState()
+        let captureHandled = startMockServer(listenerFD: listenerFD, state: captureState) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+            switch method {
+            case "workspace.create":
+                return self.v2Response(id: id, ok: true, result: ["workspace_id": workspaceID])
+            case "workspace.remote.configure":
+                return self.v2Response(id: id, ok: true, result: [
+                    "workspace_id": workspaceID,
+                    "workspace_ref": "workspace:9",
+                    "remote": ["enabled": true, "state": "connecting"],
+                ])
+            default:
+                return self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected", "message": "Unexpected method \(method)"]
+                )
+            }
+        }
+
+        var captureEnvironment = ProcessInfo.processInfo.environment
+        captureEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        captureEnvironment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        captureEnvironment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+
+        let captureResult = runProcess(
+            executablePath: cliPath,
+            arguments: [
+                "ssh",
+                "--no-focus",
+                "--ssh-option", "ControlMaster no",
+                "--ssh-option", "ControlPath /tmp/cmux-ssh-%C",
+                "cmux-remotecommand-host",
+            ],
+            environment: captureEnvironment,
+            timeout: 5
+        )
+        wait(for: [captureHandled], timeout: 5)
+        XCTAssertFalse(captureResult.timedOut, captureResult.stderr)
+        XCTAssertEqual(captureResult.status, 0, captureResult.stderr)
+
+        let requests = captureState.commands.compactMap(jsonObject)
+        let createParams = try XCTUnwrap(
+            requests.first { $0["method"] as? String == "workspace.create" }?["params"] as? [String: Any]
+        )
+        let startupCommand = try XCTUnwrap(createParams["initial_command"] as? String)
+
+        let harness = try makeRemoteCommandHostHarness(prefix: "cmux-ssh-rc-bootstrap")
+        defer { harness.cleanup() }
+
+        let startupResult = runProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", startupCommand],
+            environment: harness.startupEnvironment(
+                socketPath: socketPath,
+                workspaceID: workspaceID,
+                surfaceID: "22222222-2222-2222-2222-222222222222"
+            ),
+            timeout: 10
+        )
+
+        XCTAssertFalse(startupResult.timedOut, startupResult.stderr)
+        XCTAssertFalse(
+            startupResult.stderr.contains("Cannot execute command-line and remote command."),
+            "The bootstrap installer hop must override a host-configured RemoteCommand; stderr: \(startupResult.stderr)"
+        )
+        XCTAssertEqual(startupResult.status, 0, startupResult.stderr)
+
+        let events = harness.recordedSSHEvents()
+        XCTAssertTrue(
+            events.contains("invocation kind=command override=none"),
+            "The bootstrap installer hop must pass -o RemoteCommand=none; events: \(events)"
+        )
+        XCTAssertFalse(
+            events.contains("invocation kind=command override=absent"),
+            "A cmux-supplied command-line remote command reached ssh without a RemoteCommand override; events: \(events)"
+        )
+        XCTAssertTrue(
+            events.contains("invocation kind=session override=custom"),
+            "The interactive session hop must keep carrying cmux's own -o RemoteCommand=<bootstrap>, not have it cleared to none; events: \(events)"
+        )
+    }
+
+    /// The app-side restore/reattach startup script builder shares the same
+    /// foreground-auth `ssh ... <dest> true` shape as the CLI.
+    func testSSHPTYAttachForegroundAuthOverridesHostConfiguredRemoteCommand() throws {
+        let command = SSHPTYAttachStartupCommandBuilder.command(
+            sessionID: "ssh-w-s",
+            foregroundAuth: SSHPTYAttachStartupCommandBuilder.ForegroundAuth(
+                destination: "cmux-remotecommand-host",
+                port: 2222,
+                identityFile: nil,
+                sshOptions: [
+                    "ControlMaster=auto",
+                    "ControlPersist=600",
+                    "ControlPath=/tmp/cmux-ssh-%C",
+                ],
+                token: "auth-token"
+            ),
+            remoteCommand: "printf ready"
+        )
+        XCTAssertTrue(
+            command.contains("-o RemoteCommand=none -T cmux-remotecommand-host true"),
+            "Restore foreground auth must override a host-configured RemoteCommand before running its command-line `true`; command: \(command)"
+        )
+    }
+
+    // MARK: - Fake RemoteCommand-host harness
+
+    struct RemoteCommandHostHarness {
+        let root: URL
+        let binDirectory: URL
+        let eventsFile: URL
+        let fakeCLILog: URL
+
+        func startupEnvironment(
+            socketPath: String,
+            workspaceID: String,
+            surfaceID: String
+        ) -> [String: String] {
+            var environment = ProcessInfo.processInfo.environment
+            environment["PATH"] = "\(binDirectory.path):\(environment["PATH"] ?? "/usr/bin:/bin")"
+            environment["CMUX_BUNDLED_CLI_PATH"] = binDirectory.appendingPathComponent("cmux").path
+            environment["CMUX_SOCKET_PATH"] = socketPath
+            environment["CMUX_WORKSPACE_ID"] = workspaceID
+            environment["CMUX_SURFACE_ID"] = surfaceID
+            environment["CMUX_FAKE_SSH_EVENTS"] = eventsFile.path
+            environment["CMUX_FAKE_CLI_LOG"] = fakeCLILog.path
+            environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+            environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+            environment["CMUX_SSH_RECONNECT_LIMIT"] = "1"
+            environment["CMUX_SSH_RECONNECT_DELAY_SECONDS"] = "0"
+            return environment
+        }
+
+        func recordedSSHEvents() -> [String] {
+            ((try? String(contentsOf: eventsFile, encoding: .utf8)) ?? "")
+                .split(separator: "\n")
+                .map(String.init)
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+
+    /// Installs a fake `ssh` simulating a host whose ssh_config sets
+    /// `RequestTTY yes` + `RemoteCommand sudo su -`, and a fake `cmux` for the
+    /// startup script's session-end reporting.
+    func makeRemoteCommandHostHarness(prefix: String) throws -> RemoteCommandHostHarness {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        let binDirectory = root.appendingPathComponent("bin", isDirectory: true)
+        try fileManager.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+
+        let harness = RemoteCommandHostHarness(
+            root: root,
+            binDirectory: binDirectory,
+            eventsFile: root.appendingPathComponent("fake-ssh-events.log"),
+            fakeCLILog: root.appendingPathComponent("fake-cli.log")
+        )
+
+        // Mirrors OpenSSH: the first -o RemoteCommand=... wins; a positional
+        // command with no override is fatal exactly like a host-configured
+        // RemoteCommand conflict. `-G` prints a config dump and `-O` control
+        // operations never execute a remote command.
+        let fakeSSH = """
+        #!/bin/sh
+        events="${CMUX_FAKE_SSH_EVENTS:?}"
+        override=absent
+        mode=session
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            -o)
+              if [ "$override" = absent ]; then
+                case "$2" in
+                  RemoteCommand=none|remotecommand=none) override=none ;;
+                  RemoteCommand=*|remotecommand=*) override=custom ;;
+                esac
+              fi
+              shift 2 ;;
+            -o*)
+              if [ "$override" = absent ]; then
+                case "${1#-o}" in
+                  RemoteCommand=none|remotecommand=none) override=none ;;
+                  RemoteCommand=*|remotecommand=*) override=custom ;;
+                esac
+              fi
+              shift ;;
+            -G) mode=config; shift ;;
+            -O) mode=controlop; shift 2 ;;
+            -S|-p|-i|-l|-F|-E|-e|-b|-c|-D|-I|-J|-L|-m|-Q|-R|-W|-w|-B) shift 2 ;;
+            --) shift; shift; break ;;
+            -*) shift ;;
+            *) shift; break ;;
+          esac
+        done
+        if [ "$mode" = config ]; then
+          printf 'invocation kind=config override=%s\\n' "$override" >> "$events"
+          printf 'controlpath none\\n'
+          exit 0
+        fi
+        if [ "$mode" = controlop ]; then
+          printf 'invocation kind=controlop override=%s\\n' "$override" >> "$events"
+          exit 0
+        fi
+        if [ $# -gt 0 ]; then mode=command; fi
+        printf 'invocation kind=%s override=%s\\n' "$mode" "$override" >> "$events"
+        if [ "$mode" = command ] && [ "$override" = absent ]; then
+          printf '%s\\n' 'Cannot execute command-line and remote command.' >&2
+          exit 255
+        fi
+        cat >/dev/null 2>&1 || true
+        exit 0
+        """
+        let fakeSSHURL = binDirectory.appendingPathComponent("ssh")
+        try fakeSSH.appending("\n").write(to: fakeSSHURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeSSHURL.path)
+
+        let fakeCLI = """
+        #!/bin/sh
+        printf '%s\\n' "$*" >> "${CMUX_FAKE_CLI_LOG:?}"
+        exit 0
+        """
+        let fakeCLIURL = binDirectory.appendingPathComponent("cmux")
+        try fakeCLI.appending("\n").write(to: fakeCLIURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeCLIURL.path)
+
+        return harness
+    }
+}


### PR DESCRIPTION
## Problem

`cmux ssh dev-host` fails and loops the reconnect banner when the host alias is configured for interactive logins:

```
Host dev-host
  HostName example.internal
  User root
  RequestTTY yes
  RemoteCommand sudo su -
```

```
Cannot execute command-line and remote command.

[cmux] ssh exited with status 255; reconnecting (attempt 1/20).
```

OpenSSH refuses a command-line remote command while the host config sets `RemoteCommand` (reproducible outside cmux: `ssh dev-host true` → same fatal, exit 255). cmux-controlled invocations pass their own remote commands — the default `cmux ssh` flow dies on its very first hop, the foreground-auth `ssh … <dest> true`.

## Fix

New shared `CmuxFoundation.SSHHostConfiguredRemoteCommand` (`-o RemoteCommand=none`, OpenSSH ≥ 7.6 — macOS has shipped newer clients since 10.13.2), applied inside every builder that appends a cmux-supplied remote command:

- **CLI `cmux ssh`**: foreground-auth hop, bootstrap installer hop, and the `cmux ssh <dest> -- <command>` passthrough branch. Inserted right after `ssh`, so under OpenSSH's first-value-per-option rule it also wins over caller-supplied options. The session hop keeps carrying cmux's own `-o RemoteCommand=<bootstrap>` (which already overrides the config), and bare interactive invocations (VM attach) are untouched, so hosts without a configured `RemoteCommand` behave identically.
- **App restore/reattach**: `SSHPTYAttachStartupCommandBuilder` foreground auth.
- **Coordinator batch plumbing** (bootstrap probes/install, bootstrap-TTY read, port scans, upload cleanup, relay metadata, stale-listener cleanup) via `sshCommonArguments(batchMode:)`, which now also pins `-o RequestTTY=no` so a host `RequestTTY force` cannot CRLF-corrupt parsed pipes.
- **cmuxd stdio transport**: `WorkspaceRemoteConfiguration.daemonTransportArguments` (this is what the persistent remote PTY rides, so PTY attach works on these hosts).
- **ssh-tmux stack** via `RemoteTmuxHost.sshControlArguments` (interactive auth, `tmux -CC` control mode — which keeps its forced `-tt` — and one-shot discovery/mutation commands).
- **File explorer listing, remote git status, drag-drop upload cleanup** argv builders.

Invocations with no remote command (`-N` forwards, `-O` control ops, `-G` config dumps, plain interactive shells) are unchanged. `scp`/`sftp` already pass `-oRemoteCommand=none` themselves since OpenSSH 7.6.

## Two-commit structure (regression test policy)

1. **58843b1** — regression tests only, expected **red**:
   - `cmuxTests/SSHConfiguredRemoteCommandHostTests`: end-to-end `cmux ssh` startup scripts (both the persistent-PTY foreground-auth flow and the bootstrap-install flow) executed against a fake `ssh` that mirrors OpenSSH's real rule (positional command + no `RemoteCommand` override → the exact fatal + exit 255; first `-o RemoteCommand` wins; `none` clears), plus the app-side foreground-auth argv.
   - `cmuxTests/RemoteTmuxHostRemoteCommandOverrideTests`, `CmuxCoreTests` (daemon transport), `CmuxRemoteSessionTests` (coordinator batch argv + option ordering).
2. **second commit** — the fix, plus updates to argv-pinning tests (`WorkspaceRemoteConfigurationSSHBatchCommandsTests` exact arrays; the `CLIRemoteShellStartupPerformanceTests` fake ssh now models first-wins/`none`-clears), and a `GitStatusProvider.fetchStatusSSH` argv test.

## Verification

- `swift test` for CmuxCore (8/8) and CmuxRemoteSession (42/42) — red on commit 1 for the new suites, green with the fix.
- The end-to-end scenario was reproduced with the release CLI before writing the Swift tests: the generated default-flow startup script fails with the exact reported output against a RemoteCommand-simulating fake ssh, and completes exit 0 (auth → `ssh-pty-attach` bridge handoff) once the override is present.
- OpenSSH semantics (fatal, `none` clearing, first-value-wins, `-N` exemption) verified empirically against OpenSSH 10.2 with a synthetic ssh_config.
- No user-facing strings added or changed (argv/wire behavior only), so no localization updates are required.

Fixes #7246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785800535&installation_id=133855650&pr_number=7359&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7359&signature=99a35883a53fd46b0f44cc920f4e99bc3c78df02d0ba0ba5be67f5f8a5b35865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cmux ssh failing on hosts that set RemoteCommand/RequestTTY by clearing the host RemoteCommand when cmux sends its own command and disabling TTY for batch ops to prevent reconnect loops and CRLF issues. Applies across default, bootstrap, tmux, daemon, file explorer, and git status flows.

- **Bug Fixes**
  - Add -o RemoteCommand=none via `CmuxFoundation` `SSHHostConfiguredRemoteCommand` to all cmux-controlled ssh calls that pass a command (foreground auth, bootstrap installer, passthrough, daemon transport, coordinator batch, ssh-tmux, file explorer, remote git status); place it before the destination and ahead of user -o options.
  - Keep cmux’s own -o RemoteCommand=<bootstrap> on the session hop; interactive shells and -N/-O/-G remain unchanged.
  - Pin -o RequestTTY=no for batch/parseable commands to avoid PTY CRLF corruption and ensure first-wins over caller-configured options.
  - Add regression tests for default and bootstrap flows, ssh-tmux, daemon transport, coordinator batch argv/order, file explorer git status, and updated fake-ssh semantics (first-wins, none clears).

- **Refactors**
  - Make `SSHHostConfiguredRemoteCommand` an instantiable struct (per package conventions) and update call sites; no behavior change.

<sup>Written for commit 759c48c899803d898b858bbd3ea16d01e28145bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

