### PR TITLE
Fail closed in cmuxOnly socket mode when peer PID is unavailable

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -36,6 +36,20 @@ nonisolated private struct SocketLineProcessingResult: Sendable {
     let response: String?
     let authenticated: Bool
 }
+
+nonisolated enum CmuxOnlySocketAuthorization: Equatable, Sendable {
+    /// Peer PID confirmed to descend from cmux -> full command access.
+    case allowCommands
+    /// Reject the connection outright with this wire-protocol message.
+    case rejectConnection(String)
+    /// Peer PID unavailable but same-UID: allow a liveness probe only.
+    case probeOnlyNoCommands
+
+    var allowsCommands: Bool {
+        if case .allowCommands = self { return true }
+        return false
+    }
+}
 // Agent notification gating types (AgentNotifyCategory / AgentTurnCompleteMode /
 // AgentNotificationMeta / agentNotificationShouldDeliver) live in AgentNotificationGate.swift.
 
@@ -1471,43 +1485,59 @@ class TerminalController {
 
         // In cmuxOnly mode, verify the connecting process is a descendant of cmux.
         // In allowAll mode (env-var only), skip the ancestry check.
+        var commandsAllowed = true
         if socketServer.accessMode == .cmuxOnly {
             // Use pre-captured peer PID if available (captured in accept loop before
             // the peer can disconnect), falling back to live lookup.
             let pid = peerPid ?? transport.peerProcessID(of: socket)
-            if let pid {
-                guard isDescendant(pid) else {
-                    _ = writeSocketResponse(
-                        "ERROR: Access denied — only processes started inside cmux can connect",
-                        to: socket
-                    )
-                    return
-                }
-            }
-            // If pid is nil, LOCAL_PEERPID failed (peer disconnected before we
-            // could read it — common with ncat --send-only). We still verify the
-            // peer runs as the same user via LOCAL_PEERCRED. This is the same
-            // security boundary as the socket file permissions (0600), so it does
-            // not widen the attack surface. We also require that the peer actually
-            // sent data (checked in the read loop below) — a connect-only probe
-            // with no data is harmless.
-            if pid == nil {
-                guard transport.peerHasSameUID(socket) else {
-                    _ = writeSocketResponse(
-                        "ERROR: Unable to verify client process",
-                        to: socket
-                    )
-                    return
-                }
+            switch Self.cmuxOnlyAuthorization(
+                peerPID: pid,
+                isDescendant: { isDescendant($0) },
+                peerHasSameUID: { transport.peerHasSameUID(socket) }
+            ) {
+            case .allowCommands:
+                commandsAllowed = true
+            case .probeOnlyNoCommands:
+                commandsAllowed = false
+            case .rejectConnection(let message):
+                _ = writeSocketResponse(message, to: socket)
+                return
             }
         }
 
+        serveClientCommands(socket: socket, commandsAllowed: commandsAllowed)
+    }
+
+    nonisolated static func cmuxOnlyAuthorization(
+        peerPID: pid_t?,
+        isDescendant: (pid_t) -> Bool,
+        peerHasSameUID: () -> Bool
+    ) -> CmuxOnlySocketAuthorization {
+        if let pid = peerPID {
+            return isDescendant(pid)
+                ? .allowCommands
+                : .rejectConnection("ERROR: Access denied — only processes started inside cmux can connect")
+        }
+        return peerHasSameUID()
+            ? .allowCommands
+            : .rejectConnection("ERROR: Unable to verify client process")
+    }
+
+    private nonisolated func serveClientCommands(socket: Int32, commandsAllowed: Bool) {
         var authenticated = false
         let lineReader = ControlClientLineReader(socket: socket)
 
         while let line = lineReader.nextLine(shouldContinueReading: { socketServer.isRunning }) {
             let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
+
+            if !commandsAllowed {
+                _ = writeSocketResponse(
+                    "ERROR: Access denied — only processes started inside cmux can connect",
+                    to: socket
+                )
+                return
+            }
 
             var shouldCloseSocket = false
             autoreleasepool {
@@ -1538,6 +1568,12 @@ class TerminalController {
             }
         }
     }
+
+#if DEBUG
+    nonisolated func debugServeClientCommandsForTesting(socket: Int32, commandsAllowed: Bool) {
+        serveClientCommands(socket: socket, commandsAllowed: commandsAllowed)
+    }
+#endif
 
     private nonisolated func processSocketLine(
         _ command: String,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1519,7 +1519,7 @@ class TerminalController {
                 : .rejectConnection("ERROR: Access denied — only processes started inside cmux can connect")
         }
         return peerHasSameUID()
-            ? .allowCommands
+            ? .probeOnlyNoCommands
             : .rejectConnection("ERROR: Unable to verify client process")
     }
 

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -288,6 +288,110 @@ final class TerminalControllerSocketSecurityTests {
         XCTAssertTrue(wrongAuthThenPing[1].hasPrefix("ERROR:"))
     }
 
+    @Test func testCmuxOnlyAuthorizationDecisionMatrix() {
+        let descendantPID = pid_t(4242)
+        let deniedPID = pid_t(4343)
+
+        let descendant = TerminalController.cmuxOnlyAuthorization(
+            peerPID: descendantPID,
+            isDescendant: { $0 == descendantPID },
+            peerHasSameUID: { false }
+        )
+        XCTAssertEqual(descendant, .allowCommands)
+        XCTAssertTrue(descendant.allowsCommands)
+
+        let nonDescendant = TerminalController.cmuxOnlyAuthorization(
+            peerPID: deniedPID,
+            isDescendant: { _ in false },
+            peerHasSameUID: { true }
+        )
+        XCTAssertEqual(
+            nonDescendant,
+            .rejectConnection("ERROR: Access denied — only processes started inside cmux can connect")
+        )
+        XCTAssertFalse(nonDescendant.allowsCommands)
+
+        let nilSameUID = TerminalController.cmuxOnlyAuthorization(
+            peerPID: nil,
+            isDescendant: { _ in true },
+            peerHasSameUID: { true }
+        )
+        XCTAssertEqual(nilSameUID, .probeOnlyNoCommands)
+        XCTAssertFalse(nilSameUID.allowsCommands)
+
+        let nilDifferentUID = TerminalController.cmuxOnlyAuthorization(
+            peerPID: nil,
+            isDescendant: { _ in true },
+            peerHasSameUID: { false }
+        )
+        XCTAssertEqual(nilDifferentUID, .rejectConnection("ERROR: Unable to verify client process"))
+        XCTAssertFalse(nilDifferentUID.allowsCommands)
+    }
+
+    @Test func testCmuxOnlyAuthorizationOnlyVerifiedDescendantsAllowCommands() {
+        let cases: [(peerPID: pid_t?, isDescendant: Bool, sameUID: Bool)] = [
+            (pid_t(5001), false, true),
+            (pid_t(5002), false, false),
+            (nil, true, true),
+            (nil, true, false),
+        ]
+
+        for testCase in cases {
+            let authorization = TerminalController.cmuxOnlyAuthorization(
+                peerPID: testCase.peerPID,
+                isDescendant: { _ in testCase.isDescendant },
+                peerHasSameUID: { testCase.sameUID }
+            )
+            XCTAssertFalse(authorization.allowsCommands)
+        }
+    }
+
+    @Test func testNilPeerSameUIDReadLoopRejectsCommandBytes() throws {
+#if DEBUG
+        let authorization = TerminalController.cmuxOnlyAuthorization(
+            peerPID: nil,
+            isDescendant: { _ in true },
+            peerHasSameUID: { true }
+        )
+
+        let socketPath = makeSocketPath("probe-only-loop")
+        TerminalController.shared.start(
+            tabManager: TabManager(),
+            socketPath: socketPath,
+            accessMode: .allowAll
+        )
+        try waitForSocket(at: socketPath)
+        defer { TerminalController.shared.stop() }
+
+        var fds = [Int32](repeating: -1, count: 2)
+        guard Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &fds) == 0 else {
+            throw posixError("socketpair(AF_UNIX)")
+        }
+
+        let serverFD = fds[0]
+        let clientFD = fds[1]
+        let served = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            TerminalController.shared.debugServeClientCommandsForTesting(
+                socket: serverFD,
+                commandsAllowed: authorization.allowsCommands
+            )
+            Darwin.close(serverFD)
+            served.signal()
+        }
+
+        defer { Darwin.close(clientFD) }
+        try writeLine("ping", to: clientFD)
+        let response = try readLine(from: clientFD)
+
+        XCTAssertTrue(response.hasPrefix("ERROR: Access denied"))
+        XCTAssertFalse(response.localizedCaseInsensitiveContains("PONG"))
+        XCTAssertEqual(served.wait(timeout: .now() + 5) == .success, true)
+#else
+        return
+#endif
+    }
+
     @Test func testSocketCommandPolicyDistinguishesFocusIntent() throws {
 #if DEBUG
         let nonFocus = TerminalController.debugSocketCommandPolicySnapshot(


### PR DESCRIPTION
## What

In `cmuxOnly` control-socket mode, the connection handler verifies that a connecting process descends from cmux via `LOCAL_PEERPID`. When that lookup returned `nil` (the peer disconnected before its PID could be captured), the handler downgraded to a same-UID check via `LOCAL_PEERCRED` and then still read and processed buffered command lines. That let an unverified same-UID client's commands run even though `cmuxOnly` advertises that "only processes started inside cmux terminals can send commands."

## Change

Route the peer-metadata decision through a single pure function `cmuxOnlyAuthorization(peerPID:isDescendant:peerHasSameUID:)`:

- Verified cmux descendant → full command access.
- Known non-descendant PID → connection rejected.
- Unavailable PID + same UID → treated as a liveness probe only; commands are refused.
- Unavailable PID + different UID → connection rejected.

The read loop is extracted into `serveClientCommands(socket:commandsAllowed:)`, which fails closed: on a probe-only connection it rejects with "Access denied" on the first command line before any bytes are processed. A connect-only probe (no data) still closes harmlessly, so liveness checks keep working.

Only `cmuxOnly` is affected; `off`, `automation`, `password`, and `allowAll` behavior is unchanged. The socket file already restricts access to the same macOS user (`0600`); this closes the narrow window where an unverified same-UID process could send commands before its ancestry was confirmed.

## Tests

Added to the already-wired `cmuxTests/TerminalControllerSocketSecurityTests.swift` (behavioral, no source-shape assertions):

- `testCmuxOnlyAuthorizationDecisionMatrix` — asserts each peer state maps to the correct authorization, including unavailable-PID + same-UID → probe-only (no command access).
- `testCmuxOnlyAuthorizationOnlyVerifiedDescendantsAllowCommands` — invariant tying the mode's promise to the code: only a verified cmux descendant may send commands.
- `testNilPeerSameUIDReadLoopRejectsCommandBytes` — drives the read loop through the decision output with a send-and-close client and asserts the command is refused (Access denied, not PONG).

Two-commit structure: the first commit adds the tests plus the decision seam while keeping the old permissive behavior, so CI goes red; the second commit installs the fail-closed policy and CI goes green.

## Verification

The macOS app target is built and unit-tested in CI (local xcodebuild is guarded on dev machines). The `CmuxControlSocket` transport package is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785901587&installation_id=133855650&pr_number=7431&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7431&signature=d6bd565ac28fdc16033b8580c1230e4b147def6c94bd13a0c952e2503fd6b953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Tightens authorization on the control socket in cmuxOnly mode; incorrect policy could block legitimate clients or leave a security gap, though scope is limited to that mode.
> 
> **Overview**
> **cmuxOnly** control-socket handling no longer runs commands when peer ancestry cannot be verified. Authorization is centralized in `cmuxOnlyAuthorization` and `CmuxOnlySocketAuthorization`: verified cmux descendants get full access; known non-descendants and wrong-UID peers are rejected at connect; **nil PID + same UID** is **probe-only** (connect OK, no commands).
> 
> The read loop moves to `serveClientCommands(socket:commandsAllowed:)`, which returns **Access denied** on the first command line when `commandsAllowed` is false, before any command processing. Other access modes are unchanged.
> 
> Tests cover the decision matrix, the “only descendants allow commands” invariant, and a DEBUG integration test that `ping` is refused on probe-only connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d996252381d769487e170184284cbce31b9e6744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmuxOnly` control-socket mode to fail closed when the peer PID is unavailable, so only verified cmux descendants can execute commands. Same-UID connections without a PID are treated as liveness probes and are denied on the first command.

- **Bug Fixes**
  - Centralized auth via `cmuxOnlyAuthorization`: verified descendant → allow; known non-descendant → reject; PID unavailable + same UID → probe-only; PID unavailable + different UID → reject.
  - Extracted `serveClientCommands` to enforce fail-closed behavior: probe-only connections receive “Access denied” on the first command; connect-only probes still close cleanly. Closes the window where unverified same-UID clients could run buffered commands.
  - Added tests for the decision matrix and read loop; other modes (`off`, `automation`, `password`, `allowAll`) are unchanged.

<sup>Written for commit d996252381d769487e170184284cbce31b9e6744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

