### PR TITLE
Auto-submit external TestFlight beta reviews

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -32,9 +32,9 @@ on:
     # successful run (SHA compare, not a wall-clock window), so an iOS-affecting
     # change reaches the TestFlight beta lane within ~2h of landing on main, and
     # a failed or missed run retries the not-yet-uploaded commit instead of
-    # permanently stranding it. These uploads are external-eligible too, so the
-    # first build of a new MARKETING_VERSION may wait on Apple Beta App Review
-    # before founders can install it.
+    # permanently stranding it. These uploads are external-eligible too, and the
+    # post-upload external-distribution job auto-submits the first build of a new
+    # MARKETING_VERSION for Apple Beta App Review.
     #
     # Why ~2h and not a push trigger / per-commit: a per-push lane needs either a
     # shared concurrency group (which cancels superseded pending runs into red
@@ -358,8 +358,10 @@ jobs:
         run: |
           set -euo pipefail
           # --auto-version: every beta stamps the next-release marketing version.
-          # --external: publish the same main-tracking build to the external lane
-          # once Apple allows that MARKETING_VERSION.
+          # --external: publish the same main-tracking build to the external lane.
+          # The post-upload job assigns the build to the external group and, when
+          # Apple reports READY_FOR_BETA_SUBMISSION for a new MARKETING_VERSION,
+          # auto-submits it for Beta App Review.
           # --notes-from-range: auto-generate audience-appropriate "What to
           # Test" notes from the commits since the previous beta (skipped if we
           # have no base SHA yet).
@@ -390,7 +392,7 @@ jobs:
             echo "- lane: \`beta\` (bundle id \`dev.cmux.app.beta\`, external-eligible)"
             echo "- signing: manual (CI-imported iOS distribution cert + beta profile)"
             echo "- build number (CFBundleVersion): \`${BUILD_NUMBER}\`"
-            echo "- audience: internal testers immediately, external testers after Apple Beta App Review for a new MARKETING_VERSION"
+            echo "- audience: internal testers immediately, external testers automatically after external-group assignment; new MARKETING_VERSIONs are auto-submitted for Apple Beta App Review"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Persist uploaded build metadata

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -423,7 +423,7 @@ jobs:
     needs: [decide, upload]
     if: always() && (needs.decide.outputs.should_build == 'true' || needs.decide.outputs.should_assign_only == 'true') && github.ref == 'refs/heads/main' && (needs.upload.result == 'success' || needs.decide.outputs.should_assign_only == 'true')
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 20
+    timeout-minutes: 40
     env:
       ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
       ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -81,9 +81,9 @@ jobs:
             const forceBuild = process.env.FORCE_BUILD === 'true';
             const { owner, repo } = context.repo;
 
-            // The head_sha of the most recent run on main whose *upload job*
-            // succeeded is the last uploaded beta commit. We intentionally do NOT
-            // key this off whole-workflow success: a later post-upload job (for
+            // The head_sha of the most recent CANONICAL run on main whose *upload
+            // job* succeeded is the last uploaded beta commit. We intentionally do
+            // NOT key this off whole-workflow success: a later post-upload job (for
             // example external-group assignment) may fail after the IPA has already
             // been uploaded, and re-uploading the same SHA on the next schedule
             // would create duplicate TestFlight builds for one commit. We always
@@ -96,6 +96,21 @@ jobs:
             // last_uploaded_sha and poison the next real beta's notes base (the
             // generator also fails closed to a fallback line when the base is not
             // an ancestor of HEAD).
+            //
+            // Manual marketing-version-override uploads are deliberately excluded
+            // from this canonical lane. They ship the current main SHA under an
+            // older approved MARKETING_VERSION as a one-off escape hatch, but they
+            // must NOT suppress the next scheduled auto-versioned beta for the same
+            // commit. Override runs upload a dedicated
+            // ios-testflight-build-metadata-override artifact instead of the
+            // canonical ios-testflight-build-metadata artifact, and we skip only
+            // those runs here.
+            //
+            // Backward compatibility: before this patch there was no
+            // marketing_version_override dispatch path in this workflow at all, so
+            // any older workflow_dispatch run that only has the canonical artifact
+            // is necessarily a normal immediate beta cut and SHOULD count as the
+            // last canonical upload.
             let lastUploadedSha = null;
             let lastUploadedRunId = null;
             let lastAssignmentSucceeded = false;
@@ -121,6 +136,21 @@ jobs:
                   });
                   const uploadJob = jobs.data.jobs.find((job) => job.name === 'Upload to TestFlight');
                   if (uploadJob?.conclusion === 'success') {
+                    const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                      owner,
+                      repo,
+                      run_id: run.id,
+                      per_page: 100,
+                    });
+                    const artifactNames = new Set(
+                      (artifacts.data.artifacts || []).map((artifact) => artifact.name)
+                    );
+                    if (
+                      artifactNames.has('ios-testflight-build-metadata-override') &&
+                      !artifactNames.has('ios-testflight-build-metadata')
+                    ) {
+                      continue;
+                    }
                     lastUploadedSha = run.head_sha;
                     lastUploadedRunId = String(run.id);
                     const assignJob = jobs.data.jobs.find(
@@ -134,7 +164,35 @@ jobs:
                     // Only the post-migration workflow shape can enter the
                     // assignment-only path.
                     lastAssignmentRetrySupported = !!assignJob;
-                    lastAssignmentSucceeded = assignJob?.conclusion === 'success';
+                    // A same-version sibling already in Beta App Review is a
+                    // legitimate "pending" state outside CI's control, so the
+                    // assign job returns success but uploads a dedicated pending
+                    // artifact. That lets the schedule retry assignment-only
+                    // later without turning the current main commit red.
+                    //
+                    // Fail closed for RECENT pre-migration success runs that
+                    // have NO assignment-state artifact at all. The old helper
+                    // could report success both when the build was truly
+                    // complete and when it was merely pending behind a sibling
+                    // review, so a fresh missing-state run should be retried; a
+                    // genuinely-complete build will short-circuit quickly on
+                    // the recheck.
+                    //
+                    // Do NOT fail closed forever: artifacts expire after 30
+                    // days, and an idle main branch must not fall into
+                    // permanent red assign-only retries just because historical
+                    // metadata aged out. Once the run is past the retention
+                    // horizon, treat missing state as effectively complete.
+                    const assignmentComplete =
+                      artifactNames.has('ios-testflight-assignment-state-complete');
+                    const assignmentPending =
+                      artifactNames.has('ios-testflight-assignment-state-pending');
+                    const runAgeMs = Date.now() - Date.parse(run.created_at);
+                    const assignmentArtifactRetentionMs = 30 * 24 * 60 * 60 * 1000;
+                    const assignmentStateExpired = runAgeMs > assignmentArtifactRetentionMs;
+                    lastAssignmentSucceeded =
+                      assignJob?.conclusion === 'success' &&
+                      (assignmentComplete || (!assignmentPending && assignmentStateExpired));
                     break;
                   }
                 }
@@ -428,17 +486,23 @@ jobs:
         if: success()
         env:
           FINAL_BUILD_NUMBER: ${{ steps.upload.outputs.final_build_number }}
+          INPUT_MARKETING_VERSION_OVERRIDE: ${{ github.event.inputs.marketing_version_override }}
         run: |
           set -euo pipefail
+          if [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
+            UPLOAD_MODE="marketing_version_override"
+          else
+            UPLOAD_MODE="auto_version"
+          fi
           cat > "$RUNNER_TEMP/ios-testflight-build.json" <<EOF
-          {"head_sha":"${GITHUB_SHA}","build_number":"${FINAL_BUILD_NUMBER}"}
+          {"head_sha":"${GITHUB_SHA}","build_number":"${FINAL_BUILD_NUMBER}","upload_mode":"${UPLOAD_MODE}"}
           EOF
 
       - name: Upload build metadata artifact
         if: success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ios-testflight-build-metadata
+          name: ${{ github.event.inputs.marketing_version_override != '' && 'ios-testflight-build-metadata-override' || 'ios-testflight-build-metadata' }}
           path: ${{ runner.temp }}/ios-testflight-build.json
           retention-days: 30
 
@@ -464,6 +528,7 @@ jobs:
       SHOULD_ASSIGN_ONLY: ${{ needs.decide.outputs.should_assign_only }}
       LAST_UPLOADED_RUN_ID: ${{ needs.decide.outputs.last_uploaded_run_id }}
       BUILD_NUMBER: ${{ needs.upload.outputs.final_build_number }}
+      CMUX_TESTFLIGHT_ASSIGN_STATE_OUT_FILE: ${{ runner.temp }}/ios-testflight-assign-state.txt
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -479,6 +544,7 @@ jobs:
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
 
       - name: Assign uploaded build to the external beta group
+        id: assign
         run: |
           set -euo pipefail
           if [ -z "${BUILD_NUMBER:-}" ] || [ "$BUILD_NUMBER" = "unknown" ]; then
@@ -488,3 +554,16 @@ jobs:
           python3 ./ios/scripts/asc_assign_external_testflight_group.py \
             --bundle-id dev.cmux.app.beta \
             --build-number "$BUILD_NUMBER"
+          ASSIGNMENT_STATE="unknown"
+          if [ -f "$CMUX_TESTFLIGHT_ASSIGN_STATE_OUT_FILE" ]; then
+            ASSIGNMENT_STATE="$(cat "$CMUX_TESTFLIGHT_ASSIGN_STATE_OUT_FILE")"
+          fi
+          echo "assignment_state=$ASSIGNMENT_STATE" >> "$GITHUB_OUTPUT"
+
+      - name: Upload assignment-state artifact
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.assign.outputs.assignment_state == 'sibling_review_pending' && 'ios-testflight-assignment-state-pending' || 'ios-testflight-assignment-state-complete' }}
+          path: ${{ runner.temp }}/ios-testflight-assign-state.txt
+          retention-days: 30

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -18,6 +18,10 @@ on:
         description: CFBundleVersion to stamp (defaults to UTC yyyyMMddHHmmss)
         required: false
         default: ""
