### PR TITLE
CI: default macOS-15 jobs to WarpBuild instead of dead Blacksmith pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,10 +347,10 @@ jobs:
     if: ${{ needs.changes.outputs.macos == 'true' }}
     name: app-host unit tests (${{ matrix.shard }}/4)
     # App-host XCTest needs a runner that can broker testmanagerd control
-    # sessions. Validated head-to-head that blacksmith-6vcpu-macos-15 runs the
-    # full app-host suite with 0 unexpected failures, identical to warp-15, so
-    # route through the shared MACOS_RUNNER_15 var like the other macOS jobs.
-    runs-on: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+    # sessions. Validated head-to-head that warp-macos-15-arm64-6x runs the
+    # full app-host suite with 0 unexpected failures, so route through the
+    # shared MACOS_RUNNER_15 var like the other macOS jobs.
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -717,7 +717,7 @@ jobs:
   swift-package-tests:
     needs: changes
     if: ${{ needs.changes.outputs.macos == 'true' }}
-    runs-on: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 20
     steps:
       - name: Clear stale git locks (self-hosted reused workspace)
@@ -898,7 +898,7 @@ jobs:
     # Keep lag validation separate from UI regressions so functional UI failures
     # and performance regressions stay isolated. Broader interactive UI suites
     # still run via test-e2e.yml on GitHub-hosted runners.
-    runs-on: ${{ vars.MACOS_RUNNER_DISPLAY || 'blacksmith-6vcpu-macos-15' }}
+    runs-on: ${{ vars.MACOS_RUNNER_DISPLAY || 'warp-macos-15-arm64-6x' }}
     # A cold DerivedData cache (any project.pbxproj or Package.resolved change
     # mints a new cache key with no restore-keys fallback) forces a full
     # cmux build whose Swift codegen alone can run 20+ min. Project/package
@@ -908,7 +908,7 @@ jobs:
     steps:
       - name: Validate display runner identity
         env:
-          REQUESTED_RUNNER: ${{ vars.MACOS_RUNNER_DISPLAY || 'blacksmith-6vcpu-macos-15' }}
+          REQUESTED_RUNNER: ${{ vars.MACOS_RUNNER_DISPLAY || 'warp-macos-15-arm64-6x' }}
           RUNNER_CONTEXT_NAME: ${{ runner.name }}
         run: |
           set -euo pipefail
@@ -1212,7 +1212,7 @@ jobs:
   release-ghostty-cli-helper:
     needs: changes
     if: ${{ needs.changes.outputs.macos == 'true' }}
-    runs-on: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 20
     steps:
       - name: Clear stale git locks (self-hosted reused workspace)
@@ -1396,14 +1396,14 @@ jobs:
   ui-regressions:
     needs: changes
     if: ${{ needs.changes.outputs.macos == 'true' }}
-    runs-on: ${{ vars.MACOS_RUNNER_DISPLAY || 'blacksmith-6vcpu-macos-15' }}
+    runs-on: ${{ vars.MACOS_RUNNER_DISPLAY || 'warp-macos-15-arm64-6x' }}
     # Cold builds after project/package changes can spend more than 25 minutes
     # in build-for-testing before the UI regression script starts.
     timeout-minutes: 45
     steps:
       - name: Validate display runner identity
         env:
-          REQUESTED_RUNNER: ${{ vars.MACOS_RUNNER_DISPLAY || 'blacksmith-6vcpu-macos-15' }}
+          REQUESTED_RUNNER: ${{ vars.MACOS_RUNNER_DISPLAY || 'warp-macos-15-arm64-6x' }}
           RUNNER_CONTEXT_NAME: ${{ runner.name }}
         run: |
           set -euo pipefail

--- a/tests/test_ci_release_sdk_lane.sh
+++ b/tests/test_ci_release_sdk_lane.sh
@@ -44,7 +44,7 @@ require_job_contains \
 require_job_contains \
   "$CI_FILE" \
   "release-ghostty-cli-helper" \
