### PR TITLE
Fix workspace drag pasteboard deadlock

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11397,7 +11397,7 @@ struct VerticalTabsSidebar: View {
         .opacity(dragState.draggedTabId == row.workspaceId ? 0.55 : 1)
         .onDrag {
             dragState.beginDragging(tabId: row.workspaceId)
-            return SidebarTabDragPayload.provider(for: row.workspaceId)
+            return SidebarTabDragPayload(tabId: row.workspaceId).provider()
         }
         .internalOnlyTabDrag()
         .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: ExtensionSidebarBrowserStackDropDelegate(
@@ -11475,7 +11475,7 @@ struct VerticalTabsSidebar: View {
         .opacity(dragState.draggedTabId == row.workspaceId ? 0.55 : 1)
         .onDrag {
             dragState.beginDragging(tabId: row.workspaceId)
-            return SidebarTabDragPayload.provider(for: row.workspaceId)
+            return SidebarTabDragPayload(tabId: row.workspaceId).provider()
         }
         .internalOnlyTabDrag()
         .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: ExtensionSidebarBrowserStackDropDelegate(
@@ -12334,7 +12334,7 @@ struct VerticalTabsSidebar: View {
             cmuxDebugLog("sidebar.onDrag tab=\(tabId.uuidString.prefix(5))")
             #endif
             dragState.beginDragging(tabId: tabId)
-            return SidebarTabDragPayload.provider(for: tabId)
+            return SidebarTabDragPayload(tabId: tabId).provider()
         }
         let bonsplitSourceWorkspaceId: @MainActor (UUID) -> UUID? = { tabId in
             guard let app = AppDelegate.shared else { return nil }
@@ -15640,32 +15640,6 @@ private struct SidebarMetadataMarkdownBlockRow: View {
             maxDisplayedCharacters: maxDisplayedCharacters
         )
     }
-}
-
-/// Immutable, equatable snapshot of the group list a row's "Move to Group"
-/// submenu can offer. Computed once per parent body eval and passed into
-/// each TabItemView so the row's `==` covers group changes (renames, adds,
-/// deletes) — the row's snapshot-boundary rule forbids reading
-/// `tabManager.workspaceGroups` from inside the contextMenu builder.
-enum SidebarTabDragPayload {
-    static let typeIdentifier = "com.cmux.sidebar-tab-reorder"
-    static let dropContentType = UTType(exportedAs: typeIdentifier)
-    static let dropContentTypes: [UTType] = [dropContentType]
-    static let prefix = "cmux.sidebar-tab."
-
-    static func provider(for tabId: UUID) -> NSItemProvider {
-        let provider = NSItemProvider()
-        let payload = "\(prefix)\(tabId.uuidString)"
-        provider.registerDataRepresentation(forTypeIdentifier: typeIdentifier, visibility: .ownProcess) { completion in
-            let data = payload.data(using: .utf8)
-            Task { @MainActor in
-                completion(data, nil)
-            }
-            return nil
-        }
-        return provider
-    }
-
 }
 
 enum BonsplitTabDragPayload {

--- a/Sources/Sidebar/SidebarTabDragPayload.swift
+++ b/Sources/Sidebar/SidebarTabDragPayload.swift
@@ -1,0 +1,25 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// Internal workspace-sidebar drag payload for reordering and cross-window moves.
+struct SidebarTabDragPayload {
+    static let typeIdentifier = "com.cmux.sidebar-tab-reorder"
+    static let dropContentType = UTType(exportedAs: typeIdentifier)
+    static let dropContentTypes: [UTType] = [dropContentType]
+    static let prefix = "cmux.sidebar-tab."
+
+    let tabId: UUID
+
+    func provider() -> NSItemProvider {
+        let provider = NSItemProvider()
+        let payload = "\(Self.prefix)\(tabId.uuidString)"
+        let data = Data(payload.utf8)
+        provider.registerDataRepresentation(forTypeIdentifier: Self.typeIdentifier, visibility: .ownProcess) { completion in
+            // Data is already materialized, so a synchronous pasteboard request
+            // never waits on work scheduled back to the main actor.
+            completion(data, nil)
+            return nil
+        }
+        return provider
+    }
+}

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -67,7 +67,7 @@ extension VerticalTabsSidebar {
             cmuxDebugLog("sidebar.onDrag groupAnchor=\(anchorId.uuidString.prefix(5))")
             #endif
             dragState.beginDragging(tabId: anchorId)
-            return SidebarTabDragPayload.provider(for: anchorId)
+            return SidebarTabDragPayload(tabId: anchorId).provider()
         }
         let header = SidebarWorkspaceGroupHeaderView(
             groupId: group.id,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -992,6 +992,7 @@
 		C9A57513C9A57513C9A57513 /* SidebarScrollViewConfiguratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */; };
 		E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */; };
 		F57072635F25EBCA741E125D /* SidebarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */; };
+		D73440010000000000000001 /* SidebarTabDragPayloadProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73440010000000000000002 /* SidebarTabDragPayloadProviderTests.swift */; };
 		D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */; };
 		CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
 		D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */; };
