### PR TITLE
CmuxFleet: fleet.* control-socket domain (seam + coordinator, stubbed until engine)

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandContext.swift
@@ -18,6 +18,7 @@ public protocol ControlCommandContext:
     ControlAppFocusContext,
     ControlFeedContext,
     ControlNotificationContext,
+    ControlFleetContext,
     ControlWorkspaceGroupContext,
     ControlPaneContext,
     ControlCanvasContext,

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -71,6 +71,7 @@ public final class ControlCommandCoordinator {
         if let result = handleAppFocus(request) { return result }
         if let result = handleFeed(request) { return result }
         if let result = handleNotification(request) { return result }
+        if let result = handleFleet(request) { return result }
         if let result = handleWorkspaceGroup(request) { return result }
         if let result = handlePane(request) { return result }
         if let result = handleCanvas(request) { return result }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlCommandCoordinator+Fleet.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlCommandCoordinator+Fleet.swift
@@ -1,0 +1,308 @@
+internal import Foundation
+
+/// The Fleet domain (`fleet.*`) owned by ``ControlCommandCoordinator``.
+///
+/// These commands are non-focus control-plane commands. `fleet.task.open`
+/// returns the workspace ref minted by the coordinator's handle registry, but
+/// this package layer does not activate the app or select/focus UI state.
+extension ControlCommandCoordinator {
+    /// Dispatches Fleet methods this coordinator owns.
+    ///
+    /// - Parameter request: The decoded request envelope.
+    /// - Returns: The command result, or `nil` if not a Fleet method.
+    func handleFleet(_ request: ControlRequest) -> ControlCallResult? {
+        switch request.method {
+        case "fleet.list":
+            return fleetList()
+        case "fleet.create":
+            return fleetCreate(request.params)
+        case "fleet.start":
+            return fleetStart(request.params)
+        case "fleet.stop":
+            return fleetStop(request.params)
+        case "fleet.status":
+            return fleetStatus(request.params)
+        case "fleet.task.add":
+            return fleetTaskAdd(request.params)
+        case "fleet.task.list":
+            return fleetTaskList(request.params)
+        case "fleet.task.retry":
+            return fleetTaskRetry(request.params)
+        case "fleet.task.cancel":
+            return fleetTaskCancel(request.params)
+        case "fleet.task.open":
+            return fleetTaskOpen(request.params)
+        default:
+            return nil
+        }
+    }
+
+    /// `fleet.list` — list visible Fleets.
+    func fleetList() -> ControlCallResult {
+        let fleets = (context?.controlFleetList() ?? []).map(fleetPayload)
+        return .ok(.object(["fleets": .array(fleets)]))
+    }
+
+    /// `fleet.status` — read Fleet engine status.
+    func fleetStatus(_ params: [String: JSONValue]) -> ControlCallResult {
+        let fleetID = string(params, "fleet_id")
+        let resolution = context?.controlFleetStatus(fleetID: fleetID)
+            ?? (fleetID.map { .fleetNotFound($0) } ?? .ok(ControlFleetStatusSnapshot(isRunning: false, fleets: [])))
+        switch resolution {
+        case .ok(let snapshot):
+            return .ok(.object([
+                "running": .bool(snapshot.isRunning),
+                "fleets": .array(snapshot.fleets.map(fleetPayload)),
+            ]))
+        case .fleetNotFound(let id):
+            return unknownFleetError(id)
+        }
+    }
+
+    /// `fleet.create` — create a Fleet.
+    func fleetCreate(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let name = string(params, "name") else {
+            return missingParam("name")
+        }
+        guard let repoRoot = string(params, "repo_root") else {
+            return missingParam("repo_root")
+        }
+        let maxConcurrent: Int?
+        if hasNonNull(params, "max_concurrent") {
+            guard let parsed = int(params, "max_concurrent"), parsed >= 1 else {
+                return .err(code: "invalid_params", message: "max_concurrent must be at least 1", data: nil)
+            }
+            maxConcurrent = parsed
+        } else {
+            maxConcurrent = nil
+        }
+        let inputs = ControlFleetCreateInputs(
+            name: name,
+            repoRoot: repoRoot,
+            agentCommand: string(params, "agent_command"),
+            maxConcurrent: maxConcurrent
+        )
+        let resolution = context?.controlFleetCreate(inputs: inputs) ?? .engineUnavailable
+        switch resolution {
+        case .created(let snapshot):
+            return .ok(.object(["fleet": fleetPayload(snapshot)]))
+        case .invalidConfiguration(let reason):
+            return .err(code: "invalid_params", message: reason, data: nil)
+        case .engineUnavailable:
+            return engineUnavailableError()
+        }
+    }
+
+    /// `fleet.start` — start a Fleet.
+    func fleetStart(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let fleetID = string(params, "fleet_id") else {
+            return missingParam("fleet_id")
+        }
+        let resolution = context?.controlFleetStart(fleetID: fleetID) ?? .engineUnavailable
+        return fleetLifecycleResult(resolution)
+    }
+
+    /// `fleet.stop` — stop a Fleet.
+    func fleetStop(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let fleetID = string(params, "fleet_id") else {
+            return missingParam("fleet_id")
+        }
+        let resolution = context?.controlFleetStop(fleetID: fleetID) ?? .engineUnavailable
+        return fleetLifecycleResult(resolution)
+    }
+
+    /// `fleet.task.add` — add a task to a Fleet.
+    func fleetTaskAdd(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let fleetID = string(params, "fleet_id") else {
+            return missingParam("fleet_id")
+        }
+        guard let title = string(params, "title") else {
+            return missingParam("title")
+        }
+        let inputs = ControlFleetTaskAddInputs(
+            fleetID: fleetID,
+            title: title,
+            body: string(params, "body"),
+            priority: hasNonNull(params, "priority") ? int(params, "priority") : nil
+        )
+        let resolution = context?.controlFleetTaskAdd(inputs: inputs) ?? .engineUnavailable
+        switch resolution {
+        case .added(let snapshot):
+            return .ok(.object(["task": taskPayload(snapshot)]))
+        case .fleetNotFound(let id):
+            return unknownFleetError(id)
+        case .engineUnavailable:
+            return engineUnavailableError()
+        }
+    }
+
+    /// `fleet.task.list` — list tasks with optional filters.
+    func fleetTaskList(_ params: [String: JSONValue]) -> ControlCallResult {
+        let fleetID = string(params, "fleet_id")
+        let state: ControlFleetTaskStateName?
+        if hasNonNull(params, "state") {
+            guard let rawState = string(params, "state"),
+                  let parsedState = ControlFleetTaskStateName(rawValue: rawState)
+            else {
+                return invalidStateFilterError()
+            }
+            state = parsedState
+        } else {
+            state = nil
+        }
+
+        let resolution = context?.controlFleetTaskList(fleetID: fleetID, state: state)
+            ?? (fleetID.map { .fleetNotFound($0) } ?? .ok([]))
+        switch resolution {
+        case .ok(let tasks):
+            return .ok(.object(["tasks": .array(tasks.map(taskPayload))]))
+        case .fleetNotFound(let id):
+            return unknownFleetError(id)
+        }
+    }
+
+    /// `fleet.task.retry` — retry a task.
+    func fleetTaskRetry(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let taskID = string(params, "task_id") else {
+            return missingParam("task_id")
+        }
+        let resolution = context?.controlFleetTaskRetry(taskID: taskID) ?? .engineUnavailable
+        return fleetTaskActionResult(resolution)
+    }
+
+    /// `fleet.task.cancel` — cancel a task.
+    func fleetTaskCancel(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let taskID = string(params, "task_id") else {
+            return missingParam("task_id")
+        }
+        let resolution = context?.controlFleetTaskCancel(taskID: taskID) ?? .engineUnavailable
+        return fleetTaskActionResult(resolution)
+    }
+
+    /// `fleet.task.open` — open a task's workspace.
+    func fleetTaskOpen(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let taskID = string(params, "task_id") else {
+            return missingParam("task_id")
+        }
+        let resolution = context?.controlFleetTaskOpen(taskID: taskID) ?? .engineUnavailable
+        switch resolution {
+        case .opened(let workspaceID):
+            return .ok(.object([
+                "task_id": .string(taskID),
+                "workspace_id": ref(.workspace, workspaceID),
+            ]))
+        case .taskNotFound(let id):
+            return unknownTaskError(id)
+        case .workspaceUnavailable:
+            return .err(code: "invalid_state", message: "task has no workspace yet", data: nil)
+        case .engineUnavailable:
+            return engineUnavailableError()
+        }
+    }
+
+    /// Converts a Fleet snapshot to its wire payload.
+    private func fleetPayload(_ snapshot: ControlFleetSnapshot) -> JSONValue {
+        .object([
+            "fleet_id": .string(snapshot.fleetID),
+            "name": .string(snapshot.name),
+            "repo_root": .string(snapshot.repoRoot),
+            "running": .bool(snapshot.isRunning),
+            "counts": fleetTaskCountsPayload(snapshot.taskCounts),
+        ])
+    }
+
+    /// Converts task counts to a complete state-keyed object.
+    private func fleetTaskCountsPayload(_ counts: [ControlFleetTaskStateName: Int]) -> JSONValue {
+        var payload: [String: JSONValue] = [:]
+        payload.reserveCapacity(ControlFleetTaskStateName.allCases.count)
+        for state in ControlFleetTaskStateName.allCases {
+            payload[state.rawValue] = .int(Int64(counts[state] ?? 0))
+        }
+        return .object(payload)
+    }
+
+    /// Converts a Fleet task snapshot to its wire payload.
+    private func taskPayload(_ snapshot: ControlFleetTaskSnapshot) -> JSONValue {
+        .object([
+            "task_id": .string(snapshot.taskID),
+            "fleet_id": .string(snapshot.fleetID),
+            "source": .string(snapshot.source),
+            "title": .string(snapshot.title),
+            "state": .string(snapshot.state.rawValue),
+            "blocked": .bool(snapshot.isBlocked),
+            "attempts": .int(Int64(snapshot.attempts)),
+            "priority": snapshot.priority.map { .int(Int64($0)) } ?? .null,
+            "labels": .array(snapshot.labels.map { .string($0) }),
+            "url": orNull(snapshot.url),
+            "workspace_id": orNull(snapshot.workspaceID),
+            "surface_id": orNull(snapshot.surfaceID),
+            "directory": orNull(snapshot.directoryPath),
+            "branch": orNull(snapshot.branch),
+            "pr": pullRequestPayload(snapshot.pullRequest),
+            "last_error": orNull(snapshot.lastError),
+            "created_at": .double(snapshot.createdAt),
+            "updated_at": .double(snapshot.updatedAt),
+        ])
+    }
+
+    /// Converts pull-request metadata to its wire payload.
+    private func pullRequestPayload(_ pullRequest: ControlFleetTaskPullRequest?) -> JSONValue {
+        guard let pullRequest else { return .null }
+        return .object([
+            "url": orNull(pullRequest.url),
+            "status": .string(pullRequest.status),
+        ])
+    }
+
+    /// Maps lifecycle resolutions to Fleet wire results.
+    private func fleetLifecycleResult(_ resolution: ControlFleetLifecycleResolution) -> ControlCallResult {
+        switch resolution {
+        case .ok(let snapshot):
+            return .ok(.object(["fleet": fleetPayload(snapshot)]))
+        case .fleetNotFound(let id):
+            return unknownFleetError(id)
+        case .engineUnavailable:
+            return engineUnavailableError()
+        }
+    }
+
+    /// Maps task action resolutions to Fleet wire results.
+    private func fleetTaskActionResult(_ resolution: ControlFleetTaskActionResolution) -> ControlCallResult {
+        switch resolution {
+        case .ok(let snapshot):
+            return .ok(.object(["task": taskPayload(snapshot)]))
+        case .taskNotFound(let id):
+            return unknownTaskError(id)
+        case .invalidState(let current):
+            return .err(code: "invalid_state", message: "task is in state \(current.rawValue)", data: nil)
+        case .engineUnavailable:
+            return engineUnavailableError()
+        }
+    }
+
+    /// Builds an `invalid_params` error for a missing parameter.
+    private func missingParam(_ key: String) -> ControlCallResult {
+        .err(code: "invalid_params", message: "missing required parameter: \(key)", data: nil)
+    }
+
+    /// Builds the Fleet-engine unavailable error.
+    private func engineUnavailableError() -> ControlCallResult {
+        .err(code: "unavailable", message: "fleet engine is not available in this build", data: nil)
+    }
+
+    /// Builds an unknown-Fleet error.
+    private func unknownFleetError(_ id: String) -> ControlCallResult {
+        .err(code: "not_found", message: "unknown fleet: \(id)", data: nil)
+    }
+
+    /// Builds an unknown-task error.
+    private func unknownTaskError(_ id: String) -> ControlCallResult {
+        .err(code: "not_found", message: "unknown task: \(id)", data: nil)
+    }
+
+    /// Builds an invalid state-filter error listing valid wire values.
+    private func invalidStateFilterError() -> ControlCallResult {
+        let valid = ControlFleetTaskStateName.allCases.map(\.rawValue).joined(separator: ", ")
+        return .err(code: "invalid_params", message: "state must be one of: \(valid)", data: nil)
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetContext.swift
@@ -1,0 +1,71 @@
+/// The Fleet-domain slice of the control-command seam.
+///
+/// PR 2 of the #7361 chain defines only the socket package contract and the app
+/// target's unavailable stubs. PR 3 replaces the app stubs with the FleetEngine
+/// bridge while keeping this protocol as the coordinator boundary.
+@MainActor
+public protocol ControlFleetContext: AnyObject {
+    /// Lists every visible Fleet.
+    ///
+    /// - Returns: The Fleet snapshots in app-defined order.
+    func controlFleetList() -> [ControlFleetSnapshot]
+
+    /// Reads Fleet engine status, optionally scoped to one Fleet.
+    ///
+    /// - Parameter fleetID: The optional Fleet identifier.
+    /// - Returns: The status resolution.
+    func controlFleetStatus(fleetID: String?) -> ControlFleetStatusResolution
+
+    /// Creates a Fleet.
+    ///
+    /// - Parameter inputs: The validated creation inputs.
+    /// - Returns: The creation resolution.
+    func controlFleetCreate(inputs: ControlFleetCreateInputs) -> ControlFleetCreateResolution
+
+    /// Starts a Fleet.
+    ///
+    /// - Parameter fleetID: The Fleet identifier.
+    /// - Returns: The lifecycle resolution.
+    func controlFleetStart(fleetID: String) -> ControlFleetLifecycleResolution
+
+    /// Stops a Fleet.
+    ///
+    /// - Parameter fleetID: The Fleet identifier.
+    /// - Returns: The lifecycle resolution.
+    func controlFleetStop(fleetID: String) -> ControlFleetLifecycleResolution
+
+    /// Adds a task to a Fleet.
+    ///
+    /// - Parameter inputs: The validated task creation inputs.
+    /// - Returns: The task-add resolution.
+    func controlFleetTaskAdd(inputs: ControlFleetTaskAddInputs) -> ControlFleetTaskAddResolution
+
+    /// Lists Fleet tasks, optionally filtered by Fleet and state.
+    ///
+    /// - Parameters:
+    ///   - fleetID: The optional Fleet identifier.
+    ///   - state: The optional task-state filter.
+    /// - Returns: The task-list resolution.
+    func controlFleetTaskList(
+        fleetID: String?,
+        state: ControlFleetTaskStateName?
+    ) -> ControlFleetTaskListResolution
+
+    /// Retries a Fleet task.
+    ///
+    /// - Parameter taskID: The task identifier.
+    /// - Returns: The task-action resolution.
+    func controlFleetTaskRetry(taskID: String) -> ControlFleetTaskActionResolution
+
+    /// Cancels a Fleet task.
+    ///
+    /// - Parameter taskID: The task identifier.
+    /// - Returns: The task-action resolution.
+    func controlFleetTaskCancel(taskID: String) -> ControlFleetTaskActionResolution
+
+    /// Opens the workspace associated with a Fleet task.
+    ///
+    /// - Parameter taskID: The task identifier.
+    /// - Returns: The task-open resolution.
+    func controlFleetTaskOpen(taskID: String) -> ControlFleetTaskOpenResolution
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetInputs.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetInputs.swift
@@ -1,0 +1,51 @@
+/// Inputs for `fleet.create`.
+public struct ControlFleetCreateInputs: Sendable, Equatable {
+    /// The Fleet display name.
+    public var name: String
+    /// The repository root this Fleet manages.
+    public var repoRoot: String
+    /// The optional agent command.
+    public var agentCommand: String?
+    /// The optional maximum number of concurrent tasks.
+    public var maxConcurrent: Int?
+
+    /// Creates `fleet.create` inputs.
+    ///
+    /// - Parameters:
+    ///   - name: The Fleet display name.
+    ///   - repoRoot: The repository root this Fleet manages.
+    ///   - agentCommand: The optional agent command.
+    ///   - maxConcurrent: The optional maximum number of concurrent tasks.
+    public init(name: String, repoRoot: String, agentCommand: String?, maxConcurrent: Int?) {
+        self.name = name
+        self.repoRoot = repoRoot
+        self.agentCommand = agentCommand
+        self.maxConcurrent = maxConcurrent
+    }
+}
+
+/// Inputs for `fleet.task.add`.
+public struct ControlFleetTaskAddInputs: Sendable, Equatable {
+    /// The Fleet that should receive the task.
+    public var fleetID: String
+    /// The task title.
+    public var title: String
+    /// The optional task body.
+    public var body: String?
+    /// The optional scheduling priority.
+    public var priority: Int?
+
+    /// Creates `fleet.task.add` inputs.
+    ///
+    /// - Parameters:
+    ///   - fleetID: The Fleet that should receive the task.
+    ///   - title: The task title.
+    ///   - body: The optional task body.
+    ///   - priority: The optional scheduling priority.
+    public init(fleetID: String, title: String, body: String?, priority: Int?) {
+        self.fleetID = fleetID
+        self.title = title
+        self.body = body
+        self.priority = priority
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetResolutions.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetResolutions.swift
@@ -1,0 +1,71 @@
+public import Foundation
+
+/// The outcome of `fleet.status`.
+public enum ControlFleetStatusResolution: Sendable, Equatable {
+    /// The status snapshot was read.
+    case ok(ControlFleetStatusSnapshot)
+    /// No Fleet exists for the requested identifier.
+    case fleetNotFound(String)
+}
+
+/// The outcome of `fleet.create`.
+public enum ControlFleetCreateResolution: Sendable, Equatable {
+    /// The Fleet was created.
+    case created(ControlFleetSnapshot)
+    /// The requested configuration is invalid.
+    case invalidConfiguration(reason: String)
+    /// The Fleet engine is not linked into this app build.
+    case engineUnavailable
+}
+
+/// The outcome of `fleet.start` and `fleet.stop`.
+public enum ControlFleetLifecycleResolution: Sendable, Equatable {
+    /// The lifecycle mutation succeeded.
+    case ok(ControlFleetSnapshot)
+    /// No Fleet exists for the requested identifier.
+    case fleetNotFound(String)
+    /// The Fleet engine is not linked into this app build.
+    case engineUnavailable
+}
+
+/// The outcome of `fleet.task.add`.
+public enum ControlFleetTaskAddResolution: Sendable, Equatable {
+    /// The task was added.
+    case added(ControlFleetTaskSnapshot)
+    /// No Fleet exists for the requested identifier.
+    case fleetNotFound(String)
+    /// The Fleet engine is not linked into this app build.
+    case engineUnavailable
+}
+
+/// The outcome of `fleet.task.list`.
+public enum ControlFleetTaskListResolution: Sendable, Equatable {
+    /// The task snapshots were read.
+    case ok([ControlFleetTaskSnapshot])
+    /// No Fleet exists for the requested identifier.
+    case fleetNotFound(String)
+}
+
+/// The outcome of `fleet.task.retry` and `fleet.task.cancel`.
+public enum ControlFleetTaskActionResolution: Sendable, Equatable {
+    /// The task mutation succeeded.
+    case ok(ControlFleetTaskSnapshot)
+    /// No task exists for the requested identifier.
+    case taskNotFound(String)
+    /// The task cannot be mutated from its current state.
+    case invalidState(current: ControlFleetTaskStateName)
+    /// The Fleet engine is not linked into this app build.
+    case engineUnavailable
+}
+
+/// The outcome of `fleet.task.open`.
+public enum ControlFleetTaskOpenResolution: Sendable, Equatable {
+    /// The task workspace was opened.
+    case opened(workspaceID: UUID)
+    /// No task exists for the requested identifier.
+    case taskNotFound(String)
+    /// The task has no workspace available yet.
+    case workspaceUnavailable
+    /// The Fleet engine is not linked into this app build.
+    case engineUnavailable
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetSnapshot.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetSnapshot.swift
@@ -1,0 +1,38 @@
+/// A read-only summary of one Fleet engine instance.
+///
+/// The app target exposes this value through ``ControlFleetContext`` and the
+/// coordinator converts it to the `fleet.list` / `fleet.status` wire payload.
+public struct ControlFleetSnapshot: Sendable, Equatable {
+    /// The stable Fleet identifier on the wire.
+    public var fleetID: String
+    /// The Fleet display name.
+    public var name: String
+    /// The repository root this Fleet manages.
+    public var repoRoot: String
+    /// Whether the Fleet is currently running.
+    public var isRunning: Bool
+    /// Task counts keyed by state; the coordinator writes every state key.
+    public var taskCounts: [ControlFleetTaskStateName: Int]
+
+    /// Creates a Fleet summary snapshot.
+    ///
+    /// - Parameters:
+    ///   - fleetID: The stable Fleet identifier on the wire.
+    ///   - name: The Fleet display name.
+    ///   - repoRoot: The repository root this Fleet manages.
+    ///   - isRunning: Whether the Fleet is currently running.
+    ///   - taskCounts: Task counts keyed by state.
+    public init(
+        fleetID: String,
+        name: String,
+        repoRoot: String,
+        isRunning: Bool,
+        taskCounts: [ControlFleetTaskStateName: Int]
+    ) {
+        self.fleetID = fleetID
+        self.name = name
+        self.repoRoot = repoRoot
+        self.isRunning = isRunning
+        self.taskCounts = taskCounts
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetStatusSnapshot.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetStatusSnapshot.swift
@@ -1,0 +1,20 @@
+/// A read-only Fleet engine status snapshot.
+///
+/// Used by `fleet.status` to report the aggregate engine running state and the
+/// visible Fleets.
+public struct ControlFleetStatusSnapshot: Sendable, Equatable {
+    /// Whether the Fleet engine is currently running.
+    public var isRunning: Bool
+    /// The Fleets visible to the engine.
+    public var fleets: [ControlFleetSnapshot]
+
+    /// Creates a Fleet engine status snapshot.
+    ///
+    /// - Parameters:
+    ///   - isRunning: Whether the Fleet engine is currently running.
+    ///   - fleets: The Fleets visible to the engine.
+    public init(isRunning: Bool, fleets: [ControlFleetSnapshot]) {
+        self.isRunning = isRunning
+        self.fleets = fleets
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetTaskSnapshot.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetTaskSnapshot.swift
@@ -1,0 +1,121 @@
+/// Pull-request metadata attached to a Fleet task.
+public struct ControlFleetTaskPullRequest: Sendable, Equatable {
+    /// The pull-request URL, if one exists.
+    public var url: String?
+    /// The provider-specific pull-request status.
+    public var status: String
+
+    /// Creates Fleet task pull-request metadata.
+    ///
+    /// - Parameters:
+    ///   - url: The pull-request URL, if one exists.
+    ///   - status: The provider-specific pull-request status.
+    public init(url: String?, status: String) {
+        self.url = url
+        self.status = status
+    }
+}
+
+/// A read-only summary of one Fleet task.
+///
+/// The app target exposes this value through ``ControlFleetContext`` and the
+/// coordinator converts it to Fleet task wire payloads.
+public struct ControlFleetTaskSnapshot: Sendable, Equatable {
+    /// The stable task identifier on the wire.
+    public var taskID: String
+    /// The owning Fleet identifier.
+    public var fleetID: String
+    /// The source that created the task, such as `local` or `github`.
+    public var source: String
+    /// The task title.
+    public var title: String
+    /// The current task state.
+    public var state: ControlFleetTaskStateName
+    /// Whether the task is blocked.
+    public var isBlocked: Bool
+    /// The number of attempts made for this task.
+    public var attempts: Int
+    /// The optional scheduling priority.
+    public var priority: Int?
+    /// Labels associated with the task.
+    public var labels: [String]
+    /// The source URL, if any.
+    public var url: String?
+    /// The workspace id associated with this task, if any.
+    public var workspaceID: String?
+    /// The surface id associated with this task, if any.
+    public var surfaceID: String?
+    /// The working directory associated with this task, if any.
+    public var directoryPath: String?
+    /// The branch associated with this task, if any.
+    public var branch: String?
+    /// Pull-request metadata, if any.
+    public var pullRequest: ControlFleetTaskPullRequest?
+    /// The most recent task error, if any.
+    public var lastError: String?
+    /// Creation time as Unix seconds.
+    public var createdAt: Double
+    /// Last update time as Unix seconds.
+    public var updatedAt: Double
+
+    /// Creates a Fleet task summary snapshot.
+    ///
+    /// - Parameters:
+    ///   - taskID: The stable task identifier on the wire.
+    ///   - fleetID: The owning Fleet identifier.
+    ///   - source: The source that created the task.
+    ///   - title: The task title.
+    ///   - state: The current task state.
+    ///   - isBlocked: Whether the task is blocked.
+    ///   - attempts: The number of attempts made for this task.
+    ///   - priority: The optional scheduling priority.
+    ///   - labels: Labels associated with the task.
+    ///   - url: The source URL, if any.
+    ///   - workspaceID: The workspace id associated with this task, if any.
+    ///   - surfaceID: The surface id associated with this task, if any.
+    ///   - directoryPath: The working directory associated with this task, if any.
+    ///   - branch: The branch associated with this task, if any.
+    ///   - pullRequest: Pull-request metadata, if any.
+    ///   - lastError: The most recent task error, if any.
+    ///   - createdAt: Creation time as Unix seconds.
+    ///   - updatedAt: Last update time as Unix seconds.
+    public init(
+        taskID: String,
+        fleetID: String,
+        source: String,
+        title: String,
+        state: ControlFleetTaskStateName,
+        isBlocked: Bool,
+        attempts: Int,
+        priority: Int?,
+        labels: [String],
+        url: String?,
+        workspaceID: String?,
+        surfaceID: String?,
+        directoryPath: String?,
+        branch: String?,
+        pullRequest: ControlFleetTaskPullRequest?,
+        lastError: String?,
+        createdAt: Double,
+        updatedAt: Double
+    ) {
+        self.taskID = taskID
+        self.fleetID = fleetID
+        self.source = source
+        self.title = title
+        self.state = state
+        self.isBlocked = isBlocked
+        self.attempts = attempts
+        self.priority = priority
+        self.labels = labels
+        self.url = url
+        self.workspaceID = workspaceID
+        self.surfaceID = surfaceID
+        self.directoryPath = directoryPath
+        self.branch = branch
+        self.pullRequest = pullRequest
+        self.lastError = lastError
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetTaskStateName.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Fleet/ControlFleetTaskStateName.swift
@@ -1,0 +1,27 @@
+/// Wire names for Fleet task states.
+///
+/// The raw values are the snake_case strings used by the control socket.
+public enum ControlFleetTaskStateName: String, CaseIterable, Sendable, Equatable {
+    /// The task is queued and has not started.
+    case queued
+    /// The task is provisioning its execution environment.
+    case provisioning
+    /// The task is launching its agent process.
+    case launching
+    /// The task is currently running.
+    case running
+    /// The task is waiting for user or operator input.
+    case needsInput = "needs_input"
+    /// The task is stalled and needs attention.
+    case stalled
+    /// The task is waiting before an automatic retry.
+    case retryBackoff = "retry_backoff"
+    /// The task is waiting for review.
+    case awaitingReview = "awaiting_review"
+    /// The task completed successfully.
+    case done
+    /// The task failed.
+    case failed
+    /// The task was cancelled.
+    case cancelled
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+Fleet.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+Fleet.swift
@@ -1,0 +1,26 @@
+import Foundation
+@testable import CmuxControlSocket
+
+// Benign defaults for the Fleet-domain seam, so a test fake that conforms to
+// the full `ControlCommandContext` umbrella only has to implement the domain it
+// actually exercises.
+
+extension ControlFleetContext {
+    func controlFleetList() -> [ControlFleetSnapshot] { [] }
+    func controlFleetStatus(fleetID: String?) -> ControlFleetStatusResolution {
+        fleetID.map { .fleetNotFound($0) } ?? .ok(ControlFleetStatusSnapshot(isRunning: false, fleets: []))
+    }
+    func controlFleetCreate(inputs: ControlFleetCreateInputs) -> ControlFleetCreateResolution { .engineUnavailable }
+    func controlFleetStart(fleetID: String) -> ControlFleetLifecycleResolution { .engineUnavailable }
+    func controlFleetStop(fleetID: String) -> ControlFleetLifecycleResolution { .engineUnavailable }
+    func controlFleetTaskAdd(inputs: ControlFleetTaskAddInputs) -> ControlFleetTaskAddResolution { .engineUnavailable }
+    func controlFleetTaskList(
+        fleetID: String?,
+        state: ControlFleetTaskStateName?
+    ) -> ControlFleetTaskListResolution {
+        fleetID.map { .fleetNotFound($0) } ?? .ok([])
+    }
+    func controlFleetTaskRetry(taskID: String) -> ControlFleetTaskActionResolution { .engineUnavailable }
+    func controlFleetTaskCancel(taskID: String) -> ControlFleetTaskActionResolution { .engineUnavailable }
+    func controlFleetTaskOpen(taskID: String) -> ControlFleetTaskOpenResolution { .engineUnavailable }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorFleetTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorFleetTests.swift
@@ -1,0 +1,398 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+@MainActor
+private final class FakeFleetControlCommandContext: ControlCommandContext {
+    private(set) var calls: [String] = []
+    private(set) var createInputs: ControlFleetCreateInputs?
+    private(set) var lifecycleFleetIDs: [String] = []
+    private(set) var taskAddInputs: ControlFleetTaskAddInputs?
+    private(set) var taskListArgs: (fleetID: String?, state: ControlFleetTaskStateName?)?
+    private(set) var taskIDs: [String] = []
+
+    var listSnapshots: [ControlFleetSnapshot] = []
+    var statusResolution: ControlFleetStatusResolution = .ok(ControlFleetStatusSnapshot(isRunning: false, fleets: []))
+    var createResolution: ControlFleetCreateResolution = .engineUnavailable
+    var startResolution: ControlFleetLifecycleResolution = .engineUnavailable
+    var stopResolution: ControlFleetLifecycleResolution = .engineUnavailable
+    var taskAddResolution: ControlFleetTaskAddResolution = .engineUnavailable
+    var taskListResolution: ControlFleetTaskListResolution = .ok([])
+    var taskRetryResolution: ControlFleetTaskActionResolution = .engineUnavailable
+    var taskCancelResolution: ControlFleetTaskActionResolution = .engineUnavailable
+    var taskOpenResolution: ControlFleetTaskOpenResolution = .engineUnavailable
+
+    func controlFleetList() -> [ControlFleetSnapshot] {
+        calls.append("list")
+        return listSnapshots
+    }
+
+    func controlFleetStatus(fleetID: String?) -> ControlFleetStatusResolution {
+        calls.append("status:\(fleetID ?? "<nil>")")
+        return statusResolution
+    }
+
+    func controlFleetCreate(inputs: ControlFleetCreateInputs) -> ControlFleetCreateResolution {
+        calls.append("create")
+        createInputs = inputs
+        return createResolution
+    }
+
+    func controlFleetStart(fleetID: String) -> ControlFleetLifecycleResolution {
+        calls.append("start")
+        lifecycleFleetIDs.append(fleetID)
+        return startResolution
+    }
+
+    func controlFleetStop(fleetID: String) -> ControlFleetLifecycleResolution {
+        calls.append("stop")
+        lifecycleFleetIDs.append(fleetID)
+        return stopResolution
+    }
+
+    func controlFleetTaskAdd(inputs: ControlFleetTaskAddInputs) -> ControlFleetTaskAddResolution {
+        calls.append("task.add")
+        taskAddInputs = inputs
+        return taskAddResolution
+    }
+
+    func controlFleetTaskList(
+        fleetID: String?,
+        state: ControlFleetTaskStateName?
+    ) -> ControlFleetTaskListResolution {
+        calls.append("task.list")
+        taskListArgs = (fleetID, state)
+        return taskListResolution
+    }
+
+    func controlFleetTaskRetry(taskID: String) -> ControlFleetTaskActionResolution {
+        calls.append("task.retry")
+        taskIDs.append(taskID)
+        return taskRetryResolution
+    }
+
+    func controlFleetTaskCancel(taskID: String) -> ControlFleetTaskActionResolution {
+        calls.append("task.cancel")
+        taskIDs.append(taskID)
+        return taskCancelResolution
+    }
+
+    func controlFleetTaskOpen(taskID: String) -> ControlFleetTaskOpenResolution {
+        calls.append("task.open")
+        taskIDs.append(taskID)
+        return taskOpenResolution
+    }
+}
+
+@MainActor
+@Suite("ControlCommandCoordinator Fleet domain")
+struct ControlCommandCoordinatorFleetTests {
+    private func makeCoordinator() -> (ControlCommandCoordinator, FakeFleetControlCommandContext) {
+        let context = FakeFleetControlCommandContext()
+        return (ControlCommandCoordinator(context: context), context)
+    }
+
+    private func request(_ method: String, _ params: [String: JSONValue] = [:]) -> ControlRequest {
+        ControlRequest(id: .int(1), method: method, params: params)
+    }
+
+    private var fleet: ControlFleetSnapshot {
+        ControlFleetSnapshot(
+            fleetID: "fleet-a",
+            name: "Fleet A",
+            repoRoot: "/repo/a",
+            isRunning: true,
+            taskCounts: [.queued: 2, .running: 1, .failed: 3]
+        )
+    }
+
+    private var fullTask: ControlFleetTaskSnapshot {
+        ControlFleetTaskSnapshot(
+            taskID: "task-full",
+            fleetID: "fleet-a",
+            source: "github",
+            title: "Implement feature",
+            state: .awaitingReview,
+            isBlocked: true,
+            attempts: 2,
+            priority: 7,
+            labels: ["bug", "backend"],
+            url: "https://example.com/task",
+            workspaceID: "workspace-raw",
+            surfaceID: "surface-raw",
+            directoryPath: "/repo/a",
+            branch: "feature/fleet",
+            pullRequest: ControlFleetTaskPullRequest(url: "https://example.com/pr/1", status: "open"),
+            lastError: "needs review",
+            createdAt: 1_700_000_000.25,
+            updatedAt: 1_700_000_030.5
+        )
+    }
+
+    private var minimalTask: ControlFleetTaskSnapshot {
+        ControlFleetTaskSnapshot(
+            taskID: "task-min",
+            fleetID: "fleet-a",
+            source: "local",
+            title: "Local task",
+            state: .queued,
+            isBlocked: false,
+            attempts: 0,
+            priority: nil,
+            labels: [],
+            url: nil,
+            workspaceID: nil,
+            surfaceID: nil,
+            directoryPath: nil,
+            branch: nil,
+            pullRequest: nil,
+            lastError: nil,
+            createdAt: 10,
+            updatedAt: 20
+        )
+    }
+
+    private var fleetPayload: JSONValue {
+        .object([
+            "fleet_id": .string("fleet-a"),
+            "name": .string("Fleet A"),
+            "repo_root": .string("/repo/a"),
+            "running": .bool(true),
+            "counts": .object([
+                "queued": .int(2),
+                "provisioning": .int(0),
+                "launching": .int(0),
+                "running": .int(1),
+                "needs_input": .int(0),
+                "stalled": .int(0),
+                "retry_backoff": .int(0),
+                "awaiting_review": .int(0),
+                "done": .int(0),
+                "failed": .int(3),
+                "cancelled": .int(0),
+            ]),
+        ])
+    }
+
+    private var fullTaskPayload: JSONValue {
+        .object([
+            "task_id": .string("task-full"),
+            "fleet_id": .string("fleet-a"),
+            "source": .string("github"),
+            "title": .string("Implement feature"),
+            "state": .string("awaiting_review"),
+            "blocked": .bool(true),
+            "attempts": .int(2),
+            "priority": .int(7),
+            "labels": .array([.string("bug"), .string("backend")]),
+            "url": .string("https://example.com/task"),
+            "workspace_id": .string("workspace-raw"),
+            "surface_id": .string("surface-raw"),
+            "directory": .string("/repo/a"),
+            "branch": .string("feature/fleet"),
+            "pr": .object(["url": .string("https://example.com/pr/1"), "status": .string("open")]),
+            "last_error": .string("needs review"),
+            "created_at": .double(1_700_000_000.25),
+            "updated_at": .double(1_700_000_030.5),
+        ])
+    }
+
+    private var minimalTaskPayload: JSONValue {
+        .object([
+            "task_id": .string("task-min"),
+            "fleet_id": .string("fleet-a"),
+            "source": .string("local"),
+            "title": .string("Local task"),
+            "state": .string("queued"),
+            "blocked": .bool(false),
+            "attempts": .int(0),
+            "priority": .null,
+            "labels": .array([]),
+            "url": .null,
+            "workspace_id": .null,
+            "surface_id": .null,
+            "directory": .null,
+            "branch": .null,
+            "pr": .null,
+            "last_error": .null,
+            "created_at": .double(10),
+            "updated_at": .double(20),
+        ])
+    }
+
+    @Test func routesEveryFleetMethodAndIgnoresUnknownMethods() {
+        let (coordinator, context) = makeCoordinator()
+        context.createResolution = .created(fleet)
+        context.startResolution = .ok(fleet)
+        context.stopResolution = .ok(fleet)
+        context.taskAddResolution = .added(fullTask)
+        context.taskRetryResolution = .ok(fullTask)
+        context.taskCancelResolution = .ok(fullTask)
+        context.taskOpenResolution = .workspaceUnavailable
+
+        _ = coordinator.handle(request("fleet.list"))
+        _ = coordinator.handle(request("fleet.status"))
+        _ = coordinator.handle(request("fleet.create", ["name": .string("N"), "repo_root": .string("/r")]))
+        _ = coordinator.handle(request("fleet.start", ["fleet_id": .string("fleet-a")]))
+        _ = coordinator.handle(request("fleet.stop", ["fleet_id": .string("fleet-a")]))
+        _ = coordinator.handle(request("fleet.task.add", ["fleet_id": .string("fleet-a"), "title": .string("T")]))
+        _ = coordinator.handle(request("fleet.task.list"))
+        _ = coordinator.handle(request("fleet.task.retry", ["task_id": .string("task-a")]))
+        _ = coordinator.handle(request("fleet.task.cancel", ["task_id": .string("task-a")]))
+        _ = coordinator.handle(request("fleet.task.open", ["task_id": .string("task-a")]))
+
+        #expect(context.calls == [
+            "list", "status:<nil>", "create", "start", "stop",
+            "task.add", "task.list", "task.retry", "task.cancel", "task.open",
+        ])
+        #expect(coordinator.handleFleet(request("fleet.unknown")) == nil)
+        #expect(coordinator.handle(request("fleet.unknown")) == nil)
+        #expect(coordinator.handleFleet(request("workspace.list")) == nil)
+    }
+
+    @Test func encodesSuccessPayloadsExactly() {
+        let workspaceID = UUID()
+        let (coordinator, context) = makeCoordinator()
+        context.listSnapshots = [fleet]
+        context.statusResolution = .ok(ControlFleetStatusSnapshot(isRunning: true, fleets: [fleet]))
+        context.createResolution = .created(fleet)
+        context.startResolution = .ok(fleet)
+        context.taskAddResolution = .added(fullTask)
+        context.taskListResolution = .ok([fullTask, minimalTask])
+        context.taskRetryResolution = .ok(minimalTask)
+        context.taskOpenResolution = .opened(workspaceID: workspaceID)
+
+        #expect(coordinator.handle(request("fleet.list")) == .ok(.object(["fleets": .array([fleetPayload])])))
+        #expect(coordinator.handle(request("fleet.status")) == .ok(.object([
+            "running": .bool(true),
+            "fleets": .array([fleetPayload]),
+        ])))
+        #expect(coordinator.handle(request("fleet.create", [
+            "name": .string("Fleet A"),
+            "repo_root": .string("/repo/a"),
+        ])) == .ok(.object(["fleet": fleetPayload])))
+        #expect(coordinator.handle(request("fleet.start", [
+            "fleet_id": .string("fleet-a"),
+        ])) == .ok(.object(["fleet": fleetPayload])))
+        #expect(coordinator.handle(request("fleet.task.add", [
+            "fleet_id": .string("fleet-a"),
+            "title": .string("Implement feature"),
+        ])) == .ok(.object(["task": fullTaskPayload])))
+        #expect(coordinator.handle(request("fleet.task.list")) == .ok(.object([
+            "tasks": .array([fullTaskPayload, minimalTaskPayload]),
+        ])))
+        #expect(coordinator.handle(request("fleet.task.retry", [
+            "task_id": .string("task-min"),
+        ])) == .ok(.object(["task": minimalTaskPayload])))
+
+        let workspaceRef = coordinator.handles.ensureRef(kind: .workspace, uuid: workspaceID)
+        #expect(coordinator.handle(request("fleet.task.open", [
+            "task_id": .string("task-full"),
+        ])) == .ok(.object([
+            "task_id": .string("task-full"),
+            "workspace_id": .string(workspaceRef),
+        ])))
+    }
+
+    @Test func validatesRequiredAndTypedParams() {
+        let (coordinator, _) = makeCoordinator()
+        let cases: [(String, [String: JSONValue])] = [
+            ("fleet.create", ["repo_root": .string("/r")]),
+            ("fleet.create", ["name": .string("N")]),
+            ("fleet.create", ["name": .string("N"), "repo_root": .string("/r"), "max_concurrent": .int(0)]),
+            ("fleet.start", [:]),
+            ("fleet.stop", [:]),
+            ("fleet.task.add", ["title": .string("T")]),
+            ("fleet.task.add", ["fleet_id": .string("fleet-a")]),
+            ("fleet.task.list", ["state": .string("bogus")]),
+            ("fleet.task.retry", [:]),
+            ("fleet.task.cancel", [:]),
+            ("fleet.task.open", [:]),
+        ]
+
+        for (method, params) in cases {
+            guard case .err(let code, _, _) = coordinator.handle(request(method, params)) else {
+                Issue.record("expected invalid_params for \(method)")
+                continue
+            }
+            #expect(code == "invalid_params", "for \(method)")
+        }
+    }
+
+    @Test func mapsSeamErrorsToWireCodes() {
+        let (coordinator, context) = makeCoordinator()
+        context.createResolution = .engineUnavailable
+        context.statusResolution = .fleetNotFound("fleet-missing")
+        context.taskRetryResolution = .taskNotFound("task-missing")
+        context.taskCancelResolution = .invalidState(current: .running)
+        context.taskOpenResolution = .workspaceUnavailable
+
+        #expect(errorCode(coordinator.handle(request("fleet.create", [
+            "name": .string("N"),
+            "repo_root": .string("/r"),
+        ]))) == "unavailable")
+        #expect(errorCode(coordinator.handle(request("fleet.status", [
+            "fleet_id": .string("fleet-missing"),
+        ]))) == "not_found")
+        #expect(errorCode(coordinator.handle(request("fleet.task.retry", [
+            "task_id": .string("task-missing"),
+        ]))) == "not_found")
+        let invalidState = coordinator.handle(request("fleet.task.cancel", ["task_id": .string("task-a")]))
+        #expect(errorCode(invalidState) == "invalid_state")
+        if case .err(_, let message, _) = invalidState {
+            #expect(message.contains("running"))
+        }
+        #expect(errorCode(coordinator.handle(request("fleet.task.open", [
+            "task_id": .string("task-a"),
+        ]))) == "invalid_state")
+    }
+
+    @Test func trimsArgumentsAndParsesStateFilter() {
+        let (coordinator, context) = makeCoordinator()
+        context.createResolution = .created(fleet)
+        context.startResolution = .ok(fleet)
+        context.taskAddResolution = .added(minimalTask)
+
+        _ = coordinator.handle(request("fleet.create", [
+            "name": .string("  Fleet A  "),
+            "repo_root": .string("  /repo/a  "),
+            "agent_command": .string("  codex exec  "),
+            "max_concurrent": .string("3"),
+        ]))
+        #expect(context.createInputs == ControlFleetCreateInputs(
+            name: "Fleet A",
+            repoRoot: "/repo/a",
+            agentCommand: "codex exec",
+            maxConcurrent: 3
+        ))
+
+        _ = coordinator.handle(request("fleet.start", ["fleet_id": .string("  fleet-a  ")]))
+        _ = coordinator.handle(request("fleet.task.add", [
+            "fleet_id": .string("  fleet-a  "),
+            "title": .string("  Do work  "),
+            "body": .string("  body  "),
+            "priority": .string("5"),
+        ]))
+        _ = coordinator.handle(request("fleet.task.list", [
+            "fleet_id": .string("  fleet-a  "),
+            "state": .string("running"),
+        ]))
+        _ = coordinator.handle(request("fleet.task.retry", ["task_id": .string("  task-a  ")]))
+
+        #expect(context.lifecycleFleetIDs == ["fleet-a"])
+        #expect(context.taskAddInputs == ControlFleetTaskAddInputs(
+            fleetID: "fleet-a",
+            title: "Do work",
+            body: "body",
+            priority: 5
+        ))
+        #expect(context.taskListArgs?.fleetID == "fleet-a")
+        #expect(context.taskListArgs?.state == .running)
+        #expect(context.taskIDs == ["task-a"])
+    }
+
+    private func errorCode(_ result: ControlCallResult?) -> String? {
+        guard case .err(let code, _, _) = result else { return nil }
+        return code
+    }
+}

