### PR TITLE
Add memory pressure response layer

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
@@ -93,16 +93,17 @@ extension TerminalSurface {
     /// no-ops if there is no runtime surface, it is already released, or the
     /// surface is currently visible (a hard safety net so we never blank an
     /// on-screen terminal regardless of how the caller picked it).
+    @discardableResult
     @MainActor
-    public func releaseRenderer() {
+    public func releaseRenderer() -> Bool {
 #if os(macOS)
-        guard rendererRealized, !rendererPortalVisible else { return }
+        guard rendererRealized, !rendererPortalVisible else { return false }
         // The reclamation controller is default-on and scans every registered
         // wrapper, so validate the native pointer (registry ownership +
         // liveness) before the C call instead of trusting `surface != nil`.
         // This self-heals a stale wrapper whose runtime surface was freed
         // out-of-band rather than passing a dangling pointer to Ghostty.
-        guard let surface = liveSurfaceForGhosttyAccess(reason: "renderer.release") else { return }
+        guard let surface = liveSurfaceForGhosttyAccess(reason: "renderer.release") else { return false }
         // Only advance our mirror state when the message was actually enqueued
         // (a `.forever` push can still drop on a spurious wakeup while the
         // mailbox is full). If it dropped, keep `rendererRealized = true` so the
@@ -110,7 +111,11 @@ extension TerminalSurface {
         // Ghostty's still-realized swap chain.
         if ghostty_surface_set_renderer_realized(surface, false) {
             rendererRealized = false
+            return true
         }
+        return false
+#else
+        return false
 #endif
     }
 

--- a/Sources/App/BrowserHiddenWebViewMemoryPressureResponder.swift
+++ b/Sources/App/BrowserHiddenWebViewMemoryPressureResponder.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+@MainActor
+final class BrowserHiddenWebViewMemoryPressureResponder: MemoryPressureResponder {
+    let memoryPressureResponderID = "browser-hidden-webviews"
+    let memoryPressureMinimumSeverity: MemoryPressureSeverity = .warning
+    let memoryPressurePriority = 90
+
+    private let tabManagers: @MainActor () -> [TabManager]
+
+    init(tabManagers: @escaping @MainActor () -> [TabManager]) {
+        self.tabManagers = tabManagers
+    }
+
+    func shedMemory(for snapshot: MemoryPressureSnapshot) -> MemoryPressureShedResult {
+        let discardedCount = tabManagers().reduce(0) { count, manager in
+            count + manager.discardHiddenBrowserWebViewsForSystemMemoryPressure(
+                now: snapshot.sampledAt
+            )
+        }
+        return MemoryPressureShedResult(
+            reclaimedItemCount: discardedCount,
+            detail: "hidden-browser-webviews"
+        )
+    }
+}

--- a/Sources/App/MemoryPressureFootprintSampling.swift
+++ b/Sources/App/MemoryPressureFootprintSampling.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol MemoryPressureFootprintSampling: Sendable {
+    func physicalFootprintBytes() -> UInt64?
+}

--- a/Sources/App/MemoryPressureFootprintThresholds.swift
+++ b/Sources/App/MemoryPressureFootprintThresholds.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct MemoryPressureFootprintThresholds: Equatable, Sendable {
+    static let `default` = MemoryPressureFootprintThresholds(
+        warningBytes: 8 * 1024 * 1024 * 1024,
+        criticalBytes: 16 * 1024 * 1024 * 1024
+    )
+
+    let warningBytes: UInt64
+    let criticalBytes: UInt64
+
+    init(warningBytes: UInt64, criticalBytes: UInt64) {
+        self.warningBytes = warningBytes
+        self.criticalBytes = max(criticalBytes, warningBytes)
+    }
+
+    func severity(forPhysicalFootprintBytes bytes: UInt64?) -> MemoryPressureSeverity {
+        guard let bytes else { return .normal }
+        if bytes >= criticalBytes {
+            return .critical
+        }
+        if bytes >= warningBytes {
+            return .warning
+        }
+        return .normal
+    }
+}

--- a/Sources/App/MemoryPressureMonitor.swift
+++ b/Sources/App/MemoryPressureMonitor.swift
@@ -75,10 +75,12 @@ final class MemoryPressureMonitor {
     }
 
     func recordSystemPressure(_ severity: MemoryPressureSeverity, at sampledAt: Date = Date()) {
-        activeSystemSeverity = severity
+        let heldSeverity = heldSystemSeverity(at: sampledAt) ?? .normal
+        let effectiveSeverity = max(severity, heldSeverity)
+        activeSystemSeverity = effectiveSeverity
         activeSystemSeverityExpiresAt = sampledAt.addingTimeInterval(systemPressureHoldDuration)
         apply(
-            systemSeverity: severity,
+            systemSeverity: effectiveSeverity,
             physicalFootprintBytes: footprintSampler.physicalFootprintBytes(),
             sampledAt: sampledAt
         )
@@ -121,6 +123,9 @@ final class MemoryPressureMonitor {
 
     private func startSampleTimerIfNeeded() {
         guard sampleTimer == nil else { return }
+        // task_vm_info has no push/async notification API for phys_footprint, so
+        // periodic sampling is required to detect footprint growth between
+        // system memory-pressure events.
         let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(
             deadline: .now() + sampleInterval,

--- a/Sources/App/MemoryPressureMonitor.swift
+++ b/Sources/App/MemoryPressureMonitor.swift
@@ -30,18 +30,25 @@ final class MemoryPressureMonitor {
     @ObservationIgnored
     private let sampleInterval: TimeInterval
     @ObservationIgnored
+    private let systemPressureHoldDuration: TimeInterval
+    @ObservationIgnored
     private let queue = DispatchQueue(label: "com.cmux.memory-pressure", qos: .utility)
     @ObservationIgnored
     private var memoryPressureSource: DispatchSourceMemoryPressure?
     @ObservationIgnored
     private var sampleTimer: DispatchSourceTimer?
+    @ObservationIgnored
+    private var activeSystemSeverity: MemoryPressureSeverity = .normal
+    @ObservationIgnored
+    private var activeSystemSeverityExpiresAt: Date?
 
     init(
         registry: MemoryPressureResponderRegistry? = nil,
         footprintSampler: any MemoryPressureFootprintSampling = TaskVMInfoMemoryPressureFootprintSampler(),
         thresholds: MemoryPressureFootprintThresholds = .default,
         criticalPersistenceDuration: TimeInterval = 60,
-        sampleInterval: TimeInterval = 30
+        sampleInterval: TimeInterval = 30,
+        systemPressureHoldDuration: TimeInterval = 120
     ) {
         self.registry = registry ?? MemoryPressureResponderRegistry()
         self.footprintSampler = footprintSampler
@@ -50,6 +57,7 @@ final class MemoryPressureMonitor {
             criticalPersistenceDuration: criticalPersistenceDuration
         )
         self.sampleInterval = sampleInterval
+        self.systemPressureHoldDuration = Swift.max(0, systemPressureHoldDuration)
     }
 
     func start() {
@@ -60,13 +68,15 @@ final class MemoryPressureMonitor {
 
     func samplePhysicalFootprint(at sampledAt: Date = Date()) {
         apply(
-            systemSeverity: nil,
+            systemSeverity: heldSystemSeverity(at: sampledAt),
             physicalFootprintBytes: footprintSampler.physicalFootprintBytes(),
             sampledAt: sampledAt
         )
     }
 
     func recordSystemPressure(_ severity: MemoryPressureSeverity, at sampledAt: Date = Date()) {
+        activeSystemSeverity = severity
+        activeSystemSeverityExpiresAt = sampledAt.addingTimeInterval(systemPressureHoldDuration)
         apply(
             systemSeverity: severity,
             physicalFootprintBytes: footprintSampler.physicalFootprintBytes(),
@@ -111,6 +121,17 @@ final class MemoryPressureMonitor {
         }
         sampleTimer = timer
         timer.resume()
+    }
+
+    private func heldSystemSeverity(at sampledAt: Date) -> MemoryPressureSeverity? {
+        guard activeSystemSeverity >= .warning,
+              let activeSystemSeverityExpiresAt,
+              sampledAt <= activeSystemSeverityExpiresAt else {
+            activeSystemSeverity = .normal
+            activeSystemSeverityExpiresAt = nil
+            return nil
+        }
+        return activeSystemSeverity
     }
 
     private func apply(

--- a/Sources/App/MemoryPressureMonitor.swift
+++ b/Sources/App/MemoryPressureMonitor.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Observation
+import OSLog
+
+@MainActor
+@Observable
+final class MemoryPressureMonitor {
+    static let shared = MemoryPressureMonitor()
+
+    private static let logger = Logger(
+        subsystem: "com.cmuxterm.app",
+        category: "MemoryPressure"
+    )
+    private static let signposter = OSSignposter(
+        subsystem: "com.cmuxterm.app",
+        category: "MemoryPressure"
+    )
+
+    let registry: MemoryPressureResponderRegistry
+    private(set) var currentSeverity: MemoryPressureSeverity = .normal
+    private(set) var physicalFootprintBytes: UInt64?
+
+    @ObservationIgnored
+    var onPersistentCriticalPressure: (@MainActor (MemoryPressureSnapshot) -> Void)?
+
+    @ObservationIgnored
+    private let footprintSampler: any MemoryPressureFootprintSampling
+    @ObservationIgnored
+    private var stateTracker: MemoryPressureStateTracker
+    @ObservationIgnored
+    private let sampleInterval: TimeInterval
+    @ObservationIgnored
+    private let queue = DispatchQueue(label: "com.cmux.memory-pressure", qos: .utility)
+    @ObservationIgnored
+    private var memoryPressureSource: DispatchSourceMemoryPressure?
+    @ObservationIgnored
+    private var sampleTimer: DispatchSourceTimer?
+
+    init(
+        registry: MemoryPressureResponderRegistry? = nil,
+        footprintSampler: any MemoryPressureFootprintSampling = TaskVMInfoMemoryPressureFootprintSampler(),
+        thresholds: MemoryPressureFootprintThresholds = .default,
+        criticalPersistenceDuration: TimeInterval = 60,
+        sampleInterval: TimeInterval = 30
+    ) {
+        self.registry = registry ?? MemoryPressureResponderRegistry()
+        self.footprintSampler = footprintSampler
+        stateTracker = MemoryPressureStateTracker(
+            thresholds: thresholds,
+            criticalPersistenceDuration: criticalPersistenceDuration
+        )
+        self.sampleInterval = sampleInterval
+    }
+
+    func start() {
+        startMemoryPressureSourceIfNeeded()
+        startSampleTimerIfNeeded()
+        samplePhysicalFootprint(at: Date())
+    }
+
+    func samplePhysicalFootprint(at sampledAt: Date = Date()) {
+        apply(
+            systemSeverity: nil,
+            physicalFootprintBytes: footprintSampler.physicalFootprintBytes(),
+            sampledAt: sampledAt
+        )
+    }
+
+    func recordSystemPressure(_ severity: MemoryPressureSeverity, at sampledAt: Date = Date()) {
+        apply(
+            systemSeverity: severity,
+            physicalFootprintBytes: footprintSampler.physicalFootprintBytes(),
+            sampledAt: sampledAt
+        )
+    }
+
+    private func startMemoryPressureSourceIfNeeded() {
+        guard memoryPressureSource == nil else { return }
+        // DispatchSource memory-pressure notifications are the system signal
+        // emitted before the kernel's low-swap kill path. There is no async
+        // native replacement for this signal.
+        let source = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical],
+            queue: queue
+        )
+        source.setEventHandler { [weak self, weak source] in
+            let event = source?.data ?? []
+            let severity: MemoryPressureSeverity = event.contains(.critical) ? .critical : .warning
+            let sampledAt = Date()
+            Task { @MainActor in
+                self?.recordSystemPressure(severity, at: sampledAt)
+            }
+        }
+        memoryPressureSource = source
+        source.resume()
+    }
+
+    private func startSampleTimerIfNeeded() {
+        guard sampleTimer == nil else { return }
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(
+            deadline: .now() + sampleInterval,
+            repeating: sampleInterval,
+            leeway: .seconds(5)
+        )
+        timer.setEventHandler { [weak self] in
+            let sampledAt = Date()
+            Task { @MainActor in
+                self?.samplePhysicalFootprint(at: sampledAt)
+            }
+        }
+        sampleTimer = timer
+        timer.resume()
+    }
+
+    private func apply(
+        systemSeverity: MemoryPressureSeverity?,
+        physicalFootprintBytes: UInt64?,
+        sampledAt: Date
+    ) {
+        let evaluation = stateTracker.ingest(
+            systemSeverity: systemSeverity,
+            physicalFootprintBytes: physicalFootprintBytes,
+            sampledAt: sampledAt
+        )
+        currentSeverity = evaluation.snapshot.severity
+        self.physicalFootprintBytes = evaluation.snapshot.physicalFootprintBytes
+
+        if evaluation.didTransition {
+            logTransition(evaluation)
+        }
+        if evaluation.snapshot.severity >= .warning {
+            registry.dispatch(evaluation.snapshot)
+        }
+        if evaluation.didBecomePersistentCritical {
+            onPersistentCriticalPressure?(evaluation.snapshot)
+        }
+    }
+
+    private func logTransition(_ evaluation: MemoryPressureStateEvaluation) {
+        let snapshot = evaluation.snapshot
+        let footprint = Self.byteDescription(snapshot.physicalFootprintBytes)
+        Self.logger.info(
+            "memoryPressure.transition previous=\(evaluation.previousSeverity.logName, privacy: .public) severity=\(snapshot.severity.logName, privacy: .public) footprint=\(footprint, privacy: .public)"
+        )
+        let signpostID = Self.signposter.makeSignpostID()
+        Self.signposter.emitEvent(
+            "MemoryPressureTransition",
+            id: signpostID,
+            "previous=\(evaluation.previousSeverity.logName) severity=\(snapshot.severity.logName) footprint=\(footprint)"
+        )
+    }
+
+    private static func byteDescription(_ bytes: UInt64?) -> String {
+        bytes.map(String.init) ?? "unknown"
+    }
+}

--- a/Sources/App/MemoryPressureMonitor.swift
+++ b/Sources/App/MemoryPressureMonitor.swift
@@ -84,6 +84,18 @@ final class MemoryPressureMonitor {
         )
     }
 
+    nonisolated static func severity(
+        forDispatchSourceEvent event: DispatchSource.MemoryPressureEvent
+    ) -> MemoryPressureSeverity? {
+        if event.contains(.critical) {
+            return .critical
+        }
+        if event.contains(.warning) {
+            return .warning
+        }
+        return nil
+    }
+
     private func startMemoryPressureSourceIfNeeded() {
         guard memoryPressureSource == nil else { return }
         // DispatchSource memory-pressure notifications are the system signal
@@ -94,8 +106,10 @@ final class MemoryPressureMonitor {
             queue: queue
         )
         source.setEventHandler { [weak self, weak source] in
-            let event = source?.data ?? []
-            let severity: MemoryPressureSeverity = event.contains(.critical) ? .critical : .warning
+            guard let event = source?.data,
+                  let severity = Self.severity(forDispatchSourceEvent: event) else {
+                return
+            }
             let sampledAt = Date()
             Task { @MainActor in
                 self?.recordSystemPressure(severity, at: sampledAt)

--- a/Sources/App/MemoryPressureResponder.swift
+++ b/Sources/App/MemoryPressureResponder.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+@MainActor
+protocol MemoryPressureResponder: AnyObject {
+    var memoryPressureResponderID: String { get }
+    var memoryPressureMinimumSeverity: MemoryPressureSeverity { get }
+    var memoryPressurePriority: Int { get }
+
+    func shedMemory(for snapshot: MemoryPressureSnapshot) -> MemoryPressureShedResult
+}

--- a/Sources/App/MemoryPressureResponderRegistry.swift
+++ b/Sources/App/MemoryPressureResponderRegistry.swift
@@ -44,19 +44,19 @@ final class MemoryPressureResponderRegistry {
                 detail: result.detail,
                 performedAt: snapshot.sampledAt
             )
-            logShedAction(action)
+            Self.logShedAction(action)
             return action
         }
     }
 
-    private func logShedAction(_ action: MemoryPressureShedAction) {
+    static func logShedAction(_ action: MemoryPressureShedAction) {
         let estimatedBytes = action.estimatedBytes.map(String.init) ?? "unknown"
         let detail = action.detail ?? "none"
-        Self.logger.info(
+        logger.info(
             "memoryPressure.shed responder=\(action.responderID, privacy: .public) severity=\(action.severity.logName, privacy: .public) reclaimedItems=\(action.reclaimedItemCount, privacy: .public) estimatedBytes=\(estimatedBytes, privacy: .public) detail=\(detail, privacy: .public)"
         )
-        let signpostID = Self.signposter.makeSignpostID()
-        Self.signposter.emitEvent(
+        let signpostID = signposter.makeSignpostID()
+        signposter.emitEvent(
             "MemoryPressureShed",
             id: signpostID,
             "responder=\(action.responderID) severity=\(action.severity.logName) reclaimedItems=\(action.reclaimedItemCount)"

--- a/Sources/App/MemoryPressureResponderRegistry.swift
+++ b/Sources/App/MemoryPressureResponderRegistry.swift
@@ -1,0 +1,65 @@
+import Foundation
+import OSLog
+
+@MainActor
+final class MemoryPressureResponderRegistry {
+    private static let logger = Logger(
+        subsystem: "com.cmuxterm.app",
+        category: "MemoryPressure"
+    )
+    private static let signposter = OSSignposter(
+        subsystem: "com.cmuxterm.app",
+        category: "MemoryPressure"
+    )
+
+    private var respondersByID: [String: any MemoryPressureResponder] = [:]
+
+    func register(_ responder: any MemoryPressureResponder) {
+        respondersByID[responder.memoryPressureResponderID] = responder
+    }
+
+    @discardableResult
+    func dispatch(_ snapshot: MemoryPressureSnapshot) -> [MemoryPressureShedAction] {
+        guard snapshot.severity >= .warning else { return [] }
+
+        let eligibleResponders = respondersByID.values
+            .filter { snapshot.severity >= $0.memoryPressureMinimumSeverity }
+            .sorted { lhs, rhs in
+                if lhs.memoryPressurePriority != rhs.memoryPressurePriority {
+                    return lhs.memoryPressurePriority > rhs.memoryPressurePriority
+                }
+                if lhs.memoryPressureMinimumSeverity != rhs.memoryPressureMinimumSeverity {
+                    return lhs.memoryPressureMinimumSeverity > rhs.memoryPressureMinimumSeverity
+                }
+                return lhs.memoryPressureResponderID < rhs.memoryPressureResponderID
+            }
+
+        return eligibleResponders.map { responder in
+            let result = responder.shedMemory(for: snapshot)
+            let action = MemoryPressureShedAction(
+                responderID: responder.memoryPressureResponderID,
+                severity: snapshot.severity,
+                reclaimedItemCount: result.reclaimedItemCount,
+                estimatedBytes: result.estimatedBytes,
+                detail: result.detail,
+                performedAt: snapshot.sampledAt
+            )
+            logShedAction(action)
+            return action
+        }
+    }
+
+    private func logShedAction(_ action: MemoryPressureShedAction) {
+        let estimatedBytes = action.estimatedBytes.map(String.init) ?? "unknown"
+        let detail = action.detail ?? "none"
+        Self.logger.info(
+            "memoryPressure.shed responder=\(action.responderID, privacy: .public) severity=\(action.severity.logName, privacy: .public) reclaimedItems=\(action.reclaimedItemCount, privacy: .public) estimatedBytes=\(estimatedBytes, privacy: .public) detail=\(detail, privacy: .public)"
+        )
+        let signpostID = Self.signposter.makeSignpostID()
+        Self.signposter.emitEvent(
+            "MemoryPressureShed",
+            id: signpostID,
+            "responder=\(action.responderID) severity=\(action.severity.logName) reclaimedItems=\(action.reclaimedItemCount)"
+        )
+    }
+}

--- a/Sources/App/MemoryPressureSeverity.swift
+++ b/Sources/App/MemoryPressureSeverity.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum MemoryPressureSeverity: Int, Comparable, Sendable {
+    case normal = 0
+    case warning = 1
+    case critical = 2
+
+    static func < (lhs: MemoryPressureSeverity, rhs: MemoryPressureSeverity) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    var logName: String {
+        switch self {
+        case .normal:
+            "normal"
+        case .warning:
+            "warning"
+        case .critical:
+            "critical"
+        }
+    }
+}

--- a/Sources/App/MemoryPressureShedAction.swift
+++ b/Sources/App/MemoryPressureShedAction.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct MemoryPressureShedAction: Equatable, Sendable {
+    let responderID: String
+    let severity: MemoryPressureSeverity
+    let reclaimedItemCount: Int
+    let estimatedBytes: UInt64?
+    let detail: String?
+    let performedAt: Date
+}

--- a/Sources/App/MemoryPressureShedResult.swift
+++ b/Sources/App/MemoryPressureShedResult.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct MemoryPressureShedResult: Equatable, Sendable {
+    let reclaimedItemCount: Int
+    let estimatedBytes: UInt64?
+    let detail: String?
+
+    init(
+        reclaimedItemCount: Int,
+        estimatedBytes: UInt64? = nil,
+        detail: String? = nil
+    ) {
+        self.reclaimedItemCount = max(0, reclaimedItemCount)
+        self.estimatedBytes = estimatedBytes
+        self.detail = detail
+    }
+}

--- a/Sources/App/MemoryPressureSnapshot.swift
+++ b/Sources/App/MemoryPressureSnapshot.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct MemoryPressureSnapshot: Equatable, Sendable {
+    let severity: MemoryPressureSeverity
+    let physicalFootprintBytes: UInt64?
+    let sampledAt: Date
+}

--- a/Sources/App/MemoryPressureStateEvaluation.swift
+++ b/Sources/App/MemoryPressureStateEvaluation.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct MemoryPressureStateEvaluation: Equatable, Sendable {
+    let previousSeverity: MemoryPressureSeverity
+    let snapshot: MemoryPressureSnapshot
+    let didTransition: Bool
+    let didBecomePersistentCritical: Bool
+}

--- a/Sources/App/MemoryPressureStateTracker.swift
+++ b/Sources/App/MemoryPressureStateTracker.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+struct MemoryPressureStateTracker: Sendable {
+    let thresholds: MemoryPressureFootprintThresholds
+    let criticalPersistenceDuration: TimeInterval
+
+    private var currentSeverity: MemoryPressureSeverity = .normal
+    private var criticalBeganAt: Date?
+    private var didReportPersistentCritical = false
+
+    init(
+        thresholds: MemoryPressureFootprintThresholds,
+        criticalPersistenceDuration: TimeInterval
+    ) {
+        self.thresholds = thresholds
+        self.criticalPersistenceDuration = criticalPersistenceDuration
+    }
+
+    mutating func ingest(
+        systemSeverity: MemoryPressureSeverity?,
+        physicalFootprintBytes: UInt64?,
+        sampledAt: Date
+    ) -> MemoryPressureStateEvaluation {
+        let previousSeverity = currentSeverity
+        let footprintSeverity = thresholds.severity(
+            forPhysicalFootprintBytes: physicalFootprintBytes
+        )
+        let nextSeverity = max(systemSeverity ?? .normal, footprintSeverity)
+        currentSeverity = nextSeverity
+
+        var didBecomePersistentCritical = false
+        if nextSeverity == .critical {
+            if criticalBeganAt == nil {
+                criticalBeganAt = sampledAt
+            }
+            if let criticalBeganAt,
+               !didReportPersistentCritical,
+               sampledAt.timeIntervalSince(criticalBeganAt) >= criticalPersistenceDuration {
+                didReportPersistentCritical = true
+                didBecomePersistentCritical = true
+            }
+        } else {
+            criticalBeganAt = nil
+            didReportPersistentCritical = false
+        }
+
+        let snapshot = MemoryPressureSnapshot(
+            severity: nextSeverity,
+            physicalFootprintBytes: physicalFootprintBytes,
+            sampledAt: sampledAt
+        )
+        return MemoryPressureStateEvaluation(
+            previousSeverity: previousSeverity,
+            snapshot: snapshot,
+            didTransition: previousSeverity != nextSeverity,
+            didBecomePersistentCritical: didBecomePersistentCritical
+        )
+    }
+}

--- a/Sources/App/NotificationCacheMemoryPressureResponder.swift
+++ b/Sources/App/NotificationCacheMemoryPressureResponder.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@MainActor
+final class NotificationCacheMemoryPressureResponder: MemoryPressureResponder {
+    let memoryPressureResponderID = "terminal-notification-throttle-caches"
+    let memoryPressureMinimumSeverity: MemoryPressureSeverity = .critical
+    let memoryPressurePriority = 10
+
+    private weak var store: TerminalNotificationStore?
+
+    init(store: TerminalNotificationStore) {
+        self.store = store
+    }
+
+    func shedMemory(for snapshot: MemoryPressureSnapshot) -> MemoryPressureShedResult {
+        let trimmedCount = store?.trimMemoryPressureCaches(now: snapshot.sampledAt) ?? 0
+        return MemoryPressureShedResult(
+            reclaimedItemCount: trimmedCount,
+            detail: "notification-throttle-caches"
+        )
+    }
+}

--- a/Sources/App/RendererRealizationController.swift
+++ b/Sources/App/RendererRealizationController.swift
@@ -5,6 +5,21 @@ import CmuxTerminal
 // `RendererRealizationPlannerInput` and the pure `RendererRealizationPlanner`
 // policy live in RendererRealizationPlanner.swift.
 
+struct RendererRealizationMemoryPressureReclaimResult: Equatable, Sendable {
+    let reclaimedCount: Int
+    let retryCandidateCount: Int
+
+    static let empty = RendererRealizationMemoryPressureReclaimResult(
+        reclaimedCount: 0,
+        retryCandidateCount: 0
+    )
+
+    func detail(prefix: String) -> String {
+        guard retryCandidateCount > 0 else { return prefix }
+        return "\(prefix) retryCandidates=\(retryCandidateCount)"
+    }
+}
+
 /// Periodically releases the GPU renderer (Metal swap chain / IOSurface, ~40MB
 /// each) of terminal surfaces that have been offscreen and idle, while keeping
 /// their PTY and terminal state alive. The renderer is rebuilt on re-show via
@@ -84,11 +99,15 @@ final class RendererRealizationController {
     }
 
     @discardableResult
-    func reclaimForSystemMemoryPressure(now: Date) -> Int {
+    func reclaimForSystemMemoryPressure(
+        now: Date,
+        onRetryResult: (@MainActor (RendererRealizationMemoryPressureReclaimResult, Date) -> Void)? = nil
+    ) -> RendererRealizationMemoryPressureReclaimResult {
         evaluate(
             now: now,
             trigger: .systemMemoryPressure,
-            remainingSystemMemoryPressureRetries: systemMemoryPressureRetryPasses
+            remainingSystemMemoryPressureRetries: systemMemoryPressureRetryPasses,
+            onSystemMemoryPressureRetryResult: onRetryResult
         )
     }
 
@@ -96,17 +115,18 @@ final class RendererRealizationController {
     /// deterministically without the timer.
     @discardableResult
     func evaluate(now: Date) -> Int {
-        evaluate(now: now, trigger: .scheduled)
+        evaluate(now: now, trigger: .scheduled).reclaimedCount
     }
 
     @discardableResult
     private func evaluate(
         now: Date,
         trigger: RendererRealizationReclaimTrigger,
-        remainingSystemMemoryPressureRetries: Int = 0
-    ) -> Int {
+        remainingSystemMemoryPressureRetries: Int = 0,
+        onSystemMemoryPressureRetryResult: (@MainActor (RendererRealizationMemoryPressureReclaimResult, Date) -> Void)? = nil
+    ) -> RendererRealizationMemoryPressureReclaimResult {
         let settings = RendererRealizationSettings.values()
-        guard settings.enabled else { return 0 }
+        guard settings.enabled else { return .empty }
 
         // Iterate the global registry rather than re-deriving per-workspace
         // visibility: each TerminalSurface carries its own authoritative
@@ -143,31 +163,41 @@ final class RendererRealizationController {
             now: now.timeIntervalSince1970,
             trigger: trigger
         )
-        guard !selected.isEmpty else { return 0 }
-        var needsSystemMemoryPressureRetry = false
+        guard !selected.isEmpty else { return .empty }
         var reclaimedCount = 0
+        var retryCandidateCount = 0
         for surface in surfaces where selected.contains(surface.id) {
-            surface.releaseRenderer()
-            reclaimedCount += 1
+            if surface.releaseRenderer() {
+                reclaimedCount += 1
+            }
             // A dropped Ghostty mailbox enqueue leaves the renderer realized.
             // Retry with the pressure policy; scheduled policy may keep recent
             // hidden surfaces warm and skip the exact surface pressure selected.
             if trigger == .systemMemoryPressure,
                !surface.isRendererPortalVisible,
                surface.isRendererRealized {
-                needsSystemMemoryPressureRetry = true
+                retryCandidateCount += 1
             }
         }
 
-        if needsSystemMemoryPressureRetry, remainingSystemMemoryPressureRetries > 0 {
+        let result = RendererRealizationMemoryPressureReclaimResult(
+            reclaimedCount: reclaimedCount,
+            retryCandidateCount: retryCandidateCount
+        )
+
+        if retryCandidateCount > 0, remainingSystemMemoryPressureRetries > 0 {
             Task { @MainActor in
-                RendererRealizationController.shared.evaluate(
+                let retryResult = RendererRealizationController.shared.evaluate(
                     now: Date(),
                     trigger: .systemMemoryPressure,
-                    remainingSystemMemoryPressureRetries: remainingSystemMemoryPressureRetries - 1
+                    remainingSystemMemoryPressureRetries: remainingSystemMemoryPressureRetries - 1,
+                    onSystemMemoryPressureRetryResult: onSystemMemoryPressureRetryResult
                 )
+                if retryResult.reclaimedCount > 0 {
+                    onSystemMemoryPressureRetryResult?(retryResult, Date())
+                }
             }
         }
-        return reclaimedCount
+        return result
     }
 }

--- a/Sources/App/RendererRealizationController.swift
+++ b/Sources/App/RendererRealizationController.swift
@@ -83,7 +83,8 @@ final class RendererRealizationController {
         }
     }
 
-    func reclaimForSystemMemoryPressure(now: Date) {
+    @discardableResult
+    func reclaimForSystemMemoryPressure(now: Date) -> Int {
         evaluate(
             now: now,
             trigger: .systemMemoryPressure,
@@ -93,17 +94,19 @@ final class RendererRealizationController {
 
     /// Run one reclamation pass. Internal so a unit/integration test can drive it
     /// deterministically without the timer.
-    func evaluate(now: Date) {
+    @discardableResult
+    func evaluate(now: Date) -> Int {
         evaluate(now: now, trigger: .scheduled)
     }
 
+    @discardableResult
     private func evaluate(
         now: Date,
         trigger: RendererRealizationReclaimTrigger,
         remainingSystemMemoryPressureRetries: Int = 0
-    ) {
+    ) -> Int {
         let settings = RendererRealizationSettings.values()
-        guard settings.enabled else { return }
+        guard settings.enabled else { return 0 }
 
         // Iterate the global registry rather than re-deriving per-workspace
         // visibility: each TerminalSurface carries its own authoritative
@@ -140,10 +143,12 @@ final class RendererRealizationController {
             now: now.timeIntervalSince1970,
             trigger: trigger
         )
-        guard !selected.isEmpty else { return }
+        guard !selected.isEmpty else { return 0 }
         var needsSystemMemoryPressureRetry = false
+        var reclaimedCount = 0
         for surface in surfaces where selected.contains(surface.id) {
             surface.releaseRenderer()
+            reclaimedCount += 1
             // A dropped Ghostty mailbox enqueue leaves the renderer realized.
             // Retry with the pressure policy; scheduled policy may keep recent
             // hidden surfaces warm and skip the exact surface pressure selected.
@@ -163,5 +168,6 @@ final class RendererRealizationController {
                 )
             }
         }
+        return reclaimedCount
     }
 }

--- a/Sources/App/RendererRealizationController.swift
+++ b/Sources/App/RendererRealizationController.swift
@@ -35,6 +35,7 @@ final class RendererRealizationController {
     private let systemMemoryPressureRetryPasses = 2
     private var timer: DispatchSourceTimer?
     private var settingsObserver: NSObjectProtocol?
+    private var systemMemoryPressureRetryTask: Task<Void, Never>?
 
     private init() {}
 
@@ -60,6 +61,8 @@ final class RendererRealizationController {
     func stop() {
         timer?.cancel()
         timer = nil
+        systemMemoryPressureRetryTask?.cancel()
+        systemMemoryPressureRetryTask = nil
         if let settingsObserver {
             NotificationCenter.default.removeObserver(settingsObserver)
             self.settingsObserver = nil
@@ -186,18 +189,32 @@ final class RendererRealizationController {
         )
 
         if retryCandidateCount > 0, remainingSystemMemoryPressureRetries > 0 {
-            Task { @MainActor in
-                let retryResult = RendererRealizationController.shared.evaluate(
-                    now: Date(),
-                    trigger: .systemMemoryPressure,
-                    remainingSystemMemoryPressureRetries: remainingSystemMemoryPressureRetries - 1,
-                    onSystemMemoryPressureRetryResult: onSystemMemoryPressureRetryResult
-                )
-                if retryResult.reclaimedCount > 0 {
-                    onSystemMemoryPressureRetryResult?(retryResult, Date())
-                }
-            }
+            scheduleSystemMemoryPressureRetry(
+                remainingRetries: remainingSystemMemoryPressureRetries - 1,
+                onRetryResult: onSystemMemoryPressureRetryResult
+            )
         }
         return result
+    }
+
+    private func scheduleSystemMemoryPressureRetry(
+        remainingRetries: Int,
+        onRetryResult: (@MainActor (RendererRealizationMemoryPressureReclaimResult, Date) -> Void)?
+    ) {
+        systemMemoryPressureRetryTask?.cancel()
+        systemMemoryPressureRetryTask = Task { @MainActor [weak self] in
+            guard let self, !Task.isCancelled else { return }
+            self.systemMemoryPressureRetryTask = nil
+            let retryResult = self.evaluate(
+                now: Date(),
+                trigger: .systemMemoryPressure,
+                remainingSystemMemoryPressureRetries: remainingRetries,
+                onSystemMemoryPressureRetryResult: onRetryResult
+            )
+            guard !Task.isCancelled else { return }
+            if retryResult.reclaimedCount > 0 {
+                onRetryResult?(retryResult, Date())
+            }
+        }
     }
 }

--- a/Sources/App/RendererRealizationMemoryPressureResponder.swift
+++ b/Sources/App/RendererRealizationMemoryPressureResponder.swift
@@ -13,10 +13,25 @@ final class RendererRealizationMemoryPressureResponder: MemoryPressureResponder 
     }
 
     func shedMemory(for snapshot: MemoryPressureSnapshot) -> MemoryPressureShedResult {
-        let reclaimedCount = controller.reclaimForSystemMemoryPressure(now: snapshot.sampledAt)
+        let responderID = memoryPressureResponderID
+        let severity = snapshot.severity
+        let result = controller.reclaimForSystemMemoryPressure(
+            now: snapshot.sampledAt
+        ) { retryResult, performedAt in
+            MemoryPressureResponderRegistry.logShedAction(
+                MemoryPressureShedAction(
+                    responderID: responderID,
+                    severity: severity,
+                    reclaimedItemCount: retryResult.reclaimedCount,
+                    estimatedBytes: nil,
+                    detail: retryResult.detail(prefix: "hidden-terminal-renderers-retry"),
+                    performedAt: performedAt
+                )
+            )
+        }
         return MemoryPressureShedResult(
-            reclaimedItemCount: reclaimedCount,
-            detail: "hidden-terminal-renderers"
+            reclaimedItemCount: result.reclaimedCount,
+            detail: result.detail(prefix: "hidden-terminal-renderers")
         )
     }
 }

--- a/Sources/App/RendererRealizationMemoryPressureResponder.swift
+++ b/Sources/App/RendererRealizationMemoryPressureResponder.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@MainActor
+final class RendererRealizationMemoryPressureResponder: MemoryPressureResponder {
+    let memoryPressureResponderID = "terminal-renderer-realization"
+    let memoryPressureMinimumSeverity: MemoryPressureSeverity = .warning
+    let memoryPressurePriority = 100
+
+    private let controller: RendererRealizationController
+
+    init(controller: RendererRealizationController) {
+        self.controller = controller
+    }
+
+    func shedMemory(for snapshot: MemoryPressureSnapshot) -> MemoryPressureShedResult {
+        let reclaimedCount = controller.reclaimForSystemMemoryPressure(now: snapshot.sampledAt)
+        return MemoryPressureShedResult(
+            reclaimedItemCount: reclaimedCount,
+            detail: "hidden-terminal-renderers"
+        )
+    }
+}

--- a/Sources/App/TaskVMInfoMemoryPressureFootprintSampler.swift
+++ b/Sources/App/TaskVMInfoMemoryPressureFootprintSampler.swift
@@ -1,0 +1,23 @@
+import Darwin
+import Foundation
+
+struct TaskVMInfoMemoryPressureFootprintSampler: MemoryPressureFootprintSampling {
+    func physicalFootprintBytes() -> UInt64? {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size
+        )
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                task_info(
+                    mach_task_self_,
+                    task_flavor_t(TASK_VM_INFO),
+                    rebound,
+                    &count
+                )
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+        return UInt64(info.phys_footprint)
+    }
+}

--- a/Sources/AppDelegate+PaneMemoryGuardrail.swift
+++ b/Sources/AppDelegate+PaneMemoryGuardrail.swift
@@ -1,6 +1,19 @@
 import Foundation
 
 extension AppDelegate {
+    /// Starts the per-pane runaway-memory guardrail and the central
+    /// memory-pressure monitor. The pane guardrail keeps its existing
+    /// process-tree accounting timer; global memory pressure is handled through
+    /// responder registration so future reclaim paths are one conformance away.
+    func startPaneMemoryGuardrailIfNeeded() {
+        let guardrail = PaneMemoryGuardrail.shared
+        guardrail.paneProvider = { [weak self] in
+            self?.paneMemoryGuardrailDescriptors() ?? []
+        }
+        guardrail.start()
+        startMemoryPressureMonitorIfNeeded()
+    }
+
     func paneMemoryGuardrailDescriptors() -> [PaneMemoryDescriptor] {
         paneMemoryGuardrailTabManagers().flatMap { manager in
             manager.tabs.flatMap { workspace in
@@ -9,14 +22,55 @@ extension AppDelegate {
         }
     }
 
-    func discardHiddenBrowserWebViewsForSystemMemoryPressure() {
-        let now = Date()
-        let discardedCount = paneMemoryGuardrailTabManagers().reduce(0) { count, manager in
-            count + manager.discardHiddenBrowserWebViewsForSystemMemoryPressure(now: now)
+    private func startMemoryPressureMonitorIfNeeded() {
+        let monitor = MemoryPressureMonitor.shared
+        monitor.registry.register(
+            RendererRealizationMemoryPressureResponder(
+                controller: RendererRealizationController.shared
+            )
+        )
+        monitor.registry.register(
+            BrowserHiddenWebViewMemoryPressureResponder { [weak self] in
+                self?.paneMemoryGuardrailTabManagers() ?? []
+            }
+        )
+        if let notificationStore {
+            monitor.registry.register(
+                NotificationCacheMemoryPressureResponder(store: notificationStore)
+            )
         }
-#if DEBUG
-        cmuxDebugLog("browser.memoryPressure.discardHidden count=\(discardedCount)")
-#endif
+        monitor.onPersistentCriticalPressure = { [weak self] snapshot in
+            self?.postPersistentCriticalMemoryPressureWarning(snapshot: snapshot)
+        }
+        monitor.start()
+    }
+
+    private func postPersistentCriticalMemoryPressureWarning(snapshot: MemoryPressureSnapshot) {
+        guard let notificationStore else { return }
+        let managers = paneMemoryGuardrailTabManagers()
+        guard let tabId = tabManager?.selectedTabId
+            ?? managers.compactMap(\.selectedTabId).first
+            ?? managers.flatMap(\.tabs).first?.id
+        else { return }
+
+        notificationStore.addNotification(
+            tabId: tabId,
+            surfaceId: nil,
+            title: String(
+                localized: "memoryPressure.critical.title",
+                defaultValue: "cmux is under critical memory pressure"
+            ),
+            subtitle: String(
+                localized: "memoryPressure.critical.subtitle",
+                defaultValue: "Hidden renderers and browsers were released"
+            ),
+            body: String(
+                localized: "memoryPressure.critical.body",
+                defaultValue: "macOS is reporting sustained critical memory pressure. cmux has shed hidden resources; close idle workspaces or restart cmux if pressure continues."
+            ),
+            cooldownKey: "memory-pressure-critical",
+            cooldownInterval: 300
+        )
     }
 
     private func paneMemoryGuardrailTabManagers() -> [TabManager] {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2104,23 +2104,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
     }
 
-    /// Starts the per-pane runaway-memory guardrail: a background timer that
-    /// attributes each pane's process-tree memory by controlling tty (monitoring
-    /// only — the user-facing sidebar badge and banner were removed in #6614) and
-    /// frees nonessential WebKit memory on system memory pressure before a single
-    /// leaking pane can OOM-suspend the whole app (issue #6313).
-    private func startPaneMemoryGuardrailIfNeeded() {
-        let guardrail = PaneMemoryGuardrail.shared
-        guardrail.paneProvider = { [weak self] in
-            self?.paneMemoryGuardrailDescriptors() ?? []
-        }
-        guardrail.onSystemMemoryPressure = { [weak self] in
-            RendererRealizationController.shared.reclaimForSystemMemoryPressure(now: Date())
-            self?.discardHiddenBrowserWebViewsForSystemMemoryPressure()
-        }
-        guardrail.start()
-    }
-
     private func scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: TerminalNotificationStore) {
         guard !didScheduleGhosttyCrashBreadcrumbCheck else { return }
         didScheduleGhosttyCrashBreadcrumbCheck = true

--- a/Sources/PaneMemoryGuardrail.swift
+++ b/Sources/PaneMemoryGuardrail.swift
@@ -7,9 +7,9 @@ import Observation
 /// One instance owns the background poll timer, scans every live pane each tick,
 /// and attributes process-tree memory by controlling tty. The user-facing
 /// warning badge and dismissible banner were removed in issue #6614, so the scan
-/// now only maintains the engine's monitoring state (surfaced in DEBUG logs) and
-/// the still-wired system memory-pressure response. The heavy libproc scan runs
-/// off the main thread; only the small state updates touch `@MainActor`.
+/// now only maintains the engine's monitoring state (surfaced in DEBUG logs).
+/// The heavy libproc scan runs off the main thread; only the small state updates
+/// touch `@MainActor`.
 @MainActor
 @Observable
 final class PaneMemoryGuardrail {
@@ -26,9 +26,6 @@ final class PaneMemoryGuardrail {
     /// Supplies the live pane set each tick (main-actor; reads ghostty/tty).
     @ObservationIgnored
     var paneProvider: (@MainActor () -> [PaneMemoryDescriptor])?
-    /// Invoked when the OS reports warning/critical system memory pressure.
-    @ObservationIgnored
-    var onSystemMemoryPressure: (@MainActor () -> Void)?
 
     @ObservationIgnored
     private var engine = PaneMemoryGuardrailEngine()
@@ -36,8 +33,6 @@ final class PaneMemoryGuardrail {
     private let timerQueue = DispatchQueue(label: "com.cmux.pane-memory-guardrail", qos: .utility)
     @ObservationIgnored
     private var timer: DispatchSourceTimer?
-    @ObservationIgnored
-    private var memoryPressureSource: DispatchSourceMemoryPressure?
     @ObservationIgnored
     private var isScanning = false
     @ObservationIgnored
@@ -48,7 +43,6 @@ final class PaneMemoryGuardrail {
     private var lastScopedScanAt = Date.distantPast
 
     func start() {
-        startSystemMemoryPressureSourceIfNeeded()
         guard timer == nil else { return }
         let timer = DispatchSource.makeTimerSource(queue: timerQueue)
         timer.schedule(
@@ -61,31 +55,6 @@ final class PaneMemoryGuardrail {
         }
         self.timer = timer
         timer.resume()
-    }
-
-    private func startSystemMemoryPressureSourceIfNeeded() {
-        guard memoryPressureSource == nil else { return }
-        // DispatchSource memory-pressure notifications are the system signal for
-        // freeing nonessential WebKit process memory; no async-native equivalent
-        // exists.
-        let source = DispatchSource.makeMemoryPressureSource(
-            eventMask: [.warning, .critical],
-            queue: timerQueue
-        )
-        source.setEventHandler { [weak self] in
-            Task { @MainActor in
-                self?.handleSystemMemoryPressure()
-            }
-        }
-        memoryPressureSource = source
-        source.resume()
-    }
-
-    private func handleSystemMemoryPressure() {
-#if DEBUG
-        cmuxDebugLog("paneMemGuard.systemMemoryPressure")
-#endif
-        onSystemMemoryPressure?()
     }
 
     // MARK: Settings

--- a/Sources/TerminalNotificationStore+MemoryPressure.swift
+++ b/Sources/TerminalNotificationStore+MemoryPressure.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension TerminalNotificationStore {
+    private static let memoryPressureThrottleCacheMaxEntries = 512
+    private static let memoryPressureThrottleCacheStaleAge: TimeInterval = 60 * 60
+
+    @discardableResult
+    func trimMemoryPressureCaches(now: Date = Date()) -> Int {
+        let beforeCount = lastNotificationDateByCooldownKey.count
+            + lastNotificationHookFailureDateByKey.count
+
+        lastNotificationDateByCooldownKey = Self.trimDateCache(
+            lastNotificationDateByCooldownKey,
+            now: now,
+            staleAge: Self.memoryPressureThrottleCacheStaleAge,
+            maxEntries: Self.memoryPressureThrottleCacheMaxEntries
+        )
+        lastNotificationHookFailureDateByKey = Self.trimDateCache(
+            lastNotificationHookFailureDateByKey,
+            now: now,
+            staleAge: Self.memoryPressureThrottleCacheStaleAge,
+            maxEntries: Self.memoryPressureThrottleCacheMaxEntries
+        )
+
+        let afterCount = lastNotificationDateByCooldownKey.count
+            + lastNotificationHookFailureDateByKey.count
+        return max(0, beforeCount - afterCount)
+    }
+
+    private static func trimDateCache<Key: Hashable>(
+        _ cache: [Key: Date],
+        now: Date,
+        staleAge: TimeInterval,
+        maxEntries: Int
+    ) -> [Key: Date] {
+        let freshEntries = cache.filter { _, date in
+            now.timeIntervalSince(date) <= staleAge
+        }
+        guard freshEntries.count > maxEntries else { return freshEntries }
+        return Dictionary(
+            uniqueKeysWithValues: freshEntries
+                .sorted { lhs, rhs in lhs.value > rhs.value }
+                .prefix(maxEntries)
+        )
+    }
+}

--- a/Sources/TerminalNotificationStore+MemoryPressure.swift
+++ b/Sources/TerminalNotificationStore+MemoryPressure.swift
@@ -24,7 +24,7 @@ extension TerminalNotificationStore {
 
         let afterCount = lastNotificationDateByCooldownKey.count
             + lastNotificationHookFailureDateByKey.count
-        return max(0, beforeCount - afterCount)
+        return Swift.max(0, beforeCount - afterCount)
     }
 
     private static func trimDateCache<Key: Hashable>(
@@ -41,6 +41,7 @@ extension TerminalNotificationStore {
             uniqueKeysWithValues: freshEntries
                 .sorted { lhs, rhs in lhs.value > rhs.value }
                 .prefix(maxEntries)
+                .map { ($0.key, $0.value) }
         )
     }
 }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -502,14 +502,14 @@ final class TerminalNotificationStore: ObservableObject {
         effects in
         store.playSuppressedNotificationFeedback(for: notification, effects: effects)
     }
-    private struct NotificationHookFailureThrottleKey: Hashable {
+    fileprivate struct NotificationHookFailureThrottleKey: Hashable {
         let hookId: String
         let sourcePath: String?
     }
 
     private static let notificationHookFailureThrottle: TimeInterval = 300
-    private var lastNotificationDateByCooldownKey: [String: Date] = [:]
-    private var lastNotificationHookFailureDateByKey: [NotificationHookFailureThrottleKey: Date] = [:]
+    fileprivate var lastNotificationDateByCooldownKey: [String: Date] = [:]
+    fileprivate var lastNotificationHookFailureDateByKey: [NotificationHookFailureThrottleKey: Date] = [:]
     private var indexes = NotificationIndexes()
 
     private init() {

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -502,14 +502,14 @@ final class TerminalNotificationStore: ObservableObject {
         effects in
         store.playSuppressedNotificationFeedback(for: notification, effects: effects)
     }
-    fileprivate struct NotificationHookFailureThrottleKey: Hashable {
+    struct NotificationHookFailureThrottleKey: Hashable {
         let hookId: String
         let sourcePath: String?
     }
 
     private static let notificationHookFailureThrottle: TimeInterval = 300
-    fileprivate var lastNotificationDateByCooldownKey: [String: Date] = [:]
-    fileprivate var lastNotificationHookFailureDateByKey: [NotificationHookFailureThrottleKey: Date] = [:]
+    var lastNotificationDateByCooldownKey: [String: Date] = [:]
+    var lastNotificationHookFailureDateByKey: [NotificationHookFailureThrottleKey: Date] = [:]
     private var indexes = NotificationIndexes()
 
     private init() {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -725,6 +725,7 @@
 		A50014F3 /* MarkdownViewerAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F1 /* MarkdownViewerAssets.swift */; };
 		A50014F5 /* MarkdownWebRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F4 /* MarkdownWebRenderer.swift */; };
 		A50014F9 /* MarkdownWebSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F8 /* MarkdownWebSupport.swift */; };
+		7490A0017490A0017490A001 /* MemoryPressureMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490A0027490A0027490A002 /* MemoryPressureMonitorTests.swift */; };
 		1A8BEE693C9E4C3190CB7F20 /* MenuBarExtraController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */; };
 		606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606500010000000000000002 /* MenuBarOnlyActivationPolicyTests.swift */; };
 		C0DE70510000000000000002 /* MenuBarProfilingLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE70510000000000000001 /* MenuBarProfilingLauncher.swift */; };
@@ -2121,6 +2122,7 @@
 		A50014F1 /* MarkdownViewerAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownViewerAssets.swift; sourceTree = "<group>"; };
 		A50014F4 /* MarkdownWebRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownWebRenderer.swift; sourceTree = "<group>"; };
 		A50014F8 /* MarkdownWebSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownWebSupport.swift; sourceTree = "<group>"; };
+		7490A0027490A0027490A002 /* MemoryPressureMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryPressureMonitorTests.swift; sourceTree = "<group>"; };
 		C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarExtraController.swift; sourceTree = "<group>"; };
 		606500010000000000000002 /* MenuBarOnlyActivationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarOnlyActivationPolicyTests.swift; sourceTree = "<group>"; };
 		C0DE70510000000000000001 /* MenuBarProfilingLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarProfilingLauncher.swift; sourceTree = "<group>"; };
@@ -4137,10 +4139,11 @@
 				F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */,
 				17C9F5BA0DD14EDC8C3E5002 /* MainWindowVisibilityControllerTests.swift */,
 				A6D1F0100000000000000001 /* MainWindowVisibilityLifecycleTests.swift */,
-				A6D1F0400000000000000001 /* ReleasingWindowControllerTests.swift */,
-				A11EAA000000000000000001 /* AppearanceSettingsTests.swift */,
-				6313FACE0000000000000001 /* PaneMemoryGuardrailTests.swift */,
-				C0DE10510000000000000002 /* MobileHostServiceSettingsTests.swift */,
+					A6D1F0400000000000000001 /* ReleasingWindowControllerTests.swift */,
+					A11EAA000000000000000001 /* AppearanceSettingsTests.swift */,
+					6313FACE0000000000000001 /* PaneMemoryGuardrailTests.swift */,
+					7490A0027490A0027490A002 /* MemoryPressureMonitorTests.swift */,
+					C0DE10510000000000000002 /* MobileHostServiceSettingsTests.swift */,
 				6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */,
 				A64610020000000000000002 /* QuitConfirmationAlertPresenterTests.swift */,
 				B7758A020000000000000002 /* TerminationWatchdogTests.swift */,
@@ -5848,6 +5851,7 @@
 				A6D1F0100000000000000002 /* MainWindowVisibilityLifecycleTests.swift in Sources */,
 				D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */,
 				D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */,
+					7490A0017490A0017490A001 /* MemoryPressureMonitorTests.swift in Sources */,
 				606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */,
 					C0DE70520000000000000002 /* MenuBarProfilingLauncherTests.swift in Sources */,
 				6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */,
@@ -5868,9 +5872,9 @@
 				9637C6D3170F4BE1A7EF6243 /* OmnibarSubmitDecisionTests.swift in Sources */,
 				0A0F00550000000000000001 /* OmpSupportTests.swift in Sources */,
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
-				C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
-				6313FACE0000000000000000 /* PaneMemoryGuardrailTests.swift in Sources */,
-				D1F0A00300000000000000C1 /* PhonePushPresenceGateTests.swift in Sources */,
+					C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
+					6313FACE0000000000000000 /* PaneMemoryGuardrailTests.swift in Sources */,
+					D1F0A00300000000000000C1 /* PhonePushPresenceGateTests.swift in Sources */,
 					B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
 					B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */,
 					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		B42450030000000000000001 /* BrowserHiddenWebViewDiscardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */; };
 		B6585001B6585001B6585001 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6585002B6585002B6585002 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift */; };
 		B42450010000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42450020000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift */; };
+		7490C0017490C0017490C001 /* BrowserHiddenWebViewMemoryPressureResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0017490D0017490D001 /* BrowserHiddenWebViewMemoryPressureResponder.swift */; };
 		4E1F28554F1B908F18559390 /* BrowserHistorySuggestionCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */; };
 		BABA25000000000000000007 /* BrowserHTTPBasicAuthPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABA25000000000000000008 /* BrowserHTTPBasicAuthPrompt.swift */; };
 		BABA25000000000000000001 /* BrowserHTTPBasicAuthPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABA25000000000000000002 /* BrowserHTTPBasicAuthPromptCoordinator.swift */; };
@@ -725,7 +726,18 @@
 		A50014F3 /* MarkdownViewerAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F1 /* MarkdownViewerAssets.swift */; };
 		A50014F5 /* MarkdownWebRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F4 /* MarkdownWebRenderer.swift */; };
 		A50014F9 /* MarkdownWebSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F8 /* MarkdownWebSupport.swift */; };
+		7490C0027490C0027490C002 /* MemoryPressureFootprintSampling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0027490D0027490D002 /* MemoryPressureFootprintSampling.swift */; };
+		7490C0037490C0037490C003 /* MemoryPressureFootprintThresholds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0037490D0037490D003 /* MemoryPressureFootprintThresholds.swift */; };
+		7490C0047490C0047490C004 /* MemoryPressureMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0047490D0047490D004 /* MemoryPressureMonitor.swift */; };
 		7490A0017490A0017490A001 /* MemoryPressureMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490A0027490A0027490A002 /* MemoryPressureMonitorTests.swift */; };
+		7490C0057490C0057490C005 /* MemoryPressureResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0057490D0057490D005 /* MemoryPressureResponder.swift */; };
+		7490C0067490C0067490C006 /* MemoryPressureResponderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0067490D0067490D006 /* MemoryPressureResponderRegistry.swift */; };
+		7490C0097490C0097490C009 /* MemoryPressureSeverity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0097490D0097490D009 /* MemoryPressureSeverity.swift */; };
+		7490C0077490C0077490C007 /* MemoryPressureShedAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0077490D0077490D007 /* MemoryPressureShedAction.swift */; };
+		7490C0087490C0087490C008 /* MemoryPressureShedResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0087490D0087490D008 /* MemoryPressureShedResult.swift */; };
+		7490C00A7490C00A7490C00A /* MemoryPressureSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D00A7490D00A7490D00A /* MemoryPressureSnapshot.swift */; };
+		7490C00B7490C00B7490C00B /* MemoryPressureStateEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D00B7490D00B7490D00B /* MemoryPressureStateEvaluation.swift */; };
+		7490C00C7490C00C7490C00C /* MemoryPressureStateTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D00C7490D00C7490D00C /* MemoryPressureStateTracker.swift */; };
 		1A8BEE693C9E4C3190CB7F20 /* MenuBarExtraController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */; };
 		606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606500010000000000000002 /* MenuBarOnlyActivationPolicyTests.swift */; };
 		C0DE70510000000000000002 /* MenuBarProfilingLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE70510000000000000001 /* MenuBarProfilingLauncher.swift */; };
