### PR TITLE
Add dashboard billing section with plan cancel and resume

### DIFF
--- a/skills/cmux-billing/SKILL.md
+++ b/skills/cmux-billing/SKILL.md
@@ -11,6 +11,7 @@ Use this skill before changing billing, pricing, Stripe, Pro entitlement, checko
 
 - `/api/billing/checkout` creates Stripe Checkout Sessions for Pro when `STRIPE_SECRET_KEY` is set. It sets `client_reference_id` to the Stack user id, auto-creates an anonymous Stack user for signed-out buyers, and falls back to the legacy Stack purchase path when Stripe is unset or `plan=team`.
 - `/api/billing/portal` resolves the current Stack user, looks up their `stripe_customers` row, and creates a Stripe customer portal session returning to `/pricing`.
+- `/api/billing/subscription` cancels or resumes the current user's active Stripe Pro subscription, and `/dashboard/billing` renders localized in-dashboard plan state and self-serve billing actions.
 - `web/services/billing/purchase.ts` is the shared idempotent recorder used by both `/api/billing/complete` and `/api/stripe/webhook`. It attaches email to the purchaser, records `billing_email_claims` on conflict, and never cross-grants based on an unverified email.
 - `cmuxPlan` in Stack `clientReadOnlyMetadata` is the only entitlement VM code reads. `cmuxVmPlan` manual override wins.
 - `resolveProPlanStatus` ORs legacy Stack products with active `stripe_subscriptions` DB rows.