--- a/Sources/TerminalController+ControlFleetContext.swift
+++ b/Sources/TerminalController+ControlFleetContext.swift
@@ -1,0 +1,56 @@
+import CmuxControlSocket
+import Foundation
+
+/// The Fleet-domain witnesses are PR 2 stubs for the #7361 Fleet control-socket
+/// chain. PR 3 replaces these bodies with the FleetEngine bridge once the app
+/// target owns live Fleet state.
+extension TerminalController: ControlFleetContext {
+    func controlFleetList() -> [ControlFleetSnapshot] {
+        []
+    }
+
+    func controlFleetStatus(fleetID: String?) -> ControlFleetStatusResolution {
+        if let fleetID {
+            return .fleetNotFound(fleetID)
+        }
+        return .ok(ControlFleetStatusSnapshot(isRunning: false, fleets: []))
+    }
+
+    func controlFleetCreate(inputs: ControlFleetCreateInputs) -> ControlFleetCreateResolution {
+        .engineUnavailable
+    }
+
+    func controlFleetStart(fleetID: String) -> ControlFleetLifecycleResolution {
+        .engineUnavailable
+    }
+
+    func controlFleetStop(fleetID: String) -> ControlFleetLifecycleResolution {
+        .engineUnavailable
+    }
+
+    func controlFleetTaskAdd(inputs: ControlFleetTaskAddInputs) -> ControlFleetTaskAddResolution {
+        .engineUnavailable
+    }
+
+    func controlFleetTaskList(
+        fleetID: String?,
+        state: ControlFleetTaskStateName?
+    ) -> ControlFleetTaskListResolution {
+        if let fleetID {
+            return .fleetNotFound(fleetID)
+        }
+        return .ok([])
+    }
+
+    func controlFleetTaskRetry(taskID: String) -> ControlFleetTaskActionResolution {
+        .engineUnavailable
+    }
+
+    func controlFleetTaskCancel(taskID: String) -> ControlFleetTaskActionResolution {
+        .engineUnavailable
+    }
+
+    func controlFleetTaskOpen(taskID: String) -> ControlFleetTaskOpenResolution {
+        .engineUnavailable
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1088,6 +1088,7 @@
 		CA52E0020000000000000000 /* TerminalController+ControlCanvasContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52F0020000000000000000 /* TerminalController+ControlCanvasContext.swift */; };
 		C0DE00000000000000000C6E /* TerminalController+ControlDebugContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C6D /* TerminalController+ControlDebugContext.swift */; };
 		C0DE00000000000000000C44 /* TerminalController+ControlFeedContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C43 /* TerminalController+ControlFeedContext.swift */; };