@@ -775,6 +787,7 @@
 		8B1B2AB6EC6ACDB2CD39A9BB /* NewBrowserWorkspaceShortcutUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04698069140539D8495D6B9B /* NewBrowserWorkspaceShortcutUITests.swift */; };
 		734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */; };
 		C06552010000000000000003 /* NotificationBurstCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06552010000000000000004 /* NotificationBurstCoalescer.swift */; };
+		7490C00D7490C00D7490C00D /* NotificationCacheMemoryPressureResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D00D7490D00D7490D00D /* NotificationCacheMemoryPressureResponder.swift */; };
 		D7AB00000000000000B021 /* NotificationDismissSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000B020 /* NotificationDismissSyncTests.swift */; };
 		C7A507000000000000005794 /* NotificationRowSnapshotBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A507000000000000005795 /* NotificationRowSnapshotBoundaryTests.swift */; };
 		B7F00002 /* NotificationSoundSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F00001 /* NotificationSoundSettings.swift */; };
@@ -921,6 +934,7 @@
 		D5037010000000000000003 /* RenderableSystemSymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5037010000000000000002 /* RenderableSystemSymbol.swift */; };
 		C58410010000000000000001 /* RenderableSystemSymbolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58410010000000000000002 /* RenderableSystemSymbolTests.swift */; };
 		D36A00040000000000000001 /* RendererRealizationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00040000000000000002 /* RendererRealizationController.swift */; };