--- a/web/app/[locale]/dashboard/billing/page.tsx
+++ b/web/app/[locale]/dashboard/billing/page.tsx
@@ -1,0 +1,266 @@
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
+import { cloudDb } from "@/db/client";
+import { stripeCustomers, stripeSubscriptions } from "@/db/schema";
+import { Link } from "@/i18n/navigation";
+import {
+  ACTIVE_STRIPE_PRO_STATUSES,
+  PRO_PLAN_ID,
+  resolveProPlanStatus,
+} from "@/services/billing/pro";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = {
+  billing?: string | string[];
+};
+
+type StripeSubscriptionRow = {
+  id: string;
+  status: string;
+  priceId: string | null;
+  currentPeriodEnd: Date | null;
+  cancelAtPeriodEnd: boolean;
+  raw: Record<string, unknown> | null;
+};
+
+export default async function DashboardBillingPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>;
+  searchParams?: Promise<SearchParams>;
+}) {
+  const { locale } = await params;
+  const query = await searchParams;
+
+  if (!isStackConfigured()) {
+    redirect("/");
+  }
+  const user = await getStackServerApp().getUser({ or: "return-null" });
+  if (!user) {
+    redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard/billing")));
+  }
+
+  const t = await getTranslations({ locale, namespace: "dashboard.billing" });
+  const status = await resolveProPlanStatus(user);
+  const [subscription, hasStripeCustomer] = await Promise.all([
+    latestActiveStripeSubscription(user.id),
+    hasCustomerRow(user.id),
+  ]);
+  const banner = billingBanner(Array.isArray(query?.billing) ? query?.billing[0] : query?.billing);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-3 py-4">
+      <div className="mb-4 border-b border-border pb-3">
+        <p className="text-xs font-medium text-muted">{t("eyebrow")}</p>
+        <h1 className="mt-1 text-sm font-medium">{t("title")}</h1>
+        <p className="mt-1 max-w-2xl text-muted">{t("description")}</p>
+      </div>
+
+      {banner ? (
+        <div className="mb-3 border border-border bg-background p-3 text-sm">
+          {t(`banners.${banner}`)}
+        </div>
+      ) : null}
+
+      {!status.isPro ? (
+        <FreePlan t={t} />
+      ) : subscription ? (
+        <StripePlan
+          t={t}
+          locale={locale}
+          subscription={subscription}
+          canManageBilling={hasStripeCustomer}
+        />
+      ) : (
+        <LegacyPlan t={t} />
+      )}
+    </div>
+  );
+}
+
+async function latestActiveStripeSubscription(stackUserId: string): Promise<StripeSubscriptionRow | null> {
+  const rows = await cloudDb()
+    .select({
+      id: stripeSubscriptions.id,
+      status: stripeSubscriptions.status,
+      priceId: stripeSubscriptions.priceId,
+      currentPeriodEnd: stripeSubscriptions.currentPeriodEnd,
+      cancelAtPeriodEnd: stripeSubscriptions.cancelAtPeriodEnd,
+      raw: stripeSubscriptions.raw,
+    })
+    .from(stripeSubscriptions)
+    .where(
+      and(
+        eq(stripeSubscriptions.stackUserId, stackUserId),
+        eq(stripeSubscriptions.plan, PRO_PLAN_ID),
+        inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES),
+      ),
+    )
+    .orderBy(desc(stripeSubscriptions.currentPeriodEnd), desc(stripeSubscriptions.updatedAt))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+async function hasCustomerRow(stackUserId: string): Promise<boolean> {
+  const rows = await cloudDb()
+    .select({ id: stripeCustomers.id })
+    .from(stripeCustomers)
+    .where(eq(stripeCustomers.stackUserId, stackUserId))
+    .limit(1);
+  return rows.length > 0;
+}
+
+function FreePlan({ t }: { t: Awaited<ReturnType<typeof getTranslations>> }) {
+  return (
+    <section className="border border-border p-3">
+      <h2 className="text-sm font-medium">{t("free.name")}</h2>
+      <p className="mt-2 max-w-2xl text-muted">{t("free.body")}</p>
+      <Link
+        href="/pricing"
+        className="mt-3 inline-block border border-border bg-background px-3 py-1.5 text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground hover:bg-foreground hover:text-background"
+      >
+        {t("actions.viewPricing")}
+      </Link>
+    </section>
+  );
+}
+
+function StripePlan({
+  t,
+  locale,
+  subscription,
+  canManageBilling,
+}: {
+  t: Awaited<ReturnType<typeof getTranslations>>;
+  locale: string;
+  subscription: StripeSubscriptionRow;
+  canManageBilling: boolean;
+}) {
+  const price = priceCopy(subscription);
+  const periodDate = subscription.currentPeriodEnd
+    ? formatBillingDate(subscription.currentPeriodEnd, locale)
+    : t("dates.unknown");
+
+  return (
+    <section className="border border-border p-3">
+      <h2 className="text-sm font-medium">{t("pro.name")}</h2>
+      <p className="mt-2 max-w-2xl text-muted">
+        {subscription.cancelAtPeriodEnd
+          ? t("pro.pendingBody", { date: periodDate })
+          : t("pro.activeBody", { date: periodDate })}
+      </p>
+
+      <div className="mt-4 grid border border-border sm:grid-cols-2">
+        <BillingMetric
+          label={subscription.cancelAtPeriodEnd ? t("details.endsOn") : t("details.renewsOn")}
+          value={periodDate}
+        />
+        {price ? <BillingMetric label={t("details.price")} value={price} /> : null}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-start gap-2">
+        {subscription.cancelAtPeriodEnd ? (
+          <form method="post" action="/api/billing/subscription">
+            <input type="hidden" name="action" value="resume" />
+            <button
+              type="submit"
+              className="border border-border bg-foreground px-3 py-1.5 text-background focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground"
+            >
+              {t("actions.resume")}
+            </button>
+          </form>
+        ) : (
+          <details className="border border-border px-3 py-1.5">
+            <summary className="cursor-pointer text-foreground">{t("actions.cancelSummary")}</summary>
+            <form method="post" action="/api/billing/subscription" className="mt-3 max-w-md">
+              <input type="hidden" name="action" value="cancel" />
+              <p className="text-muted">{t("cancel.body", { date: periodDate })}</p>
+              <label className="mt-3 flex items-start gap-2 text-muted">
+                <input
+                  required
+                  type="checkbox"
+                  name="confirm"
+                  value="yes"
+                  className="mt-0.5"
+                />
+                <span>{t("cancel.checkbox")}</span>
+              </label>
+              <button
+                type="submit"
+                className="mt-3 border border-border bg-background px-3 py-1.5 text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground hover:bg-foreground hover:text-background"
+              >
+                {t("actions.confirmCancel")}
+              </button>
+            </form>
+          </details>
+        )}
+
+        {canManageBilling ? (
+          <a
+            href="/api/billing/portal"
+            className="border border-border bg-background px-3 py-1.5 text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground hover:bg-foreground hover:text-background"
+          >
+            {t("actions.manageBilling")}
+          </a>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function LegacyPlan({ t }: { t: Awaited<ReturnType<typeof getTranslations>> }) {
+  return (
+    <section className="border border-border p-3">
+      <h2 className="text-sm font-medium">{t("pro.name")}</h2>
+      <p className="mt-2 max-w-2xl text-muted">{t("legacy.body")}</p>
+    </section>
+  );
+}
+
+function BillingMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border-b border-border p-3 sm:border-b-0 sm:border-r">
+      <p className="text-xs text-muted">{label}</p>
+      <p className="mt-2 font-mono text-xs tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function billingBanner(value: string | undefined) {
+  return value === "cancelled" || value === "resumed" || value === "nosub" || value === "error"
+    ? value
+    : null;
+}
+
+function priceCopy(subscription: StripeSubscriptionRow): string | null {
+  const lookupKey = priceLookupKey(subscription) ?? subscription.priceId;
+  if (lookupKey === "cmux-pro-monthly") return "$30/month";
+  if (lookupKey === "cmux-pro-yearly") return "$240/year";
+  return null;
+}
+
+function priceLookupKey(subscription: StripeSubscriptionRow): string | null {
+  const raw = subscription.raw;
+  const items = raw && typeof raw === "object" ? raw.items : null;
+  const data = items && typeof items === "object" && "data" in items
+    ? (items as { data?: unknown }).data
+    : null;
+  const firstItem = Array.isArray(data) ? data[0] : null;
+  const price = firstItem && typeof firstItem === "object" && "price" in firstItem
+    ? (firstItem as { price?: unknown }).price
+    : null;
+  const lookupKey = price && typeof price === "object" && "lookup_key" in price
+    ? (price as { lookup_key?: unknown }).lookup_key
+    : null;
+  return typeof lookupKey === "string" ? lookupKey : null;
+}
+
+function formatBillingDate(date: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale, { dateStyle: "medium" }).format(date);
+}

--- a/web/app/[locale]/dashboard/dashboard-shell.tsx
+++ b/web/app/[locale]/dashboard/dashboard-shell.tsx
@@ -39,6 +39,16 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
         },
       ],
     },