+		C0DE00000000000000000C48 /* TerminalController+ControlFleetContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C47 /* TerminalController+ControlFleetContext.swift */; };
 		C0DE00000000000000000C52 /* TerminalController+ControlMobileHostContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C51 /* TerminalController+ControlMobileHostContext.swift */; };
 		C0DE00000000000000000C46 /* TerminalController+ControlNotificationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C45 /* TerminalController+ControlNotificationContext.swift */; };
 		C0DE00000000000000000C56 /* TerminalController+ControlPaneContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C55 /* TerminalController+ControlPaneContext.swift */; };
@@ -2391,6 +2392,7 @@
 		CA52F0020000000000000000 /* TerminalController+ControlCanvasContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlCanvasContext.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C6D /* TerminalController+ControlDebugContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlDebugContext.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C43 /* TerminalController+ControlFeedContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlFeedContext.swift"; sourceTree = "<group>"; };
+		C0DE00000000000000000C47 /* TerminalController+ControlFleetContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlFleetContext.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C51 /* TerminalController+ControlMobileHostContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlMobileHostContext.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C45 /* TerminalController+ControlNotificationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlNotificationContext.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C55 /* TerminalController+ControlPaneContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlPaneContext.swift"; sourceTree = "<group>"; };
@@ -3176,6 +3178,7 @@
 				C0DE00000000000000000C31 /* TerminalControllerControlCommandContext.swift */,
 				C0DE00000000000000000C41 /* TerminalController+ControlAppFocusContext.swift */,
 				C0DE00000000000000000C43 /* TerminalController+ControlFeedContext.swift */,
