### PR TITLE
Swallow terminal focus-transfer clicks

### DIFF
--- a/Sources/GhosttyNSView+PointerFocusActivation.swift
+++ b/Sources/GhosttyNSView+PointerFocusActivation.swift
@@ -2,23 +2,21 @@ import CmuxTerminalCore
 
 extension GhosttyNSView {
     func terminalPointerShouldForwardActivation() -> Bool {
-        TerminalPointerFocusActivationPolicy().shouldForwardToTerminal(
-            wasFocusedBeforePointerDown: terminalWasFocusedBeforePointerDown()
-        )
-    }
-
-    private func terminalWasFocusedBeforePointerDown() -> Bool {
-        guard let terminalSurface else { return true }
+        guard let terminalSurface else { return false }
         guard desiredFocus else { return false }
 
+        let policy = TerminalPointerFocusActivationPolicy()
         switch terminalSurface.focusPlacement {
         case .workspace:
-            return terminalSurface.owningWorkspace().map { $0.focusedPanelId == terminalSurface.id } ?? true
+            return policy.shouldForwardToTerminal(
+                currentPanelId: terminalSurface.id,
+                focusedPanelId: terminalSurface.owningWorkspace()?.focusedPanelId
+            )
         case .rightSidebarDock:
-            guard let dock = AppDelegate.shared?.windowDockContainingPanel(terminalSurface.id) else {
-                return true
-            }
-            return dock.focusedPanelId == terminalSurface.id
+            return policy.shouldForwardToTerminal(
+                currentPanelId: terminalSurface.id,
+                focusedPanelId: AppDelegate.shared?.windowDockContainingPanel(terminalSurface.id)?.focusedPanelId
+            )
         }
     }
 }

