### PR TITLE
Revert "Fix terminal path fragments opening as HTTPS URLs"

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/BrowserHostNormalizing.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/BrowserHostNormalizing.swift
@@ -1,12 +1,21 @@
+public import Foundation
+
 /// Browser-domain host validation consumed by the terminal link router.
 ///
 /// The terminal must route web links exactly like the embedded browser would
-/// accept explicit URL hosts, without importing the browser domain. The app's
-/// browser layer conforms and is injected into ``TerminalLinkRouter``.
+/// accept them, without importing the browser domain. The app's browser layer
+/// conforms and is injected into ``TerminalLinkRouter``.
 public protocol BrowserHostNormalizing: Sendable {
     /// Returns the canonical host for raw host text, or `nil` when the text
     /// contains no host the embedded browser could load.
     ///
     /// - Parameter rawHost: The host component extracted from a candidate URL.
     func normalizedHost(_ rawHost: String) -> String?
+
+    /// Resolves free-form terminal text (bare domains, `localhost:port`,
+    /// scheme-less hosts) into a browser-navigable web URL, or `nil` when the
+    /// text is not navigable.
+    ///
+    /// - Parameter input: The raw link text.
+    func navigableWebURL(_ input: String) -> URL?
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -6,11 +6,13 @@ import CMUXDebugLog
 /// Routes a link activated inside a terminal to the embedded browser or the
 /// system.
 ///
-/// Routing precedence: absolute file-system paths open externally; `http` and
-/// `https` URLs open embedded when the injected ``BrowserHostNormalizing``
-/// accepts their host, externally otherwise; other schemes open externally;
-/// scheme-less text that did not already resolve through the caller's
-/// file-path pass is ignored.
+/// Routing precedence, preserved exactly from the legacy resolver: absolute
+/// file-system paths open externally; `http`/`https` URLs open embedded when
+/// the injected ``BrowserHostNormalizing`` accepts their host, externally
+/// otherwise; other schemes open externally; scheme-less text that the
+/// browser can navigate (bare domains, localhost) opens embedded subject to
+/// the same host check; anything else falls back to an external URL when it
+/// parses at all.
 public struct TerminalLinkRouter: Sendable {
     private let hostNormalizer: any BrowserHostNormalizing
 
@@ -65,9 +67,28 @@ public struct TerminalLinkRouter: Sendable {
             return .external(parsed)
         }
 
+        if let webURL = hostNormalizer.navigableWebURL(trimmed) {
+            guard hostNormalizer.normalizedHost(webURL.host ?? "") != nil else {
+                #if DEBUG
+                logDebugEvent("link.resolve result=external(bareHost-invalidHost) url=\(webURL)")
+                #endif
+                return .external(webURL)
+            }
+            #if DEBUG
+            logDebugEvent("link.resolve result=embeddedBrowser(bareHost) url=\(webURL)")
+            #endif
+            return .embeddedBrowser(webURL)
+        }
+
+        guard let fallback = URL(string: trimmed) else {
+            #if DEBUG
+            logDebugEvent("link.resolve result=nil (unparseable)")
+            #endif
+            return nil
+        }
         #if DEBUG
-        logDebugEvent("link.resolve result=nil (schemeless)")
+        logDebugEvent("link.resolve result=external(fallback) url=\(fallback)")
         #endif
-        return nil
+        return .external(fallback)
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -3,7 +3,8 @@ import Testing
 import CmuxTerminalCore
 
 /// A deterministic stand-in for the browser domain: hosts containing a dot or
-/// equal to localhost are accepted for explicit web URLs.
+/// equal to localhost are navigable, and scheme-less host-ish text becomes an
+/// HTTPS URL the way the embedded browser's omnibox would treat it.
 private struct StubHostNormalizer: BrowserHostNormalizing {
     var rejectsEveryHost = false
 
@@ -13,6 +14,14 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         guard !trimmed.isEmpty else { return nil }
         guard trimmed.contains(".") || trimmed == "localhost" else { return nil }
         return trimmed
+    }
+
+    func navigableWebURL(_ input: String) -> URL? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains(" ") else { return nil }
+        if URL(string: trimmed)?.scheme != nil { return URL(string: trimmed) }
+        guard trimmed.contains(".") || trimmed.lowercased().hasPrefix("localhost") else { return nil }
+        return URL(string: "https://\(trimmed)")
     }
 }
 