+		7490C00E7490C00E7490C00E /* RendererRealizationMemoryPressureResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D00E7490D00E7490D00E /* RendererRealizationMemoryPressureResponder.swift */; };
 		D36A00060000000000000001 /* RendererRealizationPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00060000000000000002 /* RendererRealizationPlanner.swift */; };
 		D36A00050000000000000001 /* RendererRealizationPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */; };
 		D36A00070000000000000001 /* RendererRealizationReclaimTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00070000000000000002 /* RendererRealizationReclaimTrigger.swift */; };
@@ -1150,6 +1164,7 @@
 		C7A506000000000000000002 /* TaskManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A506000000000000000001 /* TaskManagerView.swift */; };
 		C7A507000000000000004529 /* TaskManagerViewSnapshotBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A507000000000000004530 /* TaskManagerViewSnapshotBoundaryTests.swift */; };
 		C7A502000000000000000002 /* TaskManagerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A502000000000000000001 /* TaskManagerWindowController.swift */; };
+		7490C00F7490C00F7490C00F /* TaskVMInfoMemoryPressureFootprintSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D00F7490D00F7490D00F /* TaskVMInfoMemoryPressureFootprintSampler.swift */; };
 		46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */; };
 		E4D1768B7041CDE4F9A084A4 /* TerminalClearScreenKeepScrollbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */; };
 		C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */; };
