### PR TITLE
mux: add Linux valgrind memory-leak CI job

### DIFF
--- a/.github/workflows/mux.yml
+++ b/.github/workflows/mux.yml
@@ -50,6 +50,11 @@ jobs:
 
       - name: Build test binaries
         working-directory: mux
+        env:
+          # Force libghostty-vt's zig build onto a baseline CPU target so its
+          # SIMD codegen stays within what valgrind's instruction emulation
+          # supports (see crates/ghostty-vt-sys/build.rs).
+          CMUX_GHOSTTY_VT_ZIG_CPU: baseline
         run: |
           mkdir -p target
           cargo test --workspace --locked --no-run --message-format=json > target/cargo-test-binaries.jsonl

--- a/.github/workflows/mux.yml
+++ b/.github/workflows/mux.yml
@@ -21,6 +21,81 @@ permissions:
   contents: read
 
 jobs:
+  valgrind-leak-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y valgrind
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Rust version
+        run: |
+          rustc --version || true
+          if ! command -v cargo >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Build test binaries
+        working-directory: mux
+        run: |
+          mkdir -p target
+          cargo test --workspace --locked --no-run --message-format=json > target/cargo-test-binaries.jsonl
+          python3 <<'PY'
+          import json
+          import sys
+
+          seen = set()
+          with open("target/cargo-test-binaries.jsonl", "r", encoding="utf-8") as messages:
+              with open("target/valgrind-test-binaries.txt", "w", encoding="utf-8") as output:
+                  for line in messages:
+                      try:
+                          message = json.loads(line)
+                      except json.JSONDecodeError:
+                          continue
+                      if not message.get("profile", {}).get("test"):
+                          continue
+                      executable = message.get("executable")
+                      if not executable or executable in seen:
+                          continue
+                      seen.add(executable)
+                      print(executable, file=output)
+
+          if not seen:
+              raise SystemExit("cargo did not report any test binaries")
+          print(f"Collected {len(seen)} test binaries", file=sys.stderr)
+          PY
+
+      - name: Run test binaries under valgrind
+        working-directory: mux
+        run: |
+          while IFS= read -r bin; do
+            [ -n "$bin" ] || continue
+            echo "Running valgrind for $bin"
+            if ! valgrind \
+              --error-exitcode=1 \
+              --leak-check=full \
+              --show-leak-kinds=definite \
+              --errors-for-leak-kinds=definite \
+              --track-origins=yes \
+              -- "$bin"; then
+              echo "Valgrind failed for $bin" >&2
+              exit 1
+            fi
+          done < target/valgrind-test-binaries.txt
+
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os == 'macos' && (vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15') || 'ubuntu-latest' }}

--- a/.github/workflows/mux.yml
+++ b/.github/workflows/mux.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   valgrind-leak-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/mux/crates/ghostty-vt-sys/build.rs
+++ b/mux/crates/ghostty-vt-sys/build.rs
@@ -23,6 +23,7 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed=CMUX_GHOSTTY_SRC");
     println!("cargo:rerun-if-env-changed=ZIG");
+    println!("cargo:rerun-if-env-changed=CMUX_GHOSTTY_VT_ZIG_CPU");
     println!("cargo:rerun-if-changed={}", ghostty_dir.join("include").display());
     println!("cargo:rerun-if-changed={}", ghostty_dir.join("build.zig").display());
     println!("cargo:rerun-if-changed={}", ghostty_dir.join("src").display());
@@ -45,6 +46,14 @@ fn main() {
         if let Some(zig_target) = zig_target_for_rust_target(&target) {
             command.arg(format!("-Dtarget={zig_target}"));
         }
+    }
+    // Valgrind's instruction emulation doesn't cover every CPU-native SIMD
+    // extension zig's default target detection can select (e.g. some AVX-512
+    // variants), which SIGILLs under valgrind. CI's valgrind job sets this to
+    // "baseline" to match the same workaround ghostty's own build.zig uses
+    // for its valgrind step (see `Config.baselineTarget()`).
+    if let Ok(cpu) = env::var("CMUX_GHOSTTY_VT_ZIG_CPU") {
+        command.arg(format!("-Dcpu={cpu}"));
     }
     let status = command.arg("--prefix").arg(&prefix).status().unwrap_or_else(|e| {
         panic!("failed to run `{zig} build` in {}: {e}", ghostty_dir.display())

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -73,10 +73,16 @@ use_existing_zig_if_available() {
 use_existing_zig_if_available
 
 case "$(uname -s)" in
-  Darwin) ZIG_OS="macos" ;;
-  Linux) ZIG_OS="linux" ;;
+  Darwin)
+    ZIG_OS="macos"
+    ZIG_UNSUPPORTED_OS="macOS"
+    ;;
+  Linux)
+    ZIG_OS="linux"
+    ZIG_UNSUPPORTED_OS="Linux"
+    ;;
   *)
-    echo "Unsupported OS for Zig install: $(uname -s)" >&2
+    echo "Unsupported operating system: $(uname -s)" >&2
     exit 1
     ;;
 esac
@@ -85,7 +91,7 @@ case "$(uname -m)" in
   arm64 | aarch64) ZIG_ARCH="aarch64" ;;
   x86_64) ZIG_ARCH="x86_64" ;;
   *)
-    echo "Unsupported architecture for Zig install: $(uname -m)" >&2
+    echo "Unsupported ${ZIG_UNSUPPORTED_OS} architecture: $(uname -m)" >&2
     exit 1
     ;;
 esac
