### PR TITLE
mux: per-surface agent state machine with hook authority and title detection

### DIFF
--- a/mux/crates/mux-core/src/agent.rs
+++ b/mux/crates/mux-core/src/agent.rs
@@ -1,0 +1,518 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::SurfaceId;
+
+pub const DEFAULT_AGENTS: [&str; 4] = ["claude", "codex", "opencode", "pi"];
+pub const DETECTION_DEBOUNCE: Duration = Duration::from_millis(150);
+pub const IDLE_QUIET: Duration = Duration::from_secs(2);
+
+pub fn default_agents() -> Vec<String> {
+    DEFAULT_AGENTS.iter().map(|agent| (*agent).to_string()).collect()
+}
+
+pub fn normalize_agents(agents: &[String]) -> Vec<String> {
+    let mut normalized = agents
+        .iter()
+        .map(|agent| agent.trim().to_lowercase())
+        .filter(|agent| !agent.is_empty())
+        .collect::<Vec<_>>();
+    if normalized.is_empty() {
+        normalized = default_agents();
+    }
+    normalized
+}
+
+/// The first configured agent program appearing as a word in the title.
+pub fn identify_agent(title: &str, agents: &[String]) -> Option<String> {
+    let lower = title.to_lowercase();
+    let words = lower
+        .split(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>();
+    agents.iter().find(|agent| words.contains(&agent.as_str())).cloned()
+}
+
+pub fn title_has_action_required(title: &str) -> bool {
+    title.to_lowercase().contains("action required")
+}
+
+pub fn title_has_braille_spinner(title: &str) -> bool {
+    title.trim_start().chars().next().is_some_and(|ch| ('\u{2800}'..='\u{28ff}').contains(&ch))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentState {
+    Working,
+    Blocked,
+    Idle,
+    Done,
+    Unknown,
+}
+
+impl AgentState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AgentState::Working => "working",
+            AgentState::Blocked => "blocked",
+            AgentState::Idle => "idle",
+            AgentState::Done => "done",
+            AgentState::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentSource {
+    Detection,
+    Hook,
+}
+
+impl AgentSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AgentSource::Detection => "detection",
+            AgentSource::Hook => "hook",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentInfo {
+    pub agent: Option<String>,
+    pub state: AgentState,
+    pub source: AgentSource,
+    pub custom_status: Option<String>,
+    pub session_ref: Option<String>,
+    pub last_change: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentEntry {
+    pub surface: SurfaceId,
+    pub agent: String,
+    pub state: AgentState,
+    pub source: AgentSource,
+    pub custom_status: Option<String>,
+    pub session_ref: Option<String>,
+    pub last_change: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentStateChange {
+    pub surface: SurfaceId,
+    pub agent: String,
+    pub state: AgentState,
+    pub source: AgentSource,
+    pub custom_status: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct AgentStore {
+    detection: HashMap<SurfaceId, AgentInfo>,
+    hook: HashMap<SurfaceId, AgentInfo>,
+    effective: HashMap<SurfaceId, AgentInfo>,
+    sessions: HashMap<SurfaceId, AgentSession>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AgentSession {
+    agent: String,
+    session_ref: String,
+}
+
+impl AgentStore {
+    pub(crate) fn list(&self) -> Vec<AgentEntry> {
+        let mut entries = self
+            .effective
+            .iter()
+            .filter_map(|(surface, info)| {
+                let info = self.with_session(*surface, info.clone());
+                let agent = info.agent.clone()?;
+                Some(AgentEntry {
+                    surface: *surface,
+                    agent,
+                    state: info.state,
+                    source: info.source,
+                    custom_status: info.custom_status.clone(),
+                    session_ref: info.session_ref.clone(),
+                    last_change: info.last_change,
+                })
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|entry| entry.surface);
+        entries
+    }
+
+    pub(crate) fn effective(&self, surface: SurfaceId) -> Option<AgentInfo> {
+        self.effective.get(&surface).cloned().map(|info| self.with_session(surface, info))
+    }
+
+    pub(crate) fn record_session(
+        &mut self,
+        surface: SurfaceId,
+        agent: String,
+        session_ref: Option<String>,
+    ) {
+        let Some(session_ref) = session_ref else { return };
+        self.sessions.insert(surface, AgentSession { agent, session_ref });
+    }
+
+    pub(crate) fn apply_detection(
+        &mut self,
+        surface: SurfaceId,
+        mut info: AgentInfo,
+    ) -> Option<AgentStateChange> {
+        info.source = AgentSource::Detection;
+        preserve_last_change(self.detection.get(&surface), &mut info);
+        self.detection.insert(surface, info.clone());
+        if self.hook.contains_key(&surface) {
+            return None;
+        }
+        self.set_effective(surface, Some(info))
+    }
+
+    pub(crate) fn apply_hook(
+        &mut self,
+        surface: SurfaceId,
+        mut info: AgentInfo,
+    ) -> Option<AgentStateChange> {
+        preserve_last_change(self.hook.get(&surface), &mut info);
+        self.hook.insert(surface, info.clone());
+        self.set_effective(surface, Some(info))
+    }
+
+    pub(crate) fn clear_detection(&mut self, surface: SurfaceId) -> Option<AgentStateChange> {
+        self.detection.remove(&surface);
+        if self.hook.contains_key(&surface) {
+            return None;
+        }
+        self.effective.remove(&surface);
+        None
+    }
+
+    pub(crate) fn clear_hook(
+        &mut self,
+        surface: SurfaceId,
+        last_change: u64,
+    ) -> Option<AgentStateChange> {
+        if let Some(next) = self.detection.get(&surface).cloned() {
+            self.hook.remove(&surface);
+            self.set_effective(surface, Some(next))
+        } else {
+            self.finish_and_clear(surface, AgentSource::Hook, last_change)
+        }
+    }
+
+    pub(crate) fn finish_and_clear(
+        &mut self,
+        surface: SurfaceId,
+        source: AgentSource,
+        last_change: u64,
+    ) -> Option<AgentStateChange> {
+        let current = self
+            .effective
+            .get(&surface)
+            .or_else(|| self.hook.get(&surface))
+            .or_else(|| self.detection.get(&surface))
+            .cloned();
+        self.effective.remove(&surface);
+        self.hook.remove(&surface);
+        self.detection.remove(&surface);
+        self.sessions.remove(&surface);
+
+        let mut current = current?;
+        let agent = current.agent.take()?;
+        if current.state == AgentState::Done {
+            return None;
+        }
+        let done = AgentInfo {
+            agent: Some(agent),
+            state: AgentState::Done,
+            source,
+            custom_status: None,
+            session_ref: current.session_ref,
+            last_change,
+        };
+        AgentStore::change_from(surface, &done)
+    }
+
+    fn set_effective(
+        &mut self,
+        surface: SurfaceId,
+        next: Option<AgentInfo>,
+    ) -> Option<AgentStateChange> {
+        let changed = match (self.effective.get(&surface), next.as_ref()) {
+            (Some(prev), Some(next)) => !same_visible_agent_info(prev, next),
+            (None, Some(_)) => true,
+            (Some(_), None) => true,
+            (None, None) => false,
+        };
+        match next {
+            Some(next) => {
+                let next = match self.effective.get(&surface) {
+                    Some(prev) if same_visible_agent_info(prev, &next) => {
+                        let mut next = next;
+                        next.last_change = prev.last_change;
+                        next
+                    }
+                    _ => next,
+                };
+                self.effective.insert(surface, next.clone());
+                changed.then(|| AgentStore::change_from(surface, &next)).flatten()
+            }
+            None => {
+                self.effective.remove(&surface);
+                None
+            }
+        }
+    }
+
+    fn change_from(surface: SurfaceId, info: &AgentInfo) -> Option<AgentStateChange> {
+        Some(AgentStateChange {
+            surface,
+            agent: info.agent.clone()?,
+            state: info.state,
+            source: info.source,
+            custom_status: info.custom_status.clone(),
+        })
+    }
+
+    fn with_session(&self, surface: SurfaceId, mut info: AgentInfo) -> AgentInfo {
+        if info.session_ref.is_none() {
+            if let Some(session) = self.sessions.get(&surface) {
+                if info.agent.as_deref() == Some(session.agent.as_str()) {
+                    info.session_ref = Some(session.session_ref.clone());
+                }
+            }
+        }
+        info
+    }
+}
+
+fn same_visible_agent_info(a: &AgentInfo, b: &AgentInfo) -> bool {
+    a.agent == b.agent
+        && a.state == b.state
+        && a.source == b.source
+        && a.custom_status == b.custom_status
+}
+
+fn preserve_last_change(prev: Option<&AgentInfo>, next: &mut AgentInfo) {
+    if let Some(prev) = prev {
+        if same_visible_agent_info(prev, next) {
+            next.last_change = prev.last_change;
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DetectorEvent {
+    Activity { surface: SurfaceId, title: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DetectorAction {
+    Active { surface: SurfaceId, title: String },
+    Quiet { surface: SurfaceId, title: String },
+}
+
+#[derive(Debug)]
+struct PendingDetection {
+    title: String,
+    active_due: Instant,
+    idle_due: Instant,
+    active_reported: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct AgentDetector {
+    debounce: Duration,
+    idle_quiet: Duration,
+    pending: HashMap<SurfaceId, PendingDetection>,
+}
+
+impl Default for AgentDetector {
+    fn default() -> Self {
+        AgentDetector::new(DETECTION_DEBOUNCE, IDLE_QUIET)
+    }
+}
+
+impl AgentDetector {
+    fn new(debounce: Duration, idle_quiet: Duration) -> Self {
+        AgentDetector { debounce, idle_quiet, pending: HashMap::new() }
+    }
+
+    pub(crate) fn ingest(&mut self, now: Instant, event: DetectorEvent) {
+        match event {
+            DetectorEvent::Activity { surface, title } => {
+                self.pending.insert(
+                    surface,
+                    PendingDetection {
+                        title,
+                        active_due: now + self.debounce,
+                        idle_due: now + self.idle_quiet,
+                        active_reported: false,
+                    },
+                );
+            }
+        }
+    }
+
+    pub(crate) fn next_deadline(&self) -> Option<Instant> {
+        self.pending
+            .values()
+            .flat_map(|pending| {
+                let active = (!pending.active_reported).then_some(pending.active_due);
+                [active, Some(pending.idle_due)]
+            })
+            .flatten()
+            .min()
+    }
+
+    pub(crate) fn drain_due(&mut self, now: Instant) -> Vec<DetectorAction> {
+        let mut actions = Vec::new();
+        let surfaces = self.pending.keys().copied().collect::<Vec<_>>();
+        for surface in surfaces {
+            let Some(pending) = self.pending.get_mut(&surface) else { continue };
+            if !pending.active_reported && pending.active_due <= now {
+                pending.active_reported = true;
+                actions.push(DetectorAction::Active { surface, title: pending.title.clone() });
+            }
+            if pending.idle_due <= now {
+                let pending = self.pending.remove(&surface).expect("pending key existed");
+                actions.push(DetectorAction::Quiet { surface, title: pending.title });
+            }
+        }
+        actions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn info(agent: &str, state: AgentState, source: AgentSource, last_change: u64) -> AgentInfo {
+        AgentInfo {
+            agent: Some(agent.to_string()),
+            state,
+            source,
+            custom_status: None,
+            session_ref: None,
+            last_change,
+        }
+    }
+
+    #[test]
+    fn detection_then_hook_override_then_clear_returns_to_detection() {
+        let mut store = AgentStore::default();
+        let changed =
+            store.apply_detection(7, info("codex", AgentState::Working, AgentSource::Detection, 1));
+        assert_eq!(changed.as_ref().map(|c| c.state), Some(AgentState::Working));
+        assert_eq!(store.effective(7).unwrap().source, AgentSource::Detection);
+
+        let changed = store.apply_hook(7, info("codex", AgentState::Blocked, AgentSource::Hook, 2));
+        assert_eq!(changed.as_ref().map(|c| c.state), Some(AgentState::Blocked));
+        assert_eq!(store.effective(7).unwrap().source, AgentSource::Hook);
+
+        let changed =
+            store.apply_detection(7, info("codex", AgentState::Idle, AgentSource::Detection, 3));
+        assert!(changed.is_none());
+        assert_eq!(store.effective(7).unwrap().state, AgentState::Blocked);
+
+        let changed = store.clear_hook(7, 4).expect("clear should reveal detection state");
+        assert_eq!(changed.state, AgentState::Idle);
+        assert_eq!(changed.source, AgentSource::Detection);
+        assert_eq!(store.effective(7).unwrap().state, AgentState::Idle);
+
+        let changed =
+            store.apply_hook(8, info("claude", AgentState::Blocked, AgentSource::Hook, 5));
+        assert_eq!(changed.as_ref().map(|c| c.state), Some(AgentState::Blocked));
+        let changed =
+            store.clear_hook(8, 6).expect("clear without fallback should emit terminal state");
+        assert_eq!(changed.agent, "claude");
+        assert_eq!(changed.state, AgentState::Done);
+        assert_eq!(changed.source, AgentSource::Hook);
+        assert!(store.effective(8).is_none());
+    }
+
+    #[test]
+    fn no_agent_detection_pass_does_not_clear_hook_authority() {
+        let mut store = AgentStore::default();
+        store.apply_detection(3, info("claude", AgentState::Working, AgentSource::Detection, 1));
+        store.apply_hook(3, info("claude", AgentState::Blocked, AgentSource::Hook, 2));
+
+        let changed = store.clear_detection(3);
+        assert!(changed.is_none());
+        let effective = store.effective(3).expect("hook state should remain effective");
+        assert_eq!(effective.agent.as_deref(), Some("claude"));
+        assert_eq!(effective.state, AgentState::Blocked);
+        assert_eq!(effective.source, AgentSource::Hook);
+    }
+
+    #[test]
+    fn done_transition_on_exit_clears_agent() {
+        let mut store = AgentStore::default();
+        store.apply_detection(9, info("claude", AgentState::Working, AgentSource::Detection, 1));
+
+        let changed =
+            store.finish_and_clear(9, AgentSource::Detection, 2).expect("done transition");
+        assert_eq!(changed.agent, "claude");
+        assert_eq!(changed.state, AgentState::Done);
+        assert_eq!(changed.source, AgentSource::Detection);
+        assert!(store.effective(9).is_none());
+        assert!(store.list().is_empty());
+    }
+
+    #[test]
+    fn unknown_is_a_real_classification() {
+        let mut store = AgentStore::default();
+        let changed = store
+            .apply_detection(11, info("opencode", AgentState::Unknown, AgentSource::Detection, 1));
+        assert_eq!(changed.as_ref().map(|c| c.state), Some(AgentState::Unknown));
+        assert_eq!(store.list()[0].state, AgentState::Unknown);
+    }
+
+    #[test]
+    fn identical_re_report_preserves_last_change() {
+        let mut store = AgentStore::default();
+        store.apply_detection(12, info("codex", AgentState::Working, AgentSource::Detection, 10));
+        assert_eq!(store.effective(12).unwrap().last_change, 10);
+
+        let changed = store
+            .apply_detection(12, info("codex", AgentState::Working, AgentSource::Detection, 99));
+        assert!(changed.is_none());
+        assert_eq!(store.effective(12).unwrap().last_change, 10);
+    }
+
+    #[test]
+    fn detector_holds_idle_until_quiet_window_after_latest_activity() {
+        let mut detector = AgentDetector::new(Duration::from_millis(150), Duration::from_secs(2));
+        let start = Instant::now();
+        detector.ingest(start, DetectorEvent::Activity { surface: 1, title: "codex".to_string() });
+
+        assert!(detector.drain_due(start + Duration::from_millis(149)).is_empty());
+        assert_eq!(
+            detector.drain_due(start + Duration::from_millis(150)),
+            vec![DetectorAction::Active { surface: 1, title: "codex".to_string() }]
+        );
+
+        detector.ingest(
+            start + Duration::from_millis(1900),
+            DetectorEvent::Activity { surface: 1, title: "codex".to_string() },
+        );
+        let actions = detector.drain_due(start + Duration::from_millis(2050));
+        assert_eq!(
+            actions,
+            vec![DetectorAction::Active { surface: 1, title: "codex".to_string() }]
+        );
+        assert!(detector.drain_due(start + Duration::from_millis(3899)).is_empty());
+        assert_eq!(
+            detector.drain_due(start + Duration::from_millis(3900)),
+            vec![DetectorAction::Quiet { surface: 1, title: "codex".to_string() }]
+        );
+    }
+}

--- a/mux/crates/mux-core/src/lib.rs
+++ b/mux/crates/mux-core/src/lib.rs
@@ -8,6 +8,7 @@
 //! [`MuxEvent`]s and read surface state; they never own terminal state
 //! themselves, which is what makes the backend attachable.
 
+mod agent;
 mod browser;
 mod model;
 mod mux;
@@ -16,6 +17,7 @@ mod surface;
 pub mod layout;
 pub mod server;
 
+pub use agent::{AgentEntry, AgentInfo, AgentSource, AgentState, AgentStateChange};
 pub use layout::{
     layout_screen, split_for_pane_edge, split_sides, LayoutResult, Rect, SplitEdge, SplitResize,
 };

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -3,9 +3,15 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
+use crate::agent::{
+    identify_agent, normalize_agents, title_has_action_required, title_has_braille_spinner,
+    AgentDetector, AgentEntry, AgentInfo, AgentSource, AgentState, AgentStateChange, AgentStore,
+    DetectorAction, DetectorEvent,
+};
 use crate::browser::BrowserRuntime;
 use crate::model::{Node, Pane, Screen, State, Workspace};
 use crate::surface::{DefaultColors, Surface, SurfaceOptions};
@@ -27,6 +33,12 @@ pub enum MuxEvent {
     SurfaceExited(SurfaceId),
     TitleChanged(SurfaceId),
     Bell(SurfaceId),
+    AgentStateChanged(AgentStateChange),
+    Notification {
+        title: String,
+        body: Option<String>,
+        level: String,
+    },
     /// The workspace/screen/pane/tab tree changed (from any frontend or
     /// the control socket).
     TreeChanged,
@@ -40,7 +52,11 @@ pub struct Mux {
     subscribers: Mutex<Vec<Sender<MuxEvent>>>,
     next_id: AtomicU64,
     next_active_at: AtomicU64,
+    next_agent_change: AtomicU64,
     surface_options: SurfaceOptions,
+    agent_names: Mutex<Vec<String>>,
+    agent_store: Mutex<AgentStore>,
+    agent_detector_tx: Sender<DetectorEvent>,
     browser_runtime: Mutex<Option<Arc<BrowserRuntime>>>,
     cell_pixels: Mutex<(u16, u16)>,
     default_colors: Mutex<DefaultColors>,
@@ -49,7 +65,9 @@ pub struct Mux {
 
 impl Mux {
     pub fn new(session: impl Into<String>, surface_options: SurfaceOptions) -> Arc<Self> {
-        Arc::new(Mux {
+        let (agent_detector_tx, agent_detector_rx) = channel();
+        let agent_names = normalize_agents(&surface_options.agents);
+        let mux = Arc::new(Mux {
             state: Mutex::new(State {
                 workspaces: Vec::new(),
                 active_workspace: 0,
@@ -59,12 +77,18 @@ impl Mux {
             subscribers: Mutex::new(Vec::new()),
             next_id: AtomicU64::new(1),
             next_active_at: AtomicU64::new(1),
+            next_agent_change: AtomicU64::new(1),
             surface_options,
+            agent_names: Mutex::new(agent_names),
+            agent_store: Mutex::new(AgentStore::default()),
+            agent_detector_tx,
             browser_runtime: Mutex::new(None),
             cell_pixels: Mutex::new((8, 16)),
             default_colors: Mutex::new(DefaultColors::default()),
             session: session.into(),
-        })
+        });
+        Mux::start_agent_detector(&mux, agent_detector_rx);
+        mux
     }
 
     fn next_id(&self) -> u64 {
@@ -73,6 +97,47 @@ impl Mux {
 
     fn next_active_at(&self) -> u64 {
         self.next_active_at.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn next_agent_change(&self) -> u64 {
+        self.next_agent_change.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn start_agent_detector(mux: &Arc<Self>, rx: Receiver<DetectorEvent>) {
+        let mux = Arc::downgrade(mux);
+        std::thread::Builder::new()
+            .name("mux-agent-detector".into())
+            .spawn(move || {
+                let mut detector = AgentDetector::default();
+                loop {
+                    let event = match detector.next_deadline() {
+                        Some(deadline) => {
+                            let now = Instant::now();
+                            match rx.recv_timeout(deadline.saturating_duration_since(now)) {
+                                Ok(event) => Some(event),
+                                Err(RecvTimeoutError::Timeout) => None,
+                                Err(RecvTimeoutError::Disconnected) => break,
+                            }
+                        }
+                        None => match rx.recv() {
+                            Ok(event) => Some(event),
+                            Err(_) => break,
+                        },
+                    };
+                    if let Some(event) = event {
+                        detector.ingest(Instant::now(), event);
+                    }
+                    let actions = detector.drain_due(Instant::now());
+                    if actions.is_empty() {
+                        continue;
+                    }
+                    let Some(mux) = mux.upgrade() else { break };
+                    for action in actions {
+                        mux.apply_detector_action(action);
+                    }
+                }
+            })
+            .expect("spawn mux agent detector");
     }
 
     pub fn subscribe(&self) -> Receiver<MuxEvent> {
@@ -84,6 +149,172 @@ impl Mux {
     pub fn emit(&self, event: MuxEvent) {
         let mut subs = self.subscribers.lock().unwrap();
         subs.retain(|tx| tx.send(event.clone()).is_ok());
+    }
+
+    pub(crate) fn observe_agent_activity(&self, surface: SurfaceId, title: String) {
+        let _ = self.agent_detector_tx.send(DetectorEvent::Activity { surface, title });
+    }
+
+    fn apply_detector_action(&self, action: DetectorAction) {
+        match action {
+            DetectorAction::Active { surface, title } => {
+                self.apply_detection_from_title(surface, &title, false);
+            }
+            DetectorAction::Quiet { surface, title } => {
+                self.apply_detection_from_title(surface, &title, true);
+            }
+        }
+    }
+
+    fn apply_detection_from_title(&self, surface: SurfaceId, title: &str, quiet: bool) {
+        if !self.surface_is_pty(surface) {
+            return;
+        }
+        let agents = self.agent_names.lock().unwrap().clone();
+        let Some(agent) = identify_agent(title, &agents) else {
+            self.clear_agent_detection(surface);
+            return;
+        };
+        let working = title_has_braille_spinner(title) || !quiet;
+        let state = if title_has_action_required(title) {
+            AgentState::Blocked
+        } else if working {
+            AgentState::Working
+        } else {
+            AgentState::Idle
+        };
+        self.apply_agent_detection(surface, agent, state, None, None);
+    }
+
+    fn surface_is_pty(&self, surface: SurfaceId) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .surfaces
+            .get(&surface)
+            .is_some_and(|surface| surface.kind() == crate::SurfaceKind::Pty)
+    }
+
+    pub fn set_agent_names(&self, agents: Vec<String>) {
+        *self.agent_names.lock().unwrap() = normalize_agents(&agents);
+    }
+
+    pub fn list_agents(&self) -> Vec<AgentEntry> {
+        self.agent_store.lock().unwrap().list()
+    }
+
+    pub fn agent_info(&self, surface: SurfaceId) -> Option<AgentInfo> {
+        self.agent_store.lock().unwrap().effective(surface)
+    }
+
+    pub fn report_agent(
+        &self,
+        surface: SurfaceId,
+        source: AgentSource,
+        agent: Option<String>,
+        state: Option<AgentState>,
+        custom_status: Option<String>,
+        session_ref: Option<String>,
+    ) -> anyhow::Result<()> {
+        if !self.surface_is_pty(surface) {
+            anyhow::bail!("unknown PTY surface {surface}");
+        }
+        if let (Some(agent), Some(session_ref)) = (agent.as_ref(), session_ref.as_ref()) {
+            self.agent_store.lock().unwrap().record_session(
+                surface,
+                agent.clone(),
+                Some(session_ref.clone()),
+            );
+        }
+        let Some(state) = state else {
+            if source == AgentSource::Hook && agent.is_none() {
+                self.clear_agent_hook(surface);
+            }
+            return Ok(());
+        };
+        match source {
+            AgentSource::Detection => {
+                let Some(agent) = agent else {
+                    self.clear_agent_detection(surface);
+                    return Ok(());
+                };
+                self.apply_agent_detection(surface, agent, state, custom_status, session_ref);
+            }
+            AgentSource::Hook => {
+                let Some(agent) = agent else {
+                    self.clear_agent_hook(surface);
+                    return Ok(());
+                };
+                let info = AgentInfo {
+                    agent: Some(agent),
+                    state,
+                    source,
+                    custom_status,
+                    session_ref,
+                    last_change: self.next_agent_change(),
+                };
+                let change = self.agent_store.lock().unwrap().apply_hook(surface, info);
+                if let Some(change) = change {
+                    self.emit(MuxEvent::AgentStateChanged(change));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn clear_agent_hook(&self, surface: SurfaceId) {
+        let change = self.agent_store.lock().unwrap().clear_hook(surface, self.next_agent_change());
+        if let Some(change) = change {
+            self.emit(MuxEvent::AgentStateChanged(change));
+        }
+    }
+
+    fn clear_agent_detection(&self, surface: SurfaceId) {
+        let change = self.agent_store.lock().unwrap().clear_detection(surface);
+        if let Some(change) = change {
+            self.emit(MuxEvent::AgentStateChanged(change));
+        }
+    }
+
+    pub fn notify(&self, title: String, body: Option<String>, level: Option<String>) {
+        self.emit(MuxEvent::Notification {
+            title,
+            body,
+            level: level.unwrap_or_else(|| "info".to_string()),
+        });
+    }
+
+    fn apply_agent_detection(
+        &self,
+        surface: SurfaceId,
+        agent: String,
+        state: AgentState,
+        custom_status: Option<String>,
+        session_ref: Option<String>,
+    ) {
+        let info = AgentInfo {
+            agent: Some(agent),
+            state,
+            source: AgentSource::Detection,
+            custom_status,
+            session_ref,
+            last_change: self.next_agent_change(),
+        };
+        let change = self.agent_store.lock().unwrap().apply_detection(surface, info);
+        if let Some(change) = change {
+            self.emit(MuxEvent::AgentStateChanged(change));
+        }
+    }
+
+    fn finish_agent(&self, surface: SurfaceId, source: AgentSource) {
+        let change = self.agent_store.lock().unwrap().finish_and_clear(
+            surface,
+            source,
+            self.next_agent_change(),
+        );
+        if let Some(change) = change {
+            self.emit(MuxEvent::AgentStateChanged(change));
+        }
     }
 
     fn spawn_surface(
@@ -678,6 +909,7 @@ impl Mux {
     /// reaps the surface out of the tree itself, so frontends only need to
     /// drop their render state.
     pub fn surface_exited(&self, id: SurfaceId) {
+        self.finish_agent(id, AgentSource::Detection);
         self.close_surface(id);
         self.emit(MuxEvent::SurfaceExited(id));
     }

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -32,8 +32,8 @@ use serde_json::{json, Value};
 
 use crate::model::{Screen, State};
 use crate::{
-    AttachFrame, DefaultColors, Mux, MuxEvent, Node, PaneId, Rgb, ScreenId, SplitDir, SurfaceId,
-    SurfaceKind, WorkspaceId,
+    AgentEntry, AgentSource, AgentState, AttachFrame, DefaultColors, Mux, MuxEvent, Node, PaneId,
+    Rgb, ScreenId, SplitDir, SurfaceId, SurfaceKind, WorkspaceId,
 };
 
 pub const PROTOCOL_VERSION: u32 = 6;
@@ -206,6 +206,29 @@ enum Command {
     },
     /// Stream mux events on this connection.
     Subscribe,
+    /// Hook or detector report for a surface's agent state.
+    ReportAgent {
+        surface: SurfaceId,
+        source: AgentSource,
+        #[serde(default)]
+        agent: Option<String>,
+        #[serde(default)]
+        state: Option<AgentState>,
+        #[serde(default)]
+        custom_status: Option<String>,
+        #[serde(default)]
+        session: Option<String>,
+    },
+    /// List surfaces with known agent state.
+    ListAgents,
+    /// Broadcast a transient notification event.
+    Notify {
+        title: String,
+        #[serde(default)]
+        body: Option<String>,
+        #[serde(default)]
+        level: Option<String>,
+    },
     /// Stream a surface: vt-state event followed by live output events.
     AttachSurface {
         surface: SurfaceId,
@@ -370,6 +393,23 @@ fn workspaces_json(state: &State) -> Value {
             })
         }).collect::<Vec<_>>(),
     })
+}
+
+fn agent_entry_json(entry: &AgentEntry) -> Value {
+    let mut value = json!({
+        "surface": entry.surface,
+        "agent": entry.agent,
+        "state": entry.state.as_str(),
+        "source": entry.source.as_str(),
+        "last_change": entry.last_change,
+    });
+    if let Some(custom_status) = entry.custom_status.as_ref() {
+        value["custom_status"] = json!(custom_status);
+    }
+    if let Some(session_ref) = entry.session_ref.as_ref() {
+        value["session"] = json!(session_ref);
+    }
+    value
 }
 
 fn get_surface(mux: &Mux, id: SurfaceId) -> anyhow::Result<Arc<crate::Surface>> {
@@ -589,6 +629,20 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             surface.try_with_terminal(|t| t.scroll_delta(delta))?;
             Ok(json!({}))
         }
+        Command::ReportAgent { surface, source, agent, state, custom_status, session } => {
+            mux.report_agent(surface, source, agent, state, custom_status, session)?;
+            Ok(json!({}))
+        }
+        Command::ListAgents => {
+            let agents = mux.list_agents();
+            Ok(json!({
+                "agents": agents.iter().map(agent_entry_json).collect::<Vec<_>>(),
+            }))
+        }
+        Command::Notify { title, body, level } => {
+            mux.notify(title, body, level);
+            Ok(json!({}))
+        }
         Command::Subscribe => {
             let events = mux.subscribe();
             let writer = writer.clone();
@@ -613,6 +667,25 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
                             json!({"event": "title-changed", "surface": id})
                         }
                         MuxEvent::Bell(id) => json!({"event": "bell", "surface": id}),
+                        MuxEvent::AgentStateChanged(change) => {
+                            let mut value = json!({
+                                "event": "agent-state-changed",
+                                "surface": change.surface,
+                                "agent": change.agent,
+                                "state": change.state.as_str(),
+                                "source": change.source.as_str(),
+                            });
+                            if let Some(custom_status) = change.custom_status.as_ref() {
+                                value["custom_status"] = json!(custom_status);
+                            }
+                            value
+                        }
+                        MuxEvent::Notification { title, body, level } => json!({
+                            "event": "notification",
+                            "title": title,
+                            "body": body,
+                            "level": level,
+                        }),
                         MuxEvent::TreeChanged => json!({"event": "tree-changed"}),
                         MuxEvent::Empty => json!({"event": "empty"}),
                     };

--- a/mux/crates/mux-core/src/surface.rs
+++ b/mux/crates/mux-core/src/surface.rs
@@ -13,10 +13,10 @@ use std::sync::{Arc, Mutex, Weak};
 use ghostty_vt::{Callbacks, RenderState, Rgb, Terminal};
 use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtySize};
 
-use crate::{Mux, MuxEvent, SurfaceId};
-
+use crate::agent::default_agents;
 pub use crate::browser::{BrowserFrame, BrowserSource};
 use crate::browser::{BrowserRuntime, BrowserSurface};
+use crate::{Mux, MuxEvent, SurfaceId};
 
 /// How to spawn surface children.
 #[derive(Debug, Clone)]
@@ -32,6 +32,8 @@ pub struct SurfaceOptions {
     pub scrollback: usize,
     /// Extra environment for children (e.g. CMUX_MUX_SOCKET).
     pub extra_env: Vec<(String, String)>,
+    /// Program names recognized as agents in surface titles.
+    pub agents: Vec<String>,
     /// Optional Chrome/Chromium binary for browser surfaces.
     pub chrome_binary: Option<String>,
     /// Optional existing Chrome CDP endpoint, as ws://... or http://host:port.
@@ -56,6 +58,7 @@ impl Default for SurfaceOptions {
             rows: 24,
             scrollback: 10_000,
             extra_env: Vec::new(),
+            agents: default_agents(),
             chrome_binary: None,
             cdp_url: None,
             browser_discover: true,
@@ -178,6 +181,8 @@ impl Surface {
         let mut cmd = CommandBuilder::new(&argv[0]);
         cmd.args(&argv[1..]);
         cmd.env("TERM", &opts.term);
+        cmd.env("CMUX_MUX_SURFACE", id.to_string());
+        cmd.env("CMUX_MUX_SURFACE_ID", id.to_string());
         for (k, v) in &opts.extra_env {
             cmd.env(k, v);
         }
@@ -250,6 +255,7 @@ impl Surface {
                         Ok(n) => n,
                     };
                     let pty = surface.as_pty().expect("surface reader got non-pty surface");
+                    let current_title;
                     {
                         let mut term = pty.term.lock().unwrap();
                         term.vt_write(&buf[..n]);
@@ -262,10 +268,13 @@ impl Surface {
                         }
                         if title_changed.swap(false, Ordering::Relaxed) {
                             let title = term.title().unwrap_or_default();
-                            *pty.title.lock().unwrap() = title;
+                            *pty.title.lock().unwrap() = title.clone();
+                            current_title = title;
                             if let Some(mux) = mux.upgrade() {
                                 mux.emit(MuxEvent::TitleChanged(surface.id));
                             }
+                        } else {
+                            current_title = pty.title.lock().unwrap().clone();
                         }
                         if let Some(pwd) = term.pwd() {
                             *pty.pwd.lock().unwrap() = Some(pwd);
@@ -274,6 +283,9 @@ impl Surface {
                     let responses = std::mem::take(&mut *pending_responses.lock().unwrap());
                     if !responses.is_empty() {
                         let _ = surface.write_bytes(&responses);
+                    }
+                    if let Some(mux) = mux.upgrade() {
+                        mux.observe_agent_activity(surface.id, current_title);
                     }
                     if !pty.dirty.swap(true, Ordering::AcqRel) {
                         if let Some(mux) = mux.upgrade() {

--- a/mux/crates/mux-core/tests/pty.rs
+++ b/mux/crates/mux-core/tests/pty.rs
@@ -424,6 +424,122 @@ fn control_socket_broadcasts_surface_resized_once_per_changed_size() {
 }
 
 #[test]
+fn control_socket_reports_and_broadcasts_agent_state() {
+    let mux = Mux::new(unique_session("test-agent-report"), shell_opts("sleep 30"));
+    let surface = mux.new_workspace(None, None).unwrap();
+
+    let sock_path = mux_core::server::serve(mux.clone(), None).unwrap();
+    let subscribe_stream = UnixStream::connect(&sock_path).unwrap();
+    subscribe_stream.set_read_timeout(Some(Duration::from_millis(100))).unwrap();
+    let mut subscribe_writer = subscribe_stream.try_clone().unwrap();
+    let mut subscribe_reader = BufReader::new(subscribe_stream);
+
+    let command_stream = UnixStream::connect(&sock_path).unwrap();
+    let mut command_writer = command_stream.try_clone().unwrap();
+    let mut command_reader = BufReader::new(command_stream);
+
+    writeln!(subscribe_writer, r#"{{"id":1,"cmd":"subscribe"}}"#).unwrap();
+    let response = wait_for(|| read_json_line(&mut subscribe_reader), Duration::from_secs(5))
+        .expect("subscribe response");
+    assert_eq!(response["ok"], true, "subscribe failed: {response}");
+
+    writeln!(
+        command_writer,
+        r#"{{"id":2,"cmd":"report-agent","surface":{},"source":"hook","agent":"codex","state":"blocked","custom_status":"needs approval","session":"session-1"}}"#,
+        surface.id
+    )
+    .unwrap();
+    let mut line = String::new();
+    command_reader.read_line(&mut line).unwrap();
+    let response: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(response["ok"], true, "report-agent failed: {line}");
+
+    line.clear();
+    writeln!(command_writer, r#"{{"id":3,"cmd":"list-agents"}}"#).unwrap();
+    command_reader.read_line(&mut line).unwrap();
+    let response: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(response["ok"], true, "list-agents failed: {line}");
+    let agents = response["data"]["agents"].as_array().unwrap();
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0]["surface"], surface.id);
+    assert_eq!(agents[0]["agent"], "codex");
+    assert_eq!(agents[0]["state"], "blocked");
+    assert_eq!(agents[0]["source"], "hook");
+    assert_eq!(agents[0]["custom_status"], "needs approval");
+    assert_eq!(agents[0]["session"], "session-1");
+
+    let event = wait_for(
+        || {
+            while let Some(value) = read_json_line(&mut subscribe_reader) {
+                if value.get("event").and_then(|v| v.as_str()) == Some("agent-state-changed") {
+                    return Some(value);
+                }
+            }
+            None
+        },
+        Duration::from_secs(5),
+    )
+    .expect("no agent-state-changed event");
+    assert_eq!(event["surface"], surface.id);
+    assert_eq!(event["agent"], "codex");
+    assert_eq!(event["state"], "blocked");
+    assert_eq!(event["source"], "hook");
+    assert_eq!(event["custom_status"], "needs approval");
+
+    mux.close_surface(surface.id);
+    mux_core::server::cleanup(&sock_path);
+}
+
+#[test]
+fn control_socket_session_report_does_not_take_hook_authority() {
+    let mux = Mux::new(unique_session("test-agent-session-only"), shell_opts("sleep 30"));
+    let surface = mux.new_workspace(None, None).unwrap();
+
+    let sock_path = mux_core::server::serve(mux.clone(), None).unwrap();
+    let stream = UnixStream::connect(&sock_path).unwrap();
+    let mut writer = stream.try_clone().unwrap();
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+
+    writeln!(
+        writer,
+        r#"{{"id":1,"cmd":"report-agent","surface":{},"source":"detection","agent":"claude","state":"working"}}"#,
+        surface.id
+    )
+    .unwrap();
+    reader.read_line(&mut line).unwrap();
+    let response: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(response["ok"], true, "detection report failed: {line}");
+
+    line.clear();
+    writeln!(
+        writer,
+        r#"{{"id":2,"cmd":"report-agent","surface":{},"source":"hook","agent":"claude","session":"session-only"}}"#,
+        surface.id
+    )
+    .unwrap();
+    reader.read_line(&mut line).unwrap();
+    let response: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(response["ok"], true, "session-only report failed: {line}");
+
+    line.clear();
+    writeln!(writer, r#"{{"id":3,"cmd":"list-agents"}}"#).unwrap();
+    reader.read_line(&mut line).unwrap();
+    let response: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(response["ok"], true, "list-agents failed: {line}");
+    let agents = response["data"]["agents"].as_array().unwrap();
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0]["surface"], surface.id);
+    assert_eq!(agents[0]["agent"], "claude");
+    assert_eq!(agents[0]["state"], "working");
+    assert_eq!(agents[0]["source"], "detection");
+    assert_eq!(agents[0]["session"], "session-only");
+
+    mux.close_surface(surface.id);
+    mux_core::server::cleanup(&sock_path);
+}
+
+#[test]
 fn default_colors_apply_to_existing_and_future_surfaces() {
     let opts = SurfaceOptions { command: Some(vec!["/bin/cat".to_string()]), ..Default::default() };
     let mux = Mux::new("test-default-colors", opts);

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -124,6 +124,7 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     surface_options.browser_discover_ports = config.browser.discover_ports.clone();
     surface_options.browser_user_data_dir = config.browser.user_data_dir.clone();
     surface_options.browser_ephemeral = config.browser.ephemeral;
+    surface_options.agents = config.tabs.agents.clone();
     if let Some(term) = args.term {
         surface_options.term = term;
     }

--- a/mux/crates/mux-tui/src/session/remote.rs
+++ b/mux/crates/mux-tui/src/session/remote.rs
@@ -111,7 +111,7 @@ impl RemoteSession {
         let protocol = ident.get("protocol").and_then(|v| v.as_u64()).unwrap_or(0);
         if protocol != SUPPORTED_PROTOCOL_VERSION {
             anyhow::bail!(
-                "unsupported cmux-mux protocol {protocol}; this client requires protocol 6 because attach-stream resize markers are authoritative; restart the cmux-mux server"
+                "unsupported cmux-mux protocol {protocol}; this client requires protocol {SUPPORTED_PROTOCOL_VERSION} because attach-stream resize markers are authoritative; restart the cmux-mux server"
             );
         }
         session.request(json!({"cmd": "subscribe"}))?;

--- a/mux/scripts/hooks/claude-code-hook.sh
+++ b/mux/scripts/hooks/claude-code-hook.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+set -u
+
+if [ -z "${CMUX_MUX_SOCKET:-}" ]; then
+    exit 0
+fi
+
+surface="${CMUX_MUX_SURFACE:-${CMUX_MUX_SURFACE_ID:-}}"
+case "$surface" in
+    ''|*[!0-9]*) exit 0 ;;
+esac
+
+if ! command -v python3 >/dev/null 2>&1; then
+    exit 0
+fi
+
+payload="$(cat 2>/dev/null || printf '')"
+
+CMUX_CLAUDE_HOOK_PAYLOAD="$payload" python3 - "$CMUX_MUX_SOCKET" "$surface" <<'PY'
+import json
+import os
+import socket
+import sys
+
+
+def text(value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def send(request):
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(0.5)
+        sock.connect(sys.argv[1])
+        sock.sendall(json.dumps(request, separators=(",", ":")).encode("utf-8") + b"\n")
+        try:
+            sock.recv(4096)
+        except OSError:
+            pass
+        sock.close()
+    except OSError:
+        pass
+
+
+try:
+    surface = int(sys.argv[2])
+except (IndexError, ValueError):
+    sys.exit(0)
+
+try:
+    payload = json.loads(os.environ.get("CMUX_CLAUDE_HOOK_PAYLOAD") or "{}")
+except json.JSONDecodeError:
+    payload = {}
+
+event = (
+    payload.get("hook_event_name")
+    or payload.get("event")
+    or payload.get("type")
+    or os.environ.get("CLAUDE_HOOK_EVENT")
+)
+
+request = {
+    "cmd": "report-agent",
+    "surface": surface,
+    "source": "hook",
+    "agent": "claude",
+}
+
+if event == "Notification":
+    message = text(payload.get("message") or payload.get("notification") or payload.get("title"))
+    request["state"] = "blocked"
+    if message:
+        request["custom_status"] = message
+elif event == "Stop":
+    request["state"] = "done"
+elif event == "SessionStart":
+    session = text(payload.get("session_id") or payload.get("transcript_path"))
+    if session:
+        request["session"] = session
+    else:
+        sys.exit(0)
+else:
+    sys.exit(0)
+
+send(request)
+PY


### PR DESCRIPTION
## Summary
- Adds a per-surface agent state machine (`AgentState`/`AgentSource`/`AgentStore` in `agent.rs`): hook reports (session lifecycle events from coding-agent hooks) take authority over title-based detection.
- Detection never clears an authoritative hook entry; a hook clear with no detection fallback emits a terminal Done transition; a session-only report (no `state`) records the session ref without entering the hook state map.
- Background title-activity detector debounces PTY output and classifies agents by title after a quiet window.
- New control-socket commands: `report-agent`, `list-agents`, `notify`. New broadcast events: `agent-state-changed`, `notification`.
- Includes `scripts/hooks/claude-code-hook.sh`, the reference hook wiring Claude Code's `Notification`/`Stop`/`SessionStart` events to `report-agent`.

Base is `feat-rust-tui-backend` (PR #7180) since this branch builds on its mux.rs/server.rs changes; will rebase onto `main` once #7180 merges.

## Test plan
- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` all pass.
- `cargo build -p mux-tui` succeeds.
- `scripts/smoke-tui.py` and `scripts/smoke-attach.py` pass.
- New unit tests in `agent.rs` cover: hook-override-then-clear-then-fallback, detection-does-not-clear-hook-authority, done-on-exit, unknown-is-real-classification, last_change-preserved-on-identical-re-report, detector-quiet-window.
- New integration tests in `tests/pty.rs`: `control_socket_reports_and_broadcasts_agent_state`, `control_socket_session_report_does_not_take_hook_authority`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785890197&installation_id=133855650&pr_number=7412&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7412&signature=78391e01310c1d08bbb2d28b3cc46cd51a532e03c39b9341a543f426c9eea75e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New background detector thread and event surface on the mux hot path (PTY reader → agent activity), but logic is isolated with unit/integration tests and hook authority rules are explicit.
> 
> **Overview**
> Adds **per-PTY-surface agent tracking** so UIs and attach clients can see which coding agent is on a tab and whether it is working, blocked, idle, or done.
> 
> A new `agent` module defines `AgentStore` (separate detection vs hook layers, hooks win), title heuristics (agent name in title, braille spinner, “action required”), and a debounced `AgentDetector` thread fed from PTY output. `Mux` wires reports, emits `AgentStateChanged` / `Notification`, and finishes agent state when a surface exits.
> 
> The control socket gains **`report-agent`**, **`list-agents`**, and **`notify`**, with matching subscribe events. PTY children get `CMUX_MUX_SURFACE` / `CMUX_MUX_SURFACE_ID`; configurable agent names flow from TUI config into `SurfaceOptions`. **`scripts/hooks/claude-code-hook.sh`** maps Claude Code hook events to `report-agent` over the unix socket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02de2625f45dc2f8af873a57676f0d3e1b293ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-surface agent state machine so surfaces can report which coding agent is active and whether it's working, blocked, idle, or done. Hook reports take authority over title-based detection, and a background detector debounces PTY output to classify agents after a quiet window.

**New Features**
- Hook reports override detection; clearing a hook with no fallback emits a terminal Done, and session-only reports record the session ref without taking authority.
- Background detector classifies agents by title after a quiet window (defaults: `claude`, `codex`, `opencode`, `pi`). Braille spinner ⇒ Working; "Action Required" ⇒ Blocked; otherwise Idle when quiet.
- Control socket gains `report-agent`, `list-agents`, and `notify` commands plus `agent-state-changed` and `notification` broadcast events.
- `tabs.agents` config feeds `SurfaceOptions.agents`; children receive `CMUX_MUX_SURFACE`/`CMUX_MUX_SURFACE_ID`.
- Adds `scripts/hooks/claude-code-hook.sh` wiring Claude Code's Notification/Stop/SessionStart events to `report-agent`.

**Migration**
- Set custom agent names via `tabs.agents`; defaults apply when unset.
- Claude Code users should install the hook script with `CMUX_MUX_SOCKET` in env.
- Clients subscribing to events should handle `agent-state-changed` and `notification`.

<sup>Written for commit 6e22a5204983d797ab277a02935757f7fdcfe56c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