+				C0DE00000000000000000C47 /* TerminalController+ControlFleetContext.swift */,
 				C0DE00000000000000000C45 /* TerminalController+ControlNotificationContext.swift */,
 				C0DE00000000000000000C61 /* TerminalController+ControlWorkspaceContext.swift */,
 				D7AB00000000000000B000 /* TerminalController+MobileNotificationSync.swift */,
@@ -5087,6 +5090,7 @@
 				CA52E0020000000000000000 /* TerminalController+ControlCanvasContext.swift in Sources */,
 				C0DE00000000000000000C6E /* TerminalController+ControlDebugContext.swift in Sources */,
 				C0DE00000000000000000C44 /* TerminalController+ControlFeedContext.swift in Sources */,
+				C0DE00000000000000000C48 /* TerminalController+ControlFleetContext.swift in Sources */,
 				C0DE00000000000000000C52 /* TerminalController+ControlMobileHostContext.swift in Sources */,
 				C0DE00000000000000000C46 /* TerminalController+ControlNotificationContext.swift in Sources */,
 				C0DE00000000000000000C56 /* TerminalController+ControlPaneContext.swift in Sources */,


### PR DESCRIPTION
## Scope

Part 2 of #7361.

Adds the `fleet.*` command domain to the `CmuxControlSocket` package following the existing coordinator seam pattern (one seam protocol per domain + typed wire values + a `handleFleet` coordinator extension), plus a stub app-side conformance:

- Methods: `fleet.list`, `fleet.create`, `fleet.start`, `fleet.stop`, `fleet.status`, `fleet.task.add`, `fleet.task.list`, `fleet.task.retry`, `fleet.task.cancel`, `fleet.task.open`.
- New `Coordinator/Fleet/` files: `ControlFleetContext` seam, `ControlFleetSnapshot` / `ControlFleetStatusSnapshot` / `ControlFleetTaskSnapshot` wire values, `ControlFleetTaskStateName` wire state vocabulary, create/task-add input structs, resolution enums, and the `handleFleet` dispatch with param validation, error mapping (`invalid_params` / `not_found` / `unavailable` / `invalid_state`), and workspace-ref minting for `fleet.task.open`.
- `ControlCommandContext` umbrella + `ControlCommandCoordinator.handle` gain the fleet domain (one line each).
- App target conforms via `Sources/TerminalController+ControlFleetContext.swift` with pre-engine stubs: reads return empty snapshots, mutations return `unavailable` ("fleet engine is not available in this build"). PR 3 of the chain replaces these bodies with the FleetEngine bridge.
- No `CmuxFleet` dependency is added to the socket package; all wire types are package-local. `Package.swift` untouched.
- Test stubs live in a new `ControlCommandContextTestStubs+Fleet.swift` (the base stubs file is at its length-budget cap and is untouched).