@@ -30,18 +39,15 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.path == "/path")
     }
 
-    @Test func schemelessBareDomainResolvesToNil() {
-        #expect(router.resolveOpenURLTarget("example.com/docs") == nil)
-    }
-
-    @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {
-        let target = router.resolveOpenURLTarget("s/pipeline-failure-state-model.md")
-        #expect(target == nil)
-    }
-
-    @Test func unresolvedRelativePathDoesNotResolveAsHTTPSURL() {
-        let target = router.resolveOpenURLTarget("README.md")
-        #expect(target == nil)
+    @Test func resolvesBareDomainAsEmbeddedBrowser() throws {
+        let target = try #require(router.resolveOpenURLTarget("example.com/docs"))
+        guard case let .embeddedBrowser(url) = target else {
+            Issue.record("Expected bare domain to be normalized as an HTTPS browser URL")
+            return
+        }
+        #expect(url.scheme == "https")
+        #expect(url.host == "example.com")
+        #expect(url.path == "/docs")
     }
 
     @Test func resolvesFileSchemeAsExternal() throws {
@@ -96,9 +102,19 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.host == "example.com")
     }
 
-    @Test func rejectedHostDoesNotAffectSchemelessText() {
-        let rejecting = TerminalLinkRouter(hostNormalizer: StubHostNormalizer(rejectsEveryHost: true))
-        #expect(rejecting.resolveOpenURLTarget("example.com/docs") == nil)
+    @Test func rejectedHostRoutesBareDomainExternally() throws {
+        let rejecting = TerminalLinkRouter(
+            hostNormalizer: StubHostNormalizer(rejectsEveryHost: true)
+        )
+        // The rejecting stub also refuses navigableWebURL inputs only at the
+        // host check, so build one that still yields a URL but fails the host
+        // gate: navigableWebURL is unaffected by rejectsEveryHost.
+        let target = rejecting.resolveOpenURLTarget("example.com/docs")
+        guard case let .external(url)? = target else {
+            Issue.record("Expected bare domain with rejected host to open externally")
+            return
+        }
+        #expect(url.host == "example.com")
     }
 
     @Test func emptyTextResolvesToNil() {
@@ -106,8 +122,18 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("   \n") == nil)
     }
 
