### PR TITLE
mux: fix panic when CDP debug log truncates mid-UTF-8-character

### DIFF
--- a/mux/crates/mux-cdp/src/client.rs
+++ b/mux/crates/mux-cdp/src/client.rs
@@ -375,9 +375,24 @@ fn reader_loop(weak: Weak<Inner>) {
     }
 }
 
+/// Truncate `text` to at most `max` bytes without splitting a multi-byte UTF-8
+/// character. Slicing raw bytes (`&text[..max]`) panics when the cutoff lands
+/// inside a code point, which is reachable here because CDP payloads carry
+/// arbitrary page text such as non-ASCII tab titles.
+fn truncate_for_log(text: &str, max: usize) -> &str {
+    if text.len() <= max {
+        return text;
+    }
+    let mut end = max;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
+}
+
 fn handle_text(inner: &Arc<Inner>, text: &str) {
     if cdp_debug() {
-        eprintln!("cdp<- {}", &text[..text.len().min(300)]);
+        eprintln!("cdp<- {}", truncate_for_log(text, 300));
     }
     let Ok(value) = serde_json::from_str::<Value>(text) else { return };
     if let Some(id) = value.get("id").and_then(|v| v.as_u64()) {
@@ -568,5 +583,30 @@ impl WsEndpoint {
             None => (host_port, 80),
         };
         Ok(WsEndpoint { host: host.trim_matches(['[', ']']).to_string(), port })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_for_log;
+
+    #[test]
+    fn truncate_for_log_does_not_split_multibyte_chars() {
+        // A 4-byte character straddling the byte cutoff must be dropped whole.
+        // Slicing raw bytes here (`&text[..300]`) would panic because offset 300
+        // lands inside the emoji.
+        let mut text = "x".repeat(299);
+        text.push('😀'); // occupies bytes 299..303
+        text.push_str(&"y".repeat(50));
+        assert!(!text.is_char_boundary(300));
+
+        let truncated = truncate_for_log(&text, 300);
+        assert_eq!(truncated, "x".repeat(299));
+        assert!(text.starts_with(truncated));
+    }
+
+    #[test]
+    fn truncate_for_log_returns_short_input_unchanged() {
+        assert_eq!(truncate_for_log("hello", 300), "hello");
     }
 }


### PR DESCRIPTION
`handle_text` in `mux-cdp` logs every inbound CDP message under `CMUX_MUX_CDP_DEBUG`:

```rust
eprintln!("cdp<- {}", &text[..text.len().min(300)]);
```

`&text[..300]` slices by byte offset. When the cutoff falls inside a multi-byte UTF-8 character it panics (`byte index 300 is not a char boundary`). CDP payloads carry arbitrary page text, so a `Target.targetInfoChanged` for a tab whose title crosses offset 300 with a non-ASCII character is enough to hit it. The panic happens on the detached `mux-cdp-reader` thread, so it's swallowed: the reader stops, pending `call()`s time out, and the session goes quiet with no error. It only triggers with the debug flag set — i.e. while debugging the browser.

Truncate on a char boundary instead. Two unit tests cover the helper; the multi-byte one panics against the old byte slice and passes with the fix.

Verified in `mux/`:
- `cargo test -p mux-cdp` — 4 unit + 3 integration tests pass
- `cargo fmt --check` — clean
- `cargo clippy -p mux-cdp --all-targets --locked -- -D warnings` — clean

The change is confined to `mux-cdp`, which doesn't depend on ghostty, so I ran crate-scoped checks rather than the full `--workspace` build (that needs the `ghostty` submodule). The same slice is present in the open #7378.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785943800&installation_id=133855650&pr_number=7462&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7462&signature=d1cad44e80101f1a8c1ab24ccb9c5dc2cde0955f9c4f1bc81efbf2f4588191cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a panic in `mux-cdp` debug logging by truncating CDP messages on UTF‑8 character boundaries. This keeps the reader thread running when `CMUX_MUX_CDP_DEBUG` is set and avoids silent session stalls.

- **Bug Fixes**
  - Replaced `&text[..min(300)]` with a safe `truncate_for_log(text, 300)` that never splits multi-byte characters.
  - Added two unit tests for multi-byte truncation and short input.

<sup>Written for commit 6470411e827f6690c2cac3008faf1d4518ea2e44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of logged CDP message text to avoid crashes when truncating content with non-ASCII characters.
  * Ensured longer log messages are safely shortened without splitting multi-byte characters.
* **Tests**
  * Added coverage for text truncation behavior, including multibyte characters and short inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->