### PR TITLE
Serialize per-user Vault upload-grant quota reservation

### DIFF
--- a/web/app/api/vault/uploads/route.ts
+++ b/web/app/api/vault/uploads/route.ts
@@ -1,13 +1,10 @@
-import { and, eq, inArray, lt } from "drizzle-orm";
+import { eq, inArray, lt } from "drizzle-orm";
 import type { Span } from "@opentelemetry/api";
 import { cloudDb } from "../../../../db/client";
-import { vaultSessions, vaultSnapshots, vaultUploadGrants } from "../../../../db/schema";
+import { vaultSnapshots, vaultUploadGrants } from "../../../../db/schema";
 import { vaultConfig } from "../../../../services/vault/config";
-import { buildObjectKey, deleteObject, presignPut } from "../../../../services/vault/storage";
-import {
-  getVaultPendingGrantBytes,
-  getVaultStoredCompressedBytes,
-} from "../../../../services/vault/usage";
+import { deleteObject, presignPut } from "../../../../services/vault/storage";
+import { reserveVaultUploadGrants } from "../../../../services/vault/usage";
 import { withAuthedVaultApiRoute } from "../../../../services/vault/routeHelpers";
 import { readVaultJsonObject, validateVaultBatch } from "../../../../services/vault/validation";
 import { jsonResponse } from "../../../../services/vms/routeHelpers";
@@ -55,68 +52,29 @@ async function handlePost(request: Request, userId: string, span: Span): Promise
 
   await gcExpiredGrants(db, now);
 
-  // Per-user storage quota covers committed snapshots plus unexpired upload
-  // grants, so minting URLs and never committing still consumes quota (the
-  // presigned ContentLength is signed, bounding each upload to its declared
-  // size). Grants for keys in this batch are excluded from the pending sum and
-  // re-added per item below, so retries are not double-counted. The commit
-  // route re-checks, so previously issued URLs cannot bypass the quota either.
-  const batchObjectKeys = batch.value.map((item) =>
-    buildObjectKey(userId, item.agent, item.agentSessionId, item.sha256),
-  );
-  let projectedUserBytes =
-    (await getVaultStoredCompressedBytes(db, userId)) +
-    (await getVaultPendingGrantBytes(db, userId, now, batchObjectKeys));
+  const outcomes = await reserveVaultUploadGrants(db, {
+    userId,
+    items: batch.value,
+    maxUploadBytes: config.maxUploadBytes,
+    maxUserBytes: config.maxUserBytes,
+    now,
+    grantTtlMs: UPLOAD_GRANT_TTL_MS,
+  });
+
   const results = [];
