### PR TITLE
Bake dev toolchains into the Cloud VM base images

### DIFF
--- a/web/scripts/build-cloud-vm-images.ts
+++ b/web/scripts/build-cloud-vm-images.ts
@@ -22,20 +22,38 @@ const STRICT_SEMVER_RE =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
 const CLOUD_SHELL_PACKAGES = [
   "bash",
+  "build-essential",
   "ca-certificates",
   "curl",
   "dirmngr",
   "git",
   "gnupg",
+  "golang-go",
   "gpg-agent",
   "libssl3t64",
   "locales",
   "openssl",
+  "pkg-config",
   "python3",
+  "python3-pip",
+  "python3-venv",
   "sudo",
   "unzip",
   "xz-utils",
 ];
+const TOOLCHAIN_SHIMS_DIR = "/usr/local/share/mise/shims";
+const RUSTUP_HOME = "/opt/rustup";
+const CARGO_HOME = "/opt/cargo";
+const TOOLCHAIN_PATH = [
+  TOOLCHAIN_SHIMS_DIR,
+  `${CARGO_HOME}/bin`,
+  "/usr/local/sbin",
+  "/usr/local/bin",
+  "/usr/sbin",
+  "/usr/bin",
+  "/sbin",
+  "/bin",
+].join(":");
 const PRIMARY_LINUX_USER = "cmux";
 const NODE_MAJOR = String(positiveIntFromEnv("CMUX_CLOUD_IMAGE_NODE_MAJOR", 22));
 const BUN_VERSION = semverFromEnv("CMUX_CLOUD_IMAGE_BUN_VERSION", "1.3.13");