-  'runs-on: ${{ vars.MACOS_RUNNER_15 || '\''blacksmith-6vcpu-macos-15'\'' }}' \
+  'runs-on: ${{ vars.MACOS_RUNNER_15 || '\''warp-macos-15-arm64-6x'\'' }}' \
   "CI must build the real Ghostty CLI helper on macOS 15"
 
 require_job_contains \


### PR DESCRIPTION
## Problem

The Blacksmith macOS pool is retired. Any CI run already queued against `blacksmith-6vcpu-macos-15` sits queued forever (GitHub never re-evaluates `runs-on` after a job is queued), which is what stuck the last push run on `main` for ~7.5h with every Linux job green and only the macOS jobs (swift-package-tests, app-host unit tests, release-ghostty-cli-helper, ui-regressions) hung.

The runner labels are driven by repo variables (`MACOS_RUNNER_15`, `MACOS_RUNNER_DISPLAY`), which already point at `warp-macos-15-arm64-6x`. But the in-workflow `|| '...'` fallbacks still named the dead Blacksmith pool, so clearing/unsetting a var would silently route these jobs back into the permanently-queued state.

## Change

Point every macOS-15 fallback in `ci.yml` at `warp-macos-15-arm64-6x` to match the live repo vars. `release-build` keeps its Blacksmith macOS-26 fallback (disk-heavy universal build; that fallback is explicitly enforced by `tests/test_ci_self_hosted_guard.sh`). Updated the stale app-host comment.

No behavior change while the vars are set; this only fixes the failure mode when a var is cleared.

## Verification

- `./tests/test_ci_self_hosted_guard.sh` passes locally (exit 0).
- The live `main` CI (post var-flip) already ran fully green on WarpBuild: https://github.com/manaflow-ai/cmux/actions/runs/28735661079

Meta/CI-only change; no tagged app build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785836119&installation_id=133855650&pr_number=7393&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7393&signature=33a5aa0ce7d26b635047a5dd3f54321782d6166392a796a24f3e48ce2c09287f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only runner label fallbacks; no app code or release-build macOS-26 lane changes.
> 
> **Overview**
> Updates **`.github/workflows/ci.yml`** so macOS-15 jobs no longer fall back to the retired **`blacksmith-6vcpu-macos-15`** pool when `MACOS_RUNNER_15` / `MACOS_RUNNER_DISPLAY` are unset. Every affected `runs-on` and display-runner validation step now uses **`warp-macos-15-arm64-6x`**, aligned with the live repo variables.
> 
> Touched jobs: **app-host unit tests**, **swift-package-tests**, **tests-build-and-lag**, **release-ghostty-cli-helper**, and **ui-regressions**. The app-host job comment is refreshed to reference Warp instead of Blacksmith. **`release-build`** is unchanged and still defaults to **`blacksmith-6vcpu-macos-26`**.
> 
> No change while vars are set; this only fixes jobs that would otherwise queue forever on a dead label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6338d15b9b172f1d8ec0c61ae64333f0b19ae465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default macOS-15 CI jobs to WarpBuild to prevent hangs on the retired Blacksmith pool. Aligns `ci.yml` fallbacks with `MACOS_RUNNER_15` and `MACOS_RUNNER_DISPLAY` so clearing a var won’t stall runs.

- **Bug Fixes**
  - Switch macOS-15 `runs-on` fallbacks to `warp-macos-15-arm64-6x` in `ci.yml` (app-host tests, Swift package tests, UI regressions, `release-ghostty-cli-helper`); refreshed the app-host comment.
  - Keep `release-build` fallback to Blacksmith macOS-26 (guarded by `tests/test_ci_self_hosted_guard.sh`); update `tests/test_ci_release_sdk_lane.sh` to expect Warp for `release-ghostty-cli-helper`.

<sup>Written for commit bab26e9cefe45913eb0ec403a4fbd88c5f437d0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple macOS CI jobs to run on the new `warp-macos-15-arm64-6x` runner.
  * Adjusted CI runner identity validation for the release SDK lane to match the updated macOS runner default.
  * Updated inline workflow notes to reflect the new macOS build environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->