+      marketing_version_override:
+        description: Optional one-time MARKETING_VERSION override (for example 1.0.1)
+        required: false
+        default: ""
       force:
         # Manual (workflow_dispatch) runs always upload, so this only documents
         # intent. It exists so the no-new-commits skip can be bypassed if the
@@ -355,24 +359,43 @@ jobs:
           # of the per-build "What to Test" commit range. Empty on the very first
           # run / a missing history, where the generator falls back gracefully.
           LAST_UPLOADED_SHA: ${{ needs.decide.outputs.last_uploaded_sha }}
+          # Optional manual one-off override that reuses an older approved
+          # MARKETING_VERSION so external testers can install it immediately.
+          INPUT_MARKETING_VERSION_OVERRIDE: ${{ github.event.inputs.marketing_version_override }}
         run: |
           set -euo pipefail
-          # --auto-version: every beta stamps the next-release marketing version.
-          # --external: publish the same main-tracking build to the external lane.
-          # The post-upload job assigns the build to the external group and, when
-          # Apple reports READY_FOR_BETA_SUBMISSION for a new MARKETING_VERSION,
-          # auto-submits it for Beta App Review.
-          # --notes-from-range: auto-generate audience-appropriate "What to
-          # Test" notes from the commits since the previous beta (skipped if we
-          # have no base SHA yet).
-          ARGS=(--lane beta --signing manual --auto-version --external)
-          if [ -n "${LAST_UPLOADED_SHA:-}" ]; then
-            ARGS+=(--notes-from-range "$LAST_UPLOADED_SHA")
+          if [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
+            # One-time operator escape hatch: upload latest main as another build
+            # of an already-approved MARKETING_VERSION, which avoids starting a
+            # fresh Beta App Review for that version. This path intentionally
+            # skips changelog-driven notes because ios/CHANGELOG.md tracks the
+            # current release line, not the reused older version.
+            if [ -n "${INPUT_BUILD_NUMBER:-}" ]; then
+              echo "build_number is not supported together with marketing_version_override in the cloud override path" >&2
+              exit 1
+            fi
+            ./ios/scripts/cloud-testflight.sh \
+              --external \
+              --marketing-version "$INPUT_MARKETING_VERSION_OVERRIDE" \
+              --skip-notes
+          else
+            # --auto-version: every beta stamps the next-release marketing version.
+            # --external: publish the same main-tracking build to the external lane.
+            # The post-upload job assigns the build to the external group and, when
+            # Apple reports READY_FOR_BETA_SUBMISSION for a new MARKETING_VERSION,
+            # auto-submits it for Beta App Review.
+            # --notes-from-range: auto-generate audience-appropriate "What to
+            # Test" notes from the commits since the previous beta (skipped if we
+            # have no base SHA yet).
+            ARGS=(--lane beta --signing manual --auto-version --external)
+            if [ -n "${LAST_UPLOADED_SHA:-}" ]; then
+              ARGS+=(--notes-from-range "$LAST_UPLOADED_SHA")
+            fi
+            if [ -n "${INPUT_BUILD_NUMBER:-}" ]; then
+              ARGS+=(--build-number "$INPUT_BUILD_NUMBER")
+            fi
+            ./ios/scripts/upload-testflight.sh "${ARGS[@]}"
           fi
-          if [ -n "${INPUT_BUILD_NUMBER:-}" ]; then
-            ARGS+=(--build-number "$INPUT_BUILD_NUMBER")
-          fi
-          ./ios/scripts/upload-testflight.sh "${ARGS[@]}"
           if [ -f "$CMUX_BUILD_NUMBER_OUT_FILE" ]; then
             FINAL_BN="$(cat "$CMUX_BUILD_NUMBER_OUT_FILE")"
           else
@@ -385,12 +408,18 @@ jobs:
         if: always()
         env:
           BUILD_NUMBER: ${{ steps.upload.outputs.final_build_number || github.event.inputs.build_number || 'unknown' }}
+          INPUT_MARKETING_VERSION_OVERRIDE: ${{ github.event.inputs.marketing_version_override }}
         run: |
           {
             echo "### iOS TestFlight upload"
             echo
             echo "- lane: \`beta\` (bundle id \`dev.cmux.app.beta\`, external-eligible)"
             echo "- signing: manual (CI-imported iOS distribution cert + beta profile)"
+            if [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
+              echo "- marketing version override: \`${INPUT_MARKETING_VERSION_OVERRIDE}\`"
+            else
+              echo "- marketing version: auto-versioned from the beta lane"
+            fi
             echo "- build number (CFBundleVersion): \`${BUILD_NUMBER}\`"
             echo "- audience: internal testers immediately, external testers automatically after external-group assignment; new MARKETING_VERSIONs are auto-submitted for Apple Beta App Review"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/ios/README.md
+++ b/ios/README.md
@@ -102,7 +102,10 @@ external-eligible builds too, so founders track `main` once the current version
 has cleared that review gate. The upload path assigns the processed build to the
 app's external beta group automatically, auto-selecting the single external
 group or using `IOS_TESTFLIGHT_EXTERNAL_GROUP_ID` / `IOS_TESTFLIGHT_EXTERNAL_GROUP_NAME`
-repo variables when the app has multiple external groups.
+repo variables when the app has multiple external groups. When Apple reports the
+build as `READY_FOR_BETA_SUBMISSION`, the same lane also creates the beta app
+review submission automatically so a new `MARKETING_VERSION` is not left stuck
+at "Ready to Submit".
 
 ## TestFlight GitHub Actions signing
 
@@ -110,9 +113,11 @@ repo variables when the app has multiple external groups.
 automatic App Store Connect export has produced IPAs whose signed app entitlements
 omit `aps-environment=production`. That upload is intentionally blocked because
 TestFlight push would silently fail. The workflow tracks `main` on a schedule and
-uploads beta builds as external-eligible, so internal testers get the build
-immediately and external testers get the same `main` build once Apple has
-approved that `MARKETING_VERSION` for Beta App Review.
+uploads beta builds as external-eligible. Internal testers get the build
+immediately, and the post-upload external distribution step both assigns the
+build to the founders group and auto-submits a new `MARKETING_VERSION` for Beta
+App Review so external testers get the same `main` build as soon as Apple
+approves it.
 
 Required GitHub secrets:
 

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -36,6 +36,15 @@ import urllib.parse
 import urllib.request
 
 API_BASE = "https://api.appstoreconnect.apple.com"
+ACTIVE_EXTERNAL_BUILD_STATES = {
+    "READY_FOR_BETA_TESTING",
+    "IN_BETA_REVIEW",
+    "WAITING_FOR_BETA_REVIEW",
+}
+ACTIVE_BETA_REVIEW_STATES = {
+    "WAITING_FOR_REVIEW",
+    "IN_REVIEW",
+}
 
 
 def _b64u(data: bytes) -> bytes:
@@ -195,6 +204,22 @@ def _build_beta_detail(token: str, build_id: str) -> Dict[str, str]:
     }
 
 
+def _build_pre_release_version(token: str, build_id: str) -> Dict[str, str]:
+    status, body = _request(
+        token,
+        "GET",
+        f"/v1/builds/{build_id}/preReleaseVersion?fields[preReleaseVersions]=version",
+    )
+    if status != 200:
+        raise RuntimeError(f"pre-release version lookup HTTP {status} (code={_asc_error_code(body)})")
+    data = body.get("data") or {}
+    attrs = data.get("attributes") or {}
+    return {
+        "id": str(data.get("id") or ""),
+        "version": str(attrs.get("version") or ""),
+    }
+
+
 def _beta_review_submission(token: str, build_id: str) -> Optional[Dict[str, str]]:
     status, body = _request(
         token,
@@ -209,6 +234,14 @@ def _beta_review_submission(token: str, build_id: str) -> Optional[Dict[str, str
         return None
     attrs = data[0].get("attributes") or {}
     return {"id": data[0]["id"], "beta_review_state": str(attrs.get("betaReviewState") or "")}
+
+
+def _pre_release_version_build_ids(token: str, pre_release_version_id: str) -> List[str]:
+    builds = _paged_get(
+        token,
+        f"/v1/preReleaseVersions/{pre_release_version_id}/relationships/builds?limit=200",
+    )
+    return [str(item.get("id") or "") for item in builds if item.get("id")]
 
 
 def _list_beta_groups(token: str, app_id: str) -> List[Dict]:
@@ -306,45 +339,120 @@ def _submit_beta_review(token: str, build_id: str) -> None:
         raise RuntimeError(f"submit beta app review HTTP {status} (code={_asc_error_code(body)})")
 
 
-def _ensure_external_review_submission(token: str, build_id: str, build_number: str) -> None:
-    detail = _build_beta_detail(token, build_id)
-    external_state = detail["external_build_state"]
-    if external_state == "READY_FOR_BETA_SUBMISSION":
+def _find_active_review_submission_on_sibling_build(
+    token: str,
+    build_id: str,
+) -> Optional[Dict[str, str]]:
+    pre_release_version = _build_pre_release_version(token, build_id)
+    pre_release_version_id = pre_release_version["id"]
+    if not pre_release_version_id:
+        return None
+    for sibling_build_id in _pre_release_version_build_ids(token, pre_release_version_id):
+        if sibling_build_id == build_id:
+            continue
+        submission = _beta_review_submission(token, sibling_build_id)
+        if submission is None:
+            continue
+        review_state = submission["beta_review_state"]
+        if review_state in ACTIVE_BETA_REVIEW_STATES:
+            return {
+                "build_id": sibling_build_id,
+                "submission_id": submission["id"],
+                "beta_review_state": review_state,
+                "pre_release_version": pre_release_version["version"],
+            }
+    return None
+
+
+def _ensure_external_review_submission(
+    token: str,
+    build_id: str,
+    build_number: str,
+    deadline: float,
+    poll_seconds: int,
+) -> None:
+    while True:
+        detail = _build_beta_detail(token, build_id)
+        external_state = detail["external_build_state"]
         submission = _beta_review_submission(token, build_id)
-        if submission is not None:
+        sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
+
+        if sibling_submission is not None:
             print(
                 "asc_assign_external_testflight_group: build "
-                f"{build_number} already has beta app review submission {submission['id']} "
-                f"(state={submission['beta_review_state'] or 'unknown'})"
+                f"{build_number} stays pending while sibling build {sibling_submission['build_id']} "
+                f"for version {sibling_submission['pre_release_version'] or 'unknown'} remains in "
+                f"beta review (submission {sibling_submission['submission_id']}, "
+                f"state={sibling_submission['beta_review_state']})"
             )
             return
-        _submit_beta_review(token, build_id)
-        print(
-            f"asc_assign_external_testflight_group: submitted build {build_number} for beta app review"
-        )
-        return
 
-    if external_state in ("READY_FOR_BETA_TESTING", "IN_BETA_REVIEW", "WAITING_FOR_BETA_REVIEW"):
-        print(
-            "asc_assign_external_testflight_group: build "
-            f"{build_number} external state is {external_state}"
-        )
-        return
+        if external_state == "READY_FOR_BETA_SUBMISSION":
+            if submission is not None:
+                review_state = submission["beta_review_state"]
+                if review_state in ACTIVE_BETA_REVIEW_STATES:
+                    print(
+                        "asc_assign_external_testflight_group: build "
+                        f"{build_number} already has beta app review submission {submission['id']} "
+                        f"(state={review_state or 'unknown'})"
+                    )
+                    return
+                raise RuntimeError(
+                    "build "
+                    f"{build_number} has beta app review submission {submission['id']} "
+                    f"in unexpected betaReviewState={review_state or '<empty>'}"
+                )
 
-    submission = _beta_review_submission(token, build_id)
-    if submission is not None:
-        print(
-            "asc_assign_external_testflight_group: build "
-            f"{build_number} external state is {external_state or 'unknown'} with submission "
-            f"{submission['id']} (state={submission['beta_review_state'] or 'unknown'})"
-        )
-        return
+            try:
+                _submit_beta_review(token, build_id)
+            except RuntimeError:
+                sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
+                if sibling_submission is None:
+                    raise
+                print(
+                    "asc_assign_external_testflight_group: build "
+                    f"{build_number} stays pending while sibling build {sibling_submission['build_id']} "
+                    f"for version {sibling_submission['pre_release_version'] or 'unknown'} remains in "
+                    f"beta review (submission {sibling_submission['submission_id']}, "
+                    f"state={sibling_submission['beta_review_state']})"
+                )
+                return
+            print(
+                f"asc_assign_external_testflight_group: submitted build {build_number} for beta app review"
+            )
+            return
 
-    raise RuntimeError(
-        "build "
-        f"{build_number} is in unexpected externalBuildState={external_state or '<empty>'} "
-        "with no beta app review submission"
-    )
+        if external_state in ACTIVE_EXTERNAL_BUILD_STATES:
+            print(
+                "asc_assign_external_testflight_group: build "
+                f"{build_number} external state is {external_state}"
+            )
+            return
+
+        if submission is not None:
+            review_state = submission["beta_review_state"]
+            if review_state in ACTIVE_BETA_REVIEW_STATES:
+                print(
+                    "asc_assign_external_testflight_group: build "
+                    f"{build_number} external state is {external_state or 'unknown'} with submission "
+                    f"{submission['id']} (state={review_state or 'unknown'})"
+                )
+                return
+            raise RuntimeError(
+                "build "
+                f"{build_number} external state is {external_state or '<empty>'} with beta app review "
+                f"submission {submission['id']} in unexpected betaReviewState={review_state or '<empty>'}"
+            )
+
+        if time.time() >= deadline:
+            raise RuntimeError(
+                "build "
+                f"{build_number} is in unexpected externalBuildState={external_state or '<empty>'} "
+                "with no beta app review submission"
+            )
+
+        time.sleep(max(1, poll_seconds))
+        token = _token()
 
 
 def main() -> int:
@@ -401,7 +509,13 @@ def main() -> int:
             f"already has access to all builds"
         )
         token = _token()
-        _ensure_external_review_submission(token, build_id, args.build_number)
+        _ensure_external_review_submission(
+            token,
+            build_id,
+            args.build_number,
+            deadline,
+            args.poll_seconds,
+        )
         return 0
 
     if _group_has_build(token, target_group["id"], build_id):
@@ -410,7 +524,13 @@ def main() -> int:
             f"{_describe_group(target_group)}"
         )
         token = _token()
-        _ensure_external_review_submission(token, build_id, args.build_number)
+        _ensure_external_review_submission(
+            token,
+            build_id,
+            args.build_number,
+            deadline,
+            args.poll_seconds,
+        )
         return 0
 
     token = _token()
@@ -420,7 +540,13 @@ def main() -> int:
         f"{_describe_group(target_group)}"
     )
     token = _token()
-    _ensure_external_review_submission(token, build_id, args.build_number)
+    _ensure_external_review_submission(
+        token,
+        build_id,
+        args.build_number,
+        deadline,
+        args.poll_seconds,
+    )
     return 0
 
 

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -364,6 +364,16 @@ def _find_active_review_submission_on_sibling_build(
     return None
 
 
+def _pending_sibling_review_error(build_number: str, sibling_submission: Dict[str, str]) -> RuntimeError:
+    return RuntimeError(
+        "build "
+        f"{build_number} is still pending while sibling build {sibling_submission['build_id']} for "
+        f"version {sibling_submission['pre_release_version'] or 'unknown'} remains in beta review "
+        f"(submission {sibling_submission['submission_id']}, "
+        f"state={sibling_submission['beta_review_state']}); retry external assignment later"
+    )
+
+
 def _ensure_external_review_submission(
     token: str,
     build_id: str,
@@ -376,51 +386,6 @@ def _ensure_external_review_submission(
         external_state = detail["external_build_state"]
         submission = _beta_review_submission(token, build_id)
         sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
-
-        if sibling_submission is not None:
-            print(
-                "asc_assign_external_testflight_group: build "
-                f"{build_number} stays pending while sibling build {sibling_submission['build_id']} "
-                f"for version {sibling_submission['pre_release_version'] or 'unknown'} remains in "
-                f"beta review (submission {sibling_submission['submission_id']}, "
-                f"state={sibling_submission['beta_review_state']})"
-            )
-            return
-
-        if external_state == "READY_FOR_BETA_SUBMISSION":
-            if submission is not None:
-                review_state = submission["beta_review_state"]
-                if review_state in ACTIVE_BETA_REVIEW_STATES:
-                    print(
-                        "asc_assign_external_testflight_group: build "
-                        f"{build_number} already has beta app review submission {submission['id']} "
-                        f"(state={review_state or 'unknown'})"
-                    )
-                    return
-                raise RuntimeError(
-                    "build "
-                    f"{build_number} has beta app review submission {submission['id']} "
-                    f"in unexpected betaReviewState={review_state or '<empty>'}"
-                )
-
-            try:
-                _submit_beta_review(token, build_id)
-            except RuntimeError:
-                sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
-                if sibling_submission is None:
-                    raise
-                print(
-                    "asc_assign_external_testflight_group: build "
-                    f"{build_number} stays pending while sibling build {sibling_submission['build_id']} "
-                    f"for version {sibling_submission['pre_release_version'] or 'unknown'} remains in "
-                    f"beta review (submission {sibling_submission['submission_id']}, "
-                    f"state={sibling_submission['beta_review_state']})"
-                )
-                return
-            print(
-                f"asc_assign_external_testflight_group: submitted build {build_number} for beta app review"
-            )
-            return
 
         if external_state in ACTIVE_EXTERNAL_BUILD_STATES:
             print(
@@ -443,6 +408,37 @@ def _ensure_external_review_submission(
                 f"{build_number} external state is {external_state or '<empty>'} with beta app review "
                 f"submission {submission['id']} in unexpected betaReviewState={review_state or '<empty>'}"
             )
+
+        if sibling_submission is not None:
+            raise _pending_sibling_review_error(build_number, sibling_submission)
+
+        if external_state == "READY_FOR_BETA_SUBMISSION":
+            try:
+                _submit_beta_review(token, build_id)
+            except RuntimeError:
+                submission = _beta_review_submission(token, build_id)
+                if submission is not None:
+                    review_state = submission["beta_review_state"]
+                    if review_state in ACTIVE_BETA_REVIEW_STATES:
+                        print(
+                            "asc_assign_external_testflight_group: build "
+                            f"{build_number} external state is READY_FOR_BETA_SUBMISSION with submission "
+                            f"{submission['id']} (state={review_state or 'unknown'})"
+                        )
+                        return
+                    raise RuntimeError(
+                        "build "
+                        f"{build_number} external state is READY_FOR_BETA_SUBMISSION with beta app review "
+                        f"submission {submission['id']} in unexpected betaReviewState={review_state or '<empty>'}"
+                    )
+                sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
+                if sibling_submission is not None:
+                    raise _pending_sibling_review_error(build_number, sibling_submission)
+                raise
+            print(
+                f"asc_assign_external_testflight_group: submitted build {build_number} for beta app review"
+            )
+            return
 
         if time.time() >= deadline:
             raise RuntimeError(

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -383,10 +383,19 @@ def _ensure_external_review_submission(
 ) -> None:
     last_submit_error = ""
     while True:
-        detail = _build_beta_detail(token, build_id)
-        external_state = detail["external_build_state"]
-        submission = _beta_review_submission(token, build_id)
-        sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
+        try:
+            detail = _build_beta_detail(token, build_id)
+            external_state = detail["external_build_state"]
+            submission = _beta_review_submission(token, build_id)
+            sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
+        except RuntimeError as exc:
+            if time.time() >= deadline:
+                raise RuntimeError(
+                    f"build {build_number} review metadata did not become readable within the timeout window: {exc}"
+                )
+            time.sleep(max(1, poll_seconds))
+            token = _token()
+            continue
 
         if external_state in ACTIVE_EXTERNAL_BUILD_STATES:
             print(

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -381,6 +381,7 @@ def _ensure_external_review_submission(
     deadline: float,
     poll_seconds: int,
 ) -> None:
+    last_submit_error = ""
     while True:
         detail = _build_beta_detail(token, build_id)
         external_state = detail["external_build_state"]
@@ -415,7 +416,8 @@ def _ensure_external_review_submission(
         if external_state == "READY_FOR_BETA_SUBMISSION":
             try:
                 _submit_beta_review(token, build_id)
-            except RuntimeError:
+                last_submit_error = ""
+            except RuntimeError as exc:
                 submission = _beta_review_submission(token, build_id)
                 if submission is not None:
                     review_state = submission["beta_review_state"]
@@ -434,13 +436,25 @@ def _ensure_external_review_submission(
                 sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
                 if sibling_submission is not None:
                     raise _pending_sibling_review_error(build_number, sibling_submission)
-                raise
+                last_submit_error = str(exc) or "submit beta app review did not succeed yet"
+                if time.time() >= deadline:
+                    raise RuntimeError(
+                        f"build {build_number} failed to submit beta app review within the timeout window"
+                    )
+                time.sleep(max(1, poll_seconds))
+                token = _token()
+                continue
             print(
                 f"asc_assign_external_testflight_group: submitted build {build_number} for beta app review"
             )
             return
 
         if time.time() >= deadline:
+            if last_submit_error:
+                raise RuntimeError(
+                    f"build {build_number} did not become externally reviewable within the timeout window "
+                    f"({last_submit_error})"
+                )
             raise RuntimeError(
                 "build "
                 f"{build_number} is in unexpected externalBuildState={external_state or '<empty>'} "
@@ -509,7 +523,7 @@ def main() -> int:
             token,
             build_id,
             args.build_number,
-            deadline,
+            time.time() + max(0, args.timeout_seconds),
             args.poll_seconds,
         )
         return 0
@@ -524,7 +538,7 @@ def main() -> int:
             token,
             build_id,
             args.build_number,
-            deadline,
+            time.time() + max(0, args.timeout_seconds),
             args.poll_seconds,
         )
         return 0
@@ -540,7 +554,7 @@ def main() -> int:
         token,
         build_id,
         args.build_number,
-        deadline,
+        time.time() + max(0, args.timeout_seconds),
         args.poll_seconds,
     )
     return 0

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -5,6 +5,9 @@
 but testers do not receive it until the build is added to an external beta group.
 This helper resolves the app from its bundle id, waits for the uploaded build to
 appear, selects the external beta group, and attaches the build to that group.
+When Apple reports the build as `READY_FOR_BETA_SUBMISSION` (the first external
+build of a MARKETING_VERSION), it also creates the beta app review submission so
+external testers can actually receive that version once review clears.
 
 Group selection:
 - `--group-id` / `CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID` wins.
@@ -177,6 +180,37 @@ def _find_build(token: str, app_id: str, build_number: str) -> Optional[Tuple[st
     return data[0]["id"], str(attrs.get("processingState") or "")
 
 
+def _build_beta_detail(token: str, build_id: str) -> Dict[str, str]:
+    status, body = _request(
+        token,
+        "GET",
+        f"/v1/builds/{build_id}/buildBetaDetail",
+    )
+    if status != 200:
+        raise RuntimeError(f"build beta detail lookup HTTP {status} (code={_asc_error_code(body)})")
+    attrs = (body.get("data") or {}).get("attributes") or {}
+    return {
+        "external_build_state": str(attrs.get("externalBuildState") or ""),
+        "internal_build_state": str(attrs.get("internalBuildState") or ""),
+    }
+
+
+def _beta_review_submission(token: str, build_id: str) -> Optional[Dict[str, str]]:
+    status, body = _request(
+        token,
+        "GET",
+        f"/v1/betaAppReviewSubmissions?filter[build]={build_id}"
+        "&fields[betaAppReviewSubmissions]=betaReviewState&limit=1",
+    )
+    if status != 200:
+        raise RuntimeError(f"beta app review submission lookup HTTP {status} (code={_asc_error_code(body)})")
+    data = body.get("data", [])
+    if not data:
+        return None
+    attrs = data[0].get("attributes") or {}
+    return {"id": data[0]["id"], "beta_review_state": str(attrs.get("betaReviewState") or "")}
+
+
 def _list_beta_groups(token: str, app_id: str) -> List[Dict]:
     raw = _paged_get(
         token,
@@ -253,6 +287,66 @@ def _assign_build(token: str, group_id: str, build_id: str) -> None:
         raise RuntimeError(f"assign build HTTP {status} (code={_asc_error_code(body)})")
 
 
+def _submit_beta_review(token: str, build_id: str) -> None:
+    payload = {
+        "data": {
+            "type": "betaAppReviewSubmissions",
+            "relationships": {
+                "build": {
+                    "data": {
+                        "type": "builds",
+                        "id": build_id,
+                    }
+                }
+            },
+        }
+    }
+    status, body = _request(token, "POST", "/v1/betaAppReviewSubmissions", payload)
+    if status not in (200, 201):
+        raise RuntimeError(f"submit beta app review HTTP {status} (code={_asc_error_code(body)})")
+
+
+def _ensure_external_review_submission(token: str, build_id: str, build_number: str) -> None:
+    detail = _build_beta_detail(token, build_id)
+    external_state = detail["external_build_state"]
+    if external_state == "READY_FOR_BETA_SUBMISSION":
+        submission = _beta_review_submission(token, build_id)
+        if submission is not None:
+            print(
+                "asc_assign_external_testflight_group: build "
+                f"{build_number} already has beta app review submission {submission['id']} "
+                f"(state={submission['beta_review_state'] or 'unknown'})"
+            )
+            return
+        _submit_beta_review(token, build_id)
+        print(
+            f"asc_assign_external_testflight_group: submitted build {build_number} for beta app review"
+        )
+        return
+
+    if external_state in ("READY_FOR_BETA_TESTING", "IN_BETA_REVIEW", "WAITING_FOR_BETA_REVIEW"):
+        print(
+            "asc_assign_external_testflight_group: build "
+            f"{build_number} external state is {external_state}"
+        )
+        return
+
+    submission = _beta_review_submission(token, build_id)
+    if submission is not None:
+        print(
+            "asc_assign_external_testflight_group: build "
+            f"{build_number} external state is {external_state or 'unknown'} with submission "
+            f"{submission['id']} (state={submission['beta_review_state'] or 'unknown'})"
+        )
+        return
+
+    raise RuntimeError(
+        "build "
+        f"{build_number} is in unexpected externalBuildState={external_state or '<empty>'} "
+        "with no beta app review submission"
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--bundle-id", required=True)
@@ -306,6 +400,8 @@ def main() -> int:
             f"asc_assign_external_testflight_group: group {_describe_group(target_group)} "
             f"already has access to all builds"
         )
+        token = _token()
+        _ensure_external_review_submission(token, build_id, args.build_number)
         return 0
 
     if _group_has_build(token, target_group["id"], build_id):
@@ -313,6 +409,8 @@ def main() -> int:
             f"asc_assign_external_testflight_group: build {args.build_number} already assigned to "
             f"{_describe_group(target_group)}"
         )
+        token = _token()
+        _ensure_external_review_submission(token, build_id, args.build_number)
         return 0
 
     token = _token()
@@ -321,6 +419,8 @@ def main() -> int:
         f"asc_assign_external_testflight_group: assigned build {args.build_number} to "
         f"{_describe_group(target_group)}"
     )
+    token = _token()
+    _ensure_external_review_submission(token, build_id, args.build_number)
     return 0
 
 

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -386,7 +386,6 @@ def _ensure_external_review_submission(
             detail = _build_beta_detail(token, build_id)
             external_state = detail["external_build_state"]
             submission = _beta_review_submission(token, build_id)
-            sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
         except RuntimeError as exc:
             if time.time() >= deadline:
                 raise RuntimeError(
@@ -418,11 +417,20 @@ def _ensure_external_review_submission(
                 f"submission {submission['id']} in unexpected betaReviewState={review_state or '<empty>'}"
             )
 
-        if sibling_submission is not None:
-            _report_pending_sibling_review(build_number, sibling_submission)
-            return
-
         if external_state == "READY_FOR_BETA_SUBMISSION":
+            try:
+                sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
+            except RuntimeError as exc:
+                if time.time() >= deadline:
+                    raise RuntimeError(
+                        f"build {build_number} sibling review metadata did not become readable within the timeout window: {exc}"
+                    )
+                time.sleep(max(1, poll_seconds))
+                token = _token()
+                continue
+            if sibling_submission is not None:
+                _report_pending_sibling_review(build_number, sibling_submission)
+                return
             try:
                 _submit_beta_review(token, build_id)
                 last_submit_error = ""

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -364,15 +364,14 @@ def _find_active_review_submission_on_sibling_build(
     return None
 
 
-def _pending_sibling_review_error(build_number: str, sibling_submission: Dict[str, str]) -> RuntimeError:
-    return RuntimeError(
-        "build "
-        f"{build_number} is still pending while sibling build {sibling_submission['build_id']} for "
+def _report_pending_sibling_review(build_number: str, sibling_submission: Dict[str, str]) -> None:
+    print(
+        "asc_assign_external_testflight_group: build "
+        f"{build_number} stays pending while sibling build {sibling_submission['build_id']} for "
         f"version {sibling_submission['pre_release_version'] or 'unknown'} remains in beta review "
         f"(submission {sibling_submission['submission_id']}, "
-        f"state={sibling_submission['beta_review_state']}); retry external assignment later"
+        f"state={sibling_submission['beta_review_state']})"
     )
-
 
 def _ensure_external_review_submission(
     token: str,
@@ -420,7 +419,8 @@ def _ensure_external_review_submission(
             )
 
         if sibling_submission is not None:
-            raise _pending_sibling_review_error(build_number, sibling_submission)
+            _report_pending_sibling_review(build_number, sibling_submission)
+            return
 
         if external_state == "READY_FOR_BETA_SUBMISSION":
             try:
@@ -444,7 +444,8 @@ def _ensure_external_review_submission(
                     )
                 sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
                 if sibling_submission is not None:
-                    raise _pending_sibling_review_error(build_number, sibling_submission)
+                    _report_pending_sibling_review(build_number, sibling_submission)
+                    return
                 last_submit_error = str(exc) or "submit beta app review did not succeed yet"
                 if time.time() >= deadline:
                     raise RuntimeError(

--- a/ios/scripts/asc_assign_external_testflight_group.py
+++ b/ios/scripts/asc_assign_external_testflight_group.py
@@ -37,11 +37,17 @@ import urllib.request
 
 API_BASE = "https://api.appstoreconnect.apple.com"
 ACTIVE_EXTERNAL_BUILD_STATES = {
+    "BETA_APPROVED",
     "READY_FOR_BETA_TESTING",
     "IN_BETA_REVIEW",
     "WAITING_FOR_BETA_REVIEW",
 }
-ACTIVE_BETA_REVIEW_STATES = {
+ACTIVE_CURRENT_BUILD_BETA_REVIEW_STATES = {
+    "APPROVED",
+    "WAITING_FOR_REVIEW",
+    "IN_REVIEW",
+}
+ACTIVE_SIBLING_BETA_REVIEW_STATES = {
     "WAITING_FOR_REVIEW",
     "IN_REVIEW",
 }
@@ -354,7 +360,7 @@ def _find_active_review_submission_on_sibling_build(
         if submission is None:
             continue
         review_state = submission["beta_review_state"]
-        if review_state in ACTIVE_BETA_REVIEW_STATES:
+        if review_state in ACTIVE_SIBLING_BETA_REVIEW_STATES:
             return {
                 "build_id": sibling_build_id,
                 "submission_id": submission["id"],
@@ -363,15 +369,29 @@ def _find_active_review_submission_on_sibling_build(
             }
     return None
 
-
-def _report_pending_sibling_review(build_number: str, sibling_submission: Dict[str, str]) -> None:
-    print(
-        "asc_assign_external_testflight_group: build "
+def _pending_sibling_review_message(build_number: str, sibling_submission: Dict[str, str]) -> str:
+    return (
+        "build "
         f"{build_number} stays pending while sibling build {sibling_submission['build_id']} for "
         f"version {sibling_submission['pre_release_version'] or 'unknown'} remains in beta review "
         f"(submission {sibling_submission['submission_id']}, "
         f"state={sibling_submission['beta_review_state']})"
     )
+
+
+def _report_pending_sibling_review(build_number: str, sibling_submission: Dict[str, str]) -> None:
+    print(
+        "asc_assign_external_testflight_group: "
+        f"{_pending_sibling_review_message(build_number, sibling_submission)}"
+    )
+
+
+def _write_state(state_out: str, state: str) -> None:
+    if not state_out:
+        return
+    with open(state_out, "w", encoding="utf-8") as fh:
+        fh.write(state)
+
 
 def _ensure_external_review_submission(
     token: str,
@@ -379,7 +399,7 @@ def _ensure_external_review_submission(
     build_number: str,
     deadline: float,
     poll_seconds: int,
-) -> None:
+) -> str:
     last_submit_error = ""
     while True:
         try:
@@ -400,17 +420,17 @@ def _ensure_external_review_submission(
                 "asc_assign_external_testflight_group: build "
                 f"{build_number} external state is {external_state}"
             )
-            return
+            return "current_build_active"
 
         if submission is not None:
             review_state = submission["beta_review_state"]
-            if review_state in ACTIVE_BETA_REVIEW_STATES:
+            if review_state in ACTIVE_CURRENT_BUILD_BETA_REVIEW_STATES:
                 print(
                     "asc_assign_external_testflight_group: build "
                     f"{build_number} external state is {external_state or 'unknown'} with submission "
                     f"{submission['id']} (state={review_state or 'unknown'})"
                 )
-                return
+                return "current_build_review_pending"
             raise RuntimeError(
                 "build "
                 f"{build_number} external state is {external_state or '<empty>'} with beta app review "
@@ -430,30 +450,43 @@ def _ensure_external_review_submission(
                 continue
             if sibling_submission is not None:
                 _report_pending_sibling_review(build_number, sibling_submission)
-                return
+                return "sibling_review_pending"
             try:
                 _submit_beta_review(token, build_id)
                 last_submit_error = ""
             except RuntimeError as exc:
-                submission = _beta_review_submission(token, build_id)
-                if submission is not None:
-                    review_state = submission["beta_review_state"]
-                    if review_state in ACTIVE_BETA_REVIEW_STATES:
-                        print(
-                            "asc_assign_external_testflight_group: build "
-                            f"{build_number} external state is READY_FOR_BETA_SUBMISSION with submission "
-                            f"{submission['id']} (state={review_state or 'unknown'})"
+                try:
+                    submission = _beta_review_submission(token, build_id)
+                    if submission is not None:
+                        review_state = submission["beta_review_state"]
+                        if review_state in ACTIVE_CURRENT_BUILD_BETA_REVIEW_STATES:
+                            print(
+                                "asc_assign_external_testflight_group: build "
+                                f"{build_number} external state is READY_FOR_BETA_SUBMISSION with submission "
+                                f"{submission['id']} (state={review_state or 'unknown'})"
+                            )
+                            return "current_build_review_pending"
+                        raise RuntimeError(
+                            "build "
+                            f"{build_number} external state is READY_FOR_BETA_SUBMISSION with beta app review "
+                            f"submission {submission['id']} in unexpected betaReviewState={review_state or '<empty>'}"
                         )
-                        return
-                    raise RuntimeError(
-                        "build "
-                        f"{build_number} external state is READY_FOR_BETA_SUBMISSION with beta app review "
-                        f"submission {submission['id']} in unexpected betaReviewState={review_state or '<empty>'}"
+                    sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
+                    if sibling_submission is not None:
+                        _report_pending_sibling_review(build_number, sibling_submission)
+                        return "sibling_review_pending"
+                except RuntimeError as recovery_exc:
+                    last_submit_error = (
+                        f"{str(exc) or 'submit beta app review did not succeed yet'}; "
+                        f"recovery lookup failed: {recovery_exc}"
                     )
-                sibling_submission = _find_active_review_submission_on_sibling_build(token, build_id)
-                if sibling_submission is not None:
-                    _report_pending_sibling_review(build_number, sibling_submission)
-                    return
+                    if time.time() >= deadline:
+                        raise RuntimeError(
+                            f"build {build_number} failed to submit beta app review within the timeout window"
+                        )
+                    time.sleep(max(1, poll_seconds))
+                    token = _token()
+                    continue
                 last_submit_error = str(exc) or "submit beta app review did not succeed yet"
                 if time.time() >= deadline:
                     raise RuntimeError(
@@ -465,7 +498,7 @@ def _ensure_external_review_submission(
             print(
                 f"asc_assign_external_testflight_group: submitted build {build_number} for beta app review"
             )
-            return
+            return "submitted_beta_review"
 
         if time.time() >= deadline:
             if last_submit_error:
@@ -491,6 +524,7 @@ def main() -> int:
     parser.add_argument("--group-name", default=os.environ.get("CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME", ""))
     parser.add_argument("--timeout-seconds", type=int, default=900)
     parser.add_argument("--poll-seconds", type=int, default=20)
+    parser.add_argument("--state-out", default=os.environ.get("CMUX_TESTFLIGHT_ASSIGN_STATE_OUT_FILE", ""))
     args = parser.parse_args()
 
     if args.group_id and args.group_name:
@@ -537,13 +571,14 @@ def main() -> int:
             f"already has access to all builds"
         )
         token = _token()
-        _ensure_external_review_submission(
+        state = _ensure_external_review_submission(
             token,
             build_id,
             args.build_number,
             time.time() + max(0, args.timeout_seconds),
             args.poll_seconds,
         )
+        _write_state(args.state_out, state)
         return 0
 
     if _group_has_build(token, target_group["id"], build_id):
@@ -552,13 +587,14 @@ def main() -> int:
             f"{_describe_group(target_group)}"
         )
         token = _token()
-        _ensure_external_review_submission(
+        state = _ensure_external_review_submission(
             token,
             build_id,
             args.build_number,
             time.time() + max(0, args.timeout_seconds),
             args.poll_seconds,
         )
+        _write_state(args.state_out, state)
         return 0
 
     token = _token()
@@ -568,13 +604,14 @@ def main() -> int:
         f"{_describe_group(target_group)}"
     )
     token = _token()
-    _ensure_external_review_submission(
+    state = _ensure_external_review_submission(
         token,
         build_id,
         args.build_number,
         time.time() + max(0, args.timeout_seconds),
         args.poll_seconds,
     )
+    _write_state(args.state_out, state)
     return 0
 
 

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -121,7 +121,9 @@ Options:
                             MARKETING_VERSION. With ASC API-key auth, the script
                             also assigns the processed build to the selected
                             external beta group (single external group by
-                            default, or CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID / _NAME).
+                            default, or CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID / _NAME)
+                            and auto-submits a new MARKETING_VERSION for Beta App
+                            Review when Apple reports READY_FOR_BETA_SUBMISSION.
                             Also set via
                             CMUX_TESTFLIGHT_EXTERNAL=1.
   --archive-path <path>     Reuse an existing archive instead of archiving.
@@ -939,12 +941,13 @@ fi
 
 # --external means "ship to founders", not merely "make this build externally
 # eligible in principle". After upload, assign the processed build to the app's
-# external beta group so external testers actually receive it. This is fatal: a
-# red CI/upload is preferable to claiming the external lane tracked main when the
-# build never reached the founders group.
+# external beta group so external testers actually receive it, and create the
+# Beta App Review submission when Apple requires one for a new
+# MARKETING_VERSION. This is fatal: a red CI/upload is preferable to claiming
+# the external lane tracked main when the build never reached the founders lane.
 if [[ "$EXPORT_ONLY" -ne 1 && "$EXTERNAL_TESTING" -eq 1 && "$ASSIGN_EXTERNAL_GROUP" -eq 1 ]]; then
   if [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" || ( -z "${ASC_API_KEY_PATH:-}" && -z "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
-    echo "warning: no ASC API key (JWT) available; uploaded the external-eligible build but skipped automatic external-group assignment. Supply ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH (or ASC_API_KEY_P8_BASE64) to assign the build automatically." >&2
+    echo "warning: no ASC API key (JWT) available; uploaded the external-eligible build but skipped automatic external-group assignment and Beta App Review submission. Supply ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH (or ASC_API_KEY_P8_BASE64) to distribute the build automatically." >&2
     exit 0
   fi
   echo "assigning external TestFlight build $SHIPPED_BUILD_NUMBER to the founders beta group" >&2

--- a/tests/test_ios_testflight_external_distribution.py
+++ b/tests/test_ios_testflight_external_distribution.py
@@ -39,6 +39,9 @@ def _group(group_id, name, is_internal, has_access_to_all_builds=False):
 
 def main():
     module = _load_module()
+    real_time = module.time.time
+    real_sleep = module.time.sleep
+    module._token = lambda: "jwt"
 
     groups = [
         _group("internal-1", "cmux beta", True),
@@ -95,12 +98,13 @@ def main():
         submissions.append((token, build_id))
 
     module._submit_beta_review = fake_submit
+    module._find_active_review_submission_on_sibling_build = lambda token, build_id: None
     module._build_beta_detail = lambda token, build_id: {
         "external_build_state": "READY_FOR_BETA_SUBMISSION",
         "internal_build_state": "READY_FOR_BETA_TESTING",
     }
     module._beta_review_submission = lambda token, build_id: None
-    module._ensure_external_review_submission("jwt", "build-1", "42")
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
     _check(submissions == [("jwt", "build-1")], "ready-for-submission builds create a beta review submission")
 
     submissions.clear()
@@ -108,7 +112,7 @@ def main():
         "id": "submission-1",
         "beta_review_state": "WAITING_FOR_REVIEW",
     }
-    module._ensure_external_review_submission("jwt", "build-1", "42")
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
     _check(not submissions, "existing beta review submissions are not duplicated")
 
     module._build_beta_detail = lambda token, build_id: {
@@ -116,15 +120,111 @@ def main():
         "internal_build_state": "READY_FOR_BETA_TESTING",
     }
     module._beta_review_submission = lambda token, build_id: None
-    module._ensure_external_review_submission("jwt", "build-1", "42")
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
     _check(not submissions, "ready-for-testing builds do not resubmit beta review")
 
+    polls = {"count": 0}
+
+    def transient_detail(token, build_id):
+        polls["count"] += 1
+        if polls["count"] == 1:
+            return {
+                "external_build_state": "",
+                "internal_build_state": "READY_FOR_BETA_TESTING",
+            }
+        return {
+            "external_build_state": "READY_FOR_BETA_SUBMISSION",
+            "internal_build_state": "READY_FOR_BETA_TESTING",
+        }
+
+    module._build_beta_detail = transient_detail
+    module._beta_review_submission = lambda token, build_id: None
+    module.time.sleep = lambda seconds: None
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        submissions == [("jwt", "build-1")],
+        "transient empty external state retries until beta review submission is possible",
+    )
+
+    submissions.clear()
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "READY_FOR_BETA_SUBMISSION",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
+    module._find_active_review_submission_on_sibling_build = lambda token, build_id: {
+        "build_id": "build-2",
+        "submission_id": "submission-2",
+        "beta_review_state": "WAITING_FOR_REVIEW",
+        "pre_release_version": "1.0.4",
+    }
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        not submissions,
+        "same-version sibling builds already in beta review are left alone",
+    )
+
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        not submissions,
+        "same-version sibling reviews short-circuit even before external state settles",
+    )
+
+    module._find_active_review_submission_on_sibling_build = lambda token, build_id: None
+    try:
+        module._beta_review_submission = lambda token, build_id: {
+            "id": "submission-1",
+            "beta_review_state": "REJECTED",
+        }
+        module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    except RuntimeError as exc:
+        _check(
+            "unexpected betaReviewState=REJECTED" in str(exc),
+            "rejected beta review submissions fail loudly",
+        )
+    else:
+        _check(False, "rejected beta review submissions fail loudly")
+
+    submissions.clear()
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "READY_FOR_BETA_SUBMISSION",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
+    calls = {"count": 0}
+
+    def sibling_after_submit_failure(token, build_id):
+        calls["count"] += 1
+        if calls["count"] >= 2:
+            return {
+                "build_id": "build-2",
+                "submission_id": "submission-2",
+                "beta_review_state": "WAITING_FOR_REVIEW",
+                "pre_release_version": "1.0.4",
+            }
+        return None
+
+    module._find_active_review_submission_on_sibling_build = sibling_after_submit_failure
+    module._beta_review_submission = lambda token, build_id: None
+    module._submit_beta_review = lambda token, build_id: (_ for _ in ()).throw(RuntimeError("submit failed"))
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        not submissions,
+        "submit races against a sibling review are treated as pending instead of failing",
+    )
+
+    module._submit_beta_review = fake_submit
+    module._find_active_review_submission_on_sibling_build = lambda token, build_id: None
+    module._beta_review_submission = lambda token, build_id: None
+    module.time.time = lambda: real_time() + 999
     module._build_beta_detail = lambda token, build_id: {
         "external_build_state": "BETA_REJECTED",
         "internal_build_state": "READY_FOR_BETA_TESTING",
     }
     try:
-        module._ensure_external_review_submission("jwt", "build-1", "42")
+        module._ensure_external_review_submission("jwt", "build-1", "42", real_time() - 1, 1)
     except RuntimeError as exc:
         _check(
             "unexpected externalBuildState=BETA_REJECTED" in str(exc),
@@ -132,6 +232,9 @@ def main():
         )
     else:
         _check(False, "unexpected external state without submission fails loudly")
+
+    module.time.time = real_time
+    module.time.sleep = real_sleep
 
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")

--- a/tests/test_ios_testflight_external_distribution.py
+++ b/tests/test_ios_testflight_external_distribution.py
@@ -157,21 +157,29 @@ def main():
         "beta_review_state": "WAITING_FOR_REVIEW",
         "pre_release_version": "1.0.4",
     }
-    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
-    _check(
-        not submissions,
-        "same-version sibling builds already in beta review are left alone",
-    )
+    try:
+        module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    except RuntimeError as exc:
+        _check(
+            "still pending while sibling build build-2" in str(exc),
+            "same-version sibling builds already in beta review fail for later retry",
+        )
+    else:
+        _check(False, "same-version sibling builds already in beta review fail for later retry")
 
     module._build_beta_detail = lambda token, build_id: {
         "external_build_state": "",
         "internal_build_state": "READY_FOR_BETA_TESTING",
     }
-    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
-    _check(
-        not submissions,
-        "same-version sibling reviews short-circuit even before external state settles",
-    )
+    try:
+        module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    except RuntimeError as exc:
+        _check(
+            "still pending while sibling build build-2" in str(exc),
+            "same-version sibling reviews fail early even before external state settles",
+        )
+    else:
+        _check(False, "same-version sibling reviews fail early even before external state settles")
 
     module._find_active_review_submission_on_sibling_build = lambda token, build_id: None
     try:
@@ -209,10 +217,26 @@ def main():
     module._find_active_review_submission_on_sibling_build = sibling_after_submit_failure
     module._beta_review_submission = lambda token, build_id: None
     module._submit_beta_review = lambda token, build_id: (_ for _ in ()).throw(RuntimeError("submit failed"))
+    try:
+        module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    except RuntimeError as exc:
+        _check(
+            "still pending while sibling build build-2" in str(exc),
+            "submit races against a sibling review fail for later retry",
+        )
+    else:
+        _check(False, "submit races against a sibling review fail for later retry")
+
+    module._submit_beta_review = lambda token, build_id: (_ for _ in ()).throw(RuntimeError("submit failed"))
+    module._find_active_review_submission_on_sibling_build = lambda token, build_id: None
+    module._beta_review_submission = lambda token, build_id: {
+        "id": "submission-1",
+        "beta_review_state": "WAITING_FOR_REVIEW",
+    }
     module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
     _check(
         not submissions,
-        "submit races against a sibling review are treated as pending instead of failing",
+        "submit races against current-build submission treat active submission as success",
     )
 
     module._submit_beta_review = fake_submit

--- a/tests/test_ios_testflight_external_distribution.py
+++ b/tests/test_ios_testflight_external_distribution.py
@@ -201,6 +201,28 @@ def main():
         "external_build_state": "READY_FOR_BETA_SUBMISSION",
         "internal_build_state": "READY_FOR_BETA_TESTING",
     }
+    submit_attempts = {"count": 0}
+
+    def flaky_submit_then_success(token, build_id):
+        submit_attempts["count"] += 1
+        if submit_attempts["count"] == 1:
+            raise RuntimeError("temporary ASC failure")
+        submissions.append((token, build_id))
+
+    module._find_active_review_submission_on_sibling_build = lambda token, build_id: None
+    module._beta_review_submission = lambda token, build_id: None
+    module._submit_beta_review = flaky_submit_then_success
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        submissions == [("jwt", "build-1")],
+        "transient submit failures are retried until submission succeeds",
+    )
+
+    submissions.clear()
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "READY_FOR_BETA_SUBMISSION",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
     calls = {"count": 0}
 
     def sibling_after_submit_failure(token, build_id):

--- a/tests/test_ios_testflight_external_distribution.py
+++ b/tests/test_ios_testflight_external_distribution.py
@@ -41,6 +41,7 @@ def main():
     module = _load_module()
     real_time = module.time.time
     real_sleep = module.time.sleep
+    real_find_active_review_submission_on_sibling_build = module._find_active_review_submission_on_sibling_build
     module._token = lambda: "jwt"
 
     groups = [
@@ -123,6 +124,25 @@ def main():
     module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
     _check(not submissions, "ready-for-testing builds do not resubmit beta review")
 
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "BETA_APPROVED",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
+    module._beta_review_submission = lambda token, build_id: None
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(not submissions, "already-approved external builds are treated as idempotent success")
+
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "READY_FOR_BETA_SUBMISSION",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
+    module._beta_review_submission = lambda token, build_id: {
+        "id": "submission-1",
+        "beta_review_state": "APPROVED",
+    }
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(not submissions, "approved beta review submissions are treated as idempotent success")
+
     polls = {"count": 0}
 
     def transient_detail(token, build_id):
@@ -167,10 +187,7 @@ def main():
     )
 
     submissions.clear()
-    module._build_beta_detail = lambda token, build_id: {
-        "external_build_state": "READY_FOR_BETA_SUBMISSION",
-        "internal_build_state": "READY_FOR_BETA_TESTING",
-    }
+    module._beta_review_submission = lambda token, build_id: None
     module._find_active_review_submission_on_sibling_build = lambda token, build_id: {
         "build_id": "build-2",
         "submission_id": "submission-2",
@@ -183,7 +200,33 @@ def main():
         "same-version sibling builds already in beta review are left pending without failing",
     )
 
+    submissions.clear()
+    module._find_active_review_submission_on_sibling_build = real_find_active_review_submission_on_sibling_build
+    module._submit_beta_review = fake_submit
+    module._build_pre_release_version = lambda token, build_id: {
+        "id": "pre-release-1",
+        "version": "1.0.4",
+    }
+    module._pre_release_version_build_ids = lambda token, pre_release_version_id: ["build-1", "build-2"]
+    module._beta_review_submission = lambda token, build_id: (
+        {
+            "id": "submission-approved",
+            "beta_review_state": "APPROVED",
+        }
+        if build_id == "build-2"
+        else None
+    )
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        submissions == [("jwt", "build-1")],
+        "approved sibling submissions do not block submission of the current build",
+    )
+
     module._find_active_review_submission_on_sibling_build = lambda token, build_id: None
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "READY_FOR_BETA_SUBMISSION",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
     try:
         module._beta_review_submission = lambda token, build_id: {
             "id": "submission-1",
@@ -257,6 +300,35 @@ def main():
     _check(
         not submissions,
         "submit races against current-build submission treat active submission as success",
+    )
+
+    submissions.clear()
+    retryable_submit_attempts = {"count": 0}
+    retryable_recovery_attempts = {"count": 0}
+
+    def flaky_submit_after_recovery_failure(token, build_id):
+        retryable_submit_attempts["count"] += 1
+        if retryable_submit_attempts["count"] == 1:
+            raise RuntimeError("submit failed")
+        submissions.append((token, build_id))
+
+    def flaky_recovery_lookup(token, build_id):
+        retryable_recovery_attempts["count"] += 1
+        if retryable_recovery_attempts["count"] == 1:
+            raise RuntimeError("temporary beta submission lookup failure")
+        return None
+
+    module._submit_beta_review = flaky_submit_after_recovery_failure
+    module._find_active_review_submission_on_sibling_build = lambda token, build_id: None
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "READY_FOR_BETA_SUBMISSION",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
+    module._beta_review_submission = flaky_recovery_lookup
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        submissions == [("jwt", "build-1")],
+        "transient recovery lookups after submit failure stay inside the retry loop",
     )
 
     module._submit_beta_review = fake_submit

--- a/tests/test_ios_testflight_external_distribution.py
+++ b/tests/test_ios_testflight_external_distribution.py
@@ -177,29 +177,21 @@ def main():
         "beta_review_state": "WAITING_FOR_REVIEW",
         "pre_release_version": "1.0.4",
     }
-    try:
-        module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
-    except RuntimeError as exc:
-        _check(
-            "still pending while sibling build build-2" in str(exc),
-            "same-version sibling builds already in beta review fail for later retry",
-        )
-    else:
-        _check(False, "same-version sibling builds already in beta review fail for later retry")
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        not submissions,
+        "same-version sibling builds already in beta review are left pending without failing",
+    )
 
     module._build_beta_detail = lambda token, build_id: {
         "external_build_state": "",
         "internal_build_state": "READY_FOR_BETA_TESTING",
     }
-    try:
-        module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
-    except RuntimeError as exc:
-        _check(
-            "still pending while sibling build build-2" in str(exc),
-            "same-version sibling reviews fail early even before external state settles",
-        )
-    else:
-        _check(False, "same-version sibling reviews fail early even before external state settles")
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        not submissions,
+        "same-version sibling reviews short-circuit even before external state settles",
+    )
 
     module._find_active_review_submission_on_sibling_build = lambda token, build_id: None
     try:
@@ -259,15 +251,11 @@ def main():
     module._find_active_review_submission_on_sibling_build = sibling_after_submit_failure
     module._beta_review_submission = lambda token, build_id: None
     module._submit_beta_review = lambda token, build_id: (_ for _ in ()).throw(RuntimeError("submit failed"))
-    try:
-        module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
-    except RuntimeError as exc:
-        _check(
-            "still pending while sibling build build-2" in str(exc),
-            "submit races against a sibling review fail for later retry",
-        )
-    else:
-        _check(False, "submit races against a sibling review fail for later retry")
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        not submissions,
+        "submit races against a sibling review are treated as pending instead of failing",
+    )
 
     module._submit_beta_review = lambda token, build_id: (_ for _ in ()).throw(RuntimeError("submit failed"))
     module._find_active_review_submission_on_sibling_build = lambda token, build_id: None

--- a/tests/test_ios_testflight_external_distribution.py
+++ b/tests/test_ios_testflight_external_distribution.py
@@ -147,6 +147,26 @@ def main():
     )
 
     submissions.clear()
+    lookup_attempts = {"count": 0}
+
+    def flaky_beta_detail_lookup(token, build_id):
+        lookup_attempts["count"] += 1
+        if lookup_attempts["count"] == 1:
+            raise RuntimeError("build beta detail lookup HTTP 404")
+        return {
+            "external_build_state": "READY_FOR_BETA_SUBMISSION",
+            "internal_build_state": "READY_FOR_BETA_TESTING",
+        }
+
+    module._build_beta_detail = flaky_beta_detail_lookup
+    module._beta_review_submission = lambda token, build_id: None
+    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
+    _check(
+        submissions == [("jwt", "build-1")],
+        "transient review metadata lookup failures are retried",
+    )
+
+    submissions.clear()
     module._build_beta_detail = lambda token, build_id: {
         "external_build_state": "READY_FOR_BETA_SUBMISSION",
         "internal_build_state": "READY_FOR_BETA_TESTING",

--- a/tests/test_ios_testflight_external_distribution.py
+++ b/tests/test_ios_testflight_external_distribution.py
@@ -183,16 +183,6 @@ def main():
         "same-version sibling builds already in beta review are left pending without failing",
     )
 
-    module._build_beta_detail = lambda token, build_id: {
-        "external_build_state": "",
-        "internal_build_state": "READY_FOR_BETA_TESTING",
-    }
-    module._ensure_external_review_submission("jwt", "build-1", "42", real_time() + 1, 1)
-    _check(
-        not submissions,
-        "same-version sibling reviews short-circuit even before external state settles",
-    )
-
     module._find_active_review_submission_on_sibling_build = lambda token, build_id: None
     try:
         module._beta_review_submission = lambda token, build_id: {

--- a/tests/test_ios_testflight_external_distribution.py
+++ b/tests/test_ios_testflight_external_distribution.py
@@ -89,6 +89,50 @@ def main():
     else:
         _check(False, "missing external group fails loudly")
 
+    submissions = []
+
+    def fake_submit(token, build_id):
+        submissions.append((token, build_id))
+
+    module._submit_beta_review = fake_submit
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "READY_FOR_BETA_SUBMISSION",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
+    module._beta_review_submission = lambda token, build_id: None
+    module._ensure_external_review_submission("jwt", "build-1", "42")
+    _check(submissions == [("jwt", "build-1")], "ready-for-submission builds create a beta review submission")
+
+    submissions.clear()
+    module._beta_review_submission = lambda token, build_id: {
+        "id": "submission-1",
+        "beta_review_state": "WAITING_FOR_REVIEW",
+    }
+    module._ensure_external_review_submission("jwt", "build-1", "42")
+    _check(not submissions, "existing beta review submissions are not duplicated")
+
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "READY_FOR_BETA_TESTING",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
+    module._beta_review_submission = lambda token, build_id: None
+    module._ensure_external_review_submission("jwt", "build-1", "42")
+    _check(not submissions, "ready-for-testing builds do not resubmit beta review")
+
+    module._build_beta_detail = lambda token, build_id: {
+        "external_build_state": "BETA_REJECTED",
+        "internal_build_state": "READY_FOR_BETA_TESTING",
+    }
+    try:
+        module._ensure_external_review_submission("jwt", "build-1", "42")
+    except RuntimeError as exc:
+        _check(
+            "unexpected externalBuildState=BETA_REJECTED" in str(exc),
+            "unexpected external state without submission fails loudly",
+        )
+    else:
+        _check(False, "unexpected external state without submission fails loudly")
+
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- extend external TestFlight distribution to submit builds for Beta App Review when Apple reports `READY_FOR_BETA_SUBMISSION`
- keep the external distribution helper idempotent for already-submitted and already-approved builds
- document the new main-tracking behavior and cover the submission logic in workflow helper tests

## Testing
- python3 tests/test_ios_testflight_external_distribution.py
- bash -n ios/scripts/upload-testflight.sh
- python3.9 -m py_compile ios/scripts/asc_assign_external_testflight_group.py

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785954590&installation_id=133855650&pr_number=7464&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7464&signature=1b5397f9c42fa16c8a4657dec25daee1ec7383190bb234b3fd9ef47e61a3c353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-submits external TestFlight builds for Beta App Review when Apple marks a new MARKETING_VERSION as READY_FOR_BETA_SUBMISSION, removing a manual step and speeding up external releases. The flow is idempotent, resilient to ASC delays, handles sibling-review races, and continues to auto-assign builds to the external group.

- **New Features**
  - `asc_assign_external_testflight_group.py` now polls ASC and creates/reuses the submission for `READY_FOR_BETA_SUBMISSION`; it treats `APPROVED`/`IN_REVIEW`/`WAITING_FOR_REVIEW` as success, no-ops when the build is already approved/testable, waits if a same-version sibling build is in review, retries transient lookup/submit errors, and fails on unexpected states; writes an assign state to `${CMUX_TESTFLIGHT_ASSIGN_STATE_OUT_FILE}`.
  - The workflow uploads `ios-testflight-assignment-state-{complete|pending}` artifacts and the schedule uses them to retry assignment-only when sibling reviews block; if artifacts have expired (30d), missing state is treated as complete to avoid permanent red.
  - Adds a one-time `marketing_version_override` path to upload latest `main` under an approved MARKETING_VERSION (skips notes; disallows `build_number`); publishes `ios-testflight-build-metadata-override` and excludes override runs from canonical “last uploaded” detection.
  - Raises external distribution timeout to 40m; updates `ios/README.md`, workflow summaries, and `upload-testflight.sh` to reflect automatic submission; expands tests to cover polling/retry, sibling-review handling, submission races, and delayed metadata.

<sup>Written for commit 85a04aae6a7d0e4cb749f34f131a20ff2909074c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional manual marketing-version override for re-uploading the current iOS build without triggering a new Beta App Review cycle.
* **Documentation**
  * Updated TestFlight automation docs and command help to clearly describe automatic Beta App Review submission when builds are ready, plus required API key inputs.
* **Bug Fixes**
  * Improved external distribution reliability by better detecting when Beta App Review submissions already exist, reusing/creating them as appropriate, and refining upload/assignment behavior.
* **Tests**
  * Expanded and stabilized coverage for external review submission paths, retries, idempotency, and race/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->