### PR TITLE
Cmd+P: stop listing and resurrecting workspaces of closed windows

### DIFF
--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */; };
 		B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */; };
 		C10D51700000000000000002 /* ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D51700000000000000001 /* ClosedItemHistory.swift */; };
+		7375A0037375A0037375A003 /* ClosedMainWindowRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7375A0047375A0047375A004 /* ClosedMainWindowRoutingTests.swift */; };
 		B9000025A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */; };
 		B9000023A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */; };
 		B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */; };
@@ -1683,6 +1684,7 @@
 		C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIStdioSIGPIPERegressionTests.swift; sourceTree = "<group>"; };
 		B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatRemoteSplitTests.swift; sourceTree = "<group>"; };
 		C10D51700000000000000001 /* ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedItemHistory.swift; sourceTree = "<group>"; };
+		7375A0047375A0047375A004 /* ClosedMainWindowRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedMainWindowRoutingTests.swift; sourceTree = "<group>"; };
 		B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWindowConfirmDialogUITests.swift; sourceTree = "<group>"; };
 		B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspaceCmdDUITests.swift; sourceTree = "<group>"; };
 		B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspaceConfirmDialogUITests.swift; sourceTree = "<group>"; };
@@ -4013,6 +4015,7 @@
 				D0B10019A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift */,
 				2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */,
 				C6711B030000000000000001 /* AppDelegateSurfaceResumeTerminalIdTests.swift */,
+				7375A0047375A0047375A004 /* ClosedMainWindowRoutingTests.swift */,
 				E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */,
 		C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */,
 				120A1EF846214C938416846E /* FileExplorerRootSyncPolicyTests.swift */,
@@ -5608,6 +5611,7 @@
 				6379A0016379A0016379A001 /* CLISSHPTYResizeInputTests.swift in Sources */,
 				C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */,
 				B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */,
+				7375A0037375A0037375A003 /* ClosedMainWindowRoutingTests.swift in Sources */,
 					0CB4E9797AD54D3BB9CF06F9 /* CMUXCLI+AutoNaming.swift in Sources */,
 					C0DE31390000000000000105 /* CMUXCLIErrorOutputRegressionTests.swift in Sources */,
 					C12985000000000000000004 /* CMUXCLISentryTelemetryRegressionTests.swift in Sources */,

