### PR TITLE
[fleet demo] docs: proofread README + configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Panes get a blue ring and tabs light up when coding agents need your attention
 <tr>
 <td width="40%" valign="middle">
 <h3>Notification panel</h3>
-See all pending notifications in one place, jump to the most recent unread
+See all pending notifications in one place, and jump to the most recent unread
 </td>
 <td width="60%">
 <img src="./docs/assets/sidebar-notification-badge.png" alt="Sidebar notification badge" width="100%" />

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Yes, cmux is free to use. The source code is available on [GitHub](https://githu
 
 cmux is free and open source, and always will be. If you want to back development and get early access to what's next, including cmux AI, the iOS app, and Cloud VMs, check out [cmux Founders Edition](https://github.com/manaflow-ai/cmux#founders-edition).
 
-### I have a feature request or found a bug?
+### I have a feature request or a bug to report?
 
 We want to hear it. Open an [issue](https://github.com/manaflow-ai/cmux/issues) or [pull request](https://github.com/manaflow-ai/cmux/pulls) on GitHub, or [email us](mailto:founders@manaflow.com?subject=cmux%20feature%20request).
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Command palette navigation shortcuts, including ⌃ P, are also customizable and
 
 [Download cmux NIGHTLY](https://github.com/manaflow-ai/cmux/releases/download/nightly/cmux-nightly-macos.dmg)
 
-cmux NIGHTLY is a separate app with its own bundle ID, so it runs alongside the stable version. Built automatically from the latest `main` commit and auto-updates via its own Sparkle feed.
+cmux NIGHTLY is a separate app with its own bundle ID, so it runs alongside the stable version. It is built automatically from the latest `main` commit and auto-updates via its own Sparkle feed.
 
 Report nightly bugs on [GitHub Issues](https://github.com/manaflow-ai/cmux/issues) or in [#nightly-bugs on Discord](https://discord.gg/xsgFEVrWCZ).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ Default: `right`.
 
 ## `terminal.agentHibernation`
 
-Opt-in Agent Hibernation. cmux kills idle background agent processes to free RAM and CPU, then resumes each one with its saved session when you visit its tab. See [agent-hooks.md](agent-hooks.md#agent-hibernation) for the full behavior, including the confirmation settle window and how resume works.
+Opt-in Agent Hibernation. cmux kills idle background agent processes to free RAM and CPU, then resumes each one with its saved session when you visit its tab. See [agent-hooks.md](agent-hooks.md#agent-hibernation) for the full behavior, including the confirmation settle window and how resuming works.
 
 ```json
 {


### PR DESCRIPTION
Tiny docs pass. Created autonomously by the cmux Fleet orchestration demo (#7361 PR 3 dogfood); fine to close if unwanted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785899352&installation_id=133855650&pr_number=7424&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7424&signature=2353a9225012dc80771c0470456bbe246b0349a447177ca0059a27eb60a43df9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proofreads `README.md` and `docs/configuration.md` for clarity by fixing the Notification panel sentence, clarifying the cmux NIGHTLY line (“It is built automatically…”), updating the FAQ header to “I have a feature request or a bug to report?”, and refining Agent Hibernation wording (“how resuming works”). No functional changes.

<sup>Written for commit b42158ec6df25e054b820ad9c0b105a5d4b73733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated wording in the “Notification panel” feature description to improve punctuation/clarity.
  * Rephrased the “cmux NIGHTLY” description to keep the same meaning about running alongside stable and auto-updating via its own feed.
  * Refined the `terminal.agentHibernation` documentation to clarify the confirmation settle window and resuming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->