@@ -1207,6 +1222,7 @@
 		A5A5A501A1B2C3D4E5F60718 /* TerminalNotificationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A5A502A1B2C3D4E5F60718 /* TerminalNotificationQueue.swift */; };
 		A5A5A503A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A5A504A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift */; };
 		A5E380700000000000000001 /* TerminalNotificationSocketActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E380700000000000000002 /* TerminalNotificationSocketActionTests.swift */; };
+		7490C0107490C0107490C010 /* TerminalNotificationStore+MemoryPressure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7490D0107490D0107490D010 /* TerminalNotificationStore+MemoryPressure.swift */; };
 		596100000000000000000007 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596100000000000000000006 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift */; };
 		A5001095 /* TerminalNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001092 /* TerminalNotificationStore.swift */; };
 		D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */; };
@@ -1603,6 +1619,7 @@
 		B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHiddenWebViewDiscardManager.swift; sourceTree = "<group>"; };
 		B6585002B6585002B6585002 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserHiddenWebViewDiscardMemoryPressureTests.swift; sourceTree = "<group>"; };
 		B42450020000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHiddenWebViewDiscardPolicy.swift; sourceTree = "<group>"; };
+		7490D0017490D0017490D001 /* BrowserHiddenWebViewMemoryPressureResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/BrowserHiddenWebViewMemoryPressureResponder.swift; sourceTree = "<group>"; };
 		19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserHistorySuggestionCacheTests.swift; sourceTree = "<group>"; };
 		BABA25000000000000000008 /* BrowserHTTPBasicAuthPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHTTPBasicAuthPrompt.swift; sourceTree = "<group>"; };
 		BABA25000000000000000002 /* BrowserHTTPBasicAuthPromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHTTPBasicAuthPromptCoordinator.swift; sourceTree = "<group>"; };
@@ -2122,7 +2139,18 @@
 		A50014F1 /* MarkdownViewerAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownViewerAssets.swift; sourceTree = "<group>"; };
 		A50014F4 /* MarkdownWebRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownWebRenderer.swift; sourceTree = "<group>"; };
 		A50014F8 /* MarkdownWebSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownWebSupport.swift; sourceTree = "<group>"; };
+		7490D0027490D0027490D002 /* MemoryPressureFootprintSampling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureFootprintSampling.swift; sourceTree = "<group>"; };
+		7490D0037490D0037490D003 /* MemoryPressureFootprintThresholds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureFootprintThresholds.swift; sourceTree = "<group>"; };
+		7490D0047490D0047490D004 /* MemoryPressureMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureMonitor.swift; sourceTree = "<group>"; };
 		7490A0027490A0027490A002 /* MemoryPressureMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryPressureMonitorTests.swift; sourceTree = "<group>"; };
+		7490D0057490D0057490D005 /* MemoryPressureResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureResponder.swift; sourceTree = "<group>"; };
+		7490D0067490D0067490D006 /* MemoryPressureResponderRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureResponderRegistry.swift; sourceTree = "<group>"; };
+		7490D0097490D0097490D009 /* MemoryPressureSeverity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureSeverity.swift; sourceTree = "<group>"; };
+		7490D0077490D0077490D007 /* MemoryPressureShedAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureShedAction.swift; sourceTree = "<group>"; };
+		7490D0087490D0087490D008 /* MemoryPressureShedResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureShedResult.swift; sourceTree = "<group>"; };
+		7490D00A7490D00A7490D00A /* MemoryPressureSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureSnapshot.swift; sourceTree = "<group>"; };
+		7490D00B7490D00B7490D00B /* MemoryPressureStateEvaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureStateEvaluation.swift; sourceTree = "<group>"; };
+		7490D00C7490D00C7490D00C /* MemoryPressureStateTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MemoryPressureStateTracker.swift; sourceTree = "<group>"; };
 		C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarExtraController.swift; sourceTree = "<group>"; };
 		606500010000000000000002 /* MenuBarOnlyActivationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarOnlyActivationPolicyTests.swift; sourceTree = "<group>"; };
 		C0DE70510000000000000001 /* MenuBarProfilingLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarProfilingLauncher.swift; sourceTree = "<group>"; };
@@ -2172,6 +2200,7 @@
 		04698069140539D8495D6B9B /* NewBrowserWorkspaceShortcutUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBrowserWorkspaceShortcutUITests.swift; sourceTree = "<group>"; };
 		D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAndMenuBarTests.swift; sourceTree = "<group>"; };
 		C06552010000000000000004 /* NotificationBurstCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBurstCoalescer.swift; sourceTree = "<group>"; };
+		7490D00D7490D00D7490D00D /* NotificationCacheMemoryPressureResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/NotificationCacheMemoryPressureResponder.swift; sourceTree = "<group>"; };
 		D7AB00000000000000B020 /* NotificationDismissSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationDismissSyncTests.swift"; sourceTree = "<group>"; };
 		C7A507000000000000005795 /* NotificationRowSnapshotBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRowSnapshotBoundaryTests.swift; sourceTree = "<group>"; };
 		B7F00001 /* NotificationSoundSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSoundSettings.swift; sourceTree = "<group>"; };
@@ -2315,6 +2344,7 @@
 		D5037010000000000000002 /* RenderableSystemSymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderableSystemSymbol.swift; sourceTree = "<group>"; };
 		C58410010000000000000002 /* RenderableSystemSymbolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderableSystemSymbolTests.swift; sourceTree = "<group>"; };
 		D36A00040000000000000002 /* RendererRealizationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RendererRealizationController.swift; sourceTree = "<group>"; };
+		7490D00E7490D00E7490D00E /* RendererRealizationMemoryPressureResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RendererRealizationMemoryPressureResponder.swift; sourceTree = "<group>"; };
 		D36A00060000000000000002 /* RendererRealizationPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RendererRealizationPlanner.swift; sourceTree = "<group>"; };
 		D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RendererRealizationPlannerTests.swift; sourceTree = "<group>"; };
 		D36A00070000000000000002 /* RendererRealizationReclaimTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RendererRealizationReclaimTrigger.swift; sourceTree = "<group>"; };
@@ -2534,6 +2564,7 @@
 		C7A506000000000000000001 /* TaskManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerView.swift; sourceTree = "<group>"; };
 		C7A507000000000000004530 /* TaskManagerViewSnapshotBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerViewSnapshotBoundaryTests.swift; sourceTree = "<group>"; };
 		C7A502000000000000000001 /* TaskManagerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerWindowController.swift; sourceTree = "<group>"; };
+		7490D00F7490D00F7490D00F /* TaskVMInfoMemoryPressureFootprintSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/TaskVMInfoMemoryPressureFootprintSampler.swift; sourceTree = "<group>"; };
 		02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAndGhosttyTests.swift; sourceTree = "<group>"; };
 		F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalClearScreenKeepScrollbackTests.swift; sourceTree = "<group>"; };
 		C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCmdClickUITests.swift; sourceTree = "<group>"; };
@@ -2591,6 +2622,7 @@
 		A5A5A502A1B2C3D4E5F60718 /* TerminalNotificationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationQueue.swift; sourceTree = "<group>"; };
 		A5A5A504A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationQueueTests.swift; sourceTree = "<group>"; };
 		A5E380700000000000000002 /* TerminalNotificationSocketActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationSocketActionTests.swift; sourceTree = "<group>"; };
+		7490D0107490D0107490D010 /* TerminalNotificationStore+MemoryPressure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalNotificationStore+MemoryPressure.swift"; sourceTree = "<group>"; };
 		596100000000000000000006 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalNotificationStore+NativeNotificationDeliveryTesting.swift"; sourceTree = "<group>"; };
 		A5001092 /* TerminalNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationStore.swift; sourceTree = "<group>"; };
 		D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneDropTargetView.swift; sourceTree = "<group>"; };
@@ -3131,9 +3163,24 @@
 				9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */,
 				D5671002D5671002D5671002 /* TerminalScrollSpeedSettings.swift */,
 				D36A00010000000000000002 /* AgentHibernationController.swift */,