--- a/Sources/GhosttyNSView+PointerFocusActivation.swift
+++ b/Sources/GhosttyNSView+PointerFocusActivation.swift
@@ -1,0 +1,24 @@
+import CmuxTerminalCore
+
+extension GhosttyNSView {
+    func terminalPointerShouldForwardActivation() -> Bool {
+        TerminalPointerFocusActivationPolicy().shouldForwardToTerminal(
+            wasFocusedBeforePointerDown: terminalWasFocusedBeforePointerDown()
+        )
+    }
+
+    private func terminalWasFocusedBeforePointerDown() -> Bool {
+        guard let terminalSurface else { return true }
+        guard desiredFocus else { return false }
+
+        switch terminalSurface.focusPlacement {
+        case .workspace:
+            return terminalSurface.owningWorkspace().map { $0.focusedPanelId == terminalSurface.id } ?? true
+        case .rightSidebarDock:
+            guard let dock = AppDelegate.shared?.windowDockContainingPanel(terminalSurface.id) else {
+                return true
+            }
+            return dock.focusedPanelId == terminalSurface.id
+        }
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6469,9 +6469,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let debugPoint = convert(event.locationInWindow, from: nil)
         cmuxDebugLog("terminal.mouseDown surface=\(terminalSurface?.id.uuidString.prefix(5) ?? "nil") mods=[\(debugModifierString(event.modifierFlags))] clickCount=\(event.clickCount) point=(\(String(format: "%.0f", debugPoint.x)),\(String(format: "%.0f", debugPoint.y)))")
         #endif
-        // Split reparent/layout churn can suppress the later `becomeFirstResponder -> onFocus`
-        // callback. Treat pointer-down as explicit focus intent so clicking a ghost pane still
-        // repairs workspace/pane active state before key routing runs.
+        let shouldForwardTerminalActivation = terminalPointerShouldForwardActivation()
+        // Treat pointer-down as explicit focus intent before forwarding any terminal activation.
         if let terminalSurface {
             if terminalSurface.focusPlacement == .rightSidebarDock {
                 AppDelegate.shared?.noteRightSidebarKeyboardFocusIntent(mode: .dock, in: window)
@@ -6492,6 +6491,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 surfaceId: terminalSurface.id
             )
         }
+        guard shouldForwardTerminalActivation else { return }
         guard let surface = surface else { return }
         let eventPoint = convert(event.locationInWindow, from: nil)
         trackMousePointIfUsable(eventPoint)

--- a/Sources/TerminalPointerFocusActivationPolicy.swift
+++ b/Sources/TerminalPointerFocusActivationPolicy.swift
@@ -1,10 +1,5 @@
-enum TerminalPointerFocusActivationDecision: Equatable, Sendable {
-    case focusOnly
-    case forwardToTerminal
-}
-
 struct TerminalPointerFocusActivationPolicy: Sendable {
-    func decision(wasFocusedBeforePointerDown: Bool) -> TerminalPointerFocusActivationDecision {
-        .forwardToTerminal
+    func shouldForwardToTerminal(wasFocusedBeforePointerDown: Bool) -> Bool {
+        wasFocusedBeforePointerDown
     }
 }

--- a/Sources/TerminalPointerFocusActivationPolicy.swift
+++ b/Sources/TerminalPointerFocusActivationPolicy.swift
@@ -1,5 +1,11 @@
+import Foundation
+
 struct TerminalPointerFocusActivationPolicy: Sendable {
     func shouldForwardToTerminal(wasFocusedBeforePointerDown: Bool) -> Bool {
         wasFocusedBeforePointerDown
+    }
+
+    func shouldForwardToTerminal(currentPanelId: UUID, focusedPanelId: UUID?) -> Bool {
+        focusedPanelId == currentPanelId
     }
 }

--- a/Sources/TerminalPointerFocusActivationPolicy.swift
+++ b/Sources/TerminalPointerFocusActivationPolicy.swift
@@ -1,0 +1,10 @@
+enum TerminalPointerFocusActivationDecision: Equatable, Sendable {
+    case focusOnly
+    case forwardToTerminal
+}
+
+struct TerminalPointerFocusActivationPolicy: Sendable {
+    func decision(wasFocusedBeforePointerDown: Bool) -> TerminalPointerFocusActivationDecision {
+        .forwardToTerminal
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1214,6 +1214,8 @@
 		C0DE5A410000000000000001 /* TerminalPanelShellActivityModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5A410000000000000002 /* TerminalPanelShellActivityModel.swift */; };
 		C0DE6B420000000000000001 /* TerminalPanelTextBoxState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE6B420000000000000002 /* TerminalPanelTextBoxState.swift */; };
 		A5001403 /* TerminalPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001413 /* TerminalPanelView.swift */; };
+		C7261F010000000000000001 /* TerminalPointerFocusActivationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7261F010000000000000002 /* TerminalPointerFocusActivationPolicy.swift */; };
+		C7261F020000000000000001 /* TerminalPointerFocusActivationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7261F020000000000000002 /* TerminalPointerFocusActivationPolicyTests.swift */; };
 		D5671001D5671001D5671001 /* TerminalScrollSpeedSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5671002D5671002D5671002 /* TerminalScrollSpeedSettings.swift */; };
 		D5671101D5671101D5671101 /* TerminalScrollSpeedSettingsFileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5671102D5671102D5671102 /* TerminalScrollSpeedSettingsFileStoreTests.swift */; };
 		C0DE53350000000000000001 /* TerminalSearchOverlayHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE53350000000000000002 /* TerminalSearchOverlayHostingView.swift */; };
@@ -2597,6 +2599,8 @@
 		C0DE5A410000000000000002 /* TerminalPanelShellActivityModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanelShellActivityModel.swift; sourceTree = "<group>"; };
 		C0DE6B420000000000000002 /* TerminalPanelTextBoxState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanelTextBoxState.swift; sourceTree = "<group>"; };
 		A5001413 /* TerminalPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanelView.swift; sourceTree = "<group>"; };
+		C7261F010000000000000002 /* TerminalPointerFocusActivationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPointerFocusActivationPolicy.swift; sourceTree = "<group>"; };
+		C7261F020000000000000002 /* TerminalPointerFocusActivationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPointerFocusActivationPolicyTests.swift; sourceTree = "<group>"; };
 		D5671002D5671002D5671002 /* TerminalScrollSpeedSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/TerminalScrollSpeedSettings.swift; sourceTree = "<group>"; };
 		D5671102D5671102D5671102 /* TerminalScrollSpeedSettingsFileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalScrollSpeedSettingsFileStoreTests.swift; sourceTree = "<group>"; };
 		C0DE53350000000000000002 /* TerminalSearchOverlayHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/TerminalSearchOverlayHostingView.swift; sourceTree = "<group>"; };
@@ -3321,6 +3325,7 @@
 				A5001015 /* GhosttyTerminalView.swift */,
 				A5001B01 /* GhosttyTerminalScrollBoost.swift */,
 				D5671202D5671202D5671202 /* GhosttyTerminalScrollSpeed.swift */,
