### PR TITLE
Fix markdown panel relative local links

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -306,13 +306,19 @@ html { scroll-behavior: smooth; }
     else if (hi >= 0) { cut = hi; }
     return cut >= 0 ? s.slice(0, cut) : s;
   }
+  var knownExternalMarkdownLinkSchemes = {
+    about: true, blob: true, data: true, ftp: true, http: true,
+    https: true, javascript: true, mailto: true, sms: true, tel: true
+  };
   function isMarkdownPathLike(path) {
     var s = stripQueryFragment(path).trim();
     if (!s) { return false; }
     var colon = s.indexOf(':');
     if (colon > 0) {
       var scheme = s.slice(0, colon).toLowerCase();
-      if (scheme !== 'file') { return false; }
+      if (scheme !== 'file' && (knownExternalMarkdownLinkSchemes[scheme] || s.slice(colon, colon + 3) === '://')) {
+        return false;
+      }
     }
     var slash = Math.max(s.lastIndexOf('/'), s.lastIndexOf('\\'));
     var leaf = slash >= 0 ? s.slice(slash + 1) : s;
@@ -815,6 +821,9 @@ html { scroll-behavior: smooth; }
     }
     if (compact.indexOf('data:') === 0) {
       return name === 'src' && isSafeDataImageURL(raw);
+    }
+    if (name === 'href' && isMarkdownPathLike(raw)) {
+      return true;
     }
 
     try {
@@ -1476,7 +1485,7 @@ html { scroll-behavior: smooth; }
 
   // Local markdown file links and inline-code spans.
   // Resolution is lazy: hover/focus asks Swift whether the path exists
-  // relative to the current markdown file (and PWD fallback). Click
+  // relative to the current markdown file. Click
   // opens a new cmux markdown tab when it resolves.
   var mdFileResolveCache = {}; // raw path -> { exists, path }
   var mdFileResolvePending = {}; // requestId -> { rawPath, elements }

--- a/Sources/Panels/MarkdownPanelFileLinkResolver.swift
+++ b/Sources/Panels/MarkdownPanelFileLinkResolver.swift
@@ -16,33 +16,67 @@ enum MarkdownPanelFileLinkResolver {
     }
 
     static func resolve(rawPath: String, relativeToMarkdownFile markdownFilePath: String) -> String? {
+        guard let localFile = resolveLocalFile(rawPath: rawPath, relativeToMarkdownFile: markdownFilePath),
+              isMarkdownPathLike(localFile) else {
+            return nil
+        }
+        return localFile
+    }
+
+    static func resolveLocalFile(rawPath: String, relativeToMarkdownFile markdownFilePath: String) -> String? {
         let stripped = stripFragmentAndQuery(rawPath)
         guard !stripped.isEmpty else { return nil }
 
-        let candidatePaths: [String] = {
-            if let url = URL(string: stripped), url.scheme == "file" {
-                return [url.path]
-            }
-            if (stripped as NSString).isAbsolutePath {
-                return [stripped]
-            }
-            let markdownDir = (markdownFilePath as NSString).deletingLastPathComponent
-            let pwd = FileManager.default.currentDirectoryPath
-            return [
-                (markdownDir as NSString).appendingPathComponent(stripped),
-                (pwd as NSString).appendingPathComponent(stripped)
-            ]
-        }()
-
-        for path in candidatePaths {
+        for path in candidatePaths(for: stripped, relativeToMarkdownFile: markdownFilePath) {
             let standardized = (path as NSString).standardizingPath
-            guard isMarkdownPathLike(standardized) else { continue }
             var isDir: ObjCBool = false
             if FileManager.default.fileExists(atPath: standardized, isDirectory: &isDir), !isDir.boolValue {
                 return standardized
             }
         }
         return nil
+    }
+
+    private static func candidatePaths(for strippedPath: String, relativeToMarkdownFile markdownFilePath: String) -> [String] {
+        if let url = URL(string: strippedPath), let scheme = url.scheme?.lowercased() {
+            if scheme == "file" {
+                return [url.path]
+            }
+            if let relativePath = webKitCoercedRelativePath(from: url, scheme: scheme) {
+                return relativeCandidatePaths(relativePath, relativeToMarkdownFile: markdownFilePath)
+            }
+            return []
+        }
+        if (strippedPath as NSString).isAbsolutePath {
+            return [strippedPath]
+        }
+        return relativeCandidatePaths(strippedPath, relativeToMarkdownFile: markdownFilePath)
+    }
+
+    private static func relativeCandidatePaths(_ relativePath: String, relativeToMarkdownFile markdownFilePath: String) -> [String] {
+        let markdownDir = (markdownFilePath as NSString).deletingLastPathComponent
+        let pwd = FileManager.default.currentDirectoryPath
+        return [
+            (markdownDir as NSString).appendingPathComponent(relativePath),
+            (pwd as NSString).appendingPathComponent(relativePath)
+        ]
+    }
+
+    private static func webKitCoercedRelativePath(from url: URL, scheme: String) -> String? {
+        guard scheme == "http" || scheme == "https",
+              url.user == nil,
+              url.password == nil,
+              url.port == nil,
+              let host = url.host?.removingPercentEncoding,
+              !host.isEmpty,
+              host != "localhost",
+              !host.contains("."),
+              !host.contains(":") else {
+            return nil
+        }
+        let path = url.path.removingPercentEncoding ?? url.path
+        guard path.hasPrefix("/"), path.count > 1 else { return nil }
+        return host + path
     }
 
     private static func stripFragmentAndQuery(_ rawPath: String) -> String {

--- a/Sources/Panels/MarkdownPanelFileLinkResolver.swift
+++ b/Sources/Panels/MarkdownPanelFileLinkResolver.swift
@@ -11,7 +11,10 @@ enum MarkdownPanelFileLinkResolver {
         guard !trimmed.isEmpty else { return false }
         // Keep this intentionally path-like: code spans such as `foo.md`,
         // `docs/foo.md`, `../foo.md`, or `/tmp/foo.md` qualify. URLs do not.
-        if let url = URL(string: trimmed), url.scheme != nil, url.scheme != "file" {
+        if let url = URL(string: trimmed),
+           let scheme = url.scheme?.lowercased(),
+           scheme != "file",
+           !shouldTreatUnknownSchemeAsRelativePath(trimmed, scheme: scheme) {
             return false
         }
         let ext = (trimmed as NSString).pathExtension.lowercased()
@@ -67,11 +70,7 @@ enum MarkdownPanelFileLinkResolver {
 
     private static func relativeCandidatePaths(_ relativePath: String, relativeToMarkdownFile markdownFilePath: String) -> [String] {
         let markdownDir = (markdownFilePath as NSString).deletingLastPathComponent
-        let pwd = FileManager.default.currentDirectoryPath
-        return [
-            (markdownDir as NSString).appendingPathComponent(relativePath),
-            (pwd as NSString).appendingPathComponent(relativePath)
-        ]
+        return [(markdownDir as NSString).appendingPathComponent(relativePath)]
     }
 
     private static func webKitCoercedRelativePath(from url: URL, scheme: String) -> String? {

--- a/Sources/Panels/MarkdownPanelFileLinkResolver.swift
+++ b/Sources/Panels/MarkdownPanelFileLinkResolver.swift
@@ -2,6 +2,9 @@ import Foundation
 
 enum MarkdownPanelFileLinkResolver {
     private static let markdownExtensions: Set<String> = ["md", "markdown", "mkd", "mdx"]
+    private static let knownExternalSchemes: Set<String> = [
+        "about", "blob", "data", "ftp", "http", "https", "javascript", "mailto", "sms", "tel"
+    ]
 
     static func isMarkdownPathLike(_ rawPath: String) -> Bool {
         let trimmed = stripFragmentAndQuery(rawPath)
@@ -45,12 +48,21 @@ enum MarkdownPanelFileLinkResolver {
             if let relativePath = webKitCoercedRelativePath(from: url, scheme: scheme) {
                 return relativeCandidatePaths(relativePath, relativeToMarkdownFile: markdownFilePath)
             }
+            if shouldTreatUnknownSchemeAsRelativePath(strippedPath, scheme: scheme) {
+                return relativeCandidatePaths(strippedPath, relativeToMarkdownFile: markdownFilePath)
+            }
             return []
         }
         if (strippedPath as NSString).isAbsolutePath {
             return [strippedPath]
         }
         return relativeCandidatePaths(strippedPath, relativeToMarkdownFile: markdownFilePath)
+    }
+
+    private static func shouldTreatUnknownSchemeAsRelativePath(_ path: String, scheme: String) -> Bool {
+        guard !knownExternalSchemes.contains(scheme) else { return false }
+        let lowercasedPath = path.lowercased()
+        return lowercasedPath.hasPrefix("\(scheme):") && !lowercasedPath.hasPrefix("\(scheme)://")
     }
 
     private static func relativeCandidatePaths(_ relativePath: String, relativeToMarkdownFile markdownFilePath: String) -> [String] {

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -621,7 +621,6 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         private func resolvedMarkdownFilePath(_ rawPath: String) -> String? {
             let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return nil }
-            guard MarkdownPanelFileLinkResolver.isMarkdownPathLike(trimmed) else { return nil }
             return MarkdownPanelFileLinkResolver.resolve(rawPath: trimmed, relativeToMarkdownFile: filePath)
         }
 
@@ -838,11 +837,12 @@ struct MarkdownWebRenderer: NSViewRepresentable {
 #if DEBUG
             NSLog("MarkdownPanel.handleExternalLink url=\(url.absoluteString)")
 #endif
-            // First preference: links that resolve to local markdown files
-            // open as markdown tabs in cmux, not in the browser.
-            let fileCandidate = url.scheme == "file" ? url.path : url.absoluteString
-            if let markdownPath = resolvedMarkdownFilePath(fileCandidate) {
-                openMarkdownFile(markdownPath)
+            if let localPath = MarkdownPanelFileLinkResolver.resolveLocalFile(
+                rawPath: url.scheme == "file" ? url.path : url.absoluteString,
+                relativeToMarkdownFile: filePath
+            ) {
+                if MarkdownPanelFileLinkResolver.isMarkdownPathLike(localPath) { openMarkdownFile(localPath) }
+                else { NSWorkspace.shared.open(URL(fileURLWithPath: localPath)) }
                 return
             }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -716,6 +716,7 @@
 		D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A50014F2 /* MarkdownPanelFileLinkResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F0 /* MarkdownPanelFileLinkResolver.swift */; };
+		C74690010000000000000001 /* MarkdownPanelFileLinkResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74690010000000000000002 /* MarkdownPanelFileLinkResolverTests.swift */; };
 		D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3664001D3664001D3664001 /* MarkdownPanelTests.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
 		A50014F7 /* MarkdownRemoteImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F6 /* MarkdownRemoteImageLoader.swift */; };
@@ -2113,6 +2114,7 @@
 		D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMermaidZoomTests.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A50014F0 /* MarkdownPanelFileLinkResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelFileLinkResolver.swift; sourceTree = "<group>"; };
+		C74690010000000000000002 /* MarkdownPanelFileLinkResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelFileLinkResolverTests.swift; sourceTree = "<group>"; };
 		D3664001D3664001D3664001 /* MarkdownPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelTests.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
 		A50014F6 /* MarkdownRemoteImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownRemoteImageLoader.swift; sourceTree = "<group>"; };
@@ -4130,6 +4132,7 @@
 				C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
 				D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */,
+				C74690010000000000000002 /* MarkdownPanelFileLinkResolverTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
 				C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */,
 				C0DEFC100000000000000002 /* FilePreviewTextEditorTextKitTests.swift */,
@@ -5847,6 +5850,7 @@
 				17C9F5BA0DD14EDC8C3E5001 /* MainWindowVisibilityControllerTests.swift in Sources */,
 				A6D1F0100000000000000002 /* MainWindowVisibilityLifecycleTests.swift in Sources */,
 				D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */,
+				C74690010000000000000001 /* MarkdownPanelFileLinkResolverTests.swift in Sources */,
 				D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */,
 				606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */,
 					C0DE70520000000000000002 /* MenuBarProfilingLauncherTests.swift in Sources */,

--- a/cmuxTests/MarkdownPanelFileLinkResolverTests.swift
+++ b/cmuxTests/MarkdownPanelFileLinkResolverTests.swift
@@ -31,6 +31,27 @@ struct MarkdownPanelFileLinkResolverTests {
         #expect(resolved?.hasPrefix("https://") == false)
     }
 
+    @Test("Relative Markdown filenames containing colons resolve as local files")
+    func relativeMarkdownFilenamesContainingColonsResolveAsLocalFiles() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-link-resolver-colon-\(UUID().uuidString)", isDirectory: true)
+        let docs = root.appendingPathComponent("docs", isDirectory: true)
+        let openedFile = docs.appendingPathComponent("index.md")
+        let targetFile = docs.appendingPathComponent("chapter:one.md")
+
+        try FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
+        try "# index".write(to: openedFile, atomically: true, encoding: .utf8)
+        try "# chapter".write(to: targetFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolved = MarkdownPanelFileLinkResolver.resolve(
+            rawPath: "chapter:one.md",
+            relativeToMarkdownFile: openedFile.path
+        )
+
+        #expect(resolved == targetFile.path)
+    }
+
     @Test("Dotted HTTPS hosts remain remote URLs")
     func dottedHTTPSHostsRemainRemoteURLs() throws {
         let root = FileManager.default.temporaryDirectory
@@ -46,6 +67,27 @@ struct MarkdownPanelFileLinkResolverTests {
 
         let resolved = MarkdownPanelFileLinkResolver.resolve(
             rawPath: "https://example.com/plan.md",
+            relativeToMarkdownFile: openedFile.path
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test("Known external schemes remain remote URLs")
+    func knownExternalSchemesRemainRemoteURLs() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-link-resolver-mailto-\(UUID().uuidString)", isDirectory: true)
+        let docs = root.appendingPathComponent("docs", isDirectory: true)
+        let openedFile = docs.appendingPathComponent("index.md")
+        let matchingLocalFile = docs.appendingPathComponent("mailto:chapter.md")
+
+        try FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
+        try "# index".write(to: openedFile, atomically: true, encoding: .utf8)
+        try "# local".write(to: matchingLocalFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolved = MarkdownPanelFileLinkResolver.resolve(
+            rawPath: "mailto:chapter.md",
             relativeToMarkdownFile: openedFile.path
         )
 

--- a/cmuxTests/MarkdownPanelFileLinkResolverTests.swift
+++ b/cmuxTests/MarkdownPanelFileLinkResolverTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Markdown panel file link resolver")
+struct MarkdownPanelFileLinkResolverTests {
+    @Test("WebKit HTTPS coercion of a relative Markdown href resolves as a local file")
+    func webKitHTTPSCoercionOfRelativeMarkdownHrefResolvesAsLocalFile() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-link-resolver-\(UUID().uuidString)", isDirectory: true)
+        let docs = root.appendingPathComponent("docs", isDirectory: true)
+        let openedFile = docs.appendingPathComponent("index.md")
+        let targetFile = docs.appendingPathComponent("raw/plans/agent-ticket-v2/w5-runner-design.md")
+
+        try FileManager.default.createDirectory(at: targetFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "# index".write(to: openedFile, atomically: true, encoding: .utf8)
+        try "# runner".write(to: targetFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolved = MarkdownPanelFileLinkResolver.resolve(
+            rawPath: "https://raw/plans/agent-ticket-v2/w5-runner-design.md",
+            relativeToMarkdownFile: openedFile.path
+        )
+
+        #expect(resolved == targetFile.path)
+        #expect(resolved?.hasPrefix("https://") == false)
+    }
+}

--- a/cmuxTests/MarkdownPanelFileLinkResolverTests.swift
+++ b/cmuxTests/MarkdownPanelFileLinkResolverTests.swift
@@ -30,4 +30,50 @@ struct MarkdownPanelFileLinkResolverTests {
         #expect(resolved == targetFile.path)
         #expect(resolved?.hasPrefix("https://") == false)
     }
+
+    @Test("Dotted HTTPS hosts remain remote URLs")
+    func dottedHTTPSHostsRemainRemoteURLs() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-link-resolver-remote-\(UUID().uuidString)", isDirectory: true)
+        let docs = root.appendingPathComponent("docs", isDirectory: true)
+        let openedFile = docs.appendingPathComponent("index.md")
+        let matchingLocalFile = docs.appendingPathComponent("example.com/plan.md")
+
+        try FileManager.default.createDirectory(at: matchingLocalFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "# index".write(to: openedFile, atomically: true, encoding: .utf8)
+        try "# local".write(to: matchingLocalFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolved = MarkdownPanelFileLinkResolver.resolve(
+            rawPath: "https://example.com/plan.md",
+            relativeToMarkdownFile: openedFile.path
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test("WebKit HTTPS coercion of a relative non-Markdown href resolves as a local file")
+    func webKitHTTPSCoercionOfRelativeNonMarkdownHrefResolvesAsLocalFile() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-link-resolver-file-\(UUID().uuidString)", isDirectory: true)
+        let docs = root.appendingPathComponent("docs", isDirectory: true)
+        let openedFile = docs.appendingPathComponent("index.md")
+        let targetFile = docs.appendingPathComponent("assets/spec.txt")
+
+        try FileManager.default.createDirectory(at: targetFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "# index".write(to: openedFile, atomically: true, encoding: .utf8)
+        try "spec".write(to: targetFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolved = MarkdownPanelFileLinkResolver.resolveLocalFile(
+            rawPath: "https://assets/spec.txt",
+            relativeToMarkdownFile: openedFile.path
+        )
+
+        #expect(resolved == targetFile.path)
+        #expect(MarkdownPanelFileLinkResolver.resolve(
+            rawPath: "https://assets/spec.txt",
+            relativeToMarkdownFile: openedFile.path
+        ) == nil)
+    }
 }

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -6285,9 +6285,9 @@ extension SessionPersistenceTests {
 
     func testMarkdownFileLinkResolverRecognizesMarkdownPathLikeStrings() {
         XCTAssertTrue(MarkdownPanelFileLinkResolver.isMarkdownPathLike("other-markdown.md"))
-        XCTAssertTrue(MarkdownPanelFileLinkResolver.isMarkdownPathLike("test/markdown.md"))
         XCTAssertTrue(MarkdownPanelFileLinkResolver.isMarkdownPathLike("../notes/plan.mdx#section"))
         XCTAssertTrue(MarkdownPanelFileLinkResolver.isMarkdownPathLike("file:///tmp/plan.markdown"))
+        XCTAssertTrue(MarkdownPanelFileLinkResolver.isMarkdownPathLike("chapter:one.md"))
 
         XCTAssertFalse(MarkdownPanelFileLinkResolver.isMarkdownPathLike("https://example.com/plan.md"))
         XCTAssertFalse(MarkdownPanelFileLinkResolver.isMarkdownPathLike("mailto:person@example.com"))
@@ -6316,18 +6316,18 @@ extension SessionPersistenceTests {
         XCTAssertEqual(resolved, adjacentFile.path)
     }
 
-    func testMarkdownFileLinkResolverFallsBackToProcessWorkingDirectory() throws {
+    func testMarkdownFileLinkResolverDoesNotFallBackToProcessWorkingDirectory() throws {
         let originalCWD = FileManager.default.currentDirectoryPath
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-markdown-link-resolver-cwd-\(UUID().uuidString)", isDirectory: true)
         let docs = root.appendingPathComponent("docs", isDirectory: true)
         let openedFile = docs.appendingPathComponent("index.md")
-        let fallbackFile = root.appendingPathComponent("test/markdown.md")
+        let unrelatedCWDFile = root.appendingPathComponent("test/markdown.md")
 
         try FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: fallbackFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: unrelatedCWDFile.deletingLastPathComponent(), withIntermediateDirectories: true)
         try "index".write(to: openedFile, atomically: true, encoding: .utf8)
-        try "fallback".write(to: fallbackFile, atomically: true, encoding: .utf8)
+        try "unrelated".write(to: unrelatedCWDFile, atomically: true, encoding: .utf8)
         defer {
             FileManager.default.changeCurrentDirectoryPath(originalCWD)
             try? FileManager.default.removeItem(at: root)
@@ -6338,7 +6338,7 @@ extension SessionPersistenceTests {
             rawPath: "test/markdown.md",
             relativeToMarkdownFile: openedFile.path
         )
-        XCTAssertEqual(resolved, fallbackFile.path)
+        XCTAssertNil(resolved)
     }
 
     func testMarkdownFileLinkResolverRejectsMissingAndNonMarkdownFiles() throws {


### PR DESCRIPTION
## Summary
- Resolve markdown panel link clicks through a shared local-file resolver before browser URL routing.
- Recover WebKit/omnibar-style `https://raw/...` coercions as relative local paths only when an existing local file is found.
- Route resolved Markdown files back into the native markdown panel and resolved non-Markdown files to the system file handler.
- Keep relative resolution scoped to the containing markdown file directory; no implicit process-CWD fallback.
- Keep renderer shell candidate/sanitizer checks aligned so local names like `chapter:one.md` reach the Swift resolver while known external schemes stay remote.

Closes #7469

## Tests
- Added a failing-first regression test commit for `https://raw/plans/agent-ticket-v2/w5-runner-design.md` resolving to the local Markdown file.
- Added resolver coverage for colon-containing filenames, known external schemes, dotted HTTPS hosts, and non-Markdown local targets.
- Ran `swiftc -parse Sources/Panels/MarkdownPanelFileLinkResolver.swift`.
- Ran targeted Node sanity checks for the markdown shell href predicate.
- Ran `./scripts/lint-pbxproj-test-wiring.sh`.
- Ran `python3 scripts/swift_file_length_budget.py`.
- Ran `scripts/check-pbxproj.sh`.
- Ran `git diff --check`.

Did not run local `xcodebuild` or app launch per issue guardrail. The WebKit click flow was not locally app-dogfooded; the JS candidate/sanitizer branch was patched directly and sanity-checked without launching cmux.

## Localization
No user-facing strings changed. Localization audit: changed surfaces are resolver logic, markdown shell link classification/sanitization, and tests; no `String(localized:)` or message catalog updates were required.