### PR TITLE
mux: read-screen reports the rendered viewport (fixes the macOS smoke-attach banner divergence)

### DIFF
--- a/mux/crates/ghostty-vt/src/terminal.rs
+++ b/mux/crates/ghostty-vt/src/terminal.rs
@@ -291,6 +291,27 @@ impl Terminal {
         )
     }
 
+    /// Plain-text dump of the currently rendered viewport.
+    ///
+    /// This uses the terminal formatter's read-only selection path rather
+    /// than `RenderState::update`, so callers can inspect the viewport
+    /// without clearing dirty flags needed by a concurrent renderer.
+    pub fn viewport_text(&mut self) -> Result<String> {
+        let cols = self.cols();
+        let rows = self.rows();
+        if cols == 0 || rows == 0 {
+            return Ok(String::new());
+        }
+        self.selection_text_with_tag_options(
+            sys::GHOSTTY_POINT_TAG_VIEWPORT,
+            (0, 0),
+            (cols.saturating_sub(1), rows.saturating_sub(1) as u64),
+            false,
+            true,
+        )
+        .ok_or(crate::Error::InvalidValue)
+    }
+
     /// Plain text of a selection range given in absolute screen
     /// coordinates (scrollbar offset + viewport row), inclusive.
     /// Clamps the end row when scrollback has trimmed rows after the
