### PR TITLE
Fix markdown panel link boundary around trailing punctuation

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -307,6 +307,7 @@ html { scroll-behavior: smooth; }
       code: true,
       del: true,
       em: true,
+      img: true,
       s: true,
       strong: true
     };
@@ -323,6 +324,10 @@ html { scroll-behavior: smooth; }
         return;
       }
       Array.prototype.slice.call(el.attributes || []).forEach(function(attr) {
+        var name = String(attr.name || '').toLowerCase();
+        if (tag === 'img' && (name === 'src' || name === 'alt' || name === 'title')) {
+          return;
+        }
         el.removeAttribute(attr.name);
       });
     });

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -293,6 +293,12 @@ html { scroll-behavior: smooth; }
       .replace(/>/g, '&gt;');
   }
 
+  function decodeHTML(s) {
+    var textarea = document.createElement('textarea');
+    textarea.innerHTML = String(s == null ? '' : s);
+    return textarea.value;
+  }
+
   function sanitizeLinkLabelHTML(html) {
     var template = document.createElement('template');
     template.innerHTML = String(html == null ? '' : html);
@@ -309,7 +315,8 @@ html { scroll-behavior: smooth; }
     while (walker.nextNode()) {
       elements.push(walker.currentNode);
     }
-    elements.forEach(function(el) {
+    elements.reverse().forEach(function(el) {
+      if (!el.parentNode) { return; }
       var tag = el.tagName.toLowerCase();
       if (!allowedInlineTags[tag]) {
         el.parentNode.replaceChild(document.createTextNode(el.textContent || ''), el);
@@ -1038,7 +1045,7 @@ html { scroll-behavior: smooth; }
       link(href, title, text) {
         var html = '<a href="' + escapeAttribute(href) + '"';
         if (title != null) {
-          html += ' title="' + String(title) + '"';
+          html += ' title="' + escapeAttribute(decodeHTML(title)) + '"';
         }
         return html + '>' + sanitizeLinkLabelHTML(text) + '</a>';
       }

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -293,6 +293,35 @@ html { scroll-behavior: smooth; }
       .replace(/>/g, '&gt;');
   }
 
+  function sanitizeLinkLabelHTML(html) {
+    var template = document.createElement('template');
+    template.innerHTML = String(html == null ? '' : html);
+    var allowedInlineTags = {
+      br: true,
+      code: true,
+      del: true,
+      em: true,
+      s: true,
+      strong: true
+    };
+    var walker = document.createTreeWalker(template.content, NodeFilter.SHOW_ELEMENT);
+    var elements = [];
+    while (walker.nextNode()) {
+      elements.push(walker.currentNode);
+    }
+    elements.forEach(function(el) {
+      var tag = el.tagName.toLowerCase();
+      if (!allowedInlineTags[tag]) {
+        el.parentNode.replaceChild(document.createTextNode(el.textContent || ''), el);
+        return;
+      }
+      Array.prototype.slice.call(el.attributes || []).forEach(function(attr) {
+        el.removeAttribute(attr.name);
+      });
+    });
+    return template.innerHTML;
+  }
+
   function escapeDataAttribute(s) {
     // Store raw local paths in data attributes as percent-encoded
     // strings. This avoids attribute-escaping footguns entirely.
@@ -1009,9 +1038,9 @@ html { scroll-behavior: smooth; }
       link(href, title, text) {
         var html = '<a href="' + escapeAttribute(href) + '"';
         if (title != null) {
-          html += ' title="' + escapeAttribute(title) + '"';
+          html += ' title="' + String(title) + '"';
         }
-        return html + '>' + String(text == null ? '' : text) + '</a>';
+        return html + '>' + sanitizeLinkLabelHTML(text) + '</a>';
       }
     }
   });

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -285,6 +285,14 @@ html { scroll-behavior: smooth; }
     return div.innerHTML;
   }
 
+  function escapeAttribute(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
   function escapeDataAttribute(s) {
     // Store raw local paths in data attributes as percent-encoded
     // strings. This avoids attribute-escaping footguns entirely.
@@ -997,6 +1005,13 @@ html { scroll-behavior: smooth; }
       heading(text, level, raw) {
         var slug = uniqueHeadingSlug(raw);
         return '<h' + level + ' id="' + slug + '">' + text + '</h' + level + '>\n';
+      },
+      link(href, title, text) {
+        var html = '<a href="' + escapeAttribute(href) + '"';
+        if (title != null) {
+          html += ' title="' + escapeAttribute(title) + '"';
+        }
+        return html + '>' + String(text == null ? '' : text) + '</a>';
       }
     }
   });

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -712,6 +712,7 @@
 		F5168A040000000000000001 /* MarkdownFontFamily.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A040000000000000002 /* MarkdownFontFamily.swift */; };
 		F5168A070000000000000001 /* MarkdownFontFamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A070000000000000002 /* MarkdownFontFamilyCache.swift */; };
 		F5168A030000000000000001 /* MarkdownFontSizeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A030000000000000002 /* MarkdownFontSizeSettings.swift */; };
