### PR TITLE
Add cmux __internal_flags feature flag inspector

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,10 +1,10 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-34495	CLI/cmux.swift
+34434	CLI/cmux.swift
 17961	Sources/AppDelegate.swift
-16474	Sources/ContentView.swift
-15146	Sources/TerminalController.swift
+16448	Sources/ContentView.swift
+15152	Sources/TerminalController.swift
 13185	Sources/Workspace.swift
 12348	cmuxTests/AppDelegateShortcutRoutingTests.swift
 12296	Sources/GhosttyTerminalView.swift
@@ -124,7 +124,6 @@
 803	Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
 802	Sources/TerminalController+ControlPaneContext.swift
 797	Sources/ClosedItemHistory.swift
-782	CLI/CMUXCLI+AgentHookDefinitions.swift
 779	cmuxUITests/BrowserOmnibarSuggestionsUITests.swift
 773	Sources/App/MenuBarExtraController.swift
 769	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
@@ -141,9 +140,9 @@
 718	Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
 716	Sources/TaskManagerSnapshot.swift
 715	Sources/AppleScriptSupport.swift
-712	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
 710	Sources/TerminalSSHSessionDetector.swift
 709	Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarWorkspaceReorderDropResolver.swift
+708	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
 706	CLI/CMUXCLI+Config.swift
 699	cmuxTests/TerminalNotificationClearAllTests.swift
 698	cmuxTests/RestorableAgentHookProviderResumeTests.swift
@@ -210,6 +209,7 @@
 562	cmuxTests/AgentExecutableResolverTests.swift
 561	cmuxTests/GhosttyConfigPathResolverTests.swift
 560	cmuxTests/CLISSHPTYResizeInputTests.swift
+559	CLI/CMUXCLI+AgentHookDefinitions.swift
 558	Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Config.swift
 553	Sources/RightSidebarPanelView.swift
 549	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Sidebar/ControlCommandCoordinator+SidebarMetadataV1.swift
@@ -244,12 +244,12 @@
 516	Sources/TerminalImageTransfer.swift
 514	Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
 514	cmuxUITests/UpdatePillUITests.swift
-513	Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
 513	Sources/TerminalController+ControlSidebarContext2.swift
 511	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Sidebar/ControlCommandCoordinator+SidebarReportsV1.swift
 509	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift
 508	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
 507	Sources/TerminalControllerTopSupport.swift
+506	Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatTranscriptTableView.swift
 506	Sources/App/MainWindowVisibilityController.swift
 504	Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsStoreTests.swift
 504	cmuxTests/TerminalNotificationSocketActionTests.swift