+				7490D0017490D0017490D001 /* BrowserHiddenWebViewMemoryPressureResponder.swift */,
+				7490D0027490D0027490D002 /* MemoryPressureFootprintSampling.swift */,
+				7490D0037490D0037490D003 /* MemoryPressureFootprintThresholds.swift */,
+				7490D0047490D0047490D004 /* MemoryPressureMonitor.swift */,
+				7490D0057490D0057490D005 /* MemoryPressureResponder.swift */,
+				7490D0067490D0067490D006 /* MemoryPressureResponderRegistry.swift */,
+				7490D0077490D0077490D007 /* MemoryPressureShedAction.swift */,
+				7490D0087490D0087490D008 /* MemoryPressureShedResult.swift */,
+				7490D0097490D0097490D009 /* MemoryPressureSeverity.swift */,
+				7490D00A7490D00A7490D00A /* MemoryPressureSnapshot.swift */,
+				7490D00B7490D00B7490D00B /* MemoryPressureStateEvaluation.swift */,
+				7490D00C7490D00C7490D00C /* MemoryPressureStateTracker.swift */,
+				7490D00D7490D00D7490D00D /* NotificationCacheMemoryPressureResponder.swift */,
 				D36A00040000000000000002 /* RendererRealizationController.swift */,
+				7490D00E7490D00E7490D00E /* RendererRealizationMemoryPressureResponder.swift */,
 				D36A00060000000000000002 /* RendererRealizationPlanner.swift */,
 				D36A00070000000000000002 /* RendererRealizationReclaimTrigger.swift */,
