### PR TITLE
coderouter: multi-credential LLM gateway (worker + control plane)

### DIFF
--- a/.github/workflows/coderouter.yml
+++ b/.github/workflows/coderouter.yml
@@ -1,0 +1,113 @@
+# CI/CD for the coderouter service (workers/coderouter).
+#
+# PRs touching the service run typecheck + unit tests + a wrangler dry-run
+# build. Pushes to main additionally deploy to Cloudflare. `wrangler deploy`
+# applies the Durable Object migrations declared in wrangler.toml atomically
+# with the code upload, so the service's schema can never lag a deploy.
+#
+# Required repository secrets (deploy job):
+#   CLOUDFLARE_API_TOKEN   API token with Workers Scripts:Edit on the account
+#   CLOUDFLARE_ACCOUNT_ID  the Cloudflare account id
+#
+# One-time Worker secrets (set once via `wrangler secret put`, survive every
+# deploy; see workers/coderouter/README.md):
+#   CODEROUTER_KEY_SIGNING_SECRET, CODEROUTER_INTERNAL_TOKEN,
+#   CODEROUTER_MASTER_KEY, MANAGED_ANTHROPIC_API_KEY, MANAGED_OPENAI_API_KEY
+
+name: coderouter
+
+on:
+  pull_request:
+    paths:
+      - "workers/coderouter/**"
+      - ".github/workflows/coderouter.yml"
+  push:
+    branches: [main]
+    paths:
+      - "workers/coderouter/**"
+      - ".github/workflows/coderouter.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    defaults:
+      run:
+        working-directory: workers/coderouter
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      # Wrangler requires Node >= 22; the Blacksmith ubuntu-2404 image ships
+      # Node 20, so pin it explicitly instead of relying on the runner's
+      # ambient version (GitHub-hosted ubuntu-latest happened to ship 22).
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Unit tests
+        run: bun test
+
+      - name: Wrangler dry-run build
+        run: bunx wrangler deploy --dry-run --outdir dist
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    concurrency:
+      group: coderouter-deploy
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: workers/coderouter
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      # Wrangler requires Node >= 22; Blacksmith ubuntu-2404 ships Node 20.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check Cloudflare secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          missing=()
+          [ -n "$CLOUDFLARE_API_TOKEN" ] || missing+=(CLOUDFLARE_API_TOKEN)
+          [ -n "$CLOUDFLARE_ACCOUNT_ID" ] || missing+=(CLOUDFLARE_ACCOUNT_ID)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Coderouter deploy needs repository secrets ${missing[*]}." \
+              "This is the one manual setup step: create an API token with" \
+              "Workers Scripts:Edit on the Cloudflare account and add both" \
+              "secrets in repo Settings -> Secrets and variables -> Actions" \
+              "(see workers/coderouter/README.md, Deploy)."
+            exit 1
+          fi
+
+      - name: Deploy (applies DO migrations atomically)
+        run: bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CoderouterEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CoderouterEnvironmentPolicy.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Computes per-agent environment overrides for cmux AI Gateway routing.
+///
+/// The policy is intentionally pure: callers own settings reads, secret reads,
+/// and base-URL resolution, then pass those values in here.
+public enum CoderouterEnvironmentPolicy {
+    /// Returns environment variables that route `kind` through coderouter.
+    ///
+    /// Phase 2 supports Claude Code only. Disabled settings, empty secrets,
+    /// empty gateway URLs, and unsupported kinds all return an empty dictionary.
+    ///
+    /// - Parameters:
+    ///   - kind: The agent kind string, such as `"claude"`.
+    ///   - enabled: Whether the user enabled coderouter routing.
+    ///   - secret: The stored `crk_` gateway key.
+    ///   - gatewayBaseURL: The gateway origin, without the family path suffix.
+    /// - Returns: Environment overrides for the spawned agent process.
+    public static func environment(
+        kind: String,
+        enabled: Bool,
+        secret: String?,
+        gatewayBaseURL: String
+    ) -> [String: String] {
+        guard enabled else { return [:] }
+        guard kind == "claude" else { return [:] }
+        guard let secret = secret?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !secret.isEmpty else {
+            return [:]
+        }
+        let baseURL = gatewayBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !baseURL.isEmpty else { return [:] }
+        return [
+            "ANTHROPIC_BASE_URL": baseURL.trimmingTrailingSlashes() + "/anthropic",
+            "ANTHROPIC_AUTH_TOKEN": secret,
+        ]
+    }
+}
+
+private extension String {
+    func trimmingTrailingSlashes() -> String {
+        var value = self
+        while value.hasSuffix("/") {
+            value.removeLast()
+        }
+        return value
+    }
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/AutomationCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/AutomationCatalogSection.swift
@@ -13,6 +13,11 @@ public struct AutomationCatalogSection: SettingCatalogSection {
         fileName: "socket-control-password"
     )
 
+    public let coderouterGatewayKey = SecretFileKey(
+        id: "automation.coderouterGatewayKey",
+        fileName: "coderouter-gateway-key"
+    )
+
     public let claudeCodeIntegration = DefaultsKey<Bool>(
         id: "automation.claudeCodeIntegration",
         defaultValue: true,

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/IntegrationsCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/IntegrationsCatalogSection.swift
@@ -71,5 +71,11 @@ public struct IntegrationsCatalogSection: SettingCatalogSection {
         userDefaultsKey: "suppressSubagentNotifications"
     )
 
+    public let routeClaudeThroughCoderouter = DefaultsKey<Bool>(
+        id: "integrations.routeClaudeThroughCoderouter",
+        defaultValue: false,
+        userDefaultsKey: "cmux.settings.integrations.routeClaudeThroughCoderouter"
+    )
+
     public init() {}
 }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/AgentIntegrationSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/AgentIntegrationSettingsStore.swift
@@ -18,6 +18,7 @@ public struct AgentIntegrationSettingsStore: AgentIntegrationSettingsReading {
     // UserDefaults is documented thread-safe and the reference is immutable.
     private nonisolated(unsafe) let defaults: UserDefaults
     private let keys = IntegrationsCatalogSection()
+    private let automationKeys = AutomationCatalogSection()
 
     /// Creates a store reading the given defaults suite.
     public init(defaults: UserDefaults) {
@@ -60,5 +61,30 @@ public struct AgentIntegrationSettingsStore: AgentIntegrationSettingsReading {
 
     public var suppressesSubagentNotifications: Bool {
         keys.suppressSubagentNotifications.value(in: defaults)
+    }
+
+    public var routesClaudeThroughCoderouter: Bool {
+        keys.routeClaudeThroughCoderouter.value(in: defaults)
+    }
+
+    /// Synchronously reads the stored coderouter gateway key from the same
+    /// `0600` secret file written by ``SecretFileStore``.
+    ///
+    /// Spawn setup is synchronous, so this mirrors
+    /// ``SocketControlPasswordStore``'s file-read shape instead of awaiting the
+    /// actor-backed Settings store.
+    public func coderouterGatewayKey(fileManager: FileManager = .default) -> String? {
+        let controlDirectory = SocketControlPasswordStore.defaultPasswordFileURL(fileManager: fileManager)?
+            .deletingLastPathComponent()
+            ?? CmuxStateDirectory.url(homeDirectory: fileManager.homeDirectoryForCurrentUser)
+        let secretURL = SecretFileStore(baseDirectory: controlDirectory)
+            .fileURL(for: automationKeys.coderouterGatewayKey)
+        guard fileManager.fileExists(atPath: secretURL.path),
+              let data = try? Data(contentsOf: secretURL),
+              let raw = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        let value = raw.trimmingCharacters(in: .newlines)
+        return value.isEmpty ? nil : value
     }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Coderouter/CoderouterFlow.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Coderouter/CoderouterFlow.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Host-supplied dependency for creating and displaying cmux AI Gateway keys.
+///
+/// The settings UI package does not depend on the app target or auth runtime.
+/// The host wraps those services in this protocol and injects it through
+/// ``SettingsRuntime``.
+@MainActor
+public protocol CoderouterFlow: AnyObject {
+    /// Whether the host has an authenticated cmux account snapshot.
+    var isSignedIn: Bool { get }
+
+    /// Gateway base URL exported to routed agent processes.
+    var gatewayBaseURL: String { get }
+
+    /// Creates a new gateway key and returns the one-time `crk_` secret.
+    ///
+    /// - Returns: The gateway key secret to store in ``SecretFileStore``.
+    func createKey() async throws -> String
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsRuntime.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsRuntime.swift
@@ -26,6 +26,8 @@ public struct SettingsRuntime: @unchecked Sendable {
     public let errorLog: SettingsErrorLog
     /// Optional host-owned account flow actions.
     public let accountFlow: AccountFlow?
+    /// Optional host-owned coderouter flow actions.
+    public let coderouterFlow: CoderouterFlow?
     /// Host callbacks for actions the package cannot perform itself.
     public let hostActions: SettingsHostActions
 
@@ -38,6 +40,7 @@ public struct SettingsRuntime: @unchecked Sendable {
     ///   - secretStore: Secret-file-backed settings store.
     ///   - errorLog: Rolling settings error log displayed as alerts.
     ///   - accountFlow: Optional host-owned account flow actions.
+    ///   - coderouterFlow: Optional host-owned coderouter flow actions.
     ///   - hostActions: Host callbacks for actions the package cannot perform itself.
     ///   - searchIndex: Prebuilt search index to share across settings roots. When `nil`,
     ///     the runtime builds one index from `catalog` and keeps it for its own lifetime.
@@ -49,6 +52,7 @@ public struct SettingsRuntime: @unchecked Sendable {
         secretStore: SecretFileStore,
         errorLog: SettingsErrorLog,
         accountFlow: AccountFlow? = nil,
+        coderouterFlow: CoderouterFlow? = nil,
         hostActions: SettingsHostActions = NoopSettingsHostActions(),
         searchIndex: SettingsSearchIndex? = nil
     ) {
@@ -59,6 +63,7 @@ public struct SettingsRuntime: @unchecked Sendable {
         self.secretStore = secretStore
         self.errorLog = errorLog
         self.accountFlow = accountFlow
+        self.coderouterFlow = coderouterFlow
         self.hostActions = hostActions
     }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -20,6 +20,7 @@ extension Array where Element == CuratedSettingEntry {
         [
             // Account / integrations
             .init(section: .account, id: "account", title: "Account", synonyms: "auth authentication login logout signin sign-in signout sign-out email user profile stack team"),
+            .init(section: .coderouter, id: "ai-gateway", title: String(localized: "settings.section.coderouter", defaultValue: "AI Gateway"), synonyms: "coderouter ai gateway route claude code anthropic key subscription"),
             .init(section: .automation, id: "claude-code", title: "Claude Code Integration", synonyms: "automation.claudeCodeIntegration claude code hooks agent integration status notifications"),
             .init(section: .automation, id: "claude-path", title: "Claude Binary Path", synonyms: "automation.claudeBinaryPath claude binary executable path cli command custom"),
             .init(section: .automation, id: "ripgrep-path", title: "Ripgrep Binary Path", synonyms: "automation.ripgrepBinaryPath ripgrep rg binary executable path search find nix custom"),

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
@@ -11,6 +11,7 @@ import Foundation
 /// `Sections/`.
 public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Hashable {
     case account
+    case coderouter
     case app
     case terminal
     case textBox
@@ -37,6 +38,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
     public var title: String {
         switch self {
         case .account: return "Account"
+        case .coderouter: return String(localized: "settings.section.coderouter", defaultValue: "AI Gateway")
         case .app: return "App"
         case .terminal: return "Terminal"
         case .textBox: return String(localized: "settings.section.textBox", defaultValue: "TextBox (Beta)")
@@ -60,6 +62,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
     public var symbolName: String {
         switch self {
         case .account: return "person.crop.circle"
+        case .coderouter: return "arrow.triangle.branch"
         case .app: return "gearshape"
         case .terminal: return "terminal"
         case .textBox: return "textformat"
@@ -85,6 +88,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
     public var searchKeywords: String {
         switch self {
         case .account: return "sign in team sync user profile"
+        case .coderouter: return "ai gateway coderouter route claude code anthropic key subscription"
         case .app: return "appearance language workspace notifications menu bar telemetry"
         case .terminal: return "scrollbar copy on select agent resume hibernation"
         case .textBox: return "textbox text box rich input prompt default new terminal workspace split tab focus show beta"

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -87,6 +87,7 @@ public struct SettingsWindowRoot: View {
     private var catalog: SettingCatalog { runtime.catalog }
     private var hostActions: SettingsHostActions { runtime.hostActions }
     private var accountFlow: AccountFlow? { runtime.accountFlow }
+    private var coderouterFlow: CoderouterFlow? { runtime.coderouterFlow }
 
     /// Resolves the selected section pane from the persisted raw value,
     /// defaulting to ``SettingsSectionID/account`` when the stored value
@@ -435,6 +436,14 @@ public struct SettingsWindowRoot: View {
             accountFlow: accountFlow
         )
         .id(anchorID(for: .account))
+
+        CoderouterSection(
+            defaultsStore: defaultsStore,
+            secretStore: secretStore,
+            catalog: catalog,
+            coderouterFlow: coderouterFlow
+        )
+        .id(anchorID(for: .coderouter))
 
         AppSection(
             defaultsStore: defaultsStore,

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/CoderouterSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/CoderouterSection.swift
@@ -1,0 +1,205 @@
+import CmuxFoundation
+import CmuxSettings
+import SwiftUI
+
+/// **AI Gateway** section for cmux coderouter routing.
+@MainActor
+public struct CoderouterSection: View {
+    private let coderouterFlow: CoderouterFlow?
+
+    @State private var routeClaudeModel: DefaultsValueModel<Bool>
+    @State private var gatewayKeyModel: SecretValueModel
+    @State private var isCreatingKey = false
+    @State private var revealedKey: String?
+    @State private var createKeyErrorMessage: String?
+
+    public init(
+        defaultsStore: UserDefaultsSettingsStore,
+        secretStore: SecretFileStore,
+        catalog: SettingCatalog,
+        coderouterFlow: CoderouterFlow?
+    ) {
+        self.coderouterFlow = coderouterFlow
+        _routeClaudeModel = State(initialValue: DefaultsValueModel(
+            store: defaultsStore,
+            key: catalog.integrations.routeClaudeThroughCoderouter
+        ))
+        _gatewayKeyModel = State(initialValue: SecretValueModel(
+            store: secretStore,
+            key: catalog.automation.coderouterGatewayKey,
+            errorLog: SettingsErrorLog(capacity: 4)
+        ))
+    }
+
+    public var body: some View {
+        Group {
+            SettingsSectionHeader(String(localized: "settings.section.coderouter", defaultValue: "AI Gateway"), section: .coderouter)
+            SettingsCard {
+                statusRow
+                SettingsCardDivider()
+                gatewayBaseURLRow
+                SettingsCardDivider()
+                routeClaudeRow
+                SettingsCardDivider()
+                createKeyRow
+                if let revealedKey {
+                    SettingsCardDivider()
+                    revealedKeyRow(revealedKey)
+                }
+                if let createKeyErrorMessage {
+                    SettingsCardDivider()
+                    errorRow(createKeyErrorMessage)
+                }
+                SettingsCardDivider()
+                SettingsCardNote(
+                    String(localized: "settings.coderouter.note", defaultValue: "Routing currently covers Claude Code.")
+                )
+            }
+            .settingsSearchAnchors(["setting:coderouter:gateway"])
+        }
+        .task { startObservingSettings() }
+    }
+
+    private var gatewayBaseURL: String {
+        coderouterFlow?.gatewayBaseURL ?? String(localized: "settings.coderouter.gatewayBaseURL.unavailable", defaultValue: "Unavailable")
+    }
+
+    private var hasStoredKey: Bool {
+        !gatewayKeyModel.current.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var isSignedIn: Bool {
+        coderouterFlow?.isSignedIn == true
+    }
+
+    private func startObservingSettings() {
+        routeClaudeModel.startObserving()
+        gatewayKeyModel.startObserving()
+    }
+
+    @ViewBuilder
+    private var statusRow: some View {
+        SettingsCardRow(
+            configurationReview: .action,
+            String(localized: "settings.coderouter.status", defaultValue: "Status"),
+            subtitle: statusSubtitle
+        ) {
+            Image(systemName: isSignedIn ? "checkmark.circle" : "person.crop.circle.badge.exclamationmark")
+                .foregroundStyle(isSignedIn ? Color.green : Color.secondary)
+        }
+    }
+
+    private var statusSubtitle: String {
+        if !isSignedIn {
+            return String(localized: "settings.coderouter.status.signedOut", defaultValue: "Sign in to cmux to create a gateway key.")
+        }
+        if hasStoredKey {
+            return String(localized: "settings.coderouter.status.keyStored", defaultValue: "A gateway key is stored for this Mac.")
+        }
+        return String(localized: "settings.coderouter.status.ready", defaultValue: "Create a gateway key before enabling routed Claude Code launches.")
+    }
+
+    @ViewBuilder
+    private var gatewayBaseURLRow: some View {
+        SettingsCardRow(
+            configurationReview: .action,
+            String(localized: "settings.coderouter.gatewayBaseURL", defaultValue: "Gateway Base URL")
+        ) {
+            Text(gatewayBaseURL)
+                .cmuxFont(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+    }
+
+    @ViewBuilder
+    private var routeClaudeRow: some View {
+        SettingsCardRow(
+            configurationReview: .settingsOnly,
+            searchAnchorID: "setting:coderouter:route-claude",
+            String(localized: "settings.coderouter.routeClaude", defaultValue: "Route Claude Code through the cmux gateway"),
+            subtitle: routeClaudeSubtitle
+        ) {
+            Toggle("", isOn: Binding(get: { routeClaudeModel.current }, set: { routeClaudeModel.set($0) }))
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsCoderouterRouteClaudeToggle")
+        }
+    }
+
+    private var routeClaudeSubtitle: String {
+        if routeClaudeModel.current && !hasStoredKey {
+            return String(localized: "settings.coderouter.routeClaude.subtitleNeedsKey", defaultValue: "Routing stays inactive until a gateway key is stored.")
+        }
+        return String(localized: "settings.coderouter.routeClaude.subtitle", defaultValue: "When enabled, new Claude Code launches use coderouter for Anthropic API traffic.")
+    }
+
+    @ViewBuilder
+    private var createKeyRow: some View {
+        SettingsCardRow(
+            configurationReview: .action,
+            searchAnchorID: "setting:coderouter:create-key",
+            String(localized: "settings.coderouter.createKey", defaultValue: "Create Gateway Key"),
+            subtitle: String(localized: "settings.coderouter.createKey.subtitle", defaultValue: "Creates a team-scoped key and stores it in this Mac's cmux secret store.")
+        ) {
+            Button {
+                createGatewayKey()
+            } label: {
+                if isCreatingKey {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Text(String(localized: "settings.coderouter.createKey.button", defaultValue: "Create"))
+                }
+            }
+            .disabled(!isSignedIn || isCreatingKey)
+            .accessibilityIdentifier("SettingsCoderouterCreateKeyButton")
+        }
+    }
+
+    @ViewBuilder
+    private func revealedKeyRow(_ key: String) -> some View {
+        SettingsCardRow(
+            configurationReview: .action,
+            String(localized: "settings.coderouter.revealedKey", defaultValue: "New Gateway Key"),
+            subtitle: String(localized: "settings.coderouter.revealedKey.subtitle", defaultValue: "Shown once. It has already been stored for future launches.")
+        ) {
+            Text(key)
+                .cmuxFont(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+    }
+
+    @ViewBuilder
+    private func errorRow(_ message: String) -> some View {
+        SettingsCardRow(
+            configurationReview: .action,
+            String(localized: "settings.coderouter.createKey.error", defaultValue: "Key Creation Failed"),
+            subtitle: message
+        ) {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(.orange)
+        }
+    }
+
+    private func createGatewayKey() {
+        guard let coderouterFlow, coderouterFlow.isSignedIn, !isCreatingKey else { return }
+        isCreatingKey = true
+        createKeyErrorMessage = nil
+        Task { @MainActor in
+            do {
+                let key = try await coderouterFlow.createKey()
+                gatewayKeyModel.set(key)
+                revealedKey = key
+            } catch {
+                createKeyErrorMessage = error.localizedDescription
+            }
+            isCreatingKey = false
+        }
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2055,6 +2055,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         self.sidebarState = sidebarState
         self.auth = auth
         VMClient.bootstrap(auth: auth.coordinator)
+        CoderouterClient.bootstrap(auth: auth.coordinator)
         RemotesClient.bootstrap(auth: auth.coordinator)
         PhonePushClient.shared.configure(auth: auth.coordinator)
         MobileHostService.shared.configure(auth: auth.coordinator)

--- a/Sources/Auth/AuthEnvironment.swift
+++ b/Sources/Auth/AuthEnvironment.swift
@@ -128,6 +128,45 @@ enum AuthEnvironment {
         return canonicalizedLoopbackURL(URL(string: defaultVMAPIOrigin)!)
     }
 
+    /// Base URL for the cmux-owned coderouter control plane (`/api/coderouter`).
+    ///
+    /// Resolution order mirrors ``vmAPIBaseURL``:
+    ///   1. process env `CMUX_CODEROUTER_BASE_URL`.
+    ///   2. DEBUG-only `~/.cmux-dev.env` line `CMUX_CODEROUTER_BASE_URL=...`.
+    ///   3. cmux web origin (`http://localhost:$CMUX_PORT` in Debug, cmux.com in Release).
+    static var coderouterBaseURL: URL {
+        if let overridden = ProcessInfo.processInfo.environment["CMUX_CODEROUTER_BASE_URL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !overridden.isEmpty,
+           let url = URL(string: overridden) {
+            return canonicalizedLoopbackURL(url)
+        }
+        if let override = devOverride(key: "CMUX_CODEROUTER_BASE_URL"),
+           let url = URL(string: override) {
+            return canonicalizedLoopbackURL(url)
+        }
+        return canonicalizedLoopbackURL(URL(string: defaultCoderouterOrigin)!)
+    }
+
+    /// Base URL exported to routed agents for coderouter's gateway data plane.
+    ///
+    /// This is separate from ``coderouterBaseURL``: app control calls go through
+    /// `/api/coderouter/*`, while spawned agents receive this gateway origin plus
+    /// the family path suffix (for Phase 2, `/anthropic`).
+    static var coderouterGatewayBaseURL: URL {
+        if let overridden = ProcessInfo.processInfo.environment["CMUX_CODEROUTER_GATEWAY_BASE_URL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !overridden.isEmpty,
+           let url = URL(string: overridden) {
+            return canonicalizedLoopbackURL(url)
+        }
+        if let override = devOverride(key: "CMUX_CODEROUTER_GATEWAY_BASE_URL"),
+           let url = URL(string: override) {
+            return canonicalizedLoopbackURL(url)
+        }
+        return canonicalizedLoopbackURL(URL(string: defaultCoderouterGatewayOrigin)!)
+    }
+
     /// Look up `key=value` in `~/.cmux-dev.env` for the DEBUG build. Returns nil in Release.
     /// Kept tiny on purpose — this is a "drop a file, restart the app, it picks up" override,
     /// not a real config system.
@@ -199,6 +238,22 @@ enum AuthEnvironment {
         return "http://localhost:\(cmuxPort)"
         #else
         return "https://cmux.com"
+        #endif
+    }
+
+    private static var defaultCoderouterOrigin: String {
+        #if DEBUG
+        return "http://localhost:\(cmuxPort)"
+        #else
+        return "https://cmux.com"
+        #endif
+    }
+
+    private static var defaultCoderouterGatewayOrigin: String {
+        #if DEBUG
+        return "http://localhost:\(cmuxPort)"
+        #else
+        return "https://coderouter.cmux.dev"
         #endif
     }
 

--- a/Sources/Auth/HostCoderouterFlow.swift
+++ b/Sources/Auth/HostCoderouterFlow.swift
@@ -1,0 +1,28 @@
+import CmuxAuthRuntime
+import CmuxSettingsUI
+import Foundation
+
+/// App-target adapter from ``CoderouterClient`` to the settings package's
+/// ``CoderouterFlow`` protocol.
+@MainActor
+final class HostCoderouterFlow: CoderouterFlow {
+    private let coordinator: AuthCoordinator
+
+    init(coordinator: AuthCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    var isSignedIn: Bool {
+        coordinator.currentUser != nil
+    }
+
+    var gatewayBaseURL: String {
+        AuthEnvironment.coderouterGatewayBaseURL.absoluteString
+    }
+
+    func createKey() async throws -> String {
+        let name = String(localized: "settings.coderouter.keyName", defaultValue: "cmux macOS app")
+        let result = try await CoderouterClient.shared.createKey(name: name)
+        return result.key
+    }
+}

--- a/Sources/Cloud/CoderouterClient.swift
+++ b/Sources/Cloud/CoderouterClient.swift
@@ -1,0 +1,319 @@
+import CmuxAuthRuntime
+import Foundation
+
+enum CoderouterClientError: Error, CustomStringConvertible {
+    case notSignedIn
+    case backendUnreachable(url: String, detail: String)
+    case httpStatus(Int, String)
+    case malformedResponse(String)
+
+    var description: String {
+        switch self {
+        case .notSignedIn:
+            return """
+                You are not signed in to cmux.
+
+                What to do:
+                  cmux auth login
+                  cmux auth status
+                """
+        case .backendUnreachable(let url, let detail):
+            return """
+                Cannot reach the cmux AI Gateway service at \(url).
+
+                What to do:
+                  Start the cmux web server, then retry.
+                  If you are using a local development build, check its AI Gateway service URL before launching cmux.
+
+                Details:
+                  \(detail)
+                """
+        case .httpStatus(let code, let body):
+            let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
+            return """
+                AI Gateway request failed (HTTP \(code)).
+
+                Response body:
+                  \(trimmedBody.isEmpty ? "<empty>" : trimmedBody)
+                """
+        case .malformedResponse(let message):
+            return """
+                The cmux AI Gateway backend returned a response this client could not read.
+
+                Details:
+                  \(message)
+                """
+        }
+    }
+}
+
+struct CoderouterKeySummary: Equatable, Sendable {
+    let id: String
+    let name: String
+    let policy: [String: AnySendable]
+    let createdAt: String
+    let revokedAt: String?
+    let lastUsedAt: String?
+}
+
+struct CoderouterUsageTotal: Equatable, Sendable {
+    let day: String
+    let model: String
+    let credentialClass: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheReadTokens: Int
+    let cacheWriteTokens: Int
+    let costMicros: Int
+    let requests: Int
+}
+
+struct CoderouterUsageSummary: Equatable, Sendable {
+    let days: Int
+    let balanceMicros: Int
+    let totals: [CoderouterUsageTotal]
+}
+
+/// Sendable wrapper for JSON policy values surfaced by the control plane.
+enum AnySendable: Equatable, Sendable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case array([AnySendable])
+    case object([String: AnySendable])
+    case null
+}
+
+/// Talks to the cmux coderouter control plane at `/api/coderouter/*`.
+///
+/// Stack Auth tokens come from the injected `AuthCoordinator`; the HTTP base
+/// URL comes from `AuthEnvironment.coderouterBaseURL`.
+actor CoderouterClient {
+    /// Set once by `bootstrap(auth:)` during app startup.
+    @MainActor private(set) static var shared: CoderouterClient!
+
+    /// Build the shared client with its injected auth dependency.
+    @MainActor
+    static func bootstrap(auth: AuthCoordinator, session: URLSession = .shared) {
+        shared = CoderouterClient(session: session, auth: auth)
+    }
+
+    private let session: URLSession
+    private let auth: AuthCoordinator
+
+    init(session: URLSession = .shared, auth: AuthCoordinator) {
+        self.session = session
+        self.auth = auth
+    }
+
+    func createKey(name: String) async throws -> (key: String, id: String) {
+        let (data, http) = try await request(
+            "POST",
+            path: "/api/coderouter/keys",
+            jsonBody: ["name": name]
+        )
+        try ensureOK(http, data: data)
+        let obj = try decodeJSONObject(data)
+        guard let key = obj["key"] as? String, key.hasPrefix("crk_"),
+              let id = obj["id"] as? String, !id.isEmpty else {
+            throw CoderouterClientError.malformedResponse("AI Gateway key response was missing required fields.")
+        }
+        return (key, id)
+    }
+
+    func listKeys() async throws -> [CoderouterKeySummary] {
+        let (data, http) = try await request("GET", path: "/api/coderouter/keys")
+        try ensureOK(http, data: data)
+        let obj = try decodeJSONObject(data)
+        guard let items = obj["keys"] as? [[String: Any]] else {
+            throw CoderouterClientError.malformedResponse("missing `keys` array")
+        }
+        return try items.enumerated().map { index, item in
+            try decodeKeySummary(item, index: index)
+        }
+    }
+
+    func revokeKey(id: String) async throws {
+        let (data, http) = try await request(
+            "DELETE",
+            path: "/api/coderouter/keys",
+            queryItems: [URLQueryItem(name: "id", value: id)]
+        )
+        try ensureOK(http, data: data)
+    }
+
+    func usageSummary(days: Int) async throws -> CoderouterUsageSummary {
+        let clampedDays = min(max(days, 1), 90)
+        let (data, http) = try await request(
+            "GET",
+            path: "/api/coderouter/usage",
+            queryItems: [URLQueryItem(name: "days", value: String(clampedDays))]
+        )
+        try ensureOK(http, data: data)
+        let obj = try decodeJSONObject(data)
+        let responseDays = (obj["days"] as? Int) ?? Int((obj["days"] as? Double) ?? Double(clampedDays))
+        let balanceMicros = (obj["balanceMicros"] as? Int)
+            ?? Int((obj["balanceMicros"] as? Double) ?? 0)
+        guard let rawTotals = obj["totals"] as? [[String: Any]] else {
+            throw CoderouterClientError.malformedResponse("missing `totals` array")
+        }
+        let totals = try rawTotals.enumerated().map { index, item in
+            try decodeUsageTotal(item, index: index)
+        }
+        return CoderouterUsageSummary(days: responseDays, balanceMicros: balanceMicros, totals: totals)
+    }
+
+    private func request(
+        _ method: String,
+        path: String,
+        queryItems: [URLQueryItem] = [],
+        jsonBody: [String: Any]? = nil,
+        extraHeaders: [String: String] = [:],
+        timeoutSeconds: TimeInterval? = nil
+    ) async throws -> (Data, HTTPURLResponse) {
+        let tokens: (accessToken: String, refreshToken: String)
+        do {
+            tokens = try await auth.currentTokens()
+        } catch {
+            throw CoderouterClientError.notSignedIn
+        }
+        let teamID = await auth.resolvedTeamID
+
+        guard var url = URLComponents(url: AuthEnvironment.coderouterBaseURL, resolvingAgainstBaseURL: false) else {
+            throw CoderouterClientError.malformedResponse("bad coderouterBaseURL")
+        }
+        url.path = (url.path.hasSuffix("/") ? String(url.path.dropLast()) : url.path) + path
+        if !queryItems.isEmpty {
+            url.queryItems = queryItems
+        }
+        guard let resolved = url.url else {
+            throw CoderouterClientError.malformedResponse("could not build URL for \(path)")
+        }
+
+        var req = URLRequest(url: resolved)
+        req.httpMethod = method
+        if let timeoutSeconds {
+            req.timeoutInterval = timeoutSeconds
+        }
+        req.setValue("Bearer \(tokens.accessToken)", forHTTPHeaderField: "Authorization")
+        req.setValue(tokens.refreshToken, forHTTPHeaderField: "X-Stack-Refresh-Token")
+        if let teamID, !teamID.isEmpty {
+            req.setValue(teamID, forHTTPHeaderField: "X-Cmux-Team-Id")
+        }
+        if let jsonBody {
+            req.setValue("application/json", forHTTPHeaderField: "content-type")
+            req.httpBody = try JSONSerialization.data(withJSONObject: jsonBody, options: [])
+        }
+        for (key, value) in extraHeaders {
+            req.setValue(value, forHTTPHeaderField: key)
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: req)
+        } catch let error as URLError {
+            switch error.code {
+            case .cannotConnectToHost, .cannotFindHost, .timedOut, .networkConnectionLost, .notConnectedToInternet:
+                let base = "\(AuthEnvironment.coderouterBaseURL.scheme ?? "http")://\(AuthEnvironment.coderouterBaseURL.host ?? "?"):\(AuthEnvironment.coderouterBaseURL.port ?? -1)"
+                throw CoderouterClientError.backendUnreachable(url: base, detail: error.localizedDescription)
+            default:
+                throw error
+            }
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw CoderouterClientError.malformedResponse("non-HTTP response")
+        }
+        return (data, http)
+    }
+
+    private func ensureOK(_ http: HTTPURLResponse, data: Data) throws {
+        guard (200...299).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? "<binary>"
+            throw CoderouterClientError.httpStatus(http.statusCode, body)
+        }
+    }
+
+    private func decodeJSONObject(_ data: Data) throws -> [String: Any] {
+        let parsed = try JSONSerialization.jsonObject(with: data, options: [])
+        guard let obj = parsed as? [String: Any] else {
+            throw CoderouterClientError.malformedResponse("expected JSON object, got \(type(of: parsed))")
+        }
+        return obj
+    }
+
+    private func decodeKeySummary(_ item: [String: Any], index: Int) throws -> CoderouterKeySummary {
+        guard let id = item["id"] as? String, !id.isEmpty,
+              let name = item["name"] as? String, !name.isEmpty,
+              let createdAt = item["createdAt"] as? String, !createdAt.isEmpty else {
+            throw CoderouterClientError.malformedResponse("AI Gateway key response was missing required fields for item \(index).")
+        }
+        let rawPolicy = item["policy"] as? [String: Any] ?? [:]
+        return CoderouterKeySummary(
+            id: id,
+            name: name,
+            policy: rawPolicy.reduce(into: [:]) { result, pair in
+                result[pair.key] = AnySendable(jsonValue: pair.value)
+            },
+            createdAt: createdAt,
+            revokedAt: nullableString(item["revokedAt"]),
+            lastUsedAt: nullableString(item["lastUsedAt"])
+        )
+    }
+
+    private func decodeUsageTotal(_ item: [String: Any], index: Int) throws -> CoderouterUsageTotal {
+        guard let day = item["day"] as? String, !day.isEmpty,
+              let model = item["model"] as? String, !model.isEmpty,
+              let credentialClass = item["credentialClass"] as? String, !credentialClass.isEmpty else {
+            throw CoderouterClientError.malformedResponse("AI Gateway usage response was missing required fields for item \(index).")
+        }
+        return CoderouterUsageTotal(
+            day: day,
+            model: model,
+            credentialClass: credentialClass,
+            inputTokens: intValue(item["inputTokens"]),
+            outputTokens: intValue(item["outputTokens"]),
+            cacheReadTokens: intValue(item["cacheReadTokens"]),
+            cacheWriteTokens: intValue(item["cacheWriteTokens"]),
+            costMicros: intValue(item["costMicros"]),
+            requests: intValue(item["requests"])
+        )
+    }
+
+    private func nullableString(_ value: Any?) -> String? {
+        guard let value, !(value is NSNull) else { return nil }
+        return value as? String
+    }
+
+    private func intValue(_ value: Any?) -> Int {
+        if let int = value as? Int { return int }
+        if let int64 = value as? Int64 { return Int(int64) }
+        if let double = value as? Double { return Int(double) }
+        if let number = value as? NSNumber { return number.intValue }
+        return 0
+    }
+}
+
+private extension AnySendable {
+    init(jsonValue: Any) {
+        if jsonValue is NSNull {
+            self = .null
+        } else if let string = jsonValue as? String {
+            self = .string(string)
+        } else if let number = jsonValue as? NSNumber {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                self = .bool(number.boolValue)
+            } else {
+                self = .number(number.doubleValue)
+            }
+        } else if let array = jsonValue as? [Any] {
+            self = .array(array.map(AnySendable.init(jsonValue:)))
+        } else if let object = jsonValue as? [String: Any] {
+            self = .object(object.reduce(into: [:]) { result, pair in
+                result[pair.key] = AnySendable(jsonValue: pair.value)
+            })
+        } else {
+            self = .string(String(describing: jsonValue))
+        }
+    }
+}

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CMUXAgentLaunch
+import CmuxSettings
 
 nonisolated enum TerminalStartupShellQuoting {
     static func singleQuoted(_ value: String) -> String {
@@ -444,13 +445,28 @@ enum AgentResumeCommandBuilder {
         kind: RestorableAgentKind,
         environment: [String: String]?
     ) -> [String] {
-        guard let environment, !environment.isEmpty else {
+        var selectedEnvironment: [String: String] = [:]
+        if let environment, !environment.isEmpty {
+            selectedEnvironment = AgentLaunchEnvironmentPolicy.selectedEnvironment(from: environment, kind: kind.rawValue)
+        }
+        let integrations = AgentIntegrationSettingsStore(defaults: .standard)
+        if kind == .claude, integrations.routesClaudeThroughCoderouter {
+            let overrides = CoderouterEnvironmentPolicy.environment(
+                kind: kind.rawValue,
+                enabled: true,
+                secret: integrations.coderouterGatewayKey(),
+                gatewayBaseURL: AuthEnvironment.coderouterGatewayBaseURL.absoluteString
+            )
+            for (key, value) in overrides {
+                selectedEnvironment[key] = value
+            }
+        }
+        guard !selectedEnvironment.isEmpty else {
             return []
         }
 
         var environmentParts: [String] = []
         var preservedClaudeAuthSelectionEnvironmentKeys: [String] = []
-        let selectedEnvironment = AgentLaunchEnvironmentPolicy.selectedEnvironment(from: environment, kind: kind.rawValue)
         for key in selectedEnvironment.keys.sorted() {
             guard let value = selectedEnvironment[key] else { continue }
             environmentParts.append("\(key)=\(value)")

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6108,12 +6108,39 @@ final class Workspace: Identifiable, ObservableObject {
         base: [String: String],
         remoteStartupCommand: String?
     ) -> [String: String] {
+        let integrations = AgentIntegrationSettingsStore(defaults: .standard)
+        let routeClaudeThroughCoderouter = integrations.routesClaudeThroughCoderouter
         guard remoteStartupCommand != nil,
               let remoteEnvironment = remoteConfiguration?.sshTerminalStartupEnvironment else {
-            return base
+            guard routeClaudeThroughCoderouter else { return base }
+            return coderouterMergedStartupEnvironment(base: base, integrations: integrations)
         }
         var environment = base
         for (key, value) in remoteEnvironment {
+            environment[key] = value
+        }
+        guard routeClaudeThroughCoderouter else { return environment }
+        return coderouterMergedStartupEnvironment(base: environment, integrations: integrations)
+    }
+
+    private func coderouterMergedStartupEnvironment(
+        base: [String: String],
+        integrations: AgentIntegrationSettingsStore
+    ) -> [String: String] {
+        guard let kind = base["CMUX_AGENT_LAUNCH_KIND"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !kind.isEmpty else {
+            return base
+        }
+        let overrides = CoderouterEnvironmentPolicy.environment(
+            kind: kind,
+            enabled: true,
+            secret: integrations.coderouterGatewayKey(),
+            gatewayBaseURL: AuthEnvironment.coderouterGatewayBaseURL.absoluteString
+        )
+        guard !overrides.isEmpty else { return base }
+        var environment = base
+        for (key, value) in overrides {
             environment[key] = value
         }
         return environment

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -175,6 +175,7 @@ struct cmuxApp: App {
                 coordinator: authComposition.coordinator,
                 browserSignIn: authComposition.browserSignIn
             ),
+            coderouterFlow: HostCoderouterFlow(coordinator: authComposition.coordinator),
             hostActions: HostSettingsActions(configFileURL: configFileURL)
         )
         StartupBreadcrumbLog.append("app.init.settingsRuntime.created")

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -441,6 +441,9 @@
 		E30750000000000000000004 /* CmuxWorkspaceDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30750000000000000000003 /* CmuxWorkspaceDefinition.swift */; };
 		E3B7A3000000000000000103 /* CmuxWorkspaces in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A3000000000000000102 /* CmuxWorkspaces */; };
 		C0A1E5CE01C0A1E5CE01A001 /* CoalesceLatestPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1E5CE01C0A1E5CE01A002 /* CoalesceLatestPublisher.swift */; };
+		5B9B0449E70475AF9D53E016 /* CoderouterBaseURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D8AE5182EF656FE91B4D85 /* CoderouterBaseURLTests.swift */; };
+		812366704BA4A0F46F673AFE /* CoderouterClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C47F0AA078C0AE81369EE7E /* CoderouterClient.swift */; };
+		23F96DB446688ADA2C5F878D /* CoderouterEnvironmentPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C65A70530129986FD432D9 /* CoderouterEnvironmentPolicyTests.swift */; };
 		A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */; };
 		A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E01000000000000000000E /* CodexAppServerSession.swift */; };
 		A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E040000000000000000001 /* CodexAppServerSessionTests.swift */; };
@@ -632,6 +635,7 @@
 		F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */; };
 		4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */; };
 		CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */; };
+		FB0686ADE4412855B931B4A9 /* HostCoderouterFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F16BB1274BF0632C560A1E8 /* HostCoderouterFlow.swift */; };
 		CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */; };
 		F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */; };
 		DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000002 /* InfoPlist.xcstrings */; };
@@ -1758,6 +1762,9 @@
 		43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewMouseNavigationButtonTests.swift; sourceTree = "<group>"; };
 		E30750000000000000000003 /* CmuxWorkspaceDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWorkspaceDefinition.swift; sourceTree = "<group>"; };
 		C0A1E5CE01C0A1E5CE01A002 /* CoalesceLatestPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoalesceLatestPublisher.swift; sourceTree = "<group>"; };
+		09D8AE5182EF656FE91B4D85 /* CoderouterBaseURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoderouterBaseURLTests.swift; sourceTree = "<group>"; };
+		7C47F0AA078C0AE81369EE7E /* CoderouterClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoderouterClient.swift; sourceTree = "<group>"; };
+		60C65A70530129986FD432D9 /* CoderouterEnvironmentPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoderouterEnvironmentPolicyTests.swift; sourceTree = "<group>"; };
 		A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerQueuedInput.swift; sourceTree = "<group>"; };
 		A9E01000000000000000000E /* CodexAppServerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerSession.swift; sourceTree = "<group>"; };
 		A9E040000000000000000001 /* CodexAppServerSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionTests.swift; sourceTree = "<group>"; };
@@ -1948,6 +1955,7 @@
 		F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesAgentIndex.swift; sourceTree = "<group>"; };
 		4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenRightSidebarContentMountingTests.swift; sourceTree = "<group>"; };
 		CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostAccountFlow.swift; sourceTree = "<group>"; };
+		6F16BB1274BF0632C560A1E8 /* HostCoderouterFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostCoderouterFlow.swift; sourceTree = "<group>"; };
 		CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostSettingsActions.swift; sourceTree = "<group>"; };
 		F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivePaneFirstClickFocusTests.swift; sourceTree = "<group>"; };
 		DA7A10CA710E000000000002 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
@@ -2738,6 +2746,7 @@
 				DEBDADADADADADADAD000002 /* DebugDogfoodCredentialResolver.swift */,
 				53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */,
 				CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */,
+				6F16BB1274BF0632C560A1E8 /* HostCoderouterFlow.swift */,
 			);
 			name = Auth;
 			path = Auth;
@@ -2840,6 +2849,7 @@
 		590E4F5F342E5B27010ECC8D /* Cloud */ = {
 			isa = PBXGroup;
 			children = (
+				7C47F0AA078C0AE81369EE7E /* CoderouterClient.swift */,
 				9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */,
 				REE0CA0000000000000000A1 /* RemotesClient.swift */,
 				REE0CA0000000000000000D1 /* RemoteRouteSpec.swift */,
@@ -3694,6 +3704,8 @@
 			children = (
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */,
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */,
+				09D8AE5182EF656FE91B4D85 /* CoderouterBaseURLTests.swift */,
+				60C65A70530129986FD432D9 /* CoderouterEnvironmentPolicyTests.swift */,
 				D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */,
 				D5935002A1B2C3D4E5F60718 /* GhosttyDECCKMArrowKeyTests.swift */,
 				F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */,
@@ -4669,6 +4681,7 @@
 				A5001500 /* CmuxWebView.swift in Sources */,
 				E30750000000000000000004 /* CmuxWorkspaceDefinition.swift in Sources */,
 				C0A1E5CE01C0A1E5CE01A001 /* CoalesceLatestPublisher.swift in Sources */,
+				812366704BA4A0F46F673AFE /* CoderouterClient.swift in Sources */,
 				A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */,
 				A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */,
 				C4041001000000000000001B /* CommandClickFileOpenRouter.swift in Sources */,
@@ -4796,6 +4809,7 @@
 				3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */,
 				F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */,
 				CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */,
+				FB0686ADE4412855B931B4A9 /* HostCoderouterFlow.swift in Sources */,
 				CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */,
 				4D8B37E0E11A29997632765F /* InternalTabDragConfiguration.swift in Sources */,
 				C0DEF0B10000000000000001 /* JSONCParser.swift in Sources */,
@@ -5467,6 +5481,8 @@
 				D0B1000CA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift in Sources */,
 				C0DE58990000000000000004 /* CmuxWebViewKeyDownReentryTests.swift in Sources */,
 				7D5DA4DC51454ECDBF9AC978 /* CmuxWebViewMouseNavigationButtonTests.swift in Sources */,
+				5B9B0449E70475AF9D53E016 /* CoderouterBaseURLTests.swift in Sources */,
+				23F96DB446688ADA2C5F878D /* CoderouterEnvironmentPolicyTests.swift in Sources */,
 				A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */,
 				C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */,
 				C0DEC0DE000000000000F302 /* CommandPaletteEmojiTitleSearchTests.swift in Sources */,

--- a/cmuxTests/CoderouterBaseURLTests.swift
+++ b/cmuxTests/CoderouterBaseURLTests.swift
@@ -1,0 +1,40 @@
+import Darwin
+import XCTest
+
+#if canImport(cmux_DEV)
+    @testable import cmux_DEV
+#elseif canImport(cmux)
+    @testable import cmux
+#endif
+
+final class CoderouterBaseURLTests: XCTestCase {
+    func testGatewayBaseURLEnvironmentOverrideCanonicalizesLoopback() {
+        let previousGateway = getenv("CMUX_CODEROUTER_GATEWAY_BASE_URL").map { String(cString: $0) }
+        defer {
+            if let previousGateway {
+                setenv("CMUX_CODEROUTER_GATEWAY_BASE_URL", previousGateway, 1)
+            } else {
+                unsetenv("CMUX_CODEROUTER_GATEWAY_BASE_URL")
+            }
+        }
+
+        setenv("CMUX_CODEROUTER_GATEWAY_BASE_URL", "http://127.0.0.1:3999", 1)
+
+        XCTAssertEqual(AuthEnvironment.coderouterGatewayBaseURL.absoluteString, "http://localhost:3999")
+    }
+
+    func testControlPlaneBaseURLEnvironmentOverrideCanonicalizesLoopback() {
+        let previousBase = getenv("CMUX_CODEROUTER_BASE_URL").map { String(cString: $0) }
+        defer {
+            if let previousBase {
+                setenv("CMUX_CODEROUTER_BASE_URL", previousBase, 1)
+            } else {
+                unsetenv("CMUX_CODEROUTER_BASE_URL")
+            }
+        }
+
+        setenv("CMUX_CODEROUTER_BASE_URL", "http://0.0.0.0:4888", 1)
+
+        XCTAssertEqual(AuthEnvironment.coderouterBaseURL.absoluteString, "http://localhost:4888")
+    }
+}

--- a/cmuxTests/CoderouterEnvironmentPolicyTests.swift
+++ b/cmuxTests/CoderouterEnvironmentPolicyTests.swift
@@ -1,0 +1,72 @@
+import CMUXAgentLaunch
+import XCTest
+
+final class CoderouterEnvironmentPolicyTests: XCTestCase {
+    func testClaudeEnabledReturnsAnthropicOverrides() {
+        let environment = CoderouterEnvironmentPolicy.environment(
+            kind: "claude",
+            enabled: true,
+            secret: "crk_test",
+            gatewayBaseURL: "https://coderouter.cmux.dev"
+        )
+
+        XCTAssertEqual(environment["ANTHROPIC_BASE_URL"], "https://coderouter.cmux.dev/anthropic")
+        XCTAssertEqual(environment["ANTHROPIC_AUTH_TOKEN"], "crk_test")
+        XCTAssertEqual(environment.count, 2)
+    }
+
+    func testTrailingSlashIsNormalized() {
+        let environment = CoderouterEnvironmentPolicy.environment(
+            kind: "claude",
+            enabled: true,
+            secret: "crk_test",
+            gatewayBaseURL: "https://coderouter.cmux.dev/"
+        )
+
+        XCTAssertEqual(environment["ANTHROPIC_BASE_URL"], "https://coderouter.cmux.dev/anthropic")
+    }
+
+    func testDisabledReturnsEmptyEnvironment() {
+        let environment = CoderouterEnvironmentPolicy.environment(
+            kind: "claude",
+            enabled: false,
+            secret: "crk_test",
+            gatewayBaseURL: "https://coderouter.cmux.dev"
+        )
+
+        XCTAssertEqual(environment, [:])
+    }
+
+    func testEmptySecretReturnsEmptyEnvironment() {
+        let environment = CoderouterEnvironmentPolicy.environment(
+            kind: "claude",
+            enabled: true,
+            secret: "   ",
+            gatewayBaseURL: "https://coderouter.cmux.dev"
+        )
+
+        XCTAssertEqual(environment, [:])
+    }
+
+    func testEmptyBaseURLReturnsEmptyEnvironment() {
+        let environment = CoderouterEnvironmentPolicy.environment(
+            kind: "claude",
+            enabled: true,
+            secret: "crk_test",
+            gatewayBaseURL: "   "
+        )
+
+        XCTAssertEqual(environment, [:])
+    }
+
+    func testNonClaudeKindReturnsEmptyEnvironment() {
+        let environment = CoderouterEnvironmentPolicy.environment(
+            kind: "codex",
+            enabled: true,
+            secret: "crk_test",
+            gatewayBaseURL: "https://coderouter.cmux.dev"
+        )
+
+        XCTAssertEqual(environment, [:])
+    }
+}

--- a/docs/coderouter-deploy.md
+++ b/docs/coderouter-deploy.md
@@ -1,0 +1,183 @@
+# coderouter — deployment & activation runbook
+
+This is the step-by-step to take coderouter from "code on a branch" to "a cmux
+user can route an agent through the gateway and it is metered." It documents the
+committed implementation; see `docs/coderouter.md` for architecture.
+
+coderouter has two deployables plus optional app activation:
+
+- **Control plane** — the existing `web/` Next.js app (Vercel + Aurora). Serves
+  `/api/coderouter/*`, mints keys, stores credential metadata + encrypted BYOK
+  keys, meters usage, and bills.
+- **Data plane** — the `workers/coderouter/` Cloudflare Worker + `PoolCoordinator`
+  Durable Object at `coderouter.cmux.dev`. Terminates agent traffic and routes it.
+
+## 0. The three shared secrets (read this first)
+
+Three secrets MUST be byte-identical in the worker and the web app. A mismatch
+is the most common failure and fails in ways that look unrelated:
+
+| Secret | Used by | Symptom if mismatched |
+| --- | --- | --- |
+| `CODEROUTER_KEY_SIGNING_SECRET` | web mints `crk_` keys; worker verifies their HMAC | every agent request returns 401 `key auth failed` |
+| `CODEROUTER_INTERNAL_TOKEN` | auth for worker↔web internal calls (pool sync, usage ingest, OAuth seed) | pool config never syncs; usage never flushes (401) |
+| `CODEROUTER_MASTER_KEY` | web AES-256-GCM-encrypts BYOK keys; worker decrypts | BYOK credentials unusable; managed/oauth unaffected |
+
+Generate once and reuse in both places:
+
+```bash
+openssl rand -hex 32   # CODEROUTER_KEY_SIGNING_SECRET (any high-entropy string)
+openssl rand -hex 32   # CODEROUTER_INTERNAL_TOKEN     (any high-entropy string)
+# CODEROUTER_MASTER_KEY must decode to EXACTLY 32 bytes as base64url (the crypto
+# layer uses base64url + rejects anything not 32 bytes). Generate it as base64url:
+node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+# (shell-only equivalent: openssl rand 32 | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+```
+
+## 1. Control plane (`web/`)
+
+### 1a. Run the database migration
+
+The `20260705225705_boring_morlocks` migration creates
+`coderouter_pools`, `coderouter_credentials`, `coderouter_keys`, and
+`coderouter_usage_events`. Against production Aurora (RDS IAM auth):
+
+```bash
+cd web
+bun run db:migrate:aws-rds-iam     # scripts/migrate-aws-rds-iam.ts
+# local/CI Postgres instead: bun run db:migrate
+```
+
+Verify with `bun run db:check` (drizzle reports no drift).
+
+### 1b. Set Vercel environment variables (Production + Preview)
+
+```
+CODEROUTER_KEY_SIGNING_SECRET=<shared #1>
+CODEROUTER_INTERNAL_TOKEN=<shared #2>
+CODEROUTER_MASTER_KEY=<shared #3>
+CODEROUTER_WORKER_BASE_URL=https://coderouter.cmux.dev
+CMUX_CODEROUTER_CREDIT_ITEM_ID=<optional; managed billing, see §4>
+```
+
+All are optional in `web/app/env.ts` so existing deploys keep working; coderouter
+is simply inert until they are set.
+
+### 1c. Deploy
+
+Deploy `web/` the normal way (Vercel). Confirm the routes exist:
+
+```bash
+curl -sS https://cmux.com/api/coderouter/usage -H "Authorization: Bearer <stack-access>" \
+     -H "X-Stack-Refresh-Token: <stack-refresh>" -H "X-Cmux-Team-Id: <team>"
+```
+
+The macOS app already resolves the control plane as `AuthEnvironment.coderouterBaseURL`
+(prod `https://cmux.com`, DEBUG `http://localhost:$CMUX_PORT`).
+
+## 2. Data plane (`workers/coderouter/`)
+
+### 2a. Provision Worker secrets (NOT `[vars]`)
+
+```bash
+cd workers/coderouter
+bunx wrangler secret put CODEROUTER_KEY_SIGNING_SECRET   # shared #1
+bunx wrangler secret put CODEROUTER_INTERNAL_TOKEN       # shared #2
+bunx wrangler secret put CODEROUTER_MASTER_KEY           # shared #3
+bunx wrangler secret put MANAGED_ANTHROPIC_API_KEY       # optional, §4
+bunx wrangler secret put MANAGED_OPENAI_API_KEY          # optional, §4
+```
+
+`CONTROL_PLANE_BASE_URL=https://cmux.com` is already in `wrangler.toml` `[vars]`.
+
+### 2b. Deploy
+
+Either manually:
+
+```bash
+bunx wrangler deploy
+```
+
+…or push to `main` and let `.github/workflows/coderouter.yml` deploy it (requires
+repo secrets `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` — the presence
+worker already uses these). The deploy provisions the `coderouter.cmux.dev`
+custom domain on the cmux.dev zone and applies the DO `v1` migration atomically.
+
+### 2c. Smoke test
+
+```bash
+curl -sS https://coderouter.cmux.dev/healthz      # -> 200 ok
+curl -sS https://coderouter.cmux.dev/v1/models    # -> model catalog JSON
+```
+
+## 3. Backend-only end-to-end proof (no app required)
+
+This exercises the whole data path. You need a Stack access+refresh token for a
+signed-in user and their team id.
+
+```bash
+AUTH=(-H "Authorization: Bearer $STACK_ACCESS" -H "X-Stack-Refresh-Token: $STACK_REFRESH" -H "X-Cmux-Team-Id: $TEAM")
+
+# 1) Mint a caller key (returned once)
+KEY=$(curl -sS "${AUTH[@]}" -H 'content-type: application/json' \
+  -d '{"name":"proof"}' https://cmux.com/api/coderouter/keys | jq -r .key)
+
+# 2) Add a BYOK Anthropic key to the pool
+curl -sS "${AUTH[@]}" -H 'content-type: application/json' \
+  -d '{"family":"anthropic","label":"my key","apiKey":"sk-ant-..."}' \
+  https://cmux.com/api/coderouter/credentials
+
+# 3) Call the gateway with the crk key — routed to the BYOK credential
+curl -sS https://coderouter.cmux.dev/anthropic/v1/messages \
+  -H "Authorization: Bearer $KEY" -H 'content-type: application/json' \
+  -H 'anthropic-version: 2023-06-01' \
+  -d '{"model":"claude-sonnet-4-5","max_tokens":64,"messages":[{"role":"user","content":"hi"}]}'
+
+# 4) Confirm a usage row landed
+curl -sS "${AUTH[@]}" 'https://cmux.com/api/coderouter/usage?days=1'
+```
+
+If step 3 returns a completion and step 4 shows tokens, the full pool → select →
+inject → upstream → meter path works.
+
+## 4. Optional — managed/resale tier
+
+To let teams pay cmux and use models with no credentials of their own:
+
+1. Create a Stack Auth "item" representing coderouter credits (micro-USD units).
+2. Set `CMUX_CODEROUTER_CREDIT_ITEM_ID` (web) to that item id.
+3. Set `MANAGED_ANTHROPIC_API_KEY` / `MANAGED_OPENAI_API_KEY` (worker secrets).
+4. Grant credits to a team (increase the Stack item quantity).
+
+Without these, managed is disabled and returns `insufficient_credits`; BYOK and
+subscription-OAuth credentials still route normally.
+
+## 5. Activate in the macOS app
+
+Once the backend is live, in a signed-in cmux build: **Settings → AI Gateway →
+Create gateway key**, then enable **Route Claude Code through the gateway**. New
+Claude Code launches get `ANTHROPIC_BASE_URL=https://coderouter.cmux.dev/anthropic`
++ `ANTHROPIC_AUTH_TOKEN=<crk key>` injected (Codex/OpenAI injection is Phase 3).
+
+The pool still needs at least one credential (BYOK key or connected subscription).
+Today those are added via the API (§3); the in-app add/connect UI is Phase 3.
+
+### Phase 3 (app code still to build)
+
+1. In-app "Add API key (BYOK)" form → `POST /api/coderouter/credentials`.
+2. In-app "Connect subscription" OAuth screens — OpenAI device-code + Anthropic
+   PKCE paste (control-plane routes exist; app client methods + UI do not).
+3. Codex/OpenAI launch injection (Phase 2 spawn merge is Claude-only).
+4. Usage display in the AI Gateway section → `GET /api/coderouter/usage`.
+
+## 6. Caveats
+
+- **Nothing has been exercised against live providers yet** — all tests are
+  unit-level. The first real deploy is where OAuth-refresh response shapes, the
+  `chatgpt.com/backend-api/wham/usage` and `api.anthropic.com/api/oauth/usage`
+  shapes, and provider header quirks get validated. Budget a debugging pass.
+- Keep the three shared secrets in a secret manager; rotating `CODEROUTER_MASTER_KEY`
+  invalidates every stored BYOK key (they must be re-added).
+- Dev override: point a local app/agent at a dev worker with
+  `CMUX_CODEROUTER_GATEWAY_BASE_URL` and the control plane with
+  `CMUX_CODEROUTER_BASE_URL`.

--- a/docs/coderouter.md
+++ b/docs/coderouter.md
@@ -1,0 +1,266 @@
+# coderouter
+
+coderouter is the cmux LLM gateway. It has a Cloudflare Worker data plane in
+`workers/coderouter/` and an API-only control plane in `web/app/api/coderouter/`
+backed by services in `web/services/coderouter/`.
+
+The Worker terminates caller keys, selects a team credential through a
+per-team Durable Object, forwards the request to the native upstream protocol,
+streams the response back, and reports usage. The web control plane mints
+caller keys, stores credential metadata, starts connect flows, syncs pool
+configuration to the Worker, ingests usage, and debits managed credits.
+
+## Architecture
+
+```
+Coding agent
+  |
+  | Authorization: Bearer crk_... or x-api-key: crk_...
+  v
+Cloudflare Worker: cmux-coderouter
+  - /healthz and /v1/models are public
+  - /anthropic/*, /openai/v1/*, /codex/* require a crk_ key
+  - /internal/* requires CODEROUTER_INTERNAL_TOKEN
+  |
+  | idFromName("<teamId>:<family>")
+  v
+PoolCoordinator Durable Object
+  - synced key list and credential metadata
+  - OAuth token chains
+  - sticky conversation assignments
+  - rate-limit and cooldown state
+  - buffered usage and status updates
+  |
+  +--> native upstream API
+  |
+  +--> web /api/coderouter/internal/usage-ingest
+
+web /api/coderouter/*
+  - authenticated key, credential, connect, and usage APIs
+  - service-token pool-config and usage-ingest APIs
+  - Postgres tables: coderouter_pools, coderouter_credentials,
+    coderouter_keys, coderouter_usage_events
+```
+
+One Durable Object owns one `teamId:family` pool. On a control-plane mutation,
+web builds a full `PoolConfig` and posts it to
+`/internal/pools/:poolId/sync`. If the DO has no config on first acquire, it
+lazy-pulls `/api/coderouter/internal/pool-config?poolId=...` from the web
+control plane. If that pull fails and no stored config exists, acquire returns
+`config_unavailable`, mapped to `503` with `retry-after: 5`.
+
+## Endpoints
+
+| Client base URL | Upstream rewrite | Family | Allowed credential classes |
+| --- | --- | --- | --- |
+| `https://coderouter.cmux.dev/anthropic` | strip `/anthropic`; forward path and query to `https://api.anthropic.com` | `anthropic` | `oauth`, `byok`, `managed` |
+| `https://coderouter.cmux.dev/openai/v1` | rewrite as `/v1/*` on `https://api.openai.com` | `openai` | `byok`, `managed` |
+| `https://coderouter.cmux.dev/codex` | rewrite as `/backend-api/codex/*` on `https://chatgpt.com` | `openai` | `oauth` |
+
+Public Worker routes:
+
+- `GET /healthz`: returns service liveness.
+- `GET /v1/models`: returns the Worker pricing catalog model ids.
+
+Internal Worker routes:
+
+- `POST /internal/pools/:poolId/sync`: stores a full `PoolConfig`.
+- `POST /internal/pools/:poolId/seed-oauth`: stores an OAuth chain in the DO.
+
+Public web control-plane routes, all authenticated with the existing VM auth
+helpers and team resolution:
+
+- `GET|POST|DELETE /api/coderouter/keys`
+- `GET|POST|DELETE /api/coderouter/credentials`
+- `POST /api/coderouter/credentials/import`
+- `POST /api/coderouter/connect/anthropic`
+- `POST /api/coderouter/connect/openai`
+- `GET /api/coderouter/usage`
+
+Internal web routes require `Authorization: Bearer $CODEROUTER_INTERNAL_TOKEN`:
+
+- `GET /api/coderouter/internal/pool-config?poolId=<teamId>:<family>`
+- `POST /api/coderouter/internal/usage-ingest`
+
+## Caller Keys
+
+Caller keys use the `crk_` format implemented in both
+`workers/coderouter/src/keys.ts` and `web/services/coderouter/keys.ts`:
+
+```
+crk_<base64url(payloadJSON)>.<base64url(hmac)>
+```
+
+The payload is `{"v":1,"kid":"<uuid>","team":"<teamId>","iat":<unix seconds>}`.
+The HMAC signs the `crk_<payload>` prefix with
+`CODEROUTER_KEY_SIGNING_SECRET`. Web stores only `sha256(fullKey)` in
+`coderouter_keys.secret_hash` and returns the full key exactly once from
+`POST /api/coderouter/keys`.
+
+The Worker verifies the HMAC statelessly and then asks the DO to verify that
+the `kid` is present, not revoked, and allowed by key policy.
+
+## Credential Classes
+
+- `oauth`: team-owned subscription accounts. The DO stores OAuth token chains
+  in SQLite and refreshes access tokens before use. Postgres stores only
+  metadata such as label, provider email, account id, and status.
+- `byok`: team-owned provider API keys. Web encrypts the secret as
+  `crv1:<iv>:<ciphertext-with-tag>` using AES-256-GCM with
+  `CODEROUTER_MASTER_KEY`; the encrypted envelope is synced to the DO.
+- `managed`: cmux-owned provider keys stored as Worker secrets. Managed
+  acquire requires managed billing to be enabled, a positive balance snapshot,
+  and a priced model.
+
+Selection is implemented in `workers/coderouter/src/select.ts` and
+`src/acquirePolicy.ts`. Sticky conversation assignments are reused while the
+assigned credential remains healthy. New selection prefers usable `oauth`,
+then `byok`, then `managed`, then lower-headroom `oauth`; cooling-down
+credentials are never selected, and headroom-exhausted `oauth` is used only
+when nothing else remains.
+
+The Worker strips caller auth, hop-by-hop headers, `chatgpt-account-id`, and
+all `x-coderouter-*` request headers before forwarding. It injects only the
+selected credential's upstream auth headers and returns
+`x-coderouter-credential: <class>` to the client.
+
+## Environment
+
+Worker plain vars in `workers/coderouter/wrangler.toml`:
+
+- `CONTROL_PLANE_BASE_URL`: production is `https://cmux.com`.
+
+Worker secrets, set once with `wrangler secret put`:
+
+```bash
+cd workers/coderouter
+bunx wrangler secret put CODEROUTER_KEY_SIGNING_SECRET
+bunx wrangler secret put CODEROUTER_INTERNAL_TOKEN
+bunx wrangler secret put CODEROUTER_MASTER_KEY
+bunx wrangler secret put MANAGED_ANTHROPIC_API_KEY
+bunx wrangler secret put MANAGED_OPENAI_API_KEY
+```
+
+`MANAGED_ANTHROPIC_API_KEY` and `MANAGED_OPENAI_API_KEY` are optional. Without
+one of them, managed credentials for that family cannot be acquired.
+
+Web env in `web/app/env.ts` and `web/.env.example`:
+
+- `CODEROUTER_KEY_SIGNING_SECRET`
+- `CODEROUTER_INTERNAL_TOKEN`
+- `CODEROUTER_MASTER_KEY`
+- `CODEROUTER_WORKER_BASE_URL`
+- `CMUX_CODEROUTER_CREDIT_ITEM_ID`
+
+When `CMUX_CODEROUTER_CREDIT_ITEM_ID` is unset, managed billing is disabled
+and balance reads as zero. When `CODEROUTER_WORKER_BASE_URL` or the internal
+token is missing, mutations that need Worker sync return a configuration
+error instead of silently claiming the sync happened.
+
+## Client Wiring
+
+Claude Code:
+
+```bash
+export ANTHROPIC_BASE_URL="https://coderouter.cmux.dev/anthropic"
+export ANTHROPIC_AUTH_TOKEN="crk_..."
+```
+
+Codex config:
+
+```toml
+chatgpt_base_url = "https://coderouter.cmux.dev/codex"
+openai_base_url = "https://coderouter.cmux.dev/openai/v1"
+api_key = "crk_..."
+```
+
+The same caller key can be sent as `Authorization: Bearer crk_...` or as
+`x-api-key: crk_...`.
+
+## Connect Flows
+
+Anthropic paste-code flow:
+
+1. Call `POST /api/coderouter/connect/anthropic` with `{"action":"start"}`.
+2. The API returns an `authorizeUrl` and `state`, and sets an HttpOnly state
+   cookie scoped to the connect route.
+3. Complete the provider authorization and paste back the resulting
+   `code#state` value with `{"action":"complete","code":"..."}`.
+4. Web exchanges the code, creates an `oauth` credential row with metadata
+   only, seeds the OAuth chain into the DO, and syncs the family pool.
+
+OpenAI device flow:
+
+1. Call `POST /api/coderouter/connect/openai` with `{"action":"start"}`.
+2. The API returns `deviceCode`, `userCode`, `verificationUri`, and optional
+   timing fields.
+3. Poll with `{"action":"poll","deviceCode":"..."}` until the response is
+   `{"status":"complete","credential":...}` or remains pending.
+4. If the provider rejects the device-flow shape, the API returns
+   `connect_unsupported`; use import instead.
+
+OAuth import:
+
+```http
+POST /api/coderouter/credentials/import
+```
+
+Body:
+
+```json
+{
+  "provider": "openai",
+  "accessToken": "...",
+  "refreshToken": "...",
+  "idToken": "...",
+  "accountId": "...",
+  "email": "user@example.com",
+  "expiresAt": 1783212345000,
+  "label": "Dedicated coding account"
+}
+```
+
+Import is always available. After import, coderouter owns the refresh chain;
+provider refresh rotation can invalidate the local copy.
+
+## Usage And Billing
+
+The Worker extracts usage from JSON responses and from SSE streams without
+accumulating full stream text. It reports a usage event to the DO with token
+counts, status, latency, credential class, endpoint class, model, and whether
+the usage was estimated.
+
+The DO buffers events in SQLite and flushes batches of up to 500 to
+`/api/coderouter/internal/usage-ingest`. Web inserts by `eventId` with
+`onConflictDoNothing`, re-prices managed events with the authoritative web
+catalog in `web/services/coderouter/pricing.ts`, debits the Stack item
+configured by `CMUX_CODEROUTER_CREDIT_ITEM_ID`, and returns the current
+`balanceMicros` snapshot to the DO.
+
+Pricing values are integer micro-USD per token. Each component is rounded up:
+
+```
+ceil(tokens * microsPer1M / 1_000_000)
+```
+
+Unknown models are allowed for `oauth` and `byok`; managed acquire fails with
+`model_not_priced`.
+
+## CI/CD
+
+`.github/workflows/coderouter.yml` is path-filtered to `workers/coderouter/**`
+and the workflow file. PRs run:
+
+```bash
+cd workers/coderouter
+bun install --frozen-lockfile
+bun run typecheck
+bun test
+bunx wrangler deploy --dry-run --outdir dist
+```
+
+Pushes to `main` run the same test job and then deploy with
+`bunx wrangler deploy`, serialized by the `coderouter-deploy` concurrency
+group. Deploy requires repository secrets `CLOUDFLARE_API_TOKEN` and
+`CLOUDFLARE_ACCOUNT_ID`. Worker runtime secrets are not stored in the workflow;
+they are set with `wrangler secret put` and survive deploys.

--- a/web/.env.example
+++ b/web/.env.example
@@ -68,6 +68,16 @@ CMUX_VM_CREATE_CREDIT_COST_E2B=
 CMUX_VM_CREATE_CREDIT_COST_FREESTYLE=
 CMUX_VM_CREATE_CREDIT_ITEM_ID=
 
+# coderouter control plane. Leave unset to disable key minting, worker sync,
+# BYOK secret encryption, and managed-credit debits in local/dev deploys.
+CODEROUTER_KEY_SIGNING_SECRET=
+CODEROUTER_INTERNAL_TOKEN=
+# 32 random bytes, base64 encoded. Used for crv1 BYOK secret envelopes.
+CODEROUTER_MASTER_KEY=
+CODEROUTER_WORKER_BASE_URL=
+# Optional Stack Auth item id whose integer quantity is micro-USD credits.
+CMUX_CODEROUTER_CREDIT_ITEM_ID=
+
 # OpenTelemetry/Axiom.
 OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_EXPORTER_OTLP_HEADERS=

--- a/web/app/api/coderouter/_shared.ts
+++ b/web/app/api/coderouter/_shared.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+import { unauthorized, verifyRequest, type AuthedUser } from "../../../services/vms/auth";
+import { jsonResponse, requestedVmTeamIdFromRequest } from "../../../services/vms/routeHelpers";
+import {
+  CoderouterBillingError,
+  CoderouterConfigurationError,
+  CoderouterConnectError,
+  CoderouterDatabaseError,
+  CoderouterNotFoundError,
+  CoderouterWorkerSyncError,
+} from "../../../services/coderouter/errors";
+import type { BillingCustomer } from "../../../services/coderouter/billing";
+
+export const PUBLIC_JSON_LIMIT_BYTES = 64 * 1024;
+export const USAGE_INGEST_JSON_LIMIT_BYTES = 2 * 1024 * 1024;
+
+export type AuthedCoderouterContext = {
+  readonly user: AuthedUser;
+  readonly teamId: string;
+  readonly billingCustomer: BillingCustomer;
+};
+
+export const credentialClassSchema = z.enum(["oauth", "byok", "managed"]);
+export const familySchema = z.enum(["anthropic", "openai"]);
+export const keyPolicySchema = z.object({
+  allowedClasses: z.array(credentialClassSchema).optional(),
+}).strict().optional();
+
+export async function authenticateCoderouter(request: Request): Promise<
+  | { readonly ok: true; readonly context: AuthedCoderouterContext }
+  | { readonly ok: false; readonly response: Response }
+> {
+  const user = await verifyRequest(request, {
+    requestedTeamId: requestedVmTeamIdFromRequest(request),
+    allowCookie: false,
+  });
+  if (!user) return { ok: false, response: unauthorized() };
+
+  const requested = requestedVmTeamIdFromRequest(request);
+  if (requested) {
+    const isMember = user.teamIds.includes(requested) || requested === user.id;
+    if (!isMember) return { ok: false, response: jsonResponse({ error: "team_not_found" }, 403) };
+    const requestedIsUser = requested === user.id && !user.teamIds.includes(requested);
+    return {
+      ok: true,
+      context: {
+        user,
+        teamId: requested,
+        billingCustomer: { type: requestedIsUser ? "user" : "team", id: requested },
+      },
+    };
+  }
+
+  const teamId = user.selectedTeamId ?? user.billingTeamId;
+  return {
+    ok: true,
+    context: {
+      user,
+      teamId,
+      billingCustomer: { type: user.billingCustomerType, id: user.billingTeamId },
+    },
+  };
+}
+
+export async function parseJsonBody<T>(
+  request: Request,
+  schema: z.ZodType<T>,
+  maxBytes = PUBLIC_JSON_LIMIT_BYTES,
+): Promise<{ readonly ok: true; readonly value: T } | { readonly ok: false; readonly response: Response }> {
+  const length = request.headers.get("content-length");
+  if (length && Number(length) > maxBytes) {
+    return { ok: false, response: jsonResponse({ error: "payload_too_large", message: "Request body is too large." }, 413) };
+  }
+  const raw = await request.text().catch(() => null);
+  if (raw === null || raw.length > maxBytes) {
+    return { ok: false, response: jsonResponse({ error: "invalid_request", message: "Request body could not be read." }, 400) };
+  }
+  let parsed: unknown;
+  try {
+    parsed = raw ? JSON.parse(raw) : {};
+  } catch {
+    return { ok: false, response: jsonResponse({ error: "invalid_json", message: "Request body must be JSON." }, 400) };
+  }
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      ok: false,
+      response: jsonResponse({
+        error: "invalid_request",
+        message: "Request body failed validation.",
+        issues: z.treeifyError(result.error),
+      }, 400),
+    };
+  }
+  return { ok: true, value: result.data };
+}
+
+export function coderouterErrorResponse(err: unknown): Response {
+  if (err instanceof CoderouterConfigurationError) {
+    return jsonResponse({ error: "coderouter_not_configured", message: err.message }, 503);
+  }
+  if (err instanceof CoderouterWorkerSyncError) {
+    return jsonResponse({ error: "worker_sync_failed", message: "Could not sync coderouter worker state." }, 502);
+  }
+  if (err instanceof CoderouterDatabaseError) {
+    return jsonResponse({ error: "coderouter_state_unavailable", message: "Coderouter state is temporarily unavailable." }, 503);
+  }
+  if (err instanceof CoderouterBillingError) {
+    return jsonResponse({ error: "coderouter_billing_unavailable", message: "Coderouter billing could not be updated." }, 503);
+  }
+  if (err instanceof CoderouterConnectError) {
+    const status = err.code === "provider_rejected" ? 502 : 400;
+    return jsonResponse({ error: err.code, message: err.message }, status);
+  }
+  if (err instanceof CoderouterNotFoundError) {
+    return jsonResponse({ error: "not_found", message: err.message }, 404);
+  }
+  return jsonResponse({ error: "coderouter_internal_error", message: "Coderouter request failed unexpectedly." }, 500);
+}
+
+export function cookieValue(request: Request, name: string): string | null {
+  const cookie = request.headers.get("cookie");
+  if (!cookie) return null;
+  for (const part of cookie.split(";")) {
+    const [key, ...rest] = part.trim().split("=");
+    if (key === name) return rest.join("=") || null;
+  }
+  return null;
+}

--- a/web/app/api/coderouter/connect/anthropic/route.ts
+++ b/web/app/api/coderouter/connect/anthropic/route.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import { jsonResponse } from "../../../../../services/vms/routeHelpers";
+import {
+  completeAnthropicConnect,
+  publicCredential,
+  runCoderouterWorkflow,
+  startAnthropicConnect,
+} from "../../../../../services/coderouter/workflows";
+import {
+  authenticateCoderouter,
+  coderouterErrorResponse,
+  cookieValue,
+  parseJsonBody,
+} from "../../_shared";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const STATE_COOKIE = "coderouter_anthropic_state";
+const connectSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("start") }).strict(),
+  z.object({ action: z.literal("complete"), code: z.string().min(1) }).strict(),
+]);
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await authenticateCoderouter(request);
+  if (!auth.ok) return auth.response;
+  const body = await parseJsonBody(request, connectSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    if (body.value.action === "start") {
+      const started = await runCoderouterWorkflow(startAnthropicConnect());
+      const response = jsonResponse({ authorizeUrl: started.authorizeUrl, state: started.state });
+      response.headers.set(
+        "set-cookie",
+        `${STATE_COOKIE}=${started.cookie}; HttpOnly; SameSite=Lax; Secure; Path=/api/coderouter/connect/anthropic; Max-Age=600`,
+      );
+      return response;
+    }
+
+    const row = await runCoderouterWorkflow(completeAnthropicConnect({
+      teamId: auth.context.teamId,
+      billingCustomer: auth.context.billingCustomer,
+      pastedCode: body.value.code,
+      stateCookie: cookieValue(request, STATE_COOKIE),
+    }));
+    const response = jsonResponse(publicCredential(row));
+    response.headers.set(
+      "set-cookie",
+      `${STATE_COOKIE}=; HttpOnly; SameSite=Lax; Secure; Path=/api/coderouter/connect/anthropic; Max-Age=0`,
+    );
+    return response;
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}

--- a/web/app/api/coderouter/connect/openai/route.ts
+++ b/web/app/api/coderouter/connect/openai/route.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { jsonResponse } from "../../../../../services/vms/routeHelpers";
+import {
+  pollOpenAIConnect,
+  publicCredential,
+  runCoderouterWorkflow,
+  startOpenAIConnect,
+} from "../../../../../services/coderouter/workflows";
+import {
+  authenticateCoderouter,
+  coderouterErrorResponse,
+  parseJsonBody,
+} from "../../_shared";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const connectSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("start") }).strict(),
+  z.object({ action: z.literal("poll"), deviceCode: z.string().min(1) }).strict(),
+]);
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await authenticateCoderouter(request);
+  if (!auth.ok) return auth.response;
+  const body = await parseJsonBody(request, connectSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    if (body.value.action === "start") {
+      return jsonResponse(await runCoderouterWorkflow(startOpenAIConnect()));
+    }
+    const result = await runCoderouterWorkflow(pollOpenAIConnect({
+      teamId: auth.context.teamId,
+      billingCustomer: auth.context.billingCustomer,
+      deviceCode: body.value.deviceCode,
+    }));
+    if (result.status === "pending") return jsonResponse({ status: "pending" });
+    return jsonResponse({ status: "complete", credential: publicCredential(result.credential) });
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}

--- a/web/app/api/coderouter/credentials/import/route.ts
+++ b/web/app/api/coderouter/credentials/import/route.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { jsonResponse } from "../../../../../services/vms/routeHelpers";
+import {
+  importOauthCredential,
+  publicCredential,
+  runCoderouterWorkflow,
+} from "../../../../../services/coderouter/workflows";
+import {
+  authenticateCoderouter,
+  coderouterErrorResponse,
+  familySchema,
+  parseJsonBody,
+} from "../../_shared";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const importSchema = z.object({
+  provider: familySchema,
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  idToken: z.string().min(1).optional(),
+  accountId: z.string().min(1).optional(),
+  email: z.string().email().optional(),
+  expiresAt: z.number().int().positive().optional(),
+  label: z.string().trim().min(1).max(160).optional(),
+}).strict();
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await authenticateCoderouter(request);
+  if (!auth.ok) return auth.response;
+  const body = await parseJsonBody(request, importSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    const row = await runCoderouterWorkflow(importOauthCredential({
+      teamId: auth.context.teamId,
+      billingCustomer: auth.context.billingCustomer,
+      label: body.value.label,
+      chain: {
+        provider: body.value.provider,
+        accessToken: body.value.accessToken,
+        refreshToken: body.value.refreshToken,
+        idToken: body.value.idToken,
+        accountId: body.value.accountId,
+        email: body.value.email,
+        expiresAt: body.value.expiresAt,
+      },
+    }));
+    return jsonResponse(publicCredential(row));
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}

--- a/web/app/api/coderouter/credentials/route.ts
+++ b/web/app/api/coderouter/credentials/route.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { jsonResponse } from "../../../../services/vms/routeHelpers";
+import {
+  addByokCredential,
+  disableCredential,
+  listCredentials,
+  publicCredential,
+  runCoderouterWorkflow,
+} from "../../../../services/coderouter/workflows";
+import {
+  authenticateCoderouter,
+  coderouterErrorResponse,
+  familySchema,
+  parseJsonBody,
+} from "../_shared";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const addByokSchema = z.object({
+  family: familySchema,
+  label: z.string().trim().min(1).max(160).optional(),
+  apiKey: z.string().trim().min(1),
+}).strict();
+
+export async function GET(request: Request): Promise<Response> {
+  const auth = await authenticateCoderouter(request);
+  if (!auth.ok) return auth.response;
+  try {
+    const rows = await runCoderouterWorkflow(listCredentials(auth.context.teamId));
+    return jsonResponse({ credentials: rows.map(publicCredential) });
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await authenticateCoderouter(request);
+  if (!auth.ok) return auth.response;
+  const body = await parseJsonBody(request, addByokSchema);
+  if (!body.ok) return body.response;
+
+  try {
+    const row = await runCoderouterWorkflow(addByokCredential({
+      teamId: auth.context.teamId,
+      billingCustomer: auth.context.billingCustomer,
+      family: body.value.family,
+      label: body.value.label,
+      apiKey: body.value.apiKey,
+    }));
+    return jsonResponse(publicCredential(row));
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const auth = await authenticateCoderouter(request);
+  if (!auth.ok) return auth.response;
+  const id = new URL(request.url).searchParams.get("id")?.trim();
+  if (!id) return jsonResponse({ error: "invalid_request", message: "Missing credential id." }, 400);
+  try {
+    const row = await runCoderouterWorkflow(disableCredential({
+      teamId: auth.context.teamId,
+      billingCustomer: auth.context.billingCustomer,
+      credentialId: id,
+    }));
+    return jsonResponse(publicCredential(row));
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}

--- a/web/app/api/coderouter/internal/pool-config/route.ts
+++ b/web/app/api/coderouter/internal/pool-config/route.ts
@@ -1,0 +1,23 @@
+import { jsonResponse } from "../../../../../services/vms/routeHelpers";
+import { verifyInternalBearer } from "../../../../../services/coderouter/keys";
+import {
+  poolConfigForName,
+  runCoderouterWorkflow,
+} from "../../../../../services/coderouter/workflows";
+import { coderouterErrorResponse } from "../../_shared";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request): Promise<Response> {
+  if (!verifyInternalBearer(request, process.env.CODEROUTER_INTERNAL_TOKEN)) {
+    return jsonResponse({ error: "unauthorized", message: "Unauthorized." }, 401);
+  }
+  const poolId = new URL(request.url).searchParams.get("poolId")?.trim();
+  if (!poolId) return jsonResponse({ error: "invalid_request", message: "Missing poolId." }, 400);
+  try {
+    return jsonResponse(await runCoderouterWorkflow(poolConfigForName(poolId)));
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}

--- a/web/app/api/coderouter/internal/usage-ingest/route.ts
+++ b/web/app/api/coderouter/internal/usage-ingest/route.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { jsonResponse } from "../../../../../services/vms/routeHelpers";
+import { verifyInternalBearer } from "../../../../../services/coderouter/keys";
+import {
+  ingestUsage,
+  runCoderouterWorkflow,
+} from "../../../../../services/coderouter/workflows";
+import {
+  coderouterErrorResponse,
+  credentialClassSchema,
+  parseJsonBody,
+  USAGE_INGEST_JSON_LIMIT_BYTES,
+} from "../../_shared";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const eventSchema = z.object({
+  eventId: z.string().min(1),
+  keyId: z.uuid().optional(),
+  credentialId: z.uuid().optional(),
+  family: z.string().min(1),
+  endpointClass: z.enum(["anthropic", "openai_api", "codex"]),
+  model: z.string().min(1).optional(),
+  credentialClass: credentialClassSchema,
+  status: z.number().int().min(100).max(599),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  cacheReadTokens: z.number().int().nonnegative(),
+  cacheWriteTokens: z.number().int().nonnegative(),
+  estimated: z.boolean(),
+  costMicros: z.number().int().nonnegative().nullable().optional(),
+  latencyMs: z.number().int().nonnegative().optional(),
+  ts: z.number().int().positive(),
+}).strict();
+
+const usageIngestSchema = z.object({
+  poolId: z.string().min(1),
+  events: z.array(eventSchema).max(500),
+  statusUpdates: z.array(z.object({
+    credentialId: z.uuid(),
+    status: z.enum(["active", "needs_reauth"]),
+  }).strict()).optional(),
+}).strict();
+
+export async function POST(request: Request): Promise<Response> {
+  if (!verifyInternalBearer(request, process.env.CODEROUTER_INTERNAL_TOKEN)) {
+    return jsonResponse({ error: "unauthorized", message: "Unauthorized." }, 401);
+  }
+  const body = await parseJsonBody(request, usageIngestSchema, USAGE_INGEST_JSON_LIMIT_BYTES);
+  if (!body.ok) return body.response;
+  try {
+    const result = await runCoderouterWorkflow(ingestUsage({ usage: body.value }));
+    return jsonResponse({ balanceMicros: result.balanceMicros });
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}

--- a/web/app/api/coderouter/keys/route.ts
+++ b/web/app/api/coderouter/keys/route.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { jsonResponse } from "../../../../services/vms/routeHelpers";
+import {
+  allowedClassesPolicy,
+  createKey,
+  listKeys,
+  publicKey,
+  revokeKey,
+  runCoderouterWorkflow,
+} from "../../../../services/coderouter/workflows";
+import {
+  authenticateCoderouter,
+  coderouterErrorResponse,
+  keyPolicySchema,
+  parseJsonBody,
+} from "../_shared";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const createKeySchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  policy: keyPolicySchema,
+}).strict();
+
+export async function GET(request: Request): Promise<Response> {
+  const auth = await authenticateCoderouter(request);
+  if (!auth.ok) return auth.response;
+  try {
+    const rows = await runCoderouterWorkflow(listKeys(auth.context.teamId));
+    return jsonResponse({ keys: rows.map(publicKey) });
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await authenticateCoderouter(request);
+  if (!auth.ok) return auth.response;
+  const body = await parseJsonBody(request, createKeySchema);
+  if (!body.ok) return body.response;
+
+  try {
+    const result = await runCoderouterWorkflow(createKey({
+      teamId: auth.context.teamId,
+      billingCustomer: auth.context.billingCustomer,
+      name: body.value.name,
+      policy: allowedClassesPolicy(body.value.policy?.allowedClasses),
+    }));
+    return jsonResponse({ key: result.key, ...publicKey(result.row) });
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const auth = await authenticateCoderouter(request);
+  if (!auth.ok) return auth.response;
+  const id = new URL(request.url).searchParams.get("id")?.trim();
+  if (!id) return jsonResponse({ error: "invalid_request", message: "Missing key id." }, 400);
+  try {
+    const row = await runCoderouterWorkflow(revokeKey({
+      teamId: auth.context.teamId,
+      billingCustomer: auth.context.billingCustomer,
+      keyId: id,
+    }));
+    return jsonResponse(publicKey(row));
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}

--- a/web/app/api/coderouter/usage/route.ts
+++ b/web/app/api/coderouter/usage/route.ts
@@ -1,0 +1,31 @@
+import { jsonResponse } from "../../../../services/vms/routeHelpers";
+import {
+  publicUsageSummary,
+  runCoderouterWorkflow,
+  usageSummary,
+} from "../../../../services/coderouter/workflows";
+import { authenticateCoderouter, coderouterErrorResponse } from "../_shared";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request): Promise<Response> {
+  const auth = await authenticateCoderouter(request);
+  if (!auth.ok) return auth.response;
+  const rawDays = new URL(request.url).searchParams.get("days");
+  const days = rawDays && /^\d+$/.test(rawDays) ? Math.min(Math.max(Number(rawDays), 1), 90) : 30;
+  try {
+    const summary = await runCoderouterWorkflow(usageSummary({
+      teamId: auth.context.teamId,
+      billingCustomer: auth.context.billingCustomer,
+      days,
+    }));
+    return jsonResponse({
+      days,
+      balanceMicros: summary.balanceMicros,
+      totals: publicUsageSummary(summary.rows),
+    });
+  } catch (err) {
+    return coderouterErrorResponse(err);
+  }
+}

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -46,6 +46,11 @@ export const env = createEnv({
     // Slack Incoming Webhook for the #website-waitlist channel. Optional: the
     // /api/waitlist route silently skips the Slack ping when it is unset.
     SLACK_WAITLIST_WEBHOOK_URL: z.string().url().optional(),
+    CODEROUTER_KEY_SIGNING_SECRET: z.string().min(1).optional(),
+    CODEROUTER_INTERNAL_TOKEN: z.string().min(1).optional(),
+    CODEROUTER_MASTER_KEY: z.string().min(1).optional(),
+    CODEROUTER_WORKER_BASE_URL: z.string().url().optional(),
+    CMUX_CODEROUTER_CREDIT_ITEM_ID: z.string().min(1).optional(),
   },
   client: {
     NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),
@@ -62,6 +67,11 @@ export const env = createEnv({
     STRIPE_FOUNDERS_WEBHOOK_SECRET: trimEnv(process.env.STRIPE_FOUNDERS_WEBHOOK_SECRET),
     CMUX_FOUNDERS_FROM_EMAIL: trimEnv(process.env.CMUX_FOUNDERS_FROM_EMAIL),
     SLACK_WAITLIST_WEBHOOK_URL: trimEnv(process.env.SLACK_WAITLIST_WEBHOOK_URL),
+    CODEROUTER_KEY_SIGNING_SECRET: trimEnv(process.env.CODEROUTER_KEY_SIGNING_SECRET),
+    CODEROUTER_INTERNAL_TOKEN: trimEnv(process.env.CODEROUTER_INTERNAL_TOKEN),
+    CODEROUTER_MASTER_KEY: trimEnv(process.env.CODEROUTER_MASTER_KEY),
+    CODEROUTER_WORKER_BASE_URL: trimEnv(process.env.CODEROUTER_WORKER_BASE_URL),
+    CMUX_CODEROUTER_CREDIT_ITEM_ID: trimEnv(process.env.CMUX_CODEROUTER_CREDIT_ITEM_ID),
     NEXT_PUBLIC_STACK_PROJECT_ID: stackEnv(
       process.env.NEXT_PUBLIC_STACK_PROJECT_ID,
       "00000000-0000-4000-8000-000000000000"

--- a/web/db/migrations/20260705225705_boring_morlocks/migration.sql
+++ b/web/db/migrations/20260705225705_boring_morlocks/migration.sql
@@ -1,0 +1,65 @@
+CREATE TYPE "coderouter_credential_class" AS ENUM('oauth', 'byok', 'managed');--> statement-breakpoint
+CREATE TYPE "coderouter_credential_kind" AS ENUM('oauth', 'api_key');--> statement-breakpoint
+CREATE TYPE "coderouter_credential_status" AS ENUM('active', 'needs_reauth', 'disabled');--> statement-breakpoint
+CREATE TYPE "coderouter_family" AS ENUM('anthropic', 'openai');--> statement-breakpoint
+CREATE TABLE "coderouter_credentials" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+	"pool_id" uuid NOT NULL,
+	"kind" "coderouter_credential_kind" NOT NULL,
+	"class" "coderouter_credential_class" NOT NULL,
+	"status" "coderouter_credential_status" DEFAULT 'active'::"coderouter_credential_status" NOT NULL,
+	"label" text,
+	"provider_email" text,
+	"provider_account_id" text,
+	"encrypted_secret" text,
+	"meta" jsonb DEFAULT '{}' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_used_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "coderouter_keys" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+	"team_id" text NOT NULL,
+	"name" text NOT NULL,
+	"secret_hash" text NOT NULL,
+	"policy" jsonb DEFAULT '{}' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"last_used_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "coderouter_pools" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+	"team_id" text NOT NULL,
+	"billing_customer_type" text DEFAULT 'team' NOT NULL,
+	"family" "coderouter_family" NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "coderouter_usage_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+	"event_id" text NOT NULL,
+	"team_id" text NOT NULL,
+	"key_id" uuid,
+	"credential_id" uuid,
+	"family" text NOT NULL,
+	"endpoint_class" text NOT NULL,
+	"model" text,
+	"credential_class" text NOT NULL,
+	"status" integer NOT NULL,
+	"input_tokens" bigint DEFAULT 0 NOT NULL,
+	"output_tokens" bigint DEFAULT 0 NOT NULL,
+	"cache_read_tokens" bigint DEFAULT 0 NOT NULL,
+	"cache_write_tokens" bigint DEFAULT 0 NOT NULL,
+	"estimated" boolean DEFAULT false NOT NULL,
+	"cost_micros" bigint,
+	"latency_ms" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "coderouter_credentials_pool_idx" ON "coderouter_credentials" ("pool_id");--> statement-breakpoint
+CREATE INDEX "coderouter_keys_team_idx" ON "coderouter_keys" ("team_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "coderouter_pools_team_family_unique" ON "coderouter_pools" ("team_id","family");--> statement-breakpoint
+CREATE UNIQUE INDEX "coderouter_usage_events_event_id_unique" ON "coderouter_usage_events" ("event_id");--> statement-breakpoint
+CREATE INDEX "coderouter_usage_events_team_created_idx" ON "coderouter_usage_events" ("team_id","created_at");--> statement-breakpoint
+ALTER TABLE "coderouter_credentials" ADD CONSTRAINT "coderouter_credentials_pool_id_coderouter_pools_id_fkey" FOREIGN KEY ("pool_id") REFERENCES "coderouter_pools"("id") ON DELETE CASCADE;

--- a/web/db/migrations/20260705225705_boring_morlocks/snapshot.json
+++ b/web/db/migrations/20260705225705_boring_morlocks/snapshot.json
@@ -1,0 +1,2654 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "8ebb3655-0942-43dc-911d-992f6d1ab9c0",
+  "prevIds": [
+    "ba8f09f6-d710-41c7-b9c0-153faea51c65"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "oauth",
+        "byok",
+        "managed"
+      ],
+      "name": "coderouter_credential_class",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "oauth",
+        "api_key"
+      ],
+      "name": "coderouter_credential_kind",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "active",
+        "needs_reauth",
+        "disabled"
+      ],
+      "name": "coderouter_credential_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "anthropic",
+        "openai"
+      ],
+      "name": "coderouter_family",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pty",
+        "rpc",
+        "ssh"
+      ],
+      "name": "vm_lease_kind",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "e2b",
+        "freestyle"
+      ],
+      "name": "vm_provider",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "provisioning",
+        "running",
+        "failed",
+        "paused",
+        "destroyed"
+      ],
+      "name": "vm_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_billing_grants",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_leases",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vm_usage_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cloud_vms",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "coderouter_credentials",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "coderouter_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "coderouter_pools",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "coderouter_usage_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "device_app_instances",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "device_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "devices",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "notification_send_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_customer_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_customer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "item_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "amount",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "applied_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "vm_lease_kind",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_identity_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transport",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consumed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "vm_provider",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_plan_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "vm_provider",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_vm_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "vm_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'provisioning'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "destroyed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "failure_code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "failure_message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pool_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "coderouter_credential_kind",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "coderouter_credential_class",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "class",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "coderouter_credential_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "label",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "encrypted_secret",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "secret_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_keys"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "policy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_keys"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_pools"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_pools"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'team'",
+      "generated": null,
+      "identity": null,
+      "name": "billing_customer_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_pools"
+    },
+    {
+      "type": "coderouter_family",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "family",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_pools"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_pools"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "family",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "endpoint_class",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "model",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "credential_class",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "input_tokens",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "output_tokens",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "cache_read_tokens",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "cache_write_tokens",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "estimated",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cost_micros",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "latency_ms",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'default'",
+      "generated": null,
+      "identity": null,
+      "name": "tag",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'[]'",
+      "generated": null,
+      "identity": null,
+      "name": "routes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "labels",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_seen_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'ios'",
+      "generated": null,
+      "identity": null,
+      "name": "platform",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bundle_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'production'",
+      "generated": null,
+      "identity": null,
+      "name": "environment",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_uuid",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "platform",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "labels",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_seen_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notification_send_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notification_send_events"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notification_send_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notification_send_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_customer_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "billing_customer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_billing_grants_customer_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_customer_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "billing_customer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "item_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "reason",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_billing_grants_customer_item_reason_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_vm_kind_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider_identity_handle",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_identity_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_user_expires_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "token_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_leases_token_hash_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_user_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_billing_team_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_vm_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vm_usage_events_type_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_user_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_billing_team_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"idempotency_key\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_user_idempotency_key_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "provider",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "provider_vm_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"provider_vm_id\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cloud_vms_provider_vm_id_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cloud_vms"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "pool_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coderouter_credentials_pool_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coderouter_keys_team_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coderouter_keys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "family",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coderouter_pools_team_family_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coderouter_pools"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coderouter_usage_events_event_id_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coderouter_usage_events_team_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coderouter_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "device_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "tag",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "device_app_instances_device_tag_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "last_seen_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "device_app_instances_team_last_seen_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "device_tokens_user_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "device_token",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "device_tokens_device_token_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "device_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "device_uuid",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "devices_team_device_uuid_unique",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "last_seen_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "devices_team_last_seen_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "devices_team_user_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "devices"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notification_send_events_user_created_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "notification_send_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "vm_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "cloud_vms",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "cloud_vm_leases_vm_id_cloud_vms_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "cloud_vm_leases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "vm_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "cloud_vms",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "cloud_vm_usage_events_vm_id_cloud_vms_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "cloud_vm_usage_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "pool_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "coderouter_pools",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "coderouter_credentials_pool_id_coderouter_pools_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "coderouter_credentials"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "device_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "devices",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "device_app_instances_device_id_devices_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "device_app_instances"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_billing_grants_pkey",
+      "schema": "public",
+      "table": "cloud_vm_billing_grants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_leases_pkey",
+      "schema": "public",
+      "table": "cloud_vm_leases",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vm_usage_events_pkey",
+      "schema": "public",
+      "table": "cloud_vm_usage_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cloud_vms_pkey",
+      "schema": "public",
+      "table": "cloud_vms",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "coderouter_credentials_pkey",
+      "schema": "public",
+      "table": "coderouter_credentials",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "coderouter_keys_pkey",
+      "schema": "public",
+      "table": "coderouter_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "coderouter_pools_pkey",
+      "schema": "public",
+      "table": "coderouter_pools",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "coderouter_usage_events_pkey",
+      "schema": "public",
+      "table": "coderouter_usage_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "device_app_instances_pkey",
+      "schema": "public",
+      "table": "device_app_instances",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "device_tokens_pkey",
+      "schema": "public",
+      "table": "device_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "devices_pkey",
+      "schema": "public",
+      "table": "devices",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "notification_send_events_pkey",
+      "schema": "public",
+      "table": "notification_send_events",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -1,6 +1,8 @@
 import { sql } from "drizzle-orm";
 import {
   index,
+  bigint,
+  boolean,
   integer,
   jsonb,
   pgEnum,
@@ -22,6 +24,15 @@ export const vmStatus = pgEnum("vm_status", [
 ]);
 
 export const vmLeaseKind = pgEnum("vm_lease_kind", ["pty", "rpc", "ssh"]);
+
+export const coderouterFamily = pgEnum("coderouter_family", ["anthropic", "openai"]);
+export const coderouterCredentialKind = pgEnum("coderouter_credential_kind", ["oauth", "api_key"]);
+export const coderouterCredentialClass = pgEnum("coderouter_credential_class", ["oauth", "byok", "managed"]);
+export const coderouterCredentialStatus = pgEnum("coderouter_credential_status", [
+  "active",
+  "needs_reauth",
+  "disabled",
+]);
 
 export const cloudVms = pgTable(
   "cloud_vms",
@@ -254,5 +265,87 @@ export const deviceAppInstances = pgTable(
   (table) => [
     uniqueIndex("device_app_instances_device_tag_unique").on(table.deviceId, table.tag),
     index("device_app_instances_team_last_seen_idx").on(table.teamId, table.lastSeenAt),
+  ],
+);
+
+export const coderouterPools = pgTable(
+  "coderouter_pools",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    teamId: text("team_id").notNull(),
+    billingCustomerType: text("billing_customer_type").notNull().default("team"),
+    family: coderouterFamily("family").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("coderouter_pools_team_family_unique").on(table.teamId, table.family),
+  ],
+);
+
+export const coderouterCredentials = pgTable(
+  "coderouter_credentials",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    poolId: uuid("pool_id")
+      .notNull()
+      .references(() => coderouterPools.id, { onDelete: "cascade" }),
+    kind: coderouterCredentialKind("kind").notNull(),
+    class: coderouterCredentialClass("class").notNull(),
+    status: coderouterCredentialStatus("status").notNull().default("active"),
+    label: text("label"),
+    providerEmail: text("provider_email"),
+    providerAccountId: text("provider_account_id"),
+    encryptedSecret: text("encrypted_secret"),
+    meta: jsonb("meta").$type<Record<string, unknown>>().notNull().default(sql`'{}'::jsonb`),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("coderouter_credentials_pool_idx").on(table.poolId),
+  ],
+);
+
+export const coderouterKeys = pgTable(
+  "coderouter_keys",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    teamId: text("team_id").notNull(),
+    name: text("name").notNull(),
+    secretHash: text("secret_hash").notNull(),
+    policy: jsonb("policy").$type<{ allowedClasses?: ("oauth" | "byok" | "managed")[] }>().notNull().default(sql`'{}'::jsonb`),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("coderouter_keys_team_idx").on(table.teamId),
+  ],
+);
+
+export const coderouterUsageEvents = pgTable(
+  "coderouter_usage_events",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    eventId: text("event_id").notNull(),
+    teamId: text("team_id").notNull(),
+    keyId: uuid("key_id"),
+    credentialId: uuid("credential_id"),
+    family: text("family").notNull(),
+    endpointClass: text("endpoint_class").notNull(),
+    model: text("model"),
+    credentialClass: text("credential_class").notNull(),
+    status: integer("status").notNull(),
+    inputTokens: bigint("input_tokens", { mode: "number" }).notNull().default(0),
+    outputTokens: bigint("output_tokens", { mode: "number" }).notNull().default(0),
+    cacheReadTokens: bigint("cache_read_tokens", { mode: "number" }).notNull().default(0),
+    cacheWriteTokens: bigint("cache_write_tokens", { mode: "number" }).notNull().default(0),
+    estimated: boolean("estimated").notNull().default(false),
+    costMicros: bigint("cost_micros", { mode: "number" }),
+    latencyMs: integer("latency_ms"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("coderouter_usage_events_event_id_unique").on(table.eventId),
+    index("coderouter_usage_events_team_created_idx").on(table.teamId, table.createdAt),
   ],
 );

--- a/web/services/coderouter/billing.ts
+++ b/web/services/coderouter/billing.ts
@@ -1,0 +1,102 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { CoderouterBillingError } from "./errors";
+
+export type BillingCustomerType = "team" | "user";
+
+export type BillingCustomer = {
+  readonly type: BillingCustomerType;
+  readonly id: string;
+};
+
+export type CoderouterBillingGatewayShape = {
+  readonly currentBalanceMicros: (customer: BillingCustomer) => Effect.Effect<number, CoderouterBillingError>;
+  readonly debitUsage: (customer: BillingCustomer, costMicros: number) => Effect.Effect<void, CoderouterBillingError>;
+  readonly managedBillingEnabled: () => boolean;
+};
+
+export class CoderouterBillingGateway extends Context.Tag("cmux/CoderouterBillingGateway")<
+  CoderouterBillingGateway,
+  CoderouterBillingGatewayShape
+>() {}
+
+export const CoderouterBillingGatewayLive = Layer.succeed(
+  CoderouterBillingGateway,
+  makeStackCoderouterBillingGateway(process.env),
+);
+
+export function makeStackCoderouterBillingGateway(
+  env: Record<string, string | undefined>,
+): CoderouterBillingGatewayShape {
+  const itemId = () => normalizedItemId(env.CMUX_CODEROUTER_CREDIT_ITEM_ID);
+  return {
+    managedBillingEnabled: () => itemId() !== null,
+
+    currentBalanceMicros: (customer) => {
+      const configuredItemId = itemId();
+      if (!configuredItemId) return Effect.succeed(0);
+      return Effect.tryPromise({
+        try: async () => {
+          const item = await stackItem(customer, configuredItemId);
+          return await itemQuantity(item);
+        },
+        catch: (cause) => new CoderouterBillingError("currentBalanceMicros", cause),
+      });
+    },
+
+    debitUsage: (customer, costMicros) => {
+      const configuredItemId = itemId();
+      if (!configuredItemId || costMicros <= 0) return Effect.void;
+      return Effect.tryPromise({
+        try: async () => {
+          const item = await stackItem(customer, configuredItemId);
+          const reserved = await item.tryDecreaseQuantity(costMicros);
+          if (reserved) return;
+          const remaining = Math.max(0, Math.floor(await itemQuantity(item)));
+          const floorDebit = Math.min(costMicros, remaining);
+          if (floorDebit > 0) {
+            await item.tryDecreaseQuantity(floorDebit);
+          }
+        },
+        catch: (cause) => new CoderouterBillingError("debitUsage", cause),
+      });
+    },
+  };
+}
+
+export function noOpCoderouterBillingGateway(balanceMicros = 0): CoderouterBillingGatewayShape {
+  return {
+    managedBillingEnabled: () => balanceMicros > 0,
+    currentBalanceMicros: () => Effect.succeed(balanceMicros),
+    debitUsage: () => Effect.void,
+  };
+}
+
+async function stackItem(
+  customer: BillingCustomer,
+  itemId: string,
+): Promise<{
+  readonly quantity?: number;
+  readonly getQuantity?: () => Promise<number>;
+  readonly tryDecreaseQuantity: (amount: number) => Promise<boolean>;
+}> {
+  const { getStackServerApp, isStackConfigured } = await import("../../app/lib/stack");
+  if (!isStackConfigured()) {
+    throw new Error(`Stack Auth is required for coderouter credits (${itemId})`);
+  }
+  return customer.type === "team"
+    ? await getStackServerApp().getItem({ teamId: customer.id, itemId })
+    : await getStackServerApp().getItem({ userId: customer.id, itemId });
+}
+
+async function itemQuantity(item: { readonly quantity?: number; readonly getQuantity?: () => Promise<number> }): Promise<number> {
+  if (typeof item.getQuantity === "function") return await item.getQuantity();
+  if (typeof item.quantity === "number") return item.quantity;
+  return 0;
+}
+
+function normalizedItemId(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}

--- a/web/services/coderouter/crypto.ts
+++ b/web/services/coderouter/crypto.ts
@@ -1,0 +1,56 @@
+import { CoderouterConfigurationError } from "./errors";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const ENVELOPE_PREFIX = "crv1";
+
+function toBase64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function fromBase64Url(value: string): Uint8Array {
+  return new Uint8Array(Buffer.from(value, "base64url"));
+}
+
+export async function encryptSecret(plaintext: string, masterKey = process.env.CODEROUTER_MASTER_KEY): Promise<string> {
+  const key = await importAesKey(masterKey);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: arrayBufferFromBytes(iv) },
+    key,
+    encoder.encode(plaintext),
+  );
+  return `${ENVELOPE_PREFIX}:${toBase64Url(iv)}:${toBase64Url(new Uint8Array(ciphertext))}`;
+}
+
+export async function decryptSecret(envelope: string, masterKey = process.env.CODEROUTER_MASTER_KEY): Promise<string> {
+  const parts = envelope.split(":");
+  if (parts.length !== 3 || parts[0] !== ENVELOPE_PREFIX) {
+    throw new CoderouterConfigurationError("decryptSecret", "Invalid coderouter secret envelope.");
+  }
+  const key = await importAesKey(masterKey);
+  const iv = fromBase64Url(parts[1] ?? "");
+  const ciphertext = fromBase64Url(parts[2] ?? "");
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: arrayBufferFromBytes(iv) },
+    key,
+    arrayBufferFromBytes(ciphertext),
+  );
+  return decoder.decode(plaintext);
+}
+
+async function importAesKey(masterKey: string | undefined): Promise<CryptoKey> {
+  const raw = masterKey?.trim();
+  if (!raw) {
+    throw new CoderouterConfigurationError("coderouterMasterKey", "CODEROUTER_MASTER_KEY is not configured.");
+  }
+  const bytes = fromBase64Url(raw);
+  if (bytes.byteLength !== 32) {
+    throw new CoderouterConfigurationError("coderouterMasterKey", "CODEROUTER_MASTER_KEY must be 32 base64 bytes.");
+  }
+  return crypto.subtle.importKey("raw", arrayBufferFromBytes(bytes), { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+}
+
+function arrayBufferFromBytes(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}

--- a/web/services/coderouter/errors.ts
+++ b/web/services/coderouter/errors.ts
@@ -1,0 +1,66 @@
+export class CoderouterConfigurationError extends Error {
+  readonly _tag = "CoderouterConfigurationError";
+  constructor(readonly operation: string, message: string) {
+    super(message);
+  }
+}
+
+export class CoderouterDatabaseError extends Error {
+  readonly _tag = "CoderouterDatabaseError";
+  constructor(readonly operation: string, readonly cause: unknown) {
+    super(`coderouter database operation failed: ${operation}`);
+  }
+}
+
+export class CoderouterWorkerSyncError extends Error {
+  readonly _tag = "CoderouterWorkerSyncError";
+  constructor(readonly operation: string, readonly status: number | null, readonly cause?: unknown) {
+    super(`coderouter worker sync failed: ${operation}`);
+  }
+}
+
+export class CoderouterBillingError extends Error {
+  readonly _tag = "CoderouterBillingError";
+  constructor(readonly operation: string, readonly cause: unknown) {
+    super(`coderouter billing operation failed: ${operation}`);
+  }
+}
+
+export class CoderouterConnectError extends Error {
+  readonly _tag = "CoderouterConnectError";
+  constructor(readonly code: "connect_unsupported" | "provider_rejected" | "invalid_state", message: string) {
+    super(message);
+  }
+}
+
+export class CoderouterNotFoundError extends Error {
+  readonly _tag = "CoderouterNotFoundError";
+  constructor(readonly resource: string) {
+    super(`coderouter resource not found: ${resource}`);
+  }
+}
+
+export type CoderouterWorkflowError =
+  | CoderouterConfigurationError
+  | CoderouterDatabaseError
+  | CoderouterWorkerSyncError
+  | CoderouterBillingError
+  | CoderouterConnectError
+  | CoderouterNotFoundError;
+
+export function coderouterWorkflowErrorCause(err: unknown): CoderouterWorkflowError | null {
+  if (
+    err instanceof CoderouterConfigurationError ||
+    err instanceof CoderouterDatabaseError ||
+    err instanceof CoderouterWorkerSyncError ||
+    err instanceof CoderouterBillingError ||
+    err instanceof CoderouterConnectError ||
+    err instanceof CoderouterNotFoundError
+  ) {
+    return err;
+  }
+  if (err && typeof err === "object" && "cause" in err) {
+    return coderouterWorkflowErrorCause((err as { cause?: unknown }).cause);
+  }
+  return null;
+}

--- a/web/services/coderouter/keys.ts
+++ b/web/services/coderouter/keys.ts
@@ -1,0 +1,119 @@
+import { randomUUID } from "node:crypto";
+import type { VerifiedCallerKey } from "./types";
+
+// Key format duplicated from workers/coderouter/src/keys.ts; do not import across packages.
+const encoder = new TextEncoder();
+const keyCache = new Map<string, Promise<CryptoKey>>();
+
+function toBase64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function fromBase64Url(value: string): Uint8Array | null {
+  try {
+    return new Uint8Array(Buffer.from(value, "base64url"));
+  } catch {
+    return null;
+  }
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  const cached = keyCache.get(secret);
+  if (cached) return cached;
+  const promise = crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  keyCache.set(secret, promise);
+  return promise;
+}
+
+async function sign(input: string, secret: string): Promise<string> {
+  const key = await hmacKey(secret);
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(input));
+  return toBase64Url(new Uint8Array(signature));
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(input));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function mintCallerKey(input: {
+  readonly teamId: string;
+  readonly kid?: string;
+  readonly issuedAtSeconds?: number;
+  readonly secret: string;
+}): Promise<{ readonly kid: string; readonly key: string; readonly payload: VerifiedCallerKey }> {
+  const payload: VerifiedCallerKey = {
+    v: 1,
+    kid: input.kid ?? randomUUID(),
+    team: input.teamId,
+    iat: input.issuedAtSeconds ?? Math.floor(Date.now() / 1000),
+  };
+  const payloadBytes = encoder.encode(JSON.stringify(payload));
+  const payloadPart = toBase64Url(payloadBytes);
+  const signed = `crk_${payloadPart}`;
+  const signature = await sign(signed, input.secret);
+  return { kid: payload.kid, key: `${signed}.${signature}`, payload };
+}
+
+export async function verifyCallerKey(key: string, secret: string): Promise<VerifiedCallerKey | null> {
+  if (!key.startsWith("crk_")) return null;
+  const dot = key.indexOf(".");
+  if (dot < 0) return null;
+  const payloadPart = key.slice(4, dot);
+  const signature = key.slice(dot + 1);
+  if (!payloadPart || !signature) return null;
+  const signed = key.slice(0, dot);
+  const expected = await sign(signed, secret);
+  if (!timingSafeEqualString(signature, expected)) return null;
+  const payloadBytes = fromBase64Url(payloadPart);
+  if (!payloadBytes) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(payloadBytes));
+  } catch {
+    return null;
+  }
+  return isCallerPayload(parsed) ? parsed : null;
+}
+
+export function extractBearerToken(request: Request): string | null {
+  const authorization = request.headers.get("authorization");
+  const match = authorization ? /^Bearer\s+(.+)$/i.exec(authorization.trim()) : null;
+  return match?.[1]?.trim() || null;
+}
+
+export function verifyInternalBearer(request: Request, expected: string | undefined): boolean {
+  const actual = extractBearerToken(request);
+  return !!actual && !!expected && timingSafeEqualString(actual, expected);
+}
+
+export function timingSafeEqualString(a: string, b: string): boolean {
+  const left = encoder.encode(a);
+  const right = encoder.encode(b);
+  const length = Math.max(left.length, right.length);
+  let diff = left.length ^ right.length;
+  for (let i = 0; i < length; i += 1) {
+    diff |= (left[i] ?? 0) ^ (right[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+function isCallerPayload(value: unknown): value is VerifiedCallerKey {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    record.v === 1 &&
+    typeof record.kid === "string" &&
+    record.kid.length > 0 &&
+    typeof record.team === "string" &&
+    record.team.length > 0 &&
+    typeof record.iat === "number" &&
+    Number.isFinite(record.iat)
+  );
+}

--- a/web/services/coderouter/oauthConnect.ts
+++ b/web/services/coderouter/oauthConnect.ts
@@ -1,0 +1,341 @@
+import { randomBytes } from "node:crypto";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { CoderouterConfigurationError, CoderouterConnectError } from "./errors";
+import { timingSafeEqualString } from "./keys";
+import type { Family, SeedOauth } from "./types";
+
+const ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const ANTHROPIC_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback";
+const OPENAI_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const STATE_TTL_MS = 10 * 60 * 1000;
+const encoder = new TextEncoder();
+
+export type AnthropicStart = {
+  readonly authorizeUrl: string;
+  readonly state: string;
+  readonly cookie: string;
+};
+
+export type OpenAIStart = {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly expiresIn?: number;
+  readonly interval?: number;
+};
+
+export type OpenAIPollResult =
+  | { readonly status: "pending" }
+  | { readonly status: "complete"; readonly chain: ImportedOauthChain };
+
+export type ImportedOauthChain = {
+  readonly provider: Family;
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly idToken?: string;
+  readonly accountId?: string;
+  readonly email?: string;
+  readonly expiresAt?: number;
+};
+
+export type CoderouterOAuthConnectShape = {
+  readonly startAnthropic: () => Effect.Effect<AnthropicStart, CoderouterConfigurationError>;
+  readonly completeAnthropic: (input: {
+    readonly pastedCode: string;
+    readonly stateCookie: string | null;
+  }) => Effect.Effect<ImportedOauthChain, CoderouterConfigurationError | CoderouterConnectError>;
+  readonly startOpenAI: () => Effect.Effect<OpenAIStart, CoderouterConnectError>;
+  readonly pollOpenAI: (deviceCode: string) => Effect.Effect<OpenAIPollResult, CoderouterConnectError>;
+};
+
+export class CoderouterOAuthConnect extends Context.Tag("cmux/CoderouterOAuthConnect")<
+  CoderouterOAuthConnect,
+  CoderouterOAuthConnectShape
+>() {}
+
+export const CoderouterOAuthConnectLive = Layer.succeed(
+  CoderouterOAuthConnect,
+  makeCoderouterOAuthConnect(process.env, fetch),
+);
+
+export function makeCoderouterOAuthConnect(
+  env: Record<string, string | undefined>,
+  fetchFn: typeof fetch,
+): CoderouterOAuthConnectShape {
+  return {
+    startAnthropic: () =>
+      Effect.tryPromise({
+        try: async () => {
+          const secret = stateSigningSecret(env);
+          const verifier = randomToken(48);
+          const state = randomToken(32);
+          const challenge = await pkceChallenge(verifier);
+          const cookie = await signStateCookie({ state, verifier, exp: Date.now() + STATE_TTL_MS }, secret);
+          const authorize = new URL("https://claude.ai/oauth/authorize");
+          authorize.searchParams.set("code", "true");
+          authorize.searchParams.set("client_id", ANTHROPIC_CLIENT_ID);
+          authorize.searchParams.set("response_type", "code");
+          authorize.searchParams.set("redirect_uri", ANTHROPIC_REDIRECT_URI);
+          authorize.searchParams.set("scope", "org:create_api_key user:profile user:inference");
+          authorize.searchParams.set("code_challenge", challenge);
+          authorize.searchParams.set("code_challenge_method", "S256");
+          authorize.searchParams.set("state", state);
+          return { authorizeUrl: authorize.toString(), state, cookie };
+        },
+        catch: (cause) =>
+          cause instanceof CoderouterConfigurationError
+            ? cause
+            : new CoderouterConfigurationError("startAnthropic", "Could not create OAuth state."),
+      }),
+
+    completeAnthropic: (input) =>
+      Effect.tryPromise({
+        try: async () => {
+          const secret = stateSigningSecret(env);
+          const parsed = splitPastedCode(input.pastedCode);
+          const state = await verifyStateCookie(input.stateCookie, secret);
+          if (!state || state.state !== parsed.state) {
+            throw new CoderouterConnectError("invalid_state", "OAuth state did not match.");
+          }
+          const response = await fetchFn("https://platform.claude.com/v1/oauth/token", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "anthropic-beta": "oauth-2025-04-20",
+            },
+            body: JSON.stringify({
+              grant_type: "authorization_code",
+              code: parsed.code,
+              state: parsed.state,
+              client_id: ANTHROPIC_CLIENT_ID,
+              redirect_uri: ANTHROPIC_REDIRECT_URI,
+              code_verifier: state.verifier,
+            }),
+          });
+          if (!response.ok) {
+            throw new CoderouterConnectError("provider_rejected", "Provider rejected the pasted code.");
+          }
+          const token = await response.json();
+          return anthropicChainFromToken(token);
+        },
+        catch: (cause) => {
+          if (cause instanceof CoderouterConfigurationError || cause instanceof CoderouterConnectError) return cause;
+          return new CoderouterConnectError("provider_rejected", "Provider token exchange failed.");
+        },
+      }),
+
+    startOpenAI: () =>
+      Effect.tryPromise({
+        try: async () => {
+          const response = await fetchFn("https://auth.openai.com/oauth/device/authorization", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              client_id: OPENAI_CLIENT_ID,
+              scope: "openid profile email offline_access",
+            }),
+          });
+          if (!response.ok) {
+            throw new CoderouterConnectError("connect_unsupported", "Device flow is not available; use import instead.");
+          }
+          const body = await response.json();
+          return openAIStartFromResponse(body);
+        },
+        catch: (cause) =>
+          cause instanceof CoderouterConnectError
+            ? cause
+            : new CoderouterConnectError("connect_unsupported", "Device flow is not available; use import instead."),
+      }),
+
+    pollOpenAI: (deviceCode) =>
+      Effect.tryPromise({
+        try: async () => {
+          const response = await fetchFn("https://auth.openai.com/oauth/token", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+              device_code: deviceCode,
+              client_id: OPENAI_CLIENT_ID,
+            }),
+          });
+          const body = await response.json().catch(() => ({}));
+          if (!response.ok) {
+            const error = typeof body?.error === "string" ? body.error : "";
+            if (error === "authorization_pending" || error === "slow_down") return { status: "pending" as const };
+            throw new CoderouterConnectError("provider_rejected", "Provider rejected the device flow request.");
+          }
+          return { status: "complete" as const, chain: openAIChainFromToken(body) };
+        },
+        catch: (cause) =>
+          cause instanceof CoderouterConnectError
+            ? cause
+            : new CoderouterConnectError("provider_rejected", "Device flow polling failed."),
+      }),
+  };
+}
+
+export function seedOauthFromImportedChain(credentialId: string, chain: ImportedOauthChain): SeedOauth {
+  return {
+    credentialId,
+    provider: chain.provider,
+    accessToken: chain.accessToken,
+    refreshToken: chain.refreshToken,
+    ...(chain.idToken ? { idToken: chain.idToken } : {}),
+    ...(chain.accountId ? { accountId: chain.accountId } : {}),
+    ...(chain.expiresAt ? { expiresAt: chain.expiresAt } : {}),
+  };
+}
+
+function stateSigningSecret(env: Record<string, string | undefined>): string {
+  const secret = env.CODEROUTER_KEY_SIGNING_SECRET?.trim();
+  if (!secret) {
+    throw new CoderouterConfigurationError("oauthState", "CODEROUTER_KEY_SIGNING_SECRET is not configured.");
+  }
+  return secret;
+}
+
+function randomToken(bytes: number): string {
+  return randomBytes(bytes).toString("base64url");
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(verifier));
+  return Buffer.from(digest).toString("base64url");
+}
+
+async function signStateCookie(payload: { state: string; verifier: string; exp: number }, secret: string): Promise<string> {
+  const value = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = await hmac(value, secret);
+  return `${value}.${signature}`;
+}
+
+async function verifyStateCookie(cookie: string | null, secret: string): Promise<{ state: string; verifier: string } | null> {
+  if (!cookie) return null;
+  const [value, signature] = cookie.split(".");
+  if (!value || !signature) return null;
+  const expected = await hmac(value, secret);
+  if (!timingSafeEqualString(signature, expected)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const record = parsed as Record<string, unknown>;
+  if (typeof record.state !== "string" || typeof record.verifier !== "string" || typeof record.exp !== "number") {
+    return null;
+  }
+  if (record.exp < Date.now()) return null;
+  return { state: record.state, verifier: record.verifier };
+}
+
+async function hmac(input: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(input));
+  return Buffer.from(signature).toString("base64url");
+}
+
+function splitPastedCode(value: string): { code: string; state: string } {
+  const idx = value.indexOf("#");
+  if (idx <= 0 || idx === value.length - 1) {
+    throw new CoderouterConnectError("invalid_state", "Pasted code must include state.");
+  }
+  return { code: value.slice(0, idx), state: value.slice(idx + 1) };
+}
+
+function anthropicChainFromToken(value: unknown): ImportedOauthChain {
+  const record = requireRecord(value);
+  const accessToken = stringField(record, "access_token");
+  const refreshToken = stringField(record, "refresh_token");
+  const expiresIn = numberField(record, "expires_in");
+  return {
+    provider: "anthropic",
+    accessToken,
+    refreshToken,
+    expiresAt: Date.now() + expiresIn * 1000,
+  };
+}
+
+function openAIStartFromResponse(value: unknown): OpenAIStart {
+  const record = requireRecord(value);
+  return {
+    deviceCode: stringField(record, "device_code"),
+    userCode: stringField(record, "user_code"),
+    verificationUri: stringField(record, "verification_uri"),
+    expiresIn: optionalNumberField(record, "expires_in"),
+    interval: optionalNumberField(record, "interval"),
+  };
+}
+
+function openAIChainFromToken(value: unknown): ImportedOauthChain {
+  const record = requireRecord(value);
+  const accessToken = stringField(record, "access_token");
+  const refreshToken = stringField(record, "refresh_token");
+  const idToken = stringField(record, "id_token");
+  const claims = jwtClaims(idToken);
+  return {
+    provider: "openai",
+    accessToken,
+    refreshToken,
+    idToken,
+    email: stringClaim(claims, "https://api.openai.com/profile", "email") ?? stringClaim(claims, "email"),
+    accountId: stringClaim(claims, "https://api.openai.com/auth", "chatgpt_account_id"),
+  };
+}
+
+function jwtClaims(jwt: string): Record<string, unknown> {
+  const [, payload] = jwt.split(".");
+  if (!payload) return {};
+  try {
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringClaim(claims: Record<string, unknown>, key: string, nested?: string): string | undefined {
+  const value = claims[key];
+  if (!nested) return typeof value === "string" ? value : undefined;
+  if (!value || typeof value !== "object") return undefined;
+  const nestedValue = (value as Record<string, unknown>)[nested];
+  return typeof nestedValue === "string" ? nestedValue : undefined;
+}
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new CoderouterConnectError("provider_rejected", "Provider returned an invalid response.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value) {
+    throw new CoderouterConnectError("provider_rejected", `Provider response is missing ${key}.`);
+  }
+  return value;
+}
+
+function numberField(record: Record<string, unknown>, key: string): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new CoderouterConnectError("provider_rejected", `Provider response is missing ${key}.`);
+  }
+  return value;
+}
+
+function optionalNumberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}

--- a/web/services/coderouter/pricing.ts
+++ b/web/services/coderouter/pricing.ts
@@ -1,0 +1,59 @@
+import type { Family, Usage } from "./types";
+
+export const CATALOG_AS_OF = "2026-07-05";
+
+export interface PriceEntry {
+  family: Family;
+  inputPer1M: number;
+  outputPer1M: number;
+  cacheReadPer1M: number;
+  cacheWritePer1M: number;
+}
+
+// Authoritative web catalog for billing. Duplicated by workers/coderouter/src/pricing.ts.
+// Sources checked 2026-07-05: https://www.anthropic.com/pricing and https://openai.com/api/pricing/
+export const PRICING_CATALOG: Record<string, PriceEntry> = {
+  "claude-opus-4": { family: "anthropic", inputPer1M: 15_000_000, outputPer1M: 75_000_000, cacheReadPer1M: 1_500_000, cacheWritePer1M: 18_750_000 },
+  "claude-opus-4-1": { family: "anthropic", inputPer1M: 15_000_000, outputPer1M: 75_000_000, cacheReadPer1M: 1_500_000, cacheWritePer1M: 18_750_000 },
+  "claude-sonnet-4": { family: "anthropic", inputPer1M: 3_000_000, outputPer1M: 15_000_000, cacheReadPer1M: 300_000, cacheWritePer1M: 3_750_000 },
+  "claude-sonnet-4-5": { family: "anthropic", inputPer1M: 3_000_000, outputPer1M: 15_000_000, cacheReadPer1M: 300_000, cacheWritePer1M: 3_750_000 },
+  "claude-haiku-4-5": { family: "anthropic", inputPer1M: 1_000_000, outputPer1M: 5_000_000, cacheReadPer1M: 100_000, cacheWritePer1M: 1_250_000 },
+  "gpt-5": { family: "openai", inputPer1M: 1_250_000, outputPer1M: 10_000_000, cacheReadPer1M: 125_000, cacheWritePer1M: 0 },
+  "gpt-5-mini": { family: "openai", inputPer1M: 250_000, outputPer1M: 2_000_000, cacheReadPer1M: 25_000, cacheWritePer1M: 0 },
+  "gpt-5-nano": { family: "openai", inputPer1M: 50_000, outputPer1M: 400_000, cacheReadPer1M: 5_000, cacheWritePer1M: 0 },
+  "gpt-5.5-codex": { family: "openai", inputPer1M: 1_250_000, outputPer1M: 10_000_000, cacheReadPer1M: 125_000, cacheWritePer1M: 0 },
+  "o3": { family: "openai", inputPer1M: 2_000_000, outputPer1M: 8_000_000, cacheReadPer1M: 500_000, cacheWritePer1M: 0 },
+  "o4-mini": { family: "openai", inputPer1M: 1_100_000, outputPer1M: 4_400_000, cacheReadPer1M: 275_000, cacheWritePer1M: 0 },
+};
+
+export function lookupPrice(model: string | undefined): PriceEntry | null {
+  return lookupPriceMatch(model)?.price ?? null;
+}
+
+export function lookupPriceMatch(model: string | undefined): { modelId: string; price: PriceEntry } | null {
+  if (!model) return null;
+  const id = model.toLowerCase();
+  const exact = PRICING_CATALOG[id];
+  if (exact) return { modelId: id, price: exact };
+  const key = Object.keys(PRICING_CATALOG)
+    .filter((candidate) => id.startsWith(`${candidate}-`))
+    .sort((a, b) => b.length - a.length)[0];
+  if (key) return { modelId: key, price: PRICING_CATALOG[key] as PriceEntry };
+  return null;
+}
+
+export function priceUsageMicros(model: string | undefined, usage: Usage): number | null {
+  const price = lookupPrice(model);
+  if (!price) return null;
+  return (
+    priceComponent(usage.inputTokens, price.inputPer1M) +
+    priceComponent(usage.outputTokens, price.outputPer1M) +
+    priceComponent(usage.cacheReadTokens, price.cacheReadPer1M) +
+    priceComponent(usage.cacheWriteTokens, price.cacheWritePer1M)
+  );
+}
+
+export function priceComponent(tokens: number, microsPer1M: number): number {
+  if (tokens <= 0 || microsPer1M <= 0) return 0;
+  return Math.ceil((tokens * microsPer1M) / 1_000_000);
+}

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -1,0 +1,455 @@
+import { and, desc, eq, gte, sql } from "drizzle-orm";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { cloudDb } from "../../db/client";
+import {
+  coderouterCredentials,
+  coderouterKeys,
+  coderouterPools,
+  coderouterUsageEvents,
+} from "../../db/schema";
+import { CoderouterDatabaseError, CoderouterNotFoundError } from "./errors";
+import { priceUsageMicros } from "./pricing";
+import type { BillingCustomerType } from "./billing";
+import type { CredentialClass, Family, KeyPolicy, PoolConfig, Usage, UsageIngest } from "./types";
+
+export type CoderouterPoolRow = typeof coderouterPools.$inferSelect;
+export type CoderouterCredentialRow = typeof coderouterCredentials.$inferSelect;
+export type CoderouterKeyRow = typeof coderouterKeys.$inferSelect;
+
+export type CreateCredentialInput = {
+  readonly teamId: string;
+  readonly family: Family;
+  readonly billingCustomerType: BillingCustomerType;
+  readonly kind: "oauth" | "api_key";
+  readonly class: CredentialClass;
+  readonly label?: string | null;
+  readonly providerEmail?: string | null;
+  readonly providerAccountId?: string | null;
+  readonly encryptedSecret?: string | null;
+  readonly meta?: Record<string, unknown>;
+};
+
+export type UsageSummaryRow = {
+  readonly day: string;
+  readonly model: string | null;
+  readonly credentialClass: string;
+  readonly inputTokens: UsageSummaryValue;
+  readonly outputTokens: UsageSummaryValue;
+  readonly cacheReadTokens: UsageSummaryValue;
+  readonly cacheWriteTokens: UsageSummaryValue;
+  readonly costMicros: UsageSummaryValue;
+  readonly requests: UsageSummaryValue;
+};
+
+export type UsageSummaryValue = number | string | bigint;
+
+export type IngestInsertResult = {
+  readonly inserted: number;
+  readonly managedCostMicros: number;
+};
+
+export type CoderouterRepositoryShape = {
+  readonly getOrCreatePool: (
+    teamId: string,
+    family: Family,
+    billingCustomerType?: BillingCustomerType,
+  ) => Effect.Effect<CoderouterPoolRow, CoderouterDatabaseError>;
+  readonly listPoolsForTeam: (teamId: string) => Effect.Effect<CoderouterPoolRow[], CoderouterDatabaseError>;
+  readonly poolForName: (poolName: string) => Effect.Effect<CoderouterPoolRow, CoderouterDatabaseError | CoderouterNotFoundError>;
+  readonly listKeys: (teamId: string) => Effect.Effect<CoderouterKeyRow[], CoderouterDatabaseError>;
+  readonly createKey: (input: {
+    readonly kid: string;
+    readonly teamId: string;
+    readonly name: string;
+    readonly secretHash: string;
+    readonly policy: KeyPolicy;
+  }) => Effect.Effect<CoderouterKeyRow, CoderouterDatabaseError>;
+  readonly revokeKey: (teamId: string, keyId: string) => Effect.Effect<CoderouterKeyRow, CoderouterDatabaseError | CoderouterNotFoundError>;
+  readonly listCredentials: (teamId: string) => Effect.Effect<CoderouterCredentialRow[], CoderouterDatabaseError>;
+  readonly createCredential: (input: CreateCredentialInput) => Effect.Effect<CoderouterCredentialRow, CoderouterDatabaseError>;
+  readonly disableCredential: (teamId: string, credentialId: string) => Effect.Effect<CoderouterCredentialRow, CoderouterDatabaseError | CoderouterNotFoundError>;
+  readonly buildPoolConfig: (input: {
+    readonly teamId: string;
+    readonly family: Family;
+    readonly billingCustomerType: BillingCustomerType;
+    readonly balanceMicros: number;
+    readonly managedEnabled: boolean;
+  }) => Effect.Effect<PoolConfig, CoderouterDatabaseError>;
+  readonly usageSummary: (teamId: string, days: number) => Effect.Effect<UsageSummaryRow[], CoderouterDatabaseError>;
+  readonly insertUsageEvents: (input: {
+    readonly teamId: string;
+    readonly events: readonly UsageIngest["events"][number][];
+  }) => Effect.Effect<IngestInsertResult, CoderouterDatabaseError>;
+  readonly applyStatusUpdates: (input: {
+    readonly poolName: string;
+    readonly updates: readonly { credentialId: string; status: "active" | "needs_reauth" }[];
+  }) => Effect.Effect<void, CoderouterDatabaseError>;
+};
+
+export class CoderouterRepository extends Context.Tag("cmux/CoderouterRepository")<
+  CoderouterRepository,
+  CoderouterRepositoryShape
+>() {}
+
+function dbEffect<A>(operation: string, run: () => Promise<A>): Effect.Effect<A, CoderouterDatabaseError> {
+  return Effect.tryPromise({
+    try: run,
+    catch: (cause) => new CoderouterDatabaseError(operation, cause),
+  });
+}
+
+export function poolName(teamId: string, family: Family): string {
+  return `${teamId}:${family}`;
+}
+
+export function parsePoolName(value: string): { readonly teamId: string; readonly family: Family } | null {
+  const idx = value.lastIndexOf(":");
+  if (idx <= 0) return null;
+  const teamId = value.slice(0, idx);
+  const family = value.slice(idx + 1);
+  return family === "anthropic" || family === "openai" ? { teamId, family } : null;
+}
+
+export const CoderouterRepositoryLive = Layer.succeed(CoderouterRepository, {
+  getOrCreatePool: (teamId, family, billingCustomerType = "team") =>
+    dbEffect("getOrCreatePool", async () => {
+      const db = cloudDb();
+      const [inserted] = await db
+        .insert(coderouterPools)
+        .values({ teamId, family, billingCustomerType })
+        .onConflictDoNothing({ target: [coderouterPools.teamId, coderouterPools.family] })
+        .returning();
+      if (inserted) return inserted;
+      const [existing] = await db
+        .select()
+        .from(coderouterPools)
+        .where(and(eq(coderouterPools.teamId, teamId), eq(coderouterPools.family, family)))
+        .limit(1);
+      if (!existing) throw new Error("coderouter pool missing after insert conflict");
+      return existing;
+    }),
+
+  listPoolsForTeam: (teamId) =>
+    dbEffect("listPoolsForTeam", async () => {
+      const db = cloudDb();
+      return await db.select().from(coderouterPools).where(eq(coderouterPools.teamId, teamId));
+    }),
+
+  poolForName: (name) => {
+    const parsed = parsePoolName(name);
+    if (!parsed) return Effect.fail(new CoderouterNotFoundError("pool"));
+    return Effect.tryPromise({
+      try: async () => {
+        const db = cloudDb();
+        const [pool] = await db
+          .select()
+          .from(coderouterPools)
+          .where(and(eq(coderouterPools.teamId, parsed.teamId), eq(coderouterPools.family, parsed.family)))
+          .limit(1);
+        if (!pool) throw new CoderouterNotFoundError("pool");
+        return pool;
+      },
+      catch: (cause) =>
+        cause instanceof CoderouterNotFoundError
+          ? cause
+          : new CoderouterDatabaseError("poolForName", cause),
+    });
+  },
+
+  listKeys: (teamId) =>
+    dbEffect("listKeys", async () => {
+      const db = cloudDb();
+      return await db
+        .select()
+        .from(coderouterKeys)
+        .where(eq(coderouterKeys.teamId, teamId))
+        .orderBy(desc(coderouterKeys.createdAt));
+    }),
+
+  createKey: (input) =>
+    dbEffect("createKey", async () => {
+      const db = cloudDb();
+      const [row] = await db
+        .insert(coderouterKeys)
+        .values({
+          id: input.kid,
+          teamId: input.teamId,
+          name: input.name,
+          secretHash: input.secretHash,
+          policy: input.policy,
+        })
+        .returning();
+      if (!row) throw new Error("insert returned no coderouter key row");
+      return row;
+    }),
+
+  revokeKey: (teamId, keyId) =>
+    Effect.tryPromise({
+      try: async () => {
+        const db = cloudDb();
+        const [row] = await db
+          .update(coderouterKeys)
+          .set({ revokedAt: new Date() })
+          .where(and(eq(coderouterKeys.teamId, teamId), eq(coderouterKeys.id, keyId)))
+          .returning();
+        if (!row) throw new CoderouterNotFoundError("key");
+        return row;
+      },
+      catch: (cause) =>
+        cause instanceof CoderouterNotFoundError
+          ? cause
+          : new CoderouterDatabaseError("revokeKey", cause),
+    }),
+
+  listCredentials: (teamId) =>
+    dbEffect("listCredentials", async () => {
+      const db = cloudDb();
+      return await db
+        .select({
+          id: coderouterCredentials.id,
+          poolId: coderouterCredentials.poolId,
+          kind: coderouterCredentials.kind,
+          class: coderouterCredentials.class,
+          status: coderouterCredentials.status,
+          label: coderouterCredentials.label,
+          providerEmail: coderouterCredentials.providerEmail,
+          providerAccountId: coderouterCredentials.providerAccountId,
+          encryptedSecret: coderouterCredentials.encryptedSecret,
+          meta: coderouterCredentials.meta,
+          createdAt: coderouterCredentials.createdAt,
+          lastUsedAt: coderouterCredentials.lastUsedAt,
+        })
+        .from(coderouterCredentials)
+        .innerJoin(coderouterPools, eq(coderouterCredentials.poolId, coderouterPools.id))
+        .where(eq(coderouterPools.teamId, teamId))
+        .orderBy(desc(coderouterCredentials.createdAt));
+    }),
+
+  createCredential: (input) =>
+    dbEffect("createCredential", async () => {
+      const db = cloudDb();
+      const pool = await getOrCreatePoolWithDb(input.teamId, input.family, input.billingCustomerType);
+      const [row] = await db
+        .insert(coderouterCredentials)
+        .values({
+          poolId: pool.id,
+          kind: input.kind,
+          class: input.class,
+          label: input.label ?? null,
+          providerEmail: input.providerEmail ?? null,
+          providerAccountId: input.providerAccountId ?? null,
+          encryptedSecret: input.encryptedSecret ?? null,
+          meta: input.meta ?? {},
+        })
+        .returning();
+      if (!row) throw new Error("insert returned no coderouter credential row");
+      return row;
+    }),
+
+  disableCredential: (teamId, credentialId) =>
+    Effect.tryPromise({
+      try: async () => {
+        const db = cloudDb();
+        const [row] = await db
+          .update(coderouterCredentials)
+          .set({ status: "disabled" })
+          .from(coderouterPools)
+          .where(and(
+            eq(coderouterCredentials.id, credentialId),
+            eq(coderouterCredentials.poolId, coderouterPools.id),
+            eq(coderouterPools.teamId, teamId),
+          ))
+          .returning();
+        if (!row) throw new CoderouterNotFoundError("credential");
+        return row;
+      },
+      catch: (cause) =>
+        cause instanceof CoderouterNotFoundError
+          ? cause
+          : new CoderouterDatabaseError("disableCredential", cause),
+    }),
+
+  buildPoolConfig: (input) =>
+    dbEffect("buildPoolConfig", async () => {
+      const db = cloudDb();
+      const pool = await getOrCreatePoolWithDb(input.teamId, input.family, input.billingCustomerType);
+      const keys = await db
+        .select()
+        .from(coderouterKeys)
+        .where(eq(coderouterKeys.teamId, input.teamId));
+      const credentials = await db
+        .select()
+        .from(coderouterCredentials)
+        .where(eq(coderouterCredentials.poolId, pool.id));
+      return poolConfigFromRows({
+        teamId: input.teamId,
+        family: input.family,
+        keys,
+        credentials,
+        balanceMicros: input.balanceMicros,
+        managedEnabled: input.managedEnabled,
+        configVersion: Date.now(),
+      });
+    }),
+
+  usageSummary: (teamId, days) =>
+    dbEffect("usageSummary", async () => {
+      const db = cloudDb();
+      const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+      return await db
+        .select({
+          day: sql<string>`to_char(date_trunc('day', ${coderouterUsageEvents.createdAt}), 'YYYY-MM-DD')`,
+          model: coderouterUsageEvents.model,
+          credentialClass: coderouterUsageEvents.credentialClass,
+          inputTokens: sql<UsageSummaryValue>`coalesce(sum(${coderouterUsageEvents.inputTokens}), 0)::bigint`,
+          outputTokens: sql<UsageSummaryValue>`coalesce(sum(${coderouterUsageEvents.outputTokens}), 0)::bigint`,
+          cacheReadTokens: sql<UsageSummaryValue>`coalesce(sum(${coderouterUsageEvents.cacheReadTokens}), 0)::bigint`,
+          cacheWriteTokens: sql<UsageSummaryValue>`coalesce(sum(${coderouterUsageEvents.cacheWriteTokens}), 0)::bigint`,
+          costMicros: sql<UsageSummaryValue>`coalesce(sum(${coderouterUsageEvents.costMicros}), 0)::bigint`,
+          requests: sql<UsageSummaryValue>`count(*)::bigint`,
+        })
+        .from(coderouterUsageEvents)
+        .where(and(eq(coderouterUsageEvents.teamId, teamId), gte(coderouterUsageEvents.createdAt, since)))
+        .groupBy(
+          sql`date_trunc('day', ${coderouterUsageEvents.createdAt})`,
+          coderouterUsageEvents.model,
+          coderouterUsageEvents.credentialClass,
+        )
+        .orderBy(sql`date_trunc('day', ${coderouterUsageEvents.createdAt}) desc`);
+    }),
+
+  insertUsageEvents: (input) =>
+    dbEffect("insertUsageEvents", async () => {
+      const db = cloudDb();
+      let inserted = 0;
+      let managedCostMicros = 0;
+      await db.transaction(async (tx) => {
+        for (const event of input.events) {
+          const usage: Usage = {
+            inputTokens: event.inputTokens,
+            outputTokens: event.outputTokens,
+            cacheReadTokens: event.cacheReadTokens,
+            cacheWriteTokens: event.cacheWriteTokens,
+            estimated: event.estimated,
+          };
+          const costMicros = event.credentialClass === "managed"
+            ? priceUsageMicros(event.model, usage)
+            : event.costMicros ?? null;
+          const [row] = await tx
+            .insert(coderouterUsageEvents)
+            .values({
+              eventId: event.eventId,
+              teamId: input.teamId,
+              keyId: event.keyId ?? null,
+              credentialId: event.credentialId ?? null,
+              family: event.family,
+              endpointClass: event.endpointClass,
+              model: event.model ?? null,
+              credentialClass: event.credentialClass,
+              status: event.status,
+              inputTokens: event.inputTokens,
+              outputTokens: event.outputTokens,
+              cacheReadTokens: event.cacheReadTokens,
+              cacheWriteTokens: event.cacheWriteTokens,
+              estimated: event.estimated,
+              costMicros,
+              latencyMs: event.latencyMs ?? null,
+              createdAt: new Date(event.ts),
+            })
+            .onConflictDoNothing({ target: coderouterUsageEvents.eventId })
+            .returning({ costMicros: coderouterUsageEvents.costMicros });
+          if (!row) continue;
+          inserted += 1;
+          if (event.credentialClass === "managed" && row.costMicros) {
+            managedCostMicros += row.costMicros;
+          }
+        }
+      });
+      return { inserted, managedCostMicros };
+    }),
+
+  applyStatusUpdates: (input) =>
+    dbEffect("applyStatusUpdates", async () => {
+      const parsed = parsePoolName(input.poolName);
+      if (!parsed || input.updates.length === 0) return;
+      const db = cloudDb();
+      const pool = await getOrCreatePoolWithDb(parsed.teamId, parsed.family);
+      await db.transaction(async (tx) => {
+        for (const update of input.updates) {
+          await tx
+            .update(coderouterCredentials)
+            .set({ status: update.status })
+            .where(and(eq(coderouterCredentials.id, update.credentialId), eq(coderouterCredentials.poolId, pool.id)));
+        }
+      });
+    }),
+});
+
+async function getOrCreatePoolWithDb(
+  teamId: string,
+  family: Family,
+  billingCustomerType: BillingCustomerType = "team",
+): Promise<CoderouterPoolRow> {
+  const db = cloudDb();
+  const [inserted] = await db
+    .insert(coderouterPools)
+    .values({ teamId, family, billingCustomerType })
+    .onConflictDoNothing({ target: [coderouterPools.teamId, coderouterPools.family] })
+    .returning();
+  if (inserted) return inserted;
+  const [existing] = await db
+    .select()
+    .from(coderouterPools)
+    .where(and(eq(coderouterPools.teamId, teamId), eq(coderouterPools.family, family)))
+    .limit(1);
+  if (!existing) throw new Error("coderouter pool missing after insert conflict");
+  return existing;
+}
+
+function normalizedPolicy(policy: unknown): KeyPolicy {
+  if (!policy || typeof policy !== "object") return {};
+  const allowed = (policy as { allowedClasses?: unknown }).allowedClasses;
+  if (!Array.isArray(allowed)) return {};
+  const classes = allowed.filter((value): value is CredentialClass =>
+    value === "oauth" || value === "byok" || value === "managed"
+  );
+  return classes.length > 0 ? { allowedClasses: [...new Set(classes)] } : {};
+}
+
+export function poolConfigFromRows(input: {
+  readonly teamId: string;
+  readonly family: Family;
+  readonly keys: readonly Pick<CoderouterKeyRow, "id" | "revokedAt" | "policy">[];
+  readonly credentials: readonly Pick<
+    CoderouterCredentialRow,
+    "id" | "kind" | "class" | "status" | "label" | "providerAccountId" | "encryptedSecret"
+  >[];
+  readonly balanceMicros: number;
+  readonly managedEnabled: boolean;
+  readonly configVersion: number;
+}): PoolConfig {
+  return {
+    poolId: poolName(input.teamId, input.family),
+    teamId: input.teamId,
+    family: input.family,
+    configVersion: input.configVersion,
+    keys: input.keys.map((key) => ({
+      kid: key.id,
+      revoked: key.revokedAt !== null,
+      policy: normalizedPolicy(key.policy),
+    })),
+    credentials: input.credentials.map((credential) => ({
+      id: credential.id,
+      kind: credential.kind,
+      class: credential.class,
+      status: credential.status,
+      ...(credential.label ? { label: credential.label } : {}),
+      ...(credential.providerAccountId ? { providerAccountId: credential.providerAccountId } : {}),
+      ...(credential.encryptedSecret ? { encryptedSecret: credential.encryptedSecret } : {}),
+    })),
+    managed: { enabled: input.managedEnabled },
+    balanceMicros: input.balanceMicros,
+  };
+}

--- a/web/services/coderouter/types.ts
+++ b/web/services/coderouter/types.ts
@@ -1,0 +1,80 @@
+// Pinned coderouter wire contracts. Duplicated from workers/coderouter/src/types.ts;
+// do not import across packages.
+export type Family = "anthropic" | "openai";
+export type EndpointClass = "anthropic" | "openai_api" | "codex";
+export type CredentialKind = "oauth" | "api_key";
+export type CredentialClass = "oauth" | "byok" | "managed";
+export type CredentialStatus = "active" | "needs_reauth" | "disabled";
+
+export interface PoolConfig {
+  poolId: string;
+  teamId: string;
+  family: Family;
+  configVersion: number;
+  keys: {
+    kid: string;
+    revoked: boolean;
+    policy: { allowedClasses?: CredentialClass[] };
+  }[];
+  credentials: {
+    id: string;
+    kind: CredentialKind;
+    class: CredentialClass;
+    status: CredentialStatus;
+    label?: string;
+    providerAccountId?: string;
+    encryptedSecret?: string;
+  }[];
+  managed: { enabled: boolean };
+  balanceMicros: number;
+}
+
+export interface SeedOauth {
+  credentialId: string;
+  provider: Family;
+  accessToken: string;
+  refreshToken: string;
+  idToken?: string;
+  accountId?: string;
+  expiresAt?: number;
+}
+
+export interface UsageIngest {
+  poolId: string;
+  events: {
+    eventId: string;
+    keyId?: string;
+    credentialId?: string;
+    family: string;
+    endpointClass: EndpointClass;
+    model?: string;
+    credentialClass: CredentialClass;
+    status: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    estimated: boolean;
+    costMicros?: number | null;
+    latencyMs?: number;
+    ts: number;
+  }[];
+  statusUpdates?: { credentialId: string; status: "active" | "needs_reauth" }[];
+}
+
+export interface VerifiedCallerKey {
+  v: 1;
+  kid: string;
+  team: string;
+  iat: number;
+}
+
+export interface Usage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  estimated: boolean;
+}
+
+export type KeyPolicy = { allowedClasses?: CredentialClass[] };

--- a/web/services/coderouter/workerSync.ts
+++ b/web/services/coderouter/workerSync.ts
@@ -1,0 +1,88 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { CoderouterConfigurationError, CoderouterWorkerSyncError } from "./errors";
+import type { PoolConfig, SeedOauth } from "./types";
+
+export type CoderouterWorkerSyncShape = {
+  readonly syncPool: (config: PoolConfig) => Effect.Effect<void, CoderouterConfigurationError | CoderouterWorkerSyncError>;
+  readonly seedOauth: (poolName: string, seed: SeedOauth) => Effect.Effect<void, CoderouterConfigurationError | CoderouterWorkerSyncError>;
+};
+
+export class CoderouterWorkerSync extends Context.Tag("cmux/CoderouterWorkerSync")<
+  CoderouterWorkerSync,
+  CoderouterWorkerSyncShape
+>() {}
+
+export const CoderouterWorkerSyncLive = Layer.succeed(
+  CoderouterWorkerSync,
+  makeCoderouterWorkerSync(process.env, fetch),
+);
+
+export function makeCoderouterWorkerSync(
+  env: Record<string, string | undefined>,
+  fetchFn: typeof fetch,
+): CoderouterWorkerSyncShape {
+  return {
+    syncPool: (config) =>
+      postWorker({
+        env,
+        fetchFn,
+        operation: "syncPool",
+        path: `/internal/pools/${encodeURIComponent(config.poolId)}/sync`,
+        body: config,
+      }),
+
+    seedOauth: (poolName, seed) =>
+      postWorker({
+        env,
+        fetchFn,
+        operation: "seedOauth",
+        path: `/internal/pools/${encodeURIComponent(poolName)}/seed-oauth`,
+        body: seed,
+      }),
+  };
+}
+
+export function noOpCoderouterWorkerSync(): CoderouterWorkerSyncShape {
+  return {
+    syncPool: () => Effect.void,
+    seedOauth: () => Effect.void,
+  };
+}
+
+function postWorker(input: {
+  readonly env: Record<string, string | undefined>;
+  readonly fetchFn: typeof fetch;
+  readonly operation: string;
+  readonly path: string;
+  readonly body: unknown;
+}): Effect.Effect<void, CoderouterConfigurationError | CoderouterWorkerSyncError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const base = input.env.CODEROUTER_WORKER_BASE_URL?.trim();
+      const token = input.env.CODEROUTER_INTERNAL_TOKEN?.trim();
+      if (!base) {
+        throw new CoderouterConfigurationError(input.operation, "CODEROUTER_WORKER_BASE_URL is not configured.");
+      }
+      if (!token) {
+        throw new CoderouterConfigurationError(input.operation, "CODEROUTER_INTERNAL_TOKEN is not configured.");
+      }
+      const response = await input.fetchFn(new URL(input.path, base), {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(input.body),
+      });
+      if (!response.ok) {
+        throw new CoderouterWorkerSyncError(input.operation, response.status);
+      }
+    },
+    catch: (cause) => {
+      if (cause instanceof CoderouterConfigurationError || cause instanceof CoderouterWorkerSyncError) return cause;
+      return new CoderouterWorkerSyncError(input.operation, null, cause);
+    },
+  });
+}

--- a/web/services/coderouter/workflows.ts
+++ b/web/services/coderouter/workflows.ts
@@ -1,0 +1,399 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { encryptSecret } from "./crypto";
+import {
+  CoderouterConfigurationError,
+  coderouterWorkflowErrorCause,
+  type CoderouterWorkflowError,
+} from "./errors";
+import { mintCallerKey, sha256Hex } from "./keys";
+import {
+  CoderouterBillingGateway,
+  CoderouterBillingGatewayLive,
+  type BillingCustomer,
+} from "./billing";
+import {
+  CoderouterOAuthConnect,
+  CoderouterOAuthConnectLive,
+  type ImportedOauthChain,
+} from "./oauthConnect";
+import { seedOauthFromImportedChain } from "./oauthConnect";
+import {
+  CoderouterRepository,
+  CoderouterRepositoryLive,
+  parsePoolName,
+  poolName,
+  type CoderouterCredentialRow,
+  type CoderouterKeyRow,
+  type UsageSummaryRow,
+} from "./repository";
+import {
+  CoderouterWorkerSync,
+  CoderouterWorkerSyncLive,
+} from "./workerSync";
+import type { CredentialClass, Family, KeyPolicy, PoolConfig, UsageIngest } from "./types";
+
+export const CoderouterWorkflowLive = Layer.mergeAll(
+  CoderouterRepositoryLive,
+  CoderouterBillingGatewayLive,
+  CoderouterWorkerSyncLive,
+  CoderouterOAuthConnectLive,
+);
+
+export async function runCoderouterWorkflow<A>(
+  program: Effect.Effect<
+    A,
+    CoderouterWorkflowError,
+    CoderouterRepository | CoderouterBillingGateway | CoderouterWorkerSync | CoderouterOAuthConnect
+  >,
+): Promise<A> {
+  try {
+    return await Effect.runPromise(program.pipe(Effect.provide(CoderouterWorkflowLive)));
+  } catch (err) {
+    throw coderouterWorkflowErrorCause(err) ?? err;
+  }
+}
+
+export function listKeys(teamId: string) {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    return yield* repo.listKeys(teamId);
+  });
+}
+
+export function createKey(input: {
+  readonly teamId: string;
+  readonly billingCustomer: BillingCustomer;
+  readonly name: string;
+  readonly policy: KeyPolicy;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    const secret = process.env.CODEROUTER_KEY_SIGNING_SECRET?.trim();
+    if (!secret) {
+      return yield* Effect.fail(
+        new CoderouterConfigurationError("createKey", "CODEROUTER_KEY_SIGNING_SECRET is not configured."),
+      );
+    }
+    const minted = yield* Effect.promise(() => mintCallerKey({ teamId: input.teamId, secret }));
+    const secretHash = yield* Effect.promise(() => sha256Hex(minted.key));
+    const row = yield* repo.createKey({
+      kid: minted.kid,
+      teamId: input.teamId,
+      name: input.name,
+      secretHash,
+      policy: input.policy,
+    });
+    yield* syncAllTeamPools(input.teamId, input.billingCustomer);
+    return { key: minted.key, row };
+  });
+}
+
+export function revokeKey(input: {
+  readonly teamId: string;
+  readonly billingCustomer: BillingCustomer;
+  readonly keyId: string;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    const row = yield* repo.revokeKey(input.teamId, input.keyId);
+    yield* syncAllTeamPools(input.teamId, input.billingCustomer);
+    return row;
+  });
+}
+
+export function listCredentials(teamId: string) {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    return yield* repo.listCredentials(teamId);
+  });
+}
+
+export function addByokCredential(input: {
+  readonly teamId: string;
+  readonly billingCustomer: BillingCustomer;
+  readonly family: Family;
+  readonly label?: string | null;
+  readonly apiKey: string;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    const encryptedSecret = yield* Effect.tryPromise({
+      try: () => encryptSecret(input.apiKey),
+      catch: (cause) =>
+        cause instanceof CoderouterConfigurationError
+          ? cause
+          : new CoderouterConfigurationError("encryptByok", "Could not encrypt coderouter API key."),
+    });
+    const row = yield* repo.createCredential({
+      teamId: input.teamId,
+      family: input.family,
+      billingCustomerType: input.billingCustomer.type,
+      kind: "api_key",
+      class: "byok",
+      label: input.label,
+      encryptedSecret,
+    });
+    yield* syncPoolForFamily(input.teamId, input.family, input.billingCustomer);
+    return row;
+  });
+}
+
+export function disableCredential(input: {
+  readonly teamId: string;
+  readonly billingCustomer: BillingCustomer;
+  readonly credentialId: string;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    const row = yield* repo.disableCredential(input.teamId, input.credentialId);
+    const family = yield* familyForCredential(input.teamId, row);
+    yield* syncPoolForFamily(input.teamId, family, input.billingCustomer);
+    return row;
+  });
+}
+
+export function startAnthropicConnect() {
+  return Effect.gen(function* () {
+    const oauth = yield* CoderouterOAuthConnect;
+    return yield* oauth.startAnthropic();
+  });
+}
+
+export function completeAnthropicConnect(input: {
+  readonly teamId: string;
+  readonly billingCustomer: BillingCustomer;
+  readonly pastedCode: string;
+  readonly stateCookie: string | null;
+}) {
+  return Effect.gen(function* () {
+    const oauth = yield* CoderouterOAuthConnect;
+    const chain = yield* oauth.completeAnthropic({
+      pastedCode: input.pastedCode,
+      stateCookie: input.stateCookie,
+    });
+    return yield* createOauthCredentialFromChain({
+      teamId: input.teamId,
+      billingCustomer: input.billingCustomer,
+      chain,
+      label: "Anthropic OAuth",
+    });
+  });
+}
+
+export function startOpenAIConnect() {
+  return Effect.gen(function* () {
+    const oauth = yield* CoderouterOAuthConnect;
+    return yield* oauth.startOpenAI();
+  });
+}
+
+export function pollOpenAIConnect(input: {
+  readonly teamId: string;
+  readonly billingCustomer: BillingCustomer;
+  readonly deviceCode: string;
+}) {
+  return Effect.gen(function* () {
+    const oauth = yield* CoderouterOAuthConnect;
+    const result = yield* oauth.pollOpenAI(input.deviceCode);
+    if (result.status === "pending") return result;
+    const credential = yield* createOauthCredentialFromChain({
+      teamId: input.teamId,
+      billingCustomer: input.billingCustomer,
+      chain: result.chain,
+      label: "OpenAI OAuth",
+    });
+    return { status: "complete" as const, credential };
+  });
+}
+
+export function importOauthCredential(input: {
+  readonly teamId: string;
+  readonly billingCustomer: BillingCustomer;
+  readonly chain: ImportedOauthChain;
+  readonly label?: string | null;
+}) {
+  return createOauthCredentialFromChain(input);
+}
+
+export function usageSummary(input: {
+  readonly teamId: string;
+  readonly billingCustomer: BillingCustomer;
+  readonly days: number;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    const billing = yield* CoderouterBillingGateway;
+    const [rows, balanceMicros] = yield* Effect.all([
+      repo.usageSummary(input.teamId, input.days),
+      billing.currentBalanceMicros(input.billingCustomer),
+    ]);
+    return { rows, balanceMicros };
+  });
+}
+
+export function poolConfigForName(poolNameValue: string) {
+  return Effect.gen(function* () {
+    const parsed = parsePoolName(poolNameValue);
+    if (!parsed) {
+      return yield* Effect.fail(new CoderouterConfigurationError("poolConfig", "Invalid coderouter pool id."));
+    }
+    const repo = yield* CoderouterRepository;
+    const pool = yield* repo.poolForName(poolNameValue);
+    return yield* buildPoolConfig({
+      teamId: parsed.teamId,
+      family: parsed.family,
+      billingCustomer: { type: pool.billingCustomerType as "team" | "user", id: parsed.teamId },
+    });
+  });
+}
+
+export function ingestUsage(input: {
+  readonly usage: UsageIngest;
+  readonly billingCustomer?: BillingCustomer;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    const billing = yield* CoderouterBillingGateway;
+    const parsed = parsePoolName(input.usage.poolId);
+    if (!parsed) {
+      return yield* Effect.fail(new CoderouterConfigurationError("usageIngest", "Invalid coderouter pool id."));
+    }
+    const pool = yield* repo.poolForName(input.usage.poolId);
+    const customer = input.billingCustomer ?? { type: pool.billingCustomerType as "team" | "user", id: parsed.teamId };
+    const inserted = yield* repo.insertUsageEvents({
+      teamId: parsed.teamId,
+      events: input.usage.events,
+    });
+    if (inserted.managedCostMicros > 0) {
+      yield* billing.debitUsage(customer, inserted.managedCostMicros);
+    }
+    yield* repo.applyStatusUpdates({
+      poolName: input.usage.poolId,
+      updates: input.usage.statusUpdates ?? [],
+    });
+    const balanceMicros = yield* billing.currentBalanceMicros(customer);
+    return { balanceMicros, inserted };
+  });
+}
+
+function createOauthCredentialFromChain(input: {
+  readonly teamId: string;
+  readonly billingCustomer: BillingCustomer;
+  readonly chain: ImportedOauthChain;
+  readonly label?: string | null;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    const worker = yield* CoderouterWorkerSync;
+    const row = yield* repo.createCredential({
+      teamId: input.teamId,
+      family: input.chain.provider,
+      billingCustomerType: input.billingCustomer.type,
+      kind: "oauth",
+      class: "oauth",
+      label: input.label,
+      providerEmail: input.chain.email ?? null,
+      providerAccountId: input.chain.accountId ?? null,
+      meta: {},
+    });
+    yield* worker.seedOauth(
+      poolName(input.teamId, input.chain.provider),
+      seedOauthFromImportedChain(row.id, input.chain),
+    );
+    yield* syncPoolForFamily(input.teamId, input.chain.provider, input.billingCustomer);
+    return row;
+  });
+}
+
+function syncAllTeamPools(teamId: string, billingCustomer: BillingCustomer) {
+  return Effect.gen(function* () {
+    yield* Effect.all([
+      syncPoolForFamily(teamId, "anthropic", billingCustomer),
+      syncPoolForFamily(teamId, "openai", billingCustomer),
+    ], { discard: true });
+  });
+}
+
+function syncPoolForFamily(teamId: string, family: Family, billingCustomer: BillingCustomer) {
+  return Effect.gen(function* () {
+    const worker = yield* CoderouterWorkerSync;
+    const config = yield* buildPoolConfig({ teamId, family, billingCustomer });
+    yield* worker.syncPool(config);
+  });
+}
+
+function buildPoolConfig(input: {
+  readonly teamId: string;
+  readonly family: Family;
+  readonly billingCustomer: BillingCustomer;
+}): Effect.Effect<PoolConfig, CoderouterWorkflowError, CoderouterRepository | CoderouterBillingGateway> {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    const billing = yield* CoderouterBillingGateway;
+    const balanceMicros = yield* billing.currentBalanceMicros(input.billingCustomer);
+    return yield* repo.buildPoolConfig({
+      teamId: input.teamId,
+      family: input.family,
+      billingCustomerType: input.billingCustomer.type,
+      balanceMicros,
+      managedEnabled: billing.managedBillingEnabled(),
+    });
+  });
+}
+
+function familyForCredential(teamId: string, credential: CoderouterCredentialRow) {
+  return Effect.gen(function* () {
+    const repo = yield* CoderouterRepository;
+    const pools = yield* repo.listPoolsForTeam(teamId);
+    const pool = pools.find((candidate) => candidate.id === credential.poolId);
+    if (!pool) {
+      return yield* Effect.fail(new CoderouterConfigurationError("disableCredential", "Credential pool was not found."));
+    }
+    return pool.family;
+  });
+}
+
+export function publicKey(row: CoderouterKeyRow) {
+  return {
+    id: row.id,
+    name: row.name,
+    policy: row.policy,
+    createdAt: row.createdAt.toISOString(),
+    revokedAt: row.revokedAt?.toISOString() ?? null,
+    lastUsedAt: row.lastUsedAt?.toISOString() ?? null,
+  };
+}
+
+export function publicCredential(row: CoderouterCredentialRow) {
+  return {
+    id: row.id,
+    kind: row.kind,
+    class: row.class,
+    status: row.status,
+    label: row.label,
+    providerEmail: row.providerEmail,
+    providerAccountId: row.providerAccountId,
+    createdAt: row.createdAt.toISOString(),
+    lastUsedAt: row.lastUsedAt?.toISOString() ?? null,
+  };
+}
+
+export function publicUsageSummary(rows: readonly UsageSummaryRow[]) {
+  return rows.map((row) => ({
+    day: row.day,
+    model: row.model,
+    credentialClass: row.credentialClass,
+    inputTokens: Number(row.inputTokens),
+    outputTokens: Number(row.outputTokens),
+    cacheReadTokens: Number(row.cacheReadTokens),
+    cacheWriteTokens: Number(row.cacheWriteTokens),
+    costMicros: Number(row.costMicros),
+    requests: Number(row.requests),
+  }));
+}
+
+export function allowedClassesPolicy(value: readonly CredentialClass[] | undefined): KeyPolicy {
+  if (!value || value.length === 0) return {};
+  return { allowedClasses: [...new Set(value)] };
+}

--- a/web/tests/coderouter-billing-workflows.test.ts
+++ b/web/tests/coderouter-billing-workflows.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { priceUsageMicros } from "../services/coderouter/pricing";
+import { CoderouterRepository, type CoderouterRepositoryShape } from "../services/coderouter/repository";
+import { ingestUsage } from "../services/coderouter/workflows";
+import type { UsageIngest } from "../services/coderouter/types";
+
+let stackConfigured = true;
+let quantity = 50_000;
+let tryDecreaseQuantityImpl = async (_amount: number) => true;
+const tryDecreaseQuantity = mock(async (...args: unknown[]) => tryDecreaseQuantityImpl(Number(args[0])));
+const getQuantity = mock(async () => quantity);
+const getItem = mock(async () => ({
+  getQuantity,
+  tryDecreaseQuantity,
+}));
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getItem }),
+  isStackConfigured: () => stackConfigured,
+  stackServerApp: { getItem, getUser: async () => null },
+}));
+
+const { CoderouterBillingGateway, makeStackCoderouterBillingGateway } = await import(
+  "../services/coderouter/billing"
+);
+type BillingCustomer = import("../services/coderouter/billing").BillingCustomer;
+type CoderouterBillingGatewayShape = import("../services/coderouter/billing").CoderouterBillingGatewayShape;
+
+beforeEach(() => {
+  stackConfigured = true;
+  quantity = 50_000;
+  tryDecreaseQuantity.mockClear();
+  tryDecreaseQuantityImpl = async (amount: number) => {
+    if (amount > quantity) return false;
+    quantity -= amount;
+    return true;
+  };
+  getQuantity.mockClear();
+  getItem.mockClear();
+});
+
+describe("coderouter Stack billing", () => {
+  test("debits managed usage from the configured Stack item and reads balance", async () => {
+    const gateway = makeStackCoderouterBillingGateway({
+      CMUX_CODEROUTER_CREDIT_ITEM_ID: "coderouter-credit",
+    });
+
+    await Effect.runPromise(gateway.debitUsage({ type: "team", id: "team-1" }, 123));
+    const balance = await Effect.runPromise(gateway.currentBalanceMicros({ type: "team", id: "team-1" }));
+
+    expect(getItem).toHaveBeenCalledWith({ teamId: "team-1", itemId: "coderouter-credit" });
+    expect(tryDecreaseQuantity).toHaveBeenCalledWith(123);
+    expect(balance).toBe(49_877);
+  });
+
+  test("floors insufficient managed-credit debits at zero instead of throwing", async () => {
+    quantity = 5;
+    const gateway = makeStackCoderouterBillingGateway({
+      CMUX_CODEROUTER_CREDIT_ITEM_ID: "coderouter-credit",
+    });
+
+    await Effect.runPromise(gateway.debitUsage({ type: "team", id: "team-1" }, 13));
+    const balance = await Effect.runPromise(gateway.currentBalanceMicros({ type: "team", id: "team-1" }));
+
+    expect(tryDecreaseQuantity).toHaveBeenNthCalledWith(1, 13);
+    expect(tryDecreaseQuantity).toHaveBeenNthCalledWith(2, 5);
+    expect(balance).toBe(0);
+  });
+
+  test("is disabled when the credit item env is unset", async () => {
+    stackConfigured = false;
+    const gateway = makeStackCoderouterBillingGateway({});
+
+    await Effect.runPromise(gateway.debitUsage({ type: "team", id: "team-1" }, 123));
+    expect(await Effect.runPromise(gateway.currentBalanceMicros({ type: "team", id: "team-1" }))).toBe(0);
+    expect(getItem).not.toHaveBeenCalled();
+  });
+});
+
+describe("coderouter usage ingest workflow", () => {
+  test("inserts duplicate event ids once and debits only newly inserted managed cost", async () => {
+    const debits: number[] = [];
+    const debitCustomers: BillingCustomer[] = [];
+    const seen = new Set<string>();
+    const repo = fakeRepo({
+      poolForName: () => Effect.succeed({
+        id: "pool-1",
+        teamId: "team-1",
+        billingCustomerType: "user",
+        family: "openai",
+        createdAt: new Date(),
+      }),
+      insertUsageEvents: (input) =>
+        Effect.sync(() => {
+          let inserted = 0;
+          let managedCostMicros = 0;
+          for (const event of input.events) {
+            if (seen.has(event.eventId)) continue;
+            seen.add(event.eventId);
+            inserted += 1;
+            if (event.credentialClass === "managed") {
+              managedCostMicros += priceUsageMicros(event.model, {
+                inputTokens: event.inputTokens,
+                outputTokens: event.outputTokens,
+                cacheReadTokens: event.cacheReadTokens,
+                cacheWriteTokens: event.cacheWriteTokens,
+                estimated: event.estimated,
+              }) ?? 0;
+            }
+          }
+          return { inserted, managedCostMicros };
+        }),
+    });
+    const billing: CoderouterBillingGatewayShape = {
+      managedBillingEnabled: () => true,
+      currentBalanceMicros: () => Effect.succeed(999),
+      debitUsage: (_customer: BillingCustomer, amount: number) => Effect.sync(() => {
+        debitCustomers.push(_customer);
+        debits.push(amount);
+      }),
+    };
+    const layer = Layer.mergeAll(
+      Layer.succeed(CoderouterRepository, repo),
+      Layer.succeed(CoderouterBillingGateway, billing),
+    );
+
+    const usage: UsageIngest = {
+      poolId: "team-1:openai",
+      events: [managedEvent("event-1"), managedEvent("event-1")],
+    };
+    const result = await Effect.runPromise(ingestUsage({ usage }).pipe(Effect.provide(layer)));
+
+    expect(result.inserted.inserted).toBe(1);
+    expect(debits).toEqual([13]);
+    expect(debitCustomers).toEqual([{ type: "user", id: "team-1" }]);
+    expect(result.balanceMicros).toBe(999);
+  });
+});
+
+function managedEvent(eventId: string): UsageIngest["events"][number] {
+  return {
+    eventId,
+    family: "openai",
+    endpointClass: "openai_api",
+    model: "gpt-5",
+    credentialClass: "managed",
+    status: 200,
+    inputTokens: 1,
+    outputTokens: 1,
+    cacheReadTokens: 1,
+    cacheWriteTokens: 0,
+    estimated: false,
+    ts: Date.now(),
+  };
+}
+
+function fakeRepo(overrides: Partial<CoderouterRepositoryShape>): CoderouterRepositoryShape {
+  const missing = (name: string) => () => {
+    throw new Error(`unexpected repository call: ${name}`);
+  };
+  return {
+    getOrCreatePool: missing("getOrCreatePool"),
+    listPoolsForTeam: missing("listPoolsForTeam"),
+    poolForName: missing("poolForName"),
+    listKeys: missing("listKeys"),
+    createKey: missing("createKey"),
+    revokeKey: missing("revokeKey"),
+    listCredentials: missing("listCredentials"),
+    createCredential: missing("createCredential"),
+    disableCredential: missing("disableCredential"),
+    buildPoolConfig: missing("buildPoolConfig"),
+    usageSummary: missing("usageSummary"),
+    insertUsageEvents: missing("insertUsageEvents"),
+    applyStatusUpdates: () => Effect.void,
+    ...overrides,
+  } as CoderouterRepositoryShape;
+}

--- a/web/tests/coderouter-crypto-keys.test.ts
+++ b/web/tests/coderouter-crypto-keys.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { decryptSecret, encryptSecret } from "../services/coderouter/crypto";
+import { mintCallerKey, sha256Hex, verifyCallerKey } from "../services/coderouter/keys";
+
+const encoder = new TextEncoder();
+
+describe("coderouter crypto", () => {
+  test("round-trips crv1 envelopes and rejects tampering", async () => {
+    const masterKey = Buffer.alloc(32, 7).toString("base64");
+    const encrypted = await encryptSecret("provider-secret", masterKey);
+
+    expect(encrypted.startsWith("crv1:")).toBe(true);
+    await expect(decryptSecret(encrypted, masterKey)).resolves.toBe("provider-secret");
+
+    const parts = encrypted.split(":");
+    const cipher = parts[2] ?? "";
+    parts[2] = `${cipher.slice(0, -2)}${cipher.endsWith("AA") ? "BB" : "AA"}`;
+    const tampered = parts.join(":");
+    await expect(decryptSecret(tampered, masterKey)).rejects.toThrow();
+  });
+});
+
+describe("coderouter caller keys", () => {
+  test("mints worker-compatible crk keys and hashes the full key", async () => {
+    const secret = "signing-secret";
+    const minted = await mintCallerKey({
+      teamId: "team-1",
+      kid: "11111111-1111-4111-8111-111111111111",
+      issuedAtSeconds: 1_777_000_000,
+      secret,
+    });
+
+    expect(minted.key.startsWith("crk_")).toBe(true);
+    expect(await verifyCallerKey(minted.key, secret)).toEqual({
+      v: 1,
+      kid: "11111111-1111-4111-8111-111111111111",
+      team: "team-1",
+      iat: 1_777_000_000,
+    });
+    expect(await workerStyleVerify(minted.key, secret)).toBe(true);
+    expect(await sha256Hex(minted.key)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("rejects tampered keys", async () => {
+    const minted = await mintCallerKey({ teamId: "team-1", secret: "signing-secret" });
+    const tampered = `${minted.key.slice(0, -1)}${minted.key.endsWith("A") ? "B" : "A"}`;
+
+    expect(await verifyCallerKey(tampered, "signing-secret")).toBeNull();
+  });
+});
+
+async function workerStyleVerify(key: string, secret: string): Promise<boolean> {
+  const dot = key.indexOf(".");
+  if (!key.startsWith("crk_") || dot < 0) return false;
+  const signed = key.slice(0, dot);
+  const signature = key.slice(dot + 1);
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const expected = Buffer.from(await crypto.subtle.sign("HMAC", cryptoKey, encoder.encode(signed))).toString("base64url");
+  if (signature !== expected) return false;
+  const payload = JSON.parse(Buffer.from(key.slice(4, dot), "base64url").toString("utf8"));
+  return payload.v === 1 && payload.team === "team-1";
+}

--- a/web/tests/coderouter-oauth-connect.test.ts
+++ b/web/tests/coderouter-oauth-connect.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, mock, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import { makeCoderouterOAuthConnect } from "../services/coderouter/oauthConnect";
+import { CoderouterConnectError } from "../services/coderouter/errors";
+
+describe("coderouter OAuth connect", () => {
+  test("validates anthropic paste-code state before exchanging tokens", async () => {
+    const fetchFn = mock(async () => Response.json({}));
+    const connect = makeCoderouterOAuthConnect({ CODEROUTER_KEY_SIGNING_SECRET: "state-secret" }, fetchFn as unknown as typeof fetch);
+    const started = await Effect.runPromise(connect.startAnthropic());
+
+    const error = await Effect.runPromise(
+      connect.completeAnthropic({
+        pastedCode: "auth-code#wrong-state",
+        stateCookie: started.cookie,
+      }).pipe(Effect.flip),
+    );
+
+    expect(error).toBeInstanceOf(CoderouterConnectError);
+    expect(error).toMatchObject({ code: "invalid_state" });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  test("exchanges a valid anthropic paste-code and returns a seedable chain", async () => {
+    const fetchFn = mock(async (...args: unknown[]) => {
+      const init = args[1] as RequestInit | undefined;
+      const body = JSON.parse(String(init?.body));
+      expect(typeof body.code_verifier).toBe("string");
+      return Response.json({
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        expires_in: 3600,
+      });
+    });
+    const connect = makeCoderouterOAuthConnect({ CODEROUTER_KEY_SIGNING_SECRET: "state-secret" }, fetchFn as unknown as typeof fetch);
+    const started = await Effect.runPromise(connect.startAnthropic());
+    const chain = await Effect.runPromise(connect.completeAnthropic({
+      pastedCode: `auth-code#${started.state}`,
+      stateCookie: started.cookie,
+    }));
+
+    expect(chain).toMatchObject({
+      provider: "anthropic",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+    });
+    expect(chain.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  test("maps unsupported OpenAI device flow to connect_unsupported", async () => {
+    const fetchFn = mock(async () => Response.json({ error: "not_found" }, { status: 404 }));
+    const connect = makeCoderouterOAuthConnect({}, fetchFn as unknown as typeof fetch);
+
+    const error = await Effect.runPromise(connect.startOpenAI().pipe(Effect.flip));
+
+    expect(error).toBeInstanceOf(CoderouterConnectError);
+    expect(error).toMatchObject({ code: "connect_unsupported" });
+  });
+
+  test("parses OpenAI device flow token claims", async () => {
+    const idToken = jwt({
+      "https://api.openai.com/profile": { email: "owner@example.com" },
+      "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
+    });
+    const fetchFn = mock(async () => Response.json({
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      id_token: idToken,
+    }));
+    const connect = makeCoderouterOAuthConnect({}, fetchFn as unknown as typeof fetch);
+
+    const result = await Effect.runPromise(connect.pollOpenAI("device-code"));
+
+    expect(result).toEqual({
+      status: "complete",
+      chain: {
+        provider: "openai",
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        idToken,
+        email: "owner@example.com",
+        accountId: "acct-1",
+      },
+    });
+  });
+});
+
+function jwt(payload: Record<string, unknown>): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    "signature",
+  ].join(".");
+}

--- a/web/tests/coderouter-pricing-config.test.ts
+++ b/web/tests/coderouter-pricing-config.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { priceUsageMicros } from "../services/coderouter/pricing";
+import { poolConfigFromRows } from "../services/coderouter/repository";
+
+describe("coderouter pricing", () => {
+  test("rounds each token component up and supports date-suffixed model ids", () => {
+    expect(priceUsageMicros("claude-sonnet-4-5-20250929", {
+      inputTokens: 1,
+      outputTokens: 1,
+      cacheReadTokens: 1,
+      cacheWriteTokens: 1,
+      estimated: false,
+    })).toBe(23);
+    expect(priceUsageMicros("unknown-model", {
+      inputTokens: 1,
+      outputTokens: 1,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      estimated: true,
+    })).toBeNull();
+  });
+});
+
+describe("coderouter pool config assembly", () => {
+  test("matches the pinned worker wire shape without leaking provider emails", () => {
+    const config = poolConfigFromRows({
+      teamId: "team-1",
+      family: "anthropic",
+      balanceMicros: 123,
+      managedEnabled: true,
+      configVersion: 42,
+      keys: [{
+        id: "key-1",
+        revokedAt: null,
+        policy: { allowedClasses: ["oauth", "byok", "invalid"] } as never,
+      }],
+      credentials: [{
+        id: "credential-1",
+        kind: "api_key",
+        class: "byok",
+        status: "active",
+        label: "Team key",
+        providerAccountId: null,
+        encryptedSecret: "crv1:iv:ciphertext",
+      }, {
+        id: "credential-2",
+        kind: "oauth",
+        class: "oauth",
+        status: "needs_reauth",
+        label: null,
+        providerAccountId: "acct-1",
+        encryptedSecret: null,
+      }],
+    });
+
+    expect(config).toEqual({
+      poolId: "team-1:anthropic",
+      teamId: "team-1",
+      family: "anthropic",
+      configVersion: 42,
+      keys: [{ kid: "key-1", revoked: false, policy: { allowedClasses: ["oauth", "byok"] } }],
+      credentials: [{
+        id: "credential-1",
+        kind: "api_key",
+        class: "byok",
+        status: "active",
+        label: "Team key",
+        encryptedSecret: "crv1:iv:ciphertext",
+      }, {
+        id: "credential-2",
+        kind: "oauth",
+        class: "oauth",
+        status: "needs_reauth",
+        providerAccountId: "acct-1",
+      }],
+      managed: { enabled: true },
+      balanceMicros: 123,
+    });
+  });
+});

--- a/web/tests/coderouter-routes.test.ts
+++ b/web/tests/coderouter-routes.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const OLD_TOKEN = process.env.CODEROUTER_INTERNAL_TOKEN;
+const runCoderouterWorkflow = mock(async () => ({ balanceMicros: 0 }));
+const ingestUsage = mock((input: unknown) => input);
+const poolConfigForName = mock((input: unknown) => input);
+
+mock.module("../services/coderouter/workflows", () => ({
+  ingestUsage,
+  poolConfigForName,
+  runCoderouterWorkflow,
+}));
+
+beforeEach(() => {
+  process.env.CODEROUTER_INTERNAL_TOKEN = "internal-token";
+  runCoderouterWorkflow.mockClear();
+  runCoderouterWorkflow.mockResolvedValue({ balanceMicros: 0 });
+  ingestUsage.mockClear();
+  poolConfigForName.mockClear();
+});
+
+afterAll(() => {
+  process.env.CODEROUTER_INTERNAL_TOKEN = OLD_TOKEN;
+});
+
+describe("coderouter routes", () => {
+  test("internal pool-config rejects missing service token", async () => {
+    const { GET } = await import("../app/api/coderouter/internal/pool-config/route");
+
+    const response = await GET(new Request("https://cmux.test/api/coderouter/internal/pool-config?poolId=team-1:openai"));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "unauthorized", message: "Unauthorized." });
+  });
+
+  test("usage-ingest validates request bodies before running workflows", async () => {
+    const { POST } = await import("../app/api/coderouter/internal/usage-ingest/route");
+
+    const response = await POST(new Request("https://cmux.test/api/coderouter/internal/usage-ingest", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer internal-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        poolId: "team-1:openai",
+        events: [{ eventId: "event-1", status: 200 }],
+      }),
+    }));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("invalid_request");
+    expect(runCoderouterWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("usage-ingest accepts a full 500-event worker flush larger than the public JSON cap", async () => {
+    const { POST } = await import("../app/api/coderouter/internal/usage-ingest/route");
+    const events = Array.from({ length: 500 }, (_, index) => ({
+      eventId: `event-${index}`,
+      family: "openai",
+      endpointClass: "openai_api",
+      model: "gpt-5",
+      credentialClass: "managed",
+      status: 200,
+      inputTokens: 1000,
+      outputTokens: 1000,
+      cacheReadTokens: 1000,
+      cacheWriteTokens: 0,
+      estimated: false,
+      latencyMs: 250,
+      ts: 1_777_000_000_000 + index,
+    }));
+    const body = JSON.stringify({ poolId: "team-1:openai", events });
+    expect(body.length).toBeGreaterThan(64 * 1024);
+
+    const response = await POST(new Request("https://cmux.test/api/coderouter/internal/usage-ingest", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer internal-token",
+        "content-type": "application/json",
+        "content-length": String(body.length),
+      },
+      body,
+    }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ balanceMicros: 0 });
+    expect(runCoderouterWorkflow).toHaveBeenCalled();
+  });
+});

--- a/workers/coderouter/.gitignore
+++ b/workers/coderouter/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+.dev.vars

--- a/workers/coderouter/README.md
+++ b/workers/coderouter/README.md
@@ -1,0 +1,87 @@
+# cmux-coderouter
+
+Cloudflare Worker data plane for the cmux coderouter gateway. It verifies
+`crk_` caller keys, asks a per-team `PoolCoordinator` Durable Object for the
+best credential, forwards requests to the matching upstream API, and buffers
+usage events for the control plane.
+
+The control plane owns key minting, credential management, OAuth connect
+flows, and billing. This worker keeps hot-path state close to traffic:
+credential pools, sticky conversation assignments, OAuth token chains, limit
+state, and a small usage-event buffer.
+
+## API
+
+| Route | Auth | Purpose |
+| --- | --- | --- |
+| `GET /healthz` | none | liveness |
+| `GET /v1/models` | none | worker catalog snapshot |
+| `/anthropic/*` | `crk_` key | strip `/anthropic`, forward path and query unchanged |
+| `/openai/v1/*` | `crk_` key | forward as `/v1/*` |
+| `/codex/*` | `crk_` key | forward as `/backend-api/codex/*` |
+| `POST /internal/pools/:poolId/sync` | internal bearer token | push a full pool config |
+| `POST /internal/pools/:poolId/seed-oauth` | internal bearer token | seed an OAuth chain into the pool |
+
+Caller keys are accepted as `Authorization: Bearer crk_...` or
+`x-api-key: crk_...`. Internal routes use
+`Authorization: Bearer $CODEROUTER_INTERNAL_TOKEN` and are never routed through
+caller-key auth.
+
+## Client wiring examples
+
+API-family traffic can point its base URL at:
+
+```bash
+export ANTHROPIC_BASE_URL="https://coderouter.cmux.dev/anthropic"
+export ANTHROPIC_AUTH_TOKEN="crk_..."
+```
+
+```toml
+chatgpt_base_url = "https://coderouter.cmux.dev/codex"
+openai_base_url = "https://coderouter.cmux.dev/openai/v1"
+api_key = "crk_..."
+```
+
+## Environment
+
+Plain vars in `wrangler.toml`:
+
+- `CONTROL_PLANE_BASE_URL`: production defaults to `https://cmux.com`.
+
+Worker secrets are provisioned with `wrangler secret put`, not `[vars]`, so a
+deploy does not overwrite dashboard-set values:
+
+```bash
+bunx wrangler secret put CODEROUTER_KEY_SIGNING_SECRET
+bunx wrangler secret put CODEROUTER_INTERNAL_TOKEN
+bunx wrangler secret put CODEROUTER_MASTER_KEY
+bunx wrangler secret put MANAGED_ANTHROPIC_API_KEY
+bunx wrangler secret put MANAGED_OPENAI_API_KEY
+```
+
+The managed provider keys are optional. If a key is absent, managed credentials
+for that family cannot be acquired.
+
+## Develop
+
+```bash
+bun install
+bun run typecheck
+bun test
+bun run dev
+```
+
+`bun run dev` uses `wrangler.dev.toml`, so local work targets
+`cmux-coderouter-dev` on workers.dev rather than the production custom domain.
+To run wrangler directly:
+
+```bash
+bunx wrangler dev --config wrangler.dev.toml
+```
+
+## Deploy
+
+Production deploys use `wrangler.toml`, worker name `cmux-coderouter`, and the
+custom domain `coderouter.cmux.dev`. Wrangler applies the `[[migrations]]`
+block atomically with each upload. Durable Object migrations are append-only:
+never edit a past tag; add a new migration tag when the storage class changes.

--- a/workers/coderouter/bun.lock
+++ b/workers/coderouter/bun.lock
@@ -1,0 +1,223 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "cmux-coderouter-worker",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260525.0",
+        "@types/bun": "^1.3.14",
+        "@typescript/native-preview": "7.0.0-dev.20260616.1",
+        "typescript": "^5.8.0",
+        "wrangler": "^4.20.0",
+      },
+    },
+  },
+  "packages": {
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260701.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Zd9Y1bah6DwwBN2RW8vJohffQrIUazb8UXnqSNecOxM+jJLhUuvv5IOG8dbHcV83TyZAubea6gsQXo2yH1lDdw=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260701.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yBLsjS1qCWqFyCY37qRUrYfzHHvMGvjh8zRKJ6MvUivYDhkZTzqduppK38FoqYvayLJ5KbcxH7zo5rkxGqbsaA=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260701.1", "", { "os": "linux", "cpu": "x64" }, "sha512-vMfqSIMfoo4xmZXEuUVqLpSFS921YKjiR9q7kDXPi6Vld1PK74UHg9LZuBavT2KSyemHUCTpj9y/4JSYOEyQbQ=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260701.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-HRfwbKU2pK44V2NhoM0+iH0JJSj7nQ9Wv13ifIiGYCmTtDL8/zKtEhX7kQ3D4Vy/Cpjhttl0FkfqXj1aqLDPPg=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260701.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260702.1", "", {}, "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260616.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260616.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260616.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260616.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260616.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260616.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260616.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260616.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-+AuZUl7nkLPXL1rwsyZZF7iasu0HkrL5O6aWwUC0cObD5EvNgxz3hXbBhsSvuJ8tb2JRpVwFsE0BHPcYVe5GkA=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260616.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9SwegwwE7fYutnZJjTi2PeUXhKGFg82MGjSpCFD2cj5v9YQcs5oO5QsmeeMit4fMG8Z83Jy8knOF97d9NaQ7Bg=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260616.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-gl7R8OiwEBNxzs5wjbM9XOibTs5b6/gAgu0+En9pLpYuWR/EITs8Eh0mNQui4JYTp1SkoHvn09aRZKTQf21XTg=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260616.1", "", { "os": "linux", "cpu": "arm" }, "sha512-QWXQS2CrhSpXbng7vBtCVDszFgwVBuJU8MCFhxZL0hH6s+XjQDSNNkGO1oHueBr+7HbSkkyqfNYVNXvgVMUJLQ=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260616.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-CJjplWoE+EeYtbyNeP4fyuh0QcPiQBZJSLqPS07E3ugo3d9M/IG8WnL+3GFQ0g1p4c6QC/+OC0oTTQnGcNdd2Q=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260616.1", "", { "os": "linux", "cpu": "x64" }, "sha512-UVySBNnGTAnul2kO2/EhlVZl0CeTDcd6Lzi+WkvgyCgapTcU0BX1selQ4MEPtbVWKUbt9HBhxNku2dyaCcmKVw=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260616.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-kdX0QcDXiESH0o5DFdSWw15Hth0EtQobT9tX28ofqBUwGU1FFhwTKzA6qo7chaYUSW5MMd6XIME9rBwk+WizLw=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260616.1", "", { "os": "win32", "cpu": "x64" }, "sha512-EB0Pj/0+nXifS3+wN0HdR1mKu7IieSpjMXoDjdXtJAdiPGlmKazBgHj97qn6CBvXisgLx0Eyb7tLCEQNDG53cA=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "miniflare": ["miniflare@4.20260701.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260701.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-L6eAAi6IKtyb/7J6L+YsH2vb1yBrJWKRXI293JYDiMl70+6nncdAgigex58w6WBd+CwvdMsqOyNyGs95Op5gWQ=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "workerd": ["workerd@1.20260701.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260701.1", "@cloudflare/workerd-darwin-arm64": "1.20260701.1", "@cloudflare/workerd-linux-64": "1.20260701.1", "@cloudflare/workerd-linux-arm64": "1.20260701.1", "@cloudflare/workerd-windows-64": "1.20260701.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ=="],
+
+    "wrangler": ["wrangler@4.107.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260701.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260701.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260701.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-fw69ThymNitZ0oIEBU2yNeq3kK59UKz/jyA3udwRrQIAIsxX57q5qLOpPTN7qc5t8n9pnUeofe0uxtMuhQZW8w=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+  }
+}

--- a/workers/coderouter/package.json
+++ b/workers/coderouter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cmux-coderouter-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev --config wrangler.dev.toml",
+    "deploy": "wrangler deploy",
+    "test": "bun test",
+    "typecheck": "tsgo --noEmit && tsgo --noEmit -p tsconfig.test.json",
+    "check": "bun run typecheck && bun test && wrangler deploy --dry-run --outdir dist"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260525.0",
+    "@types/bun": "^1.3.14",
+    "@typescript/native-preview": "7.0.0-dev.20260616.1",
+    "typescript": "^5.8.0",
+    "wrangler": "^4.20.0"
+  }
+}

--- a/workers/coderouter/src/acquirePolicy.ts
+++ b/workers/coderouter/src/acquirePolicy.ts
@@ -1,0 +1,16 @@
+import { lookupPrice } from "./pricing";
+import type { AcquireFailure, CredentialClass } from "./types";
+
+export function managedAcquireFailure(input: {
+  credentialClass: CredentialClass;
+  model?: string;
+  balanceMicros: number;
+  unflushedEstimateMicros: number;
+}): AcquireFailure | null {
+  if (input.credentialClass !== "managed") return null;
+  if (!lookupPrice(input.model)) return { ok: false, error: "model_not_priced" };
+  if (input.balanceMicros - input.unflushedEstimateMicros <= 0) {
+    return { ok: false, error: "insufficient_credits" };
+  }
+  return null;
+}

--- a/workers/coderouter/src/do.ts
+++ b/workers/coderouter/src/do.ts
@@ -1,0 +1,610 @@
+import { DurableObject } from "cloudflare:workers";
+import { managedAcquireFailure } from "./acquirePolicy";
+import { allowedClassesForEndpoint } from "./families";
+import { applyLimitHeaders, mergeReportedLimitState } from "./limits";
+import { refreshOAuthChain, tokenExpiresSoon, type OAuthChain } from "./oauthRefresh";
+import { priceUsageMicros } from "./pricing";
+import { decryptEnvelopeSecret } from "./secrets";
+import { selectCredential, summarizeWindows, type SelectCandidate } from "./select";
+import { buildUsageIngest, subtractFlushedEstimateMicros, type StatusUpdateRow, type UsageBufferRow } from "./usageFlush";
+import { nextUsagePollAt, normalizeUsagePoll, shouldPollCredential, zeroHeadroomUsageWindows } from "./usagePoll";
+import type {
+  AcquireRequest,
+  AcquireResult,
+  CredentialClass,
+  CredentialLimitState,
+  Family,
+  PoolConfig,
+  ReportRequest,
+  SeedOauth,
+  UsageIngest,
+} from "./types";
+
+export interface Env {
+  POOL: DurableObjectNamespace<PoolCoordinator>;
+  CONTROL_PLANE_BASE_URL: string;
+  CODEROUTER_KEY_SIGNING_SECRET: string;
+  CODEROUTER_INTERNAL_TOKEN: string;
+  CODEROUTER_MASTER_KEY?: string;
+  MANAGED_ANTHROPIC_API_KEY?: string;
+  MANAGED_OPENAI_API_KEY?: string;
+}
+
+type SqlRow = Record<string, unknown>;
+type SqlCursor = { toArray(): SqlRow[]; one<T = SqlRow>(): T | null };
+type SqlStorage = { exec(query: string, ...bindings: unknown[]): SqlCursor };
+
+interface CredentialRow {
+  id: string;
+  kind: string;
+  class: CredentialClass;
+  status: string;
+  provider_account_id: string | null;
+  encrypted_secret: string | null;
+}
+
+const META_CONFIG_VERSION = "configVersion";
+const META_POOL_ID = "poolId";
+const META_TEAM_ID = "teamId";
+const META_FAMILY = "family";
+const META_MANAGED_ENABLED = "managedEnabled";
+const META_BALANCE_MICROS = "balanceMicros";
+const META_UNFLUSHED_MICROS = "unflushedEstimateMicros";
+const META_LAST_TRAFFIC_AT = "lastTrafficAt";
+const FLUSH_BATCH_SIZE = 500;
+
+export class PoolCoordinator extends DurableObject<Env> {
+  private initialized: Promise<void> | null = null;
+  private refreshFlights = new Map<string, Promise<OAuthChain | null>>();
+
+  async syncConfig(config: PoolConfig): Promise<{ ok: true; ignored?: boolean }> {
+    await this.init();
+    const currentVersion = this.numberMeta(META_CONFIG_VERSION) ?? 0;
+    if (config.configVersion < currentVersion) {
+      await this.armOauthPollIfNeeded();
+      return { ok: true, ignored: true };
+    }
+    this.writeConfig(config);
+    await this.armOauthPollIfNeeded();
+    return { ok: true };
+  }
+
+  async seedOauth(seed: SeedOauth): Promise<{ ok: true }> {
+    await this.init();
+    this.sql.exec(
+      `INSERT OR REPLACE INTO oauth_chains
+       (credential_id, provider, access_token, refresh_token, id_token, account_id, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      seed.credentialId,
+      seed.provider,
+      seed.accessToken,
+      seed.refreshToken,
+      seed.idToken ?? null,
+      seed.accountId ?? null,
+      seed.expiresAt ?? null,
+    );
+    await this.ctx.storage.sync();
+    await this.armOauthPollIfNeeded();
+    return { ok: true };
+  }
+
+  async acquire(request: AcquireRequest): Promise<AcquireResult> {
+    await this.init();
+    const configAvailable = await this.ensureConfig(request);
+    if (!configAvailable) return { ok: false, error: "config_unavailable" };
+    this.putMeta(META_LAST_TRAFFIC_AT, String(Date.now()));
+
+    const key = this.sql.exec("SELECT kid, revoked, policy FROM keys WHERE kid = ?", request.kid).one<SqlRow>();
+    if (!key || Number(key.revoked) === 1) return { ok: false, error: "key_revoked" };
+    const policy = parseJsonRecord(key.policy);
+    const policyAllowed = Array.isArray(policy.allowedClasses)
+      ? new Set(policy.allowedClasses.filter((value): value is CredentialClass => isCredentialClass(value)))
+      : null;
+    const endpointAllowed = new Set(allowedClassesForEndpoint(request.endpointClass));
+    const excluded = new Set(request.excludeCredentialIds ?? []);
+    const allowed = (credential: CredentialRow) =>
+      credential.status === "active" &&
+      endpointAllowed.has(credential.class) &&
+      !excluded.has(credential.id) &&
+      (!policyAllowed || policyAllowed.has(credential.class)) &&
+      (credential.class !== "managed" || this.booleanMeta(META_MANAGED_ENABLED));
+
+    const credentials = this.listCredentials();
+    const eligible = credentials.filter(allowed);
+    if (eligible.length === 0) return { ok: false, error: "no_credentials" };
+
+    const sticky = this.assignment(request.conversationKey);
+    if (sticky) {
+      const credential = eligible.find((row) => row.id === sticky);
+      if (credential && this.credentialHealthy(credential.id)) {
+        const managedError = this.managedFailure(credential, request);
+        if (managedError) return managedError;
+        this.touchAssignment(request.conversationKey, credential.id);
+        return await this.buildAcquireSuccess(credential, request);
+      }
+    }
+
+    const candidates: SelectCandidate[] = eligible.map((credential) => ({
+      id: credential.id,
+      class: credential.class,
+      assignmentCount: this.assignmentCount(credential.id),
+      limitState: this.limitState(credential.id),
+    }));
+    const selected = selectCredential(candidates, Date.now());
+    if (!selected) {
+      return { ok: false, error: "all_exhausted", soonestResetSeconds: soonestReset(candidates) };
+    }
+    const credential = eligible.find((row) => row.id === selected.id);
+    if (!credential) return { ok: false, error: "no_credentials" };
+    const managedError = this.managedFailure(credential, request);
+    if (managedError) return managedError;
+    this.touchAssignment(request.conversationKey, credential.id);
+    return await this.buildAcquireSuccess(credential, request);
+  }
+
+  async report(report: ReportRequest): Promise<{ ok: true }> {
+    await this.init();
+    const now = Date.now();
+    this.putMeta(META_LAST_TRAFFIC_AT, String(now));
+    const credential = this.credential(report.credentialId);
+    const previous = this.limitState(report.credentialId);
+    const update = applyLimitHeaders({
+      family: this.family(),
+      endpointClass: report.endpointClass,
+      credentialClass: credential?.class ?? "byok",
+      status: report.status,
+      headers: report.rateLimitHeaders,
+      now,
+      previousConsecutive429: previous.consecutive429,
+      previousConsecutive401: previous.consecutive401,
+    });
+    this.writeLimitState(report.credentialId, mergeReportedLimitState(previous, update));
+    if (update.needsReauth) {
+      this.markCredentialStatus(report.credentialId, "needs_reauth");
+    }
+
+    const eventId = crypto.randomUUID();
+    const costMicros = credential?.class === "managed" ? priceUsageMicros(report.model, report.usage) : null;
+    this.sql.exec(
+      `INSERT INTO usage_buffer
+       (event_id, key_id, credential_id, family, endpoint_class, model, credential_class, status,
+        input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, estimated, cost_micros, latency_ms, ts)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      eventId,
+      report.kid,
+      report.credentialId,
+      this.family(),
+      report.endpointClass,
+      report.model ?? null,
+      credential?.class ?? "byok",
+      report.status,
+      report.usage.inputTokens,
+      report.usage.outputTokens,
+      report.usage.cacheReadTokens,
+      report.usage.cacheWriteTokens,
+      report.usage.estimated ? 1 : 0,
+      costMicros,
+      report.latencyMs,
+      now,
+    );
+    if (credential?.class === "managed" && costMicros !== null) {
+      this.putMeta(META_UNFLUSHED_MICROS, String((this.numberMeta(META_UNFLUSHED_MICROS) ?? 0) + costMicros));
+    }
+    await this.setAlarmIfSooner(now + 10_000);
+    return { ok: true };
+  }
+
+  async alarm(): Promise<void> {
+    await this.init();
+    await this.flushUsage();
+    await this.pollUsage();
+    this.pruneAssignments();
+    if (this.hasPendingUsage() || this.hasPendingStatusUpdates() || this.hasActiveOauth()) {
+      await this.ctx.storage.setAlarm(this.nextAlarmTimestamp());
+    }
+  }
+
+  private async buildAcquireSuccess(credential: CredentialRow, request: AcquireRequest): Promise<AcquireResult> {
+    let secret: string | null = null;
+    let accountId: string | undefined;
+    if (credential.class === "managed") {
+      secret = this.managedSecret(request.family);
+    } else if (credential.class === "byok") {
+      secret = credential.encrypted_secret
+        ? await decryptEnvelopeSecret(credential.encrypted_secret, this.env.CODEROUTER_MASTER_KEY)
+        : null;
+    } else {
+      const chain = await this.accessChain(credential.id);
+      if (!chain) return { ok: false, error: "no_credentials" };
+      secret = chain.accessToken;
+      accountId = chain.accountId;
+    }
+    if (!secret) return { ok: false, error: "no_credentials" };
+    const baseAuth: Record<string, string> =
+      request.endpointClass === "anthropic" && credential.class !== "oauth"
+        ? { "x-api-key": secret }
+        : { authorization: `Bearer ${secret}` };
+    const authHeaders: Record<string, string> = { ...baseAuth };
+    if (request.endpointClass === "codex" && accountId) authHeaders["chatgpt-account-id"] = accountId;
+    return {
+      ok: true,
+      credentialId: credential.id,
+      class: credential.class,
+      authHeaders,
+      upstreamBase: request.endpointClass === "anthropic" ? "https://api.anthropic.com" : request.endpointClass === "codex" ? "https://chatgpt.com" : "https://api.openai.com",
+      accountId,
+    };
+  }
+
+  private async accessChain(credentialId: string): Promise<OAuthChain | null> {
+    const chain = this.oauthChain(credentialId);
+    if (!chain) return null;
+    const provider = this.family();
+    if (!tokenExpiresSoon(provider, chain)) return chain;
+    const existing = this.refreshFlights.get(credentialId);
+    if (existing) return existing;
+    const flight = this.refreshChain(credentialId, provider, chain).finally(() => this.refreshFlights.delete(credentialId));
+    this.refreshFlights.set(credentialId, flight);
+    return flight;
+  }
+
+  private async refreshChain(credentialId: string, provider: Family, chain: OAuthChain): Promise<OAuthChain | null> {
+    const refreshed = await refreshOAuthChain(provider, chain);
+    if (!refreshed.ok) {
+      if (refreshed.failure.refreshTokenFailure) {
+        this.markCredentialStatus(credentialId, "needs_reauth");
+        await this.setAlarmIfSooner(Date.now() + 10_000);
+      }
+      return null;
+    }
+    this.sql.exec(
+      `UPDATE oauth_chains SET access_token = ?, refresh_token = ?, id_token = ?, account_id = ?, expires_at = ?
+       WHERE credential_id = ?`,
+      refreshed.chain.accessToken,
+      refreshed.chain.refreshToken,
+      refreshed.chain.idToken ?? null,
+      refreshed.chain.accountId ?? null,
+      refreshed.chain.expiresAt ?? null,
+      credentialId,
+    );
+    await this.ctx.storage.sync();
+    return refreshed.chain;
+  }
+
+  private async flushUsage(): Promise<void> {
+    const poolId = this.stringMeta(META_POOL_ID);
+    if (!poolId || !this.env.CONTROL_PLANE_BASE_URL || !this.env.CODEROUTER_INTERNAL_TOKEN) return;
+    const rows = this.sql.exec("SELECT * FROM usage_buffer ORDER BY ts LIMIT ?", FLUSH_BATCH_SIZE).toArray() as unknown as UsageBufferRow[];
+    const statusRows = this.sql.exec("SELECT * FROM status_updates").toArray() as unknown as StatusUpdateRow[];
+    if (rows.length === 0 && statusRows.length === 0) return;
+    const { body, flushedEstimateMicros } = buildUsageIngest(poolId, rows, statusRows);
+    const response = await fetch(`${this.env.CONTROL_PLANE_BASE_URL}/api/coderouter/internal/usage-ingest`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.env.CODEROUTER_INTERNAL_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      await this.ctx.storage.setAlarm(Date.now() + 60_000);
+      return;
+    }
+    const payload = (await response.json().catch(() => null)) as { balanceMicros?: unknown } | null;
+    const ids = rows.map((row) => String(row.event_id));
+    for (const id of ids) this.sql.exec("DELETE FROM usage_buffer WHERE event_id = ?", id);
+    for (const row of statusRows) this.sql.exec("DELETE FROM status_updates WHERE credential_id = ?", String(row.credential_id));
+    if (typeof payload?.balanceMicros === "number") this.putMeta(META_BALANCE_MICROS, String(payload.balanceMicros));
+    this.putMeta(
+      META_UNFLUSHED_MICROS,
+      String(subtractFlushedEstimateMicros(this.numberMeta(META_UNFLUSHED_MICROS) ?? 0, flushedEstimateMicros)),
+    );
+  }
+
+  private async pollUsage(): Promise<void> {
+    const lastTrafficAt = this.numberMeta(META_LAST_TRAFFIC_AT) ?? 0;
+    const now = Date.now();
+    const oauthRows = this.sql.exec("SELECT id FROM credentials WHERE class = 'oauth' AND status = 'active'").toArray();
+    for (const row of oauthRows) {
+      const credentialId = String(row.id);
+      const currentState = this.limitState(credentialId);
+      if (!shouldPollCredential({ now, lastTrafficAt, lastPolledAt: currentState.lastPolledAt })) continue;
+      const chain = await this.accessChain(credentialId);
+      if (!chain) continue;
+      const provider = this.family();
+      const url =
+        provider === "anthropic"
+          ? "https://api.anthropic.com/api/oauth/usage"
+          : "https://chatgpt.com/backend-api/wham/usage";
+      const headers = new Headers({ authorization: `Bearer ${chain.accessToken}` });
+      if (provider === "anthropic") headers.set("anthropic-beta", "oauth-2025-04-20");
+      if (provider === "openai" && chain.accountId) headers.set("ChatGPT-Account-ID", chain.accountId);
+      const response = await fetch(url, { headers });
+      if (response.status === 401 || response.status === 403) {
+        this.writeLimitState(credentialId, {
+          ...this.limitState(credentialId),
+          windows: zeroHeadroomUsageWindows(provider),
+          lastPolledAt: now,
+        });
+        continue;
+      }
+      if (!response.ok) {
+        this.writeLimitState(credentialId, { ...this.limitState(credentialId), lastPolledAt: now });
+        continue;
+      }
+      const payload = await response.json().catch(() => null);
+      const windows = normalizeUsagePoll(provider, payload, now);
+      this.writeLimitState(credentialId, {
+        ...this.limitState(credentialId),
+        ...(windows.length > 0 ? { windows } : {}),
+        lastPolledAt: now,
+      });
+    }
+  }
+
+  private pruneAssignments(): void {
+    this.sql.exec("DELETE FROM assignments WHERE last_used_at < ?", Date.now() - 7 * 24 * 60 * 60 * 1000);
+  }
+
+  private async ensureConfig(request: AcquireRequest): Promise<boolean> {
+    if (this.stringMeta(META_CONFIG_VERSION)) return true;
+    const poolId = `${this.teamIdFromRequest(request)}:${request.family}`;
+    if (!this.env.CONTROL_PLANE_BASE_URL || !this.env.CODEROUTER_INTERNAL_TOKEN) return false;
+    const url = new URL(`${this.env.CONTROL_PLANE_BASE_URL}/api/coderouter/internal/pool-config`);
+    url.searchParams.set("poolId", poolId);
+    const response = await fetch(url, { headers: { authorization: `Bearer ${this.env.CODEROUTER_INTERNAL_TOKEN}` } }).catch(() => null);
+    if (!response?.ok) return false;
+    const config = await response.json().catch(() => null);
+    if (!config || typeof config !== "object" || Array.isArray(config)) return false;
+    this.writeConfig(config as PoolConfig);
+    return true;
+  }
+
+  private teamIdFromRequest(request: AcquireRequest): string {
+    const existing = this.stringMeta(META_TEAM_ID);
+    if (existing) return existing;
+    return request.teamId ?? "";
+  }
+
+  private writeConfig(config: PoolConfig): void {
+    this.putMeta(META_POOL_ID, config.poolId);
+    this.putMeta(META_TEAM_ID, config.teamId);
+    this.putMeta(META_FAMILY, config.family);
+    this.putMeta(META_CONFIG_VERSION, String(config.configVersion));
+    this.putMeta(META_MANAGED_ENABLED, config.managed.enabled ? "1" : "0");
+    this.putMeta(META_BALANCE_MICROS, String(config.balanceMicros));
+    this.sql.exec("DELETE FROM keys");
+    for (const key of config.keys) {
+      this.sql.exec("INSERT INTO keys (kid, revoked, policy) VALUES (?, ?, ?)", key.kid, key.revoked ? 1 : 0, JSON.stringify(key.policy));
+    }
+    this.sql.exec("DELETE FROM credentials");
+    for (const credential of config.credentials) {
+      this.sql.exec(
+        `INSERT INTO credentials (id, kind, class, status, label, provider_account_id, encrypted_secret)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        credential.id,
+        credential.kind,
+        credential.class,
+        credential.status,
+        credential.label ?? null,
+        credential.providerAccountId ?? null,
+        credential.encryptedSecret ?? null,
+      );
+    }
+  }
+
+  private async init(): Promise<void> {
+    this.initialized ??= Promise.resolve().then(() => {
+      this.sql.exec("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+      this.sql.exec("CREATE TABLE IF NOT EXISTS keys (kid TEXT PRIMARY KEY, revoked INTEGER NOT NULL, policy TEXT NOT NULL)");
+      this.sql.exec(
+        `CREATE TABLE IF NOT EXISTS credentials (
+          id TEXT PRIMARY KEY, kind TEXT NOT NULL, class TEXT NOT NULL, status TEXT NOT NULL,
+          label TEXT, provider_account_id TEXT, encrypted_secret TEXT
+        )`,
+      );
+      this.sql.exec(
+        `CREATE TABLE IF NOT EXISTS oauth_chains (
+          credential_id TEXT PRIMARY KEY, provider TEXT NOT NULL, access_token TEXT NOT NULL,
+          refresh_token TEXT NOT NULL, id_token TEXT, account_id TEXT, expires_at INTEGER
+        )`,
+      );
+      this.sql.exec(
+        "CREATE TABLE IF NOT EXISTS assignments (conversation_key TEXT PRIMARY KEY, credential_id TEXT NOT NULL, last_used_at INTEGER NOT NULL)",
+      );
+      this.sql.exec("CREATE INDEX IF NOT EXISTS assignments_credential_idx ON assignments (credential_id)");
+      this.sql.exec("CREATE TABLE IF NOT EXISTS limit_state (credential_id TEXT PRIMARY KEY, state TEXT NOT NULL)");
+      this.sql.exec("CREATE TABLE IF NOT EXISTS status_updates (credential_id TEXT PRIMARY KEY, status TEXT NOT NULL)");
+      this.sql.exec(
+        `CREATE TABLE IF NOT EXISTS usage_buffer (
+          event_id TEXT PRIMARY KEY, key_id TEXT, credential_id TEXT, family TEXT NOT NULL,
+          endpoint_class TEXT NOT NULL, model TEXT, credential_class TEXT NOT NULL, status INTEGER NOT NULL,
+          input_tokens INTEGER NOT NULL, output_tokens INTEGER NOT NULL, cache_read_tokens INTEGER NOT NULL,
+          cache_write_tokens INTEGER NOT NULL, estimated INTEGER NOT NULL, cost_micros INTEGER, latency_ms INTEGER, ts INTEGER NOT NULL
+        )`,
+      );
+    });
+    await this.initialized;
+  }
+
+  private get sql(): SqlStorage {
+    return (this.ctx.storage as unknown as { sql: SqlStorage }).sql;
+  }
+
+  private credential(id: string): CredentialRow | null {
+    return (this.sql.exec("SELECT * FROM credentials WHERE id = ?", id).one<CredentialRow>() as CredentialRow | null) ?? null;
+  }
+
+  private listCredentials(): CredentialRow[] {
+    return this.sql.exec("SELECT * FROM credentials").toArray() as unknown as CredentialRow[];
+  }
+
+  private assignment(conversationKey: string): string | null {
+    const row = this.sql.exec("SELECT credential_id FROM assignments WHERE conversation_key = ?", conversationKey).one<SqlRow>();
+    return nullableString(row?.credential_id);
+  }
+
+  private assignmentCount(credentialId: string): number {
+    const row = this.sql.exec("SELECT COUNT(*) as count FROM assignments WHERE credential_id = ?", credentialId).one<SqlRow>();
+    return Number(row?.count ?? 0);
+  }
+
+  private credentialHealthy(credentialId: string): boolean {
+    const state = this.limitState(credentialId);
+    const summary = summarizeWindows(state.windows, Date.now(), state.cooldownUntil);
+    return !summary.exhausted && !state.needsReauth;
+  }
+
+  private limitState(credentialId: string): CredentialLimitState {
+    const row = this.sql.exec("SELECT state FROM limit_state WHERE credential_id = ?", credentialId).one<SqlRow>();
+    const parsed = parseJsonRecord(row?.state);
+    return {
+      windows: Array.isArray(parsed.windows) ? (parsed.windows as CredentialLimitState["windows"]) : [],
+      cooldownUntil: typeof parsed.cooldownUntil === "number" ? parsed.cooldownUntil : undefined,
+      consecutive429: typeof parsed.consecutive429 === "number" ? parsed.consecutive429 : 0,
+      consecutive401: typeof parsed.consecutive401 === "number" ? parsed.consecutive401 : 0,
+      needsReauth: parsed.needsReauth === true,
+      lastPolledAt: typeof parsed.lastPolledAt === "number" ? parsed.lastPolledAt : undefined,
+    };
+  }
+
+  private writeLimitState(credentialId: string, state: CredentialLimitState): void {
+    this.sql.exec("INSERT OR REPLACE INTO limit_state (credential_id, state) VALUES (?, ?)", credentialId, JSON.stringify(state));
+  }
+
+  private oauthChain(credentialId: string): OAuthChain | null {
+    const row = this.sql.exec("SELECT * FROM oauth_chains WHERE credential_id = ?", credentialId).one<SqlRow>();
+    if (!row) return null;
+    return {
+      accessToken: String(row.access_token),
+      refreshToken: String(row.refresh_token),
+      idToken: nullableString(row.id_token) ?? undefined,
+      accountId: nullableString(row.account_id) ?? undefined,
+      expiresAt: row.expires_at === null || row.expires_at === undefined ? undefined : Number(row.expires_at),
+    };
+  }
+
+  private hasPendingUsage(): boolean {
+    const row = this.sql.exec("SELECT COUNT(*) as count FROM usage_buffer").one<SqlRow>();
+    return Number(row?.count ?? 0) > 0;
+  }
+
+  private hasPendingStatusUpdates(): boolean {
+    const row = this.sql.exec("SELECT COUNT(*) as count FROM status_updates").one<SqlRow>();
+    return Number(row?.count ?? 0) > 0;
+  }
+
+  private hasActiveOauth(): boolean {
+    const row = this.sql.exec("SELECT COUNT(*) as count FROM credentials WHERE class = 'oauth' AND status = 'active'").one<SqlRow>();
+    return Number(row?.count ?? 0) > 0;
+  }
+
+  private nextAlarmTimestamp(): number {
+    const now = Date.now();
+    if (this.hasPendingUsage() || this.hasPendingStatusUpdates()) return now + 60_000;
+    const lastTrafficAt = this.numberMeta(META_LAST_TRAFFIC_AT) ?? 0;
+    const oauthRows = this.sql.exec("SELECT id FROM credentials WHERE class = 'oauth' AND status = 'active'").toArray();
+    let next: number | null = null;
+    for (const row of oauthRows) {
+      const credentialId = String(row.id);
+      const candidate = nextUsagePollAt({
+        now,
+        lastTrafficAt,
+        lastPolledAt: this.limitState(credentialId).lastPolledAt,
+      });
+      next = next === null ? candidate : Math.min(next, candidate);
+    }
+    return Math.max(now, next ?? now + 60_000);
+  }
+
+  private stringMeta(key: string): string | null {
+    const row = this.sql.exec("SELECT value FROM meta WHERE key = ?", key).one<SqlRow>();
+    return nullableString(row?.value);
+  }
+
+  private numberMeta(key: string): number | null {
+    const value = this.stringMeta(key);
+    if (value === null) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  private booleanMeta(key: string): boolean {
+    return this.stringMeta(key) === "1";
+  }
+
+  private putMeta(key: string, value: string): void {
+    this.sql.exec("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)", key, value);
+  }
+
+  private family(): Family {
+    return this.stringMeta(META_FAMILY) === "anthropic" ? "anthropic" : "openai";
+  }
+
+  private managedSecret(family: Family): string | null {
+    return family === "anthropic" ? (this.env.MANAGED_ANTHROPIC_API_KEY ?? null) : (this.env.MANAGED_OPENAI_API_KEY ?? null);
+  }
+
+  private touchAssignment(conversationKey: string, credentialId: string): void {
+    this.sql.exec(
+      `INSERT INTO assignments (conversation_key, credential_id, last_used_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(conversation_key) DO UPDATE SET credential_id = excluded.credential_id, last_used_at = excluded.last_used_at`,
+      conversationKey,
+      credentialId,
+      Date.now(),
+    );
+  }
+
+  private markCredentialStatus(credentialId: string, status: "active" | "needs_reauth"): void {
+    this.sql.exec("UPDATE credentials SET status = ? WHERE id = ?", status, credentialId);
+    this.sql.exec("INSERT OR REPLACE INTO status_updates (credential_id, status) VALUES (?, ?)", credentialId, status);
+  }
+
+  private async setAlarmIfSooner(timestamp: number): Promise<void> {
+    const pending = await this.ctx.storage.getAlarm();
+    if (pending === null || pending > timestamp) await this.ctx.storage.setAlarm(timestamp);
+  }
+
+  private async armOauthPollIfNeeded(): Promise<void> {
+    if (this.hasActiveOauth()) await this.setAlarmIfSooner(Date.now() + 5000);
+  }
+
+  private managedFailure(credential: CredentialRow, request: AcquireRequest): AcquireResult | null {
+    return managedAcquireFailure({
+      credentialClass: credential.class,
+      model: request.model,
+      balanceMicros: this.numberMeta(META_BALANCE_MICROS) ?? 0,
+      unflushedEstimateMicros: this.numberMeta(META_UNFLUSHED_MICROS) ?? 0,
+    });
+  }
+}
+
+function parseJsonRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "string") return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function isCredentialClass(value: unknown): value is CredentialClass {
+  return value === "oauth" || value === "byok" || value === "managed";
+}
+
+function soonestReset(candidates: SelectCandidate[]): number | undefined {
+  let reset: number | undefined;
+  const now = Date.now();
+  for (const candidate of candidates) {
+    const summary = summarizeWindows(candidate.limitState.windows, now, candidate.limitState.cooldownUntil);
+    if (summary.soonestResetSeconds === undefined) continue;
+    reset = reset === undefined ? summary.soonestResetSeconds : Math.min(reset, summary.soonestResetSeconds);
+  }
+  return reset;
+}

--- a/workers/coderouter/src/families.ts
+++ b/workers/coderouter/src/families.ts
@@ -1,0 +1,166 @@
+import type { CredentialClass, EndpointClass, Family } from "./types";
+
+export const MAX_BUFFERED_BODY_BYTES = 20 * 1024 * 1024;
+
+export interface RouteMatch {
+  family: Family;
+  endpointClass: EndpointClass;
+  upstreamBase: string;
+  upstreamPath: string;
+}
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+export function matchRoute(url: URL): RouteMatch | null {
+  if (url.pathname.startsWith("/anthropic/") || url.pathname === "/anthropic") {
+    return {
+      family: "anthropic",
+      endpointClass: "anthropic",
+      upstreamBase: "https://api.anthropic.com",
+      upstreamPath: stripPrefix(url.pathname, "/anthropic") || "/",
+    };
+  }
+  if (url.pathname.startsWith("/openai/v1/") || url.pathname === "/openai/v1") {
+    return {
+      family: "openai",
+      endpointClass: "openai_api",
+      upstreamBase: "https://api.openai.com",
+      upstreamPath: `/v1${stripPrefix(url.pathname, "/openai/v1") || ""}`,
+    };
+  }
+  if (url.pathname.startsWith("/codex/") || url.pathname === "/codex") {
+    return {
+      family: "openai",
+      endpointClass: "codex",
+      upstreamBase: "https://chatgpt.com",
+      upstreamPath: `/backend-api/codex${stripPrefix(url.pathname, "/codex") || ""}`,
+    };
+  }
+  return null;
+}
+
+function stripPrefix(pathname: string, prefix: string): string {
+  const stripped = pathname.slice(prefix.length);
+  return stripped.startsWith("/") ? stripped : `/${stripped}`;
+}
+
+export function buildUpstreamUrl(route: RouteMatch, inputUrl: URL): string {
+  const url = new URL(route.upstreamBase);
+  url.pathname = route.upstreamPath;
+  url.search = inputUrl.search;
+  return url.toString();
+}
+
+export function sanitizeRequestHeaders(headers: Headers): Headers {
+  const sanitized = new Headers();
+  for (const [name, value] of headers) {
+    const lower = name.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lower)) continue;
+    if (lower === "host" || lower === "authorization" || lower === "x-api-key") continue;
+    if (lower === "chatgpt-account-id") continue;
+    if (lower.startsWith("x-coderouter-")) continue;
+    sanitized.set(name, value);
+  }
+  return sanitized;
+}
+
+export function sanitizeResponseHeaders(headers: Headers): Headers {
+  const sanitized = new Headers();
+  for (const [name, value] of headers) {
+    const lower = name.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lower)) continue;
+    sanitized.set(name, value);
+  }
+  return sanitized;
+}
+
+export function injectCredentialHeaders(
+  endpointClass: EndpointClass,
+  credentialClass: CredentialClass,
+  headers: Headers,
+  authHeaders: Record<string, string>,
+): Headers {
+  const next = sanitizeRequestHeaders(headers);
+  if (endpointClass === "anthropic") {
+    if (credentialClass === "oauth") {
+      next.set("authorization", authHeaders.authorization ?? authHeaders.Authorization ?? "");
+      mergeAnthropicBeta(next, "oauth-2025-04-20");
+    } else {
+      next.set("x-api-key", authHeaders["x-api-key"] ?? authHeaders["X-Api-Key"] ?? "");
+      removeAnthropicBeta(next, "oauth-2025-04-20");
+      next.delete("authorization");
+    }
+    return next;
+  }
+  if (endpointClass === "openai_api") {
+    next.set("authorization", authHeaders.authorization ?? authHeaders.Authorization ?? "");
+    return next;
+  }
+  next.set("authorization", authHeaders.authorization ?? authHeaders.Authorization ?? "");
+  const accountId = authHeaders["chatgpt-account-id"] ?? authHeaders["ChatGPT-Account-ID"];
+  if (accountId) next.set("ChatGPT-Account-ID", accountId);
+  return next;
+}
+
+export function mergeAnthropicBeta(headers: Headers, value: string): void {
+  const parts = parseCommaHeader(headers.get("anthropic-beta"));
+  if (!parts.includes(value)) parts.push(value);
+  if (parts.length > 0) headers.set("anthropic-beta", parts.join(","));
+}
+
+export function removeAnthropicBeta(headers: Headers, value: string): void {
+  const parts = parseCommaHeader(headers.get("anthropic-beta")).filter((part) => part !== value);
+  if (parts.length > 0) headers.set("anthropic-beta", parts.join(","));
+  else headers.delete("anthropic-beta");
+}
+
+function parseCommaHeader(value: string | null): string[] {
+  if (!value) return [];
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const raw of value.split(",")) {
+    const part = raw.trim();
+    if (!part || seen.has(part)) continue;
+    seen.add(part);
+    parts.push(part);
+  }
+  return parts;
+}
+
+export function isUsageLimitResponse(
+  endpointClass: EndpointClass,
+  credentialClass: CredentialClass,
+  status: number,
+  contentType: string | null,
+  bodyText: string | null,
+): boolean {
+  if (status === 429) return true;
+  if (endpointClass === "anthropic" && credentialClass === "oauth" && status === 401) return true;
+  if (endpointClass !== "codex" || status < 400 || !contentType?.toLowerCase().includes("json") || !bodyText) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(bodyText) as { error?: { type?: unknown; code?: unknown; message?: unknown } };
+    const error = parsed.error ?? {};
+    const typeOrCode = [error.type, error.code].filter((value): value is string => typeof value === "string");
+    if (typeOrCode.some((value) => value === "usage_limit_reached" || value === "rate_limit_exceeded")) return true;
+    return typeof error.message === "string" && error.message.toLowerCase().includes("usage limit");
+  } catch {
+    return false;
+  }
+}
+
+export function allowedClassesForEndpoint(endpointClass: EndpointClass): CredentialClass[] {
+  if (endpointClass === "codex") return ["oauth"];
+  if (endpointClass === "openai_api") return ["byok", "managed"];
+  return ["oauth", "byok", "managed"];
+}

--- a/workers/coderouter/src/index.ts
+++ b/workers/coderouter/src/index.ts
@@ -1,0 +1,245 @@
+import { PoolCoordinator } from "./do";
+import {
+  buildUpstreamUrl,
+  injectCredentialHeaders,
+  isUsageLimitResponse,
+  matchRoute,
+  MAX_BUFFERED_BODY_BYTES,
+  sanitizeResponseHeaders,
+} from "./families";
+import { extractCallerKey, verifyCallerKey } from "./keys";
+import { PRICING_CATALOG } from "./pricing";
+import { bodyWithinReplayLimit } from "./requestBody";
+import { extractConversationKey } from "./sessionKey";
+import { drainSseUsage, parseJsonUsage, ZERO_ESTIMATED_USAGE } from "./sse";
+import { verifyInternalRequest } from "./internalAuth";
+import type { Env } from "./do";
+import type { AcquireSuccess, ReportRequest, SeedOauth, Usage } from "./types";
+
+export { PoolCoordinator };
+
+function json(body: unknown, status = 200, headers?: HeadersInit): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/healthz") return json({ ok: true, service: "cmux-coderouter" });
+    if (url.pathname === "/v1/models" && request.method === "GET") return json({ data: Object.keys(PRICING_CATALOG).sort() });
+
+    if (url.pathname.startsWith("/internal/")) return handleInternal(request, env, url);
+
+    const route = matchRoute(url);
+    if (!route) return json({ error: "not_found" }, 404);
+
+    const callerKey = extractCallerKey(request.headers);
+    if (!callerKey) return json({ error: "unauthorized" }, 401);
+    const caller = await verifyCallerKey(callerKey, env.CODEROUTER_KEY_SIGNING_SECRET);
+    if (!caller) return json({ error: "unauthorized" }, 401);
+
+    const rawBody = await readRawBody(request);
+    const parsedJson = parseJsonBody(request.headers, rawBody);
+    const model = extractModel(parsedJson);
+    const conversationKey = await extractConversationKey({
+      endpointClass: route.endpointClass,
+      family: route.family,
+      headers: request.headers,
+      url,
+      parsedJson,
+      ip: request.headers.get("cf-connecting-ip"),
+    });
+
+    const pool = env.POOL.get(env.POOL.idFromName(`${caller.team}:${route.family}`)) as DurableObjectStub<PoolCoordinator>;
+    const excludeCredentialIds: string[] = [];
+    let lastResponse: Response | null = null;
+    const attempts = bodyWithinReplayLimit(rawBody?.byteLength ?? null) ? 3 : 1;
+
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      const acquired = await pool.acquire({
+        kid: caller.kid,
+        teamId: caller.team,
+        family: route.family,
+        endpointClass: route.endpointClass,
+        conversationKey,
+        model,
+        excludeCredentialIds,
+      });
+      if (!acquired.ok) return mapAcquireError(acquired);
+
+      const startedAt = Date.now();
+      const upstreamHeaders = injectCredentialHeaders(route.endpointClass, acquired.class, request.headers, acquired.authHeaders);
+      const upstreamResponse = await fetch(buildUpstreamUrl(route, url), {
+        method: request.method,
+        headers: upstreamHeaders,
+        body: rawBody && request.method !== "GET" && request.method !== "HEAD" ? rawBody.slice(0) : undefined,
+        redirect: "manual",
+      });
+      const latencyMs = Date.now() - startedAt;
+      const sniffText = await sniffErrorBody(upstreamResponse);
+      const usageLimited = isUsageLimitResponse(
+        route.endpointClass,
+        acquired.class,
+        upstreamResponse.status,
+        upstreamResponse.headers.get("content-type"),
+        sniffText,
+      );
+      if (usageLimited && attempt < attempts - 1) {
+        ctx.waitUntil(report(pool, acquired, caller.kid, conversationKey, route.endpointClass, model, upstreamResponse, latencyMs, ZERO_ESTIMATED_USAGE, true));
+        excludeCredentialIds.push(acquired.credentialId);
+        void upstreamResponse.body?.cancel().catch(() => {});
+        lastResponse = upstreamResponse;
+        continue;
+      }
+      return passThroughWithReport(
+        upstreamResponse,
+        pool,
+        acquired,
+        caller.kid,
+        conversationKey,
+        route.endpointClass,
+        model,
+        latencyMs,
+        usageLimited,
+        ctx,
+      );
+    }
+
+    return lastResponse ?? json({ error: "no_response" }, 502);
+  },
+} satisfies ExportedHandler<Env>;
+
+async function handleInternal(request: Request, env: Env, url: URL): Promise<Response> {
+  if (!verifyInternalRequest(request, env.CODEROUTER_INTERNAL_TOKEN)) return json({ error: "unauthorized" }, 401);
+  const syncMatch = /^\/internal\/pools\/([^/]+)\/sync$/.exec(url.pathname);
+  const seedMatch = /^\/internal\/pools\/([^/]+)\/seed-oauth$/.exec(url.pathname);
+  if (!syncMatch && !seedMatch) return json({ error: "not_found" }, 404);
+  if (request.method !== "POST") return json({ error: "method_not_allowed" }, 405);
+  const poolId = decodeURIComponent((syncMatch?.[1] ?? seedMatch?.[1]) as string);
+  const pool = env.POOL.get(env.POOL.idFromName(poolId)) as DurableObjectStub<PoolCoordinator>;
+  const body = (await request.json().catch(() => null)) as unknown;
+  if (!body || typeof body !== "object") return json({ error: "invalid_request" }, 400);
+  if (syncMatch) return json(await pool.syncConfig(body as Parameters<PoolCoordinator["syncConfig"]>[0]));
+  return json(await pool.seedOauth(body as SeedOauth));
+}
+
+async function passThroughWithReport(
+  response: Response,
+  pool: DurableObjectStub<PoolCoordinator>,
+  acquired: AcquireSuccess,
+  kid: string,
+  conversationKey: string,
+  endpointClass: ReportRequest["endpointClass"],
+  model: string | undefined,
+  latencyMs: number,
+  usageLimited: boolean,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const headers = sanitizeResponseHeaders(response.headers);
+  headers.set("x-coderouter-credential", acquired.class);
+  const contentType = response.headers.get("content-type") ?? "";
+  if (response.body && contentType.toLowerCase().includes("text/event-stream")) {
+    const [clientBody, reportBody] = response.body.tee();
+    ctx.waitUntil(
+      drainSseUsage(endpointClass, reportBody).then((usage) =>
+        report(pool, acquired, kid, conversationKey, endpointClass, model, response, latencyMs, usage, usageLimited),
+      ),
+    );
+    return new Response(clientBody, { status: response.status, statusText: response.statusText, headers });
+  }
+  if (contentType.toLowerCase().includes("json")) {
+    const clone = response.clone();
+    ctx.waitUntil(
+      clone
+        .json()
+        .then((payload) => parseJsonUsage(endpointClass, payload))
+        .catch(() => ({ ...ZERO_ESTIMATED_USAGE }))
+        .then((usage) => report(pool, acquired, kid, conversationKey, endpointClass, model, response, latencyMs, usage, usageLimited)),
+    );
+  } else {
+    ctx.waitUntil(report(pool, acquired, kid, conversationKey, endpointClass, model, response, latencyMs, ZERO_ESTIMATED_USAGE, usageLimited));
+  }
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+async function report(
+  pool: DurableObjectStub<PoolCoordinator>,
+  acquired: AcquireSuccess,
+  kid: string,
+  conversationKey: string,
+  endpointClass: ReportRequest["endpointClass"],
+  model: string | undefined,
+  response: Response,
+  latencyMs: number,
+  usage: Usage,
+  usageLimited: boolean,
+): Promise<void> {
+  await pool.report({
+    credentialId: acquired.credentialId,
+    kid,
+    conversationKey,
+    endpointClass,
+    model,
+    status: response.status,
+    latencyMs,
+    usage,
+    rateLimitHeaders: headersRecord(response.headers),
+    usageLimited,
+  });
+}
+
+function mapAcquireError(error: Exclude<Awaited<ReturnType<PoolCoordinator["acquire"]>>, { ok: true }>): Response {
+  if (error.error === "key_revoked") return json({ error: "key_revoked" }, 401);
+  if (error.error === "config_unavailable") return json({ error: "config_unavailable" }, 503, { "retry-after": "5" });
+  if (error.error === "no_credentials") return json({ error: "no_credentials", message: "No usable credential is configured." }, 403);
+  if (error.error === "all_exhausted") {
+    return json(
+      { error: "all_exhausted", message: "All matching credentials are temporarily limited." },
+      429,
+      error.soonestResetSeconds ? { "retry-after": String(error.soonestResetSeconds) } : undefined,
+    );
+  }
+  if (error.error === "insufficient_credits") return json({ error: "insufficient_credits" }, 402);
+  return json({ error: "model_not_priced" }, 400);
+}
+
+async function readRawBody(request: Request): Promise<ArrayBuffer | null> {
+  if (request.method === "GET" || request.method === "HEAD") return null;
+  return await request.arrayBuffer();
+}
+
+function parseJsonBody(headers: Headers, rawBody: ArrayBuffer | null): unknown | undefined {
+  if (!rawBody || rawBody.byteLength > MAX_BUFFERED_BODY_BYTES) return undefined;
+  const contentType = headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.includes("json")) return undefined;
+  try {
+    return JSON.parse(new TextDecoder().decode(rawBody));
+  } catch {
+    return undefined;
+  }
+}
+
+function extractModel(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+  const model = (payload as Record<string, unknown>).model;
+  return typeof model === "string" ? model : undefined;
+}
+
+async function sniffErrorBody(response: Response): Promise<string | null> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (response.status < 400 || !contentType.toLowerCase().includes("json")) return null;
+  return await response
+    .clone()
+    .text()
+    .catch(() => null);
+}
+
+function headersRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const [key, value] of headers) record[key] = value;
+  return record;
+}

--- a/workers/coderouter/src/internalAuth.ts
+++ b/workers/coderouter/src/internalAuth.ts
@@ -1,0 +1,25 @@
+const encoder = new TextEncoder();
+
+export function timingSafeEqualString(a: string, b: string): boolean {
+  const left = encoder.encode(a);
+  const right = encoder.encode(b);
+  const length = Math.max(left.length, right.length);
+  let diff = left.length ^ right.length;
+  for (let i = 0; i < length; i += 1) {
+    diff |= (left[i] ?? 0) ^ (right[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+export function bearerToken(headers: Headers): string | null {
+  const value = headers.get("authorization");
+  if (!value) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(value.trim());
+  return match?.[1] ?? null;
+}
+
+export function verifyInternalRequest(request: Request, expectedToken: string): boolean {
+  const token = bearerToken(request.headers);
+  if (!token) return false;
+  return timingSafeEqualString(token, expectedToken);
+}

--- a/workers/coderouter/src/keys.ts
+++ b/workers/coderouter/src/keys.ts
@@ -1,0 +1,105 @@
+import { timingSafeEqualString } from "./internalAuth";
+import type { VerifiedCallerKey } from "./types";
+
+const encoder = new TextEncoder();
+const keyCache = new Map<string, Promise<CryptoKey>>();
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(value: string): Uint8Array | null {
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+  try {
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  const cached = keyCache.get(secret);
+  if (cached) return cached;
+  const promise = crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  keyCache.set(secret, promise);
+  return promise;
+}
+
+async function sign(input: string, secret: string): Promise<string> {
+  const key = await hmacKey(secret);
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(input));
+  return toBase64Url(new Uint8Array(signature));
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(input));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function extractCallerKey(headers: Headers): string | null {
+  const authorization = headers.get("authorization");
+  if (authorization) {
+    const match = /^Bearer\s+(crk_[^\s]+)$/i.exec(authorization.trim());
+    if (match?.[1]) return match[1];
+  }
+  const apiKey = headers.get("x-api-key")?.trim();
+  return apiKey?.startsWith("crk_") ? apiKey : null;
+}
+
+export async function mintCallerKeyForTests(
+  payload: VerifiedCallerKey,
+  secret: string,
+): Promise<string> {
+  const payloadBytes = encoder.encode(JSON.stringify(payload));
+  const payloadPart = toBase64Url(payloadBytes);
+  const signed = `crk_${payloadPart}`;
+  const signature = await sign(signed, secret);
+  return `${signed}.${signature}`;
+}
+
+export async function verifyCallerKey(key: string, secret: string): Promise<VerifiedCallerKey | null> {
+  if (!key.startsWith("crk_")) return null;
+  const dot = key.indexOf(".");
+  if (dot < 0) return null;
+  const payloadPart = key.slice(4, dot);
+  const signature = key.slice(dot + 1);
+  if (!payloadPart || !signature) return null;
+  const signed = key.slice(0, dot);
+  const expected = await sign(signed, secret);
+  if (!timingSafeEqualString(signature, expected)) return null;
+  const payloadBytes = fromBase64Url(payloadPart);
+  if (!payloadBytes) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(payloadBytes));
+  } catch {
+    return null;
+  }
+  if (!isCallerPayload(parsed)) return null;
+  return parsed;
+}
+
+function isCallerPayload(value: unknown): value is VerifiedCallerKey {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    record.v === 1 &&
+    typeof record.kid === "string" &&
+    record.kid.length > 0 &&
+    typeof record.team === "string" &&
+    record.team.length > 0 &&
+    typeof record.iat === "number" &&
+    Number.isFinite(record.iat)
+  );
+}

--- a/workers/coderouter/src/limits.ts
+++ b/workers/coderouter/src/limits.ts
@@ -1,0 +1,164 @@
+import type { CredentialClass, CredentialLimitState, EndpointClass, Family, LimitWindow } from "./types";
+
+export interface ParsedLimitUpdate {
+  windows: LimitWindow[];
+  cooldownUntil?: number;
+  consecutive429: number;
+  consecutive401: number;
+  needsReauth: boolean;
+}
+
+export function headroom(windows: LimitWindow[]): number {
+  if (windows.length === 0) return 1;
+  return Math.min(...windows.map((window) => Math.max(0, 1 - window.usedPercent / 100)));
+}
+
+export function parseRetryAfterSeconds(value: string | null): number | null {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds;
+  const date = Date.parse(value);
+  if (Number.isFinite(date)) return Math.max(0, Math.ceil((date - Date.now()) / 1000));
+  return null;
+}
+
+export function cooldownAfter429(now: number, retryAfterHeader: string | null, previousConsecutive429 = 0): {
+  cooldownUntil: number;
+  consecutive429: number;
+} {
+  const retryAfter = parseRetryAfterSeconds(retryAfterHeader);
+  const consecutive429 = previousConsecutive429 + 1;
+  const backoff = Math.min(900, 60 * 2 ** Math.max(0, consecutive429 - 1));
+  const seconds = retryAfter ?? backoff;
+  return { cooldownUntil: now + seconds * 1000, consecutive429 };
+}
+
+export function applyLimitHeaders(input: {
+  family: Family;
+  endpointClass: EndpointClass;
+  credentialClass: CredentialClass;
+  status: number;
+  headers: Record<string, string>;
+  now: number;
+  previousConsecutive429?: number;
+  previousConsecutive401?: number;
+}): ParsedLimitUpdate {
+  const headers = lowerRecord(input.headers);
+  const windows = input.credentialClass === "oauth" ? [] : parseWindows(input.family, headers, input.now);
+  let cooldownUntil: number | undefined;
+  let consecutive429 = input.status === 429 ? (input.previousConsecutive429 ?? 0) : 0;
+  let consecutive401 = input.status === 401 ? (input.previousConsecutive401 ?? 0) + 1 : 0;
+  let needsReauth = false;
+  if (input.status === 429) {
+    const cooldown = cooldownAfter429(input.now, headers["retry-after"] ?? null, input.previousConsecutive429 ?? 0);
+    cooldownUntil = cooldown.cooldownUntil;
+    consecutive429 = cooldown.consecutive429;
+  }
+  if (input.status === 401 && input.credentialClass === "oauth") {
+    cooldownUntil = input.now + 5 * 60 * 1000;
+    needsReauth = consecutive401 >= 2;
+  }
+  return { windows, cooldownUntil, consecutive429, consecutive401, needsReauth };
+}
+
+export function mergeReportedLimitState(
+  previous: CredentialLimitState,
+  update: ParsedLimitUpdate,
+): CredentialLimitState {
+  return {
+    ...previous,
+    windows: update.windows.length > 0 ? update.windows : previous.windows,
+    cooldownUntil: update.cooldownUntil ?? previous.cooldownUntil,
+    consecutive429: update.consecutive429,
+    consecutive401: update.consecutive401,
+    needsReauth: update.needsReauth || previous.needsReauth,
+  };
+}
+
+export function parseWindows(family: Family, headers: Record<string, string>, now: number): LimitWindow[] {
+  return family === "anthropic" ? parseAnthropicWindows(headers, now) : parseOpenAiWindows(headers);
+}
+
+function parseAnthropicWindows(headers: Record<string, string>, now: number): LimitWindow[] {
+  const windows: LimitWindow[] = [];
+  const names = new Set<string>();
+  for (const key of Object.keys(headers)) {
+    const match = /^anthropic-ratelimit-(.+)-remaining$/.exec(key);
+    if (match?.[1]) names.add(match[1]);
+  }
+  for (const name of names) {
+    const remaining = numberHeader(headers[`anthropic-ratelimit-${name}-remaining`]);
+    const limit = numberHeader(headers[`anthropic-ratelimit-${name}-limit`]);
+    if (remaining === null || limit === null || limit <= 0) continue;
+    const reset = headers[`anthropic-ratelimit-${name}-reset`];
+    windows.push({
+      name,
+      usedPercent: clampPercent((1 - remaining / limit) * 100),
+      limitWindowSeconds: guessWindowSeconds(name),
+      resetAfterSeconds: parseResetSeconds(reset, now),
+    });
+  }
+  return windows;
+}
+
+function parseOpenAiWindows(headers: Record<string, string>): LimitWindow[] {
+  const windows: LimitWindow[] = [];
+  for (const name of ["requests", "tokens"]) {
+    const remaining = numberHeader(headers[`x-ratelimit-remaining-${name}`]);
+    const limit = numberHeader(headers[`x-ratelimit-limit-${name}`]);
+    if (remaining === null || limit === null || limit <= 0) continue;
+    windows.push({
+      name,
+      usedPercent: clampPercent((1 - remaining / limit) * 100),
+      limitWindowSeconds: parseDurationSeconds(headers[`x-ratelimit-reset-${name}`]) ?? 60,
+      resetAfterSeconds: parseDurationSeconds(headers[`x-ratelimit-reset-${name}`]) ?? 60,
+    });
+  }
+  return windows;
+}
+
+function lowerRecord(headers: Record<string, string>): Record<string, string> {
+  const lowered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) lowered[key.toLowerCase()] = value;
+  return lowered;
+}
+
+function numberHeader(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}
+
+function parseResetSeconds(value: string | undefined, now: number): number {
+  if (!value) return 0;
+  const seconds = parseDurationSeconds(value);
+  if (seconds !== null) return seconds;
+  const date = Date.parse(value);
+  return Number.isFinite(date) ? Math.max(0, Math.ceil((date - now) / 1000)) : 0;
+}
+
+function parseDurationSeconds(value: string | undefined): number | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  const numeric = Number(trimmed);
+  if (Number.isFinite(numeric)) return numeric;
+  const match = /^(\d+(?:\.\d+)?)(ms|s|m|h)?$/.exec(trimmed);
+  if (!match?.[1]) return null;
+  const amount = Number(match[1]);
+  const unit = match[2] ?? "s";
+  if (unit === "ms") return Math.ceil(amount / 1000);
+  if (unit === "m") return Math.ceil(amount * 60);
+  if (unit === "h") return Math.ceil(amount * 3600);
+  return Math.ceil(amount);
+}
+
+function guessWindowSeconds(name: string): number {
+  if (name.includes("day")) return 7 * 24 * 60 * 60;
+  if (name.includes("hour")) return 60 * 60;
+  if (name.includes("minute")) return 60;
+  return 60;
+}

--- a/workers/coderouter/src/oauthRefresh.ts
+++ b/workers/coderouter/src/oauthRefresh.ts
@@ -1,0 +1,140 @@
+import type { Family } from "./types";
+
+export interface OAuthChain {
+  accessToken: string;
+  refreshToken: string;
+  idToken?: string;
+  accountId?: string;
+  expiresAt?: number;
+}
+
+export interface RefreshResult extends OAuthChain {
+  provider: Family;
+}
+
+export interface RefreshFailure {
+  error: string;
+  refreshTokenFailure: boolean;
+}
+
+export type FetchLike = (input: Request | string | URL, init?: RequestInit) => Promise<Response>;
+
+export function buildRefreshRequest(provider: Family, refreshToken: string): Request {
+  if (provider === "openai") {
+    return new Request("https://auth.openai.com/oauth/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+      }),
+    });
+  }
+  return new Request("https://platform.claude.com/v1/oauth/token", {
+    method: "POST",
+    headers: { "content-type": "application/json", "anthropic-beta": "oauth-2025-04-20" },
+    body: JSON.stringify({
+      client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+}
+
+export async function refreshOAuthChain(
+  provider: Family,
+  chain: OAuthChain,
+  fetcher: FetchLike = fetch,
+  now = Date.now(),
+): Promise<{ ok: true; chain: RefreshResult } | { ok: false; failure: RefreshFailure }> {
+  const request = buildRefreshRequest(provider, chain.refreshToken);
+  const response = await fetcher(request);
+  const text = await response.text();
+  let payload: unknown = null;
+  try {
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    payload = null;
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      failure: {
+        error: "refresh_failed",
+        refreshTokenFailure: response.status === 400 || response.status === 401 ? mentionsRefreshToken(text) : false,
+      },
+    };
+  }
+  const parsed = provider === "openai" ? parseOpenAiRefresh(payload, chain) : parseAnthropicRefresh(payload, chain, now);
+  if (!parsed.ok) return { ok: false, failure: { error: parsed.error, refreshTokenFailure: false } };
+  return { ok: true, chain: { provider, ...parsed.chain } };
+}
+
+export function tokenExpiresSoon(provider: Family, chain: OAuthChain, now = Date.now()): boolean {
+  const expiresAt = provider === "openai" ? jwtExpiryMs(chain.accessToken) : chain.expiresAt;
+  if (typeof expiresAt !== "number") return true;
+  return expiresAt - now <= 60_000;
+}
+
+function parseOpenAiRefresh(
+  payload: unknown,
+  previous: OAuthChain,
+): { ok: true; chain: OAuthChain } | { ok: false; error: string } {
+  const record = asRecord(payload);
+  const accessToken = stringValue(record?.access_token);
+  const refreshToken = stringValue(record?.refresh_token);
+  const idToken = stringValue(record?.id_token);
+  if (!accessToken || !refreshToken || !idToken) return { ok: false, error: "invalid_refresh_response" };
+  return {
+    ok: true,
+    chain: { ...previous, accessToken, refreshToken, idToken, expiresAt: jwtExpiryMs(accessToken) ?? previous.expiresAt },
+  };
+}
+
+function parseAnthropicRefresh(
+  payload: unknown,
+  previous: OAuthChain,
+  now: number,
+): { ok: true; chain: OAuthChain } | { ok: false; error: string } {
+  const record = asRecord(payload);
+  const accessToken = stringValue(record?.access_token);
+  const expiresIn = numberValue(record?.expires_in);
+  if (!accessToken || expiresIn === null) return { ok: false, error: "invalid_refresh_response" };
+  return {
+    ok: true,
+    chain: {
+      ...previous,
+      accessToken,
+      refreshToken: stringValue(record?.refresh_token) ?? previous.refreshToken,
+      expiresAt: now + expiresIn * 1000,
+    },
+  };
+}
+
+function jwtExpiryMs(token: string): number | null {
+  const [, payload] = token.split(".");
+  if (!payload) return null;
+  try {
+    const json = JSON.parse(atob(payload.replaceAll("-", "+").replaceAll("_", "/")));
+    return typeof json.exp === "number" ? json.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+function mentionsRefreshToken(text: string): boolean {
+  return /refresh[_ -]?token|invalid_grant/i.test(text);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/workers/coderouter/src/pricing.ts
+++ b/workers/coderouter/src/pricing.ts
@@ -1,0 +1,59 @@
+import type { Family, Usage } from "./types";
+
+export const CATALOG_AS_OF = "2026-07-05";
+
+export interface PriceEntry {
+  family: Family;
+  inputPer1M: number;
+  outputPer1M: number;
+  cacheReadPer1M: number;
+  cacheWritePer1M: number;
+}
+
+// Duplicated for worker-local pricing; the web-side counterpart owns billing re-price.
+// Sources checked 2026-07-05: https://www.anthropic.com/pricing and https://openai.com/api/pricing/
+export const PRICING_CATALOG: Record<string, PriceEntry> = {
+  "claude-opus-4": { family: "anthropic", inputPer1M: 15_000_000, outputPer1M: 75_000_000, cacheReadPer1M: 1_500_000, cacheWritePer1M: 18_750_000 },
+  "claude-opus-4-1": { family: "anthropic", inputPer1M: 15_000_000, outputPer1M: 75_000_000, cacheReadPer1M: 1_500_000, cacheWritePer1M: 18_750_000 },
+  "claude-sonnet-4": { family: "anthropic", inputPer1M: 3_000_000, outputPer1M: 15_000_000, cacheReadPer1M: 300_000, cacheWritePer1M: 3_750_000 },
+  "claude-sonnet-4-5": { family: "anthropic", inputPer1M: 3_000_000, outputPer1M: 15_000_000, cacheReadPer1M: 300_000, cacheWritePer1M: 3_750_000 },
+  "claude-haiku-4-5": { family: "anthropic", inputPer1M: 1_000_000, outputPer1M: 5_000_000, cacheReadPer1M: 100_000, cacheWritePer1M: 1_250_000 },
+  "gpt-5": { family: "openai", inputPer1M: 1_250_000, outputPer1M: 10_000_000, cacheReadPer1M: 125_000, cacheWritePer1M: 0 },
+  "gpt-5-mini": { family: "openai", inputPer1M: 250_000, outputPer1M: 2_000_000, cacheReadPer1M: 25_000, cacheWritePer1M: 0 },
+  "gpt-5-nano": { family: "openai", inputPer1M: 50_000, outputPer1M: 400_000, cacheReadPer1M: 5_000, cacheWritePer1M: 0 },
+  "gpt-5.5-codex": { family: "openai", inputPer1M: 1_250_000, outputPer1M: 10_000_000, cacheReadPer1M: 125_000, cacheWritePer1M: 0 },
+  "o3": { family: "openai", inputPer1M: 2_000_000, outputPer1M: 8_000_000, cacheReadPer1M: 500_000, cacheWritePer1M: 0 },
+  "o4-mini": { family: "openai", inputPer1M: 1_100_000, outputPer1M: 4_400_000, cacheReadPer1M: 275_000, cacheWritePer1M: 0 },
+};
+
+export function lookupPrice(model: string | undefined): PriceEntry | null {
+  return lookupPriceMatch(model)?.price ?? null;
+}
+
+export function lookupPriceMatch(model: string | undefined): { modelId: string; price: PriceEntry } | null {
+  if (!model) return null;
+  const id = model.toLowerCase();
+  const exact = PRICING_CATALOG[id];
+  if (exact) return { modelId: id, price: exact };
+  const key = Object.keys(PRICING_CATALOG)
+    .filter((candidate) => id.startsWith(`${candidate}-`))
+    .sort((a, b) => b.length - a.length)[0];
+  if (key) return { modelId: key, price: PRICING_CATALOG[key] as PriceEntry };
+  return null;
+}
+
+export function priceUsageMicros(model: string | undefined, usage: Usage): number | null {
+  const price = lookupPrice(model);
+  if (!price) return null;
+  return (
+    priceComponent(usage.inputTokens, price.inputPer1M) +
+    priceComponent(usage.outputTokens, price.outputPer1M) +
+    priceComponent(usage.cacheReadTokens, price.cacheReadPer1M) +
+    priceComponent(usage.cacheWriteTokens, price.cacheWritePer1M)
+  );
+}
+
+export function priceComponent(tokens: number, microsPer1M: number): number {
+  if (tokens <= 0 || microsPer1M <= 0) return 0;
+  return Math.ceil((tokens * microsPer1M) / 1_000_000);
+}

--- a/workers/coderouter/src/requestBody.ts
+++ b/workers/coderouter/src/requestBody.ts
@@ -1,0 +1,9 @@
+import { MAX_BUFFERED_BODY_BYTES } from "./families";
+
+export function bodyWithinReplayLimit(byteLength: number | null): boolean {
+  return byteLength === null || byteLength <= MAX_BUFFERED_BODY_BYTES;
+}
+
+export function bodyWithinJsonParseLimit(byteLength: number | null): boolean {
+  return byteLength !== null && byteLength <= MAX_BUFFERED_BODY_BYTES;
+}

--- a/workers/coderouter/src/secrets.ts
+++ b/workers/coderouter/src/secrets.ts
@@ -1,0 +1,57 @@
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export async function decryptEnvelopeSecret(envelope: string, masterKeyBase64: string | undefined): Promise<string | null> {
+  if (!masterKeyBase64 || !envelope.startsWith("crv1:")) return null;
+  const [, ivPart, ciphertextPart] = envelope.split(":");
+  if (!ivPart || !ciphertextPart) return null;
+  const iv = fromBase64Url(ivPart);
+  const ciphertext = fromBase64Url(ciphertextPart);
+  const keyBytes = fromBase64(masterKeyBase64);
+  if (!iv || !ciphertext || !keyBytes || keyBytes.byteLength !== 32) return null;
+  try {
+    const key = await crypto.subtle.importKey("raw", toArrayBuffer(keyBytes), "AES-GCM", false, ["decrypt"]);
+    const plaintext = await crypto.subtle.decrypt({ name: "AES-GCM", iv: toArrayBuffer(iv) }, key, toArrayBuffer(ciphertext));
+    return decoder.decode(plaintext);
+  } catch {
+    return null;
+  }
+}
+
+export async function encryptEnvelopeForTests(plaintext: string, masterKeyBase64: string, iv: Uint8Array): Promise<string> {
+  const keyBytes = fromBase64(masterKeyBase64);
+  if (!keyBytes || keyBytes.byteLength !== 32) throw new Error("invalid key");
+  const key = await crypto.subtle.importKey("raw", toArrayBuffer(keyBytes), "AES-GCM", false, ["encrypt"]);
+  const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv: toArrayBuffer(iv) }, key, encoder.encode(plaintext));
+  return `crv1:${toBase64Url(iv)}:${toBase64Url(new Uint8Array(ciphertext))}`;
+}
+
+function fromBase64(value: string): Uint8Array | null {
+  try {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+function fromBase64Url(value: string): Uint8Array | null {
+  try {
+    const padded = value.replaceAll("-", "+").replaceAll("_", "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+    return fromBase64(padded);
+  } catch {
+    return null;
+  }
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}

--- a/workers/coderouter/src/select.ts
+++ b/workers/coderouter/src/select.ts
@@ -1,0 +1,105 @@
+import type { CredentialClass, CredentialLimitState, LimitWindow } from "./types";
+
+export interface SelectCandidate {
+  id: string;
+  class: CredentialClass;
+  assignmentCount: number;
+  limitState: CredentialLimitState;
+}
+
+export interface WindowSummary {
+  headroom: number;
+  shortHeadroom: number;
+  shortResetAfterSeconds: number | null;
+  expiryPressure: number;
+  exhausted: boolean;
+  cooldownActive: boolean;
+  soonestResetSeconds?: number;
+}
+
+export interface ScoredCandidate extends SelectCandidate {
+  tier: number;
+  usable: boolean;
+  summary: WindowSummary;
+}
+
+export function summarizeWindows(windows: LimitWindow[], now: number, cooldownUntil?: number): WindowSummary {
+  const cooldownActive = typeof cooldownUntil === "number" && cooldownUntil > now;
+  if (windows.length === 0) {
+    return {
+      headroom: 1,
+      shortHeadroom: 1,
+      shortResetAfterSeconds: null,
+      expiryPressure: 0,
+      exhausted: cooldownActive,
+      cooldownActive,
+      soonestResetSeconds: cooldownActive ? Math.ceil((cooldownUntil - now) / 1000) : undefined,
+    };
+  }
+  let headroom = 1;
+  let shortHeadroom = 1;
+  let shortResetAfterSeconds: number | null = null;
+  let soonestResetSeconds: number | undefined;
+  for (const window of windows) {
+    const remaining = Math.max(0, 1 - window.usedPercent / 100);
+    headroom = Math.min(headroom, remaining);
+    if (window.limitWindowSeconds <= 21600) {
+      shortHeadroom = Math.min(shortHeadroom, remaining);
+      if (window.resetAfterSeconds > 0) {
+        shortResetAfterSeconds =
+          shortResetAfterSeconds === null
+            ? window.resetAfterSeconds
+            : Math.min(shortResetAfterSeconds, window.resetAfterSeconds);
+      }
+    }
+    if (window.resetAfterSeconds > 0) {
+      soonestResetSeconds =
+        soonestResetSeconds === undefined ? window.resetAfterSeconds : Math.min(soonestResetSeconds, window.resetAfterSeconds);
+    }
+  }
+  if (cooldownActive) {
+    const cooldownReset = Math.ceil(((cooldownUntil ?? now) - now) / 1000);
+    soonestResetSeconds = soonestResetSeconds === undefined ? cooldownReset : Math.min(soonestResetSeconds, cooldownReset);
+  }
+  const expiryPressure = shortResetAfterSeconds && shortResetAfterSeconds > 0 ? headroom / shortResetAfterSeconds : 0;
+  return {
+    headroom,
+    shortHeadroom,
+    shortResetAfterSeconds,
+    expiryPressure,
+    exhausted: cooldownActive || headroom <= 0 || shortHeadroom <= 0,
+    cooldownActive,
+    soonestResetSeconds,
+  };
+}
+
+export function scoreCandidate(candidate: SelectCandidate, now: number): ScoredCandidate {
+  const summary = summarizeWindows(candidate.limitState.windows, now, candidate.limitState.cooldownUntil);
+  const usableForNewSession = summary.headroom >= 0.4 && summary.shortHeadroom >= 0.4 && !summary.cooldownActive;
+  let tier: number;
+  if (candidate.class === "oauth" && usableForNewSession) tier = 0;
+  else if (candidate.class === "byok" && !summary.cooldownActive) tier = 1;
+  else if (candidate.class === "managed" && !summary.cooldownActive) tier = 2;
+  else if (candidate.class === "oauth" && !summary.exhausted) tier = 3;
+  else if (candidate.class === "oauth" && !summary.cooldownActive) tier = 4;
+  else tier = 99;
+  return { ...candidate, tier, usable: tier < 99, summary };
+}
+
+export function selectCredential(candidates: SelectCandidate[], now: number): ScoredCandidate | null {
+  const scored = candidates.map((candidate) => scoreCandidate(candidate, now)).filter((candidate) => candidate.usable);
+  if (scored.length === 0) return null;
+  scored.sort(compareScoredCandidates);
+  return scored[0] ?? null;
+}
+
+export function compareScoredCandidates(a: ScoredCandidate, b: ScoredCandidate): number {
+  if (a.tier !== b.tier) return a.tier - b.tier;
+  const aUsable = a.summary.headroom >= 0.4 && a.summary.shortHeadroom >= 0.4;
+  const bUsable = b.summary.headroom >= 0.4 && b.summary.shortHeadroom >= 0.4;
+  if (aUsable !== bUsable) return aUsable ? -1 : 1;
+  if (a.summary.expiryPressure !== b.summary.expiryPressure) return b.summary.expiryPressure - a.summary.expiryPressure;
+  if (a.summary.headroom !== b.summary.headroom) return b.summary.headroom - a.summary.headroom;
+  if (a.assignmentCount !== b.assignmentCount) return a.assignmentCount - b.assignmentCount;
+  return a.id.localeCompare(b.id);
+}

--- a/workers/coderouter/src/sessionKey.ts
+++ b/workers/coderouter/src/sessionKey.ts
@@ -1,0 +1,105 @@
+import type { EndpointClass, Family } from "./types";
+
+const HEADER_NAMES = [
+  "x-coderouter-session",
+  "x-codex-window-id",
+  "x-codex-turn-state",
+  "x-codex-parent-thread-id",
+  "x-session-id",
+  "x-conversation-id",
+  "x-codex-session-id",
+  "x-claude-session-id",
+  "x-claude-code-session-id",
+  "openai-conversation-id",
+  "anthropic-conversation-id",
+  "idempotency-key",
+];
+
+const QUERY_NAMES = ["session_id", "conversation_id", "thread_id"];
+const BODY_NAMES = new Set(["session_id", "conversation_id", "thread_id"]);
+const METADATA_SESSION_RE = /_session_([0-9a-f-]{36})/i;
+const UUID_PREFIX_RE = /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}):/i;
+
+const encoder = new TextEncoder();
+
+export async function extractConversationKey(input: {
+  endpointClass: EndpointClass;
+  family: Family;
+  headers: Headers;
+  url: URL;
+  parsedJson?: unknown;
+  ip?: string | null;
+  includeQuery?: boolean;
+}): Promise<string> {
+  const header = firstHeaderValue(input.headers);
+  if (header) return prefix(input.endpointClass, normalizeId(header));
+
+  if (input.includeQuery !== false) {
+    for (const name of QUERY_NAMES) {
+      const value = input.url.searchParams.get(name);
+      if (value) return prefix(input.endpointClass, normalizeId(value));
+    }
+  }
+
+  if (input.parsedJson !== undefined) {
+    const body = findBodyValue(input.parsedJson, input.family, 0);
+    if (body) return prefix(input.endpointClass, normalizeId(body));
+  }
+
+  const hash = await sha256(`${input.ip ?? ""}\0${input.headers.get("user-agent") ?? ""}\0${input.url.pathname}`);
+  return prefix(input.endpointClass, `fallback:${hash.slice(0, 24)}`);
+}
+
+function firstHeaderValue(headers: Headers): string | null {
+  for (const name of HEADER_NAMES) {
+    const value = headers.get(name)?.trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+function normalizeId(value: string): string {
+  const trimmed = value.trim();
+  const match = UUID_PREFIX_RE.exec(trimmed);
+  return match?.[1] ?? trimmed;
+}
+
+function prefix(endpointClass: EndpointClass, value: string): string {
+  return `${endpointClass}:${value}`;
+}
+
+function findBodyValue(value: unknown, family: Family, depth: number): string | null {
+  if (depth > 6 || value === null) return null;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findBodyValue(item, family, depth + 1);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (family === "anthropic") {
+    const metadata = record.metadata;
+    if (metadata && typeof metadata === "object") {
+      const userId = (metadata as Record<string, unknown>).user_id;
+      if (typeof userId === "string") {
+        const match = METADATA_SESSION_RE.exec(userId);
+        if (match?.[1]) return match[1];
+      }
+    }
+  }
+  for (const [key, item] of Object.entries(record)) {
+    if (BODY_NAMES.has(key) && typeof item === "string" && item.trim()) return item;
+  }
+  for (const item of Object.values(record)) {
+    const found = findBodyValue(item, family, depth + 1);
+    if (found) return found;
+  }
+  return null;
+}
+
+async function sha256(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(input));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/workers/coderouter/src/sse.ts
+++ b/workers/coderouter/src/sse.ts
@@ -1,0 +1,158 @@
+import type { EndpointClass, Usage } from "./types";
+
+export const ZERO_ESTIMATED_USAGE: Usage = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  estimated: true,
+};
+
+export function parseJsonUsage(endpointClass: EndpointClass, payload: unknown): Usage {
+  const record = asRecord(payload);
+  if (!record) return { ...ZERO_ESTIMATED_USAGE };
+  if (endpointClass === "anthropic") {
+    const usage = asRecord(record.usage);
+    return usage
+      ? {
+          inputTokens: numberValue(usage.input_tokens),
+          outputTokens: numberValue(usage.output_tokens),
+          cacheReadTokens: numberValue(usage.cache_read_input_tokens),
+          cacheWriteTokens: numberValue(usage.cache_creation_input_tokens),
+          estimated: false,
+        }
+      : { ...ZERO_ESTIMATED_USAGE };
+  }
+  const usage = asRecord(record.usage) ?? asRecord(asRecord(record.response)?.usage);
+  if (!usage) return { ...ZERO_ESTIMATED_USAGE };
+  const details = asRecord(usage.input_tokens_details);
+  return {
+    inputTokens: numberValue(usage.input_tokens) || numberValue(usage.prompt_tokens),
+    outputTokens: numberValue(usage.output_tokens) || numberValue(usage.completion_tokens),
+    cacheReadTokens: numberValue(details?.cached_tokens),
+    cacheWriteTokens: 0,
+    estimated: false,
+  };
+}
+
+export function parseSseUsage(endpointClass: EndpointClass, text: string): Usage {
+  const scanner = new SseUsageScanner(endpointClass);
+  scanner.pushText(text);
+  return scanner.finish();
+}
+
+export async function drainSseUsage(endpointClass: EndpointClass, stream: ReadableStream<Uint8Array> | null): Promise<Usage> {
+  if (!stream) return { ...ZERO_ESTIMATED_USAGE };
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const scanner = new SseUsageScanner(endpointClass);
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      scanner.pushText(decoder.decode(chunk.value, { stream: true }));
+    }
+    scanner.pushText(decoder.decode());
+  } catch {
+    return { ...ZERO_ESTIMATED_USAGE };
+  }
+  return scanner.finish();
+}
+
+export class SseUsageScanner {
+  private partialLine = "";
+  private currentEvent: string | null = null;
+  private usage: Usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, estimated: true };
+  private sawUsage = false;
+  maxRetainedLineLength = 0;
+
+  constructor(private readonly endpointClass: EndpointClass) {}
+
+  pushText(text: string): void {
+    if (!text) return;
+    const combined = this.partialLine + text;
+    const lines = combined.split("\n");
+    this.partialLine = lines.pop() ?? "";
+    this.maxRetainedLineLength = Math.max(this.maxRetainedLineLength, this.partialLine.length);
+    for (const rawLine of lines) {
+      this.processLine(rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine);
+    }
+  }
+
+  finish(): Usage {
+    if (this.partialLine) {
+      this.processLine(this.partialLine);
+      this.partialLine = "";
+    }
+    this.usage.estimated = !this.sawUsage;
+    return { ...this.usage };
+  }
+
+  private processLine(line: string): void {
+    if (line.length === 0) {
+      this.currentEvent = null;
+      return;
+    }
+    if (line.startsWith("event:")) {
+      this.currentEvent = line.slice(6).trim();
+      return;
+    }
+    if (!line.startsWith("data:")) return;
+    const data = line.slice(5).trimStart();
+    if (!data || data === "[DONE]") return;
+    const payload = parseJson(data);
+    if (!payload) return;
+    if (this.endpointClass === "anthropic") this.applyAnthropicPayload(this.currentEvent, payload);
+    else this.applyOpenAiPayload(this.currentEvent, payload);
+  }
+
+  private applyAnthropicPayload(event: string | null, payload: unknown): void {
+    if (event === "message_start") {
+      const record = asRecord(payload);
+      const startUsage = asRecord(asRecord(record?.message)?.usage);
+      if (startUsage) {
+        this.usage.inputTokens = numberValue(startUsage.input_tokens);
+        this.usage.cacheWriteTokens = numberValue(startUsage.cache_creation_input_tokens);
+        this.usage.cacheReadTokens = numberValue(startUsage.cache_read_input_tokens);
+        this.sawUsage = true;
+      }
+    }
+    if (event === "message_delta") {
+      const record = asRecord(payload);
+      const deltaUsage = asRecord(record?.usage);
+      if (deltaUsage) {
+        this.usage.outputTokens = numberValue(deltaUsage.output_tokens);
+        this.sawUsage = true;
+      }
+    }
+  }
+
+  private applyOpenAiPayload(event: string | null, payload: unknown): void {
+    if (event === "response.completed") {
+      this.usage = parseJsonUsage("openai_api", asRecord(payload)?.response);
+      this.sawUsage = !this.usage.estimated;
+    } else {
+      const record = asRecord(payload);
+      if (record?.usage) {
+        this.usage = parseJsonUsage("openai_api", record);
+        this.sawUsage = !this.usage.estimated;
+      }
+    }
+  }
+}
+
+function parseJson(text: string): unknown | null {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}

--- a/workers/coderouter/src/types.ts
+++ b/workers/coderouter/src/types.ts
@@ -1,0 +1,141 @@
+export type Family = "anthropic" | "openai";
+export type EndpointClass = "anthropic" | "openai_api" | "codex";
+export type CredentialKind = "oauth" | "api_key";
+export type CredentialClass = "oauth" | "byok" | "managed";
+export type CredentialStatus = "active" | "needs_reauth" | "disabled";
+
+export interface PoolConfig {
+  poolId: string;
+  teamId: string;
+  family: Family;
+  configVersion: number;
+  keys: {
+    kid: string;
+    revoked: boolean;
+    policy: { allowedClasses?: CredentialClass[] };
+  }[];
+  credentials: {
+    id: string;
+    kind: CredentialKind;
+    class: CredentialClass;
+    status: CredentialStatus;
+    label?: string;
+    providerAccountId?: string;
+    encryptedSecret?: string;
+  }[];
+  managed: { enabled: boolean };
+  balanceMicros: number;
+}
+
+export interface SeedOauth {
+  credentialId: string;
+  provider: Family;
+  accessToken: string;
+  refreshToken: string;
+  idToken?: string;
+  accountId?: string;
+  expiresAt?: number;
+}
+
+export interface UsageIngest {
+  poolId: string;
+  events: {
+    eventId: string;
+    keyId?: string;
+    credentialId?: string;
+    family: string;
+    endpointClass: EndpointClass;
+    model?: string;
+    credentialClass: CredentialClass;
+    status: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    estimated: boolean;
+    costMicros?: number | null;
+    latencyMs?: number;
+    ts: number;
+  }[];
+  statusUpdates?: { credentialId: string; status: "active" | "needs_reauth" }[];
+}
+
+export interface VerifiedCallerKey {
+  v: 1;
+  kid: string;
+  team: string;
+  iat: number;
+}
+
+export interface Usage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  estimated: boolean;
+}
+
+export interface LimitWindow {
+  name: string;
+  usedPercent: number;
+  limitWindowSeconds: number;
+  resetAfterSeconds: number;
+}
+
+export interface CredentialLimitState {
+  windows: LimitWindow[];
+  cooldownUntil?: number;
+  consecutive429?: number;
+  consecutive401?: number;
+  needsReauth?: boolean;
+  lastPolledAt?: number;
+}
+
+export interface AcquireRequest {
+  kid: string;
+  teamId?: string;
+  family: Family;
+  endpointClass: EndpointClass;
+  conversationKey: string;
+  model?: string;
+  estimate?: boolean;
+  excludeCredentialIds?: string[];
+}
+
+export interface AcquireSuccess {
+  ok: true;
+  credentialId: string;
+  class: CredentialClass;
+  authHeaders: Record<string, string>;
+  upstreamBase: string;
+  accountId?: string;
+}
+
+export type AcquireErrorCode =
+  | "key_revoked"
+  | "config_unavailable"
+  | "no_credentials"
+  | "all_exhausted"
+  | "insufficient_credits"
+  | "model_not_priced";
+
+export interface AcquireFailure {
+  ok: false;
+  error: AcquireErrorCode;
+  soonestResetSeconds?: number;
+}
+
+export type AcquireResult = AcquireSuccess | AcquireFailure;
+
+export interface ReportRequest {
+  credentialId: string;
+  kid: string;
+  conversationKey: string;
+  endpointClass: EndpointClass;
+  model?: string;
+  status: number;
+  latencyMs: number;
+  usage: Usage;
+  rateLimitHeaders: Record<string, string>;
+  usageLimited: boolean;
+}

--- a/workers/coderouter/src/usageFlush.ts
+++ b/workers/coderouter/src/usageFlush.ts
@@ -1,0 +1,75 @@
+import type { EndpointClass, UsageIngest } from "./types";
+
+export interface UsageBufferRow {
+  event_id: unknown;
+  key_id: unknown;
+  credential_id: unknown;
+  family: unknown;
+  endpoint_class: unknown;
+  model: unknown;
+  credential_class: unknown;
+  status: unknown;
+  input_tokens: unknown;
+  output_tokens: unknown;
+  cache_read_tokens: unknown;
+  cache_write_tokens: unknown;
+  estimated: unknown;
+  cost_micros: unknown;
+  latency_ms: unknown;
+  ts: unknown;
+}
+
+export interface StatusUpdateRow {
+  credential_id: unknown;
+  status: unknown;
+}
+
+export function buildUsageIngest(
+  poolId: string,
+  rows: UsageBufferRow[],
+  statusRows: StatusUpdateRow[],
+): { body: UsageIngest; flushedEstimateMicros: number } {
+  const events = rows.map((row) => ({
+    eventId: String(row.event_id),
+    keyId: nullableString(row.key_id) ?? undefined,
+    credentialId: nullableString(row.credential_id) ?? undefined,
+    family: String(row.family),
+    endpointClass: row.endpoint_class as EndpointClass,
+    model: nullableString(row.model) ?? undefined,
+    credentialClass: row.credential_class as UsageIngest["events"][number]["credentialClass"],
+    status: Number(row.status),
+    inputTokens: Number(row.input_tokens),
+    outputTokens: Number(row.output_tokens),
+    cacheReadTokens: Number(row.cache_read_tokens),
+    cacheWriteTokens: Number(row.cache_write_tokens),
+    estimated: Number(row.estimated) === 1,
+    costMicros: row.cost_micros === null || row.cost_micros === undefined ? null : Number(row.cost_micros),
+    latencyMs: row.latency_ms === null || row.latency_ms === undefined ? undefined : Number(row.latency_ms),
+    ts: Number(row.ts),
+  }));
+  const statusUpdates = statusRows
+    .map((row) => ({
+      credentialId: String(row.credential_id),
+      status: row.status === "active" ? ("active" as const) : ("needs_reauth" as const),
+    }))
+    .filter((row) => row.credentialId.length > 0);
+  return {
+    body: {
+      poolId,
+      events,
+      ...(statusUpdates.length > 0 ? { statusUpdates } : {}),
+    },
+    flushedEstimateMicros: events.reduce(
+      (sum, event) => sum + (event.credentialClass === "managed" ? (event.costMicros ?? 0) : 0),
+      0,
+    ),
+  };
+}
+
+export function subtractFlushedEstimateMicros(current: number, flushed: number): number {
+  return Math.max(0, current - flushed);
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/workers/coderouter/src/usagePoll.ts
+++ b/workers/coderouter/src/usagePoll.ts
@@ -1,0 +1,94 @@
+import type { Family, LimitWindow } from "./types";
+
+export const ACTIVE_TRAFFIC_WINDOW_MS = 10 * 60 * 1000;
+export const ACTIVE_POLL_INTERVAL_MS = 2 * 60 * 1000;
+export const IDLE_POLL_INTERVAL_MS = 15 * 60 * 1000;
+
+export function usagePollIntervalMs(now: number, lastTrafficAt: number): number {
+  return now - lastTrafficAt <= ACTIVE_TRAFFIC_WINDOW_MS ? ACTIVE_POLL_INTERVAL_MS : IDLE_POLL_INTERVAL_MS;
+}
+
+export function shouldPollCredential(input: {
+  now: number;
+  lastTrafficAt: number;
+  lastPolledAt?: number;
+}): boolean {
+  if (typeof input.lastPolledAt !== "number") return true;
+  return input.now - input.lastPolledAt >= usagePollIntervalMs(input.now, input.lastTrafficAt);
+}
+
+export function nextUsagePollAt(input: {
+  now: number;
+  lastTrafficAt: number;
+  lastPolledAt?: number;
+}): number {
+  if (typeof input.lastPolledAt !== "number") return input.now;
+  return input.lastPolledAt + usagePollIntervalMs(input.now, input.lastTrafficAt);
+}
+
+export function zeroHeadroomUsageWindows(family: Family): LimitWindow[] {
+  return [
+    {
+      name: family === "anthropic" ? "usage_poll_auth" : "primary_window",
+      usedPercent: 100,
+      limitWindowSeconds: IDLE_POLL_INTERVAL_MS / 1000,
+      resetAfterSeconds: IDLE_POLL_INTERVAL_MS / 1000,
+    },
+  ];
+}
+
+export function normalizeUsagePoll(family: Family, payload: unknown, now: number): LimitWindow[] {
+  return family === "anthropic" ? normalizeAnthropicUsage(payload, now) : normalizeOpenAiUsage(payload);
+}
+
+export function normalizeOpenAiUsage(payload: unknown): LimitWindow[] {
+  const record = asRecord(payload);
+  const rateLimit = asRecord(record?.rate_limit);
+  const windows: LimitWindow[] = [];
+  for (const key of ["primary_window", "secondary_window"]) {
+    const window = asRecord(rateLimit?.[key]);
+    const parsed = usageWindowFromPercent(key, window);
+    if (parsed) windows.push(parsed);
+  }
+  return windows;
+}
+
+export function normalizeAnthropicUsage(payload: unknown, now: number): LimitWindow[] {
+  const record = asRecord(payload);
+  const windows: LimitWindow[] = [];
+  for (const key of ["five_hour", "seven_day", "seven_day_opus", "seven_day_sonnet"]) {
+    const window = asRecord(record?.[key]);
+    if (!window) continue;
+    const utilization = numberValue(window.utilization);
+    const resetsAt = typeof window.resets_at === "string" ? Date.parse(window.resets_at) : Number.NaN;
+    if (utilization === null || !Number.isFinite(resetsAt)) continue;
+    windows.push({
+      name: key,
+      usedPercent: clampPercent(utilization),
+      limitWindowSeconds: key === "five_hour" ? 5 * 60 * 60 : 7 * 24 * 60 * 60,
+      resetAfterSeconds: Math.max(0, Math.ceil((resetsAt - now) / 1000)),
+    });
+  }
+  return windows;
+}
+
+function usageWindowFromPercent(name: string, window: Record<string, unknown> | null): LimitWindow | null {
+  if (!window) return null;
+  const usedPercent = numberValue(window.used_percent);
+  const limitWindowSeconds = numberValue(window.limit_window_seconds);
+  const resetAfterSeconds = numberValue(window.reset_after_seconds);
+  if (usedPercent === null || limitWindowSeconds === null || resetAfterSeconds === null) return null;
+  return { name, usedPercent: clampPercent(usedPercent), limitWindowSeconds, resetAfterSeconds };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}

--- a/workers/coderouter/test/acquirePolicy.test.ts
+++ b/workers/coderouter/test/acquirePolicy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { managedAcquireFailure } from "../src/acquirePolicy";
+
+describe("acquire policy", () => {
+  test("applies managed balance and model checks to reused credentials too", () => {
+    expect(
+      managedAcquireFailure({
+        credentialClass: "managed",
+        model: "gpt-5-mini",
+        balanceMicros: 0,
+        unflushedEstimateMicros: 0,
+      }),
+    ).toEqual({ ok: false, error: "insufficient_credits" });
+
+    expect(
+      managedAcquireFailure({
+        credentialClass: "managed",
+        model: "unknown-model",
+        balanceMicros: 100,
+        unflushedEstimateMicros: 0,
+      }),
+    ).toEqual({ ok: false, error: "model_not_priced" });
+
+    expect(
+      managedAcquireFailure({
+        credentialClass: "byok",
+        model: "unknown-model",
+        balanceMicros: 0,
+        unflushedEstimateMicros: 0,
+      }),
+    ).toBeNull();
+  });
+});

--- a/workers/coderouter/test/families.test.ts
+++ b/workers/coderouter/test/families.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { buildUpstreamUrl, injectCredentialHeaders, matchRoute, sanitizeRequestHeaders } from "../src/families";
+
+describe("families", () => {
+  test("maps prefixes to upstream paths", () => {
+    const anthropic = matchRoute(new URL("https://router.example/anthropic/v1/messages?a=1"));
+    expect(anthropic?.endpointClass).toBe("anthropic");
+    expect(buildUpstreamUrl(anthropic!, new URL("https://router.example/anthropic/v1/messages?a=1"))).toBe(
+      "https://api.anthropic.com/v1/messages?a=1",
+    );
+
+    const openai = matchRoute(new URL("https://router.example/openai/v1/responses"));
+    expect(openai?.upstreamPath).toBe("/v1/responses");
+  });
+
+  test("strips inbound auth and private headers", () => {
+    const headers = sanitizeRequestHeaders(
+      new Headers({
+        authorization: "Bearer crk_secret",
+        "x-api-key": "crk_secret",
+        "x-coderouter-debug": "1",
+        connection: "close",
+        "content-type": "application/json",
+      }),
+    );
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("x-api-key")).toBeNull();
+    expect(headers.get("x-coderouter-debug")).toBeNull();
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
+  test("merges and removes oauth beta for anthropic credentials", () => {
+    const oauth = injectCredentialHeaders(
+      "anthropic",
+      "oauth",
+      new Headers({ "anthropic-beta": "tools, oauth-2025-04-20", authorization: "Bearer crk" }),
+      { authorization: "Bearer access" },
+    );
+    expect(oauth.get("authorization")).toBe("Bearer access");
+    expect(oauth.get("x-api-key")).toBeNull();
+    expect(oauth.get("anthropic-beta")).toBe("tools,oauth-2025-04-20");
+
+    const byok = injectCredentialHeaders(
+      "anthropic",
+      "byok",
+      new Headers({ "anthropic-beta": "oauth-2025-04-20,files" }),
+      { "x-api-key": "provider-key" },
+    );
+    expect(byok.get("authorization")).toBeNull();
+    expect(byok.get("x-api-key")).toBe("provider-key");
+    expect(byok.get("anthropic-beta")).toBe("files");
+  });
+
+  test("injects bearer headers for api and account header for codex", () => {
+    const api = injectCredentialHeaders("openai_api", "managed", new Headers({ authorization: "Bearer crk" }), {
+      authorization: "Bearer provider",
+    });
+    expect(api.get("authorization")).toBe("Bearer provider");
+
+    const codex = injectCredentialHeaders("codex", "oauth", new Headers({ "chatgpt-account-id": "inbound" }), {
+      authorization: "Bearer access",
+      "chatgpt-account-id": "acct",
+    });
+    expect(codex.get("ChatGPT-Account-ID")).toBe("acct");
+  });
+});

--- a/workers/coderouter/test/keys.test.ts
+++ b/workers/coderouter/test/keys.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { bearerToken, timingSafeEqualString } from "../src/internalAuth";
+import { mintCallerKeyForTests, verifyCallerKey } from "../src/keys";
+
+describe("caller keys", () => {
+  test("round-trips and rejects tampering", async () => {
+    const secret = "test-secret";
+    const payload = { v: 1 as const, kid: "kid-1", team: "team-1", iat: 123 };
+    const key = await mintCallerKeyForTests(payload, secret);
+    await expect(verifyCallerKey(key, secret)).resolves.toEqual(payload);
+    await expect(verifyCallerKey(`${key.slice(0, -1)}x`, secret)).resolves.toBeNull();
+    await expect(verifyCallerKey(key, "other")).resolves.toBeNull();
+  });
+
+  test("constant-time compare keeps length mismatch on the same path", () => {
+    expect(timingSafeEqualString("abc", "abc")).toBe(true);
+    expect(timingSafeEqualString("abc", "abd")).toBe(false);
+    expect(timingSafeEqualString("abc", "abcx")).toBe(false);
+  });
+
+  test("extracts bearer tokens", () => {
+    const headers = new Headers({ authorization: "Bearer secret" });
+    expect(bearerToken(headers)).toBe("secret");
+  });
+});

--- a/workers/coderouter/test/limits.test.ts
+++ b/workers/coderouter/test/limits.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { applyLimitHeaders, cooldownAfter429, mergeReportedLimitState, parseRetryAfterSeconds, parseWindows } from "../src/limits";
+import { shouldPollCredential } from "../src/usagePoll";
+
+describe("limits", () => {
+  test("parses provider windows", () => {
+    const anthropic = parseWindows(
+      "anthropic",
+      {
+        "anthropic-ratelimit-requests-remaining": "20",
+        "anthropic-ratelimit-requests-limit": "100",
+        "anthropic-ratelimit-requests-reset": "60",
+      },
+      Date.now(),
+    );
+    expect(anthropic[0]?.usedPercent).toBe(80);
+    expect(anthropic[0]?.resetAfterSeconds).toBe(60);
+
+    const openai = parseWindows(
+      "openai",
+      {
+        "x-ratelimit-remaining-requests": "5",
+        "x-ratelimit-limit-requests": "10",
+        "x-ratelimit-reset-requests": "2m",
+      },
+      Date.now(),
+    );
+    expect(openai[0]).toMatchObject({ name: "requests", usedPercent: 50, resetAfterSeconds: 120 });
+  });
+
+  test("applies retry-after and exponential cooldown", () => {
+    expect(parseRetryAfterSeconds("12")).toBe(12);
+    expect(cooldownAfter429(1000, null, 0)).toEqual({ cooldownUntil: 61_000, consecutive429: 1 });
+    expect(cooldownAfter429(1000, null, 2)).toEqual({ cooldownUntil: 241_000, consecutive429: 3 });
+    const update = applyLimitHeaders({
+      family: "openai",
+      endpointClass: "openai_api",
+      credentialClass: "byok",
+      status: 429,
+      headers: { "retry-after": "7" },
+      now: 1000,
+    });
+    expect(update.cooldownUntil).toBe(8000);
+  });
+
+  test("marks oauth reauth on second 401", () => {
+    const update = applyLimitHeaders({
+      family: "anthropic",
+      endpointClass: "anthropic",
+      credentialClass: "oauth",
+      status: 401,
+      headers: {},
+      now: 1000,
+      previousConsecutive401: 1,
+    });
+    expect(update.needsReauth).toBe(true);
+    expect(update.cooldownUntil).toBe(301000);
+  });
+
+  test("does not replace oauth poll windows from response headers but still applies 429 cooldown", () => {
+    const update = applyLimitHeaders({
+      family: "anthropic",
+      endpointClass: "anthropic",
+      credentialClass: "oauth",
+      status: 429,
+      headers: {
+        "anthropic-ratelimit-requests-remaining": "0",
+        "anthropic-ratelimit-requests-limit": "100",
+        "retry-after": "9",
+      },
+      now: 1000,
+    });
+    expect(update.windows).toEqual([]);
+    expect(update.cooldownUntil).toBe(10_000);
+    expect(update.consecutive429).toBe(1);
+  });
+
+  test("reported requests preserve last poll time for oauth cadence", () => {
+    const now = 1_000_000;
+    const previous = {
+      windows: [{ name: "primary_window", usedPercent: 25, limitWindowSeconds: 3600, resetAfterSeconds: 120 }],
+      lastPolledAt: now - 60_000,
+      consecutive429: 0,
+      consecutive401: 0,
+      needsReauth: false,
+    };
+    const update = applyLimitHeaders({
+      family: "openai",
+      endpointClass: "codex",
+      credentialClass: "oauth",
+      status: 200,
+      headers: {},
+      now,
+      previousConsecutive429: previous.consecutive429,
+      previousConsecutive401: previous.consecutive401,
+    });
+    const merged = mergeReportedLimitState(previous, update);
+    expect(merged.lastPolledAt).toBe(previous.lastPolledAt);
+    expect(shouldPollCredential({ now, lastTrafficAt: now, lastPolledAt: merged.lastPolledAt })).toBe(false);
+  });
+});

--- a/workers/coderouter/test/oauthRefresh.test.ts
+++ b/workers/coderouter/test/oauthRefresh.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { buildRefreshRequest, refreshOAuthChain } from "../src/oauthRefresh";
+
+function jwt(exp: number): string {
+  return `x.${btoa(JSON.stringify({ exp })).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "")}.y`;
+}
+
+describe("oauth refresh", () => {
+  test("builds provider refresh requests", async () => {
+    const request = buildRefreshRequest("openai", "refresh");
+    expect(request.url).toBe("https://auth.openai.com/oauth/token");
+    expect(await request.json()).toMatchObject({ grant_type: "refresh_token", refresh_token: "refresh" });
+
+    const anthropic = buildRefreshRequest("anthropic", "refresh");
+    expect(anthropic.headers.get("anthropic-beta")).toBe("oauth-2025-04-20");
+  });
+
+  test("requires all openai rotated token fields", async () => {
+    const ok = await refreshOAuthChain(
+      "openai",
+      { accessToken: "old", refreshToken: "old-refresh" },
+      async () => new Response(JSON.stringify({ access_token: jwt(999), refresh_token: "new-refresh", id_token: "id" })),
+      0,
+    );
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.chain.refreshToken).toBe("new-refresh");
+
+    const bad = await refreshOAuthChain(
+      "openai",
+      { accessToken: "old", refreshToken: "old-refresh" },
+      async () => new Response(JSON.stringify({ access_token: "new" })),
+      0,
+    );
+    expect(bad.ok).toBe(false);
+  });
+
+  test("keeps anthropic refresh token when omitted and flags refresh-token failures", async () => {
+    const ok = await refreshOAuthChain(
+      "anthropic",
+      { accessToken: "old", refreshToken: "old-refresh" },
+      async () => new Response(JSON.stringify({ access_token: "new", expires_in: 60 })),
+      1000,
+    );
+    expect(ok.ok).toBe(true);
+    if (ok.ok) {
+      expect(ok.chain.refreshToken).toBe("old-refresh");
+      expect(ok.chain.expiresAt).toBe(61_000);
+    }
+
+    const bad = await refreshOAuthChain(
+      "anthropic",
+      { accessToken: "old", refreshToken: "bad" },
+      async () => new Response('{"error":"invalid refresh_token"}', { status: 401 }),
+      0,
+    );
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.failure.refreshTokenFailure).toBe(true);
+  });
+});

--- a/workers/coderouter/test/pricing.test.ts
+++ b/workers/coderouter/test/pricing.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { lookupPrice, priceComponent, priceUsageMicros } from "../src/pricing";
+
+describe("pricing", () => {
+  test("rounds each component up", () => {
+    expect(priceComponent(1, 1)).toBe(1);
+    expect(priceComponent(1_000_000, 3)).toBe(3);
+  });
+
+  test("matches exact ids and date-suffixed model ids", () => {
+    expect(lookupPrice("gpt-5")?.family).toBe("openai");
+    expect(lookupPrice("gpt-5-mini-2026-01-01")).toMatchObject({
+      family: "openai",
+      inputPer1M: 250_000,
+      outputPer1M: 2_000_000,
+    });
+    expect(lookupPrice("claude-sonnet-4-5-20250929")).toMatchObject({
+      family: "anthropic",
+      inputPer1M: 3_000_000,
+      outputPer1M: 15_000_000,
+    });
+    expect(lookupPrice("missing-model")).toBeNull();
+  });
+
+  test("returns null for unknown models", () => {
+    expect(priceUsageMicros("unknown", { inputTokens: 10, outputTokens: 10, cacheReadTokens: 0, cacheWriteTokens: 0, estimated: false })).toBeNull();
+    expect(priceUsageMicros("gpt-5", { inputTokens: 1, outputTokens: 1, cacheReadTokens: 1, cacheWriteTokens: 0, estimated: false })).toBeGreaterThan(0);
+  });
+});

--- a/workers/coderouter/test/secrets.test.ts
+++ b/workers/coderouter/test/secrets.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { decryptEnvelopeSecret, encryptEnvelopeForTests } from "../src/secrets";
+
+describe("secret envelopes", () => {
+  test("decrypts crv1 envelopes and rejects tampering", async () => {
+    const key = btoa(String.fromCharCode(...new Uint8Array(32).fill(7)));
+    const envelope = await encryptEnvelopeForTests("provider-secret", key, new Uint8Array(12).fill(3));
+    await expect(decryptEnvelopeSecret(envelope, key)).resolves.toBe("provider-secret");
+    await expect(decryptEnvelopeSecret(`${envelope.slice(0, -1)}A`, key)).resolves.toBeNull();
+    await expect(decryptEnvelopeSecret(envelope, undefined)).resolves.toBeNull();
+  });
+});

--- a/workers/coderouter/test/select.test.ts
+++ b/workers/coderouter/test/select.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { scoreCandidate, selectCredential } from "../src/select";
+
+const now = 1_000_000;
+const state = (usedPercent: number, resetAfterSeconds = 100) => ({
+  windows: [{ name: "short", usedPercent, limitWindowSeconds: 3600, resetAfterSeconds }],
+});
+
+describe("selection", () => {
+  test("prioritizes usable oauth over byok and managed", () => {
+    const selected = selectCredential(
+      [
+        { id: "m", class: "managed", assignmentCount: 0, limitState: { windows: [] } },
+        { id: "o", class: "oauth", assignmentCount: 5, limitState: state(20) },
+        { id: "b", class: "byok", assignmentCount: 0, limitState: { windows: [] } },
+      ],
+      now,
+    );
+    expect(selected?.id).toBe("o");
+  });
+
+  test("uses byok before oauth below the 40 percent floor", () => {
+    const selected = selectCredential(
+      [
+        { id: "o", class: "oauth", assignmentCount: 0, limitState: state(70) },
+        { id: "b", class: "byok", assignmentCount: 0, limitState: { windows: [] } },
+      ],
+      now,
+    );
+    expect(selected?.id).toBe("b");
+    expect(scoreCandidate({ id: "o", class: "oauth", assignmentCount: 0, limitState: state(70) }, now).tier).toBe(3);
+  });
+
+  test("tie-breaks by expiry pressure, headroom, assignment count, then id", () => {
+    expect(
+      selectCredential(
+        [
+          { id: "a", class: "oauth", assignmentCount: 0, limitState: state(20, 200) },
+          { id: "b", class: "oauth", assignmentCount: 0, limitState: state(20, 100) },
+        ],
+        now,
+      )?.id,
+    ).toBe("b");
+
+    expect(
+      selectCredential(
+        [
+          { id: "b", class: "oauth", assignmentCount: 2, limitState: state(20, 100) },
+          { id: "a", class: "oauth", assignmentCount: 1, limitState: state(20, 100) },
+        ],
+        now,
+      )?.id,
+    ).toBe("a");
+  });
+
+  test("excludes cooldown candidates", () => {
+    const selected = selectCredential(
+      [{ id: "o", class: "oauth", assignmentCount: 0, limitState: { ...state(0), cooldownUntil: now + 1000 } }],
+      now,
+    );
+    expect(selected).toBeNull();
+  });
+
+  test("returns exhausted oauth by window as last resort but still refuses cooldown", () => {
+    const exhaustedByWindow = selectCredential(
+      [{ id: "o", class: "oauth", assignmentCount: 0, limitState: state(100) }],
+      now,
+    );
+    expect(exhaustedByWindow?.id).toBe("o");
+    expect(exhaustedByWindow?.tier).toBe(4);
+
+    const cooldownExhausted = selectCredential(
+      [{ id: "o", class: "oauth", assignmentCount: 0, limitState: { ...state(100), cooldownUntil: now + 1000 } }],
+      now,
+    );
+    expect(cooldownExhausted).toBeNull();
+  });
+});

--- a/workers/coderouter/test/sessionKey.test.ts
+++ b/workers/coderouter/test/sessionKey.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { extractConversationKey } from "../src/sessionKey";
+
+const base = {
+  endpointClass: "codex" as const,
+  family: "openai" as const,
+  url: new URL("https://router.example/codex/messages"),
+};
+
+describe("session extraction", () => {
+  test("prefers headers and collapses uuid suffixes", async () => {
+    const headers = new Headers({ "x-codex-session-id": "11111111-1111-1111-1111-111111111111:turn-2" });
+    await expect(extractConversationKey({ ...base, headers })).resolves.toBe(
+      "codex:11111111-1111-1111-1111-111111111111",
+    );
+  });
+
+  test("uses query parameters before body", async () => {
+    const url = new URL("https://router.example/anthropic/messages?thread_id=query-thread");
+    await expect(
+      extractConversationKey({
+        endpointClass: "anthropic",
+        family: "anthropic",
+        headers: new Headers(),
+        url,
+        parsedJson: { thread_id: "body-thread" },
+      }),
+    ).resolves.toBe("anthropic:query-thread");
+  });
+
+  test("recurses body and extracts metadata session ids", async () => {
+    await expect(
+      extractConversationKey({
+        endpointClass: "anthropic",
+        family: "anthropic",
+        headers: new Headers(),
+        url: new URL("https://router.example/anthropic/messages"),
+        parsedJson: { metadata: { user_id: "user_session_22222222-2222-2222-2222-222222222222" } },
+      }),
+    ).resolves.toBe("anthropic:22222222-2222-2222-2222-222222222222");
+
+    await expect(
+      extractConversationKey({
+        ...base,
+        headers: new Headers(),
+        parsedJson: { nested: [{ deep: { conversation_id: "deep-id" } }] },
+      }),
+    ).resolves.toBe("codex:deep-id");
+  });
+
+  test("falls back to a stable hashed key", async () => {
+    const input = { ...base, headers: new Headers({ "user-agent": "ua" }), ip: "127.0.0.1" };
+    const first = await extractConversationKey(input);
+    const second = await extractConversationKey(input);
+    expect(first).toBe(second);
+    expect(first.startsWith("codex:fallback:")).toBe(true);
+  });
+});

--- a/workers/coderouter/test/sse.test.ts
+++ b/workers/coderouter/test/sse.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { drainSseUsage, parseJsonUsage, parseSseUsage, SseUsageScanner } from "../src/sse";
+
+describe("usage extraction", () => {
+  test("extracts anthropic message_start and final delta", () => {
+    const usage = parseSseUsage(
+      "anthropic",
+      [
+        "event: message_start",
+        'data: {"message":{"usage":{"input_tokens":10,"cache_creation_input_tokens":2,"cache_read_input_tokens":3}}}',
+        "",
+        "event: message_delta",
+        'data: {"usage":{"output_tokens":4}}',
+        "",
+        "event: message_delta",
+        'data: {"usage":{"output_tokens":8}}',
+        "",
+      ].join("\n"),
+    );
+    expect(usage).toEqual({ inputTokens: 10, outputTokens: 8, cacheReadTokens: 3, cacheWriteTokens: 2, estimated: false });
+  });
+
+  test("extracts response.completed and final chunk usage", () => {
+    const usage = parseSseUsage(
+      "openai_api",
+      [
+        "event: response.completed",
+        'data: {"response":{"usage":{"input_tokens":11,"output_tokens":12,"input_tokens_details":{"cached_tokens":5}}}}',
+        "",
+      ].join("\n"),
+    );
+    expect(usage).toEqual({ inputTokens: 11, outputTokens: 12, cacheReadTokens: 5, cacheWriteTokens: 0, estimated: false });
+
+    expect(
+      parseSseUsage("openai_api", 'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2}}\n\n'),
+    ).toMatchObject({ inputTokens: 1, outputTokens: 2, estimated: false });
+  });
+
+  test("returns estimated zeros when usage is missing", () => {
+    expect(parseSseUsage("openai_api", "data: {}\n\n").estimated).toBe(true);
+    expect(parseJsonUsage("anthropic", {}).estimated).toBe(true);
+  });
+
+  test("scans large split streams without retaining completed lines", async () => {
+    const scanner = new SseUsageScanner("openai_api");
+    const filler = `data: {"noise":"${"x".repeat(64 * 1024)}"}\n\n`;
+    scanner.pushText(filler);
+    scanner.pushText("event: response.completed\n");
+    const usageLine = 'data: {"response":{"usage":{"input_tokens":21,"output_tokens":34,"input_tokens_details":{"cached_tokens":8}}}}\n\n';
+    for (let index = 0; index < usageLine.length; index += 7) {
+      scanner.pushText(usageLine.slice(index, index + 7));
+    }
+
+    expect(scanner.finish()).toEqual({ inputTokens: 21, outputTokens: 34, cacheReadTokens: 8, cacheWriteTokens: 0, estimated: false });
+    expect(scanner.maxRetainedLineLength).toBeLessThan(usageLine.length);
+
+    const chunks = [
+      "event: response.completed\n",
+      'data: {"response":{"usage":{"input_tokens":5,',
+      '"output_tokens":6,"input_tokens_details":{"cached_tokens":2}}}}\n\n',
+    ];
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+        controller.close();
+      },
+    });
+    await expect(drainSseUsage("openai_api", stream)).resolves.toEqual({
+      inputTokens: 5,
+      outputTokens: 6,
+      cacheReadTokens: 2,
+      cacheWriteTokens: 0,
+      estimated: false,
+    });
+  });
+});

--- a/workers/coderouter/test/usageFlush.test.ts
+++ b/workers/coderouter/test/usageFlush.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { buildUsageIngest, subtractFlushedEstimateMicros } from "../src/usageFlush";
+
+describe("usage flush", () => {
+  test("includes pending status updates until a flush succeeds", () => {
+    const { body } = buildUsageIngest(
+      "team:openai",
+      [],
+      [{ credential_id: "cred-1", status: "needs_reauth" }],
+    );
+    expect(body).toEqual({
+      poolId: "team:openai",
+      events: [],
+      statusUpdates: [{ credentialId: "cred-1", status: "needs_reauth" }],
+    });
+  });
+
+  test("subtracts only the flushed managed estimate total", () => {
+    const { flushedEstimateMicros } = buildUsageIngest(
+      "team:openai",
+      [
+        {
+          event_id: "event-1",
+          key_id: "kid",
+          credential_id: "cred-1",
+          family: "openai",
+          endpoint_class: "openai_api",
+          model: "gpt-5-mini",
+          credential_class: "managed",
+          status: 200,
+          input_tokens: 1,
+          output_tokens: 1,
+          cache_read_tokens: 0,
+          cache_write_tokens: 0,
+          estimated: 0,
+          cost_micros: 7,
+          latency_ms: 10,
+          ts: 1000,
+        },
+      ],
+      [],
+    );
+
+    expect(flushedEstimateMicros).toBe(7);
+    expect(subtractFlushedEstimateMicros(12, flushedEstimateMicros)).toBe(5);
+    expect(subtractFlushedEstimateMicros(3, flushedEstimateMicros)).toBe(0);
+  });
+});

--- a/workers/coderouter/test/usagePoll.test.ts
+++ b/workers/coderouter/test/usagePoll.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ACTIVE_POLL_INTERVAL_MS,
+  IDLE_POLL_INTERVAL_MS,
+  nextUsagePollAt,
+  normalizeAnthropicUsage,
+  normalizeOpenAiUsage,
+  shouldPollCredential,
+  usagePollIntervalMs,
+  zeroHeadroomUsageWindows,
+} from "../src/usagePoll";
+
+describe("usage poll normalization", () => {
+  test("normalizes openai windows", () => {
+    expect(
+      normalizeOpenAiUsage({
+        rate_limit: {
+          primary_window: { used_percent: 25, limit_window_seconds: 3600, reset_after_seconds: 120 },
+          secondary_window: { used_percent: 50, limit_window_seconds: 86400, reset_after_seconds: 240 },
+        },
+      }),
+    ).toEqual([
+      { name: "primary_window", usedPercent: 25, limitWindowSeconds: 3600, resetAfterSeconds: 120 },
+      { name: "secondary_window", usedPercent: 50, limitWindowSeconds: 86400, resetAfterSeconds: 240 },
+    ]);
+  });
+
+  test("normalizes anthropic windows", () => {
+    const now = Date.parse("2026-01-01T00:00:00Z");
+    expect(
+      normalizeAnthropicUsage(
+        {
+          five_hour: { utilization: 10, resets_at: "2026-01-01T01:00:00Z" },
+          seven_day: { utilization: 20, resets_at: "2026-01-02T00:00:00Z" },
+        },
+        now,
+      ),
+    ).toEqual([
+      { name: "five_hour", usedPercent: 10, limitWindowSeconds: 18000, resetAfterSeconds: 3600 },
+      { name: "seven_day", usedPercent: 20, limitWindowSeconds: 604800, resetAfterSeconds: 86400 },
+    ]);
+  });
+
+  test("uses active and idle per-credential poll cadence", () => {
+    const now = 1_000_000;
+    expect(usagePollIntervalMs(now, now - 9 * 60 * 1000)).toBe(ACTIVE_POLL_INTERVAL_MS);
+    expect(usagePollIntervalMs(now, now - 11 * 60 * 1000)).toBe(IDLE_POLL_INTERVAL_MS);
+    expect(shouldPollCredential({ now, lastTrafficAt: now, lastPolledAt: now - ACTIVE_POLL_INTERVAL_MS })).toBe(true);
+    expect(shouldPollCredential({ now, lastTrafficAt: now, lastPolledAt: now - ACTIVE_POLL_INTERVAL_MS + 1 })).toBe(false);
+    expect(shouldPollCredential({ now, lastTrafficAt: 0, lastPolledAt: now - IDLE_POLL_INTERVAL_MS })).toBe(true);
+    expect(nextUsagePollAt({ now, lastTrafficAt: 0, lastPolledAt: now - 1000 })).toBe(now - 1000 + IDLE_POLL_INTERVAL_MS);
+  });
+
+  test("auth-like poll failures map to temporary zero-headroom windows", () => {
+    expect(zeroHeadroomUsageWindows("anthropic")).toEqual([
+      { name: "usage_poll_auth", usedPercent: 100, limitWindowSeconds: 900, resetAfterSeconds: 900 },
+    ]);
+  });
+});

--- a/workers/coderouter/tsconfig.json
+++ b/workers/coderouter/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types/experimental"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers/coderouter/tsconfig.test.json
+++ b/workers/coderouter/tsconfig.test.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
+  "include": [
+    "test/**/*.ts",
+    "src/acquirePolicy.ts",
+    "src/families.ts",
+    "src/internalAuth.ts",
+    "src/keys.ts",
+    "src/limits.ts",
+    "src/oauthRefresh.ts",
+    "src/pricing.ts",
+    "src/secrets.ts",
+    "src/select.ts",
+    "src/sessionKey.ts",
+    "src/sse.ts",
+    "src/types.ts",
+    "src/usageFlush.ts",
+    "src/usagePoll.ts"
+  ]
+}

--- a/workers/coderouter/wrangler.dev.toml
+++ b/workers/coderouter/wrangler.dev.toml
@@ -1,0 +1,28 @@
+# DEV-ONLY config for cmux-coderouter-dev: same worker + DO as production, but
+# on the workers.dev URL, NOT the production coderouter.cmux.dev custom domain.
+# Use:
+#   bunx wrangler deploy --config wrangler.dev.toml
+#
+# Durable Object migrations are append-only. Never hand-edit past migration
+# tags; append a new migration when a storage class changes.
+#
+# Secrets are provisioned with `wrangler secret put`, not [vars].
+
+name = "cmux-coderouter-dev"
+main = "src/index.ts"
+compatibility_date = "2026-05-01"
+workers_dev = true
+
+[vars]
+CONTROL_PLANE_BASE_URL = "https://cmux.com"
+
+[observability]
+enabled = true
+
+[[durable_objects.bindings]]
+name = "POOL"
+class_name = "PoolCoordinator"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["PoolCoordinator"]

--- a/workers/coderouter/wrangler.toml
+++ b/workers/coderouter/wrangler.toml
@@ -1,0 +1,42 @@
+# cmux coderouter service — Cloudflare Worker + SQLite Durable Objects.
+#
+# One PoolCoordinator Durable Object per team/family owns synced caller keys,
+# credential metadata, OAuth token chains, sticky conversation assignments,
+# limit state, and buffered usage events. The web control plane is authoritative
+# for team membership, key minting, credential metadata, and billing.
+#
+# Deploys should run from a path-filtered workflow on push to main. The
+# [[migrations]] block below is the service's schema migration story: wrangler
+# applies Durable Object class migrations atomically with every deploy, so the
+# code and its storage classes can never drift the way lagging SQL migrations
+# can. Never hand-edit past migration tags; append a new one.
+#
+# Secrets are intentionally NOT in [vars]: values set here overwrite
+# dashboard-set values on every deploy. Provision them once as Worker secrets:
+#   wrangler secret put CODEROUTER_KEY_SIGNING_SECRET
+#   wrangler secret put CODEROUTER_INTERNAL_TOKEN
+#   wrangler secret put CODEROUTER_MASTER_KEY
+#   wrangler secret put MANAGED_ANTHROPIC_API_KEY
+#   wrangler secret put MANAGED_OPENAI_API_KEY
+
+name = "cmux-coderouter"
+main = "src/index.ts"
+compatibility_date = "2026-05-01"
+
+[vars]
+CONTROL_PLANE_BASE_URL = "https://cmux.com"
+
+[observability]
+enabled = true
+
+[[durable_objects.bindings]]
+name = "POOL"
+class_name = "PoolCoordinator"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["PoolCoordinator"]
+
+[[routes]]
+pattern = "coderouter.cmux.dev"
+custom_domain = true


### PR DESCRIPTION
## What

**coderouter** is a cmux-native multi-credential LLM gateway. A team points its coding agents at one base URL with one key, and each request is routed to the best available credential in that team's pool — subscription OAuth accounts first, then BYOK API keys, then cmux-managed metered access (pay cmux, use any model). Built from scratch (Cloudflare Worker + Durable Objects data plane, Next.js/Effect/Drizzle control plane), landed through a plan→code→adversarial-judge loop.

### Phase 1 — gateway backend (committed)

**Data plane — `workers/coderouter/`** (Cloudflare Worker + SQLite Durable Object)
- Native passthrough for `/anthropic/*`, `/openai/v1/*`, `/codex/*` with per-credential-kind auth injection and header sanitization.
- One `PoolCoordinator` DO per `team:family` owns credentials, OAuth token chains (never stored in Postgres), sticky conversation→credential assignments, rate-limit state, usage buffer, managed budget.
- Headroom-scored tiered selection (OAuth → BYOK → managed → exhausted-oauth last resort), 40% new-session floor, cooldowns, transparent pre-stream failover.
- Rotation-safe single-flight OAuth refresh, provider usage polling, alarm-driven usage flush, bounded-memory streaming SSE usage extraction, stateless HMAC `crk_` keys + DO revocation. **39 unit tests.**

**Control plane — `web/`** (Next.js + Drizzle + Stack Auth + Effect)
- Four tables; OAuth chains never persisted; BYOK keys sealed with AES-256-GCM envelope encryption.
- Effect services mirroring `services/vms`: repository, Stack-items credit billing (0-floored debits), key minting, worker pool sync + OAuth seeding, connect flows (Anthropic PKCE, OpenAI device/import).
- Team-scoped `/api/coderouter/*` routes; service-token internal routes (pool-config, idempotent usage-ingest). **16 tests.**

**CI + docs** — `.github/workflows/coderouter.yml` (mirrors presence.yml); `docs/coderouter.md`.

### Phase 2 — macOS app integration (committed)

- `AuthEnvironment.coderouterBaseURL`/`coderouterGatewayBaseURL`; `CoderouterClient` actor (mirrors `VMClient`).
- Pure `CoderouterEnvironmentPolicy` helper (leaf `CMUXAgentLaunch` package) computing per-agent-kind env overrides — Claude only for now; `[]` when disabled/keyless.
- **AI Gateway** Settings section behind a package-defined `CoderouterFlow` protocol (+ app `HostCoderouterFlow`); default-off routing toggle; key stored via `SecretFileStore`.
- Gated spawn injection at a single shared `Workspace` startup-env producer + the `RestorableAgentSession` respawn path. **No change to `mergedStartupEnvironment`, no `CmuxTerminal` edits.** Token never allowlisted, never logged. Localized (19 locales), pbxproj-wired XCTests (8 tests).

## Status
Not yet deployed (needs Cloudflare + `CODEROUTER_*` secrets) and routing is opt-in (default-off toggle). No existing behavior changes; all new env vars optional. Deferred to Phase 3: in-app OAuth connect UI, Codex/OpenAI launch injection, managed-credit resale go-live.

## Verification
- `workers/coderouter`: `bun run check` — 39 tests + wrangler dry-run.
- `web`: typecheck + 16 tests + `bun db:check`.
- macOS: full Debug app builds; `cmux-unit` XCTest suites pass (8 tests); localization audit (18 keys × 19 locales) and secret-policy audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)