### PR TITLE
Fix terminal path fragments opening as HTTPS URLs

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/BrowserHostNormalizing.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/BrowserHostNormalizing.swift
@@ -1,21 +1,12 @@
-public import Foundation
-
 /// Browser-domain host validation consumed by the terminal link router.
 ///
 /// The terminal must route web links exactly like the embedded browser would
-/// accept them, without importing the browser domain. The app's browser layer
-/// conforms and is injected into ``TerminalLinkRouter``.
+/// accept explicit URL hosts, without importing the browser domain. The app's
+/// browser layer conforms and is injected into ``TerminalLinkRouter``.
 public protocol BrowserHostNormalizing: Sendable {
     /// Returns the canonical host for raw host text, or `nil` when the text
     /// contains no host the embedded browser could load.
     ///
     /// - Parameter rawHost: The host component extracted from a candidate URL.
     func normalizedHost(_ rawHost: String) -> String?
-
-    /// Resolves free-form terminal text (bare domains, `localhost:port`,
-    /// scheme-less hosts) into a browser-navigable web URL, or `nil` when the
-    /// text is not navigable.
-    ///
-    /// - Parameter input: The raw link text.
-    func navigableWebURL(_ input: String) -> URL?
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -6,13 +6,11 @@ import CMUXDebugLog
 /// Routes a link activated inside a terminal to the embedded browser or the
 /// system.
 ///
-/// Routing precedence, preserved exactly from the legacy resolver: absolute
-/// file-system paths open externally; `http`/`https` URLs open embedded when
-/// the injected ``BrowserHostNormalizing`` accepts their host, externally
-/// otherwise; other schemes open externally; scheme-less text that the
-/// browser can navigate (bare domains, localhost) opens embedded subject to
-/// the same host check; anything else falls back to an external URL when it
-/// parses at all.
+/// Routing precedence: absolute file-system paths open externally; `http` and
+/// `https` URLs open embedded when the injected ``BrowserHostNormalizing``
+/// accepts their host, externally otherwise; other schemes open externally;
+/// scheme-less text that did not already resolve through the caller's
+/// file-path pass is ignored.
 public struct TerminalLinkRouter: Sendable {
     private let hostNormalizer: any BrowserHostNormalizing
 
@@ -67,28 +65,9 @@ public struct TerminalLinkRouter: Sendable {
             return .external(parsed)
         }
 
-        if let webURL = hostNormalizer.navigableWebURL(trimmed) {
-            guard hostNormalizer.normalizedHost(webURL.host ?? "") != nil else {
-                #if DEBUG
-                logDebugEvent("link.resolve result=external(bareHost-invalidHost) url=\(webURL)")
-                #endif
-                return .external(webURL)
-            }
-            #if DEBUG
-            logDebugEvent("link.resolve result=embeddedBrowser(bareHost) url=\(webURL)")
-            #endif
-            return .embeddedBrowser(webURL)
-        }
-
-        guard let fallback = URL(string: trimmed) else {
-            #if DEBUG
-            logDebugEvent("link.resolve result=nil (unparseable)")
-            #endif
-            return nil
-        }
         #if DEBUG
-        logDebugEvent("link.resolve result=external(fallback) url=\(fallback)")
+        logDebugEvent("link.resolve result=nil (schemeless)")
         #endif
-        return .external(fallback)
+        return nil
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -3,8 +3,7 @@ import Testing
 import CmuxTerminalCore
 
 /// A deterministic stand-in for the browser domain: hosts containing a dot or
-/// equal to localhost are navigable, and scheme-less host-ish text becomes an
-/// HTTPS URL the way the embedded browser's omnibox would treat it.
+/// equal to localhost are accepted for explicit web URLs.
 private struct StubHostNormalizer: BrowserHostNormalizing {
     var rejectsEveryHost = false
 
@@ -14,14 +13,6 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         guard !trimmed.isEmpty else { return nil }
         guard trimmed.contains(".") || trimmed == "localhost" else { return nil }
         return trimmed
-    }
-
-    func navigableWebURL(_ input: String) -> URL? {
-        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, !trimmed.contains(" ") else { return nil }
-        if URL(string: trimmed)?.scheme != nil { return URL(string: trimmed) }
-        guard trimmed.contains(".") || trimmed.lowercased().hasPrefix("localhost") else { return nil }
-        return URL(string: "https://\(trimmed)")
     }
 }
 
@@ -39,15 +30,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.path == "/path")
     }
 