@@ -175,7 +193,7 @@ async function buildE2BTemplate(
   const template = Template({ fileContextPath })
     .fromUbuntuImage("24.04")
     .aptInstall(CLOUD_SHELL_PACKAGES, { noInstallRecommends: true })
-    .setEnvs({ LANG: UTF8_LOCALE, LC_ALL: UTF8_LOCALE, LANGUAGE: UTF8_LOCALE })
+    .setEnvs(cloudImageRuntimeEnvironment())
     .copy(path.basename(daemonPath), "/usr/local/bin/cmuxd-remote", {
       forceUpload: true,
       mode: 0o755,
@@ -370,13 +388,21 @@ export function cloudImageSmokeTestCommands(): string[] {
   const agentToolVersionChecks = cloudAgentToolPackageSpecs().flatMap((tool) =>
     tool.binaries.map((binary) => `${binary} --version >/tmp/cmux-${tool.name}-version.txt 2>&1`)
   );
+  const toolchainEnv = toolchainSmokeEnvironmentPrefix();
   return [
+    "printf 'int main(void) { return 0; }\\n' >/tmp/cmux-build-smoke.c && gcc /tmp/cmux-build-smoke.c -o /tmp/cmux-build-smoke && /tmp/cmux-build-smoke && g++ --version >/dev/null && make --version >/dev/null && pkg-config --version >/dev/null && rm -f /tmp/cmux-build-smoke.c /tmp/cmux-build-smoke",
     "openssl version -a >/tmp/cmux-openssl-version.txt 2>&1",
     "python3 -X faulthandler -c 'import ssl; print(ssl.OPENSSL_VERSION)'",
     "python3 -m http.server --help >/dev/null",
-    "node --version >/tmp/cmux-node-version.txt 2>&1",
+    "python3 -m pip --version >/tmp/cmux-pip-version.txt 2>&1",
+    "python3 -m venv /tmp/cmux-venv-smoke && rm -rf /tmp/cmux-venv-smoke",
+    `${toolchainEnv} test "$(command -v node)" = "${TOOLCHAIN_SHIMS_DIR}/node" && node --version >/tmp/cmux-node-version.txt 2>&1 && mise which node >/tmp/cmux-mise-node-path.txt 2>&1`,
     "npm --version >/tmp/cmux-npm-version.txt 2>&1",
     "bun --version >/tmp/cmux-bun-version.txt 2>&1",
+    "go version >/tmp/cmux-go-version.txt 2>&1",
+    "gh --version >/tmp/cmux-gh-version.txt 2>&1",
+    `${toolchainEnv} rustup show active-toolchain >/tmp/cmux-rustup-toolchain.txt 2>&1 && grep -q '^stable' /tmp/cmux-rustup-toolchain.txt && rustc --version >/tmp/cmux-rustc-version.txt 2>&1 && cargo --version >/tmp/cmux-cargo-version.txt 2>&1`,
+    "mise --version >/tmp/cmux-mise-version.txt 2>&1",
     "cmux --help >/tmp/cmux-cli-help.txt 2>&1",
     "cmux --socket /tmp/cmux-browser-smoke.sock browser >/tmp/cmux-browser-help.txt 2>&1; status=$?; test \"$status\" -eq 2 && grep -q 'requires a subcommand' /tmp/cmux-browser-help.txt",
     "cmuxd-remote version >/tmp/cmuxd-remote-version.txt 2>&1",
@@ -423,8 +449,11 @@ export function cloudToolInstallCommands(): string[] {
     "rm -f /etc/apt/keyrings/nodesource.gpg",
     "curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg",
     `printf '%s\\n' ${shellQuote(`deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main`)} > /etc/apt/sources.list.d/nodesource.list`,
+    "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg",
+    "chmod 0644 /etc/apt/keyrings/githubcli-archive-keyring.gpg",
+    "printf '%s\\n' \"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\" > /etc/apt/sources.list.d/github-cli.list",
     "apt-get update",
-    "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nodejs",
+    "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gh nodejs",
     "npm config set fund false",
     "npm config set audit false",
     bunInstallCommand(),
@@ -432,6 +461,9 @@ export function cloudToolInstallCommands(): string[] {
     toolPackages.length > 0
       ? `npm install -g --omit=dev --no-audit --fund=false ${toolPackages.map((tool) => shellQuote(tool.packageSpec)).join(" ")} >/tmp/cmux-npm-install.txt 2>&1`
       : "true",
+    miseInstallCommand(),
+    rustupInstallCommand(),
+    toolchainProfileCommand(),
     "rm -rf /root/.npm/_cacache /var/lib/apt/lists/*",
   ];
 }
@@ -463,6 +495,57 @@ function bunInstallCommand(): string {
   return `{ ${commands.join(" && ")}; } >/tmp/cmux-bun-install.txt 2>&1`;
 }
 
+function miseInstallCommand(): string {
+  const commands = [
+    "set -eu",
+    "install -d -m 0755 /etc/mise /usr/local/share/mise",
+    "printf '[tools]\\nnode = \"lts\"\\n' >/etc/mise/config.toml",
+    "curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh",
+    "MISE_YES=1 mise install --system node@lts",
+    "MISE_DATA_DIR=/usr/local/share/mise mise reshim --force",
+    "chmod -R a+rX /etc/mise /usr/local/share/mise",
+    "rm -rf /root/.cache/mise /usr/local/share/mise/downloads",
+  ];
+  return `{ ${commands.join(" && ")}; } >/tmp/cmux-mise-install.txt 2>&1`;
+}
+
+function rustupInstallCommand(): string {
+  const commands = [
+    "set -eu",
+    `export RUSTUP_HOME=${shellQuote(RUSTUP_HOME)}`,
+    `export CARGO_HOME=${shellQuote(CARGO_HOME)}`,
+    "curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs -o /tmp/cmux-rustup-init.sh",
+    "sh /tmp/cmux-rustup-init.sh -y --profile minimal --default-toolchain stable --no-modify-path",
+    "rm -f /tmp/cmux-rustup-init.sh",
+    "rm -rf \"$RUSTUP_HOME/downloads\" \"$RUSTUP_HOME/tmp\" \"$CARGO_HOME/registry\"",
+    "chmod -R a+rX \"$RUSTUP_HOME\" \"$CARGO_HOME\"",
+  ];
+  return `{ ${commands.join(" && ")}; } >/tmp/cmux-rustup-install.txt 2>&1`;
+}
+
+function toolchainProfileCommand(): string {
+  const envLines = Object.entries(cloudImageRuntimeEnvironment())
+    .map(([key, value]) => `${key}="${value}"`)
+    .join("\\n");
+  const profile = [
+    `export RUSTUP_HOME=${RUSTUP_HOME}`,
+    `case ":\${PATH:-}:" in *":${TOOLCHAIN_SHIMS_DIR}:"*) ;; *) PATH="${TOOLCHAIN_SHIMS_DIR}:${CARGO_HOME}/bin:\${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}" ;; esac`,
+    "export PATH",
+  ].join("\\n");
+  return [
+    `printf '%b\\n' ${shellQuote(envLines)} >/etc/environment`,
+    `printf '%b\\n' ${shellQuote(profile)} >/etc/profile.d/cmux-toolchains.sh`,
+    "chmod 0644 /etc/environment /etc/profile.d/cmux-toolchains.sh",
+  ].join(" && ");
+}
+
+function toolchainSmokeEnvironmentPrefix(): string {
+  return [
+    `export PATH=${shellQuote(TOOLCHAIN_PATH)}`,
+    `RUSTUP_HOME=${shellQuote(RUSTUP_HOME)}`,
+  ].join(" ") + "; ";
+}
+
 function freestylePythonOpenSSLCommands(): string[] {
   return [
     "apt-get update",
@@ -478,10 +561,10 @@ function freestylePythonOpenSSLCommands(): string[] {
   ];
 }
 
-function freestyleBaseDockerfileContent(daemonURL: string): string {
+export function freestyleBaseDockerfileContent(daemonURL: string): string {
   return [
     "FROM ubuntu:24.04",
-    `ENV LANG=${UTF8_LOCALE} LC_ALL=${UTF8_LOCALE} LANGUAGE=${UTF8_LOCALE}`,
+    dockerEnvLine(cloudImageRuntimeEnvironment()),
     `RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${CLOUD_SHELL_PACKAGES.join(" ")} && rm -rf /var/lib/apt/lists/*`,
     ...freestylePythonOpenSSLCommands().map((command) => `RUN ${command}`),
     `RUN curl -fsSL ${shellQuote(daemonURL)} -o /usr/local/bin/cmuxd-remote && chmod 0755 /usr/local/bin/cmuxd-remote`,
@@ -489,9 +572,59 @@ function freestyleBaseDockerfileContent(daemonURL: string): string {
     ...cloudRootSetupCommands().map((command) => `RUN ${command}`),
     ...cloudImageSmokeTestCommands().map((command) => `RUN ${command}`),
     "RUN mkdir -p /etc/systemd/system/multi-user.target.wants",
-    "RUN cat <<'EOF' >/etc/systemd/system/cmuxd-ws.service\n[Unit]\nDescription=cmuxd websocket daemon\nAfter=network.target\n\n[Service]\nType=simple\nUser=root\nExecStart=/usr/local/bin/cmuxd-remote serve --ws --listen 0.0.0.0:7777 --auth-lease-file /tmp/cmux/attach-pty-lease.json --rpc-auth-lease-file /tmp/cmux/attach-rpc-lease.json --shell /bin/bash\nRestart=always\nRestartSec=1\n\n[Install]\nWantedBy=multi-user.target\nEOF",
+    `RUN ${freestyleSystemdServiceCommand()}`,
     "RUN ln -sf /etc/systemd/system/cmuxd-ws.service /etc/systemd/system/multi-user.target.wants/cmuxd-ws.service",
   ].join("\n");
+}
+
+export function cloudImageRuntimeEnvironment(): Record<string, string> {
+  return {
+    LANG: UTF8_LOCALE,
+    LC_ALL: UTF8_LOCALE,
+    LANGUAGE: UTF8_LOCALE,
+    PATH: TOOLCHAIN_PATH,
+    RUSTUP_HOME,
+  };
+}
+
+export function cloudShellPackageNames(): readonly string[] {
+  return CLOUD_SHELL_PACKAGES;
+}
+
+function dockerEnvLine(env: Record<string, string>): string {
+  return `ENV ${Object.entries(env).map(([key, value]) => `${key}=${dockerEnvValue(value)}`).join(" ")}`;
+}
+
+function dockerEnvValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\s/g, "\\$&");
+}
+
+function freestyleSystemdServiceCommand(): string {
+  const service = [
+    "[Unit]",
+    "Description=cmuxd websocket daemon",
+    "After=network.target",
+    "",
+    "[Service]",
+    "Type=simple",
+    "User=root",
+    ...systemdEnvironmentLines(cloudImageRuntimeEnvironment()),
+    "ExecStart=/usr/local/bin/cmuxd-remote serve --ws --listen 0.0.0.0:7777 --auth-lease-file /tmp/cmux/attach-pty-lease.json --rpc-auth-lease-file /tmp/cmux/attach-rpc-lease.json --shell /bin/bash",
+    "Restart=always",
+    "RestartSec=1",
+    "",
+    "[Install]",
+    "WantedBy=multi-user.target",
+  ].join("\n");
+  return `cat <<'EOF' >/etc/systemd/system/cmuxd-ws.service\n${service}\nEOF`;
+}
+
+export function systemdEnvironmentLines(env: Record<string, string>): string[] {
+  return Object.entries(env).map(([key, value]) => `Environment=${key}=${systemdEnvironmentValue(value)}`);
+}
+
+function systemdEnvironmentValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
 }
 
 async function remoteDaemonBuildURL(tag: string, daemonPath: string): Promise<string> {
@@ -642,7 +775,8 @@ function abortError(): Error {
 function imageNotes(metadata: ImageBuildMetadata): string {
   return [
     `binarySha256=${metadata.binarySha256}`,
-    `nodeMajor=${metadata.nodeMajor}`,
+    `nodeSourceMajor=${metadata.nodeMajor}`,
+    "nodeDefault=mise-node-lts-shim",
     `agentTools=${metadata.agentToolPackageSpecs.join(",")}`,
   ].join(" ");
 }

--- a/web/tests/build-cloud-vm-images.test.ts
+++ b/web/tests/build-cloud-vm-images.test.ts
@@ -2,13 +2,17 @@ import { describe, expect, test } from "bun:test";
 import { Freestyle } from "freestyle";
 import {
   cloudAgentToolPackageSpecs,
+  cloudImageRuntimeEnvironment,
   cloudImageSmokeTestCommands,
+  cloudShellPackageNames,
   cloudToolInstallCommands,
   findFreestyleSnapshotByName,
+  freestyleBaseDockerfileContent,
   freestyleRecoveryWindowStart,
   pinnedNpmPackageVersion,
   positiveIntFromEnv,
   semverFromEnv,
+  systemdEnvironmentLines,
   waitForFreestyleSnapshotByName,
   waitForRetryInterval,
 } from "../scripts/build-cloud-vm-images";
@@ -106,12 +110,97 @@ describe("Cloud VM image build helpers", () => {
     expect(bunInstall).toContain("sha256sum -c");
   });
 
+  test("base image installs native build and Python packaging apt tools", () => {
+    const packages = cloudShellPackageNames();
+
+    for (const packageName of [
+      "build-essential",
+      "pkg-config",
+      "python3-pip",
+      "python3-venv",
+      "golang-go",
+    ]) {
+      expect(packages.includes(packageName)).toBe(true);
+    }
+  });
+
+  test("GitHub CLI is installed from the official apt repository", () => {
+    const commands = cloudToolInstallCommands().join("\n");
+
+    expect(commands).toContain("https://cli.github.com/packages/githubcli-archive-keyring.gpg");
+    expect(commands).toContain("https://cli.github.com/packages stable main");
+    expect(commands).toContain("apt-get install -y --no-install-recommends gh nodejs");
+  });
+
+  test("mise installs Node LTS through system shims", () => {
+    const commands = cloudToolInstallCommands().join("\n");
+
+    expect(commands).toContain("MISE_INSTALL_PATH=/usr/local/bin/mise");
+    expect(commands).toContain("node = \"lts\"");
+    expect(commands).toContain("mise install --system node@lts");
+    expect(commands).toContain("MISE_DATA_DIR=/usr/local/share/mise mise reshim --force");
+    expect(cloudImageRuntimeEnvironment().PATH.split(":")).toContain("/usr/local/share/mise/shims");
+  });
+
+  test("rustup uses a minimal stable toolchain in the shared cargo path", () => {
+    const commands = cloudToolInstallCommands().join("\n");
+
+    expect(commands).toContain("https://sh.rustup.rs");
+    expect(commands).toContain("--profile minimal --default-toolchain stable --no-modify-path");
+    expect(commands).toContain("RUSTUP_HOME='/opt/rustup'");
+    expect(commands).toContain("CARGO_HOME='/opt/cargo'");
+    expect(cloudImageRuntimeEnvironment().PATH.split(":")).toContain("/opt/cargo/bin");
+    expect(cloudImageRuntimeEnvironment()).not.toHaveProperty("CARGO_HOME");
+  });
+
+  test("toolchain profile and environment are wired for non-login commands", () => {
+    const profileInstall = cloudToolInstallCommands().find((command) =>
+      command.includes("/etc/profile.d/cmux-toolchains.sh")
+    );
+
+    expect(profileInstall).toContain("/etc/environment");
+    expect(profileInstall).toContain("/usr/local/share/mise/shims:/opt/cargo/bin");
+    expect(cloudImageRuntimeEnvironment()).toMatchObject({
+      RUSTUP_HOME: "/opt/rustup",
+    });
+    expect(profileInstall).not.toContain("export CARGO_HOME=");
+  });
+
+  test("Freestyle systemd service inherits toolchain runtime environment", () => {
+    const dockerfile = freestyleBaseDockerfileContent("https://example.com/cmuxd-remote");
+    const systemdEnv = systemdEnvironmentLines(cloudImageRuntimeEnvironment());
+
+    for (const line of systemdEnv) {
+      expect(dockerfile).toContain(line);
+    }
+    expect(dockerfile).toContain("Environment=PATH=/usr/local/share/mise/shims:/opt/cargo/bin");
+    expect(dockerfile).toContain("Environment=RUSTUP_HOME=/opt/rustup");
+    expect(dockerfile).not.toContain("Environment=CARGO_HOME=");
+  });
+
   test("image smoke checks exercise the cmux browser entrypoint without a daemon", () => {
     const browserSmoke = cloudImageSmokeTestCommands().find((command) =>
       command.includes("cmux-browser-help.txt")
     );
     expect(browserSmoke).toContain("--socket /tmp/cmux-browser-smoke.sock browser");
     expect(browserSmoke).toContain("requires a subcommand");
+  });
+
+  test("image smoke checks cover baked toolchain commands", () => {
+    const smoke = cloudImageSmokeTestCommands().join("\n");
+
+    expect(smoke).toContain("gcc /tmp/cmux-build-smoke.c -o /tmp/cmux-build-smoke");
+    expect(smoke).toContain("g++ --version");
+    expect(smoke).toContain("make --version");
+    expect(smoke).toContain("pkg-config --version");
+    expect(smoke).toContain("python3 -m pip --version");
+    expect(smoke).toContain("python3 -m venv /tmp/cmux-venv-smoke");
+    expect(smoke).toContain("test \"$(command -v node)\" = \"/usr/local/share/mise/shims/node\"");
+    expect(smoke).toContain("mise which node");
+    expect(smoke).toContain("go version");
+    expect(smoke).toContain("gh --version");
+    expect(smoke).toContain("rustup show active-toolchain");
+    expect(smoke).toContain("grep -q '^stable'");
   });
 
   test("snapshot recovery window tolerates provider clock skew", () => {


### PR DESCRIPTION
Implements the toolchain half of https://github.com/manaflow-ai/cmux/issues/7383 (self-serve `.cmux/vm-setup.sh` is a follow-up). From the agent trial: the base image was JS-only — no C toolchain (any native addon fails), no pip, no rust/go/mise/gh.

Adds build-essential + pkg-config, python3-pip/venv, gh via the official apt repo, system-wide mise with node@lts shims, rustup stable in /opt/rustup, and golang-go. The load-bearing fix from the /fable review: runtime env is generated from one constant into the image env, /etc/environment, profile.d, AND `cmuxd-ws.service`'s `[Service]` section — systemd services never read /etc/environment, so without the unit lines every daemon-spawned exec/PTY session would miss the toolchain PATH (build-time smoke masked this). CARGO_HOME stays build-time-only so non-root cargo state lands in writable ~/.cargo. Smoke checks compile and run a real C program.

Two /fable judge rounds (round 1 REVISE: systemd env propagation, cargo permissions, order revert, presence-only smoke; round 2 APPROVE). 19 tests, typecheck clean. No manifest/default-pointer switch — rollout: `bun scripts/build-cloud-vm-images.ts --target freestyle --tag toolchain-20260706a`, validate node/gcc/rustc as the non-root user on a booted VM, then update `FREESTYLE_SANDBOX_SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785923403&installation_id=133855650&pr_number=7455&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7455&signature=105aa7d0d6174e51b566694ff6753e20f15453512eb2f81a7afdec5b889134ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect cloud image build scripts and tests, but incorrect PATH/systemd env would break all daemon-spawned agent shells until a new snapshot is built and rolled out.
> 
> **Overview**
> Cloud VM base images (E2B and Freestyle) now ship **native build**, **Python packaging**, **Go**, **GitHub CLI**, **mise-managed Node LTS**, and **rustup stable**, so agent sessions can compile C/C++, use pip/venv, and run common dev CLIs without a separate setup step.
> 
> Install steps add apt packages (`build-essential`, `pkg-config`, `python3-pip`/`venv`, `golang-go`), the official `gh` repo, system-wide **mise** with `node@lts` shims, and **rustup** under `/opt/rustup` with binaries on `PATH`. **Default `node` is expected from mise shims** (Nodesource `nodejs` remains for npm); build metadata notes now distinguish `nodeSourceMajor` vs `nodeDefault=mise-node-lts-shim`.
> 
> **Runtime env is centralized** in `cloudImageRuntimeEnvironment()` and propagated to E2B template env, Docker `ENV`, `/etc/environment`, `/etc/profile.d/cmux-toolchains.sh`, and **`cmuxd-ws.service` `Environment=` lines** so systemd-spawned shells get the toolchain `PATH` and `RUSTUP_HOME` (not only `/etc/environment`). `CARGO_HOME` is install-time only so user cargo state stays in writable `~/.cargo`.
> 
> **Smoke tests** compile/run a small C binary and assert gcc/g++/make/pkg-config, pip/venv, mise `node`, go, gh, and stable rust/cargo. New unit tests lock install strings, env wiring, and Freestyle Dockerfile/systemd output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b76d13cf32a1149cf478c432dfcd8b3aff44cde8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bakes a full dev toolchain into Cloud VM base images and fixes PATH/env propagation so shells and systemd‑spawned processes see the tools. Enables native Node addons and common CLIs out of the box. Part of #7383.

- **New Features**
  - Installs `build-essential`, `pkg-config`, `python3-pip`, `python3-venv`, `golang-go`, and `gh` (from the official apt repo).
  - Adds system-wide `mise` with Node LTS; PATH defaults to the `mise` shims while keeping `nodejs` via apt.
  - Installs `rustup` (stable, minimal) with `RUSTUP_HOME=/opt/rustup`; PATH includes `/opt/cargo/bin` without exporting `CARGO_HOME` at runtime.
  - Adds smoke checks: compile and run a C program; verify `gcc`, `pkg-config`, `pip`/`venv`, `node` via `mise` shims, `go`, `gh`, `rustup`/`rustc`/`cargo`, and `mise`.

- **Bug Fixes**
  - Centralizes the runtime env (`PATH`, `RUSTUP_HOME`) and injects it into the image env, `/etc/environment`, `/etc/profile.d`, and the `cmuxd-ws.service` `[Service]` env so systemd sessions get the toolchain.

<sup>Written for commit b76d13cf32a1149cf478c432dfcd8b3aff44cde8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud VM images now include broader toolchain setup and verification, including support for common build, Python, Rust, Go, and GitHub CLI tooling.
  * Runtime environment settings are now applied consistently across image builds and smoke tests.

* **Bug Fixes**
  * Improved cloud image startup and shell environment handling so toolchain paths and profiles are available in more command contexts.
  * Updated smoke checks to better validate the installed tools and their expected versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->