### PR TITLE
Route browser analytics through first-party API

### DIFF
--- a/web/app/[locale]/(landing)/tracked-link.tsx
+++ b/web/app/[locale]/(landing)/tracked-link.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import posthog from "posthog-js";
 import { Link, usePathname } from "@/i18n/navigation";
+import { captureAnalyticsClick } from "../../lib/analytics";
 
 // Localized internal link that records a PostHog click event, so we can see how
 // many clicks each guide / landing page gets and where they came from.
@@ -21,7 +21,7 @@ export function TrackedLink({
     <Link
       href={href}
       className={className}
-      onClick={() => posthog.capture(event, { target: href, from: pathname })}
+      onClick={() => captureAnalyticsClick(event, { target: href, from: pathname })}
     >
       {children}
     </Link>

--- a/web/app/[locale]/components/download-button.tsx
+++ b/web/app/[locale]/components/download-button.tsx
@@ -2,9 +2,9 @@
 
 import { Menu } from "@base-ui-components/react/menu";
 import { useTranslations } from "next-intl";
-import posthog from "posthog-js";
 import { useState } from "react";
 import { Link, usePathname } from "../../../i18n/navigation";
+import { captureAnalyticsClick } from "../../lib/analytics";
 import {
   DOWNLOAD_CONFIRMATION_HREF,
   DOWNLOAD_CONFIRMATION_PATH,
@@ -91,7 +91,7 @@ export function DownloadButton({
     "group flex items-center justify-center hover:bg-background/[0.04] dark:hover:bg-background/[0.03] data-[popup-open]:bg-background/[0.04] dark:data-[popup-open]:bg-background/[0.03]";
 
   const captureMac = () =>
-    posthog.capture("cmuxterm_download_clicked", { location, platform: "mac" });
+    captureAnalyticsClick("cmuxterm_download_clicked", { location, platform: "mac" });
 
   // The Apple mark artwork has an 814:1000 aspect ratio. Derive the box width
   // from its height so the glyph fills the frame instead of letterboxing inside
@@ -194,7 +194,7 @@ export function DownloadButton({
                 <Menu.Item
                   render={<Link href="/ios" target="_blank" rel="noreferrer" />}
                   onClick={() =>
-                    posthog.capture("cmuxterm_download_clicked", {
+                    captureAnalyticsClick("cmuxterm_download_clicked", {
                       location,
                       platform: "ios",
                     })
@@ -214,7 +214,7 @@ export function DownloadButton({
                     <Menu.Item
                       key={platform}
                       onClick={() => {
-                        posthog.capture("cmuxterm_waitlist_opened", {
+                        captureAnalyticsClick("cmuxterm_waitlist_opened", {
                           location,
                           platform,
                         });

--- a/web/app/[locale]/components/faq-platform-answer.tsx
+++ b/web/app/[locale]/components/faq-platform-answer.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import posthog from "posthog-js";
 import { useState } from "react";
+import { captureAnalyticsClick } from "../../lib/analytics";
 import { WaitlistDialog } from "./waitlist-dialog";
 
 const LOCATION = "faq";
@@ -24,7 +24,7 @@ export function FaqPlatformAnswer({ linkClass }: { linkClass: string }) {
             <button
               type="button"
               onClick={() => {
-                posthog.capture("cmuxterm_waitlist_opened", {
+                captureAnalyticsClick("cmuxterm_waitlist_opened", {
                   location: LOCATION,
                   platform: "any",
                 });

--- a/web/app/[locale]/components/github-button.tsx
+++ b/web/app/[locale]/components/github-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import posthog from "posthog-js";
+import { captureAnalyticsClick } from "../../lib/analytics";
 
 export function GitHubButton({ location = "hero" }: { location?: string }) {
   const t = useTranslations("common");
@@ -10,7 +10,7 @@ export function GitHubButton({ location = "hero" }: { location?: string }) {
       href="https://github.com/manaflow-ai/cmux"
       target="_blank"
       rel="noopener noreferrer"
-      onClick={() => posthog.capture("cmuxterm_github_clicked", { location })}
+      onClick={() => captureAnalyticsClick("cmuxterm_github_clicked", { location })}
       className="inline-flex items-center whitespace-nowrap gap-2 rounded-full border border-border px-5 py-2.5 text-[15px] font-medium text-foreground hover:bg-code-bg transition-colors"
     >
       <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">

--- a/web/app/[locale]/components/github-stars.tsx
+++ b/web/app/[locale]/components/github-stars.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import posthog from "posthog-js";
+import { captureAnalyticsClick } from "../../lib/analytics";
 
 const STARS_CACHE_TTL_MS = 300_000;
 let cachedStars: number | null = null;
@@ -105,7 +105,7 @@ export function GitHubStarsBadge({
       target="_blank"
       rel="noopener noreferrer"
       onClick={() =>
-        posthog.capture("cmuxterm_github_clicked", { location })
+        captureAnalyticsClick("cmuxterm_github_clicked", { location })
       }
       className={classes}
     >

--- a/web/app/[locale]/components/nav-links.tsx
+++ b/web/app/[locale]/components/nav-links.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { Link } from "../../../i18n/navigation";
-import posthog from "posthog-js";
+import { captureAnalyticsClick } from "../../lib/analytics";
 import { ProUpgradeVisibility } from "./pro-upgrade-visibility";
 
 export function NavLinks() {
@@ -37,7 +37,7 @@ export function NavLinks() {
         <Link
           href="/pricing"
           onClick={() =>
-            posthog.capture("cmuxterm_pricing_nav_clicked", { location: "nav" })
+            captureAnalyticsClick("cmuxterm_pricing_nav_clicked", { location: "nav" })
           }
           className="hover:text-foreground transition-colors"
         >
@@ -48,7 +48,7 @@ export function NavLinks() {
         href="https://github.com/manaflow-ai/cmux"
         target="_blank"
         rel="noopener noreferrer"
-        onClick={() => posthog.capture("cmuxterm_github_clicked", { location: "navbar" })}
+        onClick={() => captureAnalyticsClick("cmuxterm_github_clicked", { location: "navbar" })}
         className="hover:text-foreground transition-colors"
       >
         {t("github")}

--- a/web/app/[locale]/components/pro-cta-link.tsx
+++ b/web/app/[locale]/components/pro-cta-link.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import posthog from "posthog-js";
 import {
   pricingActionClassName,
   type PricingActionSize,
 } from "../../components/pricing-shared";
+import { captureAnalyticsClick } from "../../lib/analytics";
 import {
   isClientConfigFlagEnabled,
   useClientConfigFlag,
@@ -44,7 +44,7 @@ export function ProCtaLink({
     <a
       href={checkout ? checkoutHref : fallbackHref}
       onClick={() =>
-        posthog.capture("cmuxterm_pro_cta_clicked", {
+        captureAnalyticsClick("cmuxterm_pro_cta_clicked", {
           location,
           checkout,
         })

--- a/web/app/[locale]/components/waitlist-callout.tsx
+++ b/web/app/[locale]/components/waitlist-callout.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import posthog from "posthog-js";
 import { useState } from "react";
+import { captureAnalyticsClick } from "../../lib/analytics";
 import { WaitlistDialog } from "./waitlist-dialog";
 
 /**
@@ -27,7 +27,7 @@ export function WaitlistCallout({
         <button
           type="button"
           onClick={() => {
-            posthog.capture("cmuxterm_waitlist_opened", {
+            captureAnalyticsClick("cmuxterm_waitlist_opened", {
               location,
               platform: "any",
             });

--- a/web/app/[locale]/components/waitlist-dialog.tsx
+++ b/web/app/[locale]/components/waitlist-dialog.tsx
@@ -3,8 +3,8 @@
 import { Checkbox } from "@base-ui-components/react/checkbox";
 import { Dialog } from "@base-ui-components/react/dialog";
 import { useTranslations } from "next-intl";
-import posthog from "posthog-js";
 import { useRef, useState } from "react";
+import { captureAnalyticsEvent } from "../../lib/analytics";
 import {
   WAITLIST_EARLY_ACCESS_FLAGS,
   WAITLIST_PLATFORMS,
@@ -29,53 +29,34 @@ const SUBMIT_DELAY_MS = 600;
 const VALIDATE_TIMEOUT_MS = 4000;
 
 /**
- * Records a waitlist signup by POSTing the event straight to PostHog's capture
- * endpoint and awaiting delivery, so the UI shows success only when the record
- * is actually accepted (posthog-js `capture` is fire-and-forget). The event
- * `$set`s the email and Early Access enrollment, so the signup persists
- * server-side even if the SDK's own requests are blocked. Returns whether the
- * server accepted it.
+ * Records a waitlist signup through cmux's first-party analytics route and
+ * awaits delivery, so the UI shows success only when PostHog accepts the
+ * server-forwarded event. The event `$set`s the email and Early Access
+ * enrollment, so the signup persists server-side even when browser extensions
+ * block tracker-shaped PostHog ingest URLs.
  */
 async function recordWaitlistSignup(
   email: string,
   platforms: WaitlistPlatform[],
   location: string,
 ): Promise<boolean> {
-  const host = posthog.config?.api_host;
-  const token = posthog.config?.token;
-  if (!host || !token) return false;
   const enrollment = Object.fromEntries(
     platforms.map((p) => [
       `$feature_enrollment/${WAITLIST_EARLY_ACCESS_FLAGS[p]}`,
       true,
     ]),
   );
-  try {
-    // `/e/` is the capture endpoint posthog-js itself posts events to (through
-    // the same first-party `api_host` proxy), so this matches the SDK's path
-    // and payload shape rather than inventing a new one.
-    const res = await fetch(`${host.replace(/\/+$/, "")}/e/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      keepalive: true,
-      body: JSON.stringify({
-        api_key: token,
-        event: "cmuxterm_waitlist_signup",
-        properties: {
-          distinct_id: email,
-          email,
-          platforms,
-          location,
-          $set: { email, ...enrollment },
-          $set_once: { waitlist_email: email },
-        },
-        timestamp: new Date().toISOString(),
-      }),
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
+  return await captureAnalyticsEvent(
+    "cmuxterm_waitlist_signup",
+    {
+      email,
+      platforms,
+      location,
+      $set: { email, ...enrollment },
+      $set_once: { waitlist_email: email },
+    },
+    { distinctId: email, keepalive: true },
+  );
 }
 
 /**

--- a/web/app/[locale]/posthog.tsx
+++ b/web/app/[locale]/posthog.tsx
@@ -4,14 +4,21 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, Suspense } from "react";
+import { captureAnalyticsClick } from "../lib/analytics";
 
 if (typeof window !== "undefined") {
   posthog.init("phc_opOVu7oFzR9wD3I6ZahFGOV2h3mqGpl5EHyQvmHciDP", {
-    api_host: "https://r.cmux.com",
+    api_host: "/api/analytics/posthog-sdk-disabled",
     ui_host: "https://us.posthog.com",
+    autocapture: false,
     person_profiles: "identified_only",
     capture_pageview: false,
-    capture_pageleave: true,
+    capture_pageleave: false,
+    disable_session_recording: true,
+    disable_surveys: true,
+    disable_external_dependency_loading: true,
+    advanced_disable_flags: true,
+    advanced_disable_decide: true,
     advanced_disable_feature_flags: true,
   });
 }
@@ -25,7 +32,7 @@ function PageviewTracker() {
       let url = window.origin + pathname;
       const search = searchParams.toString();
       if (search) url += "?" + search;
-      posthog.capture("$pageview", { $current_url: url });
+      captureAnalyticsClick("$pageview", { $current_url: url });
     }
   }, [pathname, searchParams]);
 

--- a/web/app/api/analytics/browser-events/route.ts
+++ b/web/app/api/analytics/browser-events/route.ts
@@ -16,7 +16,7 @@ const BROWSER_ANALYTICS_FORWARD_TIMEOUT_MS = 3_000;
 
 export async function POST(request: Request): Promise<Response> {
   if (process.env.VERCEL === "1") {
-    const rateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID?.trim();
+    const rateLimitId = process.env.CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID?.trim();
     if (!rateLimitId) {
       console.error("browser-events.route.rate_limit_not_configured");
       return jsonResponse({ error: "analytics_unavailable" }, 503);

--- a/web/app/api/analytics/browser-events/route.ts
+++ b/web/app/api/analytics/browser-events/route.ts
@@ -1,0 +1,60 @@
+import { jsonResponse } from "../../../../services/vms/routeHelpers";
+import { readBoundedJsonObject } from "../../../../services/apns/routePolicy";
+import {
+  MAX_BROWSER_ANALYTICS_REQUEST_BYTES,
+  POSTHOG_HOST,
+  POSTHOG_PROJECT_KEY,
+  parseBrowserAnalyticsEvent,
+} from "../../../../services/analytics/browserEventPolicy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await readBoundedJsonObject(request, MAX_BROWSER_ANALYTICS_REQUEST_BYTES);
+  if (!body.ok) {
+    return jsonResponse({ error: body.error }, body.error === "request_too_large" ? 413 : 400);
+  }
+
+  const event = parseBrowserAnalyticsEvent(body.value);
+  if (!event.ok) {
+    return jsonResponse({ error: event.error }, 400);
+  }
+
+  const forwarded = await forwardBrowserEvent(event.value);
+  if (!forwarded.ok) {
+    return jsonResponse({ error: "forward_failed" }, forwarded.status);
+  }
+  return jsonResponse({ ok: true });
+}
+
+async function forwardBrowserEvent(event: {
+  readonly event: string;
+  readonly distinctId: string;
+  readonly properties: Record<string, unknown>;
+  readonly timestamp?: string;
+}): Promise<{ readonly ok: true } | { readonly ok: false; readonly status: number }> {
+  try {
+    const response = await fetch(`${POSTHOG_HOST}/batch/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: POSTHOG_PROJECT_KEY,
+        batch: [
+          {
+            event: event.event,
+            distinct_id: event.distinctId,
+            properties: event.properties,
+            timestamp: event.timestamp,
+          },
+        ],
+      }),
+    });
+    if (!response.ok) {
+      return { ok: false, status: response.status >= 500 ? 502 : 400 };
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, status: 502 };
+  }
+}

--- a/web/app/api/analytics/browser-events/route.ts
+++ b/web/app/api/analytics/browser-events/route.ts
@@ -1,3 +1,5 @@
+import { checkRateLimit } from "@vercel/firewall";
+
 import { jsonResponse } from "../../../../services/vms/routeHelpers";
 import { readBoundedJsonObject } from "../../../../services/apns/routePolicy";
 import {
@@ -10,7 +12,29 @@ import {
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+const BROWSER_ANALYTICS_FORWARD_TIMEOUT_MS = 3_000;
+
 export async function POST(request: Request): Promise<Response> {
+  if (process.env.VERCEL === "1") {
+    const rateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID?.trim();
+    if (!rateLimitId) {
+      console.error("browser-events.route.rate_limit_not_configured");
+      return jsonResponse({ error: "analytics_unavailable" }, 503);
+    }
+
+    const { error, rateLimited } = await checkRateLimit(rateLimitId, { request });
+    if (rateLimited || error === "blocked") {
+      return jsonResponse({ error: "rate_limited" }, 429);
+    }
+    if (error === "not-found") {
+      console.error("browser-events.route.rate_limit_not_found", rateLimitId);
+      return jsonResponse({ error: "analytics_unavailable" }, 503);
+    } else if (error) {
+      console.error("browser-events.route.rate_limit_error", error);
+      return jsonResponse({ error: "analytics_unavailable" }, 503);
+    }
+  }
+
   const body = await readBoundedJsonObject(request, MAX_BROWSER_ANALYTICS_REQUEST_BYTES);
   if (!body.ok) {
     return jsonResponse({ error: body.error }, body.error === "request_too_large" ? 413 : 400);
@@ -49,6 +73,7 @@ async function forwardBrowserEvent(event: {
           },
         ],
       }),
+      signal: AbortSignal.timeout(BROWSER_ANALYTICS_FORWARD_TIMEOUT_MS),
     });
     if (!response.ok) {
       return { ok: false, status: response.status >= 500 ? 502 : 400 };

--- a/web/app/api/analytics/browser-events/route.ts
+++ b/web/app/api/analytics/browser-events/route.ts
@@ -3,6 +3,12 @@ import { checkRateLimit } from "@vercel/firewall";
 import { jsonResponse } from "../../../../services/vms/routeHelpers";
 import { readBoundedJsonObject } from "../../../../services/apns/routePolicy";
 import {
+  WAITLIST_EARLY_ACCESS_FLAGS,
+  WAITLIST_PLATFORMS,
+  type WaitlistPlatform,
+} from "../../../lib/download";
+import {
+  type BrowserAnalyticsEvent,
   MAX_BROWSER_ANALYTICS_REQUEST_BYTES,
   POSTHOG_HOST,
   POSTHOG_PROJECT_KEY,
@@ -13,6 +19,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const BROWSER_ANALYTICS_FORWARD_TIMEOUT_MS = 3_000;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export async function POST(request: Request): Promise<Response> {
   if (process.env.VERCEL === "1") {
@@ -45,7 +52,12 @@ export async function POST(request: Request): Promise<Response> {
     return jsonResponse({ error: event.error }, 400);
   }
 
-  const forwarded = await forwardBrowserEvent(event.value);
+  const prepared = prepareBrowserEvent(event.value);
+  if (!prepared.ok) {
+    return jsonResponse({ error: prepared.error }, 400);
+  }
+
+  const forwarded = await forwardBrowserEvent(prepared.value);
   if (!forwarded.ok) {
     return jsonResponse({ error: "forward_failed" }, forwarded.status);
   }
@@ -68,7 +80,7 @@ async function forwardBrowserEvent(event: {
           {
             event: event.event,
             distinct_id: event.distinctId,
-            properties: postHogProperties(event),
+            properties: event.properties,
             timestamp: event.timestamp,
           },
         ],
@@ -84,16 +96,82 @@ async function forwardBrowserEvent(event: {
   }
 }
 
-function postHogProperties(event: {
-  readonly event: string;
-  readonly properties: Record<string, unknown>;
-}): Record<string, unknown> {
+function prepareBrowserEvent(
+  event: BrowserAnalyticsEvent,
+): { readonly ok: true; readonly value: BrowserAnalyticsEvent }
+  | { readonly ok: false; readonly error: string } {
   if (event.event === "cmuxterm_waitlist_signup") {
-    return event.properties;
+    return prepareWaitlistSignupEvent(event);
   }
 
   return {
-    ...event.properties,
-    $process_person_profile: false,
+    ok: true,
+    value: {
+      ...event,
+      properties: {
+        ...event.properties,
+        $process_person_profile: false,
+      },
+    },
   };
+}
+
+function prepareWaitlistSignupEvent(
+  event: BrowserAnalyticsEvent,
+): { readonly ok: true; readonly value: BrowserAnalyticsEvent }
+  | { readonly ok: false; readonly error: string } {
+  const email = waitlistEmail(event.properties.email);
+  if (!email || event.distinctId !== email) {
+    return { ok: false, error: "invalid_waitlist_signup" };
+  }
+
+  const platforms = waitlistPlatforms(event.properties.platforms);
+  if (!platforms) {
+    return { ok: false, error: "invalid_waitlist_signup" };
+  }
+
+  const location = waitlistLocation(event.properties.location);
+  const enrollment = Object.fromEntries(
+    platforms.map((platform) => [
+      `$feature_enrollment/${WAITLIST_EARLY_ACCESS_FLAGS[platform]}`,
+      true,
+    ]),
+  );
+
+  return {
+    ok: true,
+    value: {
+      ...event,
+      properties: {
+        email,
+        platforms,
+        ...(location ? { location } : {}),
+        $set: { email, ...enrollment },
+        $set_once: { waitlist_email: email },
+      },
+    },
+  };
+}
+
+function waitlistEmail(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const email = value.trim();
+  return email.length <= 320 && EMAIL_PATTERN.test(email) ? email : null;
+}
+
+function waitlistLocation(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const location = value.trim();
+  return location ? location.slice(0, 64) : null;
+}
+
+function waitlistPlatforms(value: unknown): WaitlistPlatform[] | null {
+  if (!Array.isArray(value)) return null;
+  const platforms = Array.from(new Set(value));
+  if (platforms.length < 1 || platforms.length > WAITLIST_PLATFORMS.length) return null;
+  return platforms.every(isWaitlistPlatform) ? platforms : null;
+}
+
+function isWaitlistPlatform(value: unknown): value is WaitlistPlatform {
+  return typeof value === "string" && WAITLIST_PLATFORMS.includes(value as WaitlistPlatform);
 }

--- a/web/app/api/analytics/browser-events/route.ts
+++ b/web/app/api/analytics/browser-events/route.ts
@@ -68,7 +68,7 @@ async function forwardBrowserEvent(event: {
           {
             event: event.event,
             distinct_id: event.distinctId,
-            properties: event.properties,
+            properties: postHogProperties(event),
             timestamp: event.timestamp,
           },
         ],
@@ -82,4 +82,18 @@ async function forwardBrowserEvent(event: {
   } catch {
     return { ok: false, status: 502 };
   }
+}
+
+function postHogProperties(event: {
+  readonly event: string;
+  readonly properties: Record<string, unknown>;
+}): Record<string, unknown> {
+  if (event.event === "cmuxterm_waitlist_signup") {
+    return event.properties;
+  }
+
+  return {
+    ...event.properties,
+    $process_person_profile: false,
+  };
 }

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -46,6 +46,7 @@ export const env = createEnv({
     CMUX_FEEDBACK_FROM_EMAIL: z.string().email(),
     CMUX_FEEDBACK_RATE_LIMIT_ID: z.string().min(1),
     CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: requireVercelNonPreviewValue("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID"),
+    CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID: requireVercelNonPreviewValue("CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID"),
     STACK_SECRET_SERVER_KEY: z.string().min(1),
     // APNs push (iOS notifications). Optional: the app boots without them; the
     // push route returns a clear "not configured" error until they are set.
@@ -89,6 +90,7 @@ export const env = createEnv({
     CMUX_FEEDBACK_FROM_EMAIL: trimEnv(process.env.CMUX_FEEDBACK_FROM_EMAIL),
     CMUX_FEEDBACK_RATE_LIMIT_ID: trimEnv(process.env.CMUX_FEEDBACK_RATE_LIMIT_ID),
     CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: trimEnv(process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID),
+    CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID: trimEnv(process.env.CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID),
     CMUX_APNS_KEY_P8: trimEnv(process.env.CMUX_APNS_KEY_P8),
     CMUX_APNS_KEY_ID: trimEnv(process.env.CMUX_APNS_KEY_ID),
     CMUX_APNS_TEAM_ID: trimEnv(process.env.CMUX_APNS_TEAM_ID),

--- a/web/app/lib/analytics.ts
+++ b/web/app/lib/analytics.ts
@@ -12,6 +12,9 @@ export type AnalyticsValue =
 
 export type AnalyticsProperties = Record<string, AnalyticsValue>;
 
+const FALLBACK_DISTINCT_ID_KEY = "cmux.analytics.distinct_id";
+let memoryFallbackDistinctId: string | null = null;
+
 export async function captureAnalyticsEvent(
   event: string,
   properties: AnalyticsProperties = {},
@@ -50,9 +53,8 @@ export function getAnalyticsDistinctId(): string {
     const distinctId = posthog.get_distinct_id();
     if (typeof distinctId === "string" && distinctId.trim()) return distinctId;
   } catch {
-    return "anonymous";
   }
-  return "anonymous";
+  return getFallbackDistinctId();
 }
 
 function browserProperties(): AnalyticsProperties {
@@ -63,4 +65,66 @@ function browserProperties(): AnalyticsProperties {
     $pathname: window.location.pathname,
     $lib: "cmux-web",
   };
+}
+
+function getFallbackDistinctId(): string {
+  const storage = browserStorage();
+  const stored = readStoredDistinctId(storage);
+  if (stored) {
+    memoryFallbackDistinctId = stored;
+    return stored;
+  }
+
+  if (memoryFallbackDistinctId) {
+    writeStoredDistinctId(storage, memoryFallbackDistinctId);
+    return memoryFallbackDistinctId;
+  }
+
+  const generated = createFallbackDistinctId();
+  memoryFallbackDistinctId = generated;
+  writeStoredDistinctId(storage, generated);
+  return generated;
+}
+
+function browserStorage(): Storage | null {
+  try {
+    return typeof globalThis.localStorage === "undefined"
+      ? null
+      : globalThis.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readStoredDistinctId(storage: Storage | null): string | null {
+  if (!storage) return null;
+  try {
+    const value = storage.getItem(FALLBACK_DISTINCT_ID_KEY)?.trim();
+    return value || null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredDistinctId(storage: Storage | null, distinctId: string): void {
+  if (!storage) return;
+  try {
+    storage.setItem(FALLBACK_DISTINCT_ID_KEY, distinctId);
+  } catch {
+    // Storage can be disabled by privacy settings. The in-memory fallback above
+    // still keeps one id for this page lifetime.
+  }
+}
+
+function createFallbackDistinctId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return `cmux-web-${uuid}`;
+
+  const bytes = new Uint8Array(16);
+  globalThis.crypto?.getRandomValues?.(bytes);
+  if (bytes.some((byte) => byte !== 0)) {
+    return `cmux-web-${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  return `cmux-web-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }

--- a/web/app/lib/analytics.ts
+++ b/web/app/lib/analytics.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import posthog from "posthog-js";
+
+export type AnalyticsValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly AnalyticsValue[]
+  | { readonly [key: string]: AnalyticsValue };
+
+export type AnalyticsProperties = Record<string, AnalyticsValue>;
+
+export async function captureAnalyticsEvent(
+  event: string,
+  properties: AnalyticsProperties = {},
+  options: { readonly distinctId?: string; readonly keepalive?: boolean } = {},
+): Promise<boolean> {
+  try {
+    const response = await fetch("/api/analytics/browser-events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      keepalive: options.keepalive ?? true,
+      body: JSON.stringify({
+        event,
+        distinctId: options.distinctId ?? getAnalyticsDistinctId(),
+        properties: {
+          ...browserProperties(),
+          ...properties,
+        },
+        timestamp: new Date().toISOString(),
+      }),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export function captureAnalyticsClick(
+  event: string,
+  properties: AnalyticsProperties = {},
+): void {
+  void captureAnalyticsEvent(event, properties, { keepalive: true });
+}
+
+export function getAnalyticsDistinctId(): string {
+  try {
+    const distinctId = posthog.get_distinct_id();
+    if (typeof distinctId === "string" && distinctId.trim()) return distinctId;
+  } catch {
+    return "anonymous";
+  }
+  return "anonymous";
+}
+
+function browserProperties(): AnalyticsProperties {
+  if (typeof window === "undefined") return {};
+  return {
+    $current_url: window.location.href,
+    $host: window.location.host,
+    $pathname: window.location.pathname,
+    $lib: "cmux-web",
+  };
+}

--- a/web/services/analytics/browserEventPolicy.ts
+++ b/web/services/analytics/browserEventPolicy.ts
@@ -1,0 +1,129 @@
+import { POSTHOG_HOST, POSTHOG_PROJECT_KEY } from "./iosEventPolicy";
+
+export { POSTHOG_HOST, POSTHOG_PROJECT_KEY };
+
+export const MAX_BROWSER_ANALYTICS_REQUEST_BYTES = 32 * 1024;
+export const MAX_BROWSER_ANALYTICS_PROPERTIES = 64;
+export const MAX_BROWSER_ANALYTICS_ARRAY_ITEMS = 20;
+export const MAX_BROWSER_ANALYTICS_DEPTH = 3;
+export const MAX_BROWSER_ANALYTICS_STRING_CHARS = 2048;
+
+const ALLOWED_BROWSER_EVENTS: ReadonlySet<string> = new Set([
+  "$pageview",
+  "cmuxterm_download_clicked",
+  "cmuxterm_github_clicked",
+  "cmuxterm_pricing_nav_clicked",
+  "cmuxterm_pro_cta_clicked",
+  "cmuxterm_waitlist_opened",
+  "cmuxterm_waitlist_signup",
+  "compare_back_clicked",
+  "compare_link_clicked",
+  "guide_link_clicked",
+]);
+
+export type BrowserAnalyticsValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly BrowserAnalyticsValue[]
+  | { readonly [key: string]: BrowserAnalyticsValue };
+
+export type BrowserAnalyticsEvent = {
+  readonly event: string;
+  readonly distinctId: string;
+  readonly properties: Record<string, BrowserAnalyticsValue>;
+  readonly timestamp?: string;
+};
+
+export type BrowserAnalyticsEventResult =
+  | { readonly ok: true; readonly value: BrowserAnalyticsEvent }
+  | { readonly ok: false; readonly error: string };
+
+export function parseBrowserAnalyticsEvent(
+  body: Record<string, unknown>,
+): BrowserAnalyticsEventResult {
+  if (!isAllowedBrowserAnalyticsEvent(body.event)) {
+    return { ok: false, error: "unknown_event" };
+  }
+
+  const distinctId = boundedString(body.distinctId, 512);
+  if (!distinctId) {
+    return { ok: false, error: "missing_distinct_id" };
+  }
+
+  const rawProperties =
+    body.properties && typeof body.properties === "object" && !Array.isArray(body.properties)
+      ? (body.properties as Record<string, unknown>)
+      : {};
+  const properties = sanitizeProperties(rawProperties);
+  const timestamp = boundedString(body.timestamp, 64);
+
+  return {
+    ok: true,
+    value: {
+      event: body.event,
+      distinctId,
+      properties,
+      timestamp: timestamp || undefined,
+    },
+  };
+}
+
+export function isAllowedBrowserAnalyticsEvent(name: unknown): name is string {
+  return typeof name === "string" && ALLOWED_BROWSER_EVENTS.has(name);
+}
+
+function sanitizeProperties(
+  rawProperties: Record<string, unknown>,
+): Record<string, BrowserAnalyticsValue> {
+  const properties: Record<string, BrowserAnalyticsValue> = {};
+  let count = 0;
+  for (const [key, value] of Object.entries(rawProperties)) {
+    if (count >= MAX_BROWSER_ANALYTICS_PROPERTIES) break;
+    const sanitizedKey = boundedString(key, 128);
+    if (!sanitizedKey) continue;
+    const sanitizedValue = sanitizeValue(value, 0);
+    if (sanitizedValue === undefined) continue;
+    properties[sanitizedKey] = sanitizedValue;
+    count += 1;
+  }
+  return properties;
+}
+
+function sanitizeValue(
+  value: unknown,
+  depth: number,
+): BrowserAnalyticsValue | undefined {
+  if (value === null) return null;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value === "string") return value.slice(0, MAX_BROWSER_ANALYTICS_STRING_CHARS);
+  if (depth >= MAX_BROWSER_ANALYTICS_DEPTH) return undefined;
+  if (Array.isArray(value)) {
+    const items: BrowserAnalyticsValue[] = [];
+    for (const item of value.slice(0, MAX_BROWSER_ANALYTICS_ARRAY_ITEMS)) {
+      const sanitized = sanitizeValue(item, depth + 1);
+      if (sanitized !== undefined) items.push(sanitized);
+    }
+    return items;
+  }
+  if (typeof value === "object") {
+    const result: Record<string, BrowserAnalyticsValue> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      const sanitizedKey = boundedString(key, 128);
+      if (!sanitizedKey) continue;
+      const sanitized = sanitizeValue(nested, depth + 1);
+      if (sanitized !== undefined) result[sanitizedKey] = sanitized;
+    }
+    return result;
+  }
+  return undefined;
+}
+
+function boundedString(value: unknown, maxChars: number): string | null {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (!text || text.length > maxChars) return null;
+  return text;
+}

--- a/web/tests/analytics-client.test.ts
+++ b/web/tests/analytics-client.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let currentPostHogDistinctId: () => string = () => "posthog-distinct-id";
+const postHogDistinctId = mock(() => currentPostHogDistinctId());
+
+mock.module("posthog-js", () => ({
+  default: {
+    get_distinct_id: postHogDistinctId,
+  },
+}));
+
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+const { getAnalyticsDistinctId } = await import("../app/lib/analytics");
+
+afterAll(() => {
+  if (originalLocalStorageDescriptor) {
+    Object.defineProperty(globalThis, "localStorage", originalLocalStorageDescriptor);
+  } else {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+  }
+});
+
+beforeEach(() => {
+  postHogDistinctId.mockClear();
+  currentPostHogDistinctId = () => "posthog-distinct-id";
+  setLocalStorage(new MemoryStorage());
+});
+
+describe("analytics client distinct id", () => {
+  test("uses the PostHog distinct id when it is available", () => {
+    expect(getAnalyticsDistinctId()).toBe("posthog-distinct-id");
+  });
+
+  test("persists a generated fallback id when PostHog returns a blank id", () => {
+    currentPostHogDistinctId = () => " ";
+
+    const first = getAnalyticsDistinctId();
+    const second = getAnalyticsDistinctId();
+
+    expect(first).toStartWith("cmux-web-");
+    expect(second).toBe(first);
+    expect(globalThis.localStorage.getItem("cmux.analytics.distinct_id")).toBe(first);
+  });
+
+  test("uses an existing browser fallback id when PostHog throws", () => {
+    globalThis.localStorage.setItem("cmux.analytics.distinct_id", "cmux-web-existing-browser-id");
+    currentPostHogDistinctId = () => {
+      throw new Error("posthog unavailable");
+    };
+
+    expect(getAnalyticsDistinctId()).toBe("cmux-web-existing-browser-id");
+  });
+
+  test("keeps a page-lifetime fallback id when browser storage is unavailable", () => {
+    currentPostHogDistinctId = () => "";
+    setLocalStorage(undefined);
+
+    const first = getAnalyticsDistinctId();
+    const second = getAnalyticsDistinctId();
+
+    expect(first).not.toBe("anonymous");
+    expect(first).toStartWith("cmux-web-");
+    expect(second).toBe(first);
+  });
+});
+
+function setLocalStorage(storage: Storage | undefined): void {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+}
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}

--- a/web/tests/browser-analytics-route.test.ts
+++ b/web/tests/browser-analytics-route.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(async () => new Response("ok", { status: 200 }));
+
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+const { POST } = await import("../app/api/analytics/browser-events/route");
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+beforeEach(() => {
+  fetchMock.mockClear();
+  fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+});
+
+function request(body: unknown): Request {
+  return new Request("https://cmux.test/api/analytics/browser-events", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("browser analytics route", () => {
+  test("forwards allowlisted browser events to PostHog from the server", async () => {
+    const response = await POST(request({
+      event: "cmuxterm_download_clicked",
+      distinctId: "visitor-1",
+      properties: {
+        location: "hero",
+        platform: "mac",
+        nested: { kept: true },
+      },
+      timestamp: "2026-07-07T12:00:00.000Z",
+    }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calls = (fetchMock as unknown as {
+      mock: { calls: Array<[string | URL | Request, RequestInit?]> };
+    }).mock.calls;
+    expect(calls[0]?.[0]).toBe("https://r.cmux.com/batch/");
+    const body = JSON.parse((calls[0]?.[1]?.body as string) ?? "{}");
+    expect(body).toMatchObject({
+      api_key: "phc_opOVu7oFzR9wD3I6ZahFGOV2h3mqGpl5EHyQvmHciDP",
+      batch: [
+        {
+          event: "cmuxterm_download_clicked",
+          distinct_id: "visitor-1",
+          properties: {
+            location: "hero",
+            platform: "mac",
+            nested: { kept: true },
+          },
+          timestamp: "2026-07-07T12:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  test("preserves waitlist enrollment properties", async () => {
+    const response = await POST(request({
+      event: "cmuxterm_waitlist_signup",
+      distinctId: "ada@example.com",
+      properties: {
+        email: "ada@example.com",
+        platforms: ["linux", "windows"],
+        $set: {
+          email: "ada@example.com",
+          "$feature_enrollment/cmux-linux-early-access": true,
+        },
+        $set_once: { waitlist_email: "ada@example.com" },
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    const calls = (fetchMock as unknown as {
+      mock: { calls: Array<[string | URL | Request, RequestInit?]> };
+    }).mock.calls;
+    const body = JSON.parse((calls[0]?.[1]?.body as string) ?? "{}");
+    expect(body.batch[0].properties).toEqual({
+      email: "ada@example.com",
+      platforms: ["linux", "windows"],
+      $set: {
+        email: "ada@example.com",
+        "$feature_enrollment/cmux-linux-early-access": true,
+      },
+      $set_once: { waitlist_email: "ada@example.com" },
+    });
+  });
+
+  test("rejects arbitrary event names before forwarding", async () => {
+    const response = await POST(request({
+      event: "anything_goes",
+      distinctId: "visitor-1",
+      properties: { location: "hero" },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "unknown_event" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/tests/browser-analytics-route.test.ts
+++ b/web/tests/browser-analytics-route.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const originalFetch = globalThis.fetch;
 const originalVercel = process.env.VERCEL;
-const originalClientConfigRateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID;
+const originalBrowserAnalyticsRateLimitId = process.env.CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID;
 
 const fetchMock = mock(async () => new Response("ok", { status: 200 }));
 const checkRateLimit = mock(async () => ({ rateLimited: false, error: null }));
@@ -19,12 +19,12 @@ const { POSTHOG_PROJECT_KEY } = await import("../services/analytics/browserEvent
 afterAll(() => {
   globalThis.fetch = originalFetch;
   restoreEnv("VERCEL", originalVercel);
-  restoreEnv("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID", originalClientConfigRateLimitId);
+  restoreEnv("CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID", originalBrowserAnalyticsRateLimitId);
 });
 
 beforeEach(() => {
   process.env.VERCEL = "0";
-  process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID = "cmux-client-config-test";
+  process.env.CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID = "cmux-browser-analytics-test";
   fetchMock.mockClear();
   fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
   checkRateLimit.mockClear();
@@ -141,7 +141,7 @@ describe("browser analytics route", () => {
 
   test("rate-limits Vercel requests before parsing or forwarding", async () => {
     process.env.VERCEL = "1";
-    process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID = " cmux-client-config-test\n";
+    process.env.CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID = " cmux-browser-analytics-test\n";
     checkRateLimit.mockResolvedValue({ rateLimited: true, error: null });
 
     const response = await POST(rawRequest("{"));
@@ -152,7 +152,7 @@ describe("browser analytics route", () => {
     const calls = (checkRateLimit as unknown as {
       mock: { calls: Array<[string, { request: Request }]> };
     }).mock.calls;
-    expect(calls[0]?.[0]).toBe("cmux-client-config-test");
+    expect(calls[0]?.[0]).toBe("cmux-browser-analytics-test");
     expect(calls[0]?.[1]?.request.url).toBe("https://cmux.test/api/analytics/browser-events");
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/web/tests/browser-analytics-route.test.ts
+++ b/web/tests/browser-analytics-route.test.ts
@@ -1,19 +1,34 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const originalFetch = globalThis.fetch;
+const originalVercel = process.env.VERCEL;
+const originalClientConfigRateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID;
+
 const fetchMock = mock(async () => new Response("ok", { status: 200 }));
+const checkRateLimit = mock(async () => ({ rateLimited: false, error: null }));
+
+mock.module("@vercel/firewall", () => ({
+  checkRateLimit,
+}));
 
 globalThis.fetch = fetchMock as unknown as typeof fetch;
 
 const { POST } = await import("../app/api/analytics/browser-events/route");
+const { POSTHOG_PROJECT_KEY } = await import("../services/analytics/browserEventPolicy");
 
 afterAll(() => {
   globalThis.fetch = originalFetch;
+  restoreEnv("VERCEL", originalVercel);
+  restoreEnv("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID", originalClientConfigRateLimitId);
 });
 
 beforeEach(() => {
+  process.env.VERCEL = "0";
+  process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID = "cmux-client-config-test";
   fetchMock.mockClear();
   fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+  checkRateLimit.mockClear();
+  checkRateLimit.mockResolvedValue({ rateLimited: false, error: null });
 });
 
 function request(body: unknown): Request {
@@ -22,6 +37,22 @@ function request(body: unknown): Request {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
+}
+
+function rawRequest(body: string): Request {
+  return new Request("https://cmux.test/api/analytics/browser-events", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
 }
 
 describe("browser analytics route", () => {
@@ -46,7 +77,7 @@ describe("browser analytics route", () => {
     expect(calls[0]?.[0]).toBe("https://r.cmux.com/batch/");
     const body = JSON.parse((calls[0]?.[1]?.body as string) ?? "{}");
     expect(body).toMatchObject({
-      api_key: "phc_opOVu7oFzR9wD3I6ZahFGOV2h3mqGpl5EHyQvmHciDP",
+      api_key: POSTHOG_PROJECT_KEY,
       batch: [
         {
           event: "cmuxterm_download_clicked",
@@ -102,6 +133,24 @@ describe("browser analytics route", () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: "unknown_event" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("rate-limits Vercel requests before parsing or forwarding", async () => {
+    process.env.VERCEL = "1";
+    process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID = " cmux-client-config-test\n";
+    checkRateLimit.mockResolvedValue({ rateLimited: true, error: null });
+
+    const response = await POST(rawRequest("{"));
+
+    expect(response.status).toBe(429);
+    expect(await response.json()).toEqual({ error: "rate_limited" });
+    expect(checkRateLimit).toHaveBeenCalledTimes(1);
+    const calls = (checkRateLimit as unknown as {
+      mock: { calls: Array<[string, { request: Request }]> };
+    }).mock.calls;
+    expect(calls[0]?.[0]).toBe("cmux-client-config-test");
+    expect(calls[0]?.[1]?.request.url).toBe("https://cmux.test/api/analytics/browser-events");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/web/tests/browser-analytics-route.test.ts
+++ b/web/tests/browser-analytics-route.test.ts
@@ -64,6 +64,7 @@ describe("browser analytics route", () => {
         location: "hero",
         platform: "mac",
         nested: { kept: true },
+        $process_person_profile: true,
       },
       timestamp: "2026-07-07T12:00:00.000Z",
     }));
@@ -86,6 +87,7 @@ describe("browser analytics route", () => {
             location: "hero",
             platform: "mac",
             nested: { kept: true },
+            $process_person_profile: false,
           },
           timestamp: "2026-07-07T12:00:00.000Z",
         },
@@ -122,6 +124,7 @@ describe("browser analytics route", () => {
       },
       $set_once: { waitlist_email: "ada@example.com" },
     });
+    expect(body.batch[0].properties).not.toHaveProperty("$process_person_profile");
   });
 
   test("rejects arbitrary event names before forwarding", async () => {

--- a/web/tests/browser-analytics-route.test.ts
+++ b/web/tests/browser-analytics-route.test.ts
@@ -102,11 +102,12 @@ describe("browser analytics route", () => {
       properties: {
         email: "ada@example.com",
         platforms: ["linux", "windows"],
+        location: "download-menu",
         $set: {
-          email: "ada@example.com",
-          "$feature_enrollment/cmux-linux-early-access": true,
+          email: "mallory@example.com",
+          "$feature_enrollment/anything-goes": true,
         },
-        $set_once: { waitlist_email: "ada@example.com" },
+        $set_once: { waitlist_email: "mallory@example.com" },
       },
     }));
 
@@ -117,14 +118,31 @@ describe("browser analytics route", () => {
     const body = JSON.parse((calls[0]?.[1]?.body as string) ?? "{}");
     expect(body.batch[0].properties).toEqual({
       email: "ada@example.com",
+      location: "download-menu",
       platforms: ["linux", "windows"],
       $set: {
         email: "ada@example.com",
-        "$feature_enrollment/cmux-linux-early-access": true,
+        "$feature_enrollment/cmux-for-linux": true,
+        "$feature_enrollment/cmux-for-windows": true,
       },
       $set_once: { waitlist_email: "ada@example.com" },
     });
     expect(body.batch[0].properties).not.toHaveProperty("$process_person_profile");
+  });
+
+  test("rejects invalid waitlist signup mutations before forwarding", async () => {
+    const response = await POST(request({
+      event: "cmuxterm_waitlist_signup",
+      distinctId: "ada@example.com",
+      properties: {
+        email: "ada@example.com",
+        platforms: ["linux", "anything-goes"],
+      },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_waitlist_signup" });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("rejects arbitrary event names before forwarding", async () => {

--- a/web/tests/client-config-env.test.ts
+++ b/web/tests/client-config-env.test.ts
@@ -22,9 +22,10 @@ describe("client config env validation", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).not.toContain("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID is required");
+    expect(result.stderr).not.toContain("CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID is required");
   });
 
-  test("requires the limiter id in explicit Vercel production deployments", () => {
+  test("requires limiter ids in explicit Vercel production deployments", () => {
     const result = importEnv({
       ...requiredEnv,
       VERCEL: "1",
@@ -33,14 +34,16 @@ describe("client config env validation", () => {
 
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID is required");
+    expect(result.stderr).toContain("CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID is required");
   });
 
-  test("accepts explicit Vercel production deployments with the limiter id", () => {
+  test("accepts explicit Vercel production deployments with limiter ids", () => {
     const result = importEnv({
       ...requiredEnv,
       VERCEL: "1",
       VERCEL_ENV: "production",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
+      CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID: "browser-analytics-rule",
     });
 
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- Move browser analytics capture to `/api/analytics/browser-events`, an allowlisted first-party route that forwards to PostHog server-side.
- Disable PostHog browser SDK network capture surfaces while keeping local distinct-id persistence for attribution.
- Send pageviews, clicks, and waitlist signups through the first-party helper instead of direct `r.cmux.com` or `/e/` browser requests.

## Testing
- `bun test tests/browser-analytics-route.test.ts`
- `bun run typecheck`
- `bunx eslint app/[locale]/posthog.tsx app/[locale]/(landing)/tracked-link.tsx app/[locale]/components/download-button.tsx app/[locale]/components/faq-platform-answer.tsx app/[locale]/components/github-button.tsx app/[locale]/components/github-stars.tsx app/[locale]/components/nav-links.tsx app/[locale]/components/pro-cta-link.tsx app/[locale]/components/waitlist-callout.tsx app/[locale]/components/waitlist-dialog.tsx app/lib/analytics.ts app/api/analytics/browser-events/route.ts services/analytics/browserEventPolicy.ts tests/browser-analytics-route.test.ts`
- `bun run lint` currently fails on unrelated pre-existing lint errors in billing/vault/test files.

## Issues
- Related: user-reported uBlock Origin block of `https://r.cmux.com/i/v0/e/?...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785985006&installation_id=133855650&pr_number=7484&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7484&signature=4d206b090e00d52678b77c76f49d4c86b90d5b0d7513b0a60ff78cfeac696ed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all marketing analytics and waitlist person properties in PostHog; misconfiguration of the new rate limiter or forwarding could drop events or block signups in production until env is set.
> 
> **Overview**
> Browser analytics no longer posts directly to `r.cmux.com` from the client. **Clicks, pageviews, and waitlist signups** go through new helpers in `app/lib/analytics.ts` that POST to **`/api/analytics/browser-events`**, which allowlists events, sanitizes payloads, rate-limits on Vercel via **`CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID`**, and forwards to PostHog **`/batch/`** server-side.
> 
> **`posthog-js`** is reconfigured so the SDK does not drive ingest: `api_host` points at a disabled path, autocapture/pageleave/session recording/surveys/flags/decide are off, and **`$pageview`** is sent via the first-party helper. The SDK remains mainly for **`get_distinct_id`**, with a **localStorage/in-memory fallback** when that is unavailable.
> 
> **Waitlist signup** stops using a direct browser POST to PostHog’s `/e/` endpoint; it uses **`captureAnalyticsEvent`** and the route **re-validates** email, platforms, and **`distinctId`** before applying server-controlled **`$set`** / Early Access enrollment.
> 
> Landing and marketing UI components swap **`posthog.capture`** for **`captureAnalyticsClick`** (download, GitHub, pricing, pro CTA, tracked links, waitlist opens).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be9c2bc786ce36fdde523c4ffc9e4c41e1091a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all browser analytics through a first‑party API that forwards events to PostHog server‑side, with a dedicated Vercel rate limiter, a persistent fallback distinct id, anonymous‑profile behavior for non‑signup events, and strict server validation for waitlist signups. This avoids uBlock/extension blocks on `r.cmux.com` while keeping attribution via the SDK or a local fallback.

- **New Features**
  - Added `/api/analytics/browser-events` to allowlist events, sanitize payloads, rate‑limit via Vercel Firewall using `CMUX_BROWSER_ANALYTICS_RATE_LIMIT_ID`, and forward to PostHog `/batch/` (returns 429 when limited, 503 if misconfigured). Sets `$process_person_profile: false` for forwarded events.
  - Validates waitlist signups: requires `distinctId === email`, allowlists platforms, and normalizes `$set`/`$set_once` (adds `$feature_enrollment/*`); rejects invalid payloads before forwarding while preserving enrollment for valid signups.
  - Added `app/lib/analytics.ts` with `captureAnalyticsEvent` and `captureAnalyticsClick`, plus a stored fallback distinct id (localStorage with in‑memory backup). `$pageview` and clicks use this helper. Tests cover forwarding, event validation (incl. waitlist), rate limiting, distinct‑id fallback, and profile‑processing behavior.

- **Refactors**
  - Replaced direct `posthog-js` captures with `captureAnalyticsClick` across links/buttons and routed waitlist signup through the first‑party API; UI waits for server acceptance.
  - Reconfigured `posthog-js` to not send network analytics (disabled autocapture, pageleave, session recording, surveys, flags/decide, and external dependency loading) and set `api_host` to a disabled path; SDK remains for `get_distinct_id` only.

<sup>Written for commit be9c2bc786ce36fdde523c4ffc9e4c41e1091a6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser analytics API endpoint that validates allowlisted events, enforces rate limiting, and forwards approved events for tracking.
* **Bug Fixes / Improvements**
  * Centralized click and pageview tracking through a shared client analytics helper, removing direct third-party tracking calls across key UI flows.
  * Improved waitlist tracking to use the shared helper, with safer delivery/acceptance handling.
  * Added stricter event allowlisting, payload sanitization, and clearer handling for unknown and rate-limited requests.
  * Added distinct-id fallback logic with local persistence when needed.
* **Tests**
  * Added automated coverage for the analytics route and distinct-id behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->