### PR TITLE
Restore hibernated agent lifecycle to .idle on un-hibernation

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -5,7 +5,7 @@
 17954	Sources/AppDelegate.swift
 16471	Sources/ContentView.swift
 14270	Sources/TerminalController.swift
-13172	Sources/Workspace.swift
+13190	Sources/Workspace.swift
 12348	cmuxTests/AppDelegateShortcutRoutingTests.swift
 12296	Sources/GhosttyTerminalView.swift
 11669	Sources/Panels/BrowserPanel.swift
@@ -24,8 +24,8 @@
 4483	Sources/cmuxApp.swift
 4482	Sources/Panels/FilePreviewPanel.swift
 4367	cmuxTests/BrowserPanelTests.swift
-4283	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 4121	Sources/BrowserWindowPortal.swift
+4283	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 3934	Sources/Feed/FeedPanelView.swift
 3926	cmuxTests/TabManagerUnitTests.swift
 3896	cmuxTests/WindowAndDragTests.swift
@@ -83,7 +83,7 @@
 1197	cmuxTests/CodexAppServerSessionTests.swift
 1166	Sources/VaultAgentProcessScanner.swift
 1147	cmuxTests/PiVaultAgentPersistenceTests.swift
-1121	cmuxTests/AgentHibernationTests.swift
+1128	cmuxTests/AgentHibernationTests.swift
 1110	Sources/AppDelegate+CmuxSSHURL.swift
 1093	cmuxUITests/BonsplitTabDragUITests.swift
 1087	Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteFuzzyMatcher.swift

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4759,6 +4759,24 @@ final class Workspace: Identifiable, ObservableObject {
         recordAgentLifecycleChange(panelId: panelId)
     }
 