+		D7470002D7470002D7470002 /* MarkdownLinkBoundaryRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7470001D7470001D7470001 /* MarkdownLinkBoundaryRegressionTests.swift */; };
 		F5168A050000000000000001 /* MarkdownMaxWidthSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A050000000000000002 /* MarkdownMaxWidthSettings.swift */; };
 		D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
@@ -2109,6 +2110,7 @@
 		F5168A040000000000000002 /* MarkdownFontFamily.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownFontFamily.swift; sourceTree = "<group>"; };
 		F5168A070000000000000002 /* MarkdownFontFamilyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownFontFamilyCache.swift; sourceTree = "<group>"; };
 		F5168A030000000000000002 /* MarkdownFontSizeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownFontSizeSettings.swift; sourceTree = "<group>"; };
+		D7470001D7470001D7470001 /* MarkdownLinkBoundaryRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownLinkBoundaryRegressionTests.swift; sourceTree = "<group>"; };
 		F5168A050000000000000002 /* MarkdownMaxWidthSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownMaxWidthSettings.swift; sourceTree = "<group>"; };
 		D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMermaidZoomTests.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
@@ -4129,6 +4131,7 @@
 				4C1A7E10B2D34F56A8C90014 /* MobileHostStatusVerificationLimiterTests.swift */,
 				C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
+				D7470001D7470001D7470001 /* MarkdownLinkBoundaryRegressionTests.swift */,
 				D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
 				C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */,
@@ -5846,6 +5849,7 @@
 				6512F0C06512F0C06512F002 /* MainWindowFocusRestoreTests.swift in Sources */,
 				17C9F5BA0DD14EDC8C3E5001 /* MainWindowVisibilityControllerTests.swift in Sources */,
 				A6D1F0100000000000000002 /* MainWindowVisibilityLifecycleTests.swift in Sources */,
+				D7470002D7470002D7470002 /* MarkdownLinkBoundaryRegressionTests.swift in Sources */,
 				D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */,
 				D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */,
 				606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */,

