### PR TITLE
Make iOS beta workflow external-eligible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Validate TestFlight notes generator
         run: python3 tests/test_ios_testflight_notes.py
 
+      - name: Validate external TestFlight group assignment helper
+        run: python3 tests/test_ios_testflight_external_distribution.py
+
       - name: Validate cmux scheme test configuration
         run: ./tests/test_ci_scheme_testaction_debug.sh
 

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -387,10 +387,12 @@ jobs:
 
       - name: Persist uploaded build metadata
         if: success()
+        env:
+          FINAL_BUILD_NUMBER: ${{ steps.upload.outputs.final_build_number }}
         run: |
           set -euo pipefail
           cat > "$RUNNER_TEMP/ios-testflight-build.json" <<EOF
-          {"head_sha":"${GITHUB_SHA}","build_number":"${{ steps.upload.outputs.final_build_number }}"}
+          {"head_sha":"${GITHUB_SHA}","build_number":"${FINAL_BUILD_NUMBER}"}
           EOF
 
       - name: Upload build metadata artifact

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -202,6 +202,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+        with:
+          persist-credentials: false
           submodules: recursive
           # Full history + tags so generate-testflight-notes.sh can walk the
           # commit range since the last beta and --auto-version can read ios-v*.
@@ -438,6 +440,10 @@ jobs:
       - name: Assign uploaded build to the external beta group
         run: |
           set -euo pipefail
+          if [ -z "${BUILD_NUMBER:-}" ] || [ "$BUILD_NUMBER" = "unknown" ]; then
+            echo "missing uploaded build number for external TestFlight assignment" >&2
+            exit 1
+          fi
           python3 ./ios/scripts/asc_assign_external_testflight_group.py \
             --bundle-id dev.cmux.app.beta \
             --build-number "$BUILD_NUMBER"

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -95,6 +95,7 @@ jobs:
             let lastUploadedSha = null;
             let lastUploadedRunId = null;
             let lastAssignmentSucceeded = false;