-  for (const item of batch.value) {
-    // Per-item so one oversized transcript cannot block the rest of the batch.
-    if (item.compressedSizeBytes > config.maxUploadBytes) {
+  for (const outcome of outcomes) {
+    const item = outcome.item;
+    if (outcome.kind === "error") {
       results.push({
         agent: item.agent,
         agentSessionId: item.agentSessionId,
         relPath: item.relPath,
         status: "error",
-        error: "upload_too_large",
+        error: outcome.error,
       });
       continue;
     }
-    if (projectedUserBytes + item.compressedSizeBytes > config.maxUserBytes) {
-      results.push({
-        agent: item.agent,
-        agentSessionId: item.agentSessionId,
-        relPath: item.relPath,
-        status: "error",
-        error: "quota_exceeded",
-      });
-      continue;
-    }
-
-    const [existing] = await db
-      .select({
-        id: vaultSessions.id,
-        latestSha256: vaultSessions.latestSha256,
-        relPath: vaultSessions.relPath,
-        cwd: vaultSessions.cwd,
-      })
-      .from(vaultSessions)
-      .where(
-        and(
-          eq(vaultSessions.userId, userId),
-          eq(vaultSessions.agent, item.agent),
-          eq(vaultSessions.agentSessionId, item.agentSessionId),
-        ),
-      )
-      .limit(1);
-
-    if (existing && existing.latestSha256 === item.sha256) {
-      // Same content can still move on disk (e.g. Codex archiving a session),
-      // so keep the restore metadata current even when no upload is needed.
-      if (existing.relPath !== item.relPath || existing.cwd !== item.cwd) {
-        await db
-          .update(vaultSessions)
-          .set({ relPath: item.relPath, cwd: item.cwd })
-          .where(eq(vaultSessions.id, existing.id));
-      }
+    if (outcome.kind === "unchanged") {
       results.push({
         agent: item.agent,
         agentSessionId: item.agentSessionId,
@@ -125,33 +83,13 @@ async function handlePost(request: Request, userId: string, span: Span): Promise
       });
       continue;
     }
-
-    const objectKey = buildObjectKey(userId, item.agent, item.agentSessionId, item.sha256);
-    await db
-      .insert(vaultUploadGrants)
-      .values({
-        userId,
-        objectKey,
-        compressedSizeBytes: item.compressedSizeBytes,
-        createdAt: now,
-        expiresAt: new Date(now.getTime() + UPLOAD_GRANT_TTL_MS),
-      })
-      .onConflictDoUpdate({
-        target: vaultUploadGrants.objectKey,
-        set: {
-          compressedSizeBytes: item.compressedSizeBytes,
-          createdAt: now,
-          expiresAt: new Date(now.getTime() + UPLOAD_GRANT_TTL_MS),
-        },
-      });
-    projectedUserBytes += item.compressedSizeBytes;
     results.push({
       agent: item.agent,
       agentSessionId: item.agentSessionId,
       relPath: item.relPath,
       status: "upload",
-      objectKey,
-      putUrl: await presignPut(objectKey, item.compressedSizeBytes),
+      objectKey: outcome.objectKey,
+      putUrl: await presignPut(outcome.objectKey, item.compressedSizeBytes),
     });
   }
   setSpanAttributes(span, {

--- a/web/services/vault/usage.ts
+++ b/web/services/vault/usage.ts
@@ -1,16 +1,33 @@
 import { and, eq, gt, notInArray, sql } from "drizzle-orm";
 import type { cloudDb } from "../../db/client";
 import { vaultSessions, vaultSnapshots, vaultUploadGrants } from "../../db/schema";
+import { buildObjectKey } from "./storage";
 import { logVaultQuotaError } from "./logging";
 
-type VaultDb = ReturnType<typeof cloudDb>;
+type CloudDb = ReturnType<typeof cloudDb>;
+type VaultTx = Parameters<Parameters<CloudDb["transaction"]>[0]>[0];
+type VaultDb = CloudDb | VaultTx;
+
+export type VaultGrantItem = {
+  agent: string;
+  agentSessionId: string;
+  sha256: string;
+  relPath: string;
+  cwd: string | null;
+  compressedSizeBytes: number;
+};
+
+export type VaultReservationOutcome =
+  | { kind: "granted"; objectKey: string; item: VaultGrantItem }
+  | { kind: "unchanged"; item: VaultGrantItem }
+  | { kind: "error"; error: "upload_too_large" | "quota_exceeded"; item: VaultGrantItem };
+
+export type VaultReserveHooks = { afterQuotaRead?: () => Promise<void> };
 
 /**
  * Total compressed bytes a user currently has stored across all snapshots.
  * Used by the uploads (presign) and commit routes to enforce the per-user
- * storage quota. Concurrent batches can each read the same total before the
- * other commits, so enforcement overshoots by at most one in-flight batch
- * (25 items x maxUploadBytes); that bound is acceptable for a cost cap.
+ * storage quota.
  */
 export async function getVaultStoredCompressedBytes(
   db: VaultDb,
@@ -29,6 +46,95 @@ export async function getVaultStoredCompressedBytes(
     logVaultQuotaError("get_stored_compressed_bytes", error);
     throw error;
   }
+}
+
+export async function reserveVaultUploadGrants(
+  db: CloudDb,
+  params: {
+    userId: string;
+    items: readonly VaultGrantItem[];
+    maxUploadBytes: number;
+    maxUserBytes: number;
+    now: Date;
+    grantTtlMs: number;
+  },
+  hooks: VaultReserveHooks = {},
+): Promise<VaultReservationOutcome[]> {
+  const batchObjectKeys = params.items.map((item) =>
+    buildObjectKey(params.userId, item.agent, item.agentSessionId, item.sha256),
+  );
+  const expiresAt = new Date(params.now.getTime() + params.grantTtlMs);
+
+  return await db.transaction(async (tx) => {
+    let projectedUserBytes =
+      (await getVaultStoredCompressedBytes(tx, params.userId)) +
+      (await getVaultPendingGrantBytes(tx, params.userId, params.now, batchObjectKeys));
+
+    await hooks.afterQuotaRead?.();
+
+    const outcomes: VaultReservationOutcome[] = [];
+    for (const item of params.items) {
+      if (item.compressedSizeBytes > params.maxUploadBytes) {
+        outcomes.push({ kind: "error", error: "upload_too_large", item });
+        continue;
+      }
+      if (projectedUserBytes + item.compressedSizeBytes > params.maxUserBytes) {
+        outcomes.push({ kind: "error", error: "quota_exceeded", item });
+        continue;
+      }
+
+      const [existing] = await tx
+        .select({
+          id: vaultSessions.id,
+          latestSha256: vaultSessions.latestSha256,
+          relPath: vaultSessions.relPath,
+          cwd: vaultSessions.cwd,
+        })
+        .from(vaultSessions)
+        .where(
+          and(
+            eq(vaultSessions.userId, params.userId),
+            eq(vaultSessions.agent, item.agent),
+            eq(vaultSessions.agentSessionId, item.agentSessionId),
+          ),
+        )
+        .limit(1);
+
+      if (existing && existing.latestSha256 === item.sha256) {
+        if (existing.relPath !== item.relPath || existing.cwd !== item.cwd) {
+          await tx
+            .update(vaultSessions)
+            .set({ relPath: item.relPath, cwd: item.cwd })
+            .where(eq(vaultSessions.id, existing.id));
+        }
+        outcomes.push({ kind: "unchanged", item });
+        continue;
+      }
+
+      const objectKey = buildObjectKey(params.userId, item.agent, item.agentSessionId, item.sha256);
+      await tx
+        .insert(vaultUploadGrants)
+        .values({
+          userId: params.userId,
+          objectKey,
+          compressedSizeBytes: item.compressedSizeBytes,
+          createdAt: params.now,
+          expiresAt,
+        })
+        .onConflictDoUpdate({
+          target: vaultUploadGrants.objectKey,
+          set: {
+            compressedSizeBytes: item.compressedSizeBytes,
+            createdAt: params.now,
+            expiresAt,
+          },
+        });
+      projectedUserBytes += item.compressedSizeBytes;
+      outcomes.push({ kind: "granted", objectKey, item });
+    }
+
+    return outcomes;
+  });
 }
 
 /**

--- a/web/services/vault/usage.ts
+++ b/web/services/vault/usage.ts
@@ -66,6 +66,8 @@ export async function reserveVaultUploadGrants(
   const expiresAt = new Date(params.now.getTime() + params.grantTtlMs);
 
   return await db.transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${params.userId}, 9))`);
+
     let projectedUserBytes =
       (await getVaultStoredCompressedBytes(tx, params.userId)) +
       (await getVaultPendingGrantBytes(tx, params.userId, params.now, batchObjectKeys));

--- a/web/tests/vault-upload-quota-race.test.ts
+++ b/web/tests/vault-upload-quota-race.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { eq, sql as drizzleSql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "../db/schema";
+import { closeCloudDbForTests } from "../db/client";
+import { vaultUploadGrants } from "../db/schema";
+import {
+  reserveVaultUploadGrants,
+  type VaultGrantItem,
+  type VaultReservationOutcome,
+} from "../services/vault/usage";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+function databaseURL() {
+  const url = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+  }
+  return url;
+}
+
+function openDb() {
+  const client = postgres(databaseURL(), { max: 1 });
+  return { client, db: drizzle({ client, schema }) };
+}
+
+type TestDb = ReturnType<typeof openDb>;
+
+let dbA: TestDb | null = null;
+let dbB: TestDb | null = null;
+
+beforeAll(() => {
+  if (!runDbTests) return;
+  dbA = openDb();
+  dbB = openDb();
+});
+
+afterAll(async () => {
+  await closeCloudDbForTests();
+  await dbA?.client.end();
+  await dbB?.client.end();
+});
+
+describe("vault upload quota reservations", () => {
+  dbTest("races two near-quota batches; exactly one reserves", async () => {
+    if (!dbA || !dbB) throw new Error("test database not initialized");
+    await truncateVaultTables(dbA);
+
+    const now = new Date("2026-07-01T12:00:00Z");
+    const userId = "vault-race-user";
+    const bytes = 1_000;
+    const commonParams = {
+      userId,
+      maxUploadBytes: bytes,
+      maxUserBytes: bytes,
+      now,
+      grantTtlMs: 24 * 60 * 60 * 1000,
+    };
+    const hooks = { afterQuotaRead: () => delay(150) };
+
+    const [a, b] = await Promise.all([
+      reserveVaultUploadGrants(
+        dbA.db,
+        {
+          ...commonParams,
+          items: [grantItem({ agentSessionId: "race-a", sha256: "sha-a", compressedSizeBytes: bytes })],
+        },
+        hooks,
+      ),
+      reserveVaultUploadGrants(
+        dbB.db,
+        {
+          ...commonParams,
+          items: [grantItem({ agentSessionId: "race-b", sha256: "sha-b", compressedSizeBytes: bytes })],
+        },
+        hooks,
+      ),
+    ]);
+
+    expect([a, b].filter((outcomes) => outcomes.some((outcome) => outcome.kind === "granted"))).toHaveLength(1);
+    expect([a, b].filter((outcomes) => hasQuotaExceeded(outcomes))).toHaveLength(1);
+    expect(await grantStats(dbA, userId)).toEqual({ count: 1, bytes });
+  });
+
+  dbTest("idempotent retry of an existing object key does not double-count under the lock", async () => {
+    if (!dbA) throw new Error("test database not initialized");
+    await truncateVaultTables(dbA);
+
+    const now = new Date("2026-07-01T12:00:00Z");
+    const userId = "vault-idempotent-user";
+    const bytes = 1_000;
+    const item = grantItem({ agentSessionId: "retry-session", sha256: "retry-sha", compressedSizeBytes: bytes });
+    const params = {
+      userId,
+      items: [item],
+      maxUploadBytes: bytes,
+      maxUserBytes: bytes,
+      now,
+      grantTtlMs: 24 * 60 * 60 * 1000,
+    };
+
+    expect(await reserveVaultUploadGrants(dbA.db, params)).toMatchObject([{ kind: "granted" }]);
+    expect(await reserveVaultUploadGrants(dbA.db, params)).toMatchObject([{ kind: "granted" }]);
+    expect(await grantStats(dbA, userId)).toEqual({ count: 1, bytes });
+  });
+});
+
+function grantItem(input: {
+  agentSessionId: string;
+  sha256: string;
+  compressedSizeBytes: number;
+}): VaultGrantItem {
+  return {
+    agent: "codex",
+    agentSessionId: input.agentSessionId,
+    sha256: input.sha256,
+    relPath: `.cmux/sessions/${input.agentSessionId}.jsonl`,
+    cwd: "/tmp/cmux-vault-test",
+    compressedSizeBytes: input.compressedSizeBytes,
+  };
+}
+
+async function truncateVaultTables(db: TestDb): Promise<void> {
+  await db.client`truncate vault_upload_grants, vault_snapshots, vault_sessions restart identity cascade`;
+}
+
+async function grantStats(db: TestDb, userId: string): Promise<{ count: number; bytes: number }> {
+  const [row] = await db.db
+    .select({
+      count: drizzleSql<number>`count(*)::int`,
+      bytes: drizzleSql<number>`coalesce(sum(${vaultUploadGrants.compressedSizeBytes}), 0)::double precision`,
+    })
+    .from(vaultUploadGrants)
+    .where(eq(vaultUploadGrants.userId, userId));
+  return { count: row?.count ?? 0, bytes: row?.bytes ?? 0 };
+}
+
+function hasQuotaExceeded(outcomes: readonly VaultReservationOutcome[]): boolean {
+  return outcomes.some((outcome) => outcome.kind === "error" && outcome.error === "quota_exceeded");
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## What

The Vault upload-presign route (`web/app/api/vault/uploads/route.ts`) read the per-user storage quota (committed snapshots + pending upload grants) and then inserted grant rows and minted presigned PUT URLs, without serializing that read-then-reserve per user. Concurrent presign batches for the same user could each observe the same headroom and each reserve, over-reserving past `CMUX_VAULT_MAX_USER_BYTES`.

This serializes the reservation per user: the quota read and all grant inserts now run inside a single `db.transaction` whose first statement takes a per-user Postgres advisory transaction lock (`pg_advisory_xact_lock(hashtextextended(userId, 9))`), the same pattern already used in `services/apns/rateLimit.ts`, `app/api/device-tokens/route.ts`, and `app/api/devices/route.ts`. A second concurrent batch blocks until the first commits its grants, then reads the reduced headroom and rejects with `quota_exceeded`. Presigned URLs are minted only for granted items and only after the reservation transaction commits.

The reservation logic moved into a new `reserveVaultUploadGrants` in `services/vault/usage.ts`; the route now maps its outcomes to the same response shape (`upload` / `unchanged` / `error`) as before. Idempotent retries keep the batch's own object keys excluded from the pending sum and re-added via `onConflictDoUpdate`, so a retry of an existing object key is not double-counted. No schema/migration change (the advisory lock is runtime-only); the commit route, GC, storage, validation, and config are unchanged.

## Test

`web/tests/vault-upload-quota-race.test.ts` (gated behind `CMUX_DB_TEST=1`, like the existing VM/notification DB tests) races two near-quota batches on two dedicated connections and asserts exactly one is granted, one is `quota_exceeded`, and only one grant row persists; a second test proves an idempotent retry of the same object key does not double-count.

Two-commit structure: the first commit adds the reservation refactor **without** the lock plus the failing race test (race reproduces); the second commit adds the advisory lock (race resolved).

Verified locally against an ephemeral Postgres: without the lock both batches are granted (test fails); with the lock exactly one is granted and one is `quota_exceeded` (both tests pass). `bun run typecheck` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785901187&installation_id=133855650&pr_number=7428&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7428&signature=ca812c227197d8595922ff7b3ba1c981c82c1dbe39405b7db4f0de0cc72121d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quota enforcement on a storage-cost path; behavior under concurrency is stricter (more `quota_exceeded`) but should match intended caps, with DB tests covering the race.
> 
> **Overview**
> Fixes a **quota race** on Vault presign: concurrent upload batches for the same user could each read the same headroom and over-reserve past `maxUserBytes`.
> 
> **`reserveVaultUploadGrants`** in `services/vault/usage.ts` now owns quota checks, unchanged-session handling, and grant upserts inside one **`db.transaction`**, starting with **`pg_advisory_xact_lock(hashtextextended(userId, 9))`** (same pattern as device tokens / APNS rate limits). The uploads route delegates to it and only mints presigned PUT URLs after commit for `granted` outcomes; API shape (`upload` / `unchanged` / `error`) is unchanged.
> 
> Adds **`vault-upload-quota-race.test.ts`** (`CMUX_DB_TEST=1`) to assert concurrent near-quota batches yield exactly one grant and that retries of the same object key do not double-count quota.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db991d4d6234b39b01a5a619bd3c8a0e144e54bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize per-user Vault upload-grant reservations to prevent over-reserving storage when presign requests race. Refactors the logic into `reserveVaultUploadGrants` while keeping the route’s response shape unchanged.

- **Bug Fixes**
  - Guard quota read + grant inserts with a per-user Postgres advisory transaction lock (`pg_advisory_xact_lock(hashtextextended(userId, 9))`) so concurrent batches can’t over-reserve; the second batch waits and returns `quota_exceeded` if needed.
  - Mint presigned PUT URLs only after the reservation transaction commits and only for granted items.
  - Retries of the same object key are idempotent and not double-counted via `onConflictDoUpdate`; covered by a DB race test.

- **Refactors**
  - Moved reservation logic to `reserveVaultUploadGrants` in `web/services/vault/usage.ts`; `web/app/api/vault/uploads/route.ts` maps outcomes to the existing `upload` / `unchanged` / `error` responses.
  - No schema or migration changes.

<sup>Written for commit db991d4d6234b39b01a5a619bd3c8a0e144e54bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

