### PR TITLE
Reject symlinked transcript files in Vault sync discovery

### DIFF
--- a/vault/internal/agentdirs/agent.go
+++ b/vault/internal/agentdirs/agent.go
@@ -172,9 +172,12 @@ func statSession(agentName, root, path, id, cwd string) (Session, error) {
 }
 
 func statSessionWithLogicalPath(agentName, root, path, logicalPath, id, cwd string) (Session, error) {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return Session{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return Session{}, fmt.Errorf("%s is not a regular file: %s", path, info.Mode().String())
 	}
 	rel, err := relPath(root, logicalPath)
 	if err != nil {

--- a/vault/internal/agentdirs/agentdirs_test.go
+++ b/vault/internal/agentdirs/agentdirs_test.go
@@ -3,6 +3,7 @@ package agentdirs
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -123,6 +124,109 @@ func TestDiscoverSymlinkedRoots(t *testing.T) {
 	}
 }
 
+func TestDiscoverRejectsSymlinkedTranscript(t *testing.T) {
+	tests := []struct {
+		name      string
+		discover  func(Environ) ([]Session, error)
+		setup     func(t *testing.T, base, targetPath string) Environ
+		blockedID string
+		allowedID string
+	}{
+		{
+			name:      "claude",
+			discover:  (Claude{}).Discover,
+			blockedID: uuidA,
+			allowedID: uuidB,
+			setup: func(t *testing.T, base, targetPath string) Environ {
+				root := filepath.Join(base, "claude-config")
+				projectDir := filepath.Join(root, "projects", "-repo")
+				if err := os.MkdirAll(projectDir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				linkPath := filepath.Join(projectDir, uuidA+".jsonl")
+				if err := os.Symlink(targetPath, linkPath); err != nil {
+					t.Fatal(err)
+				}
+				writeFile(t, filepath.Join(projectDir, uuidB+".jsonl"), `{"cwd":"/repo/real"}`+"\n")
+				return Environ{
+					HomeDir: base,
+					Vars:    map[string]string{"CLAUDE_CONFIG_DIR": root},
+				}
+			},
+		},
+		{
+			name:      "codex",
+			discover:  (Codex{}).Discover,
+			blockedID: uuidA,
+			allowedID: uuidB,
+			setup: func(t *testing.T, base, targetPath string) Environ {
+				home := filepath.Join(base, "codex-home")
+				sessionDir := filepath.Join(home, ".codex", "sessions", "2026", "07", "05")
+				if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				linkPath := filepath.Join(sessionDir, "rollout-2026-07-05T00-00-00-"+uuidA+".jsonl")
+				if err := os.Symlink(targetPath, linkPath); err != nil {
+					t.Fatal(err)
+				}
+				writeFile(t,
+					filepath.Join(sessionDir, "rollout-2026-07-05T00-00-01-"+uuidB+".jsonl"),
+					`{"type":"session_meta","payload":{"id":"`+uuidB+`","cwd":"/repo/real"}}`+"\n",
+				)
+				return Environ{HomeDir: home, Vars: map[string]string{}}
+			},
+		},
+		{
+			name:      "pi",
+			discover:  (Pi{}).Discover,
+			blockedID: uuidA,
+			allowedID: uuidB,
+			setup: func(t *testing.T, base, targetPath string) Environ {
+				home := filepath.Join(base, "pi-home")
+				sessionDir := filepath.Join(home, ".pi", "agent", "sessions", "-repo")
+				if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				linkPath := filepath.Join(sessionDir, "2026-07-05T00-00-00_"+uuidA+".jsonl")
+				if err := os.Symlink(targetPath, linkPath); err != nil {
+					t.Fatal(err)
+				}
+				writeFile(t, filepath.Join(sessionDir, "2026-07-05T00-00-01_"+uuidB+".jsonl"), `{"cwd":"/repo/real"}`+"\n")
+				return Environ{HomeDir: home, Vars: map[string]string{}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := t.TempDir()
+			targetPath := filepath.Join(base, "outside-transcript.jsonl")
+			writeFile(t, targetPath, `{"type":"session_meta","payload":{"id":"`+tt.blockedID+`","cwd":"/secret"}}`+"\n")
+
+			env := tt.setup(t, base, targetPath)
+			var warnings []string
+			env.Warnings = &warnings
+
+			got, err := tt.discover(env)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("expected only the regular transcript, got %d sessions: %#v", len(got), got)
+			}
+			if got[0].AgentSessionID != tt.allowedID {
+				t.Fatalf("discovered session id = %q, want %q", got[0].AgentSessionID, tt.allowedID)
+			}
+			if containsSession(got, tt.blockedID) {
+				t.Fatalf("symlinked transcript %s was discovered: %#v", tt.blockedID, got)
+			}
+			if !containsWarning(warnings, "symlinked transcript") {
+				t.Fatalf("expected symlink warning, got %#v", warnings)
+			}
+		})
+	}
+}
+
 func TestCodexDiscoverSessionsAndArchived(t *testing.T) {
 	home := t.TempDir()
 	root := filepath.Join(home, ".codex")
@@ -186,6 +290,24 @@ func findSession(t *testing.T, sessions []Session, id string) Session {
 	}
 	t.Fatalf("session %s not found in %#v", id, sessions)
 	return Session{}
+}
+
+func containsSession(sessions []Session, id string) bool {
+	for _, session := range sessions {
+		if session.AgentSessionID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func containsWarning(warnings []string, needle string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/vault/internal/agentdirs/claude.go
+++ b/vault/internal/agentdirs/claude.go
@@ -46,6 +46,10 @@ func (a Claude) Discover(env Environ) ([]Session, error) {
 		if !uuidRE.MatchString(id) {
 			return nil
 		}
+		if entry.Type()&fs.ModeSymlink != 0 {
+			env.Warn("claude: skipping symlinked transcript %s", path)
+			return nil
+		}
 		projectName := filepath.Base(filepath.Dir(path))
 		cwd := recoverCWDFromJSONL(path)
 		if cwd == "" {

--- a/vault/internal/agentdirs/codex.go
+++ b/vault/internal/agentdirs/codex.go
@@ -50,6 +50,10 @@ func (a Codex) Discover(env Environ) ([]Session, error) {
 			if id == "" {
 				return nil
 			}
+			if entry.Type()&fs.ModeSymlink != 0 {
+				env.Warn("codex: skipping symlinked transcript %s", path)
+				return nil
+			}
 			metaID, cwd := codexMeta(path)
 			if metaID != "" {
 				id = metaID

--- a/vault/internal/agentdirs/pi.go
+++ b/vault/internal/agentdirs/pi.go
@@ -42,6 +42,10 @@ func (a Pi) Discover(env Environ) ([]Session, error) {
 		if len(matches) != 2 {
 			return nil
 		}
+		if entry.Type()&fs.ModeSymlink != 0 {
+			env.Warn("pi: skipping symlinked transcript %s", path)
+			return nil
+		}
 		cwd := recoverCWDFromJSONL(path)
 		if cwd == "" {
 			cwd = cwdFromMunged(filepath.Base(filepath.Dir(path)))

--- a/vault/internal/syncer/syncer.go
+++ b/vault/internal/syncer/syncer.go
@@ -57,11 +57,15 @@ type candidate struct {
 }
 
 func (e *Engine) Sync(ctx context.Context, opts Options) (Summary, error) {
-	var summary Summary
 	sessions, err := agentdirs.DiscoverAll(e.Env, opts.Agent)
 	if err != nil {
-		return summary, err
+		return Summary{}, err
 	}
+	return e.syncSessions(ctx, sessions, opts)
+}
+
+func (e *Engine) syncSessions(ctx context.Context, sessions []agentdirs.Session, opts Options) (Summary, error) {
+	var summary Summary
 
 	var candidates []candidate
 	for _, session := range sessions {

--- a/vault/internal/syncer/syncer.go
+++ b/vault/internal/syncer/syncer.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/manaflow-ai/cmux/vault/internal/agentdirs"
@@ -309,7 +310,7 @@ func itemKey(agent, relPath string) string {
 }
 
 func sha256File(path string) (string, error) {
-	file, err := os.Open(path)
+	file, err := openRegularNoFollow(path)
 	if err != nil {
 		return "", err
 	}
@@ -319,6 +320,27 @@ func sha256File(path string) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// openRegularNoFollow opens path for reading without following a symlinked final
+// component (O_NOFOLLOW) and confirms via fstat that the opened file is a regular
+// file. This refuses to read a transcript that was swapped for a symlink between
+// discovery and upload, so Vault never hashes or compresses the target's bytes.
+func openRegularNoFollow(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("%s is not a regular file: %s", path, info.Mode().String())
+	}
+	return file, nil
 }
 
 type compressResult struct {
@@ -336,7 +358,7 @@ func compressFile(path, tempDir string) (compressResult, error) {
 	if err := os.MkdirAll(tempDir, 0o700); err != nil {
 		return result, err
 	}
-	in, err := os.Open(path)
+	in, err := openRegularNoFollow(path)
 	if err != nil {
 		return result, err
 	}

--- a/vault/internal/syncer/syncer_test.go
+++ b/vault/internal/syncer/syncer_test.go
@@ -158,6 +158,126 @@ func TestSyncerUploadsIncrementallyAndCompresses(t *testing.T) {
 	}
 }
 
+func TestSyncerRejectsSymlinkSwappedBeforeUpload(t *testing.T) {
+	home := t.TempDir()
+	sessionRel := filepath.Join("sessions", "2026", "07", "05", "rollout-2026-07-05T00-00-00-22222222-2222-4222-8222-222222222222.jsonl")
+	sessionPath := filepath.Join(home, ".codex", sessionRel)
+	original := []byte(`{"type":"session_meta","payload":{"id":"22222222-2222-4222-8222-222222222222","cwd":"/repo"}}` + "\n")
+	writeTestFile(t, sessionPath, original)
+
+	env := agentdirs.Environ{HomeDir: home, Vars: map[string]string{}}
+	sessions, err := agentdirs.DiscoverAll(env, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 discovered session before swap, got %d: %#v", len(sessions), sessions)
+	}
+
+	secret := []byte("private transcript bytes from outside the tree\n")
+	secretPath := filepath.Join(home, "outside-secret.jsonl")
+	writeTestFile(t, secretPath, secret)
+	if err := os.Remove(sessionPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secretPath, sessionPath); err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	blobs := map[string][]byte{}
+	blobServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Query().Get("key")
+		if r.Method != "PUT" || key == "" {
+			http.Error(w, "bad blob request", http.StatusBadRequest)
+			return
+		}
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		mu.Lock()
+		blobs[key] = data
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer blobServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		switch r.URL.Path {
+		case "/api/vault/uploads":
+			var body struct {
+				Items []api.UploadItem `json:"items"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			items := make([]api.UploadResult, 0, len(body.Items))
+			for _, item := range body.Items {
+				key := item.Agent + "/" + item.RelPath
+				items = append(items, api.UploadResult{
+					Agent:          item.Agent,
+					AgentSessionID: item.AgentSessionID,
+					RelPath:        item.RelPath,
+					Status:         "upload",
+					ObjectKey:      key,
+					PutURL:         blobServer.URL + "/put?key=" + key,
+				})
+			}
+			_ = json.NewEncoder(w).Encode(api.UploadsResponse{Items: items})
+		case "/api/vault/sessions/commit":
+			var body struct {
+				Items []api.UploadItem `json:"items"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			items := make([]api.CommitResult, 0, len(body.Items))
+			for _, item := range body.Items {
+				items = append(items, api.CommitResult{Agent: item.Agent, AgentSessionID: item.AgentSessionID, RelPath: item.RelPath, Status: "committed"})
+			}
+			_ = json.NewEncoder(w).Encode(api.CommitResponse{Items: items})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer apiServer.Close()
+
+	store, err := state.Load(home, map[string]string{"CMUX_VAULT_STATE_DIR": filepath.Join(home, "state")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine := Engine{
+		Env:     env,
+		State:   store,
+		Client:  api.New(apiServer.URL, &authstore.Tokens{AccessToken: "access", RefreshToken: "refresh"}),
+		TempDir: filepath.Join(home, "tmp"),
+	}
+
+	summary, err := engine.syncSessions(context.Background(), sessions, Options{Agent: "codex"})
+	if err == nil {
+		t.Fatal("expected swapped symlink upload to fail")
+	}
+	if summary.Uploaded != 0 || summary.Failed < 1 {
+		t.Fatalf("summary = %#v, want uploaded=0 and failed>=1", summary)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for key, blob := range blobs {
+		if bytes.Contains(blob, secret) {
+			t.Fatalf("blob %s contains secret bytes in plaintext", key)
+		}
+		if bytes.Contains(decompressZstd(t, blob), secret) {
+			t.Fatalf("blob %s contains symlink target bytes after decompression", key)
+		}
+	}
+}
+
 func writeTestFile(t *testing.T, path string, data []byte) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {


### PR DESCRIPTION
Vault transcript sync (`vault/internal/agentdirs`, `vault/internal/syncer`) treated any `*.jsonl` entry in an agent transcript tree (`~/.claude`, `~/.codex`, `~/.pi`) as a regular file and stat/opened it, following symlinks. That meant a symlinked transcript would have its target's bytes read, hashed, compressed, and uploaded as private transcript data. This hardens discovery and upload to handle regular files only (CWE-59).

## What changed
- `statSessionWithLogicalPath` now uses `os.Lstat` and requires `info.Mode().IsRegular()`, the single gate every discoverer (claude, codex, pi) passes through.
- Each discoverer skips `fs.ModeSymlink` entries right after the name/id filter and before reading file contents.
- The syncer reads/hashes/compresses through a new `openRegularNoFollow` helper (`O_NOFOLLOW` + fstat `IsRegular`), wired into both `sha256File` and `compressFile`. This closes the discovery→upload window: a file swapped for a symlink after discovery is refused at open time.
- Intentional root-symlink resolution (`resolveWalkRoot`) is unchanged; symlinked transcript ROOTS still resolve and discover normally.

## Tests (two-commit red/green)
- Commit 1 adds the failing tests plus a no-behavior-change `syncSessions` extraction so the syncer test can swap the file between discovery and upload.
- Commit 2 adds the fix; tests go green.
- `TestDiscoverRejectsSymlinkedTranscript` (claude/codex/pi): a matching `*.jsonl` symlink pointing outside the tree is not surfaced; the sibling regular session still discovers; a skip warning is recorded.
- `TestSyncerRejectsSymlinkSwappedBeforeUpload`: a discovered regular session swapped for a symlink before upload fails the sync and the target bytes never reach the blob store (checked raw and after zstd decompression).

## Verification
```
cd vault
go test ./internal/agentdirs ./internal/syncer   # ok
go vet ./internal/agentdirs ./internal/syncer     # clean
go test ./...                                      # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785901218&installation_id=133855650&pr_number=7429&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7429&signature=b5a36843528c782c8d334c5ab7c4ed93de90e6b947783c20a9cda80a4e4f800a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how private transcript paths are opened and uploaded; incorrect handling could skip legitimate sessions or still leak via edge cases, but scope is limited to vault agentdirs/syncer with targeted tests.
> 
> **Overview**
> **Hardens Vault transcript sync** so symlinked `*.jsonl` entries cannot have their target’s bytes discovered, hashed, compressed, or uploaded (CWE-59).
> 
> Discovery now **skips symlink transcript files** for Claude, Codex, and Pi (with warnings) and **`statSessionWithLogicalPath` uses `Lstat` plus a regular-file check** so only real files become sessions. Symlinked transcript **roots** still resolve via existing `resolveWalkRoot` behavior.
> 
> The syncer adds **`openRegularNoFollow`** (`O_NOFOLLOW` + `fstat` regular-file check) for hashing and compression, closing the gap if a path is swapped to a symlink after discovery. **`Sync` delegates to `syncSessions`** so tests can exercise that race.
> 
> New tests cover per-agent symlink discovery rejection and a sync failure when a discovered file is replaced by a symlink before upload, asserting secret bytes never reach the blob store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 928cc8c1afc42a1d6c347f8f745fde79ad529f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Vault transcript sync to reject symlinked `*.jsonl` files and only process regular files, preventing accidental upload of symlink targets (CWE-59). Applies checks during discovery and before upload to close time-of-check/time-of-use gaps.

- **Bug Fixes**
  - `statSessionWithLogicalPath` now uses `os.Lstat` and requires `info.Mode().IsRegular()`.
  - Discoverers for `claude`, `codex`, and `pi` skip entries with `fs.ModeSymlink` before reading.
  - Syncer uses `openRegularNoFollow` (`O_NOFOLLOW` + fstat `IsRegular`) for hashing and compression to reject files swapped to symlinks after discovery.
  - Root symlink resolution via `resolveWalkRoot` is unchanged; only transcript files are restricted.

<sup>Written for commit 928cc8c1afc42a1d6c347f8f745fde79ad529f14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

