### PR TITLE
Fix client config env guard for local builds

### DIFF
--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -12,9 +12,13 @@ const skipEnvValidation =
   process.env.SKIP_ENV_VALIDATION === "1" ||
   process.env.VERCEL_ENV === "preview";
 const allowPreviewStackPlaceholders = process.env.VERCEL_ENV === "preview";
+const isVercelNonPreviewDeployment =
+  process.env.VERCEL === "1" &&
+  typeof process.env.VERCEL_ENV === "string" &&
+  process.env.VERCEL_ENV !== "preview";
 const requireVercelNonPreviewValue = (name: string): z.ZodType<string | undefined> =>
   z.string().min(1).optional().superRefine((value, context) => {
-    if (process.env.VERCEL === "1" && process.env.VERCEL_ENV !== "preview" && !value) {
+    if (isVercelNonPreviewDeployment && !value) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message: `${name} is required for deployed non-preview runtimes`,

--- a/web/tests/client-config-env.test.ts
+++ b/web/tests/client-config-env.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+const requiredEnv = {
+  PATH: process.env.PATH ?? "",
+  HOME: process.env.HOME ?? "",
+  RESEND_API_KEY: "test-resend",
+  CMUX_FEEDBACK_FROM_EMAIL: "hello@example.com",
+  CMUX_FEEDBACK_RATE_LIMIT_ID: "feedback-rule",
+  STACK_SECRET_SERVER_KEY: "stack-secret",
+  NEXT_PUBLIC_STACK_PROJECT_ID: "stack-project",
+  NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: "stack-public",
+};
+
+describe("client config env validation", () => {
+  test("allows local builds with VERCEL set but no deployment environment", () => {
+    const result = importEnv({
+      ...requiredEnv,
+      VERCEL: "1",
+      VERCEL_PREVIEW_COMMENTS_ENABLED: "0",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID is required");
+  });
+
+  test("requires the limiter id in explicit Vercel production deployments", () => {
+    const result = importEnv({
+      ...requiredEnv,
+      VERCEL: "1",
+      VERCEL_ENV: "production",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID is required");
+  });
+
+  test("accepts explicit Vercel production deployments with the limiter id", () => {
+    const result = importEnv({
+      ...requiredEnv,
+      VERCEL: "1",
+      VERCEL_ENV: "production",
+      CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+function importEnv(env: Record<string, string>): { exitCode: number; stderr: string } {
+  const result = Bun.spawnSync({
+    cmd: [process.execPath, "-e", "await import('./app/env')"],
+    env,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  return {
+    exitCode: result.exitCode,
+    stderr: new TextDecoder().decode(result.stderr),
+  };
+}

--- a/web/tests/client-config-env.test.ts
+++ b/web/tests/client-config-env.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 
 const requiredEnv = {
   PATH: process.env.PATH ?? "",
@@ -47,14 +48,16 @@ describe("client config env validation", () => {
 });
 
 function importEnv(env: Record<string, string>): { exitCode: number; stderr: string } {
-  const result = Bun.spawnSync({
-    cmd: [process.execPath, "-e", "await import('./app/env')"],
-    env,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
+  const result = spawnSync(
+    process.execPath,
+    ["-e", "await import('./app/env')"],
+    {
+      env: env as NodeJS.ProcessEnv,
+      encoding: "utf8",
+    },
+  );
   return {
-    exitCode: result.exitCode,
-    stderr: new TextDecoder().decode(result.stderr),
+    exitCode: result.status ?? 1,
+    stderr: result.stderr,
   };
 }


### PR DESCRIPTION
## Summary\n- require CMUX_CLIENT_CONFIG_RATE_LIMIT_ID only when VERCEL_ENV is explicitly non-preview\n- keep production deployment validation for missing limiter IDs\n- add subprocess coverage for local Vercel-like builds and production validation\n\n## Tests\n- bun test tests/client-config-env.test.ts tests/client-config-route.test.ts\n- env VERCEL=1 VERCEL_PREVIEW_COMMENTS_ENABLED=0 RESEND_API_KEY=test-resend CMUX_FEEDBACK_FROM_EMAIL=hello@example.com CMUX_FEEDBACK_RATE_LIMIT_ID=feedback-rule STACK_SECRET_SERVER_KEY=stack-secret NEXT_PUBLIC_STACK_PROJECT_ID=00000000-0000-4000-8000-000000000000 NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=stack-public ./node_modules/.bin/next build && bun tools/build-docs-search.mjs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785808322&installation_id=133855650&pr_number=7386&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7386&signature=08ba9e556be67dcafa20849d1d7ed7e21fbdf1620fcea164196d025ebb214015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrower env validation for one optional server var; deployed production still requires the limiter ID, with new tests locking in the behavior.
> 
> **Overview**
> Fixes **false env validation failures** when building locally with `VERCEL=1` but no `VERCEL_ENV` (e.g. Vercel CLI–like setups). `CMUX_CLIENT_CONFIG_RATE_LIMIT_ID` is now required only when **`isVercelNonPreviewDeployment`** is true: `VERCEL=1`, `VERCEL_ENV` is a defined string, and it is not `preview`. Previously, an undefined `VERCEL_ENV` still satisfied `!== "preview"`, so the limiter ID was incorrectly enforced.
> 
> **Production behavior is unchanged**: explicit `VERCEL_ENV=production` (or other non-preview values) still fails validation without the limiter ID.
> 
> Adds **`client-config-env.test.ts`** with subprocess imports of `./app/env` covering local Vercel-like builds, failing production without the ID, and passing production with it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c59f4e9078914329e194cb7861760ea1e5a46c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed env validation for client config limiter. We now require `CMUX_CLIENT_CONFIG_RATE_LIMIT_ID` only for explicit Vercel non-preview deployments, while allowing local and Vercel-like builds to run without it.

- **Bug Fixes**
  - Added `isVercelNonPreviewDeployment` guard to limit checks to `VERCEL=1` with non-preview `VERCEL_ENV`.
  - Added tests for local builds and production validation using subprocess import.

<sup>Written for commit 3af8cfb5e5cc2a78c815d0f6b406ba4650379f78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment environment detection to ensure client configuration validation behaves correctly across preview and non-preview deployments.
  * Refined environment value handling to reduce misleading validation failures when deployment variables are missing or unexpected.
* **Tests**
  * Added automated coverage for client configuration environment validation in Node-run scenarios, including success and failure cases based on deployment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->