+				7490D00F7490D00F7490D00F /* TaskVMInfoMemoryPressureFootprintSampler.swift */,
 				243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */,
 				D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */,
 				AABBCC00000000000000020B /* SidebarInlineRenameAction.swift */,
@@ -3488,6 +3535,7 @@
 				D1F0A00600000000000000F2 /* ScreenLockObserver.swift */,
 				B7F00001 /* NotificationSoundSettings.swift */,
 				A5001092 /* TerminalNotificationStore.swift */,
+				7490D0107490D0107490D010 /* TerminalNotificationStore+MemoryPressure.swift */,
 				596100000000000000000004 /* NativeNotificationDeliveryHooks.swift */,
 				D7AB00000000000000B040 /* SupersededPhoneDismissBuffer.swift */,
 				A5001097 /* TerminalNotificationPolicy.swift */,
@@ -4802,6 +4850,7 @@
 				A5008373 /* BrowserFindWebViewEvaluator.swift in Sources */,
 				B42450030000000000000001 /* BrowserHiddenWebViewDiscardManager.swift in Sources */,
 				B42450010000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift in Sources */,
+				7490C0017490C0017490C001 /* BrowserHiddenWebViewMemoryPressureResponder.swift in Sources */,
 				BABA25000000000000000007 /* BrowserHTTPBasicAuthPrompt.swift in Sources */,
 				BABA25000000000000000001 /* BrowserHTTPBasicAuthPromptCoordinator.swift in Sources */,
 				BABA2500000000000000000D /* BrowserHTTPBasicAuthPromptRequest.swift in Sources */,
@@ -5098,6 +5147,17 @@
 				A50014F3 /* MarkdownViewerAssets.swift in Sources */,
 				A50014F5 /* MarkdownWebRenderer.swift in Sources */,
 					A50014F9 /* MarkdownWebSupport.swift in Sources */,