+    {
+      label: t("accountGroup"),
+      items: [
+        {
+          href: "/dashboard/billing",
+          label: t("billing"),
+          active: pathname.startsWith("/dashboard/billing"),
+        },
+      ],
+    },
   ];
 
   return (

--- a/web/app/api/billing/subscription/route.ts
+++ b/web/app/api/billing/subscription/route.ts
@@ -1,0 +1,150 @@
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
+
+import { cloudDb } from "../../../../db/client";
+import { stripeSubscriptions } from "../../../../db/schema";
+import { localizedVaultPath, vaultSignInHref } from "../../../lib/vault-auth";
+import { getStackServerApp, isStackConfigured } from "../../../lib/stack";
+import { locales, routing } from "../../../../i18n/routing";
+import {
+  ACTIVE_STRIPE_PRO_STATUSES,
+  PRO_PLAN_ID,
+} from "../../../../services/billing/pro";
+import {
+  isStripeBillingConfigured,
+  stripe,
+} from "../../../../services/billing/stripe";
+import { captureBillingError } from "../../../../services/errors";
+import { browserMutationOriginAllowed } from "../../../../services/vms/routeHelpers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const ANONYMOUS_IF_EXISTS = "anonymous-if-exists[deprecated]" as const;
+type SubscriptionAction = "cancel" | "resume";
+
+export async function POST(request: NextRequest) {
+  let stackUserId: string | undefined;
+  let action: SubscriptionAction | null = null;
+
+  if (!browserMutationOriginAllowed(request)) {
+    return billingRedirect(request, "error");
+  }
+
+  try {
+    action = subscriptionAction(await request.formData());
+    if (!action) {
+      return billingRedirect(request, "error");
+    }
+
+    if (!isStackConfigured()) {
+      throw new Error("Billing subscription management is not configured");
+    }
+
+    const user = await currentStackUser();
+    if (!user) {
+      return NextResponse.redirect(
+        new URL(vaultSignInHref(localizedVaultPath(requestLocale(request), "/dashboard/billing")), request.url),
+        303,
+      );
+    }
+    stackUserId = user.id;
+
+    if (!isStripeBillingConfigured()) {
+      throw new Error("Billing subscription management is not configured");
+    }
+
+    const subscription = await activeStripeSubscriptionForStackUser(user.id);
+    if (!subscription) {
+      return billingRedirect(request, "nosub");
+    }
+
+    const updated = await stripe().subscriptions.update(subscription.id, {
+      cancel_at_period_end: action === "cancel",
+    });
+    await updateSubscriptionSnapshot(subscription.id, updated);
+
+    return billingRedirect(request, action === "cancel" ? "cancelled" : "resumed");
+  } catch (error) {
+    captureBillingError(error, {
+      route: "/api/billing/subscription",
+      stackUserId,
+      action,
+    });
+    return billingRedirect(request, "error");
+  }
+}
+
+async function currentStackUser() {
+  const stackServerApp = getStackServerApp();
+  return (
+    (await stackServerApp.getUser({ or: "return-null" })) ??
+    (await stackServerApp.getUser({ or: ANONYMOUS_IF_EXISTS }))
+  );
+}
+
+function subscriptionAction(formData: FormData): SubscriptionAction | null {
+  const action = formData.get("action");
+  return action === "cancel" || action === "resume" ? action : null;
+}
+
+async function activeStripeSubscriptionForStackUser(stackUserId: string) {
+  const rows = await cloudDb()
+    .select({ id: stripeSubscriptions.id })
+    .from(stripeSubscriptions)
+    .where(
+      and(
+        eq(stripeSubscriptions.stackUserId, stackUserId),
+        eq(stripeSubscriptions.plan, PRO_PLAN_ID),
+        inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES),
+      ),
+    )
+    .orderBy(desc(stripeSubscriptions.currentPeriodEnd), desc(stripeSubscriptions.updatedAt))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+async function updateSubscriptionSnapshot(
+  subscriptionId: string,
+  subscription: { cancel_at_period_end?: boolean },
+) {
+  await cloudDb()
+    .update(stripeSubscriptions)
+    .set({
+      cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),
+      raw: JSON.parse(JSON.stringify(subscription)) as Record<string, unknown>,
+      updatedAt: sql`now()`,
+    })
+    .where(eq(stripeSubscriptions.id, subscriptionId));
+}
+
+function billingRedirect(
+  request: NextRequest,
+  billing: "cancelled" | "resumed" | "nosub" | "error",
+) {
+  const url = new URL(localizedBillingPath(request), request.url);
+  url.searchParams.set("billing", billing);
+  return NextResponse.redirect(url, 303);
+}
+
+function localizedBillingPath(request: NextRequest): string {
+  const locale = requestLocale(request);
+  return locale === routing.defaultLocale
+    ? "/dashboard/billing"
+    : `/${locale}/dashboard/billing`;
+}
+
+function requestLocale(request: NextRequest): string {
+  const referer = request.headers.get("referer");
+  if (referer) {
+    try {
+      const firstSegment = new URL(referer).pathname.split("/").filter(Boolean)[0];
+      if (locales.includes(firstSegment as (typeof locales)[number])) {
+        return firstSegment;
+      }
+    } catch {
+      // Ignore malformed referers and fall back to the default locale.
+    }
+  }
+  return routing.defaultLocale;
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -51,7 +51,9 @@
       "vaultSessions": "sessions",
       "vaultCliSetup": "cli setup",
       "subrouterGroup": "subrouter",
-      "subrouterOverview": "overview"
+      "subrouterOverview": "overview",
+      "accountGroup": "account",
+      "billing": "billing"
     },
     "home": {
       "title": "dashboard",
@@ -66,6 +68,48 @@
     "subrouter": {
       "title": "subrouter",
       "description": "subrouter routes llm requests across provider accounts with failover and usage-aware scheduling."
+    },
+    "billing": {
+      "eyebrow": "account",
+      "title": "billing",
+      "description": "review your cmux plan and manage subscription billing.",
+      "banners": {
+        "cancelled": "Your plan will cancel at the end of the current billing period.",
+        "resumed": "Your plan has been resumed and will renew normally.",
+        "nosub": "No active Stripe subscription was found for this account.",
+        "error": "Billing could not be updated. Try again shortly."
+      },
+      "free": {
+        "name": "Free",
+        "body": "You are currently on the Free plan. Upgrade when you need Pro limits and hosted features."
+      },
+      "pro": {
+        "name": "cmux Pro",
+        "activeBody": "Your plan renews on {date}.",
+        "pendingBody": "Your plan is scheduled to end on {date}."
+      },
+      "legacy": {
+        "body": "You have cmux Pro through a legacy Stack subscription. This plan is managed outside Stripe self-serve billing."
+      },
+      "details": {
+        "renewsOn": "Renews on",
+        "endsOn": "Ends on",
+        "price": "Price"
+      },
+      "dates": {
+        "unknown": "unknown"
+      },
+      "cancel": {
+        "body": "Your Pro access remains active until {date}. Check the box to confirm cancellation at period end.",
+        "checkbox": "I understand my plan will end at the current period end."
+      },
+      "actions": {
+        "viewPricing": "View pricing",
+        "manageBilling": "Manage billing",
+        "cancelSummary": "Cancel plan",
+        "confirmCancel": "Confirm cancellation",
+        "resume": "Resume plan"
+      }
     },
     "aiAccounts": {
       "metaTitle": "AI accounts — cmux",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -51,7 +51,9 @@
       "vaultSessions": "セッション",
       "vaultCliSetup": "CLI設定",
       "subrouterGroup": "subrouter",
-      "subrouterOverview": "概要"
+      "subrouterOverview": "概要",
+      "accountGroup": "アカウント",
+      "billing": "請求"
     },
     "home": {
       "title": "ダッシュボード",
@@ -66,6 +68,48 @@
     "subrouter": {
       "title": "subrouter",
       "description": "subrouterはプロバイダーアカウント間でLLMリクエストをルーティングし、フェイルオーバーと使用量を考慮したスケジューリングを行います。"
+    },
+    "billing": {
+      "eyebrow": "アカウント",
+      "title": "請求",
+      "description": "cmuxプランを確認し、サブスクリプション請求を管理します。",
+      "banners": {
+        "cancelled": "現在の請求期間の終了時にプランがキャンセルされます。",
+        "resumed": "プランは再開され、通常どおり更新されます。",
+        "nosub": "このアカウントに有効なStripeサブスクリプションは見つかりませんでした。",
+        "error": "請求を更新できませんでした。しばらくしてから再試行してください。"
+      },
+      "free": {
+        "name": "Free",
+        "body": "現在はFreeプランです。Proの上限やホスト型機能が必要になったらアップグレードしてください。"
+      },
+      "pro": {
+        "name": "cmux Pro",
+        "activeBody": "プランは{date}に更新されます。",
+        "pendingBody": "プランは{date}に終了する予定です。"
+      },
+      "legacy": {
+        "body": "cmux Proは従来のStackサブスクリプションで提供されています。このプランはStripeセルフサービス請求の対象外で管理されています。"
+      },
+      "details": {
+        "renewsOn": "更新日",
+        "endsOn": "終了日",
+        "price": "料金"
+      },
+      "dates": {
+        "unknown": "不明"
+      },
+      "cancel": {
+        "body": "Proアクセスは{date}まで有効です。請求期間の終了時にキャンセルすることを確認するには、チェックボックスを選択してください。",
+        "checkbox": "現在の請求期間の終了時にプランが終了することを理解しました。"
+      },
+      "actions": {
+        "viewPricing": "料金を見る",
+        "manageBilling": "請求を管理",
+        "cancelSummary": "プランをキャンセル",
+        "confirmCancel": "キャンセルを確定",
+        "resume": "プランを再開"
+      }
     },
     "aiAccounts": {
       "metaTitle": "AIアカウント — cmux",

--- a/web/tests/billing-subscription-route.test.ts
+++ b/web/tests/billing-subscription-route.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+// Capture real implementations BY VALUE before mocking. bun's mock.module can
+// mutate an already-loaded namespace in place, so delegating through copied
+// function references avoids recursive mocks.
+const dbClientModule = await import("../db/client");
+const realCloseCloudDbForTests = dbClientModule.closeCloudDbForTests;
+const realCreateAwsRdsIamPool = dbClientModule.createAwsRdsIamPool;
+
+const stripeModule = await import("../services/billing/stripe");
+
+const signedInUser = {
+  id: "user-pro",
+  isAnonymous: false,
+};
+const anonymousUser = {
+  id: "anonymous-pro",
+  isAnonymous: true,
+};
+
+let stackConfigured = true;
+let stripeConfigured = true;
+let returnNullUser: unknown = signedInUser;
+let anonymousIfExistsUser: unknown = null;
+let subscriptionRows: { id: string }[] = [{ id: "sub_123" }];
+const dbUpdates: Array<{ values: Record<string, unknown> }> = [];
+
+const getUser = mock(async (options?: unknown) => {
+  const or =
+    options && typeof options === "object" && "or" in options
+      ? (options.or as unknown)
+      : undefined;
+  if (or === "anonymous-if-exists[deprecated]") {
+    return anonymousIfExistsUser;
+  }
+  return returnNullUser;
+});
+
+const updateSubscription = mock(stripeSubscriptionUpdateResult);
+const captureBillingError = mock(() => undefined);
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => stackConfigured,
+  stackServerApp: stackConfigured ? { getUser } : null,
+}));
+
+mock.module("../db/client", () => ({
+  createAwsRdsIamPool: realCreateAwsRdsIamPool,
+  closeCloudDbForTests: realCloseCloudDbForTests,
+  cloudDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: mock(async () => subscriptionRows),
+          }),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => {
+          dbUpdates.push({ values });
+          return Promise.resolve();
+        },
+      }),
+    }),
+  }),
+}));
+
+mock.module("../services/billing/stripe", () => ({
+  ...stripeModule,
+  isStripeBillingConfigured: () => stripeConfigured,
+  stripe: () => ({
+    subscriptions: {
+      update: updateSubscription,
+    },
+  }),
+}));
+
+mock.module("../services/errors", () => ({
+  captureBillingError,
+}));
+
+const { POST } = await import("../app/api/billing/subscription/route");
+
+describe("billing subscription route", () => {
+  beforeEach(() => {
+    stackConfigured = true;
+    stripeConfigured = true;
+    returnNullUser = signedInUser;
+    anonymousIfExistsUser = null;
+    subscriptionRows = [{ id: "sub_123" }];
+    dbUpdates.length = 0;
+    getUser.mockClear();
+    updateSubscription.mockClear();
+    mockImplementation(updateSubscription, stripeSubscriptionUpdateResult);
+    captureBillingError.mockClear();
+  });
+
+  test("cancels the current user's active subscription at period end from a same-origin form post", async () => {
+    const response = await postAction("cancel");
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/billing?billing=cancelled",
+    );
+    expect(updateSubscription).toHaveBeenCalledWith("sub_123", {
+      cancel_at_period_end: true,
+    });
+    expect(dbUpdates).toHaveLength(1);
+    expect(dbUpdates[0].values.cancelAtPeriodEnd).toBe(true);
+    expect(dbUpdates[0].values.raw).toMatchObject({
+      id: "sub_123",
+      cancel_at_period_end: true,
+    });
+  });
+
+  test("rejects cross-site form posts before auth, Stripe, or DB writes", async () => {
+    const response = await postAction("cancel", {
+      origin: "https://evil.example",
+      secFetchSite: "cross-site",
+    });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/billing?billing=error",
+    );
+    expect(getUser).not.toHaveBeenCalled();
+    expect(updateSubscription).not.toHaveBeenCalled();
+    expect(dbUpdates).toHaveLength(0);
+    expect(captureBillingError).not.toHaveBeenCalled();
+  });
+
+  test("redirects junk actions to the error banner without Stripe or DB writes", async () => {
+    const response = await postAction("garbage");
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/billing?billing=error",
+    );
+    expect(getUser).not.toHaveBeenCalled();
+    expect(updateSubscription).not.toHaveBeenCalled();
+    expect(dbUpdates).toHaveLength(0);
+    expect(captureBillingError).not.toHaveBeenCalled();
+  });
+
+  test("resumes a pending cancellation", async () => {
+    const response = await postAction("resume");
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/billing?billing=resumed",
+    );
+    expect(updateSubscription).toHaveBeenCalledWith("sub_123", {
+      cancel_at_period_end: false,
+    });
+    expect(dbUpdates[0].values.cancelAtPeriodEnd).toBe(false);
+  });
+
+  test("redirects unauthenticated users to the localized dashboard sign-in path", async () => {
+    returnNullUser = null;
+    anonymousIfExistsUser = null;
+
+    const response = await postAction("cancel", {
+      referer: "https://cmux.test/ja/dashboard/billing",
+    });
+    const location = new URL(response.headers.get("location")!);
+    const afterSignIn = new URL(
+      location.searchParams.get("after_auth_return_to")!,
+      "https://cmux.test",
+    );
+
+    expect(response.status).toBe(303);
+    expect(location.pathname).toBe("/handler/sign-in");
+    expect(afterSignIn.pathname).toBe("/handler/after-sign-in");
+    expect(afterSignIn.searchParams.get("after_auth_return_to")).toBe(
+      "/ja/dashboard/billing",
+    );
+    expect(updateSubscription).not.toHaveBeenCalled();
+  });
+
+  test("falls back to an existing anonymous purchaser", async () => {
+    returnNullUser = null;
+    anonymousIfExistsUser = anonymousUser;
+    subscriptionRows = [{ id: "sub_anonymous" }];
+
+    const response = await postAction("cancel");
+
+    expect(response.status).toBe(303);
+    expect(getUser).toHaveBeenCalledTimes(2);
+    expect(getUser).toHaveBeenCalledWith({ or: "return-null" });
+    expect(getUser).toHaveBeenCalledWith({ or: "anonymous-if-exists[deprecated]" });
+    expect(updateSubscription).toHaveBeenCalledWith("sub_anonymous", {
+      cancel_at_period_end: true,
+    });
+  });
+
+  test("redirects back with nosub when no active Stripe subscription exists", async () => {
+    subscriptionRows = [];
+
+    const response = await postAction("cancel");
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/billing?billing=nosub",
+    );
+    expect(updateSubscription).not.toHaveBeenCalled();
+    expect(captureBillingError).not.toHaveBeenCalled();
+  });
+
+  test("captures Stripe failures and redirects back with an error banner", async () => {
+    mockImplementation(updateSubscription, async () => {
+      throw new Error("stripe down");
+    });
+
+    const response = await postAction("cancel");
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/billing?billing=error",
+    );
+    expect(captureBillingError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "stripe down" }),
+      expect.objectContaining({
+        route: "/api/billing/subscription",
+        stackUserId: "user-pro",
+        action: "cancel",
+      }),
+    );
+  });
+});
+
+function postAction(
+  action: string,
+  options: {
+    referer?: string;
+    origin?: string;
+    secFetchSite?: string;
+  } = {},
+) {
+  const headers = new Headers({
+    "content-type": "application/x-www-form-urlencoded",
+    origin: options.origin ?? "https://cmux.test",
+    referer: options.referer ?? "https://cmux.test/dashboard/billing",
+  });
+  if (options.secFetchSite) {
+    headers.set("sec-fetch-site", options.secFetchSite);
+  }
+
+  return POST(
+    new NextRequest("https://cmux.test/api/billing/subscription", {
+      method: "POST",
+      headers,
+      body: new URLSearchParams({ action }),
+    }),
+  );
+}
+
+function mockImplementation(
+  fn: unknown,
+  implementation: (...args: unknown[]) => unknown,
+) {
+  (fn as { mockImplementation(next: typeof implementation): void }).mockImplementation(
+    implementation,
+  );
+}
+
+async function stripeSubscriptionUpdateResult(id: unknown, params: unknown) {
+  const updateParams = params as Record<string, unknown>;
+  return {
+    id,
+    status: "active",
+    customer: "cus_123",
+    cancel_at_period_end: updateParams.cancel_at_period_end,
+    items: { data: [] },
+  };
+}