+				C7261F010000000000000002 /* TerminalPointerFocusActivationPolicy.swift */,
 				C13519000000000000000006 /* RestorableAgentTypes.swift */,
 				D36A00030000000000000002 /* AgentHibernationLifecycleState.swift */,
 				F0ACC0E0000000000000002 /* CachedAgentProcessIdentityValidator.swift */,
@@ -4017,6 +4022,7 @@
 				DE71CE000000000000000005 /* MobileHostNetworkPathRefreshTests.swift */,
 				AA5269A0C0DE0003FACE0003 /* ForeignFirstResponderPolicyTests.swift */,
 				F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */,
+				C7261F020000000000000002 /* TerminalPointerFocusActivationPolicyTests.swift */,
 				FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
 				A5008380 /* BrowserFindJavaScriptTests.swift */,
 				C2B6A97D1F2E4C71A8B9D002 /* BrowserOmnibarPerformanceSupportTests.swift */,
@@ -5415,6 +5421,7 @@
 				C0DE5A410000000000000001 /* TerminalPanelShellActivityModel.swift in Sources */,
 				C0DE6B420000000000000001 /* TerminalPanelTextBoxState.swift in Sources */,
 				A5001403 /* TerminalPanelView.swift in Sources */,
+				C7261F010000000000000001 /* TerminalPointerFocusActivationPolicy.swift in Sources */,
 				D5671001D5671001D5671001 /* TerminalScrollSpeedSettings.swift in Sources */,
 				C0DE53350000000000000001 /* TerminalSearchOverlayHostingView.swift in Sources */,
 				A5001543 /* TerminalSSHSessionDetector.swift in Sources */,
@@ -5981,6 +5988,7 @@
 				A5A5A503A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift in Sources */,
 				A5E380700000000000000001 /* TerminalNotificationSocketActionTests.swift in Sources */,
 				596100000000000000000007 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift in Sources */,
+				C7261F020000000000000001 /* TerminalPointerFocusActivationPolicyTests.swift in Sources */,
 				D5671101D5671101D5671101 /* TerminalScrollSpeedSettingsFileStoreTests.swift in Sources */,
 				C0DE53360000000000000001 /* TerminalSearchOverlayMouseReleaseTests.swift in Sources */,
 				D3052001000000000000001 /* TerminalSurfaceResizePolicyTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -638,6 +638,7 @@
 		F0ACC0DE0000000000000001 /* GhosttyNSView+ForkConversationContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE0000000000000002 /* GhosttyNSView+ForkConversationContextMenu.swift */; };
 		D3571000A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3571001A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift */; };
 		D7AB00000000000000000005 /* GhosttyNSView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */; };
+		C7261F030000000000000001 /* GhosttyNSView+PointerFocusActivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7261F030000000000000002 /* GhosttyNSView+PointerFocusActivation.swift */; };
 		265FFB2D782433ED46B87F32 /* GhosttyNSView+RemoteReconnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47895BD8BBB2418438E708F5 /* GhosttyNSView+RemoteReconnect.swift */; };
 		EC010E01 /* GhosttyNSView+TerminalCustomUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC010E02 /* GhosttyNSView+TerminalCustomUpload.swift */; };
 		BDFCA25C0CE77A299C915E26 /* GhosttyOptionAsAltModsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F34462AE2F2EECEF5298031 /* GhosttyOptionAsAltModsTests.swift */; };
