### PR TITLE
Fail closed in the waitlist route when the rate limiter is unavailable

### DIFF
--- a/web/app/api/waitlist/route.ts
+++ b/web/app/api/waitlist/route.ts
@@ -66,6 +66,16 @@ export async function POST(request: Request) {
         if (rateLimited || error === "blocked") {
           return jsonError("Rate limit exceeded", 429);
         }
+        if (error === "not-found") {
+          console.error(
+            "waitlist.route.rate_limit_not_found",
+            env.CMUX_FEEDBACK_RATE_LIMIT_ID,
+          );
+          return jsonError("Rate limiter unavailable", 503);
+        } else if (error) {
+          console.error("waitlist.route.rate_limit_error", error);
+          return jsonError("Rate limiter unavailable", 503);
+        }
       }
 
       let payload: unknown;

--- a/web/tests/waitlist-route.test.ts
+++ b/web/tests/waitlist-route.test.ts
@@ -1,46 +1,65 @@
 // Skip env validation so importing the route doesn't require server secrets.
 // Captured + restored in afterAll so the flag can't leak into other test files
 // sharing this process and silently suppress their env validation.
-const priorSkipEnvValidation = process.env.SKIP_ENV_VALIDATION;
+const envKeys = [
+  "SKIP_ENV_VALIDATION",
+  "VERCEL",
+  "CMUX_FEEDBACK_RATE_LIMIT_ID",
+  "SLACK_WAITLIST_WEBHOOK_URL",
+] as const;
+const priorEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]])) as Record<
+  (typeof envKeys)[number],
+  string | undefined
+>;
 process.env.SKIP_ENV_VALIDATION = "1";
+process.env.VERCEL = "1";
+process.env.CMUX_FEEDBACK_RATE_LIMIT_ID = "feedback-rule";
+delete process.env.SLACK_WAITLIST_WEBHOOK_URL;
 
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-afterAll(() => {
-  if (priorSkipEnvValidation === undefined) {
-    delete process.env.SKIP_ENV_VALIDATION;
-  } else {
-    process.env.SKIP_ENV_VALIDATION = priorSkipEnvValidation;
-  }
-});
+type RateLimitResult = {
+  error?: string | null;
+  rateLimited?: boolean;
+};
 
-function dnsError(code: string): NodeJS.ErrnoException {
-  const err = new Error(code) as NodeJS.ErrnoException;
-  err.code = code;
-  return err;
-}
+let rateLimitResult: RateLimitResult = { rateLimited: false, error: null };
+const checkRateLimit = mock(async () => rateLimitResult);
+const checkEmailDeliverable = mock(async () => "ok" as const);
 
