### PR TITLE
mux: cmux-mux <verb> CLI surface per spec/cli.md

### DIFF
--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -1,0 +1,904 @@
+use std::collections::BTreeMap;
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use mux_core::platform::transport;
+use serde_json::{json, Value};
+
+const REQUEST_ID: u64 = 1;
+
+type BuildFn = fn(&FlagMap) -> Result<Value, UsageError>;
+type PrintFn = fn(&Value, &mut dyn Write) -> io::Result<()>;
+
+pub struct UsageError(String);
+
+struct CliArgs {
+    global: GlobalArgs,
+    verb: &'static VerbSpec,
+    flags: FlagMap,
+}
+
+#[derive(Default)]
+struct GlobalArgs {
+    session: Option<String>,
+    socket: Option<PathBuf>,
+    json: bool,
+}
+
+#[derive(Default)]
+struct FlagMap {
+    values: BTreeMap<String, String>,
+}
+
+struct VerbSpec {
+    name: &'static str,
+    allowed: &'static [&'static str],
+    build: BuildFn,
+    print: PrintFn,
+    stream: bool,
+}
+
+const VERBS: &[VerbSpec] = &[
+    VerbSpec {
+        name: "identify",
+        allowed: &[],
+        build: build_no_args,
+        print: print_identify,
+        stream: false,
+    },
+    VerbSpec {
+        name: "list-workspaces",
+        allowed: &[],
+        build: build_no_args,
+        print: print_tree,
+        stream: false,
+    },
+    VerbSpec {
+        name: "send",
+        allowed: &["surface", "text", "bytes"],
+        build: build_send,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "read-screen",
+        allowed: &["surface"],
+        build: build_surface,
+        print: print_read_screen,
+        stream: false,
+    },
+    VerbSpec {
+        name: "vt-state",
+        allowed: &["surface"],
+        build: build_surface,
+        print: print_vt_state,
+        stream: false,
+    },
+    VerbSpec {
+        name: "new-tab",
+        allowed: &["pane", "cwd", "cols", "rows"],
+        build: build_new_tab,
+        print: print_surface,
+        stream: false,
+    },
+    VerbSpec {
+        name: "new-browser-tab",
+        allowed: &["url", "pane", "cols", "rows"],
+        build: build_new_browser_tab,
+        print: print_surface,
+        stream: false,
+    },
+    VerbSpec {
+        name: "new-workspace",
+        allowed: &["name", "cols", "rows"],
+        build: build_new_workspace,
+        print: print_surface,
+        stream: false,
+    },
+    VerbSpec {
+        name: "new-screen",
+        allowed: &["workspace", "cols", "rows"],
+        build: build_new_screen,
+        print: print_surface,
+        stream: false,
+    },
+    VerbSpec {
+        name: "split",
+        allowed: &["pane", "dir", "cols", "rows"],
+        build: build_split,
+        print: print_surface,
+        stream: false,
+    },
+    VerbSpec {
+        name: "set-ratio",
+        allowed: &["pane", "dir", "ratio"],
+        build: build_set_ratio,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "set-default-colors",
+        allowed: &["fg", "bg"],
+        build: build_set_default_colors,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "close-surface",
+        allowed: &["surface"],
+        build: build_surface,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "close-pane",
+        allowed: &["pane"],
+        build: build_pane,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "close-screen",
+        allowed: &["screen"],
+        build: build_screen,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "close-workspace",
+        allowed: &["workspace"],
+        build: build_workspace,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "rename-pane",
+        allowed: &["pane", "name"],
+        build: build_rename_pane,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "rename-surface",
+        allowed: &["surface", "name"],
+        build: build_rename_surface,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "rename-screen",
+        allowed: &["screen", "name"],
+        build: build_rename_screen,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "rename-workspace",
+        allowed: &["workspace", "name"],
+        build: build_rename_workspace,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "resize-surface",
+        allowed: &["surface", "cols", "rows"],
+        build: build_resize_surface,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "focus-pane",
+        allowed: &["pane"],
+        build: build_pane,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "select-tab",
+        allowed: &["pane", "index", "delta"],
+        build: build_select_tab,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "select-screen",
+        allowed: &["index", "delta"],
+        build: build_select_screen,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "select-workspace",
+        allowed: &["index", "delta"],
+        build: build_select_workspace,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "move-tab",
+        allowed: &["surface", "pane", "index"],
+        build: build_move_tab,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "move-workspace",
+        allowed: &["workspace", "index"],
+        build: build_move_workspace,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "scroll-surface",
+        allowed: &["surface", "delta"],
+        build: build_scroll_surface,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "subscribe",
+        allowed: &[],
+        build: build_no_args,
+        print: print_empty,
+        stream: true,
+    },
+    VerbSpec {
+        name: "attach-surface",
+        allowed: &["surface"],
+        build: build_surface,
+        print: print_empty,
+        stream: true,
+    },
+];
+
+pub fn is_cli_invocation(args: &[String]) -> bool {
+    matches!(first_command_arg(args), FirstCommand::Help | FirstCommand::Verb)
+}
+
+pub fn run(args: &[String], usage: &str) -> i32 {
+    match parse(args) {
+        Ok(Parsed::Help) => {
+            print!("{usage}");
+            0
+        }
+        Ok(Parsed::Command(args)) => run_command(args),
+        Err(err) => {
+            eprintln!("cmux-mux: {}", err.0);
+            2
+        }
+    }
+}
+
+enum FirstCommand {
+    None,
+    Help,
+    Verb,
+}
+
+enum Parsed {
+    Help,
+    Command(CliArgs),
+}
+
+fn first_command_arg(args: &[String]) -> FirstCommand {
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--socket" | "--session" => i += 2,
+            "--json" => i += 1,
+            "-h" | "--help" => return FirstCommand::Help,
+            arg if arg.starts_with("--") => return FirstCommand::None,
+            "help" => return FirstCommand::Help,
+            arg if verb_by_name(arg).is_some() => return FirstCommand::Verb,
+            _ => return FirstCommand::None,
+        }
+    }
+    FirstCommand::None
+}
+
+fn parse(args: &[String]) -> Result<Parsed, UsageError> {
+    if matches!(first_command_arg(args), FirstCommand::Help) {
+        return Ok(Parsed::Help);
+    }
+
+    let mut global = GlobalArgs::default();
+    let mut flags = FlagMap::default();
+    let mut verb: Option<&'static VerbSpec> = None;
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        match arg {
+            "-h" | "--help" | "help" => return Ok(Parsed::Help),
+            "--json" => {
+                global.json = true;
+                i += 1;
+            }
+            "--socket" => {
+                global.socket = Some(PathBuf::from(value_after(args, i, "--socket")?));
+                i += 2;
+            }
+            "--session" => {
+                global.session = Some(value_after(args, i, "--session")?);
+                i += 2;
+            }
+            _ if verb.is_none() && verb_by_name(arg).is_some() => {
+                verb = verb_by_name(arg);
+                i += 1;
+            }
+            _ if arg.starts_with("--") => {
+                let Some(spec) = verb else {
+                    return Err(UsageError(format!("unknown global flag {arg:?}")));
+                };
+                let name = arg.trim_start_matches("--");
+                if !spec.allowed.contains(&name) {
+                    return Err(UsageError(format!("unknown flag {arg:?} for {}", spec.name)));
+                }
+                let value = value_after(args, i, arg)?;
+                if flags.values.insert(name.to_string(), value).is_some() {
+                    return Err(UsageError(format!("duplicate flag {arg:?}")));
+                }
+                i += 2;
+            }
+            _ if verb.is_some() => {
+                return Err(UsageError(format!("unexpected argument {arg:?}")));
+            }
+            _ => return Err(UsageError(format!("unknown argument {arg:?}"))),
+        }
+    }
+
+    let Some(verb) = verb else { return Err(UsageError("missing verb".to_string())) };
+    Ok(Parsed::Command(CliArgs { global, verb, flags }))
+}
+
+fn value_after(args: &[String], index: usize, flag: &str) -> Result<String, UsageError> {
+    args.get(index + 1).cloned().ok_or_else(|| UsageError(format!("{flag} needs a value")))
+}
+
+fn verb_by_name(name: &str) -> Option<&'static VerbSpec> {
+    VERBS.iter().find(|verb| verb.name == name)
+}
+
+fn run_command(args: CliArgs) -> i32 {
+    let request = match (args.verb.build)(&args.flags) {
+        Ok(mut value) => {
+            value["cmd"] = json!(args.verb.name);
+            value["id"] = json!(REQUEST_ID);
+            value
+        }
+        Err(err) => {
+            eprintln!("cmux-mux: {}", err.0);
+            return 2;
+        }
+    };
+    let socket_path = resolve_socket(&args.global);
+    let mut stream = match transport::connect(&socket_path) {
+        Ok(stream) => stream,
+        Err(err) => {
+            eprintln!("cannot connect to session socket {}: {err}", socket_path.display());
+            return 3;
+        }
+    };
+    if args.verb.stream {
+        let _ = stream.set_read_timeout(Some(Duration::from_millis(250)));
+    } else {
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+    }
+    let mut line = match serde_json::to_vec(&request) {
+        Ok(line) => line,
+        Err(err) => {
+            eprintln!("failed to encode request: {err}");
+            return 2;
+        }
+    };
+    line.push(b'\n');
+    if let Err(err) = stream.write_all(&line) {
+        eprintln!("transport error: {err}");
+        return 3;
+    }
+
+    let mut reader = BufReader::new(stream);
+    if args.verb.stream {
+        run_stream(reader)
+    } else {
+        run_one_response(&mut reader, args.global.json, args.verb.print)
+    }
+}
+
+fn resolve_socket(global: &GlobalArgs) -> PathBuf {
+    if let Some(path) = &global.socket {
+        return path.clone();
+    }
+    if let Some(path) = std::env::var_os("CMUX_MUX_SOCKET") {
+        if !path.is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+    let session = global.session.as_deref().unwrap_or("main");
+    mux_core::server::default_socket_path(session)
+}
+
+fn run_one_response(
+    reader: &mut BufReader<Box<dyn transport::Stream>>,
+    json_output: bool,
+    print_human: PrintFn,
+) -> i32 {
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                eprintln!("transport closed before response");
+                return 3;
+            }
+            Ok(_) => {}
+            Err(err) => {
+                eprintln!("transport error: {err}");
+                return 3;
+            }
+        }
+        let value = match serde_json::from_str::<Value>(&line) {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!("bad response: {err}");
+                return 3;
+            }
+        };
+        if value.get("event").is_some() {
+            continue;
+        }
+        return print_response(&value, json_output, print_human);
+    }
+}
+
+fn run_stream(mut reader: BufReader<Box<dyn transport::Stream>>) -> i32 {
+    let mut line = String::new();
+    loop {
+        if crate::shutdown_requested() {
+            return 0;
+        }
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                if line.is_empty() {
+                    return 0;
+                }
+                eprintln!("transport closed with partial stream line");
+                return 3;
+            }
+            Ok(_) if !line.ends_with('\n') => {
+                eprintln!("transport closed with partial stream line");
+                return 3;
+            }
+            Ok(_) => {}
+            Err(err)
+                if matches!(err.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut) =>
+            {
+                continue;
+            }
+            Err(err) => {
+                eprintln!("transport error: {err}");
+                return 3;
+            }
+        }
+        let value = match serde_json::from_str::<Value>(&line) {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!("bad stream line: {err}");
+                return 3;
+            }
+        };
+        if value.get("event").is_some() {
+            print!("{}", line.trim_end_matches(['\r', '\n']));
+            println!();
+            line.clear();
+            if io::stdout().flush().is_err() {
+                return 3;
+            }
+            continue;
+        }
+        if value.get("id").and_then(Value::as_u64) != Some(REQUEST_ID) {
+            line.clear();
+            continue;
+        }
+        if value.get("ok").and_then(Value::as_bool) == Some(true) {
+            line.clear();
+            continue;
+        }
+        let error = value.get("error").and_then(Value::as_str).unwrap_or("unknown error");
+        eprintln!("{error}");
+        return 1;
+    }
+}
+
+fn print_response(value: &Value, json_output: bool, print_human: PrintFn) -> i32 {
+    if value.get("ok").and_then(Value::as_bool) != Some(true) {
+        let error = value.get("error").and_then(Value::as_str).unwrap_or("unknown error");
+        eprintln!("{error}");
+        return 1;
+    }
+    let data = value.get("data").unwrap_or(&Value::Null);
+    let mut stdout = io::stdout();
+    let result = if json_output {
+        serde_json::to_writer(&mut stdout, data)
+            .and_then(|_| stdout.write_all(b"\n").map_err(serde_json::Error::io))
+            .map_err(io::Error::other)
+    } else {
+        print_human(data, &mut stdout)
+    };
+    match result.and_then(|_| stdout.flush()) {
+        Ok(()) => 0,
+        Err(err) => {
+            eprintln!("stdout error: {err}");
+            3
+        }
+    }
+}
+
+fn build_no_args(flags: &FlagMap) -> Result<Value, UsageError> {
+    flags.reject_remaining()?;
+    Ok(json!({}))
+}
+
+fn build_surface(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({ "surface": flags.required_u64("surface")? }))
+}
+
+fn build_pane(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({ "pane": flags.required_u64("pane")? }))
+}
+
+fn build_screen(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({ "screen": flags.required_u64("screen")? }))
+}
+
+fn build_workspace(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({ "workspace": flags.required_u64("workspace")? }))
+}
+
+fn build_send(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({ "surface": flags.required_u64("surface")? });
+    if let Some(text) = flags.optional("text") {
+        value["text"] = json!(text);
+    }
+    if let Some(bytes) = flags.optional("bytes") {
+        value["bytes"] = json!(bytes);
+    }
+    if value.get("text").is_none() && value.get("bytes").is_none() {
+        let mut text = String::new();
+        io::stdin()
+            .read_to_string(&mut text)
+            .map_err(|err| UsageError(format!("failed to read stdin: {err}")))?;
+        value["text"] = json!(text);
+    }
+    Ok(value)
+}
+
+fn build_new_tab(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_u64(&mut value, "pane")?;
+    flags.insert_optional_string(&mut value, "cwd");
+    flags.insert_optional_size(&mut value)?;
+    Ok(value)
+}
+
+fn build_new_browser_tab(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({ "url": flags.required("url")? });
+    flags.insert_optional_u64(&mut value, "pane")?;
+    flags.insert_optional_size(&mut value)?;
+    Ok(value)
+}
+
+fn build_new_workspace(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_string(&mut value, "name");
+    flags.insert_optional_size(&mut value)?;
+    Ok(value)
+}
+
+fn build_new_screen(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_u64(&mut value, "workspace")?;
+    flags.insert_optional_size(&mut value)?;
+    Ok(value)
+}
+
+fn build_split(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({ "pane": flags.required_u64("pane")?, "dir": flags.required_dir()? });
+    flags.insert_optional_size(&mut value)?;
+    Ok(value)
+}
+
+fn build_set_ratio(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({
+        "pane": flags.required_u64("pane")?,
+        "dir": flags.required_dir()?,
+        "ratio": flags.required_f32("ratio")?,
+    }))
+}
+
+fn build_set_default_colors(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_string(&mut value, "fg");
+    flags.insert_optional_string(&mut value, "bg");
+    Ok(value)
+}
+
+fn build_rename_pane(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({ "pane": flags.required_u64("pane")?, "name": flags.required("name")? }))
+}
+
+fn build_rename_surface(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({ "surface": flags.required_u64("surface")?, "name": flags.required("name")? }))
+}
+
+fn build_rename_screen(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({ "screen": flags.required_u64("screen")?, "name": flags.required("name")? }))
+}
+
+fn build_rename_workspace(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({ "workspace": flags.required_u64("workspace")?, "name": flags.required("name")? }))
+}
+
+fn build_resize_surface(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({
+        "surface": flags.required_u64("surface")?,
+        "cols": flags.required_u16("cols")?,
+        "rows": flags.required_u16("rows")?,
+    }))
+}
+
+fn build_select_tab(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = selector_request(flags)?;
+    flags.insert_optional_u64(&mut value, "pane")?;
+    Ok(value)
+}
+
+fn build_select_screen(flags: &FlagMap) -> Result<Value, UsageError> {
+    selector_request(flags)
+}
+
+fn build_select_workspace(flags: &FlagMap) -> Result<Value, UsageError> {
+    selector_request(flags)
+}
+
+fn build_move_tab(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({
+        "surface": flags.required_u64("surface")?,
+        "pane": flags.required_u64("pane")?,
+        "index": flags.required_usize("index")?,
+    }))
+}
+
+fn build_move_workspace(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({
+        "workspace": flags.required_u64("workspace")?,
+        "index": flags.required_usize("index")?,
+    }))
+}
+
+fn build_scroll_surface(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({
+        "surface": flags.required_u64("surface")?,
+        "delta": flags.required_isize("delta")?,
+    }))
+}
+
+fn selector_request(flags: &FlagMap) -> Result<Value, UsageError> {
+    match (flags.optional("index"), flags.optional("delta")) {
+        (Some(_), Some(_)) => Err(UsageError("use only one of --index or --delta".to_string())),
+        (Some(index), None) => Ok(json!({ "index": parse_usize("index", &index)? })),
+        (None, Some(delta)) => Ok(json!({ "delta": parse_isize("delta", &delta)? })),
+        (None, None) => Err(UsageError("one of --index or --delta is required".to_string())),
+    }
+}
+
+impl FlagMap {
+    fn reject_remaining(&self) -> Result<(), UsageError> {
+        if let Some(name) = self.values.keys().next() {
+            return Err(UsageError(format!("unexpected --{name}")));
+        }
+        Ok(())
+    }
+
+    fn optional(&self, name: &str) -> Option<String> {
+        self.values.get(name).cloned()
+    }
+
+    fn required(&self, name: &str) -> Result<String, UsageError> {
+        self.optional(name).ok_or_else(|| UsageError(format!("--{name} is required")))
+    }
+
+    fn required_u64(&self, name: &str) -> Result<u64, UsageError> {
+        parse_u64(name, &self.required(name)?)
+    }
+
+    fn required_u16(&self, name: &str) -> Result<u16, UsageError> {
+        parse_u16(name, &self.required(name)?)
+    }
+
+    fn required_usize(&self, name: &str) -> Result<usize, UsageError> {
+        parse_usize(name, &self.required(name)?)
+    }
+
+    fn required_isize(&self, name: &str) -> Result<isize, UsageError> {
+        parse_isize(name, &self.required(name)?)
+    }
+
+    fn required_f32(&self, name: &str) -> Result<f32, UsageError> {
+        self.required(name)?
+            .parse::<f32>()
+            .map_err(|_| UsageError(format!("--{name} must be a number")))
+    }
+
+    fn required_dir(&self) -> Result<String, UsageError> {
+        let dir = self.required("dir")?;
+        if dir == "right" || dir == "down" {
+            Ok(dir)
+        } else {
+            Err(UsageError("--dir must be right or down".to_string()))
+        }
+    }
+
+    fn insert_optional_string(&self, value: &mut Value, name: &str) {
+        if let Some(text) = self.optional(name) {
+            value[name] = json!(text);
+        }
+    }
+
+    fn insert_optional_u64(&self, value: &mut Value, name: &str) -> Result<(), UsageError> {
+        if let Some(raw) = self.optional(name) {
+            value[name] = json!(parse_u64(name, &raw)?);
+        }
+        Ok(())
+    }
+
+    fn insert_optional_size(&self, value: &mut Value) -> Result<(), UsageError> {
+        match (self.optional("cols"), self.optional("rows")) {
+            (Some(cols), Some(rows)) => {
+                value["cols"] = json!(parse_u16("cols", &cols)?);
+                value["rows"] = json!(parse_u16("rows", &rows)?);
+                Ok(())
+            }
+            (None, None) => Ok(()),
+            _ => Err(UsageError("--cols and --rows must be supplied together".to_string())),
+        }
+    }
+}
+
+fn parse_u64(name: &str, value: &str) -> Result<u64, UsageError> {
+    value.parse::<u64>().map_err(|_| UsageError(format!("--{name} must be a uint64")))
+}
+
+fn parse_u16(name: &str, value: &str) -> Result<u16, UsageError> {
+    value.parse::<u16>().map_err(|_| UsageError(format!("--{name} must be a uint16")))
+}
+
+fn parse_usize(name: &str, value: &str) -> Result<usize, UsageError> {
+    value.parse::<usize>().map_err(|_| UsageError(format!("--{name} must be a usize")))
+}
+
+fn parse_isize(name: &str, value: &str) -> Result<isize, UsageError> {
+    value.parse::<isize>().map_err(|_| UsageError(format!("--{name} must be an isize")))
+}
+
+fn print_empty(_: &Value, _: &mut dyn Write) -> io::Result<()> {
+    Ok(())
+}
+
+fn print_identify(data: &Value, out: &mut dyn Write) -> io::Result<()> {
+    writeln!(
+        out,
+        "cmux-mux session={} protocol={} pid={}",
+        data.get("session").and_then(Value::as_str).unwrap_or(""),
+        data.get("protocol").and_then(Value::as_u64).unwrap_or(0),
+        data.get("pid").and_then(Value::as_u64).unwrap_or(0)
+    )
+}
+
+fn print_read_screen(data: &Value, out: &mut dyn Write) -> io::Result<()> {
+    write!(out, "{}", data.get("text").and_then(Value::as_str).unwrap_or(""))
+}
+
+fn print_vt_state(data: &Value, out: &mut dyn Write) -> io::Result<()> {
+    writeln!(
+        out,
+        "cols={} rows={} data={}",
+        data.get("cols").and_then(Value::as_u64).unwrap_or(0),
+        data.get("rows").and_then(Value::as_u64).unwrap_or(0),
+        data.get("data").and_then(Value::as_str).unwrap_or("")
+    )
+}
+
+fn print_surface(data: &Value, out: &mut dyn Write) -> io::Result<()> {
+    writeln!(out, "{}", data.get("surface").and_then(Value::as_u64).unwrap_or(0))
+}
+
+fn print_tree(data: &Value, out: &mut dyn Write) -> io::Result<()> {
+    let Some(workspaces) = data.get("workspaces").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    for workspace in workspaces {
+        let workspace_id = id_field(workspace, "id");
+        writeln!(
+            out,
+            "workspace id={} name={} active={}",
+            workspace_id,
+            atom(workspace.get("name")),
+            bool_field(workspace, "active")
+        )?;
+        let Some(screens) = workspace.get("screens").and_then(Value::as_array) else {
+            continue;
+        };
+        for screen in screens {
+            let screen_id = id_field(screen, "id");
+            writeln!(
+                out,
+                "screen id={} workspace={} name={} active={} active_pane={}",
+                screen_id,
+                workspace_id,
+                atom(screen.get("name")),
+                bool_field(screen, "active"),
+                id_field(screen, "active_pane")
+            )?;
+            let Some(panes) = screen.get("panes").and_then(Value::as_array) else {
+                continue;
+            };
+            for pane in panes {
+                let pane_id = id_field(pane, "id");
+                if bool_field(pane, "dead") {
+                    writeln!(out, "pane id={} screen={} dead=true", pane_id, screen_id)?;
+                    continue;
+                }
+                writeln!(
+                    out,
+                    "pane id={} screen={} name={} active_tab={}",
+                    pane_id,
+                    screen_id,
+                    atom(pane.get("name")),
+                    id_field(pane, "active_tab")
+                )?;
+                let Some(tabs) = pane.get("tabs").and_then(Value::as_array) else {
+                    continue;
+                };
+                for tab in tabs {
+                    let size = tab.get("size");
+                    let (cols, rows) = match size {
+                        Some(size) if size.is_object() => {
+                            (id_field(size, "cols"), id_field(size, "rows"))
+                        }
+                        _ => (0, 0),
+                    };
+                    writeln!(
+                        out,
+                        "tab surface={} pane={} kind={} browser_source={} name={} title={} dead={} cols={} rows={}",
+                        id_field(tab, "surface"),
+                        pane_id,
+                        tab.get("kind").and_then(Value::as_str).unwrap_or(""),
+                        atom(tab.get("browser_source")),
+                        atom(tab.get("name")),
+                        atom(tab.get("title")),
+                        bool_field(tab, "dead"),
+                        cols,
+                        rows
+                    )?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn id_field(value: &Value, key: &str) -> u64 {
+    value.get(key).and_then(Value::as_u64).unwrap_or(0)
+}
+
+fn bool_field(value: &Value, key: &str) -> bool {
+    value.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
+fn atom(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::String(text)) => serde_json::to_string(text).unwrap_or_default(),
+        Some(Value::Null) | None => "null".to_string(),
+        Some(value) => value.to_string(),
+    }
+}

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -8,6 +8,7 @@
 
 mod app;
 mod browser_input;
+mod cli;
 mod config;
 mod host_colors;
 mod keys;
@@ -45,6 +46,7 @@ cmux-mux - terminal multiplexer backed by libghostty-vt
 USAGE:
   cmux-mux [OPTIONS]           Start a session (TUI + control socket)
   cmux-mux attach [OPTIONS]    Attach to an existing session's socket
+  cmux-mux <verb> [OPTIONS]    Run one control-socket command
 
 OPTIONS:
   --session <name>   Session name (default: main). Determines the socket path.
@@ -69,6 +71,15 @@ MOUSE
   sidebar workspace or a status-bar screen for rename/close. Click
   tab-bar entries to switch tabs (+ for a new tab), and status-bar
   screen entries to switch screens (+ for a new screen).
+
+CLI VERBS
+  identify, list-workspaces, send, read-screen, vt-state, new-tab,
+  new-browser-tab, new-workspace, new-screen, split, set-ratio,
+  set-default-colors, close-surface, close-pane, close-screen,
+  close-workspace, rename-pane, rename-surface, rename-screen,
+  rename-workspace, resize-surface, focus-pane, select-tab,
+  select-screen, select-workspace, move-tab, move-workspace,
+  scroll-surface, subscribe, attach-surface
 ";
 
 struct Args {
@@ -79,7 +90,7 @@ struct Args {
     term: Option<String>,
 }
 
-fn parse_args() -> Args {
+fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
     let mut out = Args {
         attach: false,
         session: "main".to_string(),
@@ -87,7 +98,7 @@ fn parse_args() -> Args {
         headless: false,
         term: None,
     };
-    let mut args = std::env::args().skip(1).peekable();
+    let mut args = args.into_iter().peekable();
     if args.peek().map(|s| s.as_str()) == Some("attach") {
         out.attach = true;
         args.next();
@@ -117,7 +128,15 @@ fn parse_args() -> Args {
 
 fn main() {
     install_signal_handlers();
-    let args = parse_args();
+    let raw_args = std::env::args().skip(1).collect::<Vec<_>>();
+    if raw_args.first().map(|arg| arg.as_str()) == Some("help") {
+        print!("{USAGE}");
+        std::process::exit(0);
+    }
+    if cli::is_cli_invocation(&raw_args) {
+        std::process::exit(cli::run(&raw_args, USAGE));
+    }
+    let args = parse_args(raw_args);
     let result = if args.attach { run_attach(args) } else { run_server(args) };
     if let Err(e) = result {
         eprintln!("cmux-mux: {e}");

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -1,0 +1,237 @@
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use mux_core::platform::transport;
+
+struct HeadlessServer {
+    child: Child,
+    socket: PathBuf,
+    dir: PathBuf,
+}
+
+impl HeadlessServer {
+    fn start(name: &str) -> Self {
+        let dir = unique_temp_dir(name);
+        fs::create_dir_all(&dir).unwrap();
+        let socket = dir.join("mux.sock");
+        let child = Command::new(bin())
+            .args(["--headless", "--socket"])
+            .arg(&socket)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let server = Self { child, socket, dir };
+        server.wait_for_socket();
+        server
+    }
+
+    fn wait_for_socket(&self) {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        while Instant::now() < deadline {
+            if self.socket.exists() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("headless server did not create socket at {}", self.socket.display());
+    }
+}
+
+impl Drop for HeadlessServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = fs::remove_file(&self.socket);
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn cli_verbs_cover_command_output_errors_and_streams() {
+    let server = HeadlessServer::start("matrix");
+
+    let identify = cli(&server, &["identify"]);
+    assert_success(&identify);
+    assert!(String::from_utf8_lossy(&identify.stdout).starts_with("cmux-mux session="));
+
+    let identify_json = cli(&server, &["--json", "identify"]);
+    assert_success(&identify_json);
+    let value: serde_json::Value = serde_json::from_slice(&identify_json.stdout).unwrap();
+    assert_eq!(value.get("app").and_then(|v| v.as_str()), Some("cmux-mux"));
+    assert!(value.get("protocol").and_then(|v| v.as_u64()).unwrap_or(0) >= 5);
+
+    let workspace = cli(&server, &["new-workspace", "--name", "cli-test"]);
+    assert_success(&workspace);
+    let surface = String::from_utf8(workspace.stdout).unwrap().trim().parse::<u64>().unwrap();
+    assert!(surface > 0, "new-workspace should print the new surface id");
+
+    let marker = format!("cmux_cli_marker_{}", std::process::id());
+    let marker_suffix = std::process::id().to_string();
+    let send = cli(
+        &server,
+        &[
+            "send",
+            "--surface",
+            &surface.to_string(),
+            "--text",
+            &format!("printf 'cmux_cli_marker_%s\\n' '{marker_suffix}'\n"),
+        ],
+    );
+    assert_success(&send);
+    assert!(send.stdout.is_empty(), "mutating commands should be quiet on success");
+    let screen = wait_for_screen(&server, surface, &marker);
+    assert!(screen.contains(&marker), "screen did not contain marker; got {screen:?}");
+
+    let select_bare = cli(&server, &["select-tab"]);
+    assert_eq!(select_bare.status.code(), Some(2));
+
+    let close = cli(&server, &["close-surface", "--surface", &surface.to_string()]);
+    assert_success(&close);
+    let closed_read = cli(&server, &["read-screen", "--surface", &surface.to_string()]);
+    assert_eq!(closed_read.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&closed_read.stderr).contains("unknown surface"));
+
+    let bogus = Command::new(bin())
+        .args(["--socket"])
+        .arg(server.dir.join("missing.sock"))
+        .arg("identify")
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_eq!(bogus.status.code(), Some(3));
+
+    assert_subscribe_reports_tree_changed(&server);
+}
+
+fn assert_subscribe_reports_tree_changed(server: &HeadlessServer) {
+    let mut child = Command::new(bin())
+        .args(["--socket"])
+        .arg(&server.socket)
+        .arg("subscribe")
+        .env_remove("CMUX_MUX_SOCKET")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            if tx.send(line.unwrap()).is_err() {
+                break;
+            }
+        }
+    });
+
+    std::thread::sleep(Duration::from_millis(200));
+    let tab = cli(server, &["new-tab"]);
+    assert_success(&tab);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut lines = Vec::new();
+    while Instant::now() < deadline {
+        if let Ok(line) = rx.recv_timeout(Duration::from_millis(250)) {
+            lines.push(line.clone());
+            if line.contains("\"event\":\"tree-changed\"") {
+                let _ = child.kill();
+                let _ = child.wait();
+                return;
+            }
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    panic!("subscribe did not print tree-changed event; lines={lines:?}");
+}
+
+#[test]
+fn stream_preserves_partial_line_across_read_timeout() {
+    let dir = unique_temp_dir("partial-line");
+    fs::create_dir_all(&dir).unwrap();
+    let socket = dir.join("mux.sock");
+    let listener = transport::listen(&socket).unwrap();
+    let server = std::thread::spawn(move || {
+        let mut stream = listener.accept().unwrap();
+        let mut request = String::new();
+        {
+            let read_half = stream.try_clone_box().unwrap();
+            let mut reader = BufReader::new(read_half);
+            reader.read_line(&mut request).unwrap();
+        }
+        assert!(request.contains("\"cmd\":\"subscribe\""));
+
+        stream.write_all(br#"{"event":"status","message":""#).unwrap();
+        stream.flush().unwrap();
+        std::thread::sleep(Duration::from_millis(350));
+        stream.write_all(br#"split-line-ok"}"#).unwrap();
+        stream.write_all(b"\n").unwrap();
+        stream.flush().unwrap();
+    });
+
+    let output = Command::new(bin())
+        .args(["--socket"])
+        .arg(&socket)
+        .arg("subscribe")
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    let _ = fs::remove_file(&socket);
+    let _ = fs::remove_dir_all(&dir);
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "{\"event\":\"status\",\"message\":\"split-line-ok\"}\n"
+    );
+}
+
+fn wait_for_screen(server: &HeadlessServer, surface: u64, marker: &str) -> String {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut last = String::new();
+    while Instant::now() < deadline {
+        let output = cli(server, &["read-screen", "--surface", &surface.to_string()]);
+        assert_success(&output);
+        last = String::from_utf8(output.stdout).unwrap();
+        if last.contains(marker) {
+            return last;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    last
+}
+
+fn cli(server: &HeadlessServer, args: &[&str]) -> Output {
+    Command::new(bin())
+        .args(["--socket"])
+        .arg(&server.socket)
+        .args(args)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap()
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "expected success, got status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn unique_temp_dir(name: &str) -> PathBuf {
+    let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    PathBuf::from("/tmp").join(format!("cmux-cli-{name}-{}-{stamp}", std::process::id()))
+}
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_cmux-mux")
+}

--- a/mux/docs/protocol.md
+++ b/mux/docs/protocol.md
@@ -2,6 +2,8 @@
 
 As of protocol v6, every server speaks JSON Lines over a Unix domain socket. Send one JSON object per line. Every request receives one response line. `subscribe` and `attach-surface` also push event lines on the same connection.
 
+For shell use, prefer `cmux-mux <verb>`; it wraps the same socket commands and preserves JSON output with `--json`.
+
 Default socket path:
 
 ```text


### PR DESCRIPTION
Implements every `implemented` verb from [mux/spec/cli.md](https://github.com/manaflow-ai/cmux/blob/main/mux/spec/cli.md) as `cmux-mux <verb> ...`: identify, list-workspaces, send, read-screen, vt-state, the new-*/split/close-*/rename-*/select-*/move-* families, resize-surface, focus-pane, set-ratio, set-default-colors, scroll-surface, subscribe, and attach-surface. Proposed verbs (wait-for, run, send-key, copy, ids, notify, list-agents, report-agent) are intentionally absent pending protocol additions.

Contract fidelity: socket resolution `--socket` > `CMUX_MUX_SOCKET` > `--session` > default `main` (global flags before or after the verb); exit codes 0/1/2/3 per spec; `--json` prints exact response schemas and one event JSON object per line for streams; mutations silent on success, creates print the surface id, read-screen prints text exactly; `send` reads stdin to EOF absent `--text`/`--bytes`; bare select-tab/screen/workspace exit 2. Implementation is a table-driven registry in mux-tui/src/cli.rs with zero new dependencies; legacy TUI/server/attach modes dispatch unchanged.

Tests: mux/crates/mux-tui/tests/cli.rs boots a headless server and drives the built binary as a subprocess (identify human+json, surface-id printing, send/read-screen round trip, usage/server/transport exit codes, subscribe streaming, and a regression test proving partial event lines survive >250ms mid-line writer stalls on attach streams).

Reviewed by the /fable judge (one stream-reader bug found and fixed with a regression test). Verified: cargo fmt/clippy/test workspace-clean, smoke-tui passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785982346&installation_id=133855650&pr_number=7480&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7480&signature=a2e9e3605a38f97ddda5f25467751c2bd8fc08ee0732abf35fccb5213ef304cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New client surface drives full mux control (create/close/send/focus) over the session socket; streaming and exit-code behavior are user-facing but covered by integration tests.
> 
> **Overview**
> Adds a **`cmux-mux <verb>`** path that talks to the existing JSON control socket instead of starting or attaching the TUI. A new **`cli.rs`** module registers implemented protocol verbs in a table (build JSON request, human or `--json` output, one-shot vs streaming), resolves the socket (`--socket` → `CMUX_MUX_SOCKET` → `--session`), and maps failures to spec exit codes **0/1/2/3**.
> 
> **`main`** routes verb/help invocations through this CLI before legacy server/attach parsing; usage documents the verb list. **`subscribe`** / **`attach-surface`** use a 250ms read timeout, reuse a line buffer so partial JSON survives stalls, and honor **`shutdown_requested()`** on signals.
> 
> Integration tests spawn a headless server and the real binary (identify, mutations, errors, subscribe events); a mock-socket test locks in partial-line streaming behavior. **`protocol.md`** points shell users at the verb wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17ab884ed1d26678a332c776d40378a0872525c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a table-driven `cmux-mux <verb>` CLI that implements the control-socket verbs with streaming and JSON output. This enables reliable scripting with clear exit codes while keeping TUI/server/attach unchanged.

- **New Features**
  - Implements all verbs marked implemented in the spec: identify, list-workspaces, send, read-screen, vt-state, new-*/split/close-*/rename-*/select-*/move-*, resize-surface, focus-pane, set-ratio, set-default-colors, scroll-surface, subscribe, attach-surface. Proposed verbs are intentionally omitted.
  - Protocol fidelity: socket resolution `--socket` > `CMUX_MUX_SOCKET` > `--session` > `main`; exit codes 0 ok, 1 server error, 2 usage, 3 transport; `--json` preserves schemas and streams print one JSON object per line.
  - Output rules: mutations are silent; creates print the new surface id; `read-screen` prints raw text; `send` reads stdin to EOF unless `--text`/`--bytes`; bare `select-*` without `--index`/`--delta` exits 2.
  - Internal: table-driven registry in `mux-tui/src/cli.rs`; no new dependencies. Protocol docs recommend `cmux-mux <verb>` for shell use.

- **Bug Fixes**
  - Preserve partial event lines across read timeouts in `subscribe`/`attach-surface` streams; covered by a regression test.

<sup>Written for commit 17ab884ed1d26678a332c776d40378a0872525c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line verbs for interacting with the app’s control socket, including support for human-readable and JSON output.
  * Added support for streaming responses, with improved handling of partial output and live events.
  * Extended startup behavior so command-line verb invocations are detected and handled separately from the interactive TUI.

* **Bug Fixes**
  * Improved validation for command-line flags and error handling for invalid or unknown requests.

* **Documentation**
  * Updated usage guidance to show the recommended command-line invocation format.

* **Tests**
  * Added end-to-end coverage for command-line flows and streaming output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->