### PR TITLE
Resume suspended Cloud VMs on demand in exec/attach/ssh workflows

### DIFF
--- a/web/services/vms/providerGateway.ts
+++ b/web/services/vms/providerGateway.ts
@@ -18,6 +18,7 @@ export type VmProviderGatewayShape = {
   readonly create: (provider: ProviderId, options: CreateOptions) => Effect.Effect<VMHandle, VmProviderOperationError>;
   readonly destroy: (provider: ProviderId, vmId: string) => Effect.Effect<void, VmProviderOperationError>;
   readonly getStatus?: (provider: ProviderId, vmId: string) => Effect.Effect<VMStatus, VmProviderOperationError>;
+  readonly resume?: (provider: ProviderId, vmId: string) => Effect.Effect<VMHandle, VmProviderOperationError>;
   readonly exec: (
     provider: ProviderId,
     vmId: string,
@@ -63,6 +64,8 @@ export const VmProviderGatewayLive = Layer.succeed(VmProviderGateway, {
       if (!driver.getStatus) return "running" as const;
       return await driver.getStatus(vmId);
     }),
+  resume: (provider, vmId) =>
+    providerEffect(provider, "resume", () => getProvider(provider).resume(vmId)),
   exec: (provider, vmId, command, options) =>
     providerEffect(provider, "exec", () => getProvider(provider).exec(vmId, command, options)),
   openAttach: (provider, vmId, options) =>

--- a/web/services/vms/providerGateway.ts
+++ b/web/services/vms/providerGateway.ts
@@ -19,6 +19,7 @@ export type VmProviderGatewayShape = {
   readonly destroy: (provider: ProviderId, vmId: string) => Effect.Effect<void, VmProviderOperationError>;
   readonly getStatus?: (provider: ProviderId, vmId: string) => Effect.Effect<VMStatus, VmProviderOperationError>;
   readonly resume?: (provider: ProviderId, vmId: string) => Effect.Effect<VMHandle, VmProviderOperationError>;
+  readonly pause?: (provider: ProviderId, vmId: string) => Effect.Effect<void, VmProviderOperationError>;
   readonly exec: (
     provider: ProviderId,
     vmId: string,
@@ -66,6 +67,8 @@ export const VmProviderGatewayLive = Layer.succeed(VmProviderGateway, {
     }),
   resume: (provider, vmId) =>
     providerEffect(provider, "resume", () => getProvider(provider).resume(vmId)),
+  pause: (provider, vmId) =>
+    providerEffect(provider, "pause", () => getProvider(provider).pause(vmId)),
   exec: (provider, vmId, command, options) =>
     providerEffect(provider, "exec", () => getProvider(provider).exec(vmId, command, options)),
   openAttach: (provider, vmId, options) =>

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -22,6 +22,7 @@ import {
   VmCreateFailedError,
   VmCreateInProgressError,
   VmNotFoundError,
+  VmProviderOperationError,
   isVmLimitExceededError,
   vmWorkflowErrorCause,
   type VmDatabaseError,
@@ -251,6 +252,42 @@ function dbStatusFromProviderStatus(status: "running" | "paused" | "destroyed"):
   return status;
 }
 
+const RESUME_STATUS_PROBE_TIMEOUT = "5 seconds";
+const RESUME_SETTLE_ATTEMPTS = 10;
+const RESUME_SETTLE_INTERVAL = "1 second";
+
+// resume() can legitimately return a not-yet-running handle (Freestyle maps a
+// post-start "starting" state to "creating"), so poll briefly until the VM is
+// observably running; never record a running transition for a VM that has not
+// settled, and fail without a durable write if it does not.
+function resumeUntilRunning(
+  providers: VmProviderGatewayShape,
+  vm: CloudVmRow,
+  providerVmId: string,
+): Effect.Effect<void, VmWorkflowError> {
+  return Effect.gen(function* () {
+    const getStatus = providers.getStatus;
+    const resume = providers.resume;
+    if (!resume) return;
+    const handle = yield* resume(vm.provider, providerVmId);
+    if (handle.status === "running" || !getStatus) return;
+    for (let attempt = 0; attempt < RESUME_SETTLE_ATTEMPTS; attempt += 1) {
+      const status = yield* getStatus(vm.provider, providerVmId).pipe(
+        Effect.catchAll(() => Effect.succeed(null as VMStatus | null)),
+      );
+      if (status === "running") return;
+      yield* Effect.sleep(RESUME_SETTLE_INTERVAL);
+    }
+    return yield* Effect.fail(
+      new VmProviderOperationError({
+        provider: vm.provider,
+        operation: `resume(${providerVmId})`,
+        cause: new Error("VM did not reach running after resume"),
+      }),
+    );
+  });
+}
+
 // Active-limit note: resuming a user's own existing VM is intentionally not
 // limit-gated here. Freestyle's SSH gateway resumes suspended VMs on any
 // client connect with no control-plane involvement, so this seam cannot
@@ -268,6 +305,15 @@ function preflightResumeIfSuspended(
     if (!getStatus || !resume) return;
 
     const status = yield* getStatus(vm.provider, providerVmId).pipe(
+      Effect.timeoutFail({
+        duration: RESUME_STATUS_PROBE_TIMEOUT,
+        onTimeout: () =>
+          new VmProviderOperationError({
+            provider: vm.provider,
+            operation: `getStatus(${providerVmId})`,
+            cause: new Error("status probe timed out"),
+          }),
+      }),
       Effect.catchAll((err) =>
         // Fail closed when the row durably says paused and the probe cannot
         // prove otherwise: minting endpoints against a suspended VM would
@@ -279,7 +325,7 @@ function preflightResumeIfSuspended(
     );
     if (status !== "paused") return;
 
-    yield* resume(vm.provider, providerVmId);
+    yield* resumeUntilRunning(providers, vm, providerVmId);
     yield* recordRunningTransition(
       repo,
       providers,
@@ -311,7 +357,7 @@ function withResumeOnSuspendedAfterFailure<A, E extends VmWorkflowError>(
           return yield* Effect.fail(originalError);
         }
 
-        yield* resume(vm.provider, providerVmId).pipe(
+        yield* resumeUntilRunning(providers, vm, providerVmId).pipe(
           Effect.catchAll(() => Effect.fail(originalError)),
         );
         yield* recordRunningTransition(repo, providers, vm, providerVmId, originalError);

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -260,24 +260,50 @@ const RESUME_SETTLE_INTERVAL = "1 second";
 // post-start "starting" state to "creating"), so poll briefly until the VM is
 // observably running; never record a running transition for a VM that has not
 // settled, and fail without a durable write if it does not.
+function waitForRunningStatus(
+  providers: VmProviderGatewayShape,
+  vm: CloudVmRow,
+  providerVmId: string,
+): Effect.Effect<boolean, never> {
+  return Effect.gen(function* () {
+    const getStatus = providers.getStatus;
+    if (!getStatus) return true;
+    for (let attempt = 0; attempt < RESUME_SETTLE_ATTEMPTS; attempt += 1) {
+      const status = yield* getStatus(vm.provider, providerVmId).pipe(
+        Effect.catchAll(() => Effect.succeed(null as VMStatus | null)),
+      );
+      if (status === "running") return true;
+      yield* Effect.sleep(RESUME_SETTLE_INTERVAL);
+    }
+    return false;
+  });
+}
+
+function bestEffortPause(
+  providers: VmProviderGatewayShape,
+  vm: CloudVmRow,
+  providerVmId: string,
+): Effect.Effect<void, never> {
+  const pause = providers.pause;
+  if (!pause) return Effect.void;
+  return pause(vm.provider, providerVmId).pipe(Effect.catchAll(() => Effect.void));
+}
+
 function resumeUntilRunning(
   providers: VmProviderGatewayShape,
   vm: CloudVmRow,
   providerVmId: string,
 ): Effect.Effect<void, VmWorkflowError> {
   return Effect.gen(function* () {
-    const getStatus = providers.getStatus;
     const resume = providers.resume;
     if (!resume) return;
     const handle = yield* resume(vm.provider, providerVmId);
-    if (handle.status === "running" || !getStatus) return;
-    for (let attempt = 0; attempt < RESUME_SETTLE_ATTEMPTS; attempt += 1) {
-      const status = yield* getStatus(vm.provider, providerVmId).pipe(
-        Effect.catchAll(() => Effect.succeed(null as VMStatus | null)),
-      );
-      if (status === "running") return;
-      yield* Effect.sleep(RESUME_SETTLE_INTERVAL);
-    }
+    if (handle.status === "running") return;
+    const settled = yield* waitForRunningStatus(providers, vm, providerVmId);
+    if (settled) return;
+    // The provider start already happened; roll back so a started-but-
+    // unrecorded VM is never left running outside Postgres accounting.
+    yield* bestEffortPause(providers, vm, providerVmId);
     return yield* Effect.fail(
       new VmProviderOperationError({
         provider: vm.provider,
@@ -323,6 +349,21 @@ function preflightResumeIfSuspended(
           : Effect.succeed(null as VMStatus | null),
       ),
     );
+    if (status === "creating") {
+      // Another caller's resume is in flight; wait for it rather than
+      // minting endpoints or running commands against a not-yet-ready VM.
+      const settled = yield* waitForRunningStatus(providers, vm, providerVmId);
+      if (!settled) {
+        return yield* Effect.fail(
+          new VmProviderOperationError({
+            provider: vm.provider,
+            operation: `getStatus(${providerVmId})`,
+            cause: new Error("VM stayed in a resuming state"),
+          }),
+        );
+      }
+      return;
+    }
     if (status !== "paused") return;
 
     yield* resumeUntilRunning(providers, vm, providerVmId);
@@ -353,6 +394,11 @@ function withResumeOnSuspendedAfterFailure<A, E extends VmWorkflowError>(
         const status = yield* getStatus(vm.provider, providerVmId).pipe(
           Effect.catchAll(() => Effect.succeed(null as VMStatus | null)),
         );
+        if (status === "creating") {
+          const settled = yield* waitForRunningStatus(providers, vm, providerVmId);
+          if (!settled) return yield* Effect.fail(originalError);
+          return yield* op;
+        }
         if (status !== "paused") {
           return yield* Effect.fail(originalError);
         }

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -270,6 +270,15 @@ function waitForRunningStatus(
     if (!getStatus) return true;
     for (let attempt = 0; attempt < RESUME_SETTLE_ATTEMPTS; attempt += 1) {
       const status = yield* getStatus(vm.provider, providerVmId).pipe(
+        Effect.timeoutFail({
+          duration: RESUME_STATUS_PROBE_TIMEOUT,
+          onTimeout: () =>
+            new VmProviderOperationError({
+              provider: vm.provider,
+              operation: `getStatus(${providerVmId})`,
+              cause: new Error("status probe timed out"),
+            }),
+        }),
         Effect.catchAll(() => Effect.succeed(null as VMStatus | null)),
       );
       if (status === "running") return true;
@@ -362,6 +371,14 @@ function preflightResumeIfSuspended(
           }),
         );
       }
+      // Persist the observed running state ourselves in case the resuming
+      // caller dies before its own durable write; a false return here means
+      // the row was already updated (or concurrently destroyed) and is fine.
+      yield* repo.markProviderObservedStatus({
+        id: vm.id,
+        providerVmId,
+        status: "running",
+      });
       return;
     }
     if (status !== "paused") return;
@@ -397,6 +414,11 @@ function withResumeOnSuspendedAfterFailure<A, E extends VmWorkflowError>(
         if (status === "creating") {
           const settled = yield* waitForRunningStatus(providers, vm, providerVmId);
           if (!settled) return yield* Effect.fail(originalError);
+          yield* repo.markProviderObservedStatus({
+            id: vm.id,
+            providerVmId,
+            status: "running",
+          }).pipe(Effect.catchAll(() => Effect.succeed(false)));
           return yield* op;
         }
         if (status !== "paused") {
@@ -514,12 +536,13 @@ export function openAttachEndpoint(input: {
     const repo = yield* VmRepository;
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
-    yield* revokeActiveIdentities(vm);
     // Endpoint minting can succeed against a paused VM (Freestyle openSSH only
     // grants an identity), which would hand out an endpoint while Postgres
-    // still says paused. Preflight-resume first; the after-failure recovery
-    // below stays as the backstop for a suspend racing the mint.
+    // still says paused. Preflight-resume first — and before revoking the
+    // user's existing identities, so a preflight failure never strands them
+    // with old credentials revoked and no replacement minted.
     yield* preflightResumeIfSuspended(repo, providers, vm, input.providerVmId);
+    yield* revokeActiveIdentities(vm);
     const endpoint = yield* withResumeOnSuspendedAfterFailure(
       repo,
       providers,
@@ -560,12 +583,13 @@ export function openSshEndpoint(input: {
     const repo = yield* VmRepository;
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
-    yield* revokeActiveIdentities(vm);
     // Endpoint minting can succeed against a paused VM (Freestyle openSSH only
     // grants an identity), which would hand out an endpoint while Postgres
-    // still says paused. Preflight-resume first; the after-failure recovery
-    // below stays as the backstop for a suspend racing the mint.
+    // still says paused. Preflight-resume first — and before revoking the
+    // user's existing identities, so a preflight failure never strands them
+    // with old credentials revoked and no replacement minted.
     yield* preflightResumeIfSuspended(repo, providers, vm, input.providerVmId);
+    yield* revokeActiveIdentities(vm);
     const endpoint = yield* withResumeOnSuspendedAfterFailure(
       repo,
       providers,

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -251,19 +251,39 @@ function dbStatusFromProviderStatus(status: "running" | "paused" | "destroyed"):
   return status;
 }
 
-// Replay safety: the retry only fires when getStatus — one Effect step after
-// the failure — observes "paused". Freestyle suspends only after ~10s of
-// network inactivity, and an exec that actually started running is itself
-// activity, so a VM observed paused immediately after the failure means the
-// provider rejected the call without executing the command.
-function withResumeOnSuspended<A, E extends VmWorkflowError>(
+function preflightResumeIfSuspended(
   repo: VmRepositoryShape,
-  vmRowId: string,
   providers: VmProviderGatewayShape,
-  provider: ProviderId,
+  vm: CloudVmRow,
+  providerVmId: string,
+): Effect.Effect<void, VmWorkflowError> {
+  return Effect.gen(function* () {
+    const getStatus = providers.getStatus;
+    const resume = providers.resume;
+    if (!getStatus || !resume) return;
+
+    const status = yield* getStatus(vm.provider, providerVmId).pipe(
+      Effect.catchAll(() => Effect.succeed(null as VMStatus | null)),
+    );
+    if (status !== "paused") return;
+
+    yield* resume(vm.provider, providerVmId);
+    yield* recordRunningTransition(
+      repo,
+      vm,
+      providerVmId,
+      new VmNotFoundError({ vmId: providerVmId }),
+    );
+  });
+}
+
+function withResumeOnSuspendedAfterFailure<A, E extends VmWorkflowError>(
+  repo: VmRepositoryShape,
+  providers: VmProviderGatewayShape,
+  vm: CloudVmRow,
   providerVmId: string,
   op: Effect.Effect<A, E>,
-): Effect.Effect<A, E> {
+): Effect.Effect<A, E | VmDatabaseError> {
   return op.pipe(
     Effect.catchAll((originalError) => {
       const getStatus = providers.getStatus;
@@ -271,29 +291,37 @@ function withResumeOnSuspended<A, E extends VmWorkflowError>(
       if (!getStatus || !resume) return Effect.fail(originalError);
 
       return Effect.gen(function* () {
-        const status = yield* getStatus(provider, providerVmId).pipe(
+        const status = yield* getStatus(vm.provider, providerVmId).pipe(
           Effect.catchAll(() => Effect.succeed(null as VMStatus | null)),
         );
         if (status !== "paused") {
           return yield* Effect.fail(originalError);
         }
 
-        yield* resume(provider, providerVmId).pipe(
+        yield* resume(vm.provider, providerVmId).pipe(
           Effect.catchAll(() => Effect.fail(originalError)),
         );
-        // Keep the repository source of truth in sync: a row reconciled to
-        // "paused" would otherwise stay paused while the provider VM runs,
-        // hiding it from active-VM limit enforcement. Best-effort; the
-        // provider-status refresh reconciles it if this write fails.
-        yield* repo.markProviderObservedStatus({
-          id: vmRowId,
-          providerVmId,
-          status: "running",
-        }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+        yield* recordRunningTransition(repo, vm, providerVmId, originalError);
         return yield* op;
       });
     }),
   );
+}
+
+function recordRunningTransition<E extends VmWorkflowError>(
+  repo: VmRepositoryShape,
+  vm: CloudVmRow,
+  providerVmId: string,
+  staleRowError: E,
+): Effect.Effect<void, VmDatabaseError | E> {
+  return Effect.gen(function* () {
+    const didUpdate = yield* repo.markProviderObservedStatus({
+      id: vm.id,
+      providerVmId,
+      status: "running",
+    });
+    if (!didUpdate) return yield* Effect.fail(staleRowError);
+  });
 }
 
 export function destroyVm(input: { readonly userId: string; readonly providerVmId: string }) {
@@ -332,16 +360,15 @@ export function execVm(input: {
     const repo = yield* VmRepository;
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
-    const result = yield* withResumeOnSuspended(
+    yield* preflightResumeIfSuspended(
       repo,
-      vm.id,
       providers,
-      vm.provider,
+      vm,
       input.providerVmId,
-      providers.exec(vm.provider, input.providerVmId, input.command, {
-        timeoutMs: input.timeoutMs,
-      }),
     );
+    const result = yield* providers.exec(vm.provider, input.providerVmId, input.command, {
+      timeoutMs: input.timeoutMs,
+    });
     yield* repo.recordUsageEvent({
       userId: input.userId,
       billingTeamId: vm.billingTeamId,
@@ -366,11 +393,10 @@ export function openAttachEndpoint(input: {
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
     yield* revokeActiveIdentities(vm);
-    const endpoint = yield* withResumeOnSuspended(
+    const endpoint = yield* withResumeOnSuspendedAfterFailure(
       repo,
-      vm.id,
       providers,
-      vm.provider,
+      vm,
       input.providerVmId,
       providers.openAttach(vm.provider, input.providerVmId, input.options),
     );
@@ -408,11 +434,10 @@ export function openSshEndpoint(input: {
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
     yield* revokeActiveIdentities(vm);
-    const endpoint = yield* withResumeOnSuspended(
+    const endpoint = yield* withResumeOnSuspendedAfterFailure(
       repo,
-      vm.id,
       providers,
-      vm.provider,
+      vm,
       input.providerVmId,
       providers.openSSH(vm.provider, input.providerVmId),
     );

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -411,6 +411,11 @@ export function openAttachEndpoint(input: {
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
     yield* revokeActiveIdentities(vm);
+    // Endpoint minting can succeed against a paused VM (Freestyle openSSH only
+    // grants an identity), which would hand out an endpoint while Postgres
+    // still says paused. Preflight-resume first; the after-failure recovery
+    // below stays as the backstop for a suspend racing the mint.
+    yield* preflightResumeIfSuspended(repo, providers, vm, input.providerVmId);
     const endpoint = yield* withResumeOnSuspendedAfterFailure(
       repo,
       providers,
@@ -452,6 +457,11 @@ export function openSshEndpoint(input: {
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
     yield* revokeActiveIdentities(vm);
+    // Endpoint minting can succeed against a paused VM (Freestyle openSSH only
+    // grants an identity), which would hand out an endpoint while Postgres
+    // still says paused. Preflight-resume first; the after-failure recovery
+    // below stays as the backstop for a suspend racing the mint.
+    yield* preflightResumeIfSuspended(repo, providers, vm, input.providerVmId);
     const endpoint = yield* withResumeOnSuspendedAfterFailure(
       repo,
       providers,

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -251,6 +251,11 @@ function dbStatusFromProviderStatus(status: "running" | "paused" | "destroyed"):
   return status;
 }
 
+// Active-limit note: resuming a user's own existing VM is intentionally not
+// limit-gated here. Freestyle's SSH gateway resumes suspended VMs on any
+// client connect with no control-plane involvement, so this seam cannot
+// enforce the limit; enforcement happens where allocation is decided —
+// beginCreate's reconcile re-counts provider-running VMs on the next create.
 function preflightResumeIfSuspended(
   repo: VmRepositoryShape,
   providers: VmProviderGatewayShape,
@@ -263,7 +268,14 @@ function preflightResumeIfSuspended(
     if (!getStatus || !resume) return;
 
     const status = yield* getStatus(vm.provider, providerVmId).pipe(
-      Effect.catchAll(() => Effect.succeed(null as VMStatus | null)),
+      Effect.catchAll((err) =>
+        // Fail closed when the row durably says paused and the probe cannot
+        // prove otherwise: minting endpoints against a suspended VM would
+        // hand out unusable credentials and record leases/usage for it.
+        vm.status === "paused"
+          ? Effect.fail(err)
+          : Effect.succeed(null as VMStatus | null),
+      ),
     );
     if (status !== "paused") return;
 

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -251,7 +251,14 @@ function dbStatusFromProviderStatus(status: "running" | "paused" | "destroyed"):
   return status;
 }
 
+// Replay safety: the retry only fires when getStatus — one Effect step after
+// the failure — observes "paused". Freestyle suspends only after ~10s of
+// network inactivity, and an exec that actually started running is itself
+// activity, so a VM observed paused immediately after the failure means the
+// provider rejected the call without executing the command.
 function withResumeOnSuspended<A, E extends VmWorkflowError>(
+  repo: VmRepositoryShape,
+  vmRowId: string,
   providers: VmProviderGatewayShape,
   provider: ProviderId,
   providerVmId: string,
@@ -274,6 +281,15 @@ function withResumeOnSuspended<A, E extends VmWorkflowError>(
         yield* resume(provider, providerVmId).pipe(
           Effect.catchAll(() => Effect.fail(originalError)),
         );
+        // Keep the repository source of truth in sync: a row reconciled to
+        // "paused" would otherwise stay paused while the provider VM runs,
+        // hiding it from active-VM limit enforcement. Best-effort; the
+        // provider-status refresh reconciles it if this write fails.
+        yield* repo.markProviderObservedStatus({
+          id: vmRowId,
+          providerVmId,
+          status: "running",
+        }).pipe(Effect.catchAll(() => Effect.succeed(false)));
         return yield* op;
       });
     }),
@@ -317,6 +333,8 @@ export function execVm(input: {
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
     const result = yield* withResumeOnSuspended(
+      repo,
+      vm.id,
       providers,
       vm.provider,
       input.providerVmId,
@@ -349,6 +367,8 @@ export function openAttachEndpoint(input: {
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
     yield* revokeActiveIdentities(vm);
     const endpoint = yield* withResumeOnSuspended(
+      repo,
+      vm.id,
       providers,
       vm.provider,
       input.providerVmId,
@@ -389,6 +409,8 @@ export function openSshEndpoint(input: {
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
     yield* revokeActiveIdentities(vm);
     const endpoint = yield* withResumeOnSuspended(
+      repo,
+      vm.id,
       providers,
       vm.provider,
       input.providerVmId,

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -270,6 +270,7 @@ function preflightResumeIfSuspended(
     yield* resume(vm.provider, providerVmId);
     yield* recordRunningTransition(
       repo,
+      providers,
       vm,
       providerVmId,
       new VmNotFoundError({ vmId: providerVmId }),
@@ -301,26 +302,43 @@ function withResumeOnSuspendedAfterFailure<A, E extends VmWorkflowError>(
         yield* resume(vm.provider, providerVmId).pipe(
           Effect.catchAll(() => Effect.fail(originalError)),
         );
-        yield* recordRunningTransition(repo, vm, providerVmId, originalError);
+        yield* recordRunningTransition(repo, providers, vm, providerVmId, originalError);
         return yield* op;
       });
     }),
   );
 }
 
+// After a successful provider resume, Postgres must record the running
+// transition before the workflow proceeds. When the write fails (or the row
+// was destroyed concurrently), roll the provider back to the durable state
+// with a best-effort pause so a running VM is never left invisible to
+// active-limit accounting; Freestyle's idle auto-suspend (~10s) is the
+// backstop if the pause itself fails.
 function recordRunningTransition<E extends VmWorkflowError>(
   repo: VmRepositoryShape,
+  providers: VmProviderGatewayShape,
   vm: CloudVmRow,
   providerVmId: string,
   staleRowError: E,
 ): Effect.Effect<void, VmDatabaseError | E> {
+  const rollbackPause = (): Effect.Effect<void, never> => {
+    const pause = providers.pause;
+    if (!pause) return Effect.void;
+    return pause(vm.provider, providerVmId).pipe(Effect.catchAll(() => Effect.void));
+  };
   return Effect.gen(function* () {
     const didUpdate = yield* repo.markProviderObservedStatus({
       id: vm.id,
       providerVmId,
       status: "running",
-    });
-    if (!didUpdate) return yield* Effect.fail(staleRowError);
+    }).pipe(
+      Effect.tapError(() => rollbackPause()),
+    );
+    if (!didUpdate) {
+      yield* rollbackPause();
+      return yield* Effect.fail(staleRowError);
+    }
   });
 }
 

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -372,13 +372,18 @@ function preflightResumeIfSuspended(
         );
       }
       // Persist the observed running state ourselves in case the resuming
-      // caller dies before its own durable write; a false return here means
-      // the row was already updated (or concurrently destroyed) and is fine.
-      yield* repo.markProviderObservedStatus({
+      // caller dies before its own durable write. An already-running row
+      // still matches the update (returns true); false means the row was
+      // destroyed or replaced concurrently, so fail closed. No pause
+      // rollback here: the caller that started the VM owns compensation.
+      const recorded = yield* repo.markProviderObservedStatus({
         id: vm.id,
         providerVmId,
         status: "running",
       });
+      if (!recorded) {
+        return yield* Effect.fail(new VmNotFoundError({ vmId: providerVmId }));
+      }
       return;
     }
     if (status !== "paused") return;
@@ -414,11 +419,12 @@ function withResumeOnSuspendedAfterFailure<A, E extends VmWorkflowError>(
         if (status === "creating") {
           const settled = yield* waitForRunningStatus(providers, vm, providerVmId);
           if (!settled) return yield* Effect.fail(originalError);
-          yield* repo.markProviderObservedStatus({
+          const recorded = yield* repo.markProviderObservedStatus({
             id: vm.id,
             providerVmId,
             status: "running",
           }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+          if (!recorded) return yield* Effect.fail(originalError);
           return yield* op;
         }
         if (status !== "paused") {

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -1,12 +1,13 @@
 import { createHash } from "node:crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type {
-  AttachEndpoint,
-  AttachOptions,
-  ExecResult,
-  ProviderId,
-  SSHEndpoint,
+import {
+  type AttachEndpoint,
+  type AttachOptions,
+  type ExecResult,
+  type ProviderId,
+  type SSHEndpoint,
+  type VMStatus,
 } from "./drivers";
 import {
   VmBillingGateway,
@@ -250,6 +251,35 @@ function dbStatusFromProviderStatus(status: "running" | "paused" | "destroyed"):
   return status;
 }
 
+function withResumeOnSuspended<A, E extends VmWorkflowError>(
+  providers: VmProviderGatewayShape,
+  provider: ProviderId,
+  providerVmId: string,
+  op: Effect.Effect<A, E>,
+): Effect.Effect<A, E> {
+  return op.pipe(
+    Effect.catchAll((originalError) => {
+      const getStatus = providers.getStatus;
+      const resume = providers.resume;
+      if (!getStatus || !resume) return Effect.fail(originalError);
+
+      return Effect.gen(function* () {
+        const status = yield* getStatus(provider, providerVmId).pipe(
+          Effect.catchAll(() => Effect.succeed(null as VMStatus | null)),
+        );
+        if (status !== "paused") {
+          return yield* Effect.fail(originalError);
+        }
+
+        yield* resume(provider, providerVmId).pipe(
+          Effect.catchAll(() => Effect.fail(originalError)),
+        );
+        return yield* op;
+      });
+    }),
+  );
+}
+
 export function destroyVm(input: { readonly userId: string; readonly providerVmId: string }) {
   return Effect.gen(function* () {
     const repo = yield* VmRepository;
@@ -286,9 +316,14 @@ export function execVm(input: {
     const repo = yield* VmRepository;
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
-    const result = yield* providers.exec(vm.provider, input.providerVmId, input.command, {
-      timeoutMs: input.timeoutMs,
-    });
+    const result = yield* withResumeOnSuspended(
+      providers,
+      vm.provider,
+      input.providerVmId,
+      providers.exec(vm.provider, input.providerVmId, input.command, {
+        timeoutMs: input.timeoutMs,
+      }),
+    );
     yield* repo.recordUsageEvent({
       userId: input.userId,
       billingTeamId: vm.billingTeamId,
@@ -313,7 +348,12 @@ export function openAttachEndpoint(input: {
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
     yield* revokeActiveIdentities(vm);
-    const endpoint = yield* providers.openAttach(vm.provider, input.providerVmId, input.options);
+    const endpoint = yield* withResumeOnSuspended(
+      providers,
+      vm.provider,
+      input.providerVmId,
+      providers.openAttach(vm.provider, input.providerVmId, input.options),
+    );
     yield* storeEndpointLeases(vm, endpoint).pipe(
       Effect.catchAll((err) =>
         revokeEndpointIdentity(vm.provider, endpoint).pipe(
@@ -348,7 +388,12 @@ export function openSshEndpoint(input: {
     const providers = yield* VmProviderGateway;
     const vm = yield* requireUserVm(input.userId, input.providerVmId);
     yield* revokeActiveIdentities(vm);
-    const endpoint = yield* providers.openSSH(vm.provider, input.providerVmId);
+    const endpoint = yield* withResumeOnSuspended(
+      providers,
+      vm.provider,
+      input.providerVmId,
+      providers.openSSH(vm.provider, input.providerVmId),
+    );
     yield* storeEndpointLeases(vm, endpoint).pipe(
       Effect.catchAll((err) =>
         revokeEndpointIdentity(vm.provider, endpoint).pipe(

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -386,6 +386,22 @@ function preflightResumeIfSuspended(
       }
       return;
     }
+    if (status === "running") {
+      // Freestyle's SSH gateway can resume a VM entirely outside the control
+      // plane; if the durable row still says paused, record the observed
+      // running state so active-limit reconciliation can see the VM.
+      if (vm.status === "paused") {
+        const recorded = yield* repo.markProviderObservedStatus({
+          id: vm.id,
+          providerVmId,
+          status: "running",
+        });
+        if (!recorded) {
+          return yield* Effect.fail(new VmNotFoundError({ vmId: providerVmId }));
+        }
+      }
+      return;
+    }
     if (status !== "paused") return;
 
     yield* resumeUntilRunning(providers, vm, providerVmId);

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -464,7 +464,7 @@ describe("VM Effect workflows", () => {
     expect(usageEvents).toHaveLength(1);
   });
 
-  test("openAttachEndpoint resumes a paused VM and retries attach once", async () => {
+  test("openAttachEndpoint preflight-resumes a paused VM before minting", async () => {
     const vm = testCloudVmRow({
       id: "00000000-0000-4000-8000-000000000105",
       userId: "user-workflow-attach-resume",
@@ -486,7 +486,6 @@ describe("VM Effect workflows", () => {
       openAttach: () =>
         Effect.suspend(() => {
           attachCalls += 1;
-          if (attachCalls === 1) return Effect.fail(originalError);
           return Effect.succeed(endpoint);
         }),
       getStatus: () =>
@@ -510,7 +509,7 @@ describe("VM Effect workflows", () => {
     );
 
     expect(result).toEqual(endpoint);
-    expect(attachCalls).toBe(2);
+    expect(attachCalls).toBe(1);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
     expect(observedStatuses).toEqual([
@@ -582,7 +581,7 @@ describe("VM Effect workflows", () => {
     );
 
     expect(error).toBe(markError);
-    expect(attachCalls).toBe(1);
+    expect(attachCalls).toBe(0);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
     expect(pauseCalls).toBe(1);
@@ -590,7 +589,7 @@ describe("VM Effect workflows", () => {
     expect(usageEvents).toHaveLength(0);
   });
 
-  test("openAttachEndpoint fails with original error when resumed status persistence updates no row", async () => {
+  test("openAttachEndpoint fails when resumed status persistence updates no row", async () => {
     const vm = testCloudVmRow({
       id: "00000000-0000-4000-8000-000000000111",
       userId: "user-workflow-attach-mark-false",
@@ -642,8 +641,8 @@ describe("VM Effect workflows", () => {
       }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
-    expect(error).toBe(originalError);
-    expect(attachCalls).toBe(1);
+    expect(error).toBeInstanceOf(VmNotFoundError);
+    expect(attachCalls).toBe(0);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
     expect(pauseCalls).toBe(1);
@@ -651,7 +650,7 @@ describe("VM Effect workflows", () => {
     expect(usageEvents).toHaveLength(0);
   });
 
-  test("openSshEndpoint resumes a paused VM and retries SSH endpoint minting once", async () => {
+  test("openSshEndpoint preflight-resumes a paused VM before minting", async () => {
     const vm = testCloudVmRow({
       id: "00000000-0000-4000-8000-000000000106",
       userId: "user-workflow-ssh-resume",
@@ -673,7 +672,6 @@ describe("VM Effect workflows", () => {
       openSSH: () =>
         Effect.suspend(() => {
           sshCalls += 1;
-          if (sshCalls === 1) return Effect.fail(originalError);
           return Effect.succeed(endpoint);
         }),
       getStatus: () =>
@@ -696,7 +694,7 @@ describe("VM Effect workflows", () => {
     );
 
     expect(result).toEqual(endpoint);
-    expect(sshCalls).toBe(2);
+    expect(sshCalls).toBe(1);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
     expect(observedStatuses).toEqual([
@@ -709,6 +707,62 @@ describe("VM Effect workflows", () => {
       vmId: vm.id,
       metadata: { credentialKind: "password" },
     });
+  });
+
+  test("openAttachEndpoint recovers when the VM suspends between preflight and minting", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000112",
+      userId: "user-workflow-attach-race",
+      billingTeamId: "team-workflow-attach-race",
+      providerVmId: "provider-vm-attach-race",
+      status: "running",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const leases: RecordedLease[] = [];
+    const observedStatuses: ObservedStatusUpdate[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, leases, observedStatuses });
+    const originalError = providerOperationError("openAttach", "provider attach unavailable");
+    const endpoint = testAttachEndpoint();
+    let attachCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      openAttach: () =>
+        Effect.suspend(() => {
+          attachCalls += 1;
+          if (attachCalls === 1) return Effect.fail(originalError);
+          return Effect.succeed(endpoint);
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          // Running at preflight, paused when the mint failure is investigated.
+          return statusCalls === 1 ? ("running" as const) : ("paused" as const);
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-attach-race" });
+        }),
+    };
+
+    const result = await Effect.runPromise(
+      openAttachEndpoint({
+        userId: "user-workflow-attach-race",
+        providerVmId: "provider-vm-attach-race",
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(result).toEqual(endpoint);
+    expect(attachCalls).toBe(2);
+    expect(statusCalls).toBe(2);
+    expect(resumeCalls).toBe(1);
+    expect(observedStatuses).toEqual([
+      { id: vm.id, providerVmId: "provider-vm-attach-race", status: "running" },
+    ]);
+    expect(leases).toHaveLength(1);
+    expect(usageEvents).toHaveLength(1);
   });
 
   dbTest("does not block create when usage event recording fails", async () => {

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -861,6 +861,56 @@ describe("VM Effect workflows", () => {
     ]);
   });
 
+  test("exec waits out a concurrent resume (creating) without resuming or recording", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000115",
+      userId: "user-workflow-exec-concurrent",
+      billingTeamId: "team-workflow-exec-concurrent",
+      providerVmId: "provider-vm-exec-concurrent",
+      status: "paused",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const observedStatuses: ObservedStatusUpdate[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, observedStatuses });
+    let execCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      exec: () =>
+        Effect.suspend(() => {
+          execCalls += 1;
+          return Effect.succeed({ exitCode: 0, stdout: "ok", stderr: "" });
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          // Another caller's resume is in flight; it settles on the next poll.
+          return statusCalls === 1 ? ("creating" as const) : ("running" as const);
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-exec-concurrent" });
+        }),
+    };
+
+    const result = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-concurrent",
+        providerVmId: "provider-vm-exec-concurrent",
+        command: "echo ok",
+        timeoutMs: 1000,
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(execCalls).toBe(1);
+    expect(resumeCalls).toBe(0);
+    expect(statusCalls).toBe(2);
+    expect(observedStatuses).toEqual([]);
+  });
+
   dbTest("does not block create when usage event recording fails", async () => {
     const requested = testCloudVmRow({
       status: "provisioning",

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -92,7 +92,8 @@ describe("VM Effect workflows", () => {
       status: "running",
     });
     const usageEvents: RecordedUsageEvent[] = [];
-    const repo = testWorkflowRepo({ vm, usageEvents });
+    const observedStatuses: Array<{ id: string; providerVmId: string; status: string }> = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, observedStatuses });
     const originalError = providerOperationError("exec", "provider exec unavailable");
     let execCalls = 0;
     let statusCalls = 0;
@@ -130,6 +131,9 @@ describe("VM Effect workflows", () => {
     expect(execCalls).toBe(2);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
+    expect(observedStatuses).toEqual([
+      { id: vm.id, providerVmId: "provider-vm-exec-resume", status: "running" },
+    ]);
     expect(usageEvents).toHaveLength(1);
     expect(usageEvents[0]).toMatchObject({
       eventType: "vm.exec",
@@ -1820,6 +1824,7 @@ function testWorkflowRepo(input: {
   readonly vm: CloudVmRow;
   readonly usageEvents?: RecordedUsageEvent[];
   readonly leases?: RecordedLease[];
+  readonly observedStatuses?: Array<{ id: string; providerVmId: string; status: string }>;
 }): VmRepositoryShape {
   return {
     listUserVms: () => Effect.succeed([]),
@@ -1828,7 +1833,11 @@ function testWorkflowRepo(input: {
     deleteBillingGrant: () => Effect.void,
     beginCreate: () => unusedDatabaseEffect("beginCreate"),
     activeLimitCandidates: () => Effect.succeed([]),
-    markProviderObservedStatus: () => Effect.succeed(false),
+    markProviderObservedStatus: (update) =>
+      Effect.sync(() => {
+        input.observedStatuses?.push(update);
+        return true;
+      }),
     markCreateRunning: () => unusedDatabaseEffect("markCreateRunning"),
     markCreateFailed: () => Effect.void,
     findUserVm: ({ userId, providerVmId }) =>

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -40,6 +40,7 @@ let sql: Sql | null = null;
 
 type RecordedUsageEvent = Parameters<VmRepositoryShape["recordUsageEvent"]>[0];
 type RecordedLease = Parameters<VmRepositoryShape["recordLease"]>[0];
+type ObservedStatusUpdate = Parameters<VmRepositoryShape["markProviderObservedStatus"]>[0];
 
 function databaseURL() {
   const url = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
@@ -92,9 +93,9 @@ describe("VM Effect workflows", () => {
       status: "running",
     });
     const usageEvents: RecordedUsageEvent[] = [];
-    const observedStatuses: Array<{ id: string; providerVmId: string; status: string }> = [];
+    const observedStatuses: ObservedStatusUpdate[] = [];
     const repo = testWorkflowRepo({ vm, usageEvents, observedStatuses });
-    const originalError = providerOperationError("exec", "provider exec unavailable");
+    const callOrder: string[] = [];
     let execCalls = 0;
     let statusCalls = 0;
     let resumeCalls = 0;
@@ -103,17 +104,19 @@ describe("VM Effect workflows", () => {
       exec: () =>
         Effect.suspend(() => {
           execCalls += 1;
-          if (execCalls === 1) return Effect.fail(originalError);
-          return Effect.succeed({ exitCode: 7, stdout: "retried", stderr: "" });
+          callOrder.push("exec");
+          return Effect.succeed({ exitCode: 7, stdout: "preflight", stderr: "" });
         }),
       getStatus: () =>
         Effect.sync(() => {
           statusCalls += 1;
+          callOrder.push("getStatus");
           return "paused" as const;
         }),
       resume: () =>
         Effect.sync(() => {
           resumeCalls += 1;
+          callOrder.push("resume");
           return testVmHandle({ providerVmId: "provider-vm-exec-resume" });
         }),
     };
@@ -122,15 +125,16 @@ describe("VM Effect workflows", () => {
       execVm({
         userId: "user-workflow-exec-resume",
         providerVmId: "provider-vm-exec-resume",
-        command: "echo retried",
+        command: "echo preflight",
         timeoutMs: 1000,
       }).pipe(Effect.provide(workflowLayer(repo, provider))),
     );
 
-    expect(result).toEqual({ exitCode: 7, stdout: "retried", stderr: "" });
-    expect(execCalls).toBe(2);
+    expect(result).toEqual({ exitCode: 7, stdout: "preflight", stderr: "" });
+    expect(execCalls).toBe(1);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
+    expect(callOrder).toEqual(["getStatus", "resume", "exec"]);
     expect(observedStatuses).toEqual([
       { id: vm.id, providerVmId: "provider-vm-exec-resume", status: "running" },
     ]);
@@ -138,7 +142,7 @@ describe("VM Effect workflows", () => {
     expect(usageEvents[0]).toMatchObject({
       eventType: "vm.exec",
       vmId: vm.id,
-      metadata: { commandLength: "echo retried".length, exitCode: 7 },
+      metadata: { commandLength: "echo preflight".length, exitCode: 7 },
     });
   });
 
@@ -190,7 +194,7 @@ describe("VM Effect workflows", () => {
     expect(usageEvents).toHaveLength(0);
   });
 
-  test("exec failure where resume also fails propagates the original exec error", async () => {
+  test("exec preflight resume failure propagates the resume error without exec", async () => {
     const vm = testCloudVmRow({
       id: "00000000-0000-4000-8000-000000000103",
       userId: "user-workflow-exec-resume-fails",
@@ -198,7 +202,6 @@ describe("VM Effect workflows", () => {
       status: "running",
     });
     const repo = testWorkflowRepo({ vm });
-    const originalError = providerOperationError("exec", "provider exec unavailable");
     const resumeError = providerOperationError("resume", "provider resume unavailable");
     let execCalls = 0;
     let statusCalls = 0;
@@ -208,7 +211,7 @@ describe("VM Effect workflows", () => {
       exec: () =>
         Effect.suspend(() => {
           execCalls += 1;
-          return Effect.fail(originalError);
+          return Effect.succeed({ exitCode: 0, stdout: "", stderr: "" });
         }),
       getStatus: () =>
         Effect.sync(() => {
@@ -231,8 +234,56 @@ describe("VM Effect workflows", () => {
       }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
-    expect(error).toBe(originalError);
-    expect(execCalls).toBe(1);
+    expect(error).toBe(resumeError);
+    expect(execCalls).toBe(0);
+    expect(statusCalls).toBe(1);
+    expect(resumeCalls).toBe(1);
+  });
+
+  test("exec preflight fails with VmNotFoundError when resumed status persistence updates no row", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000112",
+      userId: "user-workflow-exec-mark-false",
+      providerVmId: "provider-vm-exec-mark-false",
+      status: "running",
+    });
+    const repo = testWorkflowRepo({
+      vm,
+      markProviderObservedStatus: () => Effect.succeed(false),
+    });
+    let execCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      exec: () =>
+        Effect.sync(() => {
+          execCalls += 1;
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          return "paused" as const;
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-exec-mark-false" });
+        }),
+    };
+
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-mark-false",
+        providerVmId: "provider-vm-exec-mark-false",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(error).toBeInstanceOf(VmNotFoundError);
+    expect(execCalls).toBe(0);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
   });
@@ -317,6 +368,102 @@ describe("VM Effect workflows", () => {
     expect(usageEvents).toHaveLength(0);
   });
 
+  test("exec failure is not retried even if a later status check would report paused", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000108",
+      userId: "user-workflow-exec-no-replay",
+      providerVmId: "provider-vm-exec-no-replay",
+      status: "running",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents });
+    const originalError = providerOperationError("exec", "provider exec response dropped");
+    let execCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      exec: () =>
+        Effect.suspend(() => {
+          execCalls += 1;
+          return Effect.fail(originalError);
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          if (statusCalls === 1) return "running" as const;
+          return "paused" as const;
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-exec-no-replay" });
+        }),
+    };
+
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-no-replay",
+        providerVmId: "provider-vm-exec-no-replay",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(error).toBe(originalError);
+    expect(execCalls).toBe(1);
+    expect(statusCalls).toBe(1);
+    expect(resumeCalls).toBe(0);
+    expect(usageEvents).toHaveLength(0);
+  });
+
+  test("exec preflight getStatus failure still attempts exec once", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000109",
+      userId: "user-workflow-exec-status-fails",
+      providerVmId: "provider-vm-exec-status-fails",
+      status: "running",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents });
+    let execCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      exec: () =>
+        Effect.sync(() => {
+          execCalls += 1;
+          return { exitCode: 0, stdout: "ok", stderr: "" };
+        }),
+      getStatus: () =>
+        Effect.suspend(() => {
+          statusCalls += 1;
+          return Effect.fail(providerOperationError("getStatus", "status unavailable"));
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-exec-status-fails" });
+        }),
+    };
+
+    const result = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-status-fails",
+        providerVmId: "provider-vm-exec-status-fails",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(result).toEqual({ exitCode: 0, stdout: "ok", stderr: "" });
+    expect(execCalls).toBe(1);
+    expect(statusCalls).toBe(1);
+    expect(resumeCalls).toBe(0);
+    expect(usageEvents).toHaveLength(1);
+  });
+
   test("openAttachEndpoint resumes a paused VM and retries attach once", async () => {
     const vm = testCloudVmRow({
       id: "00000000-0000-4000-8000-000000000105",
@@ -327,7 +474,8 @@ describe("VM Effect workflows", () => {
     });
     const usageEvents: RecordedUsageEvent[] = [];
     const leases: RecordedLease[] = [];
-    const repo = testWorkflowRepo({ vm, usageEvents, leases });
+    const observedStatuses: ObservedStatusUpdate[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, leases, observedStatuses });
     const originalError = providerOperationError("openAttach", "provider attach unavailable");
     const endpoint = testAttachEndpoint();
     let attachCalls = 0;
@@ -365,6 +513,9 @@ describe("VM Effect workflows", () => {
     expect(attachCalls).toBe(2);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
+    expect(observedStatuses).toEqual([
+      { id: vm.id, providerVmId: "provider-vm-attach-resume", status: "running" },
+    ]);
     expect(leases).toHaveLength(1);
     expect(usageEvents).toHaveLength(1);
     expect(usageEvents[0]).toMatchObject({
@@ -372,6 +523,120 @@ describe("VM Effect workflows", () => {
       vmId: vm.id,
       metadata: { transport: "websocket", requireDaemon: true, daemonAvailable: false },
     });
+  });
+
+  test("openAttachEndpoint fails when resumed status persistence fails", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000110",
+      userId: "user-workflow-attach-mark-fails",
+      billingTeamId: "team-workflow-attach-mark-fails",
+      providerVmId: "provider-vm-attach-mark-fails",
+      status: "running",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const leases: RecordedLease[] = [];
+    const markError = new VmDatabaseError({
+      operation: "markProviderObservedStatus",
+      cause: new Error("database unavailable"),
+    });
+    const repo = testWorkflowRepo({
+      vm,
+      usageEvents,
+      leases,
+      markProviderObservedStatus: () => Effect.fail(markError),
+    });
+    const originalError = providerOperationError("openAttach", "provider attach unavailable");
+    let attachCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      openAttach: () =>
+        Effect.suspend(() => {
+          attachCalls += 1;
+          if (attachCalls === 1) return Effect.fail(originalError);
+          return Effect.succeed(testAttachEndpoint());
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          return "paused" as const;
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-attach-mark-fails" });
+        }),
+    };
+
+    const error = await Effect.runPromise(
+      openAttachEndpoint({
+        userId: "user-workflow-attach-mark-fails",
+        providerVmId: "provider-vm-attach-mark-fails",
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(error).toBe(markError);
+    expect(attachCalls).toBe(1);
+    expect(statusCalls).toBe(1);
+    expect(resumeCalls).toBe(1);
+    expect(leases).toHaveLength(0);
+    expect(usageEvents).toHaveLength(0);
+  });
+
+  test("openAttachEndpoint fails with original error when resumed status persistence updates no row", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000111",
+      userId: "user-workflow-attach-mark-false",
+      billingTeamId: "team-workflow-attach-mark-false",
+      providerVmId: "provider-vm-attach-mark-false",
+      status: "running",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const leases: RecordedLease[] = [];
+    const repo = testWorkflowRepo({
+      vm,
+      usageEvents,
+      leases,
+      markProviderObservedStatus: () => Effect.succeed(false),
+    });
+    const originalError = providerOperationError("openAttach", "provider attach unavailable");
+    let attachCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      openAttach: () =>
+        Effect.suspend(() => {
+          attachCalls += 1;
+          if (attachCalls === 1) return Effect.fail(originalError);
+          return Effect.succeed(testAttachEndpoint());
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          return "paused" as const;
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-attach-mark-false" });
+        }),
+    };
+
+    const error = await Effect.runPromise(
+      openAttachEndpoint({
+        userId: "user-workflow-attach-mark-false",
+        providerVmId: "provider-vm-attach-mark-false",
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(error).toBe(originalError);
+    expect(attachCalls).toBe(1);
+    expect(statusCalls).toBe(1);
+    expect(resumeCalls).toBe(1);
+    expect(leases).toHaveLength(0);
+    expect(usageEvents).toHaveLength(0);
   });
 
   test("openSshEndpoint resumes a paused VM and retries SSH endpoint minting once", async () => {
@@ -384,7 +649,8 @@ describe("VM Effect workflows", () => {
     });
     const usageEvents: RecordedUsageEvent[] = [];
     const leases: RecordedLease[] = [];
-    const repo = testWorkflowRepo({ vm, usageEvents, leases });
+    const observedStatuses: ObservedStatusUpdate[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, leases, observedStatuses });
     const originalError = providerOperationError("openSSH", "provider ssh unavailable");
     const endpoint = testSshEndpoint();
     let sshCalls = 0;
@@ -421,6 +687,9 @@ describe("VM Effect workflows", () => {
     expect(sshCalls).toBe(2);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
+    expect(observedStatuses).toEqual([
+      { id: vm.id, providerVmId: "provider-vm-ssh-resume", status: "running" },
+    ]);
     expect(leases).toHaveLength(1);
     expect(usageEvents).toHaveLength(1);
     expect(usageEvents[0]).toMatchObject({
@@ -1824,7 +2093,10 @@ function testWorkflowRepo(input: {
   readonly vm: CloudVmRow;
   readonly usageEvents?: RecordedUsageEvent[];
   readonly leases?: RecordedLease[];
-  readonly observedStatuses?: Array<{ id: string; providerVmId: string; status: string }>;
+  readonly observedStatuses?: ObservedStatusUpdate[];
+  readonly markProviderObservedStatus?: (
+    update: ObservedStatusUpdate,
+  ) => Effect.Effect<boolean, VmDatabaseError>;
 }): VmRepositoryShape {
   return {
     listUserVms: () => Effect.succeed([]),
@@ -1834,10 +2106,12 @@ function testWorkflowRepo(input: {
     beginCreate: () => unusedDatabaseEffect("beginCreate"),
     activeLimitCandidates: () => Effect.succeed([]),
     markProviderObservedStatus: (update) =>
-      Effect.sync(() => {
-        input.observedStatuses?.push(update);
-        return true;
-      }),
+      input.markProviderObservedStatus
+        ? input.markProviderObservedStatus(update)
+        : Effect.sync(() => {
+          input.observedStatuses?.push(update);
+          return true;
+        }),
     markCreateRunning: () => unusedDatabaseEffect("markCreateRunning"),
     markCreateFailed: () => Effect.void,
     findUserVm: ({ userId, providerVmId }) =>

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -9,6 +9,7 @@ import {
   noOpVmBillingGateway,
   type VmBillingGatewayShape,
 } from "../services/vms/billingGateway";
+import type { AttachEndpoint, SSHEndpoint, VMHandle } from "../services/vms/drivers";
 import { VmProviderGateway, type VmProviderGatewayShape } from "../services/vms/providerGateway";
 import {
   VmRepository,
@@ -37,6 +38,9 @@ const dbTest = runDbTests ? test : test.skip;
 
 let sql: Sql | null = null;
 
+type RecordedUsageEvent = Parameters<VmRepositoryShape["recordUsageEvent"]>[0];
+type RecordedLease = Parameters<VmRepositoryShape["recordLease"]>[0];
+
 function databaseURL() {
   const url = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
   if (!url) {
@@ -56,6 +60,18 @@ function providerLayer(
   );
 }
 
+function workflowLayer(
+  repo: VmRepositoryShape,
+  provider: VmProviderGatewayShape,
+  billing: VmBillingGatewayShape = noOpVmBillingGateway(),
+) {
+  return Layer.mergeAll(
+    Layer.succeed(VmRepository, repo),
+    Layer.succeed(VmProviderGateway, provider),
+    Layer.succeed(VmBillingGateway, billing),
+  );
+}
+
 beforeAll(() => {
   if (!runDbTests) return;
   sql = postgres(databaseURL(), { max: 1 });
@@ -67,6 +83,349 @@ afterAll(async () => {
 });
 
 describe("VM Effect workflows", () => {
+  test("exec resumes a paused VM, retries once, and records one usage event", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000101",
+      userId: "user-workflow-exec-resume",
+      billingTeamId: "team-workflow-exec-resume",
+      providerVmId: "provider-vm-exec-resume",
+      status: "running",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents });
+    const originalError = providerOperationError("exec", "provider exec unavailable");
+    let execCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      exec: () =>
+        Effect.suspend(() => {
+          execCalls += 1;
+          if (execCalls === 1) return Effect.fail(originalError);
+          return Effect.succeed({ exitCode: 7, stdout: "retried", stderr: "" });
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          return "paused" as const;
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-exec-resume" });
+        }),
+    };
+
+    const result = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-resume",
+        providerVmId: "provider-vm-exec-resume",
+        command: "echo retried",
+        timeoutMs: 1000,
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(result).toEqual({ exitCode: 7, stdout: "retried", stderr: "" });
+    expect(execCalls).toBe(2);
+    expect(statusCalls).toBe(1);
+    expect(resumeCalls).toBe(1);
+    expect(usageEvents).toHaveLength(1);
+    expect(usageEvents[0]).toMatchObject({
+      eventType: "vm.exec",
+      vmId: vm.id,
+      metadata: { commandLength: "echo retried".length, exitCode: 7 },
+    });
+  });
+
+  test("exec failure with running provider status propagates the original error without retry", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000102",
+      userId: "user-workflow-exec-running",
+      providerVmId: "provider-vm-exec-running",
+      status: "running",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents });
+    const originalError = providerOperationError("exec", "provider exec unavailable");
+    let execCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      exec: () =>
+        Effect.suspend(() => {
+          execCalls += 1;
+          return Effect.fail(originalError);
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          return "running" as const;
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-exec-running" });
+        }),
+    };
+
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-running",
+        providerVmId: "provider-vm-exec-running",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(error).toBe(originalError);
+    expect(execCalls).toBe(1);
+    expect(statusCalls).toBe(1);
+    expect(resumeCalls).toBe(0);
+    expect(usageEvents).toHaveLength(0);
+  });
+
+  test("exec failure where resume also fails propagates the original exec error", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000103",
+      userId: "user-workflow-exec-resume-fails",
+      providerVmId: "provider-vm-exec-resume-fails",
+      status: "running",
+    });
+    const repo = testWorkflowRepo({ vm });
+    const originalError = providerOperationError("exec", "provider exec unavailable");
+    const resumeError = providerOperationError("resume", "provider resume unavailable");
+    let execCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      exec: () =>
+        Effect.suspend(() => {
+          execCalls += 1;
+          return Effect.fail(originalError);
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          return "paused" as const;
+        }),
+      resume: () =>
+        Effect.suspend(() => {
+          resumeCalls += 1;
+          return Effect.fail(resumeError);
+        }),
+    };
+
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-resume-fails",
+        providerVmId: "provider-vm-exec-resume-fails",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(error).toBe(originalError);
+    expect(execCalls).toBe(1);
+    expect(statusCalls).toBe(1);
+    expect(resumeCalls).toBe(1);
+  });
+
+  test("exec failure without gateway getStatus propagates the original error", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000104",
+      userId: "user-workflow-exec-no-status",
+      providerVmId: "provider-vm-exec-no-status",
+      status: "running",
+    });
+    const repo = testWorkflowRepo({ vm });
+    const originalError = providerOperationError("exec", "provider exec unavailable");
+    let execCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      exec: () =>
+        Effect.suspend(() => {
+          execCalls += 1;
+          return Effect.fail(originalError);
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-exec-no-status" });
+        }),
+    };
+
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-no-status",
+        providerVmId: "provider-vm-exec-no-status",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(error).toBe(originalError);
+    expect(execCalls).toBe(1);
+    expect(resumeCalls).toBe(0);
+  });
+
+  test("exec failure without gateway resume skips recovery and propagates the original error", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000107",
+      userId: "user-workflow-exec-no-resume",
+      providerVmId: "provider-vm-exec-no-resume",
+      status: "running",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents });
+    const originalError = providerOperationError("exec", "provider exec unavailable");
+    let execCalls = 0;
+    let statusCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      exec: () =>
+        Effect.suspend(() => {
+          execCalls += 1;
+          return Effect.fail(originalError);
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          return "paused" as const;
+        }),
+    };
+
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-no-resume",
+        providerVmId: "provider-vm-exec-no-resume",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(error).toBe(originalError);
+    expect(execCalls).toBe(1);
+    expect(statusCalls).toBe(0);
+    expect(usageEvents).toHaveLength(0);
+  });
+
+  test("openAttachEndpoint resumes a paused VM and retries attach once", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000105",
+      userId: "user-workflow-attach-resume",
+      billingTeamId: "team-workflow-attach-resume",
+      providerVmId: "provider-vm-attach-resume",
+      status: "running",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const leases: RecordedLease[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, leases });
+    const originalError = providerOperationError("openAttach", "provider attach unavailable");
+    const endpoint = testAttachEndpoint();
+    let attachCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      openAttach: () =>
+        Effect.suspend(() => {
+          attachCalls += 1;
+          if (attachCalls === 1) return Effect.fail(originalError);
+          return Effect.succeed(endpoint);
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          return "paused" as const;
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-attach-resume" });
+        }),
+    };
+
+    const result = await Effect.runPromise(
+      openAttachEndpoint({
+        userId: "user-workflow-attach-resume",
+        providerVmId: "provider-vm-attach-resume",
+        options: { requireDaemon: true },
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(result).toEqual(endpoint);
+    expect(attachCalls).toBe(2);
+    expect(statusCalls).toBe(1);
+    expect(resumeCalls).toBe(1);
+    expect(leases).toHaveLength(1);
+    expect(usageEvents).toHaveLength(1);
+    expect(usageEvents[0]).toMatchObject({
+      eventType: "vm.attach",
+      vmId: vm.id,
+      metadata: { transport: "websocket", requireDaemon: true, daemonAvailable: false },
+    });
+  });
+
+  test("openSshEndpoint resumes a paused VM and retries SSH endpoint minting once", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000106",
+      userId: "user-workflow-ssh-resume",
+      billingTeamId: "team-workflow-ssh-resume",
+      providerVmId: "provider-vm-ssh-resume",
+      status: "running",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const leases: RecordedLease[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, leases });
+    const originalError = providerOperationError("openSSH", "provider ssh unavailable");
+    const endpoint = testSshEndpoint();
+    let sshCalls = 0;
+    let statusCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      openSSH: () =>
+        Effect.suspend(() => {
+          sshCalls += 1;
+          if (sshCalls === 1) return Effect.fail(originalError);
+          return Effect.succeed(endpoint);
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          return "paused" as const;
+        }),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-ssh-resume" });
+        }),
+    };
+
+    const result = await Effect.runPromise(
+      openSshEndpoint({
+        userId: "user-workflow-ssh-resume",
+        providerVmId: "provider-vm-ssh-resume",
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(result).toEqual(endpoint);
+    expect(sshCalls).toBe(2);
+    expect(statusCalls).toBe(1);
+    expect(resumeCalls).toBe(1);
+    expect(leases).toHaveLength(1);
+    expect(usageEvents).toHaveLength(1);
+    expect(usageEvents[0]).toMatchObject({
+      eventType: "vm.ssh_endpoint",
+      vmId: vm.id,
+      metadata: { credentialKind: "password" },
+    });
+  });
+
   dbTest("does not block create when usage event recording fails", async () => {
     const requested = testCloudVmRow({
       status: "provisioning",
@@ -1454,6 +1813,109 @@ function testCloudVmRow(overrides: Partial<CloudVmRow> = {}): CloudVmRow {
     failureCode: null,
     failureMessage: null,
     ...overrides,
+  };
+}
+
+function testWorkflowRepo(input: {
+  readonly vm: CloudVmRow;
+  readonly usageEvents?: RecordedUsageEvent[];
+  readonly leases?: RecordedLease[];
+}): VmRepositoryShape {
+  return {
+    listUserVms: () => Effect.succeed([]),
+    claimBillingGrant: () => Effect.succeed({ kind: "already_claimed" }),
+    markBillingGrantApplied: () => Effect.void,
+    deleteBillingGrant: () => Effect.void,
+    beginCreate: () => unusedDatabaseEffect("beginCreate"),
+    activeLimitCandidates: () => Effect.succeed([]),
+    markProviderObservedStatus: () => Effect.succeed(false),
+    markCreateRunning: () => unusedDatabaseEffect("markCreateRunning"),
+    markCreateFailed: () => Effect.void,
+    findUserVm: ({ userId, providerVmId }) =>
+      Effect.succeed(
+        input.vm.userId === userId && input.vm.providerVmId === providerVmId
+          ? input.vm
+          : null,
+      ),
+    markDestroyed: () => Effect.void,
+    recordLease: (lease) =>
+      Effect.sync(() => {
+        input.leases?.push(lease);
+      }),
+    activeIdentityLeases: () => Effect.succeed([]),
+    markLeasesRevoked: () => Effect.void,
+    recordUsageEvent: (event) =>
+      Effect.sync(() => {
+        input.usageEvents?.push(event);
+      }),
+    recordUsageEvents: (events) =>
+      Effect.sync(() => {
+        input.usageEvents?.push(...events);
+      }),
+  };
+}
+
+function unusedProviderGateway(): VmProviderGatewayShape {
+  return {
+    create: () => unusedProviderEffect("create"),
+    destroy: () => Effect.void,
+    exec: () => unusedProviderEffect("exec"),
+    openAttach: () => unusedProviderEffect("openAttach"),
+    openSSH: () => unusedProviderEffect("openSSH"),
+    revokeSSHIdentity: () => Effect.void,
+  };
+}
+
+function unusedDatabaseEffect<A>(operation: string): Effect.Effect<A, VmDatabaseError> {
+  return Effect.fail(new VmDatabaseError({
+    operation,
+    cause: new Error(`${operation} should not be called`),
+  }));
+}
+
+function unusedProviderEffect<A>(operation: string): Effect.Effect<A, VmProviderOperationError> {
+  return Effect.fail(providerOperationError(operation, `${operation} should not be called`));
+}
+
+function providerOperationError(operation: string, message: string): VmProviderOperationError {
+  return new VmProviderOperationError({
+    provider: "freestyle",
+    operation,
+    cause: new Error(message),
+  });
+}
+
+function testVmHandle(overrides: Partial<VMHandle> = {}): VMHandle {
+  return {
+    provider: "freestyle",
+    providerVmId: "provider-vm-test",
+    status: "running",
+    image: "snapshot-test",
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function testAttachEndpoint(): AttachEndpoint {
+  return {
+    transport: "websocket",
+    url: "wss://example.invalid/pty",
+    headers: {},
+    token: "pty-token",
+    sessionId: "pty-session",
+    expiresAtUnix: Math.floor(Date.now() / 1000) + 300,
+  };
+}
+
+function testSshEndpoint(): SSHEndpoint {
+  return {
+    transport: "ssh",
+    host: "vm-ssh.freestyle.sh",
+    port: 22,
+    username: "provider-vm-ssh-resume+cmux",
+    publicKeyFingerprint: null,
+    credential: { kind: "password", value: "token" },
+    identityHandle: "identity-ssh-resume",
   };
 }
 

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -908,7 +908,11 @@ describe("VM Effect workflows", () => {
     expect(execCalls).toBe(1);
     expect(resumeCalls).toBe(0);
     expect(statusCalls).toBe(2);
-    expect(observedStatuses).toEqual([]);
+    // The waiter persists the observed running state itself in case the
+    // resuming caller dies before its own durable write.
+    expect(observedStatuses).toEqual([
+      { id: vm.id, providerVmId: "provider-vm-exec-concurrent", status: "running" },
+    ]);
   });
 
   dbTest("does not block create when usage event recording fails", async () => {

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -808,6 +808,59 @@ describe("VM Effect workflows", () => {
     expect(usageEvents).toHaveLength(0);
   });
 
+  test("exec waits for a not-yet-running resume handle to settle before running", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000114",
+      userId: "user-workflow-exec-settle",
+      billingTeamId: "team-workflow-exec-settle",
+      providerVmId: "provider-vm-exec-settle",
+      status: "paused",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const observedStatuses: ObservedStatusUpdate[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, observedStatuses });
+    let execCalls = 0;
+    let statusCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      exec: () =>
+        Effect.suspend(() => {
+          execCalls += 1;
+          return Effect.succeed({ exitCode: 0, stdout: "ok", stderr: "" });
+        }),
+      getStatus: () =>
+        Effect.sync(() => {
+          statusCalls += 1;
+          // Preflight probe sees paused; the settle poll after resume sees running.
+          return statusCalls === 1 ? ("paused" as const) : ("running" as const);
+        }),
+      resume: () =>
+        Effect.succeed({
+          provider: "freestyle" as const,
+          providerVmId: "provider-vm-exec-settle",
+          status: "creating" as const,
+          image: "freestyle:resumed",
+          createdAt: Date.now(),
+        }),
+    };
+
+    const result = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-settle",
+        providerVmId: "provider-vm-exec-settle",
+        command: "echo ok",
+        timeoutMs: 1000,
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(execCalls).toBe(1);
+    expect(statusCalls).toBe(2);
+    expect(observedStatuses).toEqual([
+      { id: vm.id, providerVmId: "provider-vm-exec-settle", status: "running" },
+    ]);
+  });
+
   dbTest("does not block create when usage event recording fails", async () => {
     const requested = testCloudVmRow({
       status: "provisioning",

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -765,6 +765,49 @@ describe("VM Effect workflows", () => {
     expect(usageEvents).toHaveLength(1);
   });
 
+  test("openAttachEndpoint fails closed when the row is paused and the status probe fails", async () => {
+    const vm = testCloudVmRow({
+      id: "00000000-0000-4000-8000-000000000113",
+      userId: "user-workflow-attach-probe-fail",
+      billingTeamId: "team-workflow-attach-probe-fail",
+      providerVmId: "provider-vm-attach-probe-fail",
+      status: "paused",
+    });
+    const usageEvents: RecordedUsageEvent[] = [];
+    const leases: RecordedLease[] = [];
+    const repo = testWorkflowRepo({ vm, usageEvents, leases });
+    const probeError = providerOperationError("getStatus", "provider status unavailable");
+    let attachCalls = 0;
+    let resumeCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      ...unusedProviderGateway(),
+      openAttach: () =>
+        Effect.suspend(() => {
+          attachCalls += 1;
+          return Effect.succeed(testAttachEndpoint());
+        }),
+      getStatus: () => Effect.fail(probeError),
+      resume: () =>
+        Effect.sync(() => {
+          resumeCalls += 1;
+          return testVmHandle({ providerVmId: "provider-vm-attach-probe-fail" });
+        }),
+    };
+
+    const error = await Effect.runPromise(
+      openAttachEndpoint({
+        userId: "user-workflow-attach-probe-fail",
+        providerVmId: "provider-vm-attach-probe-fail",
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+    );
+
+    expect(error).toBe(probeError);
+    expect(attachCalls).toBe(0);
+    expect(resumeCalls).toBe(0);
+    expect(leases).toHaveLength(0);
+    expect(usageEvents).toHaveLength(0);
+  });
+
   dbTest("does not block create when usage event recording fails", async () => {
     const requested = testCloudVmRow({
       status: "provisioning",

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -548,6 +548,7 @@ describe("VM Effect workflows", () => {
     const originalError = providerOperationError("openAttach", "provider attach unavailable");
     let attachCalls = 0;
     let statusCalls = 0;
+    let pauseCalls = 0;
     let resumeCalls = 0;
     const provider: VmProviderGatewayShape = {
       ...unusedProviderGateway(),
@@ -567,6 +568,10 @@ describe("VM Effect workflows", () => {
           resumeCalls += 1;
           return testVmHandle({ providerVmId: "provider-vm-attach-mark-fails" });
         }),
+      pause: () =>
+        Effect.sync(() => {
+          pauseCalls += 1;
+        }),
     };
 
     const error = await Effect.runPromise(
@@ -580,6 +585,7 @@ describe("VM Effect workflows", () => {
     expect(attachCalls).toBe(1);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
+    expect(pauseCalls).toBe(1);
     expect(leases).toHaveLength(0);
     expect(usageEvents).toHaveLength(0);
   });
@@ -603,6 +609,7 @@ describe("VM Effect workflows", () => {
     const originalError = providerOperationError("openAttach", "provider attach unavailable");
     let attachCalls = 0;
     let statusCalls = 0;
+    let pauseCalls = 0;
     let resumeCalls = 0;
     const provider: VmProviderGatewayShape = {
       ...unusedProviderGateway(),
@@ -622,6 +629,10 @@ describe("VM Effect workflows", () => {
           resumeCalls += 1;
           return testVmHandle({ providerVmId: "provider-vm-attach-mark-false" });
         }),
+      pause: () =>
+        Effect.sync(() => {
+          pauseCalls += 1;
+        }),
     };
 
     const error = await Effect.runPromise(
@@ -635,6 +646,7 @@ describe("VM Effect workflows", () => {
     expect(attachCalls).toBe(1);
     expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
+    expect(pauseCalls).toBe(1);
     expect(leases).toHaveLength(0);
     expect(usageEvents).toHaveLength(0);
   });


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/7381.

Freestyle suspends idle Cloud VMs ~10 seconds after network inactivity, and its exec endpoint does not auto-resume, so every `cmux cloud exec`/`shell`/`attach` against an idle VM failed with 502 `vm_cloud_service_unavailable` (an agent trial hit a 100% exec failure rate across two fresh VMs) while plain SSH worked because Freestyle's SSH gateway resumes on connect.

`withResumeOnSuspended` in `web/services/vms/workflows.ts` runs the provider op optimistically (zero added provider RPCs on the happy path); on failure it checks gateway `getStatus`, and only a `paused` VM triggers gateway `resume` plus exactly one retry. The original error propagates unchanged when the gateway lacks `getStatus`/`resume`, the VM isn't paused, or resume itself fails. `resume` is exposed on `VmProviderGatewayShape` mirroring `getStatus`, so tests exercise the same seam production takes. Applied to `execVm`, `openAttachEndpoint`, and `openSshEndpoint`; usage events unchanged (recorded once after final success).

Two-commit structure: the first commit adds the regression tests only (red without the fix), the second adds the fix. Two /fable judge rounds reviewed the diff (round 1 APPROVE with a gateway-seam cleanup, round 2 verified inline). `bun test tests/vm-workflows.test.ts` 28 tests 0 fail, `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785810827&installation_id=133855650&pr_number=7388&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7388&signature=d018fd37d8b72b09be32f028f7c953c7571becb029c99c00e64c3c6cf57357ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core VM lifecycle paths (state sync, billing limits, credential minting) with compensating pause rollback; behavior is heavily tested but race and provider edge cases remain possible.
> 
> **Overview**
> Fixes idle Freestyle VMs failing **exec** / **attach** / **SSH** when the provider has suspended them but Postgres still shows **paused** or **running**.
> 
> **`VmProviderGateway`** gains optional **`resume`** and **`pause`**, wired through the live gateway like **`getStatus`**.
> 
> **`execVm`**, **`openAttachEndpoint`**, and **`openSshEndpoint`** now run a **preflight** path: probe provider status (with timeouts), **resume** when **paused**, poll until **running**, and **`markProviderObservedStatus`** before continuing. Attach/SSH run preflight **before** revoking identities so a failed resume does not strand credentials. Attach/SSH also wrap minting in **`withResumeOnSuspendedAfterFailure`** for a single retry if the VM suspends between preflight and mint. Failed durable writes trigger **best-effort pause** rollback so running VMs are not invisible to active-limit accounting. **Exec** does not retry on exec failure.
> 
> Adds broad **workflow unit tests** with mock repo/provider layers for resume, settle, concurrent **creating**, fail-closed probes, and persistence failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b192932b155a43afc65d83cf7e17b64d5b54ee66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-resume paused Cloud VMs for exec, attach, and SSH with preflight status checks, short timeouts, and durable running-state updates. We also record externally resumed VMs observed as running during preflight to keep active-limit accounting correct.

- **Bug Fixes**
  - Preflight: `getStatus` (5s). If `paused`, call `resume`, poll (1s x10) until `running`, persist `running`, then proceed. If `creating`, wait for `running`, persist, then proceed. If persisting fails or updates no row, fail closed; if resume never settles, best-effort provider `pause` then fail.
  - Exec: Preflight before running the command; no replay.
  - Attach/SSH: Preflight before `revokeActiveIdentities`. On mint failure when status shows `paused`/`creating`, single retry. Fail closed when the row is `paused` and the status probe fails.
  - External resumes: If preflight sees `running` while the row is `paused`, persist `running` (fail closed if the row no longer exists).

- **Migration**
  - `VmProviderGatewayShape` adds optional `resume` and `pause`. Providers with suspend/resume should implement them; others are unaffected.

<sup>Written for commit b192932b155a43afc65d83cf7e17b64d5b54ee66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resuming paused virtual machines at the provider level before retrying VM actions.
* **Bug Fixes**
  * VM workflows now detect paused providers, resume them, record the VM transition to running, and retry the original operation (including exec, attach, and SSH).
  * Improved resilience to ensure state updates don’t leave VMs in an inconsistent/hidden status.
* **Tests**
  * Added workflow tests covering paused-VM recovery success and failure cases, including correct retry/resume behavior and error propagation when recovery isn’t possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->