@@ -152,10 +158,10 @@ PY
 
 verify_zig_sha256() {
   local expected_sha256="$1"
-  if command -v shasum >/dev/null 2>&1; then
-    printf '%s  %s\n' "$expected_sha256" "$ZIG_TAR" | shasum -a 256 -c -
-  else
+  if [ "$ZIG_OS" = "linux" ]; then
     printf '%s  %s\n' "$expected_sha256" "$ZIG_TAR" | sha256sum -c -
+  else
+    printf '%s  %s\n' "$expected_sha256" "$ZIG_TAR" | shasum -a 256 -c -
   fi
 }
 

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -49,7 +49,7 @@ case "$(uname -s)" in
   Darwin) ZIG_OS="macos" ;;
   Linux) ZIG_OS="linux" ;;
   *)
-    echo "Unsupported test OS: $(uname -s)" >&2
+    echo "Unsupported test operating system: $(uname -s)" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
- Adds a `valgrind-leak-check` job (ubuntu-latest) that builds mux's cargo test binaries and runs each under `valgrind --leak-check=full`, gated only on "definitely lost" memory (`--show-leak-kinds=definite --errors-for-leak-kinds=definite --error-exitcode=1`).
- Makes `scripts/install-zig-ci.sh` OS-aware (Darwin/Linux) so the new job installs the same pinned zig version via the same verified checksum flow the existing macOS job uses. macOS behavior is unchanged.

## Why no macOS `leaks` leg
Evaluated wrapping the existing PTY smoke tests (`smoke-tui.py`/`smoke-attach.py`) with macOS's `leaks --atExit --`, and dropped it after confirming three independent blockers:
- Its exit code is always 0 regardless of outcome (confirmed even with a deliberately-leaking test binary).
- It requires the target binary to carry a `get-task-allow` entitlement or it silently reports 0 leaks even on a real leak (false-negative trap).
- It only produces a report when the launched process never re-execs. The smoke tests reach `cmux-mux` via `pty.fork()` + `os.execv()`, which breaks it — and `cmux-mux` unconditionally calls `enable_raw_mode()` so it needs a real controlling tty, ruling out a non-PTY invocation too.

Linux valgrind gives deep, precise coverage of the FFI boundary (`ghostty-vt-sys` links a Zig-built C library) without any of those failure modes.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy --workspace --all-targets --locked -- -D warnings` pass locally in `mux/`
- [x] `bash -n scripts/install-zig-ci.sh` and YAML parse of `mux.yml` pass
- [ ] First real CI run confirms the Linux job builds, discovers test binaries, and valgrind completes within the 40-minute timeout

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785910914&installation_id=133855650&pr_number=7447&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7447&signature=e13540b8b76f12d5ea701e7d56f5e4a3b5de34e72d0f07b9e0fa505087ebfbb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and optional build-script env wiring only; no runtime mux behavior change unless CMUX_GHOSTTY_VT_ZIG_CPU is set.
> 
> **Overview**
> Adds a **`valgrind-leak-check`** job to the mux workflow on Linux: it installs valgrind and pinned zig, builds all workspace test binaries with `cargo test --no-run`, collects executables from Cargo JSON output, and runs each under valgrind with **definite-leak** failures only (`--errors-for-leak-kinds=definite --error-exitcode=1`).
> 
> The valgrind build sets **`CMUX_GHOSTTY_VT_ZIG_CPU=baseline`** so `ghostty-vt-sys` passes `-Dcpu=baseline` to zig and avoids SIMD instructions valgrind cannot emulate (SIGILL). `build.rs` now watches that env var for rebuilds.
> 
> **`install-zig-ci.sh`** is extended for Linux alongside macOS: OS-specific unsupported messages, **`sha256sum`** on Linux vs **`shasum`** on Darwin. The no-sudo install test fixture picks **`linux`** vs **`macos`** from the host OS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b691c43088b46f339c9959f05be66b0ec1c7c20b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Linux CI job that runs all mux test binaries under `valgrind` and fails on definite leaks. Also makes the `zig` installer Linux-aware and allows forcing a baseline CPU for `ghostty-vt-sys` during leak checks to avoid unsupported SIMD.

- **New Features**
  - Adds `valgrind-leak-check` on a self-hosted Linux runner (`vars.LINUX_RUNNER` or `'blacksmith-4vcpu-ubuntu-2404'`) with a 40-minute timeout.
  - Builds workspace tests once and runs each binary under `valgrind` (`--leak-check=full --show-leak-kinds=definite --errors-for-leak-kinds=definite --track-origins=yes --error-exitcode=1`).
  - Skips macOS `leaks` due to unreliable exit codes and re-exec/entitlement issues.

- **Refactors**
  - `ghostty-vt-sys/build.rs` now accepts `CMUX_GHOSTTY_VT_ZIG_CPU` and forwards `-Dcpu=<value>` to `zig`; CI sets `baseline` to prevent `valgrind` SIGILL on unsupported SIMD.
  - `scripts/install-zig-ci.sh` supports Linux and macOS with the correct checksum tool (`sha256sum` on Linux, `shasum` on macOS); test updated to detect the host OS.

<sup>Written for commit b691c43088b46f339c9959f05be66b0ec1c7c20b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated leak-checking in CI to catch memory issues in test executables before merge.
* **Bug Fixes**
  * Improved build configuration so the native tooling can target a specific CPU variant when needed.
  * Updated platform detection and checksum verification behavior for more reliable installer runs across Linux and non-Linux systems.
* **Chores**
  * Refined test messaging for clearer unsupported-platform feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->