--- a/CLI/CMUXCLI+CommandSuggestions.swift
+++ b/CLI/CMUXCLI+CommandSuggestions.swift
@@ -52,6 +52,7 @@ extension CMUXCLI {
 
     static let topLevelCommandNames: Set<String> = [
         "__codex-teams-watch",
+        "__internal_flags",
         "__tmux-compat",
         "agent-hibernation",
         "auth",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3539,6 +3539,10 @@ struct CMUXCLI {
         let capturesSocketErrorsInsideCommand = ["claude-hook", "codex-hook", "feed-hook", "hooks"].contains(command) // Backwards compatibility aliases stay hidden from help.
         do {
         switch command {
+        case "__internal_flags":
+            let response = try sendV1Command("__internal_flags", client: client)
+            print(response)
+
         case "ping":
             let response = try sendV1Command("ping", client: client)
             print(response)

--- a/Sources/App/CmuxHelpCommands.swift
+++ b/Sources/App/CmuxHelpCommands.swift
@@ -33,6 +33,11 @@ extension cmuxApp {
                 }
                 #endif
             }
+            #if DEBUG
+            Button(String(localized: "menu.help.featureFlags", defaultValue: "Feature Flags…")) {
+                InternalFlagsPresenter.present()
+            }
+            #endif
 
             Divider()
 

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -2,6 +2,15 @@ import Foundation
 import Observation
 import PostHog
 
+struct CmuxFeatureFlagDefinition: Identifiable, Equatable {
+    var id: String { key }
+
+    let key: String
+    let title: String
+    let flagDescription: String
+    let defaultWhenUnavailable: Bool
+}
+
 /// PostHog-backed runtime feature flags for the macOS app (PostHog project
 /// 244066, same public key analytics uses). Values are cached in memory and
 /// refreshed when the SDK reports a flag payload, so gated UI can be toggled
@@ -22,35 +31,83 @@ import PostHog
 final class CmuxFeatureFlags {
     static let shared = CmuxFeatureFlags()
 
-    // FLAG(key: pro-upgrade-ui-enabled-release, owner: lawrencecchen,
-    //      reviewBy: 2026-10-01, defaultWhenUnavailable: false)
-    // Shows the Pro upgrade entrypoints (sidebar badge, Settings Account
-    // card, palette command, Help menu item). Release builds hide them until
-    // the PostHog flag is enabled; DEBUG keeps them visible for dogfood.
-    private(set) var isProUpgradeUIEnabled: Bool
-
-    private static let proUpgradeUIKey = "pro-upgrade-ui-enabled-release"
     #if DEBUG
     private static let proUpgradeUIDefault = true
     #else
     private static let proUpgradeUIDefault = false
     #endif
 
-    // FLAG(key: mobile-connect-button-enabled-release, owner: lawrencecchen,
-    //      reviewBy: 2026-10-01, defaultWhenUnavailable: true)
-    // Shows the top-right iPhone button that opens the Mobile Connect
-    // (phone pairing) window. Default keeps it visible when flags are
-    // unavailable; the window it opens ships in every build.
-    private(set) var isMobileConnectButtonEnabled: Bool
-
-    private static let mobileConnectButtonKey = "mobile-connect-button-enabled-release"
     private static let mobileConnectButtonDefault = true
+    private static let overrideKeyPrefix = "cmux.flags.override."
 
+    // Order is load-bearing for the typed accessors below. A keyed lookup would
+    // repeat flag-key literals and violate the feature-flag lint's single
+    // evaluation-site rule.
+    static var allFlags: [CmuxFeatureFlagDefinition] {
+        [
+            // FLAG(key: pro-upgrade-ui-enabled-release, owner: lawrencecchen,
+            //      reviewBy: 2026-10-01, defaultWhenUnavailable: false)
+            // Shows the Pro upgrade entrypoints (sidebar badge, Settings Account
+            // card, palette command, Help menu item). Release builds hide them until
+            // the PostHog flag is enabled; DEBUG keeps them visible for dogfood.
+            CmuxFeatureFlagDefinition(
+                key: "pro-upgrade-ui-enabled-release",
+                title: String(localized: "featureFlags.proUpgrade.title", defaultValue: "Pro upgrade UI"),
+                flagDescription: String(
+                    localized: "featureFlags.proUpgrade.description",
+                    defaultValue: "Shows Pro upgrade entrypoints in the sidebar, Settings, command palette, and Help menu."
+                ),
+                defaultWhenUnavailable: Self.proUpgradeUIDefault
+            ),
+
+            // FLAG(key: mobile-connect-button-enabled-release, owner: lawrencecchen,
+            //      reviewBy: 2026-10-01, defaultWhenUnavailable: true)
+            // Shows the top-right iPhone button that opens the Mobile Connect
+            // (phone pairing) window. Default keeps it visible when flags are
+            // unavailable; the window it opens ships in every build.
+            CmuxFeatureFlagDefinition(
+                key: "mobile-connect-button-enabled-release",
+                title: String(localized: "featureFlags.mobileConnect.title", defaultValue: "Mobile Connect button"),
+                flagDescription: String(
+                    localized: "featureFlags.mobileConnect.description",
+                    defaultValue: "Shows the iPhone button that opens the Mobile Connect pairing window."
+                ),
+                defaultWhenUnavailable: Self.mobileConnectButtonDefault
+            ),
+        ]
+    }
+
+    var isProUpgradeUIEnabled: Bool {
+        effectiveValue(for: Self.allFlags[0])
+    }
+
+    var isMobileConnectButtonEnabled: Bool {
+        effectiveValue(for: Self.allFlags[1])
+    }
+
+    @ObservationIgnored
+    private let defaults: UserDefaults
+    @ObservationIgnored
+    private let remoteFlagValueProvider: (String) -> Any?
+    @ObservationIgnored
     private var flagsObserver: (any NSObjectProtocol)?
 
-    private init() {
-        isProUpgradeUIEnabled = Self.proUpgradeUIDefault
-        isMobileConnectButtonEnabled = Self.mobileConnectButtonDefault
+    private var localOverridesByKey: [String: Bool] = [:]
+    private var remoteValuesByKey: [String: Bool] = [:]
+    private var effectiveValuesByKey: [String: Bool] = [:]
+
+    init(
+        defaults: UserDefaults = .standard,
+        remoteFlagValueProvider: @escaping (String) -> Any? = { PostHogSDK.shared.getFeatureFlag($0) }
+    ) {
+        self.defaults = defaults
+        self.remoteFlagValueProvider = remoteFlagValueProvider
+        localOverridesByKey = Self.allFlags.reduce(into: [:]) { values, definition in
+            if let value = Self.storedOverrideValue(for: definition.key, defaults: defaults) {
+                values[definition.key] = value
+            }
+        }
+        recomputeEffectiveValues()
     }
 
     /// Called once from AppDelegate after PostHog analytics starts. Safe when
@@ -69,31 +126,95 @@ final class CmuxFeatureFlags {
         PostHogSDK.shared.reloadFeatureFlags()
     }
 
-    private func applyLoadedFlags() {
-        let previousProUpgradeUIEnabled = isProUpgradeUIEnabled
-        let previousMobileConnectButtonEnabled = isMobileConnectButtonEnabled
+    func effectiveValue(for definition: CmuxFeatureFlagDefinition) -> Bool {
+        effectiveValuesByKey[definition.key] ?? definition.defaultWhenUnavailable
+    }
 
-        isProUpgradeUIEnabled = Self.boolFlag(
-            Self.proUpgradeUIKey,
-            default: Self.proUpgradeUIDefault
-        )
-        isMobileConnectButtonEnabled = Self.boolFlag(
-            Self.mobileConnectButtonKey,
-            default: Self.mobileConnectButtonDefault
-        )
+    func overrideValue(for definition: CmuxFeatureFlagDefinition) -> Bool? {
+        localOverridesByKey[definition.key]
+    }
 
-        if isProUpgradeUIEnabled != previousProUpgradeUIEnabled ||
-            isMobileConnectButtonEnabled != previousMobileConnectButtonEnabled {
+    func remoteValue(for definition: CmuxFeatureFlagDefinition) -> Bool? {
+        remoteValuesByKey[definition.key]
+    }
+
+    func setOverride(_ value: Bool?, for definition: CmuxFeatureFlagDefinition) {
+        let previousEffectiveValues = effectiveValuesByKey
+        if let value {
+            localOverridesByKey[definition.key] = value
+            defaults.set(value, forKey: Self.overrideDefaultsKey(for: definition.key))
+        } else {
+            localOverridesByKey.removeValue(forKey: definition.key)
+            defaults.removeObject(forKey: Self.overrideDefaultsKey(for: definition.key))
+        }
+        recomputeEffectiveValues()
+        postChangeIfNeeded(previousEffectiveValues: previousEffectiveValues)
+    }
+
+    func clearAllOverrides() {
+        let previousEffectiveValues = effectiveValuesByKey
+        var clearedAnyOverride = false
+        for definition in Self.allFlags {
+            if localOverridesByKey.removeValue(forKey: definition.key) != nil {
+                clearedAnyOverride = true
+            }
+            defaults.removeObject(forKey: Self.overrideDefaultsKey(for: definition.key))
+        }
+        guard clearedAnyOverride else { return }
+        recomputeEffectiveValues()
+        postChangeIfNeeded(previousEffectiveValues: previousEffectiveValues)
+    }
+
+    func applyLoadedFlags() {
+        let previousEffectiveValues = effectiveValuesByKey
+        remoteValuesByKey = Self.allFlags.reduce(into: [:]) { values, definition in
+            if let value = Self.coerceBoolFlagValue(remoteFlagValueProvider(definition.key)) {
+                values[definition.key] = value
+            }
+        }
+        recomputeEffectiveValues()
+        postChangeIfNeeded(previousEffectiveValues: previousEffectiveValues)
+    }
+
+    private func recomputeEffectiveValues() {
+        effectiveValuesByKey = Self.allFlags.reduce(into: [:]) { values, definition in
+            values[definition.key] = localOverridesByKey[definition.key]
+                ?? remoteValuesByKey[definition.key]
+                ?? definition.defaultWhenUnavailable
+        }
+    }
+
+    private func postChangeIfNeeded(previousEffectiveValues: [String: Bool]) {
+        if Self.allFlags.contains(where: { definition in
+            previousEffectiveValues[definition.key] != effectiveValuesByKey[definition.key]
+        }) {
             NotificationCenter.default.post(name: .cmuxFeatureFlagsDidChange, object: self)
         }
     }
 
-    private static func boolFlag(_ key: String, default fallback: Bool) -> Bool {
-        coerceBoolFlagValue(PostHogSDK.shared.getFeatureFlag(key), default: fallback)
+    private static func overrideDefaultsKey(for key: String) -> String {
+        overrideKeyPrefix + key
+    }
+
+    private static func storedOverrideValue(for key: String, defaults: UserDefaults) -> Bool? {
+        guard let value = defaults.object(forKey: overrideDefaultsKey(for: key)) else {
+            return nil
+        }
+        if let boolValue = value as? Bool {
+            return boolValue
+        }
+        if let numberValue = value as? NSNumber {
+            return numberValue.boolValue
+        }
+        return nil
     }
 
     nonisolated static func coerceBoolFlagValue(_ value: Any?, default fallback: Bool) -> Bool {
-        guard let value else { return fallback }
+        coerceBoolFlagValue(value) ?? fallback
+    }
+
+    nonisolated static func coerceBoolFlagValue(_ value: Any?) -> Bool? {
+        guard let value else { return nil }
 
         if let boolValue = value as? Bool {
             return boolValue
@@ -110,11 +231,11 @@ final class CmuxFeatureFlags {
             case "false":
                 return false
             default:
-                return fallback
+                return nil
             }
         }
 
-        return fallback
+        return nil
     }
 }
 

--- a/Sources/InternalFlagsWindow.swift
+++ b/Sources/InternalFlagsWindow.swift
@@ -1,0 +1,282 @@
+import AppKit
+import SwiftUI
+
+enum InternalFlagsPresenter {
+    @MainActor
+    static func present() {
+        InternalFlagsWindowController.shared.show()
+    }
+}
+
+@MainActor
+private final class InternalFlagsWindowController: NSWindowController {
+    static let shared = InternalFlagsWindowController()
+
+    private init() {
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 920, height: 560),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(localized: "featureFlags.window.title", defaultValue: "Feature Flags")
+        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
+        window.minSize = NSSize(width: 760, height: 420)
+        window.contentView = NSHostingView(rootView: InternalFlagsView(flags: CmuxFeatureFlags.shared))
+        super.init(window: window)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func show() {
+        if window?.isVisible != true {
+            window?.center()
+        }
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+private struct InternalFlagsView: View {
+    let flags: CmuxFeatureFlags
+
+    private var rows: [InternalFlagRowSnapshot] {
+        CmuxFeatureFlags.allFlags.map { definition in
+            InternalFlagRowSnapshot(
+                definition: definition,
+                effectiveValue: flags.effectiveValue(for: definition),
+                overrideValue: flags.overrideValue(for: definition),
+                remoteValue: flags.remoteValue(for: definition)
+            )
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(String(localized: "featureFlags.window.heading", defaultValue: "Feature Flags"))
+                    .font(.title2.weight(.semibold))
+                Text(String(
+                    localized: "featureFlags.window.subtitle",
+                    defaultValue: "Inspect PostHog flag state and local overrides for this Mac."
+                ))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 22)
+            .padding(.bottom, 16)
+
+            Divider()
+
+            InternalFlagHeaderRow()
+
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(rows) { row in
+                        InternalFlagRow(
+                            snapshot: row,
+                            setOverride: { value in
+                                flags.setOverride(value, for: row.definition)
+                            }
+                        )
+                    }
+                }
+            }
+
+            Divider()
+
+            HStack(alignment: .center, spacing: 16) {
+                Text(String(
+                    localized: "featureFlags.footer.note",
+                    defaultValue: "Overrides are local to this Mac and take precedence over remote flags."
+                ))
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+                Spacer(minLength: 12)
+
+                Button(String(localized: "featureFlags.clearAll", defaultValue: "Clear all overrides")) {
+                    flags.clearAllOverrides()
+                }
+                .disabled(!rows.contains { $0.overrideValue != nil })
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 14)
+        }
+        .frame(minWidth: 760, minHeight: 420)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+}
+
+private struct InternalFlagHeaderRow: View {
+    var body: some View {
+        HStack(spacing: 16) {
+            Text(String(localized: "featureFlags.column.flag", defaultValue: "Flag"))
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(String(localized: "featureFlags.column.current", defaultValue: "Current"))
+                .frame(width: 96, alignment: .leading)
+            Text(String(localized: "featureFlags.column.source", defaultValue: "Source"))
+                .frame(width: 96, alignment: .leading)
+            Text(String(localized: "featureFlags.column.override", defaultValue: "Override"))
+                .frame(width: 240, alignment: .leading)
+        }
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.secondary)
+        .textCase(.uppercase)
+        .padding(.horizontal, 24)
+        .padding(.vertical, 10)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+}
+
+private struct InternalFlagRowSnapshot: Identifiable, Equatable {
+    var id: String { definition.key }
+
+    let definition: CmuxFeatureFlagDefinition
+    let effectiveValue: Bool
+    let overrideValue: Bool?
+    let remoteValue: Bool?
+
+    var source: InternalFlagValueSource {
+        if overrideValue != nil {
+            return .override
+        }
+        if remoteValue != nil {
+            return .remote
+        }
+        return .default
+    }
+
+    var overrideChoice: InternalFlagOverrideChoice {
+        switch overrideValue {
+        case .some(true):
+            return .on
+        case .some(false):
+            return .off
+        case .none:
+            return .remote
+        }
+    }
+}
+
+private struct InternalFlagRow: View {
+    let snapshot: InternalFlagRowSnapshot
+    let setOverride: (Bool?) -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(snapshot.definition.title)
+                    .font(.headline)
+                    .lineLimit(1)
+                Text(snapshot.definition.key)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                Text(snapshot.definition.flagDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            InternalFlagValueBadge(isOn: snapshot.effectiveValue)
+                .frame(width: 96, alignment: .leading)
+
+            Text(snapshot.source.title)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(width: 96, alignment: .leading)
+
+            Picker(
+                String(localized: "featureFlags.override.pickerLabel", defaultValue: "Override"),
+                selection: Binding(
+                    get: { snapshot.overrideChoice },
+                    set: { choice in setOverride(choice.overrideValue) }
+                )
+            ) {
+                ForEach(InternalFlagOverrideChoice.allCases) { choice in
+                    Text(choice.title).tag(choice)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 240)
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 14)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+}
+
+private struct InternalFlagValueBadge: View {
+    let isOn: Bool
+
+    var body: some View {
+        Text(isOn ? String(localized: "featureFlags.value.on", defaultValue: "On") : String(localized: "featureFlags.value.off", defaultValue: "Off"))
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(isOn ? Color.green : Color.secondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule()
+                    .fill(isOn ? Color.green.opacity(0.14) : Color.secondary.opacity(0.12))
+            )
+    }
+}
+
+private enum InternalFlagValueSource {
+    case override
+    case remote
+    case `default`
+
+    var title: String {
+        switch self {
+        case .override:
+            return String(localized: "featureFlags.source.override", defaultValue: "Override")
+        case .remote:
+            return String(localized: "featureFlags.source.remote", defaultValue: "Remote")
+        case .default:
+            return String(localized: "featureFlags.source.default", defaultValue: "Default")
+        }
+    }
+}
+
+private enum InternalFlagOverrideChoice: CaseIterable, Hashable, Identifiable {
+    case on
+    case off
+    case remote
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .on:
+            return String(localized: "featureFlags.override.on", defaultValue: "On")
+        case .off:
+            return String(localized: "featureFlags.override.off", defaultValue: "Off")
+        case .remote:
+            return String(localized: "featureFlags.override.remote", defaultValue: "Remote")
+        }
+    }
+
+    var overrideValue: Bool? {
+        switch self {
+        case .on:
+            return true
+        case .off:
+            return false
+        case .remote:
+            return nil
+        }
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -242,6 +242,7 @@ class TerminalController {
     }
 
     private nonisolated static let focusIntentV1Commands: Set<String> = [
+        "__internal_flags",
         "focus_window",
         "select_workspace",
         "focus_surface",
@@ -1922,6 +1923,11 @@ class TerminalController {
 
         case "auth":
             return "OK: Authentication not required"
+
+        case "__internal_flags":
+            // UI-opening support command: presentation must run on the main actor.
+            InternalFlagsPresenter.present()
+            return "OK"
 
         case "list_windows":
             return listWindows()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -644,6 +644,7 @@
 		CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */; };
 		F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */; };
 		DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000002 /* InfoPlist.xcstrings */; };
+		C0DEA7720000000000000001 /* InternalFlagsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEA7720000000000000002 /* InternalFlagsWindow.swift */; };
 		4D8B37E0E11A29997632765F /* InternalTabDragConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610008EA5E3744DDBE05C8E2 /* InternalTabDragConfiguration.swift */; };
 		C0DEF0B10000000000000001 /* JSONCParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0B10000000000000002 /* JSONCParser.swift */; };
 		C0DEF0B10000000000000003 /* JSONCParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0B10000000000000002 /* JSONCParser.swift */; };
@@ -1989,6 +1990,7 @@
 		CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostSettingsActions.swift; sourceTree = "<group>"; };
 		F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivePaneFirstClickFocusTests.swift; sourceTree = "<group>"; };
 		DA7A10CA710E000000000002 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		C0DEA7720000000000000002 /* InternalFlagsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalFlagsWindow.swift; sourceTree = "<group>"; };
 		610008EA5E3744DDBE05C8E2 /* InternalTabDragConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/InternalTabDragConfiguration.swift; sourceTree = "<group>"; };
 		C0DEF0B10000000000000002 /* JSONCParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONCParser.swift; sourceTree = "<group>"; };
 		B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpToUnreadUITests.swift; sourceTree = "<group>"; };
@@ -3002,6 +3004,7 @@
 				C0DEA7710000000000000004 /* ContentView+ProCommandPalette.swift */,
 				C0DEA7710000000000000006 /* SidebarProBadge.swift */,
 				C0DEA7710000000000000008 /* FeatureFlags.swift */,
+				C0DEA7720000000000000002 /* InternalFlagsWindow.swift */,
 				C0DEA771000000000000000A /* MobileConnectTitlebarAccessory.swift */,
 				C0DEA771000000000000000C /* ProBadgeStyle.swift */,
 				C0DEA771000000000000000E /* PricingPlansScreen.swift */,
@@ -4887,6 +4890,7 @@
 				F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */,
 				CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */,
 				CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */,
+				C0DEA7720000000000000001 /* InternalFlagsWindow.swift in Sources */,
 				4D8B37E0E11A29997632765F /* InternalTabDragConfiguration.swift in Sources */,
 				C0DEF0B10000000000000001 /* JSONCParser.swift in Sources */,
 				A50012F5 /* KeyboardLayout.swift in Sources */,

--- a/cmuxTests/PostHogAnalyticsPropertiesTests.swift
+++ b/cmuxTests/PostHogAnalyticsPropertiesTests.swift
@@ -20,6 +20,114 @@ struct PostHogAnalyticsPropertiesTests {
         #expect(!CmuxFeatureFlags.coerceBoolFlagValue(nil, default: false))
     }
 
+    @MainActor
+    @Test("feature flag resolution prefers override, then remote, then default")
+    func featureFlagResolutionPrecedence() throws {
+        let flag = try #require(CmuxFeatureFlags.allFlags.first { $0.defaultWhenUnavailable })
+        let suiteName = "cmux.feature.flags.precedence.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        var remoteValues: [String: Any] = [:]
+        let flags = CmuxFeatureFlags(defaults: defaults) { key in
+            remoteValues[key]
+        }
+
+        #expect(flags.overrideValue(for: flag) == nil)
+        #expect(flags.remoteValue(for: flag) == nil)
+        #expect(flags.effectiveValue(for: flag))
+
+        remoteValues[flag.key] = false
+        flags.applyLoadedFlags()
+        #expect(flags.remoteValue(for: flag) == false)
+        #expect(!flags.effectiveValue(for: flag))
+
+        flags.setOverride(true, for: flag)
+        #expect(flags.overrideValue(for: flag) == true)
+        #expect(flags.remoteValue(for: flag) == false)
+        #expect(flags.effectiveValue(for: flag))
+
+        flags.setOverride(nil, for: flag)
+        #expect(flags.overrideValue(for: flag) == nil)
+        #expect(!flags.effectiveValue(for: flag))
+
+        remoteValues.removeValue(forKey: flag.key)
+        flags.applyLoadedFlags()
+        #expect(flags.remoteValue(for: flag) == nil)
+        #expect(flags.effectiveValue(for: flag))
+    }
+
+    @MainActor
+    @Test("feature flag overrides persist through UserDefaults")
+    func featureFlagOverridePersistenceRoundTrip() throws {
+        let flag = try #require(CmuxFeatureFlags.allFlags.first { $0.defaultWhenUnavailable })
+        let suiteName = "cmux.feature.flags.persistence.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let firstLoad = CmuxFeatureFlags(defaults: defaults) { _ in true }
+        firstLoad.setOverride(false, for: flag)
+        #expect(firstLoad.overrideValue(for: flag) == false)
+        #expect(!firstLoad.effectiveValue(for: flag))
+
+        let secondLoad = CmuxFeatureFlags(defaults: defaults) { _ in true }
+        #expect(secondLoad.overrideValue(for: flag) == false)
+        #expect(!secondLoad.effectiveValue(for: flag))
+
+        secondLoad.setOverride(nil, for: flag)
+        let thirdLoad = CmuxFeatureFlags(defaults: defaults) { _ in true }
+        #expect(thirdLoad.overrideValue(for: flag) == nil)
+        #expect(thirdLoad.effectiveValue(for: flag))
+    }
+
+    @MainActor
+    @Test("feature flag override notifications follow effective value changes")
+    func featureFlagOverrideNotificationsFollowEffectiveValueChanges() throws {
+        let flag = try #require(CmuxFeatureFlags.allFlags.first { $0.defaultWhenUnavailable })
+        let suiteName = "cmux.feature.flags.notifications.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let remoteValues: [String: Any] = [flag.key: false]
+        let flags = CmuxFeatureFlags(defaults: defaults) { key in
+            remoteValues[key]
+        }
+        flags.applyLoadedFlags()
+
+        let notificationQueue = DispatchQueue(label: "cmux.feature.flags.notification.count")
+        var notificationCount = 0
+        let token = NotificationCenter.default.addObserver(
+            forName: .cmuxFeatureFlagsDidChange,
+            object: flags,
+            queue: nil
+        ) { _ in
+            notificationQueue.sync {
+                notificationCount += 1
+            }
+        }
+        defer {
+            NotificationCenter.default.removeObserver(token)
+        }
+
+        flags.setOverride(false, for: flag)
+        #expect(notificationQueue.sync { notificationCount } == 0)
+
+        flags.setOverride(true, for: flag)
+        #expect(notificationQueue.sync { notificationCount } == 1)
+
+        flags.setOverride(true, for: flag)
+        #expect(notificationQueue.sync { notificationCount } == 1)
+
+        flags.setOverride(nil, for: flag)
+        #expect(notificationQueue.sync { notificationCount } == 2)
+    }
+
     @Test
     func dailyActivePropertiesIncludeVersionAndBuild() {
         let properties = PostHogAnalytics.dailyActiveProperties(


### PR DESCRIPTION
A hidden CLI verb, `cmux __internal_flags`, opens a native Feature Flags window in the running instance listing every registered PostHog flag with its key, description, effective value, and source (override / remote / default), plus a three-state control: Override On, Override Off, Use remote. Overrides persist in UserDefaults, take precedence over PostHog, apply live through the existing flags change notification, and work in Release builds as an internal escape hatch. The verb is declared focus-intent per the socket policy, is hidden from `cmux help`, and DEBUG builds also get a Help menu item through the same presenter. Flag defaults are unchanged; localized en + ja.

Judge-reviewed via the /fable loop (one round: focus-intent declaration). Verified: lint-feature-flags, pbxproj checks, test wiring lint, precedence/persistence/notification unit tests in the wired cmuxTests file, cloud build on tag iflags, and the window driven end to end over the debug socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785906472&installation_id=133855650&pr_number=7439&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7439&signature=72cf857c6df5999da9d0fad5c5a4e5f561d588d2bafcbe4d461406b6f378001e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all gated UI reads flags (override precedence) and exposes Release override controls via a hidden command; behavior is tested but wrong overrides could flip Pro/Mobile Connect UI locally.
> 
> **Overview**
> Adds a **Feature Flags** inspector for dogfooding and support: a hidden `cmux __internal_flags` socket command (focus-intent, not in help) opens a native window listing registered PostHog flags with effective value, source, and On/Off/Remote overrides.
> 
> **`CmuxFeatureFlags`** is refactored around a central `allFlags` registry; resolution is **override → remote → default**, with overrides in `UserDefaults`, live updates via `cmuxFeatureFlagsDidChange`, and DEBUG **Help → Feature Flags…** using the same presenter. New en/ja strings and unit tests cover precedence, persistence, and notification behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0692bc45515224276d9df73ae07e367845066310. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hidden `cmux __internal_flags` command that opens a native Feature Flags window to inspect and override app flags with live updates and persisted settings. Works in Release as an internal escape hatch.

- **New Features**
  - Feature Flags window lists each flag (key, title, description) with current value and source, plus a “Clear all overrides” action.
  - Three-state overrides (On/Off/Remote) saved in `UserDefaults` and applied instantly.
  - Resolution: override > remote (PostHog) > default; emits `cmuxFeatureFlagsDidChange` only when effective values change.
  - Hidden CLI verb `__internal_flags` (focus-intent) opens the window and prints “OK”; DEBUG adds Help → Feature Flags…; added to CLI suggestions; localized in en/ja with tests for precedence, persistence, and notifications.

<sup>Written for commit 0692bc45515224276d9df73ae07e367845066310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal “Feature Flags” window showing available flags, effective/current values, and override controls.
  * Added a Help menu entry to open the Feature Flags view (debug only).
  * Added support for a new internal CLI/command to display feature-flag information.
* **Bug Fixes**
  * Improved feature-flag value resolution order (override → remote → default), including more robust parsing and fallback behavior.
  * Corrected persistence and change notifications so updates only fire when effective values actually change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->