-// good.test has an MX; everything else has no records (undeliverable).
-mock.module("node:dns", () => ({
-  promises: {
-    resolveMx: async (domain: string) => {
-      if (domain === "good.test") {
-        return [{ exchange: "mx.good.test", priority: 10 }];
-      }
-      throw dnsError("ENOTFOUND");
-    },
-    resolve4: async () => {
-      throw dnsError("ENOTFOUND");
-    },
-    resolve6: async () => {
-      throw dnsError("ENOTFOUND");
-    },
-  },
+mock.module("@vercel/firewall", () => ({
+  checkRateLimit,
+}));
+
+mock.module("../app/api/waitlist/email-check", () => ({
+  checkEmailDeliverable,
 }));
 
 const { POST } = await import("../app/api/waitlist/route");
 
-function post(body: unknown): Request {
+afterAll(() => {
+  for (const key of envKeys) {
+    const value = priorEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+beforeEach(() => {
+  process.env.SKIP_ENV_VALIDATION = "1";
+  process.env.VERCEL = "1";
+  process.env.CMUX_FEEDBACK_RATE_LIMIT_ID = "feedback-rule";
+  delete process.env.SLACK_WAITLIST_WEBHOOK_URL;
+  rateLimitResult = { rateLimited: false, error: null };
+  checkRateLimit.mockClear();
+  checkEmailDeliverable.mockClear();
+  checkEmailDeliverable.mockResolvedValue("ok");
+});
+
+function post(body: unknown = { email: "a@example.com", platforms: ["linux"], notify: true }): Request {
   return new Request("https://cmux.test/api/waitlist", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -51,7 +70,7 @@ function post(body: unknown): Request {
 describe("waitlist route", () => {
   test("accepts a deliverable email in the validate phase", async () => {
     const res = await POST(
-      post({ email: "a@good.test", platforms: ["linux"], notify: false }),
+      post({ email: "a@example.com", platforms: ["linux"], notify: false }),
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
@@ -59,26 +78,78 @@ describe("waitlist route", () => {
       valid: true,
       slack: "skipped",
     });
+    expect(checkEmailDeliverable).toHaveBeenCalledWith("a@example.com");
   });
 
   test("rejects an undeliverable email without recording", async () => {
+    checkEmailDeliverable.mockResolvedValue("invalid");
+
     const res = await POST(
-      post({ email: "a@nope.test", platforms: ["linux"], notify: false }),
+      post({ email: "a@example.com", platforms: ["linux"], notify: false }),
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, valid: false });
+    expect(checkEmailDeliverable).toHaveBeenCalledWith("a@example.com");
   });
 
   test("rejects a disposable email", async () => {
+    checkEmailDeliverable.mockResolvedValue("invalid");
+
     const res = await POST(
       post({ email: "a@mailinator.com", platforms: ["windows"] }),
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, valid: false });
+    expect(checkEmailDeliverable).toHaveBeenCalledWith("a@mailinator.com");
   });
 
   test("rejects a malformed payload with 400", async () => {
     const res = await POST(post({ email: "not-an-email", platforms: [] }));
     expect(res.status).toBe(400);
+  });
+
+  test("fails closed without DNS validation when the Vercel limiter rule is missing", async () => {
+    rateLimitResult = { rateLimited: false, error: "not-found" };
+
+    const res = await POST(post());
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "Rate limiter unavailable" });
+    expect(checkEmailDeliverable).not.toHaveBeenCalled();
+  });
+
+  test("fails closed without DNS validation when the Vercel limiter returns an error", async () => {
+    rateLimitResult = { rateLimited: false, error: "unknown" };
+
+    const res = await POST(post());
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "Rate limiter unavailable" });
+    expect(checkEmailDeliverable).not.toHaveBeenCalled();
+  });
+
+  test("keeps blocked limiter results as 429 without DNS validation", async () => {
+    rateLimitResult = { rateLimited: false, error: "blocked" };
+
+    const res = await POST(post());
+
+    expect(res.status).toBe(429);
+    expect(await res.json()).toEqual({ error: "Rate limit exceeded" });
+    expect(checkEmailDeliverable).not.toHaveBeenCalled();
+  });
+
+  test("continues to DNS validation when the Vercel limiter allows the request", async () => {
+    rateLimitResult = { rateLimited: false, error: null };
+    checkEmailDeliverable.mockResolvedValue("ok");
+
+    const res = await POST(post());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      valid: true,
+      slack: "skipped",
+    });
+    expect(checkEmailDeliverable).toHaveBeenCalledWith("a@example.com");
   });
 });


### PR DESCRIPTION
## What

The `/api/waitlist` route only stopped a request when the Vercel firewall returned an explicit `blocked` outcome. Any other limiter state (a missing limiter rule → `not-found`, or a limiter error) fell through and the handler continued into the user-driven DNS deliverability lookup (`checkEmailDeliverable`, which resolves a caller-supplied domain's MX/A/AAAA records) and the optional Slack webhook notification. That left a public POST able to drive those side effects unthrottled whenever the limiter was unavailable.

This mirrors the fail-closed handling already in `web/app/api/client-config/route.ts`: after the `blocked` → 429 branch, `not-found` and any other limiter error now return 503 before any DNS validation or Slack notify. The change stays inside the existing `process.env.VERCEL === "1"` guard, so local/dev behavior and the normal (no-error) happy path are unchanged.

## Test

`web/tests/waitlist-route.test.ts` now mocks `@vercel/firewall` and `./email-check` and asserts:
- limiter `not-found` → 503 and `checkEmailDeliverable` is **not** called
- limiter error → 503 and `checkEmailDeliverable` is **not** called
- `blocked` → 429 (unchanged)
- clean result → proceeds to deliverability validation (200)

Two-commit structure: commit 1 adds the test against the pre-fix handler (2 fail-closed cases fail RED), commit 2 adds the fix (all 8 pass GREEN).

## Verification

- `bun test tests/waitlist-route.test.ts` → 8 pass, 0 fail
- `bun run typecheck` (tsgo --noEmit) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785901133&installation_id=133855650&pr_number=7427&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7427&signature=e8f1f7adefce40b6b45f06061132bbf742cfaf4ec36067b000b147d61e1a95eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public waitlist behavior when the limiter is misconfigured or errors (503 instead of unthrottled DNS/Slack), which is intentional fail-closed hardening on a security-sensitive path.
> 
> **Overview**
> When the Vercel firewall rate check returns **`not-found`** or any other non-block error (after the existing 429 path for `rateLimited` / `blocked`), **`POST /api/waitlist`** now responds with **503** (`Rate limiter unavailable`) and **does not** run `checkEmailDeliverable` or Slack notify. This matches the fail-closed pattern already used in `client-config`.
> 
> **`web/tests/waitlist-route.test.ts`** is reworked to mock `@vercel/firewall` and `email-check` instead of `node:dns`, with env restore/`beforeEach` setup and new cases asserting 503 on missing/error limiter, 429 on `blocked`, and normal flow when the limiter allows the request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92f716b1dccd3ddad680c573d9889dd2edcd4faf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed in the `/api/waitlist` route when the Vercel rate limiter is unavailable. We now return 503 on `not-found` or any limiter error and skip DNS/Slack side effects; `blocked` still returns 429 and local/dev behavior is unchanged.

- **Bug Fixes**
  - Treat `@vercel/firewall` results of `not-found` or any error as 503 before processing.
  - Skip `checkEmailDeliverable` and the Slack webhook unless the limiter allows the request.
  - Added tests mocking `@vercel/firewall` and email checks to cover 503 on `not-found`/errors, 429 on `blocked`, and the normal success path.

<sup>Written for commit 92f716b1dccd3ddad680c573d9889dd2edcd4faf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved waitlist submission handling when rate limiting is unavailable, returning a clear 503 response instead of a generic failure.
  * Added more reliable validation coverage for waitlist requests, including malformed payloads, blocked submissions, and email deliverability checks.
  * Ensured email validation is skipped when rate limiting can’t be checked, then resumes normally when it is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->