### PR TITLE
Fix TestFlight workflow dispatch temp env

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -528,7 +528,6 @@ jobs:
       SHOULD_ASSIGN_ONLY: ${{ needs.decide.outputs.should_assign_only }}
       LAST_UPLOADED_RUN_ID: ${{ needs.decide.outputs.last_uploaded_run_id }}
       BUILD_NUMBER: ${{ needs.upload.outputs.final_build_number }}
-      CMUX_TESTFLIGHT_ASSIGN_STATE_OUT_FILE: ${{ runner.temp }}/ios-testflight-assign-state.txt
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -547,6 +546,7 @@ jobs:
         id: assign
         run: |
           set -euo pipefail
+          export CMUX_TESTFLIGHT_ASSIGN_STATE_OUT_FILE="$RUNNER_TEMP/ios-testflight-assign-state.txt"
           if [ -z "${BUILD_NUMBER:-}" ] || [ "$BUILD_NUMBER" = "unknown" ]; then
             echo "missing uploaded build number for external TestFlight assignment" >&2
             exit 1


### PR DESCRIPTION
## Summary
- move the external assignment state temp file binding out of job-level env
- set it inside the assignment step with `RUNNER_TEMP`
- restore manual workflow_dispatch parsing so the iOS TestFlight workflow can be triggered on main

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-testflight.yml"); puts "YAML_OK"'
- confirmed the previous merged workflow failed dispatch on GitHub with `Unrecognized named-value: 'runner'` at line 531

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785968757&installation_id=133855650&pr_number=7472&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7472&signature=5f44362e014f11c385e685c03f33bcf8a1ba80a3ab807727d8e88249d5760183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS TestFlight workflow dispatch by setting the temp assign-state file path inside the assignment step using `$RUNNER_TEMP`. This removes the invalid `runner` context in job env and restores manual `workflow_dispatch` on `main`.

- **Bug Fixes**
  - Move `CMUX_TESTFLIGHT_ASSIGN_STATE_OUT_FILE` from job `env` to the assignment step via `export ...="$RUNNER_TEMP/ios-testflight-assign-state.txt"`.
  - Resolves “Unrecognized named-value: 'runner'” and re-enables manual dispatch.

<sup>Written for commit ff6c93b73d887d0166d42a50aea7d22fe2bd394e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of the iOS beta build assignment workflow, helping ensure external TestFlight builds are handled more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->