### PR TITLE
Fix markdown previews going permanently blank on cross-pane moves

### DIFF
--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -26,11 +26,23 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         session.coordinator(panelId: panelId, workspaceId: workspaceId, filePath: filePath)
     }
 
-    func makeNSView(context: Context) -> WKWebView {
+    /// Returns a throwaway container per representable; the coordinator owns
+    /// parenting the shared webview into the current one. SwiftUI can host two
+    /// representables for the same tab within one transaction (a cross-pane
+    /// move whose source pane collapses) — if both return the same NSView, the
+    /// dying host's teardown rips the webview out of the adopting host's
+    /// hierarchy permanently. Containers make teardown destroy only a container.
+    func makeNSView(context: Context) -> NSView {
+        let container = NSView()
+        container.autoresizesSubviews = true
+        ensureWebView(context: context)
+        context.coordinator.adopt(container: container)
+        return container
+    }
+
+    /// Creates the session-retained webview if needed and re-applies per-host bindings.
+    private func ensureWebView(context: Context) {
         if let webView = context.coordinator.webView {
-            if webView.superview != nil {
-                webView.removeFromSuperview()
-            }
             webView.onPointerDown = onRequestPanelFocus
             webView.onLeaveWindow = { [weak coordinator = context.coordinator] in
                 coordinator?.handleViewLeftWindow()
@@ -45,7 +57,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             context.coordinator.setFontSize(fontSize)
             context.coordinator.setFontFamily(fontFamily)
             context.coordinator.setMaxContentWidth(maxContentWidth)
-            return webView
+            return
         }
 
         let config = WKWebViewConfiguration()
@@ -90,32 +102,38 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         context.coordinator.setFontFamily(fontFamily)
         context.coordinator.setMaxContentWidth(maxContentWidth)
         context.coordinator.loadShell(theme: theme, initialMarkdown: markdown)
-        return webView
     }
 
-    func updateNSView(_ nsView: WKWebView, context: Context) {
+    func updateNSView(_ nsView: NSView, context: Context) {
         // Re-bind panel metadata in case SwiftUI recreated the wrapper while
         // the panel-owned renderer session kept the same coordinator.
         context.coordinator.bind(panelId: panelId, workspaceId: workspaceId, filePath: filePath)
-        (nsView as? MarkdownWebView)?.onPointerDown = onRequestPanelFocus
-        applyBackground(to: nsView)
-        applyAppearance(to: nsView, isDark: theme.isDark)
+        context.coordinator.adopt(container: nsView)
+        if let webView = context.coordinator.webView {
+            (webView as? MarkdownWebView)?.onPointerDown = onRequestPanelFocus
+            applyBackground(to: webView)
+            applyAppearance(to: webView, isDark: theme.isDark)
+        }
         context.coordinator.setFontSize(fontSize)
         context.coordinator.setFontFamily(fontFamily)
         context.coordinator.setMaxContentWidth(maxContentWidth)
         context.coordinator.update(markdown: markdown, theme: theme)
     }
 
-    static func dismantleNSView(_ nsView: WKWebView, coordinator: Coordinator) {
-        if let retainedWebView = coordinator.webView, retainedWebView === nsView {
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.containerWillDismantle(nsView)
+        // A raw webview handed in directly (defense in depth; hosts only hold
+        // containers now) — clean it up unless it is the session-retained one.
+        guard let webView = nsView as? WKWebView else { return }
+        if let retainedWebView = coordinator.webView, retainedWebView === webView {
             return
         }
-        nsView.configuration.userContentController.removeScriptMessageHandler(forName: "cmuxLib")
-        nsView.navigationDelegate = nil
-        nsView.uiDelegate = nil
-        (nsView as? MarkdownWebView)?.onPointerDown = nil
-        (nsView as? MarkdownWebView)?.onLeaveWindow = nil
-        (nsView as? MarkdownWebView)?.onReenterWindow = nil
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "cmuxLib")
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
+        (webView as? MarkdownWebView)?.onPointerDown = nil
+        (webView as? MarkdownWebView)?.onLeaveWindow = nil
+        (webView as? MarkdownWebView)?.onReenterWindow = nil
         coordinator.cancelImageLoads()
     }
 
@@ -267,8 +285,53 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             isShellLoading = false
             webContentProcessRecoveryAttempts = 0
             shellWasHealthyWhenDetached = false
+            currentContainer = nil
             cancelImageLoads()
             requestedLibs.removeAll()
+        }
+
+        /// The representable container that should currently host the webview.
+        private weak var currentContainer: NSView?
+        private var reparentScheduled = false
+
+        /// First-time adoption is synchronous so the initial mount is not
+        /// blank; migration defers one runloop tick, after which the SwiftUI
+        /// transaction has settled and the surviving container is unambiguous.
+        func adopt(container: NSView) {
+            guard currentContainer !== container else {
+                scheduleReparentIfNeeded()
+                return
+            }
+            currentContainer = container
+            if webView?.superview == nil {
+                reparentNow()
+            } else {
+                scheduleReparentIfNeeded()
+            }
+        }
+
+        func containerWillDismantle(_ container: NSView) {
+            // The webview may sit inside the dying container; queue a re-parent.
+            scheduleReparentIfNeeded()
+        }
+
+        private func scheduleReparentIfNeeded() {
+            guard !reparentScheduled else { return }
+            reparentScheduled = true
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.reparentScheduled = false
+                self.reparentNow()
+            }
+        }
+
+        private func reparentNow() {
+            guard let webView, let container = currentContainer else { return }
+            guard webView.superview !== container else { return }
+            webView.removeFromSuperview()
+            webView.frame = container.bounds
+            webView.autoresizingMask = [.width, .height]
+            container.addSubview(webView)
         }
 
         func loadShell(theme: MarkdownWebTheme, initialMarkdown: String) {
@@ -758,10 +821,27 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             shellWasHealthyWhenDetached = isLoaded
         }
 
+        /// A hide/unhide cycle across a runloop turn forces WebKit to
+        /// re-create its remote layer host connection after a reparent;
+        /// synchronous toggles coalesce into a no-op.
+        private func scheduleRemoteLayerNudge() {
+            DispatchQueue.main.async { [weak self] in
+                guard let webView = self?.webView, webView.window != nil else { return }
+                webView.isHidden = true
+                DispatchQueue.main.async { [weak self] in
+                    self?.webView?.isHidden = false
+                }
+            }
+        }
+
         func handleViewReenteredWindow() {
-            // A still-loaded shell — alive but merely unpainted — is left
-            // intact; the host view's repaint nudge handles that case.
-            guard !isLoaded else { return }
+            // A still-loaded shell survives the reparent with its DOM intact,
+            // but the window hop severs WebKit's remote layer host and the
+            // panel shows blank. Nudge the layer host back.
+            guard !isLoaded else {
+                scheduleRemoteLayerNudge()
+                return
+            }
             // Recover only when the document was healthy before the detach, so
             // a payload that exhausted its crash-recovery budget while attached
             // (a crash loop) is not granted a fresh budget by pane reparenting.

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -561,6 +561,31 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertFalse(coordinator.isShellLoadingForTesting)
     }
 
+    func testMarkdownRendererContainerAdoptionSurvivesLateDismantle() {
+        let coordinator = MarkdownWebRenderer.Coordinator()
+        let webView = MarkdownWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        coordinator.webView = webView
+        defer { coordinator.close() }
+
+        // First mount adopts synchronously so the initial frame isn't blank.
+        let first = NSView()
+        coordinator.adopt(container: first)
+        XCTAssertEqual(webView.superview, first)
+
+        // Cross-pane move: the new host adopts before the old one tears down.
+        let second = NSView()
+        coordinator.adopt(container: second)
+        XCTAssertEqual(webView.superview, first)
+
+        // The late teardown that used to rip the webview out permanently.
+        MarkdownWebRenderer.dismantleNSView(first, coordinator: coordinator)
+
+        let settled = expectation(description: "deferred reparent ran")
+        DispatchQueue.main.async { settled.fulfill() }
+        wait(for: [settled], timeout: 1.0)
+        XCTAssertEqual(webView.superview, second)
+    }
+
     func testMarkdownRendererNavigationFailureUnblocksFutureShellReload() {
         let coordinator = MarkdownWebRenderer.Coordinator()
         let webView = MarkdownWebView(frame: .zero, configuration: WKWebViewConfiguration())


### PR DESCRIPTION
## Problem

SwiftUI can host two `NSViewRepresentable` instances for the same markdown tab within one transaction (a cross-pane move whose source pane collapses). Both hosts previously shared the one `WKWebView` instance, so the dying host's teardown ripped the webview out of the adopting host's hierarchy — permanently: SwiftUI believed the new host still held it, so the tab stayed blank until a manual move-to-new-tab.

100% repro: move a markdown tab out of a two-tab pane so the pane collapses.

## Fix

`makeNSView` returns a throwaway container per representable, and the coordinator is the single owner of webview parenting — synchronous adopt on first mount, one-runloop-tick-deferred migration between containers so a dismantling host can never race the adopting one.

One companion change: for a reparent the shell survives with its DOM intact, the window hop still severs WebKit's remote layer host and the panel renders blank (the WebContent process snapshot shows full content). On window re-entry we schedule a hide/unhide cycle across a runloop turn, forcing WebKit to re-create the layer host connection; synchronous toggles coalesce into a no-op.

## Testing

New unit test covers first-mount adoption, deferred migration, and the late-dismantle ordering that used to orphan the webview. The fix has also been daily-driven in my fork build since Jul 3 with heavy programmatic markdown-pane open/move usage — no blank previews since.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed markdown panels losing their rendered content when moved between panes or reloaded.
  * Improved view handoff so the preview stays attached and recovers correctly after late teardown or reparenting.
  * Reduced blank markdown renders by refreshing the preview when it returns to the window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->