### PR TITLE
Require origin + JSON content-type on Vault CLI auth routes

### DIFF
--- a/web/services/vault/routeHelpers.ts
+++ b/web/services/vault/routeHelpers.ts
@@ -11,7 +11,13 @@ import {
   verifyRequest,
   type AuthedUser,
 } from "@/services/vms/auth";
-import { jsonResponse } from "@/services/vms/routeHelpers";
+import {
+  browserMutationContentTypeAllowed,
+  browserMutationOriginAllowed,
+  jsonResponse,
+  parseBearer,
+  requiresBrowserMutationProtection,
+} from "@/services/vms/routeHelpers";
 
 type VerifyRequestOptions = NonNullable<Parameters<typeof verifyRequest>[1]>;
 
@@ -62,6 +68,12 @@ export async function withAuthedVaultApiRoute(
   return withVaultApiRoute(request, route, attributes, failureLog, async (context) => {
     const user = await verify(request, verifyOptions);
     if (!user) return unauthorized();
+    const bearer = parseBearer(request);
+    if (requiresBrowserMutationProtection(request.method, bearer)) {
+      if (!browserMutationOriginAllowed(request) || !browserMutationContentTypeAllowed(request)) {
+        return jsonResponse({ error: "forbidden" }, 403);
+      }
+    }
     setSpanAttributes(context.span, { "cmux.vault.user_id": user.id });
     return handler({ ...context, user });
   });

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -219,6 +219,13 @@ export function browserMutationOriginAllowed(request: Request): boolean {
   return allowedBrowserOrigins().has(origin);
 }
 
+export function browserMutationContentTypeAllowed(request: Request): boolean {
+  const contentType = request.headers.get("content-type");
+  if (!contentType) return false;
+  const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
+  return mediaType === "application/json";
+}
+
 function requestURLOrigin(request: Request): string | null {
   try {
     return new URL(request.url).origin;

--- a/web/tests/vault-cli-auth-route.test.ts
+++ b/web/tests/vault-cli-auth-route.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getUser = mock(async () => stackUser());
+const cloudDb = mock(() => createFakeDb());
+
+const ORIGINAL_ENV = {
+  CMUX_VAULT_ENABLED: process.env.CMUX_VAULT_ENABLED,
+  CMUX_VAULT_S3_BUCKET: process.env.CMUX_VAULT_S3_BUCKET,
+};
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => true,
+  stackServerApp: { getUser },
+}));
+
+mock.module("../db/client", () => ({
+  cloudDb,
+  closeCloudDbForTests: async () => {},
+}));
+
+const { POST } = await import("../app/api/vault/cli/auth/approve/route");
+
+beforeEach(() => {
+  process.env.CMUX_VAULT_S3_BUCKET = "test-bucket";
+  process.env.CMUX_VAULT_ENABLED = "1";
+  getUser.mockClear();
+  getUser.mockResolvedValue(stackUser());
+  cloudDb.mockClear();
+});
+
+afterEach(() => {
+  restoreEnv();
+});
+
+describe("Vault CLI auth approve route", () => {
+  test("rejects cross-site cookie mutations before reaching the DB", async () => {
+    const response = await POST(approveRequest({
+      origin: "https://evil.example",
+      "sec-fetch-site": "cross-site",
+      "content-type": "application/json",
+    }));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "forbidden" });
+    expect(cloudDb).not.toHaveBeenCalled();
+  });
+
+  test("rejects cookie mutations without an Origin before reaching the DB", async () => {
+    const response = await POST(approveRequest({
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    }));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "forbidden" });
+    expect(cloudDb).not.toHaveBeenCalled();
+  });
+
+  test("rejects cookie mutations without JSON content before reaching the DB", async () => {
+    const response = await POST(approveRequest({
+      origin: "https://cmux.test",
+      "content-type": "text/plain",
+    }));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "forbidden" });
+    expect(cloudDb).not.toHaveBeenCalled();
+  });
+
+  test("allows same-origin JSON cookie mutations to reach the DB", async () => {
+    const response = await POST(approveRequest({
+      origin: "https://cmux.test",
+      "content-type": "application/json",
+    }));
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: "auth_request_not_pending" });
+    expect(cloudDb).toHaveBeenCalled();
+  });
+
+  test("allows native bearer mutations to bypass browser guards", async () => {
+    const response = await POST(approveRequest({
+      authorization: "Bearer x",
+      "x-stack-refresh-token": "y",
+      origin: "https://evil.example",
+      "sec-fetch-site": "cross-site",
+      "content-type": "application/json",
+    }));
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: "auth_request_not_pending" });
+    expect(cloudDb).toHaveBeenCalled();
+  });
+});
+
+function approveRequest(headers: HeadersInit): Request {
+  return new Request("https://cmux.test/api/vault/cli/auth/approve", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ userCode: "ABCD2345" }),
+  });
+}
+
+function createFakeDb() {
+  return {
+    select: mock(() => ({
+      from: mock(() => ({
+        where: mock(() => ({
+          orderBy: mock(() => ({
+            limit: mock(async () => []),
+          })),
+        })),
+      })),
+    })),
+  };
+}
+
+function stackUser() {
+  return {
+    id: "user-1",
+    displayName: null,
+    primaryEmail: "user@example.com",
+    selectedTeam: {
+      id: "team-1",
+      displayName: "Team 1",
+      clientReadOnlyMetadata: {},
+    },
+  };
+}
+
+function restoreEnv(): void {
+  restoreEnvValue("CMUX_VAULT_ENABLED", ORIGINAL_ENV.CMUX_VAULT_ENABLED);
+  restoreEnvValue("CMUX_VAULT_S3_BUCKET", ORIGINAL_ENV.CMUX_VAULT_S3_BUCKET);
+}
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}