--- a/cmuxTests/MarkdownLinkBoundaryRegressionTests.swift
+++ b/cmuxTests/MarkdownLinkBoundaryRegressionTests.swift
@@ -32,12 +32,13 @@ final class MarkdownLinkBoundaryRegressionTests {
     @Test
     func renderedInlineLinkTitleAndLabelAreEscapedOnce() async throws {
         try await withLoadedMarkdownShell { webView in
+            let href = #"raw/with "quote"&and.md"#
             let snapshot = try await renderLinkBoundarySnapshot(
-                #"See [<span onclick="x">label <strong>raw</strong></span> **bold**](file.md "a & \" <q>")."#,
+                #"See [<span onclick="x">label <strong>raw</strong></span> **bold**](<\#(href)> "a & \" <q>")."#,
                 in: webView
             )
 
-            #expect(snapshot.href == "file.md")
+            #expect(snapshot.href == href)
             #expect(snapshot.title == #"a & " <q>"#)
             #expect(snapshot.text == "label raw bold")
             #expect(snapshot.innerHTML == "label raw <strong>bold</strong>")

--- a/cmuxTests/MarkdownLinkBoundaryRegressionTests.swift
+++ b/cmuxTests/MarkdownLinkBoundaryRegressionTests.swift
@@ -33,14 +33,14 @@ final class MarkdownLinkBoundaryRegressionTests {
     func renderedInlineLinkTitleAndLabelAreEscapedOnce() async throws {
         try await withLoadedMarkdownShell { webView in
             let snapshot = try await renderLinkBoundarySnapshot(
-                #"See [<span onclick="x">label</span> **bold**](file.md "a & \" <q>")."#,
+                #"See [<span onclick="x">label <strong>raw</strong></span> **bold**](file.md "a & \" <q>")."#,
                 in: webView
             )
 
             #expect(snapshot.href == "file.md")
             #expect(snapshot.title == #"a & " <q>"#)
-            #expect(snapshot.text == "label bold")
-            #expect(snapshot.innerHTML == "label <strong>bold</strong>")
+            #expect(snapshot.text == "label raw bold")
+            #expect(snapshot.innerHTML == "label raw <strong>bold</strong>")
         }
     }
 

--- a/cmuxTests/MarkdownLinkBoundaryRegressionTests.swift
+++ b/cmuxTests/MarkdownLinkBoundaryRegressionTests.swift
@@ -1,0 +1,128 @@
+import AppKit
+import Testing
+import WebKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite
+final class MarkdownLinkBoundaryRegressionTests {
+    @Test
+    func renderedInlineLinkExcludesTrailingSentencePeriod() async throws {
+        let markdownURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-link-boundary-\(UUID().uuidString).md")
+        let frame = NSRect(x: 0, y: 0, width: 1_000, height: 600)
+        let webView = WKWebView(frame: frame, configuration: WKWebViewConfiguration())
+        let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = webView
+        window.orderFrontRegardless()
+        defer {
+            webView.navigationDelegate = nil
+            window.close()
+        }
+
+        let loadDelegate = MarkdownLinkBoundaryShellLoadDelegate()
+        webView.navigationDelegate = loadDelegate
+        try await loadDelegate.load(
+            MarkdownViewerAssets.shared.shellHTML(isDark: true),
+            in: webView,
+            baseURL: markdownURL
+        )
+
+        let expectedPath = "raw/plans/agent-ticket-v2/w5-runner-design.md"
+        let snapshot = try await renderLinkBoundarySnapshot(
+            """
+            The runner design doc is written: [\(expectedPath)](\(expectedPath)). It locks in the decisions we discussed...
+            """,
+            in: webView
+        )
+
+        #expect(snapshot.href == expectedPath)
+        #expect(snapshot.text == expectedPath)
+        #expect(snapshot.trailingText.hasPrefix(". It locks in"))
+        #expect(snapshot.periodHitHref == nil)
+    }
+
+    private func renderLinkBoundarySnapshot(
+        _ markdown: String,
+        in webView: WKWebView
+    ) async throws -> LinkBoundarySnapshot {
+        let data = try JSONSerialization.data(withJSONObject: [markdown])
+        let literal = try #require(String(data: data, encoding: .utf8))
+        let result = try await webView.evaluateJavaScript(
+            """
+            (function(md) {
+              window.__cmuxRenderMarkdown(md);
+              var anchor = document.querySelector('a');
+              var trailing = anchor && anchor.nextSibling;
+              var periodHit = null;
+              if (trailing && trailing.nodeType === Node.TEXT_NODE && trailing.textContent.charAt(0) === '.') {
+                var range = document.createRange();
+                range.setStart(trailing, 0);
+                range.setEnd(trailing, 1);
+                var rect = range.getBoundingClientRect();
+                periodHit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+              }
+              return {
+                href: anchor && anchor.getAttribute('href'),
+                text: anchor && anchor.textContent,
+                trailingText: trailing && trailing.textContent,
+                periodHitHref: periodHit && periodHit.getAttribute && periodHit.getAttribute('href')
+              };
+            })(\(literal)[0]);
+            """
+        )
+        let raw = try #require(result as? [String: Any])
+        return LinkBoundarySnapshot(
+            href: raw["href"] as? String,
+            text: raw["text"] as? String,
+            trailingText: raw["trailingText"] as? String ?? "",
+            periodHitHref: raw["periodHitHref"] as? String
+        )
+    }
+}
+
+private struct LinkBoundarySnapshot {
+    let href: String?
+    let text: String?
+    let trailingText: String
+    let periodHitHref: String?
+}
+
+private final class MarkdownLinkBoundaryShellLoadDelegate: NSObject, WKNavigationDelegate {
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func load(_ html: String, in webView: WKWebView, baseURL: URL) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            webView.loadHTMLString(html, baseURL: baseURL)
+        }
+    }
+
+    private func finish(_ result: Result<Void, Error>) {
+        guard let continuation else { return }
+        self.continuation = nil
+        switch result {
+        case .success:
+            continuation.resume()
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        finish(.success(()))
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        finish(.failure(error))
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        finish(.failure(error))
+    }
+}

--- a/cmuxTests/MarkdownLinkBoundaryRegressionTests.swift
+++ b/cmuxTests/MarkdownLinkBoundaryRegressionTests.swift
@@ -13,6 +13,40 @@ import WebKit
 final class MarkdownLinkBoundaryRegressionTests {
     @Test
     func renderedInlineLinkExcludesTrailingSentencePeriod() async throws {
+        try await withLoadedMarkdownShell { webView in
+            let expectedPath = "raw/plans/agent-ticket-v2/w5-runner-design.md"
+            let snapshot = try await renderLinkBoundarySnapshot(
+                """
+                The runner design doc is written: [\(expectedPath)](\(expectedPath)). It locks in the decisions we discussed...
+                """,
+                in: webView
+            )
+
+            #expect(snapshot.href == expectedPath)
+            #expect(snapshot.text == expectedPath)
+            #expect(snapshot.trailingText.hasPrefix(". It locks in"))
+            #expect(snapshot.periodHitHref == nil)
+        }
+    }
+
+    @Test
+    func renderedInlineLinkTitleAndLabelAreEscapedOnce() async throws {
+        try await withLoadedMarkdownShell { webView in
+            let snapshot = try await renderLinkBoundarySnapshot(
+                #"See [<span onclick="x">label</span> **bold**](file.md "a & \" <q>")."#,
+                in: webView
+            )
+
+            #expect(snapshot.href == "file.md")
+            #expect(snapshot.title == #"a & " <q>"#)
+            #expect(snapshot.text == "label bold")
+            #expect(snapshot.innerHTML == "label <strong>bold</strong>")
+        }
+    }
+
+    private func withLoadedMarkdownShell<T>(
+        _ body: (WKWebView) async throws -> T
+    ) async throws -> T {
         let markdownURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-markdown-link-boundary-\(UUID().uuidString).md")
         let frame = NSRect(x: 0, y: 0, width: 1_000, height: 600)
@@ -32,19 +66,7 @@ final class MarkdownLinkBoundaryRegressionTests {
             in: webView,
             baseURL: markdownURL
         )
-
-        let expectedPath = "raw/plans/agent-ticket-v2/w5-runner-design.md"
-        let snapshot = try await renderLinkBoundarySnapshot(
-            """
-            The runner design doc is written: [\(expectedPath)](\(expectedPath)). It locks in the decisions we discussed...
-            """,
-            in: webView
-        )
-
-        #expect(snapshot.href == expectedPath)
-        #expect(snapshot.text == expectedPath)
-        #expect(snapshot.trailingText.hasPrefix(". It locks in"))
-        #expect(snapshot.periodHitHref == nil)
+        return try await body(webView)
     }
 
     private func renderLinkBoundarySnapshot(
@@ -69,7 +91,9 @@ final class MarkdownLinkBoundaryRegressionTests {
               }
               return {
                 href: anchor && anchor.getAttribute('href'),
+                title: anchor && anchor.getAttribute('title'),
                 text: anchor && anchor.textContent,
+                innerHTML: anchor && anchor.innerHTML,
                 trailingText: trailing && trailing.textContent,
                 periodHitHref: periodHit && periodHit.getAttribute && periodHit.getAttribute('href')
               };
@@ -79,7 +103,9 @@ final class MarkdownLinkBoundaryRegressionTests {
         let raw = try #require(result as? [String: Any])
         return LinkBoundarySnapshot(
             href: raw["href"] as? String,
+            title: raw["title"] as? String,
             text: raw["text"] as? String,
+            innerHTML: raw["innerHTML"] as? String,
             trailingText: raw["trailingText"] as? String ?? "",
             periodHitHref: raw["periodHitHref"] as? String
         )
@@ -88,7 +114,9 @@ final class MarkdownLinkBoundaryRegressionTests {
 
 private struct LinkBoundarySnapshot {
     let href: String?
+    let title: String?
     let text: String?
+    let innerHTML: String?
     let trailingText: String
     let periodHitHref: String?
 }

--- a/cmuxTests/MarkdownLinkBoundaryRegressionTests.swift
+++ b/cmuxTests/MarkdownLinkBoundaryRegressionTests.swift
@@ -45,6 +45,21 @@ final class MarkdownLinkBoundaryRegressionTests {
         }
     }
 
+    @Test
+    func renderedLinkedMarkdownImagePreservesImageLabel() async throws {
+        try await withLoadedMarkdownShell { webView in
+            let snapshot = try await renderLinkBoundarySnapshot(
+                #"[![diagram alt](raw/diagram.png "diagram title")](dest.md)."#,
+                in: webView
+            )
+
+            #expect(snapshot.href == "dest.md")
+            #expect(snapshot.imageAlt == "diagram alt")
+            #expect(snapshot.imageTitle == "diagram title")
+            #expect(snapshot.trailingText == ".")
+        }
+    }
+
     private func withLoadedMarkdownShell<T>(
         _ body: (WKWebView) async throws -> T
     ) async throws -> T {
@@ -81,6 +96,7 @@ final class MarkdownLinkBoundaryRegressionTests {
             (function(md) {
               window.__cmuxRenderMarkdown(md);
               var anchor = document.querySelector('a');
+              var image = anchor && anchor.querySelector('img');
               var trailing = anchor && anchor.nextSibling;
               var periodHit = null;
               if (trailing && trailing.nodeType === Node.TEXT_NODE && trailing.textContent.charAt(0) === '.') {
@@ -95,6 +111,8 @@ final class MarkdownLinkBoundaryRegressionTests {
                 title: anchor && anchor.getAttribute('title'),
                 text: anchor && anchor.textContent,
                 innerHTML: anchor && anchor.innerHTML,
+                imageAlt: image && image.getAttribute('alt'),
+                imageTitle: image && image.getAttribute('title'),
                 trailingText: trailing && trailing.textContent,
                 periodHitHref: periodHit && periodHit.getAttribute && periodHit.getAttribute('href')
               };
@@ -107,6 +125,8 @@ final class MarkdownLinkBoundaryRegressionTests {
             title: raw["title"] as? String,
             text: raw["text"] as? String,
             innerHTML: raw["innerHTML"] as? String,
+            imageAlt: raw["imageAlt"] as? String,
+            imageTitle: raw["imageTitle"] as? String,
             trailingText: raw["trailingText"] as? String ?? "",
             periodHitHref: raw["periodHitHref"] as? String
         )
@@ -118,6 +138,8 @@ private struct LinkBoundarySnapshot {
     let title: String?
     let text: String?
     let innerHTML: String?
+    let imageAlt: String?
+    let imageTitle: String?
     let trailingText: String
     let periodHitHref: String?
 }


### PR DESCRIPTION
## Summary
- Add a markdown-panel WebKit regression covering `[text](url).` so the anchor href/text and hit target exclude the sentence period.
- Render markdown links explicitly from marked's link token values with attribute escaping before existing sanitizer/local-file postprocessing.

## Notes
- I could not reproduce a red failure for the exact issue on current base: direct marked, jsdom shell, and throwaway WebKit shell probes already kept the period outside the link. The first commit therefore pins the behavior rather than demonstrating a failing red state.

## Verification
- node/jsdom shell probe: href/text exclude trailing period
- throwaway Swift/WKWebView shell probe: href/text exclude period and elementFromPoint over the period has no href
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/swift_file_length_budget.py`
- `git diff --check`
- Not run: local xcodebuild tests or reload.sh, per task guardrail against local xcodebuild/app build/launch.

## Localization
No user-facing strings changed. Localization audit: reviewed the changed files and confirmed no UI text or localizable surface was added.

Closes #7470

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785990940&installation_id=133855650&pr_number=7492&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7492&signature=8af234107557d3197b3b0ed1eac114b86935019e1876a98fdbff77180033c419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to markdown viewer HTML generation and new regression tests; no auth or data-path changes, with label sanitization reducing XSS surface on link text.
> 
> **Overview**
> The markdown viewer shell now **overrides marked’s `link()` renderer** so anchors are built from escaped `href`/`title` values and a **sanitized label** (safe inline tags like `strong`/`img` kept; dangerous markup stripped) before the existing HTML sanitizer runs.
> 
> This pins **link boundary behavior** for patterns like `[path](path).` so the sentence period stays outside the anchor and isn’t part of the click target, and covers **single-escape** handling for quoted hrefs/titles plus **linked image** labels.
> 
> **`MarkdownLinkBoundaryRegressionTests`** loads the real shell in `WKWebView`, renders sample markdown via `__cmuxRenderMarkdown`, and asserts href/text, trailing punctuation, and hit-testing over the period.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4cab0cfeedf79fd045c55c400ef11420cb9fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes markdown link boundaries so trailing punctuation (like a period) is outside the link in the markdown panel. Custom `marked` `link()` now escapes `href`, decodes-then-escapes `title`, and sanitizes the label while preserving safe inline tags, including `img` with safe attributes (closes #7470).

- **Bug Fixes**
  - Override `marked` renderer `link()` to escape `href`, decode then escape `title`, and sanitize label HTML (allow: `br`, `code`, `del`, `em`, `s`, `strong`, `img`; drop attributes except `img` `src`/`alt`/`title`).
  - Add WKWebView regression tests to verify the trailing period isn’t clickable, attributes are escaped once, and linked images preserve `alt`/`title` and remain outside the punctuation boundary.

<sup>Written for commit 3d4cab0cfeedf79fd045c55c400ef11420cb9fac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown link rendering by safely escaping link `href` and `title`, decoding title entities before escaping, and sanitizing allowed inline HTML in link labels.
  * Refined link boundary behavior so trailing punctuation (such as periods) is less likely to be included in the clickable area.

* **Tests**
  * Added regression tests covering link boundary punctuation and verifying that link attributes and label HTML are escaped/preserved correctly in the markdown shell rendered in a web view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->