@@ -2038,6 +2039,7 @@
 		F0ACC0DE0000000000000002 /* GhosttyNSView+ForkConversationContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+ForkConversationContextMenu.swift"; sourceTree = "<group>"; };
 		D3571001A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+IMEComposition.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
+		C7261F030000000000000002 /* GhosttyNSView+PointerFocusActivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+PointerFocusActivation.swift"; sourceTree = "<group>"; };
 		47895BD8BBB2418438E708F5 /* GhosttyNSView+RemoteReconnect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+RemoteReconnect.swift"; sourceTree = "<group>"; };
 		EC010E02 /* GhosttyNSView+TerminalCustomUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+TerminalCustomUpload.swift"; sourceTree = "<group>"; };
 		4F34462AE2F2EECEF5298031 /* GhosttyOptionAsAltModsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyOptionAsAltModsTests.swift; sourceTree = "<group>"; };
@@ -3337,6 +3339,7 @@
 				C5D0DEC0CF00000000000B1 /* CmuxConfigStore+ConfigStoreReloading.swift */,
 				F0ACC0DE0000000000000002 /* GhosttyNSView+ForkConversationContextMenu.swift */,
 				D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */,
+				C7261F030000000000000002 /* GhosttyNSView+PointerFocusActivation.swift */,
 				47895BD8BBB2418438E708F5 /* GhosttyNSView+RemoteReconnect.swift */,
 				D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */,
 				D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */,
@@ -5045,6 +5048,7 @@
 				F0ACC0DE0000000000000001 /* GhosttyNSView+ForkConversationContextMenu.swift in Sources */,
 				D3571000A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift in Sources */,
 				D7AB00000000000000000005 /* GhosttyNSView+MoveTabToNewWorkspace.swift in Sources */,
+				C7261F030000000000000001 /* GhosttyNSView+PointerFocusActivation.swift in Sources */,
 				265FFB2D782433ED46B87F32 /* GhosttyNSView+RemoteReconnect.swift in Sources */,
 				EC010E01 /* GhosttyNSView+TerminalCustomUpload.swift in Sources */,
 				B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */,

--- a/cmuxTests/TerminalPointerFocusActivationPolicyTests.swift
+++ b/cmuxTests/TerminalPointerFocusActivationPolicyTests.swift
@@ -1,0 +1,24 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite
+struct TerminalPointerFocusActivationPolicyTests {
+    @Test
+    func unfocusedPaneFocusClickDoesNotForwardToTerminal() {
+        let policy = TerminalPointerFocusActivationPolicy()
+
+        #expect(policy.decision(wasFocusedBeforePointerDown: false) == .focusOnly)
+    }
+
+    @Test
+    func focusedPaneClickStillForwardsToTerminal() {
+        let policy = TerminalPointerFocusActivationPolicy()
+
+        #expect(policy.decision(wasFocusedBeforePointerDown: true) == .forwardToTerminal)
+    }
+}

--- a/cmuxTests/TerminalPointerFocusActivationPolicyTests.swift
+++ b/cmuxTests/TerminalPointerFocusActivationPolicyTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 #if canImport(cmux_DEV)
@@ -20,5 +21,27 @@ struct TerminalPointerFocusActivationPolicyTests {
         let policy = TerminalPointerFocusActivationPolicy()
 
         #expect(policy.shouldForwardToTerminal(wasFocusedBeforePointerDown: true))
+    }
+
+    @Test
+    func matchingFocusedPanelForwardsToTerminal() {
+        let panelId = UUID()
+        let policy = TerminalPointerFocusActivationPolicy()
+
+        #expect(policy.shouldForwardToTerminal(currentPanelId: panelId, focusedPanelId: panelId))
+    }
+
+    @Test
+    func differentFocusedPanelDoesNotForwardToTerminal() {
+        let policy = TerminalPointerFocusActivationPolicy()
+
+        #expect(!policy.shouldForwardToTerminal(currentPanelId: UUID(), focusedPanelId: UUID()))
+    }
+
+    @Test
+    func missingFocusedPanelDoesNotForwardToTerminal() {
+        let policy = TerminalPointerFocusActivationPolicy()
+
+        #expect(!policy.shouldForwardToTerminal(currentPanelId: UUID(), focusedPanelId: nil))
     }
 }

