### PR TITLE
fix(browser): answer WebKit permission requests for speech recognition, geolocation, and notifications

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -47,6 +47,10 @@
 	<string>A program running within cmux would like to use your microphone.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>A program running within cmux would like to use your camera.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>A page running within cmux would like to use speech recognition.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>A page running within cmux would like to use your location.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6342,6 +6342,49 @@ private class BrowserUIDelegate: NSObject, WKUIDelegate {
         decisionHandler(.prompt)
     }
 
+    /// WebKit SPI: without this, page geolocation requests hang unanswered.
+    /// `.prompt` defers to WebKit's own per-origin permission alert, matching
+    /// the media-capture handler above. App-level CoreLocation consent is a
+    /// separate TCC prompt gated on NSLocationUsageDescription in Info.plist.
+    @objc(_webView:requestGeolocationPermissionForOrigin:initiatedByFrame:decisionHandler:)
+    func _webView(
+        _ webView: WKWebView,
+        requestGeolocationPermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        decisionHandler(.prompt)
+    }
+
+    /// WebKit SPI: without this, Notification.requestPermission() resolves
+    /// "denied" with no prompt. The callback is boolean-only, so present the
+    /// per-origin question ourselves in the style of the JS dialog handlers.
+    @objc(_webView:requestNotificationPermissionForSecurityOrigin:decisionHandler:)
+    func _webView(
+        _ webView: WKWebView,
+        requestNotificationPermissionFor origin: WKSecurityOrigin,
+        decisionHandler: @escaping (Bool) -> Void
+    ) {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = String(
+            localized: "browser.permission.notifications.title",
+            defaultValue: "Show notifications?"
+        )
+        alert.informativeText = String(
+            format: String(
+                localized: "browser.permission.notifications.body",
+                defaultValue: "“%@” would like to show notifications."
+            ),
+            origin.host
+        )
+        alert.addButton(withTitle: String(localized: "common.allow", defaultValue: "Allow"))
+        alert.addButton(withTitle: String(localized: "common.dontAllow", defaultValue: "Don’t Allow"))
+        presentDialog(alert, for: webView) { response in
+            decisionHandler(response == .alertFirstButtonReturn)
+        }
+    }
+
     func webView(
         _ webView: WKWebView,
         runJavaScriptAlertPanelWithMessage message: String,

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -534,6 +534,50 @@ private class PopupUIDelegate: NSObject, WKUIDelegate {
     ) {
         decisionHandler(.prompt)
     }
+
+    /// WebKit SPI: without this, page geolocation requests hang unanswered.
+    /// `.prompt` defers to WebKit's own per-origin permission alert.
+    @objc(_webView:requestGeolocationPermissionForOrigin:initiatedByFrame:decisionHandler:)
+    func _webView(
+        _ webView: WKWebView,
+        requestGeolocationPermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        decisionHandler(.prompt)
+    }
+
+    /// WebKit SPI: without this, Notification.requestPermission() resolves
+    /// "denied" with no prompt. Boolean-only callback, so ask via NSAlert.
+    @objc(_webView:requestNotificationPermissionForSecurityOrigin:decisionHandler:)
+    func _webView(
+        _ webView: WKWebView,
+        requestNotificationPermissionFor origin: WKSecurityOrigin,
+        decisionHandler: @escaping (Bool) -> Void
+    ) {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = String(
+            localized: "browser.permission.notifications.title",
+            defaultValue: "Show notifications?"
+        )
+        alert.informativeText = String(
+            format: String(
+                localized: "browser.permission.notifications.body",
+                defaultValue: "“%@” would like to show notifications."
+            ),
+            origin.host
+        )
+        alert.addButton(withTitle: String(localized: "common.allow", defaultValue: "Allow"))
+        alert.addButton(withTitle: String(localized: "common.dontAllow", defaultValue: "Don’t Allow"))
+        if let window = webView.window {
+            alert.beginSheetModal(for: window) { response in
+                decisionHandler(response == .alertFirstButtonReturn)
+            }
+        } else {
+            decisionHandler(alert.runModal() == .alertFirstButtonReturn)
+        }
+    }
 }
 
 // MARK: - PopupNavigationDelegate