--- a/cmuxTests/ClosedMainWindowRoutingTests.swift
+++ b/cmuxTests/ClosedMainWindowRoutingTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+import CmuxTerminal
+import AppKit
+import Bonsplit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class ClosedMainWindowRoutingTests: XCTestCase {
+    private func makeMainWindow(id: UUID) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(id.uuidString)")
+        return window
+    }
+
+    func testClosedMainWindowIsNotListedOrFocusableWhileItsObjectsLinger() throws {
+        _ = NSApplication.shared
+        let previousAppDelegate = AppDelegate.shared
+        let app = AppDelegate()
+        defer {
+            TerminalController.shared.setActiveTabManager(nil)
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        let windowAId = UUID()
+        let windowBId = UUID()
+        let windowA = makeMainWindow(id: windowAId)
+        let windowB = makeMainWindow(id: windowBId)
+        defer {
+            app.unregisterMainWindowContextForTesting(windowId: windowAId)
+            app.unregisterMainWindowContextForTesting(windowId: windowBId)
+            windowA.orderOut(nil)
+            windowB.orderOut(nil)
+        }
+
+        let managerA = TabManager()
+        let managerB = TabManager()
+        app.registerMainWindow(
+            windowA,
+            windowId: windowAId,
+            tabManager: managerA,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: FileExplorerState()
+        )
+        app.registerMainWindow(
+            windowB,
+            windowId: windowBId,
+            tabManager: managerB,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: FileExplorerState()
+        )
+        windowB.makeKeyAndOrderFront(nil)
+        windowA.makeKeyAndOrderFront(nil)
+        TerminalController.shared.setActiveTabManager(managerA)
+
+        let workspaceB = try XCTUnwrap(managerB.selectedWorkspace)
+        let terminalPanelB = try XCTUnwrap(workspaceB.focusedTerminalPanel)
+        XCTAssertTrue(GhosttyApp.terminalSurfaceRegistry.surface(id: terminalPanelB.id) === terminalPanelB.surface)
+
+        let baselineSummaries = app.listMainWindowSummaries()
+        XCTAssertTrue(baselineSummaries.contains { $0.windowId == windowAId })
+        XCTAssertTrue(baselineSummaries.contains { $0.windowId == windowBId })
+
+        app.unregisterMainWindowContextForTesting(windowId: windowBId)
+        windowB.orderOut(nil)
+
+        XCTAssertFalse(windowB.isVisible)
+        XCTAssertFalse(windowB.isMiniaturized)
+        XCTAssertFalse(app.listMainWindowSummaries().contains { $0.windowId == windowBId })
+        XCTAssertFalse(app.focusMainWindow(windowId: windowBId))
+        XCTAssertFalse(windowB.isVisible)
+        XCTAssertTrue(app.tabManagerFor(windowId: windowBId) === managerB)
+    }
+
+    func testRecoveredVisibleWindowStaysListedAndFocusable() throws {
+        _ = NSApplication.shared
+        let previousAppDelegate = AppDelegate.shared
+        let app = AppDelegate()
+        defer {
+            TerminalController.shared.setActiveTabManager(nil)
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        let windowAId = UUID()
+        let windowCId = UUID()
+        let windowA = makeMainWindow(id: windowAId)
+        let windowC = makeMainWindow(id: windowCId)
+        defer {
+            app.unregisterMainWindowContextForTesting(windowId: windowAId)
+            app.unregisterMainWindowContextForTesting(windowId: windowCId)
+            windowA.orderOut(nil)
+            windowC.orderOut(nil)
+        }
+
+        let managerA = TabManager()
+        let managerC = TabManager()
+        app.registerMainWindow(
+            windowA,
+            windowId: windowAId,
+            tabManager: managerA,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: FileExplorerState()
+        )
+        app.registerMainWindow(
+            windowC,
+            windowId: windowCId,
+            tabManager: managerC,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: FileExplorerState()
+        )
+        windowA.makeKeyAndOrderFront(nil)
+        windowC.makeKeyAndOrderFront(nil)
+        TerminalController.shared.setActiveTabManager(managerA)
+
+        let workspaceC = try XCTUnwrap(managerC.selectedWorkspace)
+        let terminalPanelC = try XCTUnwrap(workspaceC.focusedTerminalPanel)
+        XCTAssertTrue(GhosttyApp.terminalSurfaceRegistry.surface(id: terminalPanelC.id) === terminalPanelC.surface)
+
+        app.unregisterMainWindowContextForTesting(windowId: windowCId)
+
+        XCTAssertTrue(windowC.isVisible)
+        XCTAssertTrue(app.listMainWindowSummaries().contains { $0.windowId == windowCId })
+        XCTAssertTrue(app.focusMainWindow(windowId: windowCId))
+    }
+}


### PR DESCRIPTION
Fixes #7375.

## Problem

With two windows open, closing a workspace from window B could leave it visible in window A's Cmd+P switcher, and selecting the stale row reopened ("resurrected") the closed workspace — intermittently.

## Root cause

Closing the last workspace in a window closes the window, but its recoverable main-window route (kept for issue-2907 socket-command recovery) holds the TabManager + NSWindow until they deallocate, which is nondeterministic. `listMainWindowSummaries()` listed those routes with no liveness check, the Cmd+P switcher builds its cross-window list from exactly that, and selecting a stale row called `focusMainWindow(windowId:)`, which found the zombie NSWindow via the identifier scan and ordered it back onto the screen with its closed workspace.

## Fix

- `listMainWindowSummaries()` skips recoverable routes whose window is neither visible nor miniaturized; registered windows (even while the app is hidden) and issue-2907 recovered-but-visible windows stay listed.
- New `isOpenMainWindow(windowId:)` predicate; `focusMainWindow(windowId:)` refuses to focus closed windows (moved to `AppDelegate+WindowIdentity.swift` to keep `AppDelegate.swift` within its file-length budget).
- Both palette switcher selection paths validate the captured target through one shared helper before mutating anything; stale targets are a debug-logged no-op.
- `WorkspacesModel.tabs` posts `tabsDidChange` on `didSet`, and ContentView refreshes an open palette when any window's workspace list changes (covers close/add/move/restore happening in another window while the palette is open).
- Two self-contained palette helpers moved verbatim to `ContentView+ViewCommandPalette.swift` (budget offset).

## Red/green

Commit 1 adds only the regression tests + pbxproj wiring, so CI demonstrates `testClosedMainWindowIsNotListedOrFocusableWhileItsObjectsLinger` failing on unfixed sources; commit 2 adds the fix and CI goes green. `testRecoveredVisibleWindowStaysListedAndFocusable` pins the issue-2907 recovered-window contract before and after.

## Verification

- `python3 scripts/swift_file_length_budget.py` passes after rebasing onto current main (ContentView 16455/16457, AppDelegate 17954/17963)
- `./scripts/lint-pbxproj-test-wiring.sh` passes
- Localization audit: the only `String(localized:)` changes are verbatim helper moves; added and removed key sets are identical — no new user-facing strings, no catalog changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785963933&installation_id=133855650&pr_number=7467&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7467&signature=82f205255ae54893353335eef7d5d24dad2309e361b756acc2c79927599f992b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Cmd+P from showing workspaces from windows that were closed and prevents “resurrecting” them. Fixes #7375 while keeping issue-2907 recovered, visible windows listed.

- **Bug Fixes**
  - `listMainWindowSummaries()` filters out recoverable routes whose window is neither visible nor miniaturized.
  - Added `isOpenMainWindow(windowId:)`; `focusMainWindow(...)` refuses to focus closed windows.
  - Cmd+P selection validates the target before acting; stale selections are a no-op with a debug log.
  - `WorkspacesModel.tabs` posts `tabsDidChange`; an open palette refreshes when any window’s workspace list changes.
  - Added regression tests to pin both the closed-window case and the recovered-visible-window case.

<sup>Written for commit a2a7bdaa391c47f670d454e01031d20463208db4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window routing so closed main windows are removed from the active window list and can’t be focused after being closed.
  * Kept visible windows properly available for focus and listing even when other window contexts are unregistered.
  * Strengthened handling of terminal panel focus to keep window behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->