### PR TITLE
Fail closed in the feedback route when the rate limiter is unavailable

### DIFF
--- a/web/app/api/feedback/route.ts
+++ b/web/app/api/feedback/route.ts
@@ -79,8 +79,10 @@ export async function POST(request: Request) {
             "feedback.route.rate_limit_not_found",
             feedbackConfig.rateLimitId,
           );
+          return jsonError("Feedback endpoint is not configured", 503);
         } else if (error) {
           console.error("feedback.route.rate_limit_error", error);
+          return jsonError("Feedback endpoint is not configured", 503);
         }
       }
 

--- a/web/tests/feedback-route.test.ts
+++ b/web/tests/feedback-route.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+
+const originalSkipEnvValidation = process.env.SKIP_ENV_VALIDATION;
+const originalResendApiKey = process.env.RESEND_API_KEY;
+const originalFeedbackFromEmail = process.env.CMUX_FEEDBACK_FROM_EMAIL;
+const originalFeedbackRateLimitId = process.env.CMUX_FEEDBACK_RATE_LIMIT_ID;
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.RESEND_API_KEY = "test-resend-api-key";
+process.env.CMUX_FEEDBACK_FROM_EMAIL = "feedback-from@example.com";
+process.env.CMUX_FEEDBACK_RATE_LIMIT_ID = "cmux-feedback-test";
+
+const originalVercel = process.env.VERCEL;
+const originalConsoleError = console.error;
+const checkRateLimit = mock(async () => ({ rateLimited: false, error: null }));
+const emailSendMock = mock(async () => ({ error: null }));
+
+mock.module("@vercel/firewall", () => ({
+  checkRateLimit,
+}));
+
+mock.module("resend", () => ({
+  Resend: class {
+    emails = { send: emailSendMock };
+  },
+}));
+
+const { POST } = await import("../app/api/feedback/route");
+
+afterEach(() => {
+  console.error = originalConsoleError;
+  checkRateLimit.mockClear();
+  checkRateLimit.mockResolvedValue({ rateLimited: false, error: null });
+  emailSendMock.mockClear();
+  emailSendMock.mockResolvedValue({ error: null });
+  if (typeof originalVercel === "undefined") {
+    delete process.env.VERCEL;
+  } else {
+    process.env.VERCEL = originalVercel;
+  }
+});
+
+afterAll(() => {
+  restoreEnv("SKIP_ENV_VALIDATION", originalSkipEnvValidation);
+  restoreEnv("RESEND_API_KEY", originalResendApiKey);
+  restoreEnv("CMUX_FEEDBACK_FROM_EMAIL", originalFeedbackFromEmail);
+  restoreEnv("CMUX_FEEDBACK_RATE_LIMIT_ID", originalFeedbackRateLimitId);
+});
+
+describe("feedback route", () => {
+  test("fails closed on Vercel when the feedback limiter rule is not found", async () => {
+    process.env.VERCEL = "1";
+    checkRateLimit.mockResolvedValue({ rateLimited: false, error: "not-found" });
+    const consoleError = mock(() => {});
+    console.error = consoleError as unknown as typeof console.error;
+
+    const response = await POST(feedbackRequest());
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "Feedback endpoint is not configured",
+    });
+    expect(emailSendMock).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "feedback.route.rate_limit_not_found",
+      "cmux-feedback-test",
+    );
+  });
+
+  test("fails closed on Vercel when the feedback limiter returns an error", async () => {
+    process.env.VERCEL = "1";
+    checkRateLimit.mockResolvedValue({
+      rateLimited: false,
+      error: "firewall-unavailable",
+    });
+    const consoleError = mock(() => {});
+    console.error = consoleError as unknown as typeof console.error;
+
+    const response = await POST(feedbackRequest());
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "Feedback endpoint is not configured",
+    });
+    expect(emailSendMock).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "feedback.route.rate_limit_error",
+      "firewall-unavailable",
+    );
+  });
+
+  test("sends feedback when the limiter is healthy on Vercel", async () => {
+    process.env.VERCEL = "1";
+    checkRateLimit.mockResolvedValue({ rateLimited: false, error: null });
+    emailSendMock.mockResolvedValue({ error: null });
+
+    const response = await POST(feedbackRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(emailSendMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+function feedbackRequest(): Request {
+  const formData = new FormData();
+  formData.set("email", "reporter@example.com");
+  formData.set("message", "The app should send this only when rate limiting is healthy.");
+
+  return new Request("https://cmux.test/api/feedback", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (typeof value === "undefined") {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/web/tests/test-preload.ts
+++ b/web/tests/test-preload.ts
@@ -11,3 +11,6 @@
 // these at their own top level.
 process.env.SKIP_ENV_VALIDATION = "1";
 process.env.CMUX_PUSH_RATE_LIMIT_ID ??= "cmux-push-test";
+process.env.RESEND_API_KEY ??= "cmux-feedback-test-resend-key";
+process.env.CMUX_FEEDBACK_FROM_EMAIL ??= "feedback-from@example.com";
+process.env.CMUX_FEEDBACK_RATE_LIMIT_ID ??= "cmux-feedback-test";


### PR DESCRIPTION
## What

The `/api/feedback` POST handler logged the `checkRateLimit` `not-found` and generic-error outcomes but then continued to parse the multipart body and send the Resend email with attachments. A missing or broken limiter therefore left the public endpoint able to send email without throttling.

This changes the route to return `503` after those logs, stopping the request before `request.formData()` and before `resend.emails.send`, matching the fail-closed behavior already used by `web/app/api/client-config/route.ts` for the same limiter outcomes. The `429` rate-limited/blocked branch, the span attributes, and the non-Vercel path are unchanged.

## Test

`web/tests/feedback-route.test.ts` (new) mocks `@vercel/firewall` and `resend`, then asserts:
- limiter `not-found` → `503`, email send **not** invoked, existing log line preserved
- limiter error → `503`, email send **not** invoked, existing log line preserved
- healthy limiter → `200`, email sent once (positive control)

The feedback env vars are pinned in `web/tests/test-preload.ts` with `??=` (mirroring the existing `CMUX_PUSH_RATE_LIMIT_ID` pin) so `@/app/env` resolves deterministically regardless of test-file import order in the shared bun test process.

Two-commit red/green: commit 1 adds the failing test (route returns `200` without the fix); commit 2 adds the fix.

## Verify

- `cd web && bun test tests/feedback-route.test.ts` → 3 pass
- `cd web && bun test` → full suite green
- `cd web && bun run typecheck` → clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785901050&installation_id=133855650&pr_number=7426&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7426&signature=d91c73eba7fb348b661322163e2a1839af100c4788211e8bd8e9a39931ebfbd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public feedback submission behavior when the firewall limiter is misconfigured or down; the fix reduces abuse risk but callers may see 503 instead of successful sends in those edge cases.
> 
> **Overview**
> **`/api/feedback`** on Vercel now **returns `503`** with *Feedback endpoint is not configured* when `checkRateLimit` reports **`not-found`** or any other error (after the existing logs), instead of continuing to parse multipart data and send email—aligning with **`client-config`** fail-closed behavior.
> 
> Adds **`web/tests/feedback-route.test.ts`** (mocked firewall + Resend) for those failure paths and a healthy limiter success case. Pins feedback-related env vars in **`test-preload.ts`** so `@/app/env` is stable across Bun test file order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b13182958da7996c5f13f7c8b1b0f093329cf09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed in `/api/feedback` when the rate limiter is unavailable. We now return 503 and block the email send to prevent unthrottled messages.

- **Bug Fixes**
  - On Vercel, return 503 for `checkRateLimit` `not-found` or error; 429 and non-Vercel paths unchanged.
  - Exit early before `request.formData()` and `resend.emails.send`.
  - Added tests for not-found, error, and healthy paths with mocks for `@vercel/firewall` and `resend`.

<sup>Written for commit 6b13182958da7996c5f13f7c8b1b0f093329cf09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feedback submissions now fail fast with a clear service-unavailable response when rate limiting can’t be checked, instead of continuing as if the request succeeded.
  * Improved handling for feedback rate-limit issues so valid submissions still send successfully when the limiter is healthy.

* **Tests**
  * Added coverage for feedback submission behavior under rate-limit not found, rate-limit error, and healthy conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->