@@ -318,6 +339,17 @@ impl Terminal {
         start: (u16, u64),
         end: (u16, u64),
     ) -> Option<String> {
+        self.selection_text_with_tag_options(tag, start, end, true, true)
+    }
+
+    fn selection_text_with_tag_options(
+        &mut self,
+        tag: sys::GhosttyPointTag,
+        start: (u16, u64),
+        end: (u16, u64),
+        unwrap_lines: bool,
+        trim: bool,
+    ) -> Option<String> {
         let grid_ref = |x: u16, y: u64| -> Option<sys::GhosttyGridRef> {
             let y = u32::try_from(y).ok()?;
             let point = sys::GhosttyPoint {
@@ -340,8 +372,8 @@ impl Terminal {
         let opts = sys::GhosttyFormatterTerminalOptions {
             size: std::mem::size_of::<sys::GhosttyFormatterTerminalOptions>(),
             emit: sys::GHOSTTY_FORMATTER_FORMAT_PLAIN,
-            unwrap: true,
-            trim: true,
+            unwrap: unwrap_lines,
+            trim,
             extra: sys::GhosttyFormatterTerminalExtra {
                 size: std::mem::size_of::<sys::GhosttyFormatterTerminalExtra>(),
                 ..Default::default()
@@ -352,8 +384,8 @@ impl Terminal {
         Some(String::from_utf8_lossy(&bytes).into_owned())
     }
 
-    /// Plain-text dump of the active screen (viewport plus scrollback is
-    /// not included; this formats the active screen contents).
+    /// Plain-text dump of the active screen's full page list, INCLUDING
+    /// scrollback. For the rendered viewport only, use [`Self::viewport_text`].
     pub fn plain_text(&mut self) -> Result<String> {
         let opts = sys::GhosttyFormatterTerminalOptions {
             size: std::mem::size_of::<sys::GhosttyFormatterTerminalOptions>(),

--- a/mux/crates/ghostty-vt/tests/terminal.rs
+++ b/mux/crates/ghostty-vt/tests/terminal.rs
@@ -122,6 +122,23 @@ fn plain_text_dump() {
 }
 
 #[test]
+fn viewport_text_does_not_clear_render_dirty_state() {
+    let mut term = Terminal::new(40, 5, 1000, Callbacks::default()).unwrap();
+    let mut rs = RenderState::new().unwrap();
+
+    rs.update(&mut term).unwrap();
+    rs.set_clean();
+
+    term.vt_write(b"alpha\r\nbeta");
+    let text = term.viewport_text().unwrap();
+    assert!(text.contains("alpha"), "viewport was {text:?}");
+    assert!(text.contains("beta"), "viewport was {text:?}");
+
+    rs.update(&mut term).unwrap();
+    assert_ne!(rs.dirty(), Dirty::Clean);
+}
+
+#[test]
 fn selection_text_extracts_range() {
     let mut term = Terminal::new(40, 5, 0, Callbacks::default()).unwrap();
     term.vt_write(b"hello world\r\nsecond line");

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -543,7 +543,7 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
         Command::ReadScreen { surface } => {
             let surface = get_surface(mux, surface)?;
             require_pty(&surface)?;
-            let text = surface.try_with_terminal(|t| t.plain_text())??;
+            let text = surface.try_with_terminal(|t| t.viewport_text())??;
             Ok(json!({ "text": text }))
         }
         Command::VtState { surface } => {

--- a/mux/crates/mux-core/tests/pty.rs
+++ b/mux/crates/mux-core/tests/pty.rs
@@ -312,6 +312,45 @@ fn control_socket_round_trip() {
 }
 
 #[test]
+fn control_socket_read_screen_reports_rendered_viewport_after_scrollback_clear() {
+    let mut output = String::new();
+    for row in 0..12 {
+        output.push_str(&format!("row{row:02}\\r\\n"));
+    }
+    let script = format!("printf '{output}'; printf '\\033[H\\033[2Jprompt$ '; sleep 30");
+    let mux = Mux::new(unique_session("test-read-screen-viewport"), shell_opts(&script));
+    let surface = mux.new_workspace(None, Some((17, 5))).unwrap();
+
+    let sock_path = mux_core::server::serve(mux.clone(), None).unwrap();
+    let stream = connect(&sock_path);
+    let mut writer = stream.try_clone_box().unwrap();
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+
+    let text = wait_for(
+        || {
+            line.clear();
+            writeln!(writer, r#"{{"id":1,"cmd":"read-screen","surface":{}}}"#, surface.id).unwrap();
+            reader.read_line(&mut line).unwrap();
+            let value: serde_json::Value = serde_json::from_str(&line).unwrap();
+            assert_eq!(value["ok"], true, "read-screen failed: {line}");
+            let text = value["data"]["text"].as_str().unwrap_or_default().to_string();
+            text.contains("prompt$").then_some(text)
+        },
+        Duration::from_secs(10),
+    )
+    .expect("prompt never reached rendered screen");
+    let first_line = text.lines().next().unwrap_or_default();
+    assert!(
+        first_line.contains("prompt$"),
+        "read-screen should report the rendered viewport, got {text:?}"
+    );
+
+    mux.close_surface(surface.id);
+    mux_core::server::cleanup(&sock_path);
+}
+
+#[test]
 fn control_socket_set_default_colors_merges_fields() {
     let opts = SurfaceOptions { command: Some(vec!["/bin/cat".to_string()]), ..Default::default() };
     let mux = Mux::new(format!("test-colors-{}", std::process::id()), opts);


### PR DESCRIPTION
Fixes main's persistent `test (macos)` failure in `scripts/smoke-attach.py` (`assert_client_matches_server`), which reproduces deterministically with `SHELL=/bin/bash scripts/smoke-attach.py` (3/3 before, 5/5 pass after).

Root cause (verified in code by the /fable judge, not just observed): the attach mirror was correct; the comparison oracle was wrong. `Terminal::plain_text()` formats the active screen's full page list **including scrollback** (null-selection ScreenFormatter over the `.screen` point space), while clients render the `RenderState` viewport. When macOS bash's "default interactive shell is now zsh" banner scrolled into scrollback and `\e[H\e[2J` repainted the prompt, `read-screen` kept reporting the stale banner rows. The [spec](https://github.com/manaflow-ai/cmux/blob/main/mux/spec/commands.md) already promised read-screen output "does not include prior scrollback", so the old behavior violated its own contract.

Fix: `read-screen` uses a new `Terminal::viewport_text()` built on the terminal formatter's **read-only** selection path (`GHOSTTY_POINT_TAG_VIEWPORT`, `(0,0)..(cols-1,rows-1)`, `unwrap:false`). A first-round `RenderState::update` approach was rejected in review because that snapshot consumes per-row dirty flags and would starve a concurrent TUI renderer's row refresh in non-headless sessions; `viewport_text_does_not_clear_render_dirty_state` locks in the read-only property.

Two-commit red/green: commit 1 adds the failing socket regression (scrollback + clear-screen → viewport reporting), commit 2 the fix. No ghostty submodule changes (the formatter options already existed in the C API).

Verified: cargo fmt/clippy/test workspace-clean (121 tests), smoke-tui, `SHELL=/bin/bash smoke-attach.py` 5/5. /fable judge: APPROVE after one REVISE round.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785987095&installation_id=133855650&pr_number=7488&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7488&signature=1ddefedd3e92917e15cd4ae39ade2cff78ac92f3350491c03f72300e0f94a879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the observable `read-screen` contract (intentionally aligning with spec); low blast radius but affects attach/smoke oracles and any client that assumed scrollback-inclusive text.
> 
> **Overview**
> **`read-screen`** now returns the **rendered viewport** instead of **`plain_text()`**, which still dumps the active screen **including scrollback**. That mismatch caused attach/smoke comparisons to see stale rows (e.g. macOS bash banner) after content scrolled away and the screen was cleared.
> 
> Adds **`Terminal::viewport_text()`**, formatting the full viewport via the terminal formatter’s **read-only** selection path (`GHOSTTY_POINT_TAG_VIEWPORT`, `unwrap: false`) so inspection does not consume **`RenderState`** dirty flags. Selection helpers gain **`selection_text_with_tag_options`** for configurable unwrap/trim; **`plain_text()`** docs now point callers at **`viewport_text()`** for viewport-only dumps.
> 
> Regression coverage: **`viewport_text_does_not_clear_render_dirty_state`** and a control-socket test (scrollback + clear-screen → prompt on first line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40347a814de0fa7dc950dcccb0165cba52f35807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
read-screen now returns the currently rendered viewport (not scrollback). This fixes the macOS smoke-attach mismatch and aligns with the command spec.

- **Bug Fixes**
  - `mux-core`: `read-screen` now calls `Terminal::viewport_text()` instead of `plain_text()`.
  - `ghostty-vt`: Added `viewport_text()` using the read-only formatter over `GHOSTTY_POINT_TAG_VIEWPORT`; it does not clear render dirty flags.
  - Tests: Added `viewport_text_does_not_clear_render_dirty_state` and a control socket test to verify viewport output after scrollback + clear-screen.

<sup>Written for commit 40347a814de0fa7dc950dcccb0165cba52f35807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to read only the currently visible terminal viewport as plain text.
  * Screen-read responses now return the rendered viewport instead of the full scrollback history.

* **Bug Fixes**
  * Improved screen-reading behavior after clearing scrollback so the returned text matches what is actually on screen.
  * Confirmed viewport reads do not affect the terminal’s render-dirty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->