### PR TITLE
Surface original Cloud VM create-failure causes; make billing denials and stale failures retryable

### DIFF
--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -315,6 +315,8 @@ export async function POST(request: Request): Promise<Response> {
               action: "Retry with a fresh `cmux vm new`. If it fails again, copy the details and contact support.",
               details: {
                 idempotencyKeySet: !!err.idempotencyKey,
+                failureCode: err.code,
+                failureMessage: err.message,
               },
             });
           }

--- a/web/services/vms/errors.ts
+++ b/web/services/vms/errors.ts
@@ -22,6 +22,7 @@ export class VmCreateInProgressError extends Data.TaggedError("VmCreateInProgres
 
 export class VmCreateFailedError extends Data.TaggedError("VmCreateFailedError")<{
   readonly idempotencyKey: string;
+  readonly code: string | null;
   readonly message: string;
 }> {}
 

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -16,6 +16,13 @@ export type BeginCreateResult =
   | { readonly inserted: true; readonly vm: CloudVmRow }
   | { readonly inserted: false; readonly vm: CloudVmRow };
 
+export const FAILED_CREATE_RETRY_WINDOW_MS = 15 * 60 * 1000;
+
+const RETRYABLE_FAILED_CREATE_CODES = new Set([
+  "billing_credits_insufficient",
+  "billing_reserve_failed",
+]);
+
 export type BillingGrantClaim =
   | { readonly kind: "inserted"; readonly grantId: string }
   | { readonly kind: "already_claimed" };
@@ -137,6 +144,12 @@ async function findByIdempotencyKey(
   return existing ?? null;
 }
 
+function isRetryableFailedCreate(vm: CloudVmRow, now: Date): boolean {
+  if (vm.status !== "failed") return false;
+  if (vm.failureCode && RETRYABLE_FAILED_CREATE_CODES.has(vm.failureCode)) return true;
+  return now.getTime() - vm.updatedAt.getTime() >= FAILED_CREATE_RETRY_WINDOW_MS;
+}
+
 export const VmRepositoryLive = Layer.succeed(VmRepository, {
   listUserVms: (userId, billingTeamId) =>
     dbEffect("listUserVms", async () => {
@@ -218,23 +231,32 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
         const db = cloudDb();
         try {
           return await db.transaction(async (tx) => {
+            const now = new Date();
             if (idempotencyKey) {
               const [existing] = await tx
                 .select()
                 .from(cloudVms)
                 .where(and(eq(cloudVms.userId, input.userId), eq(cloudVms.idempotencyKey, idempotencyKey)))
                 .limit(1);
-              if (existing) return { inserted: false as const, vm: existing };
+              if (existing && !isRetryableFailedCreate(existing, now)) {
+                return { inserted: false as const, vm: existing };
+              }
             }
 
             await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${input.billingTeamId}, 0))`);
+            let retryableFailedVm: CloudVmRow | null = null;
             if (idempotencyKey) {
               const [existing] = await tx
                 .select()
                 .from(cloudVms)
                 .where(and(eq(cloudVms.userId, input.userId), eq(cloudVms.idempotencyKey, idempotencyKey)))
                 .limit(1);
-              if (existing) return { inserted: false as const, vm: existing };
+              if (existing) {
+                if (!isRetryableFailedCreate(existing, now)) {
+                  return { inserted: false as const, vm: existing };
+                }
+                retryableFailedVm = existing;
+              }
             }
 
             const [active] = await tx
@@ -256,6 +278,38 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
                 billingTeamId: input.billingTeamId,
                 limit: input.maxActiveVms,
               });
+            }
+
+            if (retryableFailedVm) {
+              const [vm] = await tx
+                .update(cloudVms)
+                .set({
+                  billingTeamId: input.billingTeamId,
+                  billingPlanId: input.billingPlanId,
+                  provider: input.provider,
+                  providerVmId: null,
+                  imageId: input.image,
+                  imageVersion: input.imageVersion ?? null,
+                  status: "provisioning",
+                  failureCode: null,
+                  failureMessage: null,
+                  destroyedAt: null,
+                  updatedAt: now,
+                })
+                .where(and(eq(cloudVms.id, retryableFailedVm.id), eq(cloudVms.status, "failed")))
+                .returning();
+              if (!vm) {
+                // Lost a cross-team race for the same idempotency key: another
+                // transaction already reset this row. Treat it like the insert
+                // conflict path instead of double-creating a provider VM.
+                const [current] = await tx
+                  .select()
+                  .from(cloudVms)
+                  .where(eq(cloudVms.id, retryableFailedVm.id));
+                if (!current) throw new Error("retryable failed VM row disappeared during create");
+                return { inserted: false as const, vm: current };
+              }
+              return { inserted: true as const, vm };
             }
 
             const [vm] = await tx

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -23,6 +23,7 @@ import {
   VmCreateInProgressError,
   VmNotFoundError,
   VmProviderOperationError,
+  isVmCreateCreditsInsufficientError,
   isVmLimitExceededError,
   vmWorkflowErrorCause,
   type VmDatabaseError,
@@ -93,6 +94,7 @@ export function createVm(input: {
         return yield* Effect.fail(
           new VmCreateFailedError({
             idempotencyKey: input.idempotencyKey ?? "",
+            code: existing.failureCode,
             message: existing.failureMessage ?? "previous VM create failed",
           }),
         );
@@ -776,7 +778,9 @@ function reserveCreateCredit(
           Effect.all([
             repo.markCreateFailed({
               id: vm.id,
-              code: "billing_reserve_failed",
+              code: isVmCreateCreditsInsufficientError(err)
+                ? "billing_credits_insufficient"
+                : "billing_reserve_failed",
               message: errorMessage(err),
             }),
             repo.recordUsageEvent({

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -54,6 +54,13 @@ function callMock(fn: unknown, args: unknown[]) {
   return (fn as (...args: unknown[]) => unknown)(...args);
 }
 
+function rejectRunVmWorkflowWith(error: unknown): void {
+  (runVmWorkflow as unknown as { mockImplementation(next: () => Promise<never>): void })
+    .mockImplementation(async () => {
+      throw error;
+    });
+}
+
 mock.module("../app/lib/stack", () => ({
   getStackServerApp: () => ({ getUser }),
   isStackConfigured: () => true,
@@ -98,7 +105,11 @@ const { DELETE } = await import("../app/api/vm/[id]/route");
 const attachRoute = await import("../app/api/vm/[id]/attach-endpoint/route");
 const execRoute = await import("../app/api/vm/[id]/exec/route");
 const sshRoute = await import("../app/api/vm/[id]/ssh-endpoint/route");
-const { VmProviderOperationError } = await import("../services/vms/errors");
+const {
+  VmCreateCreditsInsufficientError,
+  VmCreateFailedError,
+  VmProviderOperationError,
+} = await import("../services/vms/errors");
 const { verifyRequest } = await import("../services/vms/auth");
 const { withAuthedVmApiRoute } = await import("../services/vms/routeHelpers");
 
@@ -251,6 +262,61 @@ describe("VM REST auth", () => {
       billingPlanId: "pro",
       maxActiveVms: 25,
     }));
+  });
+
+  test("includes original failed create cause in the idempotency failure response", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    rejectRunVmWorkflowWith(
+      new VmCreateFailedError({
+        idempotencyKey: "idem-failed",
+        code: "create",
+        message: "provider unavailable",
+      }),
+    );
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { "idempotency-key": "idem-failed", origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      error: "vm_create_failed",
+      details: {
+        idempotencyKeySet: true,
+        failureCode: "create",
+        failureMessage: "provider unavailable",
+      },
+    });
+  });
+
+  test("maps create credit exhaustion to a clean payment response", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    rejectRunVmWorkflowWith(
+      new VmCreateCreditsInsufficientError({
+        itemId: "cmux-vm-create-credit",
+        billingCustomerId: "team-1",
+        amount: 1,
+      }),
+    );
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { "idempotency-key": "idem-credits", origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toMatchObject({
+      error: "vm_create_credits_insufficient",
+      amount: 1,
+      details: { amount: 1 },
+    });
   });
 
   test("uses the native client's requested Stack team for billing", async () => {

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -12,6 +12,7 @@ import {
 import type { AttachEndpoint, SSHEndpoint, VMHandle } from "../services/vms/drivers";
 import { VmProviderGateway, type VmProviderGatewayShape } from "../services/vms/providerGateway";
 import {
+  FAILED_CREATE_RETRY_WINDOW_MS,
   VmRepository,
   VmRepositoryLive,
   type CloudVmRow,
@@ -19,6 +20,7 @@ import {
 } from "../services/vms/repository";
 import {
   VmCreateCreditsInsufficientError,
+  VmCreateFailedError,
   VmCreateInProgressError,
   VmDatabaseError,
   VmLimitExceededError,
@@ -2002,9 +2004,28 @@ describe("VM Effect workflows", () => {
     `;
     expect(failedVm).toMatchObject({
       status: "failed",
-      failureCode: "billing_reserve_failed",
+      failureCode: "billing_credits_insufficient",
       providerVmId: null,
     });
+
+    const retryError = await Effect.runPromise(
+      createVm({
+        userId: "user-workflow-credit-empty",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-credit-empty",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-credit-empty",
+        idempotencyKey: "credit-empty-1",
+      }).pipe(
+        Effect.flip,
+        Effect.provide(providerLayer(provider, billing)),
+      ),
+    );
+    expect(retryError).toBeInstanceOf(VmCreateCreditsInsufficientError);
+    expect(retryError).not.toBeInstanceOf(VmCreateFailedError);
+    expect(createCalls).toBe(0);
 
     const usageEvents = await sql<{ eventType: string }[]>`
       select event_type as "eventType" from cloud_vm_usage_events
@@ -2050,17 +2071,177 @@ describe("VM Effect workflows", () => {
     expect(recovered.providerVmId).toBe("provider-vm-credit-recovered");
   });
 
+  dbTest("concurrent cross-team retries of one idempotency key create exactly one provider VM", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+
+    await sql`
+      insert into cloud_vms (
+        user_id, billing_team_id, billing_plan_id, provider, image_id, status,
+        idempotency_key, failure_code, failure_message, updated_at
+      )
+      values (
+        'user-workflow-race-retry', 'team-race-a', 'free', 'freestyle', 'snapshot-race-old', 'failed',
+        'race-retry-1', 'billing_credits_insufficient', 'no credits',
+        ${new Date(Date.now() - FAILED_CREATE_RETRY_WINDOW_MS - 1_000)}
+      )
+    `;
+
+    let createCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      create: () =>
+        Effect.promise(async () => {
+          createCalls += 1;
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          return {
+            provider: "freestyle" as const,
+            providerVmId: `provider-vm-race-${createCalls}`,
+            status: "running" as const,
+            image: "snapshot-race-new",
+            createdAt: Date.now(),
+          };
+        }),
+      destroy: () => Effect.void,
+      exec: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      openAttach: () => Effect.fail(new Error("unused") as never),
+      openSSH: () => Effect.fail(new Error("unused") as never),
+      revokeSSHIdentity: () => Effect.void,
+    };
+
+    const attempt = (team: string) =>
+      Effect.runPromise(
+        createVm({
+          userId: "user-workflow-race-retry",
+          billingCustomerType: "team",
+          billingTeamId: team,
+          billingPlanId: "free",
+          maxActiveVms: 10,
+          provider: "freestyle",
+          image: "snapshot-race-new",
+          idempotencyKey: "race-retry-1",
+        }).pipe(Effect.provide(providerLayer(provider))),
+      );
+
+    const results = await Promise.allSettled([attempt("team-race-a"), attempt("team-race-b")]);
+    // Exactly one racer may win the row and reach the provider; the loser
+    // must observe the in-progress row instead of double-creating.
+    expect(createCalls).toBe(1);
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    expect(fulfilled.length).toBeGreaterThanOrEqual(1);
+
+    const rows = await sql<{ status: string }[]>`
+      select status from cloud_vms where idempotency_key = 'race-retry-1'
+    `;
+    expect(rows).toHaveLength(1);
+  });
+
+  dbTest("retries a stale failed create record after the retry window", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+
+    await sql`
+      insert into cloud_vms (
+        user_id,
+        billing_team_id,
+        billing_plan_id,
+        provider,
+        image_id,
+        status,
+        idempotency_key,
+        failure_code,
+        failure_message,
+        updated_at
+      )
+      values (
+        'user-workflow-stale-failed',
+        'team-workflow-stale-failed',
+        'free',
+        'freestyle',
+        'snapshot-stale-old',
+        'failed',
+        'stale-failed-1',
+        'create',
+        'provider timed out',
+        ${new Date(Date.now() - FAILED_CREATE_RETRY_WINDOW_MS - 1_000)}
+      )
+    `;
+
+    let createCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      create: () =>
+        Effect.sync(() => {
+          createCalls += 1;
+          return {
+            provider: "freestyle" as const,
+            providerVmId: "provider-vm-stale-recovered",
+            status: "running" as const,
+            image: "snapshot-stale-new",
+            createdAt: Date.now(),
+          };
+        }),
+      destroy: () => Effect.void,
+      exec: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      openAttach: () => Effect.fail(new Error("unused") as never),
+      openSSH: () => Effect.fail(new Error("unused") as never),
+      revokeSSHIdentity: () => Effect.void,
+    };
+
+    const recovered = await Effect.runPromise(
+      createVm({
+        userId: "user-workflow-stale-failed",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-stale-failed",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-stale-new",
+        idempotencyKey: "stale-failed-1",
+      }).pipe(Effect.provide(providerLayer(provider))),
+    );
+
+    expect(recovered.providerVmId).toBe("provider-vm-stale-recovered");
+    expect(createCalls).toBe(1);
+
+    const [row] = await sql<{
+      total: number;
+      status: string;
+      failureCode: string | null;
+      failureMessage: string | null;
+      imageId: string;
+    }[]>`
+      select
+        count(*) over ()::int as total,
+        status,
+        failure_code as "failureCode",
+        failure_message as "failureMessage",
+        image_id as "imageId"
+      from cloud_vms
+      where user_id = 'user-workflow-stale-failed'
+    `;
+    expect(row).toMatchObject({
+      total: 1,
+      status: "running",
+      failureCode: null,
+      failureMessage: null,
+      imageId: "snapshot-stale-new",
+    });
+  });
+
   dbTest("refunds a reserved Stack Auth credit when provider create fails", async () => {
     if (!sql) throw new Error("test database not initialized");
     await sql`truncate cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
 
+    let createCalls = 0;
     const provider: VmProviderGatewayShape = {
       create: () =>
-        Effect.fail(new VmProviderOperationError({
-          provider: "freestyle",
-          operation: "create",
-          cause: new Error("provider unavailable"),
-        })),
+        Effect.gen(function* () {
+          createCalls += 1;
+          return yield* Effect.fail(new VmProviderOperationError({
+            provider: "freestyle",
+            operation: "create",
+            cause: new Error("provider unavailable"),
+          }));
+        }),
       destroy: () => Effect.void,
       exec: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
       openAttach: () => Effect.fail(new Error("unused") as never),
@@ -2099,6 +2280,30 @@ describe("VM Effect workflows", () => {
     ).rejects.toThrow();
 
     expect(refundCalls).toBe(1);
+    expect(createCalls).toBe(1);
+
+    const retryError = await Effect.runPromise(
+      createVm({
+        userId: "user-workflow-credit-refund",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-credit-refund",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-credit-refund",
+        idempotencyKey: "credit-refund-1",
+      }).pipe(
+        Effect.flip,
+        Effect.provide(providerLayer(provider, billing)),
+      ),
+    );
+    expect(retryError).toBeInstanceOf(VmCreateFailedError);
+    expect(retryError).toMatchObject({
+      code: "create",
+      message: "provider unavailable",
+    });
+    expect(createCalls).toBe(1);
+
     const usageEvents = await sql<{ eventType: string }[]>`
       select event_type as "eventType" from cloud_vm_usage_events
       where user_id = 'user-workflow-credit-refund'


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/7382.

Three behavior changes: `vm_create_failed` responses now carry the original persisted failure code and message in details (driver-template strings only — verified nothing secret-bearing can flow through); pre-provider billing failure records (`billing_credits_insufficient`, `billing_reserve_failed`) are retryable under the existing advisory lock, so retries re-run entitlements and return the clean 402 instead of the poisoned-record 500 that masked today's credits outage; and failure records older than 15 minutes are retryable for every code, so transient poisoning self-heals. The reuse UPDATE is guarded by `status = 'failed'` with a lost-race re-select, closing a cross-team double-create race the /fable judge found (two concurrent retries of one idempotency key under different team advisory locks could both reset the row and both reach the provider — one VM orphaned, credits double-burned).

Two-commit red/green structure. Two /fable judge rounds (round 1 REVISE on the race; round 2 APPROVE with the interleaving analysis). Verified: 57 focused tests + 39 DB-backed tests (including the new real-Postgres race test) + typecheck, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785920010&installation_id=133855650&pr_number=7451&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7451&signature=67606147c6b31cc01cb71436c3ff31fd4d38cbc6823b867dd72e06962db7c2f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 23f78681c8fe2b0a996c470ae86cea12723c030d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the original VM create failure cause in API responses and makes billing denials and stale failed creates safely retryable. Also fixes a cross-team retry race so only one provider VM is created per idempotency key and credit exhaustion returns a clean 402.

- **New Features**
  - `vm_create_failed` responses now include `failureCode` and `failureMessage` from the original persisted failure.

- **Bug Fixes**
  - Retries allowed for `billing_credits_insufficient` and `billing_reserve_failed`; retries re-run billing and return 402 instead of 500.
  - Failed create records older than 15 minutes are retryable to self-heal transient poisoning.
  - Cross-team idempotency-key race fixed: update guarded by `status='failed'` with a lost‑race reselect to prevent double-creates.

<sup>Written for commit 23f78681c8fe2b0a996c470ae86cea12723c030d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved VM creation error responses with clearer failure details, including failure code and message.
  * Added support for retrying certain previously failed VM creation attempts using the same request key.

* **Bug Fixes**
  * Prevented duplicate VM creation during concurrent retries.
  * Improved handling of credit-related failures and ensured they return the appropriate payment-style response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->