### PR DESCRIPTION
## What

Vault cookie-authenticated POST routes go through `withAuthedVaultApiRoute`, which authenticates with the cookie-capable `verifyRequest` but, unlike `withAuthedVmApiRoute`, applied no browser-mutation protection. This adds the same guard the Cloud VM and subrouter routes already use.

After authentication and **before the handler runs** (so before any DB access), a cookie-authenticated `POST`/`PUT`/`PATCH`/`DELETE` must present a trusted same-site `Origin` **and** `Content-Type: application/json`, otherwise it is rejected with `403 { "error": "forbidden" }`. Native CLI/daemon callers authenticate with bearer tokens and skip the guard exactly as they do on the VM routes, so nothing changes for them.

The guard lives in the shared `withAuthedVaultApiRoute`, so it covers every cookie-authenticated Vault mutation (`cli/auth/approve`, `sessions/commit`, `uploads`) uniformly. `GET` routes are unaffected (the check only fires on mutating methods). The legitimate dashboard approval flow is a same-origin `fetch` that sends `Origin` and `application/json`, so it continues to pass.

## How

- `web/services/vms/routeHelpers.ts`: add and export `browserMutationContentTypeAllowed(request)` next to `browserMutationOriginAllowed`. It accepts a `Content-Type` whose media type is `application/json` (parameters like `; charset=utf-8` are allowed). VM and subrouter guard behavior is unchanged (they do not consume the new helper).
- `web/services/vault/routeHelpers.ts`: in `withAuthedVaultApiRoute`, after `verify(...)` returns a user and before invoking the handler, reuse `parseBearer` + `requiresBrowserMutationProtection` + `browserMutationOriginAllowed` + the new content-type helper; reject with `403` when a cookie-authenticated mutation lacks a trusted origin or a JSON content type.

## Tests

`web/tests/vault-cli-auth-route.test.ts` (mirrors `tests/vm-route-auth.test.ts` / `tests/subrouter-accounts-route.test.ts`), split into two commits so CI shows red→green:

1. cross-site cookie mutation → `403`, DB not reached
2. missing `Origin` → `403`, DB not reached
3. `text/plain` content type → `403`, DB not reached
4. same-origin JSON → reaches DB (`409 auth_request_not_pending`), i.e. the legitimate flow still works
5. native bearer, cross-site → reaches DB (`409`), i.e. daemon callers are not broken

The three rejection tests fail without the guard (they return `409`, proving the mutation reached the DB); they pass with it. Verified locally: `bun test tests/vault-cli-auth-route.test.ts` (5 pass) and `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785901602&installation_id=133855650&pr_number=7432&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7432&signature=197179ab7034e7ba5416c801808016283dcf93fa6860ba56272cb3d94bd9959f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated Vault mutation paths and CSRF-style guards; behavior change for cookie clients that omit Origin or JSON Content-Type, but aligned with existing VM patterns and bearer callers are exempt.
> 
> **Overview**
> Cookie-authenticated Vault **POST/PUT/PATCH/DELETE** routes now get the same browser-mutation checks Cloud VM routes use, plus a **JSON `Content-Type`** requirement. In `withAuthedVaultApiRoute`, after `verify` succeeds and **before** the handler (and DB), requests without a bearer pair must pass `browserMutationOriginAllowed` and the new `browserMutationContentTypeAllowed`; otherwise they return **`403 { "error": "forbidden" }`**.
> 
> `browserMutationContentTypeAllowed` is exported from `web/services/vms/routeHelpers.ts` (media type `application/json`, parameters allowed). **Native CLI/daemon** callers with bearer + refresh headers still skip the guard. **GET** routes are unchanged.
> 
> New tests in `web/tests/vault-cli-auth-route.test.ts` cover cross-site, missing `Origin`, non-JSON content type, legitimate same-origin JSON, and bearer bypass on `cli/auth/approve`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 398dacef49ad8d83670758fdb75740a716b1f9d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Vault CLI auth mutations by requiring a same-site Origin and `application/json` on cookie-authenticated requests. Cross-site or non-JSON requests now get 403 before any DB access; bearer-token callers remain unchanged.

- **Bug Fixes**
  - Applied the browser-mutation guard in `withAuthedVaultApiRoute` for POST/PUT/PATCH/DELETE.
  - Added `browserMutationContentTypeAllowed` and reused the Origin check; `GET` routes are unaffected.
  - Exempted bearer-token requests to keep CLI/daemon flows working.
  - Added tests covering cross-site, missing Origin, non-JSON rejections, and valid same-origin JSON and bearer paths.

<sup>Written for commit 398dacef49ad8d83670758fdb75740a716b1f9d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