@@ -2310,6 +2311,7 @@
 		C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrollViewConfiguratorTests.swift; sourceTree = "<group>"; };
 		9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
 		D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarState.swift; sourceTree = "<group>"; };
+		D73440010000000000000002 /* SidebarTabDragPayloadProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabDragPayloadProviderTests.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabDropIndicatorPredicateTests.swift; sourceTree = "<group>"; };
 		EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceDropPlannerTests.swift; sourceTree = "<group>"; };
@@ -4010,6 +4012,7 @@
 				C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */,
 				D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */,
 				D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */,
+				D73440010000000000000002 /* SidebarTabDragPayloadProviderTests.swift */,
 				AABBCC000000000000000205 /* SidebarInlineRenameKeyResolverTests.swift */,
 				A47E00010000000000000002 /* AuthEnvironmentTests.swift */,
 				C3677001000000000000002 /* CmuxSSHURLRequestTests.swift */,
@@ -5662,6 +5665,7 @@
 				CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */,
 				C0DE48000000000000000001 /* SidebarProviderMenuRegressionTests.swift in Sources */,
 				C9A57513C9A57513C9A57513 /* SidebarScrollViewConfiguratorTests.swift in Sources */,
+				D73440010000000000000001 /* SidebarTabDragPayloadProviderTests.swift in Sources */,
 				D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */,
 				CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,
 				D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -992,6 +992,7 @@
 		C9A57513C9A57513C9A57513 /* SidebarScrollViewConfiguratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */; };
 		E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */; };
 		F57072635F25EBCA741E125D /* SidebarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */; };
+		D7344F010000000000000001 /* SidebarTabDragPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7344F010000000000000002 /* SidebarTabDragPayload.swift */; };
 		D73440010000000000000001 /* SidebarTabDragPayloadProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73440010000000000000002 /* SidebarTabDragPayloadProviderTests.swift */; };
 		D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */; };
 		CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
@@ -2311,6 +2312,7 @@
 		C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrollViewConfiguratorTests.swift; sourceTree = "<group>"; };
 		9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
 		D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarState.swift; sourceTree = "<group>"; };
+		D7344F010000000000000002 /* SidebarTabDragPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarTabDragPayload.swift; sourceTree = "<group>"; };
 		D73440010000000000000002 /* SidebarTabDragPayloadProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabDragPayloadProviderTests.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabDropIndicatorPredicateTests.swift; sourceTree = "<group>"; };
 		EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
@@ -2991,6 +2993,7 @@
 				AABBCC000000000000000211 /* SidebarInlineRenameTextField.swift */,
 				AABBCC000000000000000207 /* SidebarRowAccessibilityModifier.swift */,
 				AABBCC000000000000000209 /* SidebarRowDragGate.swift */,
+				D7344F010000000000000002 /* SidebarTabDragPayload.swift */,
 				C9A57104C9A57104C9A57104 /* SidebarWorkspaceGroupConfigOpener.swift */,
 				C9A57106C9A57106C9A57106 /* SidebarWorkspaceGroupContextMenuRunner.swift */,
 				C9A57108C9A57108C9A57108 /* SidebarWorkspaceGroupDialogs.swift */,
@@ -5060,6 +5063,7 @@
 				C0DE35010000000000000001 /* SidebarScrim.swift in Sources */,
 				E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */,
 				F57072635F25EBCA741E125D /* SidebarState.swift in Sources */,
+				D7344F010000000000000001 /* SidebarTabDragPayload.swift in Sources */,
 				C9A57605C9A57605C9A57605 /* SidebarWorkspaceDropTargetWriters.swift in Sources */,
 				C9A57103C9A57103C9A57103 /* SidebarWorkspaceGroupConfigOpener.swift in Sources */,
 				C9A57105C9A57105C9A57105 /* SidebarWorkspaceGroupContextMenuRunner.swift in Sources */,