-    @Test func resolvesBareDomainAsEmbeddedBrowser() throws {
-        let target = try #require(router.resolveOpenURLTarget("example.com/docs"))
-        guard case let .embeddedBrowser(url) = target else {
-            Issue.record("Expected bare domain to be normalized as an HTTPS browser URL")
-            return
-        }
-        #expect(url.scheme == "https")
-        #expect(url.host == "example.com")
-        #expect(url.path == "/docs")
+    @Test func schemelessBareDomainResolvesToNil() {
+        #expect(router.resolveOpenURLTarget("example.com/docs") == nil)
     }
 
     @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {
@@ -112,19 +96,9 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.host == "example.com")
     }
 
-    @Test func rejectedHostRoutesBareDomainExternally() throws {
-        let rejecting = TerminalLinkRouter(
-            hostNormalizer: StubHostNormalizer(rejectsEveryHost: true)
-        )
-        // The rejecting stub also refuses navigableWebURL inputs only at the
-        // host check, so build one that still yields a URL but fails the host
-        // gate: navigableWebURL is unaffected by rejectsEveryHost.
-        let target = rejecting.resolveOpenURLTarget("example.com/docs")
-        guard case let .external(url)? = target else {
-            Issue.record("Expected bare domain with rejected host to open externally")
-            return
-        }
-        #expect(url.host == "example.com")
+    @Test func rejectedHostDoesNotAffectSchemelessText() {
+        let rejecting = TerminalLinkRouter(hostNormalizer: StubHostNormalizer(rejectsEveryHost: true))
+        #expect(rejecting.resolveOpenURLTarget("example.com/docs") == nil)
     }
 
     @Test func emptyTextResolvesToNil() {
@@ -132,18 +106,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("   \n") == nil)
     }
 
-    @Test func nonNavigableTokenFallsBackToExternalURL() {
-        // Scheme-less text the browser cannot navigate still becomes an
-        // external URL when Foundation can parse it as a relative URL.
-        // (Multi-word text is deliberately not asserted here: URL(string:)
-        // rejects spaces on macOS 14/15 but percent-encodes them on newer
-        // Foundation, so its routing is OS-dependent.)
-        let target = router.resolveOpenURLTarget("foo_bar")
-        guard case let .external(url)? = target else {
-            Issue.record("Expected non-navigable token to fall back to external routing")
-            return
-        }
-        #expect(url.absoluteString == "foo_bar")
+    @Test func schemelessNonPathTokenResolvesToNil() {
+        #expect(router.resolveOpenURLTarget("foo_bar") == nil)
     }
 
     @Test func openTargetURLAccessorReturnsDestination() throws {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -50,6 +50,16 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.path == "/docs")
     }
 