--- a/web/tests/dashboard-billing-page.test.tsx
+++ b/web/tests/dashboard-billing-page.test.tsx
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { stripeCustomers, stripeSubscriptions } from "../db/schema";
+import enMessages from "../messages/en.json";
+
+const dbClientModule = await import("../db/client");
+const realCloseCloudDbForTests = dbClientModule.closeCloudDbForTests;
+const realCreateAwsRdsIamPool = dbClientModule.createAwsRdsIamPool;
+
+let stackConfigured = true;
+let currentUser: typeof proUser | null = null;
+let stackProductsActive = false;
+let subscriptionRows: Array<Record<string, unknown>> = [];
+let customerRows: Array<Record<string, unknown>> = [];
+
+const proUser = {
+  id: "user-pro",
+  isAnonymous: false,
+  primaryEmail: "pro@example.com",
+  clientReadOnlyMetadata: {},
+  listProducts: mock(async () =>
+    Object.assign(
+      stackProductsActive
+        ? [
+            {
+              id: "pro",
+              quantity: 1,
+              subscription: {
+                cancelAtPeriodEnd: false,
+                currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
+              },
+            },
+          ]
+        : [],
+      { nextCursor: null },
+    ),
+  ),
+  update: mock(async () => undefined),
+};
+
+mock.module("next-intl/server", () => ({
+  getTranslations: async (input?: string | { namespace?: string }) =>
+    translator(typeof input === "string" ? input : input?.namespace),
+  setRequestLocale: () => undefined,
+}));
+
+mock.module("@/i18n/navigation", () => ({
+  Link: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  redirect: () => undefined,
+  usePathname: () => "/dashboard/billing",
+  useRouter: () => ({}),
+  getPathname: () => "/dashboard/billing",
+}));
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser: async () => currentUser }),
+  isStackConfigured: () => stackConfigured,
+  stackServerApp: stackConfigured ? { getUser: async () => currentUser } : null,
+}));
+
+mock.module("../db/client", () => ({
+  createAwsRdsIamPool: realCreateAwsRdsIamPool,
+  closeCloudDbForTests: realCloseCloudDbForTests,
+  cloudDb: () => ({
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => selectableResult(table),
+      }),
+    }),
+  }),
+}));
+
+const { default: DashboardBillingPage } = await import("../app/[locale]/dashboard/billing/page");
+
+describe("dashboard billing page", () => {
+  beforeEach(() => {
+    stackConfigured = true;
+    currentUser = proUser;
+    stackProductsActive = false;
+    subscriptionRows = [];
+    customerRows = [];
+    proUser.listProducts.mockClear();
+    proUser.update.mockClear();
+  });
+
+  test("renders the Free plan state with a pricing link", async () => {
+    const html = await renderBillingPage();
+
+    expect(html).toContain("Free");
+    expect(html).toContain("You are currently on the Free plan.");
+    expect(html).toContain('href="/pricing"');
+    expect(html).not.toContain("/api/billing/subscription");
+  });
+
+  test("renders active Stripe Pro with cancel and portal actions", async () => {
+    subscriptionRows = [stripeSubscriptionRow({ cancelAtPeriodEnd: false })];
+    customerRows = [{ id: "cus_123" }];
+
+    const html = await renderBillingPage();
+
+    expect(html).toContain("cmux Pro");
+    expect(html).toContain("Your plan renews on");
+    expect(html).toContain("$30/month");
+    expect(html).toContain("Cancel plan");
+    expect(html).toContain('action="/api/billing/subscription"');
+    expect(html).toContain('href="/api/billing/portal"');
+  });
+
+  test("renders pending cancellation with resume and end-date copy", async () => {
+    subscriptionRows = [stripeSubscriptionRow({ cancelAtPeriodEnd: true })];
+    customerRows = [{ id: "cus_123" }];
+
+    const html = await renderBillingPage();
+
+    expect(html).toContain("Your plan is scheduled to end on");
+    expect(html).toContain("Ends on");
+    expect(html).toContain("Resume plan");
+    expect(html).not.toContain("Confirm cancellation");
+  });
+
+  test("renders legacy Stack Pro without Stripe self-serve actions", async () => {
+    stackProductsActive = true;
+
+    const html = await renderBillingPage();
+
+    expect(html).toContain("cmux Pro");
+    expect(html).toContain("legacy Stack subscription");
+    expect(html).not.toContain("/api/billing/subscription");
+    expect(html).not.toContain("/api/billing/portal");
+  });
+
+  for (const [billing, message] of [
+    ["cancelled", "Your plan will cancel at the end of the current billing period."],
+    ["resumed", "Your plan has been resumed and will renew normally."],
+    ["nosub", "No active Stripe subscription was found for this account."],
+    ["error", "Billing could not be updated. Try again shortly."],
+  ] as const) {
+    test(`renders ${billing} banner`, async () => {
+      const html = await renderBillingPage({ billing });
+
+      expect(html).toContain(message);
+    });
+  }
+});
+
+function selectableResult(table: unknown) {
+  return {
+    orderBy: () => selectableResult(table),
+    limit: async () => {
+      if (table === stripeSubscriptions) return subscriptionRows;
+      if (table === stripeCustomers) return customerRows;
+      return [];
+    },
+  };
+}
+
+async function renderBillingPage(searchParams: Record<string, string> = {}) {
+  const element = await DashboardBillingPage({
+    params: Promise.resolve({ locale: "en" }),
+    searchParams: Promise.resolve(searchParams),
+  });
+  return renderToStaticMarkup(element);
+}
+
+function stripeSubscriptionRow({
+  cancelAtPeriodEnd,
+}: {
+  cancelAtPeriodEnd: boolean;
+}) {
+  return {
+    id: "sub_123",
+    status: "active",
+    priceId: "price_123",
+    currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
+    cancelAtPeriodEnd,
+    raw: {
+      items: {
+        data: [
+          {
+            price: {
+              lookup_key: "cmux-pro-monthly",
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+function translator(namespace?: string) {
+  const root = namespace ? valueAtPath(enMessages, namespace) : enMessages;
+  const t = (key: string, values?: Record<string, unknown>) => {
+    const message = String(valueAtPath(root, key));
+    return interpolate(message, values);
+  };
+  t.raw = (key: string) => valueAtPath(root, key);
+  t.rich = (key: string, values?: Record<string, unknown>) =>
+    interpolate(String(valueAtPath(root, key)), values);
+  return t;
+}
+
+function valueAtPath(root: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((value, part) => {
+    if (value && typeof value === "object" && part in value) {
+      return (value as Record<string, unknown>)[part];
+    }
+    return path;
+  }, root);
+}
+
+function interpolate(message: string, values?: Record<string, unknown>) {
+  if (!values) return message;
+  return Object.entries(values).reduce(
+    (result, [key, value]) => result.replaceAll(`{${key}}`, String(value)),
+    message,
+  );
+}


### PR DESCRIPTION
/dashboard/billing shows the current plan in four states (free, active Stripe Pro with price and renewal date, cancellation pending with the end date and a resume action, legacy Stack Pro with a managed-elsewhere note) plus localized result banners, wired into the dashboard shell nav. POST /api/billing/subscription performs cancel-at-period-end or resume: the subscription is derived strictly from the session user (anonymous purchaser fallback included), the action literal is validated, cross-origin form posts are rejected via the same browser-mutation origin check the VM routes use, Stripe is updated first and the local row synced idempotently alongside the webhook, then a 303 returns to the localized dashboard page. Plain no-JS confirm forms, en + ja.

/fable loop: judge APPROVE plus two hardening notes folded in (origin validation, junk-action coverage). Live-verified on a dev stack against a real test-mode purchase: cancel flipped cancel_at_period_end on Stripe and in the DB with the cancelled banner, resume flipped it back, both confirmed via the Stripe API. 393 web tests green in sorted order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785912971&installation_id=133855650&pr_number=7448&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7448&signature=132a7f7ec564438f5091cec470d99c27177074024c49a26e1bafda39c7cde005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live Stripe subscription state and billing DB rows, but changes are scoped to the authenticated (or anonymous purchaser) user with origin validation and test coverage.
> 
> **Overview**
> Adds **self-serve subscription management** in the dashboard: a new `/dashboard/billing` page (en/ja) shows Free, active Stripe Pro (price, renewal/end date), pending cancellation with resume, or legacy Stack Pro, plus result banners from query params. **Account → Billing** is wired into the dashboard shell nav.
> 
> **POST `/api/billing/subscription`** handles `cancel` and `resume` via plain HTML forms: same-origin checks (`browserMutationOriginAllowed`), session user (with anonymous purchaser fallback), lookup of the user’s active Stripe Pro row, Stripe `cancel_at_period_end` update, local `stripe_subscriptions` snapshot, then a localized 303 back to billing. Cancel uses a required confirmation checkbox on the page.
> 
> Docs in `skills/cmux-billing/SKILL.md` are updated; route and page tests cover origin rejection, junk actions, auth redirects, and UI states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c8d3a49b556403f500352b2919160a5ba6c475c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new dashboard billing page with plan status and self-serve cancel/resume, plus a secure subscription endpoint with same-origin checks and localized banners.

- **New Features**
  - `/dashboard/billing` shows plan state: Free, Stripe Pro active, cancel pending, or legacy Pro.
  - Displays price and renew/end date; shows localized result banners.
  - Adds “Billing” to the dashboard navigation.
  - Plain no-JS forms to cancel at period end or resume (en + ja).
  - `POST /api/billing/subscription` validates action, enforces same-origin, derives the subscription from the session user (with anonymous purchaser fallback), updates Stripe, syncs the local row, then 303-redirects to the localized billing page with a `billing` banner.
  - If no active Stripe subscription is found, redirects with `billing=nosub`.
  - Shows a link to `/api/billing/portal` when a Stripe customer exists.

<sup>Written for commit 9c8d3a49b556403f500352b2919160a5ba6c475c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized billing dashboard with plan status, renewal details, and self-serve billing actions.
  * Added support for canceling or resuming an active subscription from the dashboard.
  * Added billing navigation and localized labels in English and Japanese.

* **Bug Fixes**
  * Improved handling for missing subscriptions, sign-in redirects, and error states with clear user banners.

* **Tests**
  * Added coverage for billing page states and subscription cancel/resume flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->