+				7490C0027490C0027490C002 /* MemoryPressureFootprintSampling.swift in Sources */,
+				7490C0037490C0037490C003 /* MemoryPressureFootprintThresholds.swift in Sources */,
+				7490C0047490C0047490C004 /* MemoryPressureMonitor.swift in Sources */,
+				7490C0057490C0057490C005 /* MemoryPressureResponder.swift in Sources */,
+				7490C0067490C0067490C006 /* MemoryPressureResponderRegistry.swift in Sources */,
+				7490C0097490C0097490C009 /* MemoryPressureSeverity.swift in Sources */,
+				7490C0077490C0077490C007 /* MemoryPressureShedAction.swift in Sources */,
+				7490C0087490C0087490C008 /* MemoryPressureShedResult.swift in Sources */,
+				7490C00A7490C00A7490C00A /* MemoryPressureSnapshot.swift in Sources */,
+				7490C00B7490C00B7490C00B /* MemoryPressureStateEvaluation.swift in Sources */,
+				7490C00C7490C00C7490C00C /* MemoryPressureStateTracker.swift in Sources */,
 					1A8BEE693C9E4C3190CB7F20 /* MenuBarExtraController.swift in Sources */,
 					C0DE70510000000000000002 /* MenuBarProfilingLauncher.swift in Sources */,
 					C0DE70550000000000000002 /* MenuBarProfilingMenuItem.swift in Sources */,
@@ -5132,6 +5192,7 @@
 				00C3AA443F6DA8D94E28CE17 /* MobileWorkspaceListObserver.swift in Sources */,
 				596100000000000000000003 /* NativeNotificationDeliveryHooks.swift in Sources */,
 				C06552010000000000000003 /* NotificationBurstCoalescer.swift in Sources */,
+				7490C00D7490C00D7490C00D /* NotificationCacheMemoryPressureResponder.swift in Sources */,
 				B7F00002 /* NotificationSoundSettings.swift in Sources */,
 				A5001094 /* NotificationsPage.swift in Sources */,
 				D36090020000000000000001 /* NSWindow+CmuxPeerWindow.swift in Sources */,
@@ -5232,6 +5293,7 @@
 				0F17C0DE0F17C0DE0F17C002 /* RemoteTmuxWindowRegistry.swift in Sources */,
 				D5037010000000000000003 /* RenderableSystemSymbol.swift in Sources */,
 				D36A00040000000000000001 /* RendererRealizationController.swift in Sources */,
+				7490C00E7490C00E7490C00E /* RendererRealizationMemoryPressureResponder.swift in Sources */,
 				D36A00060000000000000001 /* RendererRealizationPlanner.swift in Sources */,
 				D36A00070000000000000001 /* RendererRealizationReclaimTrigger.swift in Sources */,
 				C6711A040000000000000001 /* RestorableAgentHookSessionRecord.swift in Sources */,
@@ -5365,6 +5427,7 @@
 				C7A504000000000000000002 /* TaskManagerTypes.swift in Sources */,
 				C7A506000000000000000002 /* TaskManagerView.swift in Sources */,
 				C7A502000000000000000002 /* TaskManagerWindowController.swift in Sources */,
+				7490C00F7490C00F7490C00F /* TaskVMInfoMemoryPressureFootprintSampler.swift in Sources */,
 				C0DE00000000000000000C42 /* TerminalController+ControlAppFocusContext.swift in Sources */,
 				C0DE00000000000000000C82 /* TerminalController+ControlBrowserPanelContext.swift in Sources */,
 				CA52E0020000000000000000 /* TerminalController+ControlCanvasContext.swift in Sources */,
@@ -5411,6 +5474,7 @@
 				A5C41101A1B2C3D4E5F60718 /* TerminalNotificationCallerResolver.swift in Sources */,
 				A5001096 /* TerminalNotificationPolicy.swift in Sources */,
 				A5A5A501A1B2C3D4E5F60718 /* TerminalNotificationQueue.swift in Sources */,
+				7490C0107490C0107490C010 /* TerminalNotificationStore+MemoryPressure.swift in Sources */,
 				A5001095 /* TerminalNotificationStore.swift in Sources */,
 				D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */,
 				A5001401 /* TerminalPanel.swift in Sources */,

