### PR TITLE
[fleet demo] docs: sync agent-hooks event list

### DIFF
--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -33,6 +33,8 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `amp`, `curs
 | Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
 | Qoder | `qodercli` | `~/.qoder/settings.json` | `qodercli --resume <id>` | PreToolUse |
 
+The canonical set of hook event names (`SessionStart`, `SessionEnd`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `PermissionRequest`, `AskUserQuestion`, `ExitPlanMode`, `TodoWrite`, `Stop`, `SubagentStart`, `SubagentStop`, `Notification`) is defined by the `HookEventName` enum in `Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamEvent.swift`, with each agent's per-event wiring in `CLI/CMUXCLI+AgentHookDefinitions.swift`.
+
 OpenCode also supports project-local Feed installation:
 
 ```bash

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -33,7 +33,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `amp`, `curs
 | Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
 | Qoder | `qodercli` | `~/.qoder/settings.json` | `qodercli --resume <id>` | PreToolUse |
 
-The canonical set of hook event names (`SessionStart`, `SessionEnd`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `PermissionRequest`, `AskUserQuestion`, `ExitPlanMode`, `TodoWrite`, `Stop`, `SubagentStart`, `SubagentStop`, `Notification`) is defined by the `HookEventName` enum in `Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamEvent.swift`, with each agent's per-event wiring in `CLI/CMUXCLI+AgentHookDefinitions.swift`.
+The canonical set of hook event names (`SessionStart`, `SessionEnd`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `PermissionRequest`, `AskUserQuestion`, `ExitPlanMode`, `TodoWrite`, `Stop`, `SubagentStart`, `SubagentStop`, `Notification`) is defined by the `HookEventName` enum in `Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamEvent.swift`, with each agent's per-event wiring in `CLI/CMUXCLI+AgentHookDefinitions.swift`. That `HookEventName` enum is the authoritative source for this list; the native per-agent event names in `CMUXCLI+AgentHookDefinitions.swift` (for example `beforeShellExecution` or `on_tool_permission`) are each agent's own vocabulary that maps onto this canonical set rather than adding to it.
 
 OpenCode also supports project-local Feed installation:
 


### PR DESCRIPTION
Doc sync against WorkstreamEvent.HookEventName. Created autonomously by the cmux Fleet orchestration demo (#7361 PR 3 dogfood); fine to close if unwanted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785899347&installation_id=133855650&pr_number=7423&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7423&signature=bb3d2bde79d8778e3950deec7bf4dc089e6c661a10a2b7c72b752a1c33409ea1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the agent hooks docs with the canonical `HookEventName` list. Adds the explicit event list and clarifies that per‑agent hook names in `CLI/CMUXCLI+AgentHookDefinitions.swift` map to `Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamEvent.swift` and do not add new events.

<sup>Written for commit 5e112476990cfe92e0bee2043f83b9ba071fccb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the canonical hook event name list is defined by the shared enum, and that each agent’s event wiring maps its native events onto this canonical set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->