Phase-1 CLI rides the existing raw passthrough, e.g. `cmux rpc fleet.list`, `cmux rpc fleet.task.add '{"fleet_id":"...","title":"..."}'` — no CLI changes needed.

No UI, localization, focus behavior, or engine logic changes. `fleet.*` methods run on the main-actor coordinator lane (no `ControlCommandExecutionPolicy` change needed).

## Tests

- `cd Packages/macOS/CmuxControlSocket && swift test` — 187 tests / 32 suites pass, including the new `ControlCommandCoordinatorFleetTests` (routing for all 10 methods + unknown-method fallthrough, exact JSONValue success encodings with populated and nil optionals, param validation, error-code mapping, handle-registry workspace ref minting, trimmed-args/typed-state-filter fidelity).
- `python3 scripts/normalize-pbxproj.py` idempotent; `./scripts/check-pbxproj.sh` passes.
- `.github/swift-file-length-budget.tsv` untouched; all new files < 500 lines.
- Tagged Debug build + socket smoke over `cmux rpc fleet.*` against the running tagged app.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785885740&installation_id=133855650&pr_number=7403&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7403&signature=7f1605a0588fb943afdabf6a7d197b39d7f5e8b17ad71a75763440d02401ac06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `fleet.*` control-socket domain to `CmuxControlSocket` with a coordinator seam and typed wire values, enabling Fleet and task RPCs. App-side handlers are stubbed for now, returning empty reads and `unavailable` for mutations.