+    /// On un-hibernation, re-apply `.idle` to the pane's agent lifecycle keys rather than
+    /// clearing them. The planner only ever hibernates a pane whose resolved lifecycle is
+    /// `.idle` (the sole state that `allowsHibernation`), and those `.idle` entries survive
+    /// hibernation in `agentLifecycleStatesByPanelId`. Resuming brings the session back at
+    /// an idle prompt, so keeping it `.idle` leaves it eligible to hibernate again on idle
+    /// time. Clearing to `.unknown` (the prior behavior) stranded restored agents as
+    /// non-idle until a fresh Stop hook fired, so they never re-hibernated. The resumed
+    /// agent's own hooks overwrite this to `.running`/`.needsInput` the moment it works.
+    func restoreAgentLifecycleToIdleAfterResume(panelId: UUID) {
+        guard let keys = agentLifecycleStatesByPanelId[panelId]?.keys, !keys.isEmpty else {
+            return
+        }
+        for key in Array(keys) {
+            agentLifecycleStatesByPanelId[panelId]?[key] = .idle
+        }
+        recordAgentLifecycleChange(panelId: panelId)
+    }
+
     func clearAllAgentLifecycleStates() {
         let panelIds = Array(agentLifecycleStatesByPanelId.keys)
         guard !panelIds.isEmpty else { return }
@@ -4845,7 +4863,7 @@ final class Workspace: Identifiable, ObservableObject {
                 : .manualResumeAvailable
             invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
         }
-        clearAgentLifecycleStates(panelId: panelId)
+        restoreAgentLifecycleToIdleAfterResume(panelId: panelId)
         AgentHibernationController.shared.recordTerminalFocus(workspaceId: id, panelId: panelId)
         if focus {
             focusPanel(panelId)

--- a/cmuxTests/AgentHibernationTests.swift
+++ b/cmuxTests/AgentHibernationTests.swift
@@ -942,12 +942,19 @@ final class AgentHibernationTests: XCTestCase {
     }
 
     @MainActor
-    func testResumeClearsStaleLifecycleState() throws {
+    func testResumeRestoresIdleLifecycleState() throws {
+        // A pane is only ever hibernated while its lifecycle is `.idle` (the sole state
+        // that `allowsHibernation`), and resuming brings the session back at an idle
+        // prompt — so un-hibernation must leave it `.idle`, keeping it eligible to
+        // hibernate again on idle time. The prior behavior cleared it to `.unknown`,
+        // which stranded restored agents as non-idle so they never re-hibernated until a
+        // fresh turn ended. The resumed agent's own hooks overwrite `.idle` the moment it
+        // actually does work.
         let workspace = Workspace()
         let panelId = try XCTUnwrap(workspace.focusedPanelId)
         let snapshot = SessionRestorableAgentSnapshot(
             kind: .codex,
-            sessionId: "codex-clear-lifecycle-on-resume",
+            sessionId: "codex-restore-idle-on-resume",
             workingDirectory: "/tmp/cmux-agent-hibernation",
             launchCommand: launch("codex", "/usr/local/bin/codex", cwd: "/tmp/cmux-agent-hibernation")
         )
@@ -960,7 +967,7 @@ final class AgentHibernationTests: XCTestCase {
         )
 
         XCTAssertTrue(workspace.resumeAgentHibernation(panelId: panelId, focus: false))
-        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .unknown)
+        XCTAssertEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .idle)
     }
 
     @MainActor


### PR DESCRIPTION
## Problem

A restored (un-hibernated) agent never re-hibernates on idle time — it only becomes hibernation-eligible again after finishing a fresh turn. Over a session the hibernation benefit degrades: every agent you click to restore piles up in the live slots and stops being reclaimed.

## Root cause

`allowsHibernation` is `self == .idle` — only `.idle` panes are eligible, and `.idle` is set only by the Stop hook (turn end). A pane hibernates only while `.idle`, and those `.idle` entries survive hibernation in `agentLifecycleStatesByPanelId` untouched. But `Workspace.resumeAgentHibernation` called `clearAgentLifecycleStates(panelId:)`, wiping them to `.unknown` on resume. Resuming re-runs the agent (e.g. `claude --resume`) which fires SessionStart(resume) but never Stop, so the pane lingers `.unknown`/`.running` and never drifts back to `.idle`.

## Fix

On un-hibernation, re-apply `.idle` to the pane's existing lifecycle keys instead of clearing them (`Workspace.restoreAgentLifecycleToIdleAfterResume`). Resuming brings the session back at an idle prompt, so `.idle` is the correct state. The resumed agent's own hooks overwrite it to `.running`/`.needsInput` the moment it does work, and the planner's activity-staleness gate (idleSeconds) plus focused-pane protection prevent any restore→instant-rehibernate thrash.

No snapshot/persistence changes needed: the `.idle` entries are already in memory at resume time; the bug was only that they were being wiped.

## Test

Two-commit red/green on the existing `AgentHibernationTests` (in-process `Workspace` model, no app harness): `testResumeClearsStaleLifecycleState` → `testResumeRestoresIdleLifecycleState`, flipping the post-resume expectation from `.unknown` to `.idle`. Commit 1 (test) fails against current code; commit 2 (fix) makes it pass.

Surfaced during PR #6721 dogfood. Separate from #6721 (which is notification-lifecycle *correctness*); this is restore-idle-eligibility.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785885828&installation_id=133855650&pr_number=7404&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7404&signature=990e43379c8a541cf9ec77e99f3f4476fa4dee269f7867fe232bfe732e136346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent hibernation eligibility in `Workspace.resumeAgentHibernation`; behavior change is narrow and covered by an updated unit test, but it affects when live terminal slots are reclaimed.
> 
> **Overview**
> Fixes restored agents **never becoming hibernation-eligible again** after un-hibernate. The hibernation planner only picks panes whose lifecycle is `.idle`; resume used to call `clearAgentLifecycleStates`, which left them `.unknown` until a Stop hook ran—resume paths often never fire Stop, so those panes stayed live and piled up.
> 
> **`resumeAgentHibernation`** now calls **`restoreAgentLifecycleToIdleAfterResume`**, which sets existing lifecycle keys back to `.idle` instead of wiping them. That matches an idle prompt after resume and lets idle-time hibernation work again; agent hooks still update `.running` / `.needsInput` when work starts.
> 
> The **`AgentHibernationTests`** case is renamed and expects **`.idle`** after resume (was `.unknown`). CI file-length budgets are bumped for `Workspace.swift` and `AgentHibernationTests.swift`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00be2a27ba90fd23ee0017c435aa97e6fd932e5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore un-hibernated agents to `.idle` instead of `.unknown` so they can re-hibernate on idle without needing a new turn. Prevents restored agents from piling up in live slots.

- **Bug Fixes**
  - On resume, set existing lifecycle keys to `.idle` (`restoreAgentLifecycleToIdleAfterResume`) instead of clearing them.
  - Updated `AgentHibernationTests` to expect `.idle` after resume (`testResumeRestoresIdleLifecycleState`).

<sup>Written for commit 00be2a27ba90fd23ee0017c435aa97e6fd932e5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resuming a hibernated agent now preserves its idle lifecycle state instead of resetting it to an unknown state.
  * Improved resume behavior so agents remain in a consistent idle state after waking back up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->