--- a/cmuxTests/TerminalPointerFocusActivationPolicyTests.swift
+++ b/cmuxTests/TerminalPointerFocusActivationPolicyTests.swift
@@ -12,13 +12,13 @@ struct TerminalPointerFocusActivationPolicyTests {
     func unfocusedPaneFocusClickDoesNotForwardToTerminal() {
         let policy = TerminalPointerFocusActivationPolicy()
 
-        #expect(policy.decision(wasFocusedBeforePointerDown: false) == .focusOnly)
+        #expect(!policy.shouldForwardToTerminal(wasFocusedBeforePointerDown: false))
     }
 
     @Test
     func focusedPaneClickStillForwardsToTerminal() {
         let policy = TerminalPointerFocusActivationPolicy()
 
-        #expect(policy.decision(wasFocusedBeforePointerDown: true) == .forwardToTerminal)
+        #expect(policy.shouldForwardToTerminal(wasFocusedBeforePointerDown: true))
     }
 }


### PR DESCRIPTION
Closes #7261

## Summary
- Add a focused regression policy for terminal pointer activation on focus-transfer clicks.
- Keep the existing focus-recovery path in `GhosttyNSView.mouseDown`, but stop before forwarding the mouse press to Ghostty when the pane was not already focused.
- Leave the external-vs-embedded browser click default unchanged; that should be a product follow-up if the defaults should be swapped.

## Tests and verification
- `python3 scripts/normalize-pbxproj.py cmux.xcodeproj/project.pbxproj`
- `scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/swift_file_length_budget.py`
- `git diff --check`

I did not run a local cmux build, launch the app, run bare `xcodebuild`, or run local XCUITests per the issue instructions. The first commit adds the regression test alone so CI can show it fails without the fix; the second commit applies the focus-click swallow.

## Localization audit
No user-facing strings were added or changed, and no localization files were touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785992192&installation_id=133855650&pr_number=7495&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7495&signature=358838717f4df3916cb4b7ed2605800b59db572c141eae0eb7ee07712c6c0932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal pointer and focus routing behavior across workspace and sidebar panes; risk is mitigated by a small policy object and dedicated unit tests, but incorrect focus detection could still break click-to-focus or block legitimate clicks.
> 
> **Overview**
> **Focus-transfer clicks** on a terminal pane no longer reach Ghostty as a mouse press when that pane was not already the focused panel, so the first click only moves focus instead of triggering shell/UI actions underneath.
> 
> A new **`TerminalPointerFocusActivationPolicy`** decides whether to forward activation (panel ID must match the workspace or right-sidebar dock focused panel). **`GhosttyNSView`** wires that through `terminalPointerShouldForwardActivation()` for both focus placements. **`mouseDown`** still runs the existing focus-recovery path (keyboard focus intent, reparent suppression clear, `makeFirstResponder`, notifications), then **returns early** before `ghostty_surface_mouse_pos` / `ghostty_surface_mouse_button` when forwarding is not allowed.
> 
> Unit tests cover the policy; Xcode project wiring adds the new sources and test target entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48c4e93b7fc6f8e3f0e4e9664eea972e9eab766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swallows focus-transfer clicks in the terminal so the first click only focuses the pane and is not forwarded to the terminal. Prevents accidental terminal actions on the first click after switching focus.

- **Bug Fixes**
  - Added `TerminalPointerFocusActivationPolicy` to forward activation only if the pane was focused before pointer down.
  - Centralized the decision in `GhosttyNSView+PointerFocusActivation` and integrated it into `GhosttyNSView.mouseDown`, preserving the focus-recovery path and early-returning when unfocused.
  - Implemented focus detection for workspace and right sidebar dock, and fail-closed when the focused panel can’t be determined.
  - Added unit tests for the activation policy.

<sup>Written for commit e48c4e93b7fc6f8e3f0e4e9664eea972e9eab766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pointer clicks on the terminal now respect the terminal’s current focus state before forwarding activation.
* **Bug Fixes**
  * Improved focus handling so pointer-down events no longer always trigger terminal activation.
  * Fixed cases where click-based activation could be forwarded when the terminal was not already focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->