- **New Features**
  - New methods: `fleet.list`, `fleet.create`, `fleet.start`, `fleet.stop`, `fleet.status`, `fleet.task.add`, `fleet.task.list`, `fleet.task.retry`, `fleet.task.cancel`, `fleet.task.open`.
  - Added `ControlFleetContext` seam and wire types: snapshots, `ControlFleetTaskStateName`, inputs, and resolution enums.
  - Implemented `handleFleet` in the coordinator with param trimming/validation and error mapping (`invalid_params`, `not_found`, `unavailable`, `invalid_state`).
  - Extended `ControlCommandContext` and `ControlCommandCoordinator` to route Fleet commands.
  - App conformance via `TerminalController+ControlFleetContext` stubs: reads return empty; mutations return `unavailable` (“fleet engine is not available in this build”).
  - No new dependencies; `Package.swift` unchanged. CLI works via existing passthrough, e.g. `cmux rpc fleet.list`.
  - Tests cover routing for all methods, exact JSON payloads, validation, error codes, and workspace-ref minting for `fleet.task.open`.

<sup>Written for commit be405f93a71ce8c73c6609b6381bb572e7f52afa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fleet management support, including viewing fleet status, listing fleets, and starting/stopping fleets.
  * Added task management actions such as creating tasks, listing tasks, retrying, canceling, and opening task workspaces.
  * Included richer fleet and task details in responses, such as state counts, metadata, and timestamps.

* **Tests**
  * Added coverage for Fleet command routing, parameter validation, and response formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->