+    @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {
+        let target = router.resolveOpenURLTarget("s/pipeline-failure-state-model.md")
+        #expect(target == nil)
+    }
+
+    @Test func unresolvedRelativePathDoesNotResolveAsHTTPSURL() {
+        let target = router.resolveOpenURLTarget("README.md")
+        #expect(target == nil)
+    }
+
     @Test func resolvesFileSchemeAsExternal() throws {
         let target = try #require(router.resolveOpenURLTarget("file:///tmp/cmux.txt"))
         guard case let .external(url) = target else {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -186,15 +186,11 @@ private func cmuxRuntimeReadClipboardCallback(
 // GhosttyApp.terminalPasteboard composition static below.
 
 /// The app-side conformance injected into ``TerminalLinkRouter``: terminal
-/// links validate hosts and resolve bare domains through the same browser
-/// rules the embedded browser uses.
+/// links validate explicit URL hosts through the same browser rules the
+/// embedded browser uses.
 struct TerminalBrowserHostNormalizer: BrowserHostNormalizing {
     func normalizedHost(_ rawHost: String) -> String? {
         BrowserInsecureHTTPSettings.normalizeHost(rawHost)
-    }
-
-    func navigableWebURL(_ input: String) -> URL? {
-        resolveBrowserNavigableURL(input)
     }
 }
 
@@ -3089,9 +3085,9 @@ class GhosttyApp {
 
             guard let target = resolveTerminalOpenURLTarget(normalizedOpenURLString) else {
                 #if DEBUG
-                cmuxDebugLog("link.openURL resolve failed, returning false")
+                cmuxDebugLog("link.openURL resolve ignored, consumed invalid token")
                 #endif
-                return false
+                return true
             }
             #if DEBUG
             if UITestCaptureSink().appendLineIfConfigured(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -5571,16 +5571,8 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
         }
     }
 
-    func testResolvesBareDomainAsEmbeddedBrowser() throws {
-        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("example.com/docs"))
-        switch target {
-        case let .embeddedBrowser(url):
-            XCTAssertEqual(url.scheme, "https")
-            XCTAssertEqual(url.host, "example.com")
-            XCTAssertEqual(url.path, "/docs")
-        default:
-            XCTFail("Expected bare domain to be normalized as an HTTPS browser URL")
-        }
+    func testSchemelessBareDomainResolvesToNil() throws {
+        XCTAssertNil(resolveTerminalOpenURLTarget("example.com/docs"))
     }
 
     func testResolvesFileSchemeAsExternal() throws {


### PR DESCRIPTION
## Summary

- Stop terminal cmd-click routing from applying browser omnibox heuristics to schemeless terminal tokens.
- Keep the existing file-first path resolution, but ignore unresolved schemeless text like `s/pipeline-failure-state-model.md` and `README.md` instead of coercing it to `https://`.
- Consume ignored Ghostty `open_url` tokens so Ghostty's fallback opener cannot launch the same bad fragment externally.

Closes #4675

## Testing

- `swift test --package-path Packages/macOS/CmuxTerminalCore`
- `python3 scripts/swift_file_length_budget.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `git diff --check`

## Coverage Notes

- Regression tests cover the reported wrapped fragment (`s/pipeline-failure-state-model.md`) and the sibling schemeless relative-path case (`README.md`) so they no longer resolve as HTTPS URLs.
- Full visual-line token reconstruction is not implemented in this patch: the Swift `open_url` callback receives the selected token string from Ghostty, not enough grid/soft-wrap context to reconstruct the whole logical token cleanly. This fix addresses the shared Swift classification choke point and prevents the bad HTTPS fallback.

## Localization

No user-facing strings changed. The only text change in app code is DEBUG logging, so `Resources/Localizable.xcstrings` was not updated.

## Demo Video

Not included. This is a terminal link-routing classification fix; per task guardrails I did not build or launch the app locally.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible terminal click behavior for schemeless text and alters Ghostty open_url success semantics; scope is localized to link routing with targeted tests.
> 
> **Overview**
> **Terminal link routing** no longer treats schemeless cmd-click tokens like bare domains or `README.md` as browser omnibox input. `BrowserHostNormalizing` is narrowed to **explicit URL host validation** only (`normalizedHost`); `navigableWebURL` and the router’s bare-host / `https://` coercion and `URL(string:)` external fallback are removed. After the existing file-path pass, unresolved schemeless text returns **`nil`** instead of opening embedded or external URLs.
> 
> In **Ghostty**’s `open_url` handler, when classification yields no target, the callback now returns **`true`** so Ghostty treats the token as handled and does not run its own external opener on the same bad fragment (e.g. `s/pipeline-failure-state-model.md`).
> 
> Tests in **CmuxTerminalCore** and app integration tests are updated to expect `nil` for schemeless domains, path fragments, and tokens like `foo_bar`, with regressions for the reported wrapped fragment and sibling relative-path cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1980b9cf10db3d7269f3a457b8e3fc35e0b62662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785993024&installation_id=133855650&pr_number=7497&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7497&signature=139c50bcc7b1e50918d509c4182ce56b1b457ed83162fe586f51b7793c206679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop cmd-click from coercing schemeless terminal tokens into HTTPS links. Schemeless fragments (e.g., s/pipeline-failure-state-model.md, README.md) are now ignored and consumed, fixing #4675 and preventing bad external opens.

- **Bug Fixes**
  - Keep file-first path resolution; only open explicit http/https, file:, or other-scheme URLs; ignore unresolved schemeless text.
  - Validate hosts only for explicit web URLs via `BrowserHostNormalizing.normalizedHost`, and consume ignored `open_url` tokens to prevent Ghostty fallback.

- **Refactors**
  - Removed `BrowserHostNormalizing.navigableWebURL` and all coercion of bare domains.
  - Simplified `TerminalLinkRouter` to return nil for schemeless input that doesn’t resolve as a file path.

<sup>Written for commit 1980b9cf10db3d7269f3a457b8e3fc35e0b62662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