--- a/cmuxTests/MemoryPressureMonitorTests.swift
+++ b/cmuxTests/MemoryPressureMonitorTests.swift
@@ -1,0 +1,268 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+private final class RecordingMemoryPressureResponder: MemoryPressureResponder {
+    let memoryPressureResponderID: String
+    let memoryPressureMinimumSeverity: MemoryPressureSeverity
+    let memoryPressurePriority: Int
+    let result: MemoryPressureShedResult
+    var calls: [MemoryPressureSnapshot] = []
+
+    init(
+        id: String,
+        minimumSeverity: MemoryPressureSeverity,
+        priority: Int,
+        result: MemoryPressureShedResult = .init(reclaimedItemCount: 1)
+    ) {
+        memoryPressureResponderID = id
+        memoryPressureMinimumSeverity = minimumSeverity
+        memoryPressurePriority = priority
+        self.result = result
+    }
+
+    func shedMemory(for snapshot: MemoryPressureSnapshot) -> MemoryPressureShedResult {
+        calls.append(snapshot)
+        return result
+    }
+}
+
+private struct FixedMemoryPressureFootprintSampler: MemoryPressureFootprintSampling {
+    let bytes: UInt64?
+
+    func physicalFootprintBytes() -> UInt64? {
+        bytes
+    }
+}
+
+struct MemoryPressureStateTrackerTests {
+    @Test func footprintThresholdsMapToSeverity() {
+        let thresholds = MemoryPressureFootprintThresholds(
+            warningBytes: 1_000,
+            criticalBytes: 2_000
+        )
+
+        #expect(thresholds.severity(forPhysicalFootprintBytes: nil) == .normal)
+        #expect(thresholds.severity(forPhysicalFootprintBytes: 999) == .normal)
+        #expect(thresholds.severity(forPhysicalFootprintBytes: 1_000) == .warning)
+        #expect(thresholds.severity(forPhysicalFootprintBytes: 1_999) == .warning)
+        #expect(thresholds.severity(forPhysicalFootprintBytes: 2_000) == .critical)
+    }
+
+    @Test func systemEventsAndFootprintSamplesDriveSeverityTransitions() {
+        let thresholds = MemoryPressureFootprintThresholds(
+            warningBytes: 1_000,
+            criticalBytes: 2_000
+        )
+        var tracker = MemoryPressureStateTracker(
+            thresholds: thresholds,
+            criticalPersistenceDuration: 10
+        )
+        let start = Date(timeIntervalSince1970: 100)
+
+        let warning = tracker.ingest(
+            systemSeverity: .warning,
+            physicalFootprintBytes: 500,
+            sampledAt: start
+        )
+        #expect(warning.previousSeverity == .normal)
+        #expect(warning.snapshot.severity == .warning)
+        #expect(warning.didTransition)
+
+        let critical = tracker.ingest(
+            systemSeverity: nil,
+            physicalFootprintBytes: 2_500,
+            sampledAt: start.addingTimeInterval(1)
+        )
+        #expect(critical.previousSeverity == .warning)
+        #expect(critical.snapshot.severity == .critical)
+        #expect(critical.didTransition)
+
+        let cleared = tracker.ingest(
+            systemSeverity: nil,
+            physicalFootprintBytes: 100,
+            sampledAt: start.addingTimeInterval(2)
+        )
+        #expect(cleared.previousSeverity == .critical)
+        #expect(cleared.snapshot.severity == .normal)
+        #expect(cleared.didTransition)
+    }
+
+    @Test func persistentCriticalPressureFiresOncePerCriticalEpisode() {
+        let thresholds = MemoryPressureFootprintThresholds(
+            warningBytes: 1_000,
+            criticalBytes: 2_000
+        )
+        var tracker = MemoryPressureStateTracker(
+            thresholds: thresholds,
+            criticalPersistenceDuration: 10
+        )
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        let initialCritical = tracker.ingest(
+            systemSeverity: .critical,
+            physicalFootprintBytes: nil,
+            sampledAt: start
+        )
+        #expect(!initialCritical.didBecomePersistentCritical)
+
+        let beforePersistence = tracker.ingest(
+            systemSeverity: nil,
+            physicalFootprintBytes: 2_500,
+            sampledAt: start.addingTimeInterval(9)
+        )
+        #expect(!beforePersistence.didBecomePersistentCritical)
+
+        let persistent = tracker.ingest(
+            systemSeverity: nil,
+            physicalFootprintBytes: 2_500,
+            sampledAt: start.addingTimeInterval(10)
+        )
+        #expect(persistent.didBecomePersistentCritical)
+
+        let stillCritical = tracker.ingest(
+            systemSeverity: .critical,
+            physicalFootprintBytes: 2_500,
+            sampledAt: start.addingTimeInterval(20)
+        )
+        #expect(!stillCritical.didBecomePersistentCritical)
+
+        _ = tracker.ingest(
+            systemSeverity: nil,
+            physicalFootprintBytes: 100,
+            sampledAt: start.addingTimeInterval(21)
+        )
+        _ = tracker.ingest(
+            systemSeverity: .critical,
+            physicalFootprintBytes: nil,
+            sampledAt: start.addingTimeInterval(30)
+        )
+        let secondEpisode = tracker.ingest(
+            systemSeverity: .critical,
+            physicalFootprintBytes: nil,
+            sampledAt: start.addingTimeInterval(40)
+        )
+        #expect(secondEpisode.didBecomePersistentCritical)
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct MemoryPressureResponderRegistryTests {
+    @Test func dispatchesEligibleRespondersInPriorityOrder() {
+        let registry = MemoryPressureResponderRegistry()
+        let low = RecordingMemoryPressureResponder(
+            id: "renderer",
+            minimumSeverity: .warning,
+            priority: 10,
+            result: .init(reclaimedItemCount: 2, estimatedBytes: 20)
+        )
+        let high = RecordingMemoryPressureResponder(
+            id: "browser",
+            minimumSeverity: .warning,
+            priority: 20,
+            result: .init(reclaimedItemCount: 3, estimatedBytes: 30)
+        )
+        let criticalOnly = RecordingMemoryPressureResponder(
+            id: "critical-only",
+            minimumSeverity: .critical,
+            priority: 100
+        )
+        registry.register(low)
+        registry.register(high)
+        registry.register(criticalOnly)
+
+        let snapshot = MemoryPressureSnapshot(
+            severity: .warning,
+            physicalFootprintBytes: 1_500,
+            sampledAt: Date(timeIntervalSince1970: 1)
+        )
+        let actions = registry.dispatch(snapshot)
+
+        #expect(actions.map(\.responderID) == ["browser", "renderer"])
+        #expect(actions.map(\.reclaimedItemCount) == [3, 2])
+        #expect(high.calls.count == 1)
+        #expect(low.calls.count == 1)
+        #expect(criticalOnly.calls.isEmpty)
+    }
+
+    @Test func criticalDispatchRunsWarningAndCriticalResponders() {
+        let registry = MemoryPressureResponderRegistry()
+        let warning = RecordingMemoryPressureResponder(
+            id: "warning",
+            minimumSeverity: .warning,
+            priority: 1
+        )
+        let critical = RecordingMemoryPressureResponder(
+            id: "critical",
+            minimumSeverity: .critical,
+            priority: 2
+        )
+        registry.register(warning)
+        registry.register(critical)
+
+        let snapshot = MemoryPressureSnapshot(
+            severity: .critical,
+            physicalFootprintBytes: 2_500,
+            sampledAt: Date(timeIntervalSince1970: 2)
+        )
+        let actions = registry.dispatch(snapshot)
+
+        #expect(actions.map(\.responderID) == ["critical", "warning"])
+        #expect(warning.calls.count == 1)
+        #expect(critical.calls.count == 1)
+    }
+
+    @Test func registeringSameResponderDoesNotDuplicateDispatch() {
+        let registry = MemoryPressureResponderRegistry()
+        let responder = RecordingMemoryPressureResponder(
+            id: "renderer",
+            minimumSeverity: .warning,
+            priority: 1
+        )
+        registry.register(responder)
+        registry.register(responder)
+
+        let snapshot = MemoryPressureSnapshot(
+            severity: .critical,
+            physicalFootprintBytes: 3_000,
+            sampledAt: Date(timeIntervalSince1970: 3)
+        )
+        let actions = registry.dispatch(snapshot)
+
+        #expect(actions.map(\.responderID) == ["renderer"])
+        #expect(responder.calls.count == 1)
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct MemoryPressureMonitorTests {
+    @Test func samplingInjectedFootprintDispatchesThroughRegistry() {
+        let registry = MemoryPressureResponderRegistry()
+        let responder = RecordingMemoryPressureResponder(
+            id: "renderer",
+            minimumSeverity: .warning,
+            priority: 1
+        )
+        registry.register(responder)
+        let monitor = MemoryPressureMonitor(
+            registry: registry,
+            footprintSampler: FixedMemoryPressureFootprintSampler(bytes: 1_500),
+            thresholds: .init(warningBytes: 1_000, criticalBytes: 2_000),
+            criticalPersistenceDuration: 10,
+            sampleInterval: 60
+        )
+
+        monitor.samplePhysicalFootprint(at: Date(timeIntervalSince1970: 4))
+
+        #expect(monitor.currentSeverity == .warning)
+        #expect(monitor.physicalFootprintBytes == 1_500)
+        #expect(responder.calls.map(\.severity) == [.warning])
+    }
+}

--- a/cmuxTests/MemoryPressureMonitorTests.swift
+++ b/cmuxTests/MemoryPressureMonitorTests.swift
@@ -265,4 +265,54 @@ struct MemoryPressureMonitorTests {
         #expect(monitor.physicalFootprintBytes == 1_500)
         #expect(responder.calls.map(\.severity) == [.warning])
     }
+
+    @Test func samplingPreservesRecentSystemPressureEvent() {
+        let registry = MemoryPressureResponderRegistry()
+        let responder = RecordingMemoryPressureResponder(
+            id: "renderer",
+            minimumSeverity: .warning,
+            priority: 1
+        )
+        registry.register(responder)
+        let monitor = MemoryPressureMonitor(
+            registry: registry,
+            footprintSampler: FixedMemoryPressureFootprintSampler(bytes: 100),
+            thresholds: .init(warningBytes: 1_000, criticalBytes: 2_000),
+            criticalPersistenceDuration: 10,
+            sampleInterval: 60,
+            systemPressureHoldDuration: 30
+        )
+        let start = Date(timeIntervalSince1970: 5)
+
+        monitor.recordSystemPressure(.critical, at: start)
+        monitor.samplePhysicalFootprint(at: start.addingTimeInterval(1))
+
+        #expect(monitor.currentSeverity == .critical)
+        #expect(responder.calls.map(\.severity) == [.critical, .critical])
+    }
+
+    @Test func heldSystemPressureExpiresWithoutNewEvents() {
+        let registry = MemoryPressureResponderRegistry()
+        let responder = RecordingMemoryPressureResponder(
+            id: "renderer",
+            minimumSeverity: .warning,
+            priority: 1
+        )
+        registry.register(responder)
+        let monitor = MemoryPressureMonitor(
+            registry: registry,
+            footprintSampler: FixedMemoryPressureFootprintSampler(bytes: 100),
+            thresholds: .init(warningBytes: 1_000, criticalBytes: 2_000),
+            criticalPersistenceDuration: 10,
+            sampleInterval: 60,
+            systemPressureHoldDuration: 30
+        )
+        let start = Date(timeIntervalSince1970: 6)
+
+        monitor.recordSystemPressure(.warning, at: start)
+        monitor.samplePhysicalFootprint(at: start.addingTimeInterval(31))
+
+        #expect(monitor.currentSeverity == .normal)
+        #expect(responder.calls.map(\.severity) == [.warning])
+    }
 }

--- a/cmuxTests/MemoryPressureMonitorTests.swift
+++ b/cmuxTests/MemoryPressureMonitorTests.swift
@@ -298,7 +298,7 @@ struct MemoryPressureMonitorTests {
         #expect(responder.calls.map(\.severity) == [.critical, .critical])
     }
 
-    @Test func heldSystemPressureExpiresWithoutNewEvents() {
+    @Test func lowerSystemPressureEventDoesNotDowngradeHeldCriticalEvent() {
         let registry = MemoryPressureResponderRegistry()
         let responder = RecordingMemoryPressureResponder(
             id: "renderer",
@@ -315,6 +315,31 @@ struct MemoryPressureMonitorTests {
             systemPressureHoldDuration: 30
         )
         let start = Date(timeIntervalSince1970: 6)
+
+        monitor.recordSystemPressure(.critical, at: start)
+        monitor.recordSystemPressure(.warning, at: start.addingTimeInterval(1))
+
+        #expect(monitor.currentSeverity == .critical)
+        #expect(responder.calls.map(\.severity) == [.critical, .critical])
+    }
+
+    @Test func heldSystemPressureExpiresWithoutNewEvents() {
+        let registry = MemoryPressureResponderRegistry()
+        let responder = RecordingMemoryPressureResponder(
+            id: "renderer",
+            minimumSeverity: .warning,
+            priority: 1
+        )
+        registry.register(responder)
+        let monitor = MemoryPressureMonitor(
+            registry: registry,
+            footprintSampler: FixedMemoryPressureFootprintSampler(bytes: 100),
+            thresholds: .init(warningBytes: 1_000, criticalBytes: 2_000),
+            criticalPersistenceDuration: 10,
+            sampleInterval: 60,
+            systemPressureHoldDuration: 30
+        )
+        let start = Date(timeIntervalSince1970: 7)
 
         monitor.recordSystemPressure(.warning, at: start)
         monitor.samplePhysicalFootprint(at: start.addingTimeInterval(31))

--- a/cmuxTests/MemoryPressureMonitorTests.swift
+++ b/cmuxTests/MemoryPressureMonitorTests.swift
@@ -243,6 +243,13 @@ struct MemoryPressureResponderRegistryTests {
 @MainActor
 @Suite(.serialized)
 struct MemoryPressureMonitorTests {
+    @Test func dispatchSourceEventMappingIgnoresEmptyEvents() {
+        #expect(MemoryPressureMonitor.severity(forDispatchSourceEvent: []) == nil)
+        #expect(MemoryPressureMonitor.severity(forDispatchSourceEvent: [.warning]) == .warning)
+        #expect(MemoryPressureMonitor.severity(forDispatchSourceEvent: [.critical]) == .critical)
+        #expect(MemoryPressureMonitor.severity(forDispatchSourceEvent: [.warning, .critical]) == .critical)
+    }
+
     @Test func samplingInjectedFootprintDispatchesThroughRegistry() {
         let registry = MemoryPressureResponderRegistry()
         let responder = RecordingMemoryPressureResponder(


### PR DESCRIPTION
Part of #7490.

## Summary
- Add a central `MemoryPressureMonitor` using DispatchSource memory-pressure warning/critical events plus periodic `task_vm_info.phys_footprint` sampling.
- Add a `MemoryPressureResponder` registry so reclaim paths register one conformance instead of adding ad-hoc observers.
- Register responders for hidden terminal renderer release, hidden browser WebView discard, and terminal notification throttle-cache trimming.
- Log and signpost pressure transitions and each shed action.
- Add a localized non-modal critical-pressure notification when critical pressure persists.

## Tests
- Added failing unit tests first in commit `07c01124e4` for severity transitions, footprint thresholds, responder ordering/deduping, and injected footprint dispatch.
- `swiftc -typecheck -parse-as-library Sources/App/MemoryPressureSeverity.swift Sources/App/MemoryPressureSnapshot.swift Sources/App/MemoryPressureFootprintThresholds.swift Sources/App/MemoryPressureStateEvaluation.swift Sources/App/MemoryPressureStateTracker.swift Sources/App/MemoryPressureFootprintSampling.swift Sources/App/TaskVMInfoMemoryPressureFootprintSampler.swift Sources/App/MemoryPressureShedResult.swift Sources/App/MemoryPressureShedAction.swift Sources/App/MemoryPressureResponder.swift Sources/App/MemoryPressureResponderRegistry.swift Sources/App/MemoryPressureMonitor.swift`
- `scripts/check-pbxproj.sh`
- `scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/swift_file_length_budget.py`
- `python3 -m json.tool Resources/Localizable.xcstrings >/dev/null`
- `git diff --check HEAD~1 HEAD`

Not run: local app build, local app launch, local Xcode tests, or local XCUITests, per the issue guardrails. The kernel low-swap `no paging space action` kill cannot be reproduced in CI; this PR tests the monitor/registry logic with injected pressure and footprint inputs instead.

## Follow-ups
- This PR does not attempt the full #5731 accumulation architecture. Additional responders, such as deeper terminal scrollback/page-cache shedding or conservative restore after pressure-kill relaunch, can plug into the new registry as follow-ups.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785992376&installation_id=133855650&pr_number=7496&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7496&signature=f64ef6373ad7f6ced5b381dac37280071f012dba22294a0c8c5b59f88ced038b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GPU renderer release and global memory reclamation under pressure; mitigated by existing visible-surface guards, idempotent release paths, and new unit tests, but behavior under real OOM is hard to fully validate in CI.
> 
> **Overview**
> Introduces a **central memory-pressure pipeline** that replaces the ad-hoc `PaneMemoryGuardrail` system-pressure callback with a shared monitor, registry, and pluggable reclaim steps.
> 
> **`MemoryPressureMonitor`** listens for macOS warning/critical `DispatchSource` events, samples **`task_vm_info.phys_footprint`** on a timer, merges footprint thresholds (default 8 GB / 16 GB) with held system severity (~2 min), and at warning+ dispatches registered responders. It logs/signposts transitions and fires **`onPersistentCriticalPressure`** after ~60s of sustained critical.
> 
> **Responders** (priority-ordered): hidden **terminal renderer** release via `RendererRealizationController` (with retry passes and `releaseRenderer()` success reporting), **hidden browser WebView** discard, and at **critical** only, **notification throttle-cache** trimming on `TerminalNotificationStore`.
> 
> **`AppDelegate`** starts the monitor alongside the pane guardrail (which now only does per-pane accounting) and posts a **cooldown-throttled in-app notification** with new localized strings when critical pressure persists.
> 
> Supporting changes: `RendererRealizationController` returns reclaim/retry counts for logging; `TerminalNotificationStore+MemoryPressure` trims cooldown caches; unit tests cover severity, dispatch order, and injected footprint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46d7e7d2d898eaebb6239f3da3da188d54729474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a central memory-pressure monitor and responder registry to proactively reclaim memory on OS warning/critical signals and high `phys_footprint`. Aligns with #7490 by shedding hidden terminal renderers/WebViews, trimming notification caches at critical, and showing a cooldown‑throttled notice when critical pressure persists.

- **New Features**
  - `MemoryPressureMonitor`: listens to DispatchSource warning/critical events, samples `task_vm_info.phys_footprint`, uses default thresholds (8GB warning, 16GB critical), holds system events for 2m, tracks 60s persistent‑critical, logs/signposts transitions, and dispatches responders by priority.
  - Responders: `RendererRealizationMemoryPressureResponder` (releases hidden terminal renderers with retry logging), `BrowserHiddenWebViewMemoryPressureResponder`, and `NotificationCacheMemoryPressureResponder` (critical‑only trim).
  - Localized, non‑modal notification for sustained critical pressure (5‑minute cooldown).

- **Refactors**
  - Moved system‑pressure handling out of `PaneMemoryGuardrail`; it now only monitors.
  - `AppDelegate` starts the monitor and registers responders; removed the old `onSystemMemoryPressure` path.
  - `TerminalSurface.releaseRenderer()` now returns a Bool; `RendererRealizationController` reports reclaimed/retry counts and schedules limited retries; `TerminalNotificationStore` exposes throttle‑cache maps and adds `trimMemoryPressureCaches()`.

<sup>Written for commit 46d7e7d2d898eaebb6239f3da3da188d54729474. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added app-wide memory-pressure monitoring that samples physical memory usage and triggers cleanup for hidden browser views, hidden/offscreen renderers, and notification caches.
  * Added sustained/“persistent critical” critical memory warnings, including cooldown-based user notification behavior.
* **Localization**
  * Added new localized messaging for critical memory-pressure warnings.
* **Tests**
  * Added end-to-end tests covering severity transitions, responder dispatch ordering, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->