-    @Test func schemelessNonPathTokenResolvesToNil() {
-        #expect(router.resolveOpenURLTarget("foo_bar") == nil)
+    @Test func nonNavigableTokenFallsBackToExternalURL() {
+        // Scheme-less text the browser cannot navigate still becomes an
+        // external URL when Foundation can parse it as a relative URL.
+        // (Multi-word text is deliberately not asserted here: URL(string:)
+        // rejects spaces on macOS 14/15 but percent-encodes them on newer
+        // Foundation, so its routing is OS-dependent.)
+        let target = router.resolveOpenURLTarget("foo_bar")
+        guard case let .external(url)? = target else {
+            Issue.record("Expected non-navigable token to fall back to external routing")
+            return
+        }
+        #expect(url.absoluteString == "foo_bar")
     }
 
     @Test func openTargetURLAccessorReturnsDestination() throws {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -186,11 +186,15 @@ private func cmuxRuntimeReadClipboardCallback(
 // GhosttyApp.terminalPasteboard composition static below.
 
 /// The app-side conformance injected into ``TerminalLinkRouter``: terminal
-/// links validate explicit URL hosts through the same browser rules the
-/// embedded browser uses.
+/// links validate hosts and resolve bare domains through the same browser
+/// rules the embedded browser uses.
 struct TerminalBrowserHostNormalizer: BrowserHostNormalizing {
     func normalizedHost(_ rawHost: String) -> String? {
         BrowserInsecureHTTPSettings.normalizeHost(rawHost)
+    }
+
+    func navigableWebURL(_ input: String) -> URL? {
+        resolveBrowserNavigableURL(input)
     }
 }
 
@@ -3085,9 +3089,9 @@ class GhosttyApp {
 
             guard let target = resolveTerminalOpenURLTarget(normalizedOpenURLString) else {
                 #if DEBUG
-                cmuxDebugLog("link.openURL resolve ignored, consumed invalid token")
+                cmuxDebugLog("link.openURL resolve failed, returning false")
                 #endif
-                return true
+                return false
             }
             #if DEBUG
             if UITestCaptureSink().appendLineIfConfigured(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -5571,8 +5571,16 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
         }
     }
 
-    func testSchemelessBareDomainResolvesToNil() throws {
-        XCTAssertNil(resolveTerminalOpenURLTarget("example.com/docs"))
+    func testResolvesBareDomainAsEmbeddedBrowser() throws {
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("example.com/docs"))
+        switch target {
+        case let .embeddedBrowser(url):
+            XCTAssertEqual(url.scheme, "https")
+            XCTAssertEqual(url.host, "example.com")
+            XCTAssertEqual(url.path, "/docs")
+        default:
+            XCTFail("Expected bare domain to be normalized as an HTTPS browser URL")
+        }
     }
 
     func testResolvesFileSchemeAsExternal() throws {


### PR DESCRIPTION
Reverts manaflow-ai/cmux#7497

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785995304&installation_id=133855650&pr_number=7499&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7499&signature=84589eb84afec08593d27192cfd73435457eca01fead4ab6bc3bfc2d98b232d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reintroduces the behavior #7497 removed: path-like or filename tokens in the terminal may be treated as navigable hosts or external URLs instead of being ignored, which can surprise users who click build output or docs paths.
> 
> **Overview**
> **Restores pre-#7497 terminal link routing** so scheme-less text is handled like the embedded browser omnibox again, instead of ignoring many tokens.
> 
> `BrowserHostNormalizing` gains **`navigableWebURL`**, wired in the app via **`resolveBrowserNavigableURL`**. **`TerminalLinkRouter`** now routes bare domains / localhost through that helper (embedded when the host passes **`normalizedHost`**, otherwise external), and uses **`URL(string:)`** as an **external fallback** when navigation resolution fails—replacing **`nil`** for many scheme-less strings.
> 
> **`GhosttyTerminalView`** treats an unresolvable link as a **failed open (`return false`)** rather than swallowing the click (`return true`). Unit tests are updated to expect embedded **`example.com/docs`** and external fallback for tokens like **`foo_bar`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1271bfd11ff401869c9e6988e004b644fe1eb182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the prior HTTPS auto-parse change and restores the legacy terminal link routing. Bare domains and localhost open in the embedded browser; path-like tokens are no longer misparsed as HTTPS, and non-navigable text only falls back to external when it parses as a URL.

- **Bug Fixes**
  - Restore routing order: absolute paths → external; http/https → embedded if host allowed, else external; other schemes → external; scheme-less navigable (bare domains, localhost) → embedded; otherwise external fallback or ignored.
  - Stop treating path fragments as HTTPS.
  - Return false when link resolution fails in the terminal view.

- **Refactors**
  - Add `navigableWebURL(_:)` to `BrowserHostNormalizing` to mirror browser omnibox behavior.
  - Update `TerminalLinkRouter` to use browser-driven normalization and an external fallback for parseable scheme-less text.
  - Implement `navigableWebURL(_:)` in `TerminalBrowserHostNormalizer` via the app’s `resolveBrowserNavigableURL`.
  - Refresh tests to cover bare-domain embedding, rejected-host external routing, and fallback behavior.

<sup>Written for commit 1271bfd11ff401869c9e6988e004b644fe1eb182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bare domains and other schemeless web-like text can now open as navigable web links in the embedded browser when valid.
  * Link handling now more consistently falls back to an external browser for URLs that can be parsed but aren’t handled internally.

* **Bug Fixes**
  * Improved routing for free-form link text, including paths like `example.com/docs`.
  * Invalid or unresolved link input is now handled more accurately, avoiding false “handled” states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->