### PR TITLE
web: replace react-wrap-balancer with CSS text-balance on landing subtitle

### DIFF
--- a/web/app/[locale]/(landing)/page.tsx
+++ b/web/app/[locale]/(landing)/page.tsx
@@ -1,6 +1,5 @@
 import { useTranslations, useLocale } from "next-intl";
 import { HeroScreenshot } from "@/app/[locale]/components/hero-screenshot";
-import Balancer from "react-wrap-balancer";
 import { TypingTagline } from "@/app/[locale]/typing";
 import { DownloadButton } from "@/app/[locale]/components/download-button";
 import { GitHubButton } from "@/app/[locale]/components/github-button";
@@ -83,19 +82,17 @@ function HomeContent() {
           </span>
         </p>
         <p
-          className="text-base text-muted lg:-mr-32 xl:-mr-48"
+          className="text-base text-muted text-balance lg:-mr-32 xl:-mr-48"
           data-dev="subtitle"
           style={{ lineHeight: 1.5 }}
         >
-          <Balancer>
-            {t.rich("subtitle", {
-              cliLink: (chunks) => (
-                <Link href="/docs/api" className={linkClass}>
-                  {chunks}
-                </Link>
-              ),
-            })}
-          </Balancer>
+          {t.rich("subtitle", {
+            cliLink: (chunks) => (
+              <Link href="/docs/api" className={linkClass}>
+                {chunks}
+              </Link>
+            ),
+          })}
         </p>
 
         {/* Download */}

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -36,7 +36,6 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-tweet": "^3.3.0",
-        "react-wrap-balancer": "^1.1.1",
         "resend": "^6.9.3",
         "shiki": "^3.22.0",
         "stripe": "22.3.0",
@@ -1929,8 +1928,6 @@
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-tweet": ["react-tweet@3.3.0", "", { "dependencies": { "@swc/helpers": "^0.5.3", "clsx": "^2.0.0", "swr": "^2.2.4" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-gSIG2169ZK7UH6rBzuU+j1xnQbH3IlOTLEkuGrRiJJTMgETik+h+26yHyyVKrLkzwrOaYPk4K3OtEKycqKgNLw=="],
-
-    "react-wrap-balancer": ["react-wrap-balancer@1.1.1", "", { "peerDependencies": { "react": ">=16.8.0 || ^17.0.0 || ^18" } }, "sha512-AB+l7FPRWl6uZ28VcJ8skkwLn2+UC62bjiw8tQUrZPlEWDVnR9MG0lghyn7EyxuJSsFEpht4G+yh2WikEqQ/5Q=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -62,7 +62,6 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-tweet": "^3.3.0",
-    "react-wrap-balancer": "^1.1.1",
     "resend": "^6.9.3",
     "shiki": "^3.22.0",
     "stripe": "22.3.0",


### PR DESCRIPTION
Fixes the console error on every landing page load in Next.js 16 / React 19:

> Encountered a script tag while rendering React component. Scripts inside React components are never executed when rendering on the client.

at `HomeContent (app/[locale]/(landing)/page.tsx:90)`. The source is `react-wrap-balancer`'s `<Balancer>`, which injects an inline `<script>` during SSR; React 19 flags any script tag rendered inside a component.

Fix: drop the library and use Tailwind v4's `text-balance` utility (native CSS `text-wrap: balance`) on the subtitle paragraph. Same visual balancing, no JS, one fewer dependency. The JSON-LD structured-data script in the same file uses `dangerouslySetInnerHTML` intentionally and is untouched.

Verified: `bun run typecheck` passes, no `react-wrap-balancer` references remain in `web/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785898029&installation_id=133855650&pr_number=7420&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7420&signature=a7c825f7e7fe957b2a8a3e17d4cdbfd6c42d91a51829a7869bebef5b05081ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Landing-page copy styling only; no auth, data, or API behavior changes.
> 
> **Overview**
> Removes **`react-wrap-balancer`** from the landing page hero subtitle and applies Tailwind’s **`text-balance`** on that paragraph instead, so line wrapping stays balanced without the library’s SSR inline script.
> 
> The subtitle still renders the same **`t.rich("subtitle", …)`** content and docs link; only the wrapper and dependency are gone (**`package.json`** / **`bun.lock`** updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cbf20ae585248356ddc6f3bb01ca3c1a72699c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the React 19/Next 16 console warning on the landing subtitle by switching from `react-wrap-balancer` to CSS `text-balance` via Tailwind v4. Same visual balance, no inline scripts.

- **Dependencies**
  - Removed `react-wrap-balancer` from `package.json` and `bun.lock`.

<sup>Written for commit 6cbf20ae585248356ddc6f3bb01ca3c1a72699c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the landing page subtitle layout and text wrapping for a cleaner display.
  * Simplified the subtitle rendering while preserving the existing link to the API docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->