### PR DESCRIPTION
## Problem

The browser panel's `WKUIDelegate` implements `requestMediaCapturePermissionFor` (camera/mic), but three sibling WebKit permission paths are unhandled, so web pages fail silently with no prompt ever shown:

| API | Behavior in current build (reproduced live) |
|---|---|
| Web Speech (`SpeechRecognition.start()`) | errors `service-not-allowed` instantly |
| Geolocation (`getCurrentPosition`) | request hangs forever, no callback |
| Notifications (`Notification.requestPermission()`) | resolves `"denied"` instantly, no prompt |

Real-world hit: any web app using the SpeechRecognition API (e.g. language-learning pronunciation tools) shows its mic-denied fallback inside cmux while working fine in Safari.

## Root causes & fixes

1. **Speech**: WebKit's `SpeechRecognitionPermissionManager` denies with `ServiceNotAllowed` at `checkUsageDescriptionStringForSpeechRecognition()` before any prompt when the host app bundle lacks `NSSpeechRecognitionUsageDescription`. → Added the key to `Resources/Info.plist`. No code needed — with the key present, WebKit runs its own TCC + per-origin prompts.
2. **Geolocation**: WebKit routes the per-origin question through the `_webView:requestGeolocationPermissionForOrigin:initiatedByFrame:decisionHandler:` UI-delegate SPI (declared in WebKit main's `WKUIDelegatePrivate.h`, macOS 12+); unimplemented = unanswered. → Implemented with `.prompt`, the same policy as the existing media-capture handler, in both `BrowserPanel` and `BrowserPopupWindowController`. Also added `NSLocationUsageDescription` for the app-level CoreLocation consent layer.
3. **Notifications**: same story via `_webView:requestNotificationPermissionForSecurityOrigin:decisionHandler:`, but the callback is boolean-only (no `.prompt` fallback available), so the handler presents a per-origin Allow / Don't Allow alert in the style of the existing JS-dialog handlers.

## Testing & honesty notes

- **Speech path verified live end-to-end**: patched `Info.plist` on a re-signed copy of the shipping app → `SpeechRecognition` goes from `service-not-allowed` to prompting and transcribing.
- **Geolocation/notification failures reproduced live** in the shipping build (probes above). The delegate implementations follow the exact SPI signatures in WebKit main and `swiftc -parse` clean, but I could not compile the app locally (no Xcode on the dev machine) — relying on CI/maintainer build for the compile gate. Happy to iterate.
- Note: granting notification *permission* doesn't by itself wire web notifications into a display path; that's a separate feature. This PR just stops the silent auto-deny so `Notification.permission` reflects a real user decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785985573&installation_id=133855650&pr_number=7486&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7486&signature=b99d07a83649017763928165e792fdd09009af80a9ac922a3e6fe96245fcf4e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches permission UX and private WebKit delegate SPI in both main and popup web views; mistakes could block or mis-prompt sensitive APIs, though policy mirrors existing media-capture handling.
> 
> **Overview**
> Fixes silent failures when embedded web pages request **speech recognition**, **geolocation**, or **notifications**—behaviors that already worked for camera/mic via `requestMediaCapturePermissionFor`.
> 
> **Info.plist** adds `NSSpeechRecognitionUsageDescription` and `NSLocationUsageDescription` so WebKit/TCC can show consent for speech and location (speech was failing with `service-not-allowed` without the speech key).
> 
> **Browser panel and popup** `WKUIDelegate` now implement private WebKit SPI: geolocation uses `.prompt` like media capture; notifications use a per-origin **Allow / Don’t Allow** `NSAlert` (boolean callback, no `.prompt`), reusing `presentDialog` in the main panel and sheet/modal logic in popups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd243aaf1efbf75f88b8f05939a3f18d7ff529a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for in-app permission prompts for speech recognition, location, and notifications.
  * Permission requests now display clearer Allow / Don’t Allow prompts, including during popup browsing.
* **Bug Fixes**
  * Fixed cases where location or notification requests could remain unanswered, ensuring prompts now always complete properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->