+            let lastAssignmentRetrySupported = false;
             let lookupFailed = false;
             try {
               for (let page = 1; page <= 20 && !lastUploadedSha; page += 1) {
@@ -121,6 +122,14 @@ jobs:
                     const assignJob = jobs.data.jobs.find(
                       (job) => job.name === 'Assign build to external TestFlight group'
                     );
+                    // Older successful upload runs predate the external-assignment
+                    // job and metadata artifact entirely. Those runs uploaded the
+                    // current main SHA, but they are NOT safe to treat as
+                    // assign-only retry candidates because there is no artifact to
+                    // download and the build may not even be external-eligible.
+                    // Only the post-migration workflow shape can enter the
+                    // assignment-only path.
+                    lastAssignmentRetrySupported = !!assignJob;
                     lastAssignmentSucceeded = assignJob?.conclusion === 'success';
                     break;
                   }
@@ -157,6 +166,7 @@ jobs:
               !forceBuild &&
               context.eventName === 'schedule' &&
               lastUploadedSha === context.sha &&
+              lastAssignmentRetrySupported &&
               !lastAssignmentSucceeded;
 
             const shouldBuild =

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -30,9 +30,11 @@ on:
     # Every ~2h (at :17 to stay off the top-of-hour rush). The decide job skips a
     # run only when the current main HEAD was already uploaded by a prior
     # successful run (SHA compare, not a wall-clock window), so an iOS-affecting
-    # change reaches internal TestFlight within ~2h of landing on main, and a
-    # failed or missed run retries the not-yet-uploaded commit instead of
-    # permanently stranding it.
+    # change reaches the TestFlight beta lane within ~2h of landing on main, and
+    # a failed or missed run retries the not-yet-uploaded commit instead of
+    # permanently stranding it. These uploads are external-eligible too, so the
+    # first build of a new MARKETING_VERSION may wait on Apple Beta App Review
+    # before founders can install it.
     #
     # Why ~2h and not a push trigger / per-commit: a per-push lane needs either a
     # shared concurrency group (which cancels superseded pending runs into red
@@ -300,9 +302,12 @@ jobs:
         run: |
           set -euo pipefail
           # --auto-version: every beta stamps the next-release marketing version.
-          # --notes-from-range: auto-generate the Internal "What to Test" from the
-          # commits since the previous beta (skipped if we have no base SHA yet).
-          ARGS=(--lane beta --signing manual --auto-version)
+          # --external: publish the same main-tracking build to the external lane
+          # once Apple allows that MARKETING_VERSION.
+          # --notes-from-range: auto-generate audience-appropriate "What to
+          # Test" notes from the commits since the previous beta (skipped if we
+          # have no base SHA yet).
+          ARGS=(--lane beta --signing manual --auto-version --external)
           if [ -n "${LAST_UPLOADED_SHA:-}" ]; then
             ARGS+=(--notes-from-range "$LAST_UPLOADED_SHA")
           fi
@@ -326,9 +331,10 @@ jobs:
           {
             echo "### iOS TestFlight upload"
             echo
-            echo "- lane: \`beta\` (bundle id \`dev.cmux.app.beta\`)"
+            echo "- lane: \`beta\` (bundle id \`dev.cmux.app.beta\`, external-eligible)"
             echo "- signing: manual (CI-imported iOS distribution cert + beta profile)"
             echo "- build number (CFBundleVersion): \`${BUILD_NUMBER}\`"
+            echo "- audience: internal testers immediately, external testers after Apple Beta App Review for a new MARKETING_VERSION"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Cleanup keychain

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -202,8 +202,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-        with:
-          persist-credentials: false
           submodules: recursive
           # Full history + tags so generate-testflight-notes.sh can walk the
           # commit range since the last beta and --auto-version can read ios-v*.

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -63,7 +63,9 @@ jobs:
     timeout-minutes: 5
     outputs:
       should_build: ${{ steps.decide.outputs.should_build }}
+      should_assign_only: ${{ steps.decide.outputs.should_assign_only }}
       last_uploaded_sha: ${{ steps.decide.outputs.last_uploaded_sha }}
+      last_uploaded_run_id: ${{ steps.decide.outputs.last_uploaded_run_id }}
     steps:
       - name: Decide whether a TestFlight upload is needed
         id: decide
@@ -91,15 +93,17 @@ jobs:
             // generator also fails closed to a fallback line when the base is not
             // an ancestor of HEAD).
             let lastUploadedSha = null;
+            let lastUploadedRunId = null;
+            let lastAssignmentSucceeded = false;
             let lookupFailed = false;
             try {
-              for (let page = 1; page <= 5 && !lastUploadedSha; page += 1) {
+              for (let page = 1; page <= 20 && !lastUploadedSha; page += 1) {
                 const runs = await github.rest.actions.listWorkflowRuns({
                   owner,
                   repo,
                   workflow_id: 'ios-testflight.yml',
                   branch: 'main',
-                  per_page: 20,
+                  per_page: 100,
                   page,
                 });
                 for (const run of runs.data.workflow_runs) {
@@ -113,10 +117,15 @@ jobs:
                   const uploadJob = jobs.data.jobs.find((job) => job.name === 'Upload to TestFlight');
                   if (uploadJob?.conclusion === 'success') {
                     lastUploadedSha = run.head_sha;
+                    lastUploadedRunId = String(run.id);
+                    const assignJob = jobs.data.jobs.find(
+                      (job) => job.name === 'Assign build to external TestFlight group'
+                    );
+                    lastAssignmentSucceeded = assignJob?.conclusion === 'success';
                     break;
                   }
                 }
-                if (runs.data.workflow_runs.length < 20) break;
+                if (runs.data.workflow_runs.length < 100) break;
               }
             } catch (e) {
               lookupFailed = true;
@@ -144,10 +153,18 @@ jobs:
             if (!forceBuild && context.eventName === 'schedule') {
               needsBuild = lastUploadedSha !== context.sha;
             }
+            const shouldAssignOnly =
+              !forceBuild &&
+              context.eventName === 'schedule' &&
+              lastUploadedSha === context.sha &&
+              !lastAssignmentSucceeded;
 
-            const shouldBuild = forceBuild || context.eventName === 'workflow_dispatch' || needsBuild;
+            const shouldBuild =
+              forceBuild || context.eventName === 'workflow_dispatch' || needsBuild;
             core.setOutput('should_build', shouldBuild ? 'true' : 'false');
+            core.setOutput('should_assign_only', shouldAssignOnly ? 'true' : 'false');
             core.setOutput('last_uploaded_sha', lastUploadedSha || '');
+            core.setOutput('last_uploaded_run_id', lastUploadedRunId || '');
             core.summary
               .addHeading('iOS TestFlight upload decision')
               .addTable([
@@ -155,7 +172,10 @@ jobs:
                 [{ data: 'force', header: true }, String(forceBuild)],
                 [{ data: 'head sha', header: true }, context.sha],
                 [{ data: 'last uploaded sha (schedule only)', header: true }, String(lastUploadedSha)],
+                [{ data: 'last uploaded run id', header: true }, String(lastUploadedRunId)],
+                [{ data: 'last external assignment succeeded', header: true }, String(lastAssignmentSucceeded)],
                 [{ data: 'should build', header: true }, String(shouldBuild)],
+                [{ data: 'should assign only', header: true }, String(shouldAssignOnly)],
               ])
               .write();
 
@@ -363,6 +383,22 @@ jobs:
             echo "- audience: internal testers immediately, external testers after Apple Beta App Review for a new MARKETING_VERSION"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Persist uploaded build metadata
+        if: success()
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/ios-testflight-build.json" <<EOF
+          {"head_sha":"${GITHUB_SHA}","build_number":"${{ steps.upload.outputs.final_build_number }}"}
+          EOF
+
+      - name: Upload build metadata artifact
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ios-testflight-build-metadata
+          path: ${{ runner.temp }}/ios-testflight-build.json
+          retention-days: 30
+
       - name: Cleanup keychain
         if: always()
         run: |
@@ -371,7 +407,7 @@ jobs:
   assign-external-group:
     name: Assign build to external TestFlight group
     needs: [decide, upload]
-    if: needs.decide.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
+    if: always() && (needs.decide.outputs.should_build == 'true' || needs.decide.outputs.should_assign_only == 'true') && github.ref == 'refs/heads/main' && (needs.upload.result == 'success' || needs.decide.outputs.should_assign_only == 'true')
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 20
     env:
@@ -380,10 +416,24 @@ jobs:
       ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
       CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID: ${{ vars.IOS_TESTFLIGHT_EXTERNAL_GROUP_ID }}
       CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME: ${{ vars.IOS_TESTFLIGHT_EXTERNAL_GROUP_NAME }}
+      GH_TOKEN: ${{ github.token }}
+      SHOULD_BUILD: ${{ needs.decide.outputs.should_build }}
+      SHOULD_ASSIGN_ONLY: ${{ needs.decide.outputs.should_assign_only }}
+      LAST_UPLOADED_RUN_ID: ${{ needs.decide.outputs.last_uploaded_run_id }}
       BUILD_NUMBER: ${{ needs.upload.outputs.final_build_number }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Restore previous uploaded build metadata
+        if: env.SHOULD_ASSIGN_ONLY == 'true'
+        run: |
+          set -euo pipefail
+          gh run download "$LAST_UPLOADED_RUN_ID" --repo manaflow-ai/cmux \
+            -n ios-testflight-build-metadata \
+            -D "$RUNNER_TEMP/ios-testflight-build"
+          BUILD_NUMBER="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["build_number"])' "$RUNNER_TEMP/ios-testflight-build/ios-testflight-build.json")"
+          echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
 
       - name: Assign uploaded build to the external beta group
         run: |

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -75,29 +75,49 @@ jobs:
             const forceBuild = process.env.FORCE_BUILD === 'true';
             const { owner, repo } = context.repo;
 
-            // The head_sha of the most recent successful run of this workflow on
-            // main is the last uploaded beta commit. We always resolve it: the
-            // schedule SHA-compare uses it to skip an already-uploaded HEAD, AND
-            // the upload job uses it as the base of the "What to Test" commit range
-            // so each build's notes reflect what changed since the previous beta.
-            // branch:'main' is required: the upload job is gated on
-            // github.ref == 'refs/heads/main', so a workflow_dispatch run on a
-            // feature branch SUCCEEDS without uploading anything. Without this
-            // filter its branch SHA would become last_uploaded_sha and poison the
-            // next real beta's notes base (the generator also fails closed to a
-            // fallback line when the base is not an ancestor of HEAD).
+            // The head_sha of the most recent run on main whose *upload job*
+            // succeeded is the last uploaded beta commit. We intentionally do NOT
+            // key this off whole-workflow success: a later post-upload job (for
+            // example external-group assignment) may fail after the IPA has already
+            // been uploaded, and re-uploading the same SHA on the next schedule
+            // would create duplicate TestFlight builds for one commit. We always
+            // resolve this SHA so the schedule SHA-compare can skip an already-
+            // uploaded HEAD, AND the upload job can use it as the base of the
+            // "What to Test" commit range. branch:'main' is required: the upload
+            // job is gated on github.ref == 'refs/heads/main', so a
+            // workflow_dispatch run on a feature branch can succeed without
+            // uploading anything. Without this filter its branch SHA would become
+            // last_uploaded_sha and poison the next real beta's notes base (the
+            // generator also fails closed to a fallback line when the base is not
+            // an ancestor of HEAD).
             let lastUploadedSha = null;
             let lookupFailed = false;
             try {
-              const runs = await github.rest.actions.listWorkflowRuns({
-                owner,
-                repo,
-                workflow_id: 'ios-testflight.yml',
-                branch: 'main',
-                status: 'success',
-                per_page: 1,
-              });
-              lastUploadedSha = runs.data.workflow_runs[0]?.head_sha ?? null;
+              for (let page = 1; page <= 5 && !lastUploadedSha; page += 1) {
+                const runs = await github.rest.actions.listWorkflowRuns({
+                  owner,
+                  repo,
+                  workflow_id: 'ios-testflight.yml',
+                  branch: 'main',
+                  per_page: 20,
+                  page,
+                });
+                for (const run of runs.data.workflow_runs) {
+                  if (run.id === context.runId || run.status !== 'completed') continue;
+                  const jobs = await github.rest.actions.listJobsForWorkflowRun({
+                    owner,
+                    repo,
+                    run_id: run.id,
+                    per_page: 100,
+                  });
+                  const uploadJob = jobs.data.jobs.find((job) => job.name === 'Upload to TestFlight');
+                  if (uploadJob?.conclusion === 'success') {
+                    lastUploadedSha = run.head_sha;
+                    break;
+                  }
+                }
+                if (runs.data.workflow_runs.length < 20) break;
+              }
             } catch (e) {
               lookupFailed = true;
               core.warning(`could not resolve last uploaded sha: ${e.message}`);
@@ -148,11 +168,15 @@ jobs:
     if: needs.decide.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
     runs-on: ${{ vars.MACOS_RUNNER_IOS || 'blacksmith-6vcpu-macos-26' }}
     timeout-minutes: 60
+    outputs:
+      final_build_number: ${{ steps.upload.outputs.final_build_number }}
     env:
       ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
       ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+      ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
       CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID: ${{ vars.IOS_TESTFLIGHT_EXTERNAL_GROUP_ID }}
       CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME: ${{ vars.IOS_TESTFLIGHT_EXTERNAL_GROUP_NAME }}
+      CMUX_TESTFLIGHT_ASSIGN_EXTERNAL_GROUP: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -343,3 +367,27 @@ jobs:
         if: always()
         run: |
           security delete-keychain ios-testflight.keychain >/dev/null 2>&1 || true
+
+  assign-external-group:
+    name: Assign build to external TestFlight group
+    needs: [decide, upload]
+    if: needs.decide.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 20
+    env:
+      ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+      ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
+      CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID: ${{ vars.IOS_TESTFLIGHT_EXTERNAL_GROUP_ID }}
+      CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME: ${{ vars.IOS_TESTFLIGHT_EXTERNAL_GROUP_NAME }}
+      BUILD_NUMBER: ${{ needs.upload.outputs.final_build_number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Assign uploaded build to the external beta group
+        run: |
+          set -euo pipefail
+          python3 ./ios/scripts/asc_assign_external_testflight_group.py \
+            --bundle-id dev.cmux.app.beta \
+            --build-number "$BUILD_NUMBER"

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -151,6 +151,8 @@ jobs:
     env:
       ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
       ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+      CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID: ${{ vars.IOS_TESTFLIGHT_EXTERNAL_GROUP_ID }}
+      CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME: ${{ vars.IOS_TESTFLIGHT_EXTERNAL_GROUP_NAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/ios/README.md
+++ b/ios/README.md
@@ -99,7 +99,10 @@ no review. An `--external` build is different: the FIRST external build of a new
 external tester can install it. Subsequent external builds of the same version
 ship without re-review. The scheduled `main` sync lane now uploads
 external-eligible builds too, so founders track `main` once the current version
-has cleared that review gate.
+has cleared that review gate. The upload path assigns the processed build to the
+app's external beta group automatically, auto-selecting the single external
+group or using `IOS_TESTFLIGHT_EXTERNAL_GROUP_ID` / `IOS_TESTFLIGHT_EXTERNAL_GROUP_NAME`
+repo variables when the app has multiple external groups.
 
 ## TestFlight GitHub Actions signing
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -97,15 +97,19 @@ Internal testers (the `cmux beta` group) get every uploaded build instantly with
 no review. An `--external` build is different: the FIRST external build of a new
 `MARKETING_VERSION` must pass a one-time Apple Beta App Review (~24h) before any
 external tester can install it. Subsequent external builds of the same version
-ship without re-review. Plan a version bump's first external cut around that
-~24h gate.
+ship without re-review. The scheduled `main` sync lane now uploads
+external-eligible builds too, so founders track `main` once the current version
+has cleared that review gate.
 
 ## TestFlight GitHub Actions signing
 
 `.github/workflows/ios-testflight.yml` uses manual export signing because Xcode's
 automatic App Store Connect export has produced IPAs whose signed app entitlements
 omit `aps-environment=production`. That upload is intentionally blocked because
-TestFlight push would silently fail.
+TestFlight push would silently fail. The workflow tracks `main` on a schedule and
+uploads beta builds as external-eligible, so internal testers get the build
+immediately and external testers get the same `main` build once Apple has
+approved that `MARKETING_VERSION` for Beta App Review.
 
 Required GitHub secrets:
 

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from typing import Dict, List, Optional
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -96,7 +97,7 @@ def _token() -> str:
     return (signing_input + b"." + _b64u(signature)).decode()
 
 
-def _asc_error_code(body: dict) -> str:
+def _asc_error_code(body: Dict) -> str:
     try:
         return str(((body.get("errors") or [{}])[0]).get("code", "unknown"))
     except Exception:
@@ -122,7 +123,7 @@ def _request(token: str, method: str, path: str, payload=None):
         return err.code, body
 
 
-def _paged_get(token: str, path: str) -> list[dict]:
+def _paged_get(token: str, path: str) -> List[Dict]:
     items = []
     next_path = path
     pages = 0
@@ -159,7 +160,7 @@ def _resolve_app_id(token: str, bundle_id: str) -> str:
     return data[0]["id"]
 
 
-def _find_build_id(token: str, app_id: str, build_number: str) -> str | None:
+def _find_build_id(token: str, app_id: str, build_number: str) -> Optional[str]:
     encoded_build = urllib.parse.quote(build_number, safe="")
     status, body = _request(
         token,
@@ -175,7 +176,7 @@ def _find_build_id(token: str, app_id: str, build_number: str) -> str | None:
     return data[0]["id"]
 
 
-def _list_beta_groups(token: str, app_id: str) -> list[dict]:
+def _list_beta_groups(token: str, app_id: str) -> List[Dict]:
     raw = _paged_get(
         token,
         f"/v1/betaGroups?filter[app]={app_id}"
@@ -195,12 +196,12 @@ def _list_beta_groups(token: str, app_id: str) -> list[dict]:
     return groups
 
 
-def _describe_group(group: dict) -> str:
+def _describe_group(group: Dict) -> str:
     kind = "internal" if group.get("is_internal") else "external"
     return f"{group.get('name') or '<unnamed>'} ({group['id']}, {kind})"
 
 
-def _select_group(groups: list[dict], group_id: str, group_name: str) -> dict:
+def _select_group(groups: List[Dict], group_id: str, group_name: str) -> Dict:
     if group_id:
         matches = [group for group in groups if group["id"] == group_id]
         if not matches:

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Assign a TestFlight build to an external beta group via App Store Connect API.
+
+`upload-testflight.sh --external` makes the build eligible for external testing,
+but testers do not receive it until the build is added to an external beta group.
+This helper resolves the app from its bundle id, waits for the uploaded build to
+appear, selects the external beta group, and attaches the build to that group.
+
+Group selection:
+- `--group-id` / `CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID` wins.
+- Else `--group-name` / `CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME` exact-matches.
+- Else it auto-selects the app's single external beta group.
+
+If multiple external groups exist and no selector is provided, it fails loudly so
+CI does not claim founders were updated when the target group was ambiguous.
+
+Auth comes from the existing ASC environment used by the upload flow:
+  ASC_API_KEY_ID, ASC_API_ISSUER_ID, and either ASC_API_KEY_PATH or
+  ASC_API_KEY_P8_BASE64.
+"""
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_BASE = "https://api.appstoreconnect.apple.com"
+
+
+def _b64u(data: bytes) -> bytes:
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+
+def _der_ecdsa_to_raw(der: bytes) -> bytes:
+    if not der or der[0] != 0x30:
+        raise RuntimeError("malformed ECDSA signature from openssl")
+    idx = 2
+    if der[1] & 0x80:
+        idx = 2 + (der[1] & 0x7F)
+    if der[idx] != 0x02:
+        raise RuntimeError("malformed ECDSA signature (r)")
+    rlen = der[idx + 1]
+    idx += 2
+    r = int.from_bytes(der[idx:idx + rlen], "big")
+    idx += rlen
+    if der[idx] != 0x02:
+        raise RuntimeError("malformed ECDSA signature (s)")
+    slen = der[idx + 1]
+    idx += 2
+    s = int.from_bytes(der[idx:idx + slen], "big")
+    return r.to_bytes(32, "big") + s.to_bytes(32, "big")
+
+
+def _sign_es256(signing_input: bytes, key_path: str) -> bytes:
+    proc = subprocess.run(
+        ["openssl", "dgst", "-sha256", "-sign", key_path],
+        input=signing_input,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("openssl signing failed")
+    return _der_ecdsa_to_raw(proc.stdout)
+
+
+def _token() -> str:
+    key_id = os.environ.get("ASC_API_KEY_ID")
+    issuer_id = os.environ.get("ASC_API_ISSUER_ID")
+    if not key_id or not issuer_id:
+        raise RuntimeError("set ASC_API_KEY_ID and ASC_API_ISSUER_ID")
+    header = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+    now = int(time.time())
+    payload = {"iss": issuer_id, "iat": now, "exp": now + 600, "aud": "appstoreconnect-v1"}
+    signing_input = _b64u(json.dumps(header).encode()) + b"." + _b64u(json.dumps(payload).encode())
+
+    key_path = os.environ.get("ASC_API_KEY_PATH")
+    if key_path:
+        signature = _sign_es256(signing_input, key_path)
+    elif os.environ.get("ASC_API_KEY_P8_BASE64"):
+        fd, tmp = tempfile.mkstemp(suffix=".p8")
+        try:
+            os.write(fd, base64.b64decode(os.environ["ASC_API_KEY_P8_BASE64"]))
+            os.close(fd)
+            signature = _sign_es256(signing_input, tmp)
+        finally:
+            os.unlink(tmp)
+    else:
+        raise RuntimeError("set ASC_API_KEY_PATH or ASC_API_KEY_P8_BASE64")
+    return (signing_input + b"." + _b64u(signature)).decode()
+
+
+def _asc_error_code(body: dict) -> str:
+    try:
+        return str(((body.get("errors") or [{}])[0]).get("code", "unknown"))
+    except Exception:
+        return "unknown"
+
+
+def _request(token: str, method: str, path: str, payload=None):
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode()
+    req = urllib.request.Request(API_BASE + path, method=method, data=data)
+    req.add_header("Authorization", "Bearer " + token)
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read() or b"{}"
+            return resp.status, json.loads(raw)
+    except urllib.error.HTTPError as err:
+        try:
+            body = json.loads(err.read() or b"{}")
+        except Exception:
+            body = {}
+        return err.code, body
+
+
+def _paged_get(token: str, path: str) -> list[dict]:
+    items = []
+    next_path = path
+    pages = 0
+    while next_path:
+        if pages >= 50:
+            raise RuntimeError("too many ASC pages while enumerating beta groups/builds")
+        status, body = _request(token, "GET", next_path)
+        if status != 200:
+            raise RuntimeError(f"ASC GET {next_path} HTTP {status} (code={_asc_error_code(body)})")
+        items.extend(body.get("data", []))
+        next_url = (body.get("links") or {}).get("next")
+        if not next_url:
+            next_path = None
+        elif next_url.startswith(API_BASE):
+            next_path = next_url[len(API_BASE):]
+        else:
+            raise RuntimeError("unexpected App Store Connect pagination URL")
+        pages += 1
+    return items
+
+
+def _resolve_app_id(token: str, bundle_id: str) -> str:
+    encoded = urllib.parse.quote(bundle_id, safe="")
+    status, body = _request(
+        token,
+        "GET",
+        f"/v1/apps?filter[bundleId]={encoded}&fields[apps]=bundleId&limit=1",
+    )
+    if status != 200:
+        raise RuntimeError(f"apps lookup HTTP {status} (code={_asc_error_code(body)})")
+    data = body.get("data", [])
+    if not data:
+        raise RuntimeError(f"no app found for bundle id {bundle_id}")
+    return data[0]["id"]
+
+
+def _find_build_id(token: str, app_id: str, build_number: str) -> str | None:
+    encoded_build = urllib.parse.quote(build_number, safe="")
+    status, body = _request(
+        token,
+        "GET",
+        f"/v1/builds?filter[app]={app_id}&filter[version]={encoded_build}"
+        f"&fields[builds]=version,processingState&limit=1",
+    )
+    if status != 200:
+        raise RuntimeError(f"build lookup HTTP {status} (code={_asc_error_code(body)})")
+    data = body.get("data", [])
+    if not data:
+        return None
+    return data[0]["id"]
+
+
+def _list_beta_groups(token: str, app_id: str) -> list[dict]:
+    raw = _paged_get(
+        token,
+        f"/v1/betaGroups?filter[app]={app_id}"
+        "&fields[betaGroups]=name,isInternalGroup,hasAccessToAllBuilds&limit=200",
+    )
+    groups = []
+    for item in raw:
+        attrs = item.get("attributes") or {}
+        groups.append(
+            {
+                "id": item["id"],
+                "name": attrs.get("name", ""),
+                "is_internal": bool(attrs.get("isInternalGroup", False)),
+                "has_access_to_all_builds": bool(attrs.get("hasAccessToAllBuilds", False)),
+            }
+        )
+    return groups
+
+
+def _describe_group(group: dict) -> str:
+    kind = "internal" if group.get("is_internal") else "external"
+    return f"{group.get('name') or '<unnamed>'} ({group['id']}, {kind})"
+
+
+def _select_group(groups: list[dict], group_id: str, group_name: str) -> dict:
+    if group_id:
+        matches = [group for group in groups if group["id"] == group_id]
+        if not matches:
+            raise RuntimeError(f"no beta group found for id {group_id}")
+        group = matches[0]
+        if group["is_internal"]:
+            raise RuntimeError(f"group {group_id} is internal, expected an external beta group")
+        return group
+
+    if group_name:
+        matches = [group for group in groups if group["name"] == group_name]
+        if not matches:
+            raise RuntimeError(f"no beta group found named {group_name!r}")
+        if len(matches) > 1:
+            raise RuntimeError(
+                f"multiple beta groups matched {group_name!r}: "
+                + ", ".join(_describe_group(group) for group in matches)
+            )
+        group = matches[0]
+        if group["is_internal"]:
+            raise RuntimeError(f"group {group_name!r} is internal, expected an external beta group")
+        return group
+
+    external_groups = [group for group in groups if not group["is_internal"]]
+    if not external_groups:
+        raise RuntimeError("no external beta groups found for this app")
+    if len(external_groups) > 1:
+        raise RuntimeError(
+            "multiple external beta groups found; set CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID "
+            "or CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME. Candidates: "
+            + ", ".join(_describe_group(group) for group in external_groups)
+        )
+    return external_groups[0]
+
+
+def _group_has_build(token: str, group_id: str, build_id: str) -> bool:
+    relationships = _paged_get(
+        token,
+        f"/v1/betaGroups/{group_id}/relationships/builds?limit=200",
+    )
+    return any(item.get("id") == build_id for item in relationships)
+
+
+def _assign_build(token: str, group_id: str, build_id: str) -> None:
+    payload = {"data": [{"type": "builds", "id": build_id}]}
+    status, body = _request(token, "POST", f"/v1/betaGroups/{group_id}/relationships/builds", payload)
+    if status not in (200, 201, 204):
+        raise RuntimeError(f"assign build HTTP {status} (code={_asc_error_code(body)})")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--build-number", required=True, help="CFBundleVersion of the uploaded build")
+    parser.add_argument("--group-id", default=os.environ.get("CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID", ""))
+    parser.add_argument("--group-name", default=os.environ.get("CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME", ""))
+    parser.add_argument("--timeout-seconds", type=int, default=900)
+    parser.add_argument("--poll-seconds", type=int, default=20)
+    args = parser.parse_args()
+
+    if args.group_id and args.group_name:
+        raise RuntimeError("set only one of --group-id or --group-name")
+
+    token = _token()
+    app_id = _resolve_app_id(token, args.bundle_id)
+    groups = _list_beta_groups(token, app_id)
+    target_group = _select_group(groups, args.group_id.strip(), args.group_name.strip())
+
+    deadline = time.time() + max(0, args.timeout_seconds)
+    build_id = None
+    while True:
+        token = _token()
+        build_id = _find_build_id(token, app_id, args.build_number)
+        if build_id:
+            break
+        if time.time() >= deadline:
+            raise RuntimeError(
+                f"build {args.build_number} not visible on App Store Connect within {args.timeout_seconds}s"
+            )
+        time.sleep(max(1, args.poll_seconds))
+
+    if target_group["has_access_to_all_builds"]:
+        print(
+            f"asc_assign_external_testflight_group: group {_describe_group(target_group)} "
+            f"already has access to all builds"
+        )
+        return 0
+
+    if _group_has_build(token, target_group["id"], build_id):
+        print(
+            f"asc_assign_external_testflight_group: build {args.build_number} already assigned to "
+            f"{_describe_group(target_group)}"
+        )
+        return 0
+
+    token = _token()
+    _assign_build(token, target_group["id"], build_id)
+    print(
+        f"asc_assign_external_testflight_group: assigned build {args.build_number} to "
+        f"{_describe_group(target_group)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"asc_assign_external_testflight_group: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -27,7 +27,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -160,7 +160,7 @@ def _resolve_app_id(token: str, bundle_id: str) -> str:
     return data[0]["id"]
 
 
-def _find_build_id(token: str, app_id: str, build_number: str) -> Optional[str]:
+def _find_build(token: str, app_id: str, build_number: str) -> Optional[Tuple[str, str]]:
     encoded_build = urllib.parse.quote(build_number, safe="")
     status, body = _request(
         token,
@@ -173,7 +173,8 @@ def _find_build_id(token: str, app_id: str, build_number: str) -> Optional[str]:
     data = body.get("data", [])
     if not data:
         return None
-    return data[0]["id"]
+    attrs = data[0].get("attributes") or {}
+    return data[0]["id"], str(attrs.get("processingState") or "")
 
 
 def _list_beta_groups(token: str, app_id: str) -> List[Dict]:
@@ -271,17 +272,34 @@ def main() -> int:
     target_group = _select_group(groups, args.group_id.strip(), args.group_name.strip())
 
     deadline = time.time() + max(0, args.timeout_seconds)
-    build_id = None
+    build = None
     while True:
         token = _token()
-        build_id = _find_build_id(token, app_id, args.build_number)
-        if build_id:
+        build = _find_build(token, app_id, args.build_number)
+        if build:
             break
         if time.time() >= deadline:
             raise RuntimeError(
                 f"build {args.build_number} not visible on App Store Connect within {args.timeout_seconds}s"
             )
         time.sleep(max(1, args.poll_seconds))
+
+    build_id, processing_state = build
+    while processing_state != "VALID":
+        if processing_state in ("FAILED", "INVALID"):
+            raise RuntimeError(
+                f"build {args.build_number} entered processingState={processing_state}"
+            )
+        if time.time() >= deadline:
+            raise RuntimeError(
+                f"build {args.build_number} did not reach processingState=VALID within {args.timeout_seconds}s"
+            )
+        time.sleep(max(1, args.poll_seconds))
+        token = _token()
+        build = _find_build(token, app_id, args.build_number)
+        if not build:
+            raise RuntimeError(f"build {args.build_number} disappeared from App Store Connect")
+        build_id, processing_state = build
 
     if target_group["has_access_to_all_builds"]:
         print(

--- a/ios/scripts/generate-testflight-notes.sh
+++ b/ios/scripts/generate-testflight-notes.sh
@@ -5,8 +5,8 @@
 # since the previous beta instead of a hand-maintained changelog top entry.
 #
 #   internal (default): terse, dev-facing bullets, keeps the PR number.
-#   external:           a cleaned DRAFT (no PR numbers, no conventional prefix)
-#                       for human curation before a founders cut.
+#   external:           cleaned user-facing bullets (no PR numbers, no
+#                       conventional prefix), suitable for the external beta lane.
 #
 # Output is the bullet list only (no "### Internal" heading), suitable to pass to
 # `set-testflight-notes.sh --notes "$(...)"`. An empty or unreachable range emits
@@ -95,8 +95,8 @@ while IFS= read -r subject; do
   fi
 
   if [[ "$AUDIENCE" == "external" ]]; then
-    # Clean for founders: strip "(#N)" / "#N", and a leading conventional prefix
-    # like "ios:" / "fix(mobile):". Keep it a DRAFT; a human curates wording.
+    # Clean for founders/external beta: strip "(#N)" / "#N", and a leading
+    # conventional prefix like "ios:" / "fix(mobile):".
     clean="$(printf '%s' "$subject" \
       | sed -E 's/ *\(#[0-9]+\)//g; s/ +#[0-9]+//g' \
       | sed -E 's/^[a-z]+(\([^)]*\))?(!)?: *//')"

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -117,7 +117,8 @@ Options:
                             groups (e.g. "cmux beta") instantly but can never
                             be added to an external group. External-eligible
                             builds must pass Apple Beta App Review (~24h) before
-                            external testers can install. Also set via
+                            external testers can install the first build of a new
+                            MARKETING_VERSION. Also set via
                             CMUX_TESTFLIGHT_EXTERNAL=1.
   --archive-path <path>     Reuse an existing archive instead of archiving.
   --export-only             Stop after exporting the signed IPA.
@@ -130,8 +131,8 @@ Options:
                             iOS-affecting commits in <base>..HEAD instead of the
                             ios/CHANGELOG.md top entry (used by the every-2h beta
                             lane so each build's notes reflect what changed since
-                            the previous beta). Skips the changelog preflight and
-                            version-match guard.
+                            the previous beta for the selected audience). Skips
+                            the changelog preflight and version-match guard.
   --auto-version            Stamp the build's MARKETING_VERSION at archive time
                             (no repo commit) to the next patch above the last
                             iOS release (newest ios-v<X.Y.Z> tag, else the
@@ -179,7 +180,8 @@ SIGNING="manual"
 # Default 0 keeps the historical internal-only behavior (fast dogfood, no Apple
 # review). Set to 1 by --external or CMUX_TESTFLIGHT_EXTERNAL=1 to drop the
 # testFlightInternalTestingOnly flag so the build can be added to an external
-# group; such builds then require a one-time Apple Beta App Review per version.
+# group; such builds then require a one-time Apple Beta App Review per
+# MARKETING_VERSION.
 EXTERNAL_TESTING=0
 if [[ "${CMUX_TESTFLIGHT_EXTERNAL:-}" == "1" ]]; then
   EXTERNAL_TESTING=1
@@ -193,11 +195,11 @@ if [[ "${CMUX_TESTFLIGHT_SKIP_NOTES:-}" == "1" ]]; then
 fi
 # --notes-from-range <base>: auto-generate the "What to Test" notes from the
 # iOS-affecting commits in <base>..HEAD (via generate-testflight-notes.sh) instead
-# of the hand-maintained ios/CHANGELOG.md top entry. Used by the every-2h beta lane
-# so each build's notes reflect what actually changed since the previous beta. When
-# set, the changelog preflight + version-match guard are skipped (the notes no
-# longer come from the changelog, and --auto-version stamps a version the changelog
-# would not match).
+# of the hand-maintained ios/CHANGELOG.md top entry. Used by the every-2h beta
+# lane so each build's notes reflect what actually changed since the previous
+# beta for whichever audience is being shipped. When set, the changelog
+# preflight + version-match guard are skipped (the notes no longer come from the
+# changelog, and --auto-version stamps a version the changelog would not match).
 NOTES_RANGE_BASE=""
 # --auto-version: stamp the build's MARKETING_VERSION at archive time (no repo
 # commit-back, mirroring the timestamp build number) to the next patch above the
@@ -862,9 +864,9 @@ fi
 # API needs the ASC API key (JWT); the Apple ID upload path has no key, so notes are
 # only attempted when the ASC API creds are present.
 #
-# Audience: --external uses the curated External block; the default internal cut uses
-# the terse Internal block. SHIPPED_BUILD_NUMBER is the CFBundleVersion that actually
-# shipped (post-guard, or the reused archive's embedded version).
+# Audience: --external uses the External audience; the default internal cut uses
+# the terse Internal block. SHIPPED_BUILD_NUMBER is the CFBundleVersion that
+# actually shipped (post-guard, or the reused archive's embedded version).
 if [[ "$SKIP_NOTES" -eq 1 ]]; then
   echo "note: --skip-notes set; not setting TestFlight What to Test notes" >&2
 elif [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" || ( -z "${ASC_API_KEY_PATH:-}" && -z "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -118,7 +118,11 @@ Options:
                             be added to an external group. External-eligible
                             builds must pass Apple Beta App Review (~24h) before
                             external testers can install the first build of a new
-                            MARKETING_VERSION. Also set via
+                            MARKETING_VERSION. With ASC API-key auth, the script
+                            also assigns the processed build to the selected
+                            external beta group (single external group by
+                            default, or CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID / _NAME).
+                            Also set via
                             CMUX_TESTFLIGHT_EXTERNAL=1.
   --archive-path <path>     Reuse an existing archive instead of archiving.
   --export-only             Stop after exporting the signed IPA.
@@ -923,4 +927,24 @@ else
   else
     echo "warning: could not set TestFlight What to Test notes for build $SHIPPED_BUILD_NUMBER (the upload succeeded; re-run ios/scripts/set-testflight-notes.sh --build-number $SHIPPED_BUILD_NUMBER --audience $NOTES_AUDIENCE once the build finishes processing)" >&2
   fi
+fi
+
+# --external means "ship to founders", not merely "make this build externally
+# eligible in principle". After upload, assign the processed build to the app's
+# external beta group so external testers actually receive it. This is fatal: a
+# red CI/upload is preferable to claiming the external lane tracked main when the
+# build never reached the founders group.
+if [[ "$EXPORT_ONLY" -ne 1 && "$EXTERNAL_TESTING" -eq 1 ]]; then
+  if [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" || ( -z "${ASC_API_KEY_PATH:-}" && -z "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
+    echo "error: --external requires ASC API-key auth to assign the uploaded build to an external beta group. Set ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH (or ASC_API_KEY_P8_BASE64)." >&2
+    exit 1
+  fi
+  echo "assigning external TestFlight build $SHIPPED_BUILD_NUMBER to the founders beta group" >&2
+  ASC_API_KEY_ID="$ASC_API_KEY_ID" ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \
+    ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-}" ASC_API_KEY_P8_BASE64="${ASC_API_KEY_P8_BASE64:-}" \
+    CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID="${CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID:-}" \
+    CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME="${CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME:-}" \
+    python3 "$SCRIPT_DIR/asc_assign_external_testflight_group.py" \
+      --bundle-id "$PRODUCT_BUNDLE_IDENTIFIER" \
+      --build-number "$SHIPPED_BUILD_NUMBER"
 fi

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -944,8 +944,8 @@ fi
 # build never reached the founders group.
 if [[ "$EXPORT_ONLY" -ne 1 && "$EXTERNAL_TESTING" -eq 1 && "$ASSIGN_EXTERNAL_GROUP" -eq 1 ]]; then
   if [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" || ( -z "${ASC_API_KEY_PATH:-}" && -z "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
-    echo "error: --external requires ASC API-key auth to assign the uploaded build to an external beta group. Set ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH (or ASC_API_KEY_P8_BASE64)." >&2
-    exit 1
+    echo "warning: no ASC API key (JWT) available; uploaded the external-eligible build but skipped automatic external-group assignment. Supply ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH (or ASC_API_KEY_P8_BASE64) to assign the build automatically." >&2
+    exit 0
   fi
   echo "assigning external TestFlight build $SHIPPED_BUILD_NUMBER to the founders beta group" >&2
   ASC_API_KEY_ID="$ASC_API_KEY_ID" ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -190,6 +190,14 @@ EXTERNAL_TESTING=0
 if [[ "${CMUX_TESTFLIGHT_EXTERNAL:-}" == "1" ]]; then
   EXTERNAL_TESTING=1
 fi
+# Whether this invocation should assign an uploaded external build to the
+# external beta group itself. The scheduled GitHub Actions lane disables this and
+# runs assignment in a separate post-upload job so a distribution failure cannot
+# cause duplicate uploads of the same SHA on the next schedule.
+ASSIGN_EXTERNAL_GROUP=1
+if [[ "${CMUX_TESTFLIGHT_ASSIGN_EXTERNAL_GROUP:-1}" == "0" ]]; then
+  ASSIGN_EXTERNAL_GROUP=0
+fi
 # After a successful upload, push the top ios/CHANGELOG.md entry to the build's
 # TestFlight "What to Test" so testers see what changed instead of an opaque
 # timestamp. Set to 1 by --skip-notes or CMUX_TESTFLIGHT_SKIP_NOTES=1.
@@ -934,7 +942,7 @@ fi
 # external beta group so external testers actually receive it. This is fatal: a
 # red CI/upload is preferable to claiming the external lane tracked main when the
 # build never reached the founders group.
-if [[ "$EXPORT_ONLY" -ne 1 && "$EXTERNAL_TESTING" -eq 1 ]]; then
+if [[ "$EXPORT_ONLY" -ne 1 && "$EXTERNAL_TESTING" -eq 1 && "$ASSIGN_EXTERNAL_GROUP" -eq 1 ]]; then
   if [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" || ( -z "${ASC_API_KEY_PATH:-}" && -z "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
     echo "error: --external requires ASC API-key auth to assign the uploaded build to an external beta group. Set ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH (or ASC_API_KEY_P8_BASE64)." >&2
     exit 1

--- a/tests/test_ios_testflight_external_distribution.py
+++ b/tests/test_ios_testflight_external_distribution.py
@@ -54,6 +54,20 @@ def main():
     _check(chosen["id"] == "external-1", "explicit external group id resolves correctly")
 
     try:
+        module._select_group(groups, "missing-group", "")
+    except RuntimeError as exc:
+        _check("no beta group found for id missing-group" in str(exc), "missing group id fails loudly")
+    else:
+        _check(False, "missing group id fails loudly")
+
+    try:
+        module._select_group(groups, "", "Missing Group")
+    except RuntimeError as exc:
+        _check("no beta group found named 'Missing Group'" in str(exc), "missing group name fails loudly")
+    else:
+        _check(False, "missing group name fails loudly")
+
+    try:
         module._select_group(groups, "", "cmux beta")
     except RuntimeError as exc:
         _check("internal" in str(exc), "explicit internal group is rejected")

--- a/tests/test_ios_testflight_external_distribution.py
+++ b/tests/test_ios_testflight_external_distribution.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Tests for ios/scripts/asc_assign_external_testflight_group.py selection logic."""
+
+import importlib.util
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT = os.path.join(REPO_ROOT, "ios", "scripts", "asc_assign_external_testflight_group.py")
+
+FAILURES = []
+
+
+def _check(condition, message):
+    if condition:
+        print(f"ok: {message}")
+    else:
+        FAILURES.append(message)
+        print(f"FAIL: {message}")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("asc_assign_external_testflight_group", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load module from {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _group(group_id, name, is_internal, has_access_to_all_builds=False):
+    return {
+        "id": group_id,
+        "name": name,
+        "is_internal": is_internal,
+        "has_access_to_all_builds": has_access_to_all_builds,
+    }
+
+
+def main():
+    module = _load_module()
+
+    groups = [
+        _group("internal-1", "cmux beta", True),
+        _group("external-1", "Founders Edition", False),
+    ]
+    chosen = module._select_group(groups, "", "")
+    _check(chosen["id"] == "external-1", "auto-select picks the single external group")
+
+    chosen = module._select_group(groups, "", "Founders Edition")
+    _check(chosen["id"] == "external-1", "explicit external group name resolves correctly")
+
+    chosen = module._select_group(groups, "external-1", "")
+    _check(chosen["id"] == "external-1", "explicit external group id resolves correctly")
+
+    try:
+        module._select_group(groups, "", "cmux beta")
+    except RuntimeError as exc:
+        _check("internal" in str(exc), "explicit internal group is rejected")
+    else:
+        _check(False, "explicit internal group is rejected")
+
+    ambiguous_groups = groups + [_group("external-2", "VIP Founders", False)]
+    try:
+        module._select_group(ambiguous_groups, "", "")
+    except RuntimeError as exc:
+        _check("multiple external beta groups" in str(exc), "ambiguous external groups fail loudly")
+    else:
+        _check(False, "ambiguous external groups fail loudly")
+
+    try:
+        module._select_group([_group("internal-1", "cmux beta", True)], "", "")
+    except RuntimeError as exc:
+        _check("no external beta groups" in str(exc), "missing external group fails loudly")
+    else:
+        _check(False, "missing external group fails loudly")
+
+    if FAILURES:
+        print(f"\n{len(FAILURES)} failure(s)")
+        sys.exit(1)
+    print("\nall ios testflight external distribution tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -122,12 +122,15 @@ describe("VM Effect workflows", () => {
     };
 
     const result = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-exec-resume",
-        providerVmId: "provider-vm-exec-resume",
-        command: "echo preflight",
-        timeoutMs: 1000,
-      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        execVm({
+          userId: "user-workflow-exec-resume",
+          providerVmId: "provider-vm-exec-resume",
+          command: "echo preflight",
+          timeoutMs: 1000,
+        }),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(result).toEqual({ exitCode: 7, stdout: "preflight", stderr: "" });
@@ -179,12 +182,17 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-exec-running",
-        providerVmId: "provider-vm-exec-running",
-        command: "true",
-        timeoutMs: 1000,
-      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        Effect.flip(
+          execVm({
+            userId: "user-workflow-exec-running",
+            providerVmId: "provider-vm-exec-running",
+            command: "true",
+            timeoutMs: 1000,
+          }),
+        ),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(error).toBe(originalError);
@@ -226,12 +234,17 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-exec-resume-fails",
-        providerVmId: "provider-vm-exec-resume-fails",
-        command: "true",
-        timeoutMs: 1000,
-      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        Effect.flip(
+          execVm({
+            userId: "user-workflow-exec-resume-fails",
+            providerVmId: "provider-vm-exec-resume-fails",
+            command: "true",
+            timeoutMs: 1000,
+          }),
+        ),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(error).toBe(resumeError);
@@ -274,12 +287,17 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-exec-mark-false",
-        providerVmId: "provider-vm-exec-mark-false",
-        command: "true",
-        timeoutMs: 1000,
-      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        Effect.flip(
+          execVm({
+            userId: "user-workflow-exec-mark-false",
+            providerVmId: "provider-vm-exec-mark-false",
+            command: "true",
+            timeoutMs: 1000,
+          }),
+        ),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(error).toBeInstanceOf(VmNotFoundError);
@@ -314,12 +332,17 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-exec-no-status",
-        providerVmId: "provider-vm-exec-no-status",
-        command: "true",
-        timeoutMs: 1000,
-      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        Effect.flip(
+          execVm({
+            userId: "user-workflow-exec-no-status",
+            providerVmId: "provider-vm-exec-no-status",
+            command: "true",
+            timeoutMs: 1000,
+          }),
+        ),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(error).toBe(originalError);
@@ -354,12 +377,17 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-exec-no-resume",
-        providerVmId: "provider-vm-exec-no-resume",
-        command: "true",
-        timeoutMs: 1000,
-      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        Effect.flip(
+          execVm({
+            userId: "user-workflow-exec-no-resume",
+            providerVmId: "provider-vm-exec-no-resume",
+            command: "true",
+            timeoutMs: 1000,
+          }),
+        ),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(error).toBe(originalError);
@@ -402,12 +430,17 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-exec-no-replay",
-        providerVmId: "provider-vm-exec-no-replay",
-        command: "true",
-        timeoutMs: 1000,
-      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        Effect.flip(
+          execVm({
+            userId: "user-workflow-exec-no-replay",
+            providerVmId: "provider-vm-exec-no-replay",
+            command: "true",
+            timeoutMs: 1000,
+          }),
+        ),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(error).toBe(originalError);
@@ -449,12 +482,15 @@ describe("VM Effect workflows", () => {
     };
 
     const result = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-exec-status-fails",
-        providerVmId: "provider-vm-exec-status-fails",
-        command: "true",
-        timeoutMs: 1000,
-      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        execVm({
+          userId: "user-workflow-exec-status-fails",
+          providerVmId: "provider-vm-exec-status-fails",
+          command: "true",
+          timeoutMs: 1000,
+        }),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(result).toEqual({ exitCode: 0, stdout: "ok", stderr: "" });
@@ -501,11 +537,14 @@ describe("VM Effect workflows", () => {
     };
 
     const result = await Effect.runPromise(
-      openAttachEndpoint({
-        userId: "user-workflow-attach-resume",
-        providerVmId: "provider-vm-attach-resume",
-        options: { requireDaemon: true },
-      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        openAttachEndpoint({
+          userId: "user-workflow-attach-resume",
+          providerVmId: "provider-vm-attach-resume",
+          options: { requireDaemon: true },
+        }),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(result).toEqual(endpoint);
@@ -574,10 +613,15 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      openAttachEndpoint({
-        userId: "user-workflow-attach-mark-fails",
-        providerVmId: "provider-vm-attach-mark-fails",
-      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        Effect.flip(
+          openAttachEndpoint({
+            userId: "user-workflow-attach-mark-fails",
+            providerVmId: "provider-vm-attach-mark-fails",
+          }),
+        ),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(error).toBe(markError);
@@ -635,10 +679,15 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      openAttachEndpoint({
-        userId: "user-workflow-attach-mark-false",
-        providerVmId: "provider-vm-attach-mark-false",
-      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        Effect.flip(
+          openAttachEndpoint({
+            userId: "user-workflow-attach-mark-false",
+            providerVmId: "provider-vm-attach-mark-false",
+          }),
+        ),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(error).toBeInstanceOf(VmNotFoundError);
@@ -687,10 +736,13 @@ describe("VM Effect workflows", () => {
     };
 
     const result = await Effect.runPromise(
-      openSshEndpoint({
-        userId: "user-workflow-ssh-resume",
-        providerVmId: "provider-vm-ssh-resume",
-      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        openSshEndpoint({
+          userId: "user-workflow-ssh-resume",
+          providerVmId: "provider-vm-ssh-resume",
+        }),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(result).toEqual(endpoint);
@@ -748,10 +800,13 @@ describe("VM Effect workflows", () => {
     };
 
     const result = await Effect.runPromise(
-      openAttachEndpoint({
-        userId: "user-workflow-attach-race",
-        providerVmId: "provider-vm-attach-race",
-      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        openAttachEndpoint({
+          userId: "user-workflow-attach-race",
+          providerVmId: "provider-vm-attach-race",
+        }),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(result).toEqual(endpoint);
@@ -795,10 +850,15 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      openAttachEndpoint({
-        userId: "user-workflow-attach-probe-fail",
-        providerVmId: "provider-vm-attach-probe-fail",
-      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        Effect.flip(
+          openAttachEndpoint({
+            userId: "user-workflow-attach-probe-fail",
+            providerVmId: "provider-vm-attach-probe-fail",
+          }),
+        ),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(error).toBe(probeError);
@@ -845,12 +905,15 @@ describe("VM Effect workflows", () => {
     };
 
     const result = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-exec-settle",
-        providerVmId: "provider-vm-exec-settle",
-        command: "echo ok",
-        timeoutMs: 1000,
-      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        execVm({
+          userId: "user-workflow-exec-settle",
+          providerVmId: "provider-vm-exec-settle",
+          command: "echo ok",
+          timeoutMs: 1000,
+        }),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(result.exitCode).toBe(0);
@@ -896,12 +959,15 @@ describe("VM Effect workflows", () => {
     };
 
     const result = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-exec-concurrent",
-        providerVmId: "provider-vm-exec-concurrent",
-        command: "echo ok",
-        timeoutMs: 1000,
-      }).pipe(Effect.provide(workflowLayer(repo, provider))),
+      Effect.provide(
+        execVm({
+          userId: "user-workflow-exec-concurrent",
+          providerVmId: "provider-vm-exec-concurrent",
+          command: "echo ok",
+          timeoutMs: 1000,
+        }),
+        workflowLayer(repo, provider),
+      ),
     );
 
     expect(result.exitCode).toBe(0);
@@ -976,17 +1042,20 @@ describe("VM Effect workflows", () => {
     );
 
     const created = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-usage-events",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-usage-events",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "freestyle",
-        image: "snapshot-test",
-        imageVersion: "test-version",
-        idempotencyKey: "usage-events",
-      }).pipe(Effect.provide(layer)),
+      Effect.provide(
+        createVm({
+          userId: "user-workflow-usage-events",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-usage-events",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-test",
+          imageVersion: "test-version",
+          idempotencyKey: "usage-events",
+        }),
+        layer,
+      ),
     );
 
     expect(created.providerVmId).toBe("provider-vm-usage-events");
@@ -1030,8 +1099,8 @@ describe("VM Effect workflows", () => {
       idempotencyKey: "idem-1",
     });
     const layer = providerLayer(provider);
-    const first = await Effect.runPromise(program.pipe(Effect.provide(layer)));
-    const second = await Effect.runPromise(program.pipe(Effect.provide(layer)));
+    const first = await Effect.runPromise(Effect.provide(program, layer));
+    const second = await Effect.runPromise(Effect.provide(program, layer));
 
     expect(first).toEqual(second);
     expect(createCalls).toBe(1);
@@ -1088,13 +1157,15 @@ describe("VM Effect workflows", () => {
     const layer = providerLayer(provider);
 
     const endpoint1 = await Effect.runPromise(
-      openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }).pipe(
-        Effect.provide(layer),
+      Effect.provide(
+        openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }),
+        layer,
       ),
     );
     const endpoint2 = await Effect.runPromise(
-      openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }).pipe(
-        Effect.provide(layer),
+      Effect.provide(
+        openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }),
+        layer,
       ),
     );
 
@@ -1143,18 +1214,20 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-limit-new",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-limit",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "e2b",
-        image: "cmuxd-ws:test",
-        idempotencyKey: "limit-new-1",
-      }).pipe(
-        Effect.flip,
-        Effect.provide(providerLayer(provider)),
+      Effect.provide(
+        Effect.flip(
+          createVm({
+            userId: "user-workflow-limit-new",
+            billingCustomerType: "team",
+            billingTeamId: "team-workflow-limit",
+            billingPlanId: "free",
+            maxActiveVms: 1,
+            provider: "e2b",
+            image: "cmuxd-ws:test",
+            idempotencyKey: "limit-new-1",
+          }),
+        ),
+        providerLayer(provider),
       ),
     );
 
@@ -1197,16 +1270,19 @@ describe("VM Effect workflows", () => {
     };
 
     const created = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-paused-slot-new",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-paused-slot",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "freestyle",
-        image: "snapshot-test",
-        idempotencyKey: "paused-slot-new",
-      }).pipe(Effect.provide(providerLayer(provider))),
+      Effect.provide(
+        createVm({
+          userId: "user-workflow-paused-slot-new",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-paused-slot",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-test",
+          idempotencyKey: "paused-slot-new",
+        }),
+        providerLayer(provider),
+      ),
     );
 
     expect(created.providerVmId).toBe("provider-vm-paused-new");
@@ -1249,16 +1325,19 @@ describe("VM Effect workflows", () => {
     };
 
     const created = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-under-limit-new",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-under-limit",
-        billingPlanId: "free",
-        maxActiveVms: 2,
-        provider: "freestyle",
-        image: "snapshot-test",
-        idempotencyKey: "under-limit-new",
-      }).pipe(Effect.provide(providerLayer(provider))),
+      Effect.provide(
+        createVm({
+          userId: "user-workflow-under-limit-new",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-under-limit",
+          billingPlanId: "free",
+          maxActiveVms: 2,
+          provider: "freestyle",
+          image: "snapshot-test",
+          idempotencyKey: "under-limit-new",
+        }),
+        providerLayer(provider),
+      ),
     );
 
     expect(created.providerVmId).toBe("provider-vm-under-limit-new");
@@ -1301,16 +1380,19 @@ describe("VM Effect workflows", () => {
     };
 
     const created = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-provider-paused-new",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-provider-paused",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "freestyle",
-        image: "snapshot-test",
-        idempotencyKey: "provider-paused-new",
-      }).pipe(Effect.provide(providerLayer(provider))),
+      Effect.provide(
+        createVm({
+          userId: "user-workflow-provider-paused-new",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-provider-paused",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-test",
+          idempotencyKey: "provider-paused-new",
+        }),
+        providerLayer(provider),
+      ),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-paused-new");
@@ -1367,16 +1449,19 @@ describe("VM Effect workflows", () => {
     };
 
     const created = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-provider-deleted-new",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-provider-deleted",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "freestyle",
-        image: "snapshot-test",
-        idempotencyKey: "provider-deleted-new",
-      }).pipe(Effect.provide(providerLayer(provider))),
+      Effect.provide(
+        createVm({
+          userId: "user-workflow-provider-deleted-new",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-provider-deleted",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-test",
+          idempotencyKey: "provider-deleted-new",
+        }),
+        providerLayer(provider),
+      ),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-deleted-new");
@@ -1446,16 +1531,19 @@ describe("VM Effect workflows", () => {
     };
 
     const created = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-provider-concurrent-new",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-provider-concurrent",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "freestyle",
-        image: "snapshot-test",
-        idempotencyKey: "provider-concurrent-new",
-      }).pipe(Effect.provide(providerLayer(provider))),
+      Effect.provide(
+        createVm({
+          userId: "user-workflow-provider-concurrent-new",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-provider-concurrent",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-test",
+          idempotencyKey: "provider-concurrent-new",
+        }),
+        providerLayer(provider),
+      ),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-concurrent-new");
@@ -1501,18 +1589,20 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-provider-creating-new",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-provider-creating",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "freestyle",
-        image: "snapshot-test",
-        idempotencyKey: "provider-creating-new",
-      }).pipe(
-        Effect.flip,
-        Effect.provide(providerLayer(provider)),
+      Effect.provide(
+        Effect.flip(
+          createVm({
+            userId: "user-workflow-provider-creating-new",
+            billingCustomerType: "team",
+            billingTeamId: "team-workflow-provider-creating",
+            billingPlanId: "free",
+            maxActiveVms: 1,
+            provider: "freestyle",
+            image: "snapshot-test",
+            idempotencyKey: "provider-creating-new",
+          }),
+        ),
+        providerLayer(provider),
       ),
     );
 
@@ -1556,18 +1646,20 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-provider-running-new",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-provider-running",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "freestyle",
-        image: "snapshot-test",
-        idempotencyKey: "provider-running-new",
-      }).pipe(
-        Effect.flip,
-        Effect.provide(providerLayer(provider)),
+      Effect.provide(
+        Effect.flip(
+          createVm({
+            userId: "user-workflow-provider-running-new",
+            billingCustomerType: "team",
+            billingTeamId: "team-workflow-provider-running",
+            billingPlanId: "free",
+            maxActiveVms: 1,
+            provider: "freestyle",
+            image: "snapshot-test",
+            idempotencyKey: "provider-running-new",
+          }),
+        ),
+        providerLayer(provider),
       ),
     );
 
@@ -1617,16 +1709,19 @@ describe("VM Effect workflows", () => {
     };
 
     const created = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-provider-destroy-race-new",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-provider-destroy-race",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "freestyle",
-        image: "snapshot-test",
-        idempotencyKey: "provider-destroy-race-new",
-      }).pipe(Effect.provide(providerLayer(provider))),
+      Effect.provide(
+        createVm({
+          userId: "user-workflow-provider-destroy-race-new",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-provider-destroy-race",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-test",
+          idempotencyKey: "provider-destroy-race-new",
+        }),
+        providerLayer(provider),
+      ),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-destroy-race-new");
@@ -1702,9 +1797,9 @@ describe("VM Effect workflows", () => {
           )
         `;
         retry = Effect.runPromise(
-          createVm(input).pipe(
-            Effect.flip,
-            Effect.provide(layer),
+          Effect.provide(
+            Effect.flip(createVm(input)),
+            layer,
           ),
         );
         await waitForBlockedAdvisoryLock(testSql, input.billingTeamId);
@@ -1758,21 +1853,25 @@ describe("VM Effect workflows", () => {
     const layer = providerLayer(provider);
 
     await Effect.runPromise(
-      destroyVm({ userId: "user-workflow-reuse-slot", providerVmId: "provider-vm-reuse-old" }).pipe(
-        Effect.provide(layer),
+      Effect.provide(
+        destroyVm({ userId: "user-workflow-reuse-slot", providerVmId: "provider-vm-reuse-old" }),
+        layer,
       ),
     );
     const created = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-reuse-slot",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-reuse-slot",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "e2b",
-        image: "cmuxd-ws:test",
-        idempotencyKey: "reuse-slot-new",
-      }).pipe(Effect.provide(layer)),
+      Effect.provide(
+        createVm({
+          userId: "user-workflow-reuse-slot",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-reuse-slot",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "e2b",
+          image: "cmuxd-ws:test",
+          idempotencyKey: "reuse-slot-new",
+        }),
+        layer,
+      ),
     );
 
     expect(created.providerVmId).toBe("provider-vm-reuse-new");
@@ -1840,8 +1939,8 @@ describe("VM Effect workflows", () => {
     });
     const layer = providerLayer(provider, billing);
 
-    const first = await Effect.runPromise(program.pipe(Effect.provide(layer)));
-    const second = await Effect.runPromise(program.pipe(Effect.provide(layer)));
+    const first = await Effect.runPromise(Effect.provide(program, layer));
+    const second = await Effect.runPromise(Effect.provide(program, layer));
 
     expect(first).toEqual(second);
     expect(createCalls).toBe(1);
@@ -1911,16 +2010,19 @@ describe("VM Effect workflows", () => {
     const layer = providerLayer(provider, billing);
     for (const idempotencyKey of ["credit-grant-1", "credit-grant-2"]) {
       await Effect.runPromise(
-        createVm({
-          userId: "user-workflow-credit-grant",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-credit-grant",
-          billingPlanId: "free",
-          maxActiveVms: 10,
-          provider: "e2b",
-          image: "cmuxd-ws:credit-grant",
-          idempotencyKey,
-        }).pipe(Effect.provide(layer)),
+        Effect.provide(
+          createVm({
+            userId: "user-workflow-credit-grant",
+            billingCustomerType: "team",
+            billingTeamId: "team-workflow-credit-grant",
+            billingPlanId: "free",
+            maxActiveVms: 10,
+            provider: "e2b",
+            image: "cmuxd-ws:credit-grant",
+            idempotencyKey,
+          }),
+          layer,
+        ),
       );
     }
 
@@ -1973,18 +2075,20 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-credit-empty",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-credit-empty",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "freestyle",
-        image: "snapshot-credit-empty",
-        idempotencyKey: "credit-empty-1",
-      }).pipe(
-        Effect.flip,
-        Effect.provide(providerLayer(provider, billing)),
+      Effect.provide(
+        Effect.flip(
+          createVm({
+            userId: "user-workflow-credit-empty",
+            billingCustomerType: "team",
+            billingTeamId: "team-workflow-credit-empty",
+            billingPlanId: "free",
+            maxActiveVms: 1,
+            provider: "freestyle",
+            image: "snapshot-credit-empty",
+            idempotencyKey: "credit-empty-1",
+          }),
+        ),
+        providerLayer(provider, billing),
       ),
     );
 
@@ -2035,16 +2139,19 @@ describe("VM Effect workflows", () => {
     };
 
     const recovered = await Effect.runPromise(
-      createVm({
-        userId: "user-workflow-credit-empty",
-        billingCustomerType: "team",
-        billingTeamId: "team-workflow-credit-empty",
-        billingPlanId: "free",
-        maxActiveVms: 1,
-        provider: "freestyle",
-        image: "snapshot-credit-recovered",
-        idempotencyKey: "credit-empty-2",
-      }).pipe(Effect.provide(providerLayer(recoveryProvider))),
+      Effect.provide(
+        createVm({
+          userId: "user-workflow-credit-empty",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-credit-empty",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-credit-recovered",
+          idempotencyKey: "credit-empty-2",
+        }),
+        providerLayer(recoveryProvider),
+      ),
     );
 
     expect(recovered.providerVmId).toBe("provider-vm-credit-recovered");
@@ -2085,16 +2192,19 @@ describe("VM Effect workflows", () => {
 
     await expect(
       Effect.runPromise(
-        createVm({
-          userId: "user-workflow-credit-refund",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-credit-refund",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-credit-refund",
-          idempotencyKey: "credit-refund-1",
-        }).pipe(Effect.provide(providerLayer(provider, billing))),
+        Effect.provide(
+          createVm({
+            userId: "user-workflow-credit-refund",
+            billingCustomerType: "team",
+            billingTeamId: "team-workflow-credit-refund",
+            billingPlanId: "free",
+            maxActiveVms: 1,
+            provider: "freestyle",
+            image: "snapshot-credit-refund",
+            idempotencyKey: "credit-refund-1",
+          }),
+          providerLayer(provider, billing),
+        ),
       ),
     ).rejects.toThrow();
 
@@ -2142,12 +2252,14 @@ describe("VM Effect workflows", () => {
     };
 
     const error = await Effect.runPromise(
-      openAttachEndpoint({
-        userId: "user-workflow-attacker",
-        providerVmId: "provider-vm-private-1",
-      }).pipe(
-        Effect.flip,
-        Effect.provide(providerLayer(provider)),
+      Effect.provide(
+        Effect.flip(
+          openAttachEndpoint({
+            userId: "user-workflow-attacker",
+            providerVmId: "provider-vm-private-1",
+          }),
+        ),
+        providerLayer(provider),
       ),
     );
     expect(error).toBeInstanceOf(VmNotFoundError);
@@ -2192,23 +2304,32 @@ describe("VM Effect workflows", () => {
     const layer = providerLayer(provider);
 
     const destroyError = await Effect.runPromise(
-      destroyVm({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }).pipe(
-        Effect.flip,
-        Effect.provide(layer),
+      Effect.provide(
+        Effect.flip(
+          destroyVm({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }),
+        ),
+        layer,
       ),
     );
     const execError = await Effect.runPromise(
-      execVm({
-        userId: "user-workflow-attacker",
-        providerVmId: "provider-vm-private-2",
-        command: "true",
-        timeoutMs: 1000,
-      }).pipe(Effect.flip, Effect.provide(layer)),
+      Effect.provide(
+        Effect.flip(
+          execVm({
+            userId: "user-workflow-attacker",
+            providerVmId: "provider-vm-private-2",
+            command: "true",
+            timeoutMs: 1000,
+          }),
+        ),
+        layer,
+      ),
     );
     const sshError = await Effect.runPromise(
-      openSshEndpoint({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }).pipe(
-        Effect.flip,
-        Effect.provide(layer),
+      Effect.provide(
+        Effect.flip(
+          openSshEndpoint({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }),
+        ),
+        layer,
       ),
     );
 
@@ -2259,13 +2380,15 @@ describe("VM Effect workflows", () => {
     const layer = providerLayer(provider);
 
     await Effect.runPromise(
-      openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }).pipe(
-        Effect.provide(layer),
+      Effect.provide(
+        openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }),
+        layer,
       ),
     );
     await Effect.runPromise(
-      openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }).pipe(
-        Effect.provide(layer),
+      Effect.provide(
+        openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }),
+        layer,
       ),
     );
 

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import * as Effect from "effect/Effect";
+import { pipe } from "effect/Function";
 import * as Layer from "effect/Layer";
 import postgres, { type Sql } from "postgres";
 import { closeCloudDbForTests } from "../db/client";
@@ -73,6 +74,13 @@ function workflowLayer(
   );
 }
 
+function runWithLayer<A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  layer: Layer.Layer<any, any, any>,
+) {
+  return Effect.runPromise(pipe(effect, Effect.provide(layer)));
+}
+
 beforeAll(() => {
   if (!runDbTests) return;
   sql = postgres(databaseURL(), { max: 1 });
@@ -121,16 +129,14 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await Effect.runPromise(
-      Effect.provide(
-        execVm({
-          userId: "user-workflow-exec-resume",
-          providerVmId: "provider-vm-exec-resume",
-          command: "echo preflight",
-          timeoutMs: 1000,
-        }),
-        workflowLayer(repo, provider),
-      ),
+    const result = await runWithLayer(
+      execVm({
+        userId: "user-workflow-exec-resume",
+        providerVmId: "provider-vm-exec-resume",
+        command: "echo preflight",
+        timeoutMs: 1000,
+      }),
+      workflowLayer(repo, provider),
     );
 
     expect(result).toEqual({ exitCode: 7, stdout: "preflight", stderr: "" });
@@ -181,18 +187,16 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          execVm({
-            userId: "user-workflow-exec-running",
-            providerVmId: "provider-vm-exec-running",
-            command: "true",
-            timeoutMs: 1000,
-          }),
-        ),
-        workflowLayer(repo, provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        execVm({
+          userId: "user-workflow-exec-running",
+          providerVmId: "provider-vm-exec-running",
+          command: "true",
+          timeoutMs: 1000,
+        }),
       ),
+      workflowLayer(repo, provider),
     );
 
     expect(error).toBe(originalError);
@@ -233,18 +237,16 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          execVm({
-            userId: "user-workflow-exec-resume-fails",
-            providerVmId: "provider-vm-exec-resume-fails",
-            command: "true",
-            timeoutMs: 1000,
-          }),
-        ),
-        workflowLayer(repo, provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        execVm({
+          userId: "user-workflow-exec-resume-fails",
+          providerVmId: "provider-vm-exec-resume-fails",
+          command: "true",
+          timeoutMs: 1000,
+        }),
       ),
+      workflowLayer(repo, provider),
     );
 
     expect(error).toBe(resumeError);
@@ -286,18 +288,16 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          execVm({
-            userId: "user-workflow-exec-mark-false",
-            providerVmId: "provider-vm-exec-mark-false",
-            command: "true",
-            timeoutMs: 1000,
-          }),
-        ),
-        workflowLayer(repo, provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        execVm({
+          userId: "user-workflow-exec-mark-false",
+          providerVmId: "provider-vm-exec-mark-false",
+          command: "true",
+          timeoutMs: 1000,
+        }),
       ),
+      workflowLayer(repo, provider),
     );
 
     expect(error).toBeInstanceOf(VmNotFoundError);
@@ -331,18 +331,16 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          execVm({
-            userId: "user-workflow-exec-no-status",
-            providerVmId: "provider-vm-exec-no-status",
-            command: "true",
-            timeoutMs: 1000,
-          }),
-        ),
-        workflowLayer(repo, provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        execVm({
+          userId: "user-workflow-exec-no-status",
+          providerVmId: "provider-vm-exec-no-status",
+          command: "true",
+          timeoutMs: 1000,
+        }),
       ),
+      workflowLayer(repo, provider),
     );
 
     expect(error).toBe(originalError);
@@ -376,18 +374,16 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          execVm({
-            userId: "user-workflow-exec-no-resume",
-            providerVmId: "provider-vm-exec-no-resume",
-            command: "true",
-            timeoutMs: 1000,
-          }),
-        ),
-        workflowLayer(repo, provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        execVm({
+          userId: "user-workflow-exec-no-resume",
+          providerVmId: "provider-vm-exec-no-resume",
+          command: "true",
+          timeoutMs: 1000,
+        }),
       ),
+      workflowLayer(repo, provider),
     );
 
     expect(error).toBe(originalError);
@@ -429,18 +425,16 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          execVm({
-            userId: "user-workflow-exec-no-replay",
-            providerVmId: "provider-vm-exec-no-replay",
-            command: "true",
-            timeoutMs: 1000,
-          }),
-        ),
-        workflowLayer(repo, provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        execVm({
+          userId: "user-workflow-exec-no-replay",
+          providerVmId: "provider-vm-exec-no-replay",
+          command: "true",
+          timeoutMs: 1000,
+        }),
       ),
+      workflowLayer(repo, provider),
     );
 
     expect(error).toBe(originalError);
@@ -481,16 +475,14 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await Effect.runPromise(
-      Effect.provide(
-        execVm({
-          userId: "user-workflow-exec-status-fails",
-          providerVmId: "provider-vm-exec-status-fails",
-          command: "true",
-          timeoutMs: 1000,
-        }),
-        workflowLayer(repo, provider),
-      ),
+    const result = await runWithLayer(
+      execVm({
+        userId: "user-workflow-exec-status-fails",
+        providerVmId: "provider-vm-exec-status-fails",
+        command: "true",
+        timeoutMs: 1000,
+      }),
+      workflowLayer(repo, provider),
     );
 
     expect(result).toEqual({ exitCode: 0, stdout: "ok", stderr: "" });
@@ -536,15 +528,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await Effect.runPromise(
-      Effect.provide(
-        openAttachEndpoint({
-          userId: "user-workflow-attach-resume",
-          providerVmId: "provider-vm-attach-resume",
-          options: { requireDaemon: true },
-        }),
-        workflowLayer(repo, provider),
-      ),
+    const result = await runWithLayer(
+      openAttachEndpoint({
+        userId: "user-workflow-attach-resume",
+        providerVmId: "provider-vm-attach-resume",
+        options: { requireDaemon: true },
+      }),
+      workflowLayer(repo, provider),
     );
 
     expect(result).toEqual(endpoint);
@@ -612,16 +602,14 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          openAttachEndpoint({
-            userId: "user-workflow-attach-mark-fails",
-            providerVmId: "provider-vm-attach-mark-fails",
-          }),
-        ),
-        workflowLayer(repo, provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        openAttachEndpoint({
+          userId: "user-workflow-attach-mark-fails",
+          providerVmId: "provider-vm-attach-mark-fails",
+        }),
       ),
+      workflowLayer(repo, provider),
     );
 
     expect(error).toBe(markError);
@@ -678,16 +666,14 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          openAttachEndpoint({
-            userId: "user-workflow-attach-mark-false",
-            providerVmId: "provider-vm-attach-mark-false",
-          }),
-        ),
-        workflowLayer(repo, provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        openAttachEndpoint({
+          userId: "user-workflow-attach-mark-false",
+          providerVmId: "provider-vm-attach-mark-false",
+        }),
       ),
+      workflowLayer(repo, provider),
     );
 
     expect(error).toBeInstanceOf(VmNotFoundError);
@@ -735,14 +721,12 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await Effect.runPromise(
-      Effect.provide(
-        openSshEndpoint({
-          userId: "user-workflow-ssh-resume",
-          providerVmId: "provider-vm-ssh-resume",
-        }),
-        workflowLayer(repo, provider),
-      ),
+    const result = await runWithLayer(
+      openSshEndpoint({
+        userId: "user-workflow-ssh-resume",
+        providerVmId: "provider-vm-ssh-resume",
+      }),
+      workflowLayer(repo, provider),
     );
 
     expect(result).toEqual(endpoint);
@@ -799,14 +783,12 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await Effect.runPromise(
-      Effect.provide(
-        openAttachEndpoint({
-          userId: "user-workflow-attach-race",
-          providerVmId: "provider-vm-attach-race",
-        }),
-        workflowLayer(repo, provider),
-      ),
+    const result = await runWithLayer(
+      openAttachEndpoint({
+        userId: "user-workflow-attach-race",
+        providerVmId: "provider-vm-attach-race",
+      }),
+      workflowLayer(repo, provider),
     );
 
     expect(result).toEqual(endpoint);
@@ -849,16 +831,14 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          openAttachEndpoint({
-            userId: "user-workflow-attach-probe-fail",
-            providerVmId: "provider-vm-attach-probe-fail",
-          }),
-        ),
-        workflowLayer(repo, provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        openAttachEndpoint({
+          userId: "user-workflow-attach-probe-fail",
+          providerVmId: "provider-vm-attach-probe-fail",
+        }),
       ),
+      workflowLayer(repo, provider),
     );
 
     expect(error).toBe(probeError);
@@ -904,16 +884,14 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await Effect.runPromise(
-      Effect.provide(
-        execVm({
-          userId: "user-workflow-exec-settle",
-          providerVmId: "provider-vm-exec-settle",
-          command: "echo ok",
-          timeoutMs: 1000,
-        }),
-        workflowLayer(repo, provider),
-      ),
+    const result = await runWithLayer(
+      execVm({
+        userId: "user-workflow-exec-settle",
+        providerVmId: "provider-vm-exec-settle",
+        command: "echo ok",
+        timeoutMs: 1000,
+      }),
+      workflowLayer(repo, provider),
     );
 
     expect(result.exitCode).toBe(0);
@@ -958,16 +936,14 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await Effect.runPromise(
-      Effect.provide(
-        execVm({
-          userId: "user-workflow-exec-concurrent",
-          providerVmId: "provider-vm-exec-concurrent",
-          command: "echo ok",
-          timeoutMs: 1000,
-        }),
-        workflowLayer(repo, provider),
-      ),
+    const result = await runWithLayer(
+      execVm({
+        userId: "user-workflow-exec-concurrent",
+        providerVmId: "provider-vm-exec-concurrent",
+        command: "echo ok",
+        timeoutMs: 1000,
+      }),
+      workflowLayer(repo, provider),
     );
 
     expect(result.exitCode).toBe(0);
@@ -1041,21 +1017,19 @@ describe("VM Effect workflows", () => {
       Layer.succeed(VmBillingGateway, noOpVmBillingGateway()),
     );
 
-    const created = await Effect.runPromise(
-      Effect.provide(
-        createVm({
-          userId: "user-workflow-usage-events",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-usage-events",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-test",
-          imageVersion: "test-version",
-          idempotencyKey: "usage-events",
-        }),
-        layer,
-      ),
+    const created = await runWithLayer(
+      createVm({
+        userId: "user-workflow-usage-events",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-usage-events",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-test",
+        imageVersion: "test-version",
+        idempotencyKey: "usage-events",
+      }),
+      layer,
     );
 
     expect(created.providerVmId).toBe("provider-vm-usage-events");
@@ -1099,8 +1073,8 @@ describe("VM Effect workflows", () => {
       idempotencyKey: "idem-1",
     });
     const layer = providerLayer(provider);
-    const first = await Effect.runPromise(Effect.provide(program, layer));
-    const second = await Effect.runPromise(Effect.provide(program, layer));
+    const first = await runWithLayer(program, layer);
+    const second = await runWithLayer(program, layer);
 
     expect(first).toEqual(second);
     expect(createCalls).toBe(1);
@@ -1156,17 +1130,13 @@ describe("VM Effect workflows", () => {
     };
     const layer = providerLayer(provider);
 
-    const endpoint1 = await Effect.runPromise(
-      Effect.provide(
-        openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }),
-        layer,
-      ),
+    const endpoint1 = await runWithLayer(
+      openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }),
+      layer,
     );
-    const endpoint2 = await Effect.runPromise(
-      Effect.provide(
-        openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }),
-        layer,
-      ),
+    const endpoint2 = await runWithLayer(
+      openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }),
+      layer,
     );
 
     expect(endpoint1.identityHandle).toBe("identity-1");
@@ -1213,22 +1183,20 @@ describe("VM Effect workflows", () => {
       revokeSSHIdentity: () => Effect.void,
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          createVm({
-            userId: "user-workflow-limit-new",
-            billingCustomerType: "team",
-            billingTeamId: "team-workflow-limit",
-            billingPlanId: "free",
-            maxActiveVms: 1,
-            provider: "e2b",
-            image: "cmuxd-ws:test",
-            idempotencyKey: "limit-new-1",
-          }),
-        ),
-        providerLayer(provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        createVm({
+          userId: "user-workflow-limit-new",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-limit",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "e2b",
+          image: "cmuxd-ws:test",
+          idempotencyKey: "limit-new-1",
+        }),
       ),
+      providerLayer(provider),
     );
 
     expect(error).toBeInstanceOf(VmLimitExceededError);
@@ -1269,20 +1237,18 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await Effect.runPromise(
-      Effect.provide(
-        createVm({
-          userId: "user-workflow-paused-slot-new",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-paused-slot",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-test",
-          idempotencyKey: "paused-slot-new",
-        }),
-        providerLayer(provider),
-      ),
+    const created = await runWithLayer(
+      createVm({
+        userId: "user-workflow-paused-slot-new",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-paused-slot",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-test",
+        idempotencyKey: "paused-slot-new",
+      }),
+      providerLayer(provider),
     );
 
     expect(created.providerVmId).toBe("provider-vm-paused-new");
@@ -1324,20 +1290,18 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await Effect.runPromise(
-      Effect.provide(
-        createVm({
-          userId: "user-workflow-under-limit-new",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-under-limit",
-          billingPlanId: "free",
-          maxActiveVms: 2,
-          provider: "freestyle",
-          image: "snapshot-test",
-          idempotencyKey: "under-limit-new",
-        }),
-        providerLayer(provider),
-      ),
+    const created = await runWithLayer(
+      createVm({
+        userId: "user-workflow-under-limit-new",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-under-limit",
+        billingPlanId: "free",
+        maxActiveVms: 2,
+        provider: "freestyle",
+        image: "snapshot-test",
+        idempotencyKey: "under-limit-new",
+      }),
+      providerLayer(provider),
     );
 
     expect(created.providerVmId).toBe("provider-vm-under-limit-new");
@@ -1379,20 +1343,18 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await Effect.runPromise(
-      Effect.provide(
-        createVm({
-          userId: "user-workflow-provider-paused-new",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-provider-paused",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-test",
-          idempotencyKey: "provider-paused-new",
-        }),
-        providerLayer(provider),
-      ),
+    const created = await runWithLayer(
+      createVm({
+        userId: "user-workflow-provider-paused-new",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-provider-paused",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-test",
+        idempotencyKey: "provider-paused-new",
+      }),
+      providerLayer(provider),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-paused-new");
@@ -1448,20 +1410,18 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await Effect.runPromise(
-      Effect.provide(
-        createVm({
-          userId: "user-workflow-provider-deleted-new",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-provider-deleted",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-test",
-          idempotencyKey: "provider-deleted-new",
-        }),
-        providerLayer(provider),
-      ),
+    const created = await runWithLayer(
+      createVm({
+        userId: "user-workflow-provider-deleted-new",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-provider-deleted",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-test",
+        idempotencyKey: "provider-deleted-new",
+      }),
+      providerLayer(provider),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-deleted-new");
@@ -1530,20 +1490,18 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await Effect.runPromise(
-      Effect.provide(
-        createVm({
-          userId: "user-workflow-provider-concurrent-new",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-provider-concurrent",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-test",
-          idempotencyKey: "provider-concurrent-new",
-        }),
-        providerLayer(provider),
-      ),
+    const created = await runWithLayer(
+      createVm({
+        userId: "user-workflow-provider-concurrent-new",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-provider-concurrent",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-test",
+        idempotencyKey: "provider-concurrent-new",
+      }),
+      providerLayer(provider),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-concurrent-new");
@@ -1588,22 +1546,20 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          createVm({
-            userId: "user-workflow-provider-creating-new",
-            billingCustomerType: "team",
-            billingTeamId: "team-workflow-provider-creating",
-            billingPlanId: "free",
-            maxActiveVms: 1,
-            provider: "freestyle",
-            image: "snapshot-test",
-            idempotencyKey: "provider-creating-new",
-          }),
-        ),
-        providerLayer(provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        createVm({
+          userId: "user-workflow-provider-creating-new",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-provider-creating",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-test",
+          idempotencyKey: "provider-creating-new",
+        }),
       ),
+      providerLayer(provider),
     );
 
     expect(error).toBeInstanceOf(VmLimitExceededError);
@@ -1645,22 +1601,20 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          createVm({
-            userId: "user-workflow-provider-running-new",
-            billingCustomerType: "team",
-            billingTeamId: "team-workflow-provider-running",
-            billingPlanId: "free",
-            maxActiveVms: 1,
-            provider: "freestyle",
-            image: "snapshot-test",
-            idempotencyKey: "provider-running-new",
-          }),
-        ),
-        providerLayer(provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        createVm({
+          userId: "user-workflow-provider-running-new",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-provider-running",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-test",
+          idempotencyKey: "provider-running-new",
+        }),
       ),
+      providerLayer(provider),
     );
 
     expect(error).toBeInstanceOf(VmLimitExceededError);
@@ -1708,20 +1662,18 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await Effect.runPromise(
-      Effect.provide(
-        createVm({
-          userId: "user-workflow-provider-destroy-race-new",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-provider-destroy-race",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-test",
-          idempotencyKey: "provider-destroy-race-new",
-        }),
-        providerLayer(provider),
-      ),
+    const created = await runWithLayer(
+      createVm({
+        userId: "user-workflow-provider-destroy-race-new",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-provider-destroy-race",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-test",
+        idempotencyKey: "provider-destroy-race-new",
+      }),
+      providerLayer(provider),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-destroy-race-new");
@@ -1796,12 +1748,7 @@ describe("VM Effect workflows", () => {
             ${input.idempotencyKey}
           )
         `;
-        retry = Effect.runPromise(
-          Effect.provide(
-            Effect.flip(createVm(input)),
-            layer,
-          ),
-        );
+        retry = runWithLayer(Effect.flip(createVm(input)), layer);
         await waitForBlockedAdvisoryLock(testSql, input.billingTeamId);
       });
     } finally {
@@ -1852,26 +1799,22 @@ describe("VM Effect workflows", () => {
     };
     const layer = providerLayer(provider);
 
-    await Effect.runPromise(
-      Effect.provide(
-        destroyVm({ userId: "user-workflow-reuse-slot", providerVmId: "provider-vm-reuse-old" }),
-        layer,
-      ),
+    await runWithLayer(
+      destroyVm({ userId: "user-workflow-reuse-slot", providerVmId: "provider-vm-reuse-old" }),
+      layer,
     );
-    const created = await Effect.runPromise(
-      Effect.provide(
-        createVm({
-          userId: "user-workflow-reuse-slot",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-reuse-slot",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "e2b",
-          image: "cmuxd-ws:test",
-          idempotencyKey: "reuse-slot-new",
-        }),
-        layer,
-      ),
+    const created = await runWithLayer(
+      createVm({
+        userId: "user-workflow-reuse-slot",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-reuse-slot",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "e2b",
+        image: "cmuxd-ws:test",
+        idempotencyKey: "reuse-slot-new",
+      }),
+      layer,
     );
 
     expect(created.providerVmId).toBe("provider-vm-reuse-new");
@@ -1939,8 +1882,8 @@ describe("VM Effect workflows", () => {
     });
     const layer = providerLayer(provider, billing);
 
-    const first = await Effect.runPromise(Effect.provide(program, layer));
-    const second = await Effect.runPromise(Effect.provide(program, layer));
+    const first = await runWithLayer(program, layer);
+    const second = await runWithLayer(program, layer);
 
     expect(first).toEqual(second);
     expect(createCalls).toBe(1);
@@ -2009,20 +1952,18 @@ describe("VM Effect workflows", () => {
 
     const layer = providerLayer(provider, billing);
     for (const idempotencyKey of ["credit-grant-1", "credit-grant-2"]) {
-      await Effect.runPromise(
-        Effect.provide(
-          createVm({
-            userId: "user-workflow-credit-grant",
-            billingCustomerType: "team",
-            billingTeamId: "team-workflow-credit-grant",
-            billingPlanId: "free",
-            maxActiveVms: 10,
-            provider: "e2b",
-            image: "cmuxd-ws:credit-grant",
-            idempotencyKey,
-          }),
-          layer,
-        ),
+      await runWithLayer(
+        createVm({
+          userId: "user-workflow-credit-grant",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-credit-grant",
+          billingPlanId: "free",
+          maxActiveVms: 10,
+          provider: "e2b",
+          image: "cmuxd-ws:credit-grant",
+          idempotencyKey,
+        }),
+        layer,
       );
     }
 
@@ -2074,22 +2015,20 @@ describe("VM Effect workflows", () => {
       refundCreate: () => Effect.void,
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          createVm({
-            userId: "user-workflow-credit-empty",
-            billingCustomerType: "team",
-            billingTeamId: "team-workflow-credit-empty",
-            billingPlanId: "free",
-            maxActiveVms: 1,
-            provider: "freestyle",
-            image: "snapshot-credit-empty",
-            idempotencyKey: "credit-empty-1",
-          }),
-        ),
-        providerLayer(provider, billing),
+    const error = await runWithLayer(
+      Effect.flip(
+        createVm({
+          userId: "user-workflow-credit-empty",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-credit-empty",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-credit-empty",
+          idempotencyKey: "credit-empty-1",
+        }),
       ),
+      providerLayer(provider, billing),
     );
 
     expect(error).toBeInstanceOf(VmCreateCreditsInsufficientError);
@@ -2138,20 +2077,18 @@ describe("VM Effect workflows", () => {
       revokeSSHIdentity: () => Effect.void,
     };
 
-    const recovered = await Effect.runPromise(
-      Effect.provide(
-        createVm({
-          userId: "user-workflow-credit-empty",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-credit-empty",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-credit-recovered",
-          idempotencyKey: "credit-empty-2",
-        }),
-        providerLayer(recoveryProvider),
-      ),
+    const recovered = await runWithLayer(
+      createVm({
+        userId: "user-workflow-credit-empty",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-credit-empty",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-credit-recovered",
+        idempotencyKey: "credit-empty-2",
+      }),
+      providerLayer(recoveryProvider),
     );
 
     expect(recovered.providerVmId).toBe("provider-vm-credit-recovered");
@@ -2191,20 +2128,18 @@ describe("VM Effect workflows", () => {
     };
 
     await expect(
-      Effect.runPromise(
-        Effect.provide(
-          createVm({
-            userId: "user-workflow-credit-refund",
-            billingCustomerType: "team",
-            billingTeamId: "team-workflow-credit-refund",
-            billingPlanId: "free",
-            maxActiveVms: 1,
-            provider: "freestyle",
-            image: "snapshot-credit-refund",
-            idempotencyKey: "credit-refund-1",
-          }),
-          providerLayer(provider, billing),
-        ),
+      runWithLayer(
+        createVm({
+          userId: "user-workflow-credit-refund",
+          billingCustomerType: "team",
+          billingTeamId: "team-workflow-credit-refund",
+          billingPlanId: "free",
+          maxActiveVms: 1,
+          provider: "freestyle",
+          image: "snapshot-credit-refund",
+          idempotencyKey: "credit-refund-1",
+        }),
+        providerLayer(provider, billing),
       ),
     ).rejects.toThrow();
 
@@ -2251,16 +2186,14 @@ describe("VM Effect workflows", () => {
       revokeSSHIdentity: () => Effect.void,
     };
 
-    const error = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          openAttachEndpoint({
-            userId: "user-workflow-attacker",
-            providerVmId: "provider-vm-private-1",
-          }),
-        ),
-        providerLayer(provider),
+    const error = await runWithLayer(
+      Effect.flip(
+        openAttachEndpoint({
+          userId: "user-workflow-attacker",
+          providerVmId: "provider-vm-private-1",
+        }),
       ),
+      providerLayer(provider),
     );
     expect(error).toBeInstanceOf(VmNotFoundError);
     expect(attachCalls).toBe(0);
@@ -2303,34 +2236,28 @@ describe("VM Effect workflows", () => {
     };
     const layer = providerLayer(provider);
 
-    const destroyError = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          destroyVm({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }),
-        ),
-        layer,
+    const destroyError = await runWithLayer(
+      Effect.flip(
+        destroyVm({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }),
       ),
+      layer,
     );
-    const execError = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          execVm({
-            userId: "user-workflow-attacker",
-            providerVmId: "provider-vm-private-2",
-            command: "true",
-            timeoutMs: 1000,
-          }),
-        ),
-        layer,
+    const execError = await runWithLayer(
+      Effect.flip(
+        execVm({
+          userId: "user-workflow-attacker",
+          providerVmId: "provider-vm-private-2",
+          command: "true",
+          timeoutMs: 1000,
+        }),
       ),
+      layer,
     );
-    const sshError = await Effect.runPromise(
-      Effect.provide(
-        Effect.flip(
-          openSshEndpoint({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }),
-        ),
-        layer,
+    const sshError = await runWithLayer(
+      Effect.flip(
+        openSshEndpoint({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }),
       ),
+      layer,
     );
 
     expect(destroyError).toBeInstanceOf(VmNotFoundError);
@@ -2379,17 +2306,13 @@ describe("VM Effect workflows", () => {
     };
     const layer = providerLayer(provider);
 
-    await Effect.runPromise(
-      Effect.provide(
-        openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }),
-        layer,
-      ),
+    await runWithLayer(
+      openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }),
+      layer,
     );
-    await Effect.runPromise(
-      Effect.provide(
-        openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }),
-        layer,
-      ),
+    await runWithLayer(
+      openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }),
+      layer,
     );
 
     const leases = await sql<{ kind: string; sessionId: string | null }[]>`

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import * as Effect from "effect/Effect";
-import { pipe } from "effect/Function";
 import * as Layer from "effect/Layer";
 import postgres, { type Sql } from "postgres";
 import { closeCloudDbForTests } from "../db/client";
@@ -74,10 +73,6 @@ function workflowLayer(
   );
 }
 
-function runWithLayer(effect: any, layer: any) {
-  return Effect.runPromise(pipe(effect, Effect.provide(layer)));
-}
-
 beforeAll(() => {
   if (!runDbTests) return;
   sql = postgres(databaseURL(), { max: 1 });
@@ -126,14 +121,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await runWithLayer(
+    const result = await Effect.runPromise(
       execVm({
         userId: "user-workflow-exec-resume",
         providerVmId: "provider-vm-exec-resume",
         command: "echo preflight",
         timeoutMs: 1000,
-      }),
-      workflowLayer(repo, provider),
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(result).toEqual({ exitCode: 7, stdout: "preflight", stderr: "" });
@@ -184,16 +178,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        execVm({
-          userId: "user-workflow-exec-running",
-          providerVmId: "provider-vm-exec-running",
-          command: "true",
-          timeoutMs: 1000,
-        }),
-      ),
-      workflowLayer(repo, provider),
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-running",
+        providerVmId: "provider-vm-exec-running",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(error).toBe(originalError);
@@ -234,16 +225,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        execVm({
-          userId: "user-workflow-exec-resume-fails",
-          providerVmId: "provider-vm-exec-resume-fails",
-          command: "true",
-          timeoutMs: 1000,
-        }),
-      ),
-      workflowLayer(repo, provider),
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-resume-fails",
+        providerVmId: "provider-vm-exec-resume-fails",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(error).toBe(resumeError);
@@ -285,16 +273,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        execVm({
-          userId: "user-workflow-exec-mark-false",
-          providerVmId: "provider-vm-exec-mark-false",
-          command: "true",
-          timeoutMs: 1000,
-        }),
-      ),
-      workflowLayer(repo, provider),
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-mark-false",
+        providerVmId: "provider-vm-exec-mark-false",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(error).toBeInstanceOf(VmNotFoundError);
@@ -328,16 +313,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        execVm({
-          userId: "user-workflow-exec-no-status",
-          providerVmId: "provider-vm-exec-no-status",
-          command: "true",
-          timeoutMs: 1000,
-        }),
-      ),
-      workflowLayer(repo, provider),
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-no-status",
+        providerVmId: "provider-vm-exec-no-status",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(error).toBe(originalError);
@@ -371,16 +353,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        execVm({
-          userId: "user-workflow-exec-no-resume",
-          providerVmId: "provider-vm-exec-no-resume",
-          command: "true",
-          timeoutMs: 1000,
-        }),
-      ),
-      workflowLayer(repo, provider),
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-no-resume",
+        providerVmId: "provider-vm-exec-no-resume",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(error).toBe(originalError);
@@ -422,16 +401,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        execVm({
-          userId: "user-workflow-exec-no-replay",
-          providerVmId: "provider-vm-exec-no-replay",
-          command: "true",
-          timeoutMs: 1000,
-        }),
-      ),
-      workflowLayer(repo, provider),
+    const error = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-exec-no-replay",
+        providerVmId: "provider-vm-exec-no-replay",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(error).toBe(originalError);
@@ -472,14 +448,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await runWithLayer(
+    const result = await Effect.runPromise(
       execVm({
         userId: "user-workflow-exec-status-fails",
         providerVmId: "provider-vm-exec-status-fails",
         command: "true",
         timeoutMs: 1000,
-      }),
-      workflowLayer(repo, provider),
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(result).toEqual({ exitCode: 0, stdout: "ok", stderr: "" });
@@ -525,13 +500,12 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await runWithLayer(
+    const result = await Effect.runPromise(
       openAttachEndpoint({
         userId: "user-workflow-attach-resume",
         providerVmId: "provider-vm-attach-resume",
         options: { requireDaemon: true },
-      }),
-      workflowLayer(repo, provider),
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(result).toEqual(endpoint);
@@ -599,14 +573,11 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        openAttachEndpoint({
-          userId: "user-workflow-attach-mark-fails",
-          providerVmId: "provider-vm-attach-mark-fails",
-        }),
-      ),
-      workflowLayer(repo, provider),
+    const error = await Effect.runPromise(
+      openAttachEndpoint({
+        userId: "user-workflow-attach-mark-fails",
+        providerVmId: "provider-vm-attach-mark-fails",
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(error).toBe(markError);
@@ -663,14 +634,11 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        openAttachEndpoint({
-          userId: "user-workflow-attach-mark-false",
-          providerVmId: "provider-vm-attach-mark-false",
-        }),
-      ),
-      workflowLayer(repo, provider),
+    const error = await Effect.runPromise(
+      openAttachEndpoint({
+        userId: "user-workflow-attach-mark-false",
+        providerVmId: "provider-vm-attach-mark-false",
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(error).toBeInstanceOf(VmNotFoundError);
@@ -718,12 +686,11 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await runWithLayer(
+    const result = await Effect.runPromise(
       openSshEndpoint({
         userId: "user-workflow-ssh-resume",
         providerVmId: "provider-vm-ssh-resume",
-      }),
-      workflowLayer(repo, provider),
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(result).toEqual(endpoint);
@@ -780,12 +747,11 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await runWithLayer(
+    const result = await Effect.runPromise(
       openAttachEndpoint({
         userId: "user-workflow-attach-race",
         providerVmId: "provider-vm-attach-race",
-      }),
-      workflowLayer(repo, provider),
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(result).toEqual(endpoint);
@@ -828,14 +794,11 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        openAttachEndpoint({
-          userId: "user-workflow-attach-probe-fail",
-          providerVmId: "provider-vm-attach-probe-fail",
-        }),
-      ),
-      workflowLayer(repo, provider),
+    const error = await Effect.runPromise(
+      openAttachEndpoint({
+        userId: "user-workflow-attach-probe-fail",
+        providerVmId: "provider-vm-attach-probe-fail",
+      }).pipe(Effect.flip, Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(error).toBe(probeError);
@@ -881,14 +844,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await runWithLayer(
+    const result = await Effect.runPromise(
       execVm({
         userId: "user-workflow-exec-settle",
         providerVmId: "provider-vm-exec-settle",
         command: "echo ok",
         timeoutMs: 1000,
-      }),
-      workflowLayer(repo, provider),
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(result.exitCode).toBe(0);
@@ -933,14 +895,13 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const result = await runWithLayer(
+    const result = await Effect.runPromise(
       execVm({
         userId: "user-workflow-exec-concurrent",
         providerVmId: "provider-vm-exec-concurrent",
         command: "echo ok",
         timeoutMs: 1000,
-      }),
-      workflowLayer(repo, provider),
+      }).pipe(Effect.provide(workflowLayer(repo, provider))),
     );
 
     expect(result.exitCode).toBe(0);
@@ -1014,7 +975,7 @@ describe("VM Effect workflows", () => {
       Layer.succeed(VmBillingGateway, noOpVmBillingGateway()),
     );
 
-    const created = await runWithLayer(
+    const created = await Effect.runPromise(
       createVm({
         userId: "user-workflow-usage-events",
         billingCustomerType: "team",
@@ -1025,8 +986,7 @@ describe("VM Effect workflows", () => {
         image: "snapshot-test",
         imageVersion: "test-version",
         idempotencyKey: "usage-events",
-      }),
-      layer,
+      }).pipe(Effect.provide(layer)),
     );
 
     expect(created.providerVmId).toBe("provider-vm-usage-events");
@@ -1070,8 +1030,8 @@ describe("VM Effect workflows", () => {
       idempotencyKey: "idem-1",
     });
     const layer = providerLayer(provider);
-    const first = await runWithLayer(program, layer);
-    const second = await runWithLayer(program, layer);
+    const first = await Effect.runPromise(program.pipe(Effect.provide(layer)));
+    const second = await Effect.runPromise(program.pipe(Effect.provide(layer)));
 
     expect(first).toEqual(second);
     expect(createCalls).toBe(1);
@@ -1127,13 +1087,15 @@ describe("VM Effect workflows", () => {
     };
     const layer = providerLayer(provider);
 
-    const endpoint1 = await runWithLayer(
-      openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }),
-      layer,
+    const endpoint1 = await Effect.runPromise(
+      openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }).pipe(
+        Effect.provide(layer),
+      ),
     );
-    const endpoint2 = await runWithLayer(
-      openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }),
-      layer,
+    const endpoint2 = await Effect.runPromise(
+      openSshEndpoint({ userId: "user-workflow-ssh", providerVmId: "provider-vm-ssh-1" }).pipe(
+        Effect.provide(layer),
+      ),
     );
 
     expect(endpoint1.identityHandle).toBe("identity-1");
@@ -1180,20 +1142,20 @@ describe("VM Effect workflows", () => {
       revokeSSHIdentity: () => Effect.void,
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        createVm({
-          userId: "user-workflow-limit-new",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-limit",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "e2b",
-          image: "cmuxd-ws:test",
-          idempotencyKey: "limit-new-1",
-        }),
+    const error = await Effect.runPromise(
+      createVm({
+        userId: "user-workflow-limit-new",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-limit",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "e2b",
+        image: "cmuxd-ws:test",
+        idempotencyKey: "limit-new-1",
+      }).pipe(
+        Effect.flip,
+        Effect.provide(providerLayer(provider)),
       ),
-      providerLayer(provider),
     );
 
     expect(error).toBeInstanceOf(VmLimitExceededError);
@@ -1234,7 +1196,7 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await runWithLayer(
+    const created = await Effect.runPromise(
       createVm({
         userId: "user-workflow-paused-slot-new",
         billingCustomerType: "team",
@@ -1244,8 +1206,7 @@ describe("VM Effect workflows", () => {
         provider: "freestyle",
         image: "snapshot-test",
         idempotencyKey: "paused-slot-new",
-      }),
-      providerLayer(provider),
+      }).pipe(Effect.provide(providerLayer(provider))),
     );
 
     expect(created.providerVmId).toBe("provider-vm-paused-new");
@@ -1287,7 +1248,7 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await runWithLayer(
+    const created = await Effect.runPromise(
       createVm({
         userId: "user-workflow-under-limit-new",
         billingCustomerType: "team",
@@ -1297,8 +1258,7 @@ describe("VM Effect workflows", () => {
         provider: "freestyle",
         image: "snapshot-test",
         idempotencyKey: "under-limit-new",
-      }),
-      providerLayer(provider),
+      }).pipe(Effect.provide(providerLayer(provider))),
     );
 
     expect(created.providerVmId).toBe("provider-vm-under-limit-new");
@@ -1340,7 +1300,7 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await runWithLayer(
+    const created = await Effect.runPromise(
       createVm({
         userId: "user-workflow-provider-paused-new",
         billingCustomerType: "team",
@@ -1350,8 +1310,7 @@ describe("VM Effect workflows", () => {
         provider: "freestyle",
         image: "snapshot-test",
         idempotencyKey: "provider-paused-new",
-      }),
-      providerLayer(provider),
+      }).pipe(Effect.provide(providerLayer(provider))),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-paused-new");
@@ -1407,7 +1366,7 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await runWithLayer(
+    const created = await Effect.runPromise(
       createVm({
         userId: "user-workflow-provider-deleted-new",
         billingCustomerType: "team",
@@ -1417,8 +1376,7 @@ describe("VM Effect workflows", () => {
         provider: "freestyle",
         image: "snapshot-test",
         idempotencyKey: "provider-deleted-new",
-      }),
-      providerLayer(provider),
+      }).pipe(Effect.provide(providerLayer(provider))),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-deleted-new");
@@ -1487,7 +1445,7 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await runWithLayer(
+    const created = await Effect.runPromise(
       createVm({
         userId: "user-workflow-provider-concurrent-new",
         billingCustomerType: "team",
@@ -1497,8 +1455,7 @@ describe("VM Effect workflows", () => {
         provider: "freestyle",
         image: "snapshot-test",
         idempotencyKey: "provider-concurrent-new",
-      }),
-      providerLayer(provider),
+      }).pipe(Effect.provide(providerLayer(provider))),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-concurrent-new");
@@ -1543,20 +1500,20 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        createVm({
-          userId: "user-workflow-provider-creating-new",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-provider-creating",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-test",
-          idempotencyKey: "provider-creating-new",
-        }),
+    const error = await Effect.runPromise(
+      createVm({
+        userId: "user-workflow-provider-creating-new",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-provider-creating",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-test",
+        idempotencyKey: "provider-creating-new",
+      }).pipe(
+        Effect.flip,
+        Effect.provide(providerLayer(provider)),
       ),
-      providerLayer(provider),
     );
 
     expect(error).toBeInstanceOf(VmLimitExceededError);
@@ -1598,20 +1555,20 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        createVm({
-          userId: "user-workflow-provider-running-new",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-provider-running",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-test",
-          idempotencyKey: "provider-running-new",
-        }),
+    const error = await Effect.runPromise(
+      createVm({
+        userId: "user-workflow-provider-running-new",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-provider-running",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-test",
+        idempotencyKey: "provider-running-new",
+      }).pipe(
+        Effect.flip,
+        Effect.provide(providerLayer(provider)),
       ),
-      providerLayer(provider),
     );
 
     expect(error).toBeInstanceOf(VmLimitExceededError);
@@ -1659,7 +1616,7 @@ describe("VM Effect workflows", () => {
         }),
     };
 
-    const created = await runWithLayer(
+    const created = await Effect.runPromise(
       createVm({
         userId: "user-workflow-provider-destroy-race-new",
         billingCustomerType: "team",
@@ -1669,8 +1626,7 @@ describe("VM Effect workflows", () => {
         provider: "freestyle",
         image: "snapshot-test",
         idempotencyKey: "provider-destroy-race-new",
-      }),
-      providerLayer(provider),
+      }).pipe(Effect.provide(providerLayer(provider))),
     );
 
     expect(created.providerVmId).toBe("provider-vm-provider-destroy-race-new");
@@ -1745,7 +1701,12 @@ describe("VM Effect workflows", () => {
             ${input.idempotencyKey}
           )
         `;
-        retry = runWithLayer(Effect.flip(createVm(input)), layer);
+        retry = Effect.runPromise(
+          createVm(input).pipe(
+            Effect.flip,
+            Effect.provide(layer),
+          ),
+        );
         await waitForBlockedAdvisoryLock(testSql, input.billingTeamId);
       });
     } finally {
@@ -1796,11 +1757,12 @@ describe("VM Effect workflows", () => {
     };
     const layer = providerLayer(provider);
 
-    await runWithLayer(
-      destroyVm({ userId: "user-workflow-reuse-slot", providerVmId: "provider-vm-reuse-old" }),
-      layer,
+    await Effect.runPromise(
+      destroyVm({ userId: "user-workflow-reuse-slot", providerVmId: "provider-vm-reuse-old" }).pipe(
+        Effect.provide(layer),
+      ),
     );
-    const created = await runWithLayer(
+    const created = await Effect.runPromise(
       createVm({
         userId: "user-workflow-reuse-slot",
         billingCustomerType: "team",
@@ -1810,8 +1772,7 @@ describe("VM Effect workflows", () => {
         provider: "e2b",
         image: "cmuxd-ws:test",
         idempotencyKey: "reuse-slot-new",
-      }),
-      layer,
+      }).pipe(Effect.provide(layer)),
     );
 
     expect(created.providerVmId).toBe("provider-vm-reuse-new");
@@ -1879,8 +1840,8 @@ describe("VM Effect workflows", () => {
     });
     const layer = providerLayer(provider, billing);
 
-    const first = await runWithLayer(program, layer);
-    const second = await runWithLayer(program, layer);
+    const first = await Effect.runPromise(program.pipe(Effect.provide(layer)));
+    const second = await Effect.runPromise(program.pipe(Effect.provide(layer)));
 
     expect(first).toEqual(second);
     expect(createCalls).toBe(1);
@@ -1949,7 +1910,7 @@ describe("VM Effect workflows", () => {
 
     const layer = providerLayer(provider, billing);
     for (const idempotencyKey of ["credit-grant-1", "credit-grant-2"]) {
-      await runWithLayer(
+      await Effect.runPromise(
         createVm({
           userId: "user-workflow-credit-grant",
           billingCustomerType: "team",
@@ -1959,8 +1920,7 @@ describe("VM Effect workflows", () => {
           provider: "e2b",
           image: "cmuxd-ws:credit-grant",
           idempotencyKey,
-        }),
-        layer,
+        }).pipe(Effect.provide(layer)),
       );
     }
 
@@ -2012,20 +1972,20 @@ describe("VM Effect workflows", () => {
       refundCreate: () => Effect.void,
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        createVm({
-          userId: "user-workflow-credit-empty",
-          billingCustomerType: "team",
-          billingTeamId: "team-workflow-credit-empty",
-          billingPlanId: "free",
-          maxActiveVms: 1,
-          provider: "freestyle",
-          image: "snapshot-credit-empty",
-          idempotencyKey: "credit-empty-1",
-        }),
+    const error = await Effect.runPromise(
+      createVm({
+        userId: "user-workflow-credit-empty",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-credit-empty",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-credit-empty",
+        idempotencyKey: "credit-empty-1",
+      }).pipe(
+        Effect.flip,
+        Effect.provide(providerLayer(provider, billing)),
       ),
-      providerLayer(provider, billing),
     );
 
     expect(error).toBeInstanceOf(VmCreateCreditsInsufficientError);
@@ -2074,7 +2034,7 @@ describe("VM Effect workflows", () => {
       revokeSSHIdentity: () => Effect.void,
     };
 
-    const recovered = await runWithLayer(
+    const recovered = await Effect.runPromise(
       createVm({
         userId: "user-workflow-credit-empty",
         billingCustomerType: "team",
@@ -2084,8 +2044,7 @@ describe("VM Effect workflows", () => {
         provider: "freestyle",
         image: "snapshot-credit-recovered",
         idempotencyKey: "credit-empty-2",
-      }),
-      providerLayer(recoveryProvider),
+      }).pipe(Effect.provide(providerLayer(recoveryProvider))),
     );
 
     expect(recovered.providerVmId).toBe("provider-vm-credit-recovered");
@@ -2125,7 +2084,7 @@ describe("VM Effect workflows", () => {
     };
 
     await expect(
-      runWithLayer(
+      Effect.runPromise(
         createVm({
           userId: "user-workflow-credit-refund",
           billingCustomerType: "team",
@@ -2135,8 +2094,7 @@ describe("VM Effect workflows", () => {
           provider: "freestyle",
           image: "snapshot-credit-refund",
           idempotencyKey: "credit-refund-1",
-        }),
-        providerLayer(provider, billing),
+        }).pipe(Effect.provide(providerLayer(provider, billing))),
       ),
     ).rejects.toThrow();
 
@@ -2183,14 +2141,14 @@ describe("VM Effect workflows", () => {
       revokeSSHIdentity: () => Effect.void,
     };
 
-    const error = await runWithLayer(
-      Effect.flip(
-        openAttachEndpoint({
-          userId: "user-workflow-attacker",
-          providerVmId: "provider-vm-private-1",
-        }),
+    const error = await Effect.runPromise(
+      openAttachEndpoint({
+        userId: "user-workflow-attacker",
+        providerVmId: "provider-vm-private-1",
+      }).pipe(
+        Effect.flip,
+        Effect.provide(providerLayer(provider)),
       ),
-      providerLayer(provider),
     );
     expect(error).toBeInstanceOf(VmNotFoundError);
     expect(attachCalls).toBe(0);
@@ -2233,28 +2191,25 @@ describe("VM Effect workflows", () => {
     };
     const layer = providerLayer(provider);
 
-    const destroyError = await runWithLayer(
-      Effect.flip(
-        destroyVm({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }),
+    const destroyError = await Effect.runPromise(
+      destroyVm({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }).pipe(
+        Effect.flip,
+        Effect.provide(layer),
       ),
-      layer,
     );
-    const execError = await runWithLayer(
-      Effect.flip(
-        execVm({
-          userId: "user-workflow-attacker",
-          providerVmId: "provider-vm-private-2",
-          command: "true",
-          timeoutMs: 1000,
-        }),
-      ),
-      layer,
+    const execError = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-attacker",
+        providerVmId: "provider-vm-private-2",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(layer)),
     );
-    const sshError = await runWithLayer(
-      Effect.flip(
-        openSshEndpoint({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }),
+    const sshError = await Effect.runPromise(
+      openSshEndpoint({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }).pipe(
+        Effect.flip,
+        Effect.provide(layer),
       ),
-      layer,
     );
 
     expect(destroyError).toBeInstanceOf(VmNotFoundError);
@@ -2303,13 +2258,15 @@ describe("VM Effect workflows", () => {
     };
     const layer = providerLayer(provider);
 
-    await runWithLayer(
-      openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }),
-      layer,
+    await Effect.runPromise(
+      openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }).pipe(
+        Effect.provide(layer),
+      ),
     );
-    await runWithLayer(
-      openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }),
-      layer,
+    await Effect.runPromise(
+      openAttachEndpoint({ userId: "user-workflow-attach", providerVmId: "provider-vm-attach-1" }).pipe(
+        Effect.provide(layer),
+      ),
     );
 
     const leases = await sql<{ kind: string; sessionId: string | null }[]>`

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -74,10 +74,7 @@ function workflowLayer(
   );
 }
 
-function runWithLayer<A, E, R>(
-  effect: Effect.Effect<A, E, R>,
-  layer: Layer.Layer<any, any, any>,
-) {
+function runWithLayer(effect: any, layer: any) {
   return Effect.runPromise(pipe(effect, Effect.provide(layer)));
 }
 


### PR DESCRIPTION
## Summary
- make the scheduled iOS TestFlight workflow upload external-eligible beta builds from `main`
- keep the existing auto-version and commit-range note generation, now applied to the selected audience
- update the iOS TestFlight docs/comments to explain the Beta App Review gate for new marketing versions

## Verification
- `bash -n ios/scripts/upload-testflight.sh ios/scripts/generate-testflight-notes.sh`
- `python3 tests/test_ios_testflight_notes.py`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785896310&installation_id=133855650&pr_number=7419&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7419&signature=f7edf8d72f7047a18f9d9ba0250a1d0a33a93c544c5fcb9cc929dbf9b0060c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The scheduled iOS TestFlight workflow now uploads external-eligible builds from `main`, auto-assigns them to the founders external group, and can retry assignment without re-uploading. Also fixes the TestFlight workflow checkout and adds CI coverage for external group selection.

- **Refactors**
  - Split external distribution into a new “Assign build to external TestFlight group” job; `upload-testflight.sh` adds `--external`, can auto-assign with ASC JWT (disabled in CI via `CMUX_TESTFLIGHT_ASSIGN_EXTERNAL_GROUP=0`), and publishes the final build number as an output and artifact. Added `asc_assign_external_testflight_group.py` to wait for VALID, select the external group by id/name or auto-pick the single group, respect “access to all builds,” and fail on ambiguous/missing groups; added a CI test to validate selection.
  - The decide step now scans past runs for a successful “Upload to TestFlight” job (not whole-workflow), exposes `should_assign_only` and `last_uploaded_run_id`, skips rebuilding when the same SHA was already uploaded, and only allows assignment-only retries when the prior run includes the assignment job/artifact—guarding legacy uploads to avoid duplicates.

- **Bug Fixes**
  - Fixed a bad checkout step in the TestFlight workflow.

<sup>Written for commit 47ccf912055f26ccac690f2cb35b2b0cbc2926b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TestFlight scheduled uploads now include an external-eligible lane and can automatically assign eligible builds to the app’s external beta group after Apple Beta App Review for new marketing versions.
* **Bug Fixes**
  * Improves beta upload scheduling and prevents unnecessary re-uploads by tracking the last successful upload and enabling safe “reassign-only” flows.
* **Documentation**
  * Updated iOS TestFlight docs and script help to clarify internal vs external availability and external group selection behavior.
* **Tests**
  * Added automated coverage for external group selection and a CI guard step to validate it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->