--- a/cmuxTests/SidebarTabDragPayloadProviderTests.swift
+++ b/cmuxTests/SidebarTabDragPayloadProviderTests.swift
@@ -14,7 +14,7 @@ struct SidebarTabDragPayloadProviderTests {
     @Test @MainActor
     func providerFulfillsDataRepresentationWhileMainActorIsSynchronouslyWaiting() throws {
         let workspaceId = UUID()
-        let provider = SidebarTabDragPayload.provider(for: workspaceId)
+        let provider = SidebarTabDragPayload(tabId: workspaceId).provider()
         let completion = DispatchSemaphore(value: 0)
         let resultBox = SidebarTabDragPayloadProviderResultBox()
 

--- a/cmuxTests/SidebarTabDragPayloadProviderTests.swift
+++ b/cmuxTests/SidebarTabDragPayloadProviderTests.swift
@@ -1,0 +1,61 @@
+import AppKit
+import Foundation
+import os
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+struct SidebarTabDragPayloadProviderTests {
+    @Test @MainActor
+    func providerFulfillsDataRepresentationWhileMainActorIsSynchronouslyWaiting() throws {
+        let workspaceId = UUID()
+        let provider = SidebarTabDragPayload.provider(for: workspaceId)
+        let completion = DispatchSemaphore(value: 0)
+        let resultBox = SidebarTabDragPayloadProviderResultBox()
+
+        #expect(provider.registeredTypeIdentifiers.contains(SidebarTabDragPayload.typeIdentifier))
+
+        provider.loadDataRepresentation(forTypeIdentifier: SidebarTabDragPayload.typeIdentifier) { data, error in
+            resultBox.record(data: data, error: error)
+            completion.signal()
+        }
+
+        let waitResult = completion.wait(timeout: .now() + .milliseconds(500))
+        guard waitResult == .success else {
+            Issue.record("Workspace drag payload provider did not complete while the main actor was synchronously waiting")
+            return
+        }
+
+        let result = resultBox.snapshot()
+        #expect(result.errorDescription == nil)
+        let data = try #require(result.data)
+        #expect(String(data: data, encoding: .utf8) == "\(SidebarTabDragPayload.prefix)\(workspaceId.uuidString)")
+    }
+}
+
+fileprivate final class SidebarTabDragPayloadProviderResultBox: @unchecked Sendable {
+    fileprivate struct State: Sendable {
+        var data: Data? = nil
+        var errorDescription: String? = nil
+    }
+
+    // The NSItemProvider completion can run on a background queue while this
+    // regression test intentionally blocks the main actor.
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    func record(data: Data?, error: (any Error)?) {
+        state.withLock {
+            $0.data = data
+            $0.errorDescription = error.map { String(describing: $0) }
+        }
+    }
+
+    func snapshot() -> State {
+        state.withLock { $0 }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a regression test that exercises the workspace drag NSItemProvider while the main actor is synchronously waiting.
- Extract SidebarTabDragPayload out of ContentView and precompute its small internal payload before registering the drag representation.
- Preserve .ownProcess visibility for the internal workspace drag type while fulfilling data immediately, with no Task/MainActor hop.

## Why this fix
The deadlock in #7344 happens when SwiftUI's pasteboard provider synchronously asks the item provider to fulfill promised data on the main thread while cmux's provider completion is scheduled back to the main actor. The payload is just a static workspace-id string, so cmux now builds the Data before registration and calls the completion synchronously from the provider closure. That keeps the internal payload process-local and removes the sync-over-main-actor wait that wedged cmux when a foreign drop target requested the dragged data.

## Validation
- python3 scripts/normalize-pbxproj.py --check
- ./scripts/check-pbxproj.sh
- ./scripts/lint-pbxproj-test-wiring.sh
- python3 scripts/swift_file_length_budget.py
- Standalone Swift sanity check that the own-process NSItemProvider data representation completes and returns raw data bytes

Closes #7344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar tab drag-and-drop reliability for the “move to group” flow by updating how drag payloads are created and supplied.

* **New Features**
  * Added a dedicated sidebar tab drag/drop payload implementation to standardize payload type identification and data generation.

* **Tests**
  * Added tests covering sidebar drag payload provider behavior, including verifying payload contents and completion handling when the main thread is synchronously blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->