### PR TITLE
Fix terminal path fragments opening as HTTPS URLs

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/BrowserHostNormalizing.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/BrowserHostNormalizing.swift
@@ -1,21 +1,12 @@
-public import Foundation
-
 /// Browser-domain host validation consumed by the terminal link router.
 ///
 /// The terminal must route web links exactly like the embedded browser would
-/// accept them, without importing the browser domain. The app's browser layer
-/// conforms and is injected into ``TerminalLinkRouter``.
+/// accept explicit URL hosts, without importing the browser domain. The app's
+/// browser layer conforms and is injected into ``TerminalLinkRouter``.
 public protocol BrowserHostNormalizing: Sendable {
     /// Returns the canonical host for raw host text, or `nil` when the text
     /// contains no host the embedded browser could load.
     ///
     /// - Parameter rawHost: The host component extracted from a candidate URL.
     func normalizedHost(_ rawHost: String) -> String?
-
-    /// Resolves free-form terminal text (bare domains, `localhost:port`,
-    /// scheme-less hosts) into a browser-navigable web URL, or `nil` when the
-    /// text is not navigable.
-    ///
-    /// - Parameter input: The raw link text.
-    func navigableWebURL(_ input: String) -> URL?
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/BrowserHostNormalizing.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/BrowserHostNormalizing.swift
@@ -1,7 +1,9 @@
-/// Browser-domain host validation consumed by the terminal link router.
+public import Foundation
+
+/// Browser-domain URL validation consumed by the terminal link router.
 ///
 /// The terminal must route web links exactly like the embedded browser would
-/// accept explicit URL hosts, without importing the browser domain. The app's
+/// accept navigable URL text, without importing the browser domain. The app's
 /// browser layer conforms and is injected into ``TerminalLinkRouter``.
 public protocol BrowserHostNormalizing: Sendable {
     /// Returns the canonical host for raw host text, or `nil` when the text
@@ -9,4 +11,9 @@ public protocol BrowserHostNormalizing: Sendable {
     ///
     /// - Parameter rawHost: The host component extracted from a candidate URL.
     func normalizedHost(_ rawHost: String) -> String?
+
+    /// Resolves raw text the same way the browser address field would.
+    ///
+    /// - Parameter input: The candidate URL text from the terminal.
+    func navigableWebURL(_ input: String) -> URL?
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -59,7 +59,14 @@ public struct TerminalLinkRouter: Sendable {
             }
         }
 
-        if Self.looksLikeSingleLabelPathFragment(trimmed) {
+        if Self.looksLikeUnresolvedFileLineReference(trimmed) {
+            #if DEBUG
+            logDebugEvent("link.resolve result=nil (fileLine)")
+            #endif
+            return nil
+        }
+
+        if Self.looksLikeWrappedFilePathFragment(trimmed) {
             #if DEBUG
             logDebugEvent("link.resolve result=nil (pathFragment)")
             #endif
@@ -99,7 +106,22 @@ public struct TerminalLinkRouter: Sendable {
         return .embeddedBrowser(url)
     }
 
-    private static func looksLikeSingleLabelPathFragment(_ value: String) -> Bool {
+    private static func looksLikeUnresolvedFileLineReference(_ value: String) -> Bool {
+        guard value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              let colon = value.lastIndex(of: ":"),
+              colon < value.index(before: value.endIndex),
+              value[value.index(after: colon)...].allSatisfy(\.isNumber),
+              hasKnownFileExtension(value[..<colon]) else {
+            return false
+        }
+        guard !value[..<colon].contains(where: \.isUppercase),
+              let port = Int(value[value.index(after: colon)...]) else {
+            return true
+        }
+        return !Self.commonWebPorts.contains(port)
+    }
+
+    private static func looksLikeWrappedFilePathFragment(_ value: String) -> Bool {
         guard value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
               let slash = value.firstIndex(of: "/"),
               slash > value.startIndex else {
@@ -107,6 +129,34 @@ public struct TerminalLinkRouter: Sendable {
         }
         let hostCandidate = value[..<slash].lowercased()
         guard hostCandidate != "localhost" else { return false }
-        return hostCandidate.rangeOfCharacter(from: CharacterSet(charactersIn: ".:[]")) == nil
+        guard hostCandidate.rangeOfCharacter(from: CharacterSet(charactersIn: ".:[]")) == nil else {
+            return false
+        }
+        let pathStart = value.index(after: slash)
+        let pathEnd = value[pathStart...].firstIndex { character in
+            character == "?" || character == "#"
+        } ?? value.endIndex
+        let path = value[pathStart..<pathEnd]
+        let lastComponentStart = path.lastIndex(of: "/").map(path.index(after:)) ?? path.startIndex
+        return hasKnownFileExtension(path[lastComponentStart...])
     }
+
+    private static func hasKnownFileExtension(_ value: some StringProtocol) -> Bool {
+        guard let dot = value.lastIndex(of: "."),
+              dot < value.index(before: value.endIndex) else {
+            return false
+        }
+        switch value[value.index(after: dot)...].lowercased() {
+        case "c", "cc", "cpp", "css", "go", "h", "hpp", "html", "java",
+             "js", "jsx", "json", "m", "md", "mm", "php", "py", "rb", "rs",
+             "sh", "swift", "toml", "ts", "tsx", "txt", "yaml", "yml", "zsh":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static let commonWebPorts: Set<Int> = [
+        80, 443, 3000, 3001, 4200, 5000, 5173, 5174, 8000, 8080, 8443, 9000,
+    ]
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -118,7 +118,7 @@ public struct TerminalLinkRouter: Sendable {
         if Self.fileExtensionTopLevelDomains.contains(fileExtension),
            let port = trailingNumericSuffix(value),
            hasSingleLocationSuffix(value, after: fileReference),
-           isValidPort(port) {
+           isPlausibleFileLikeHostPort(port) {
             return false
         }
         return true
@@ -198,8 +198,12 @@ public struct TerminalLinkRouter: Sendable {
         return value[..<colon].elementsEqual(fileReference)
     }
 
-    private static func isValidPort(_ value: some StringProtocol) -> Bool {
-        UInt16(value) != nil
+    private static func isPlausibleFileLikeHostPort(_ value: some StringProtocol) -> Bool {
+        guard let port = UInt16(value) else { return false }
+        // Bare `name.ext:number` is ambiguous when ext is also a TLD. Explicit
+        // schemes route before this guard; keep low diagnostic-like line
+        // numbers fail-closed while preserving common web/dev port shapes.
+        return port == 80 || port == 443 || port >= 500
     }
 
     private static let commonSourceBasenames: Set<String> = [

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -117,7 +117,7 @@ public struct TerminalLinkRouter: Sendable {
         if Self.commonSourceBasenames.contains(stem(fileReference)) { return true }
         if Self.fileExtensionTopLevelDomains.contains(fileExtension),
            let port = trailingNumericSuffix(value),
-           isWebLikePort(port) {
+           isValidPort(port) {
             return false
         }
         return true
@@ -189,9 +189,8 @@ public struct TerminalLinkRouter: Sendable {
         return value[value.index(after: colon)...]
     }
 
-    private static func isWebLikePort(_ value: some StringProtocol) -> Bool {
-        guard let port = Int(value), port > 0, port <= 65_535 else { return false }
-        return port == 80 || port == 443 || port >= 1024
+    private static func isValidPort(_ value: some StringProtocol) -> Bool {
+        UInt16(value) != nil
     }
 
     private static let commonSourceBasenames: Set<String> = [

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -195,7 +195,8 @@ public struct TerminalLinkRouter: Sendable {
     }
 
     private static let commonSourceBasenames: Set<String> = [
-        "app", "config", "index", "lib", "main", "package", "readme", "server", "utils",
+        "app", "build", "changelog", "config", "foo", "index", "lib", "main",
+        "package", "readme", "script", "server", "utils",
     ]
 
     private static let fileExtensionTopLevelDomains: Set<String> = [

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -114,12 +114,7 @@ public struct TerminalLinkRouter: Sendable {
               hasKnownFileExtension(value[..<colon]) else {
             return false
         }
-        if value[..<colon].contains("/") { return true }
-        guard !value[..<colon].contains(where: \.isUppercase),
-              let port = Int(value[value.index(after: colon)...]) else {
-            return true
-        }
-        return !Self.commonWebPorts.contains(port)
+        return true
     }
 
     private static func looksLikeWrappedFilePathFragment(_ value: String) -> Bool {
@@ -157,8 +152,4 @@ public struct TerminalLinkRouter: Sendable {
             return false
         }
     }
-
-    private static let commonWebPorts: Set<Int> = [
-        80, 443, 3000, 3001, 4200, 5000, 5173, 5174, 8000, 8080, 8443, 9000,
-    ]
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -6,13 +6,11 @@ import CMUXDebugLog
 /// Routes a link activated inside a terminal to the embedded browser or the
 /// system.
 ///
-/// Routing precedence, preserved exactly from the legacy resolver: absolute
-/// file-system paths open externally; `http`/`https` URLs open embedded when
-/// the injected ``BrowserHostNormalizing`` accepts their host, externally
-/// otherwise; other schemes open externally; scheme-less text that the
-/// browser can navigate (bare domains, localhost) opens embedded subject to
-/// the same host check; anything else falls back to an external URL when it
-/// parses at all.
+/// Routing precedence: absolute file-system paths open externally; `http` and
+/// `https` URLs open embedded when the injected ``BrowserHostNormalizing``
+/// accepts their host, externally otherwise; other schemes open externally;
+/// scheme-less text that did not already resolve through the caller's
+/// file-path pass is ignored.
 public struct TerminalLinkRouter: Sendable {
     private let hostNormalizer: any BrowserHostNormalizing
 
@@ -67,28 +65,9 @@ public struct TerminalLinkRouter: Sendable {
             return .external(parsed)
         }
 
-        if let webURL = hostNormalizer.navigableWebURL(trimmed) {
-            guard hostNormalizer.normalizedHost(webURL.host ?? "") != nil else {
-                #if DEBUG
-                logDebugEvent("link.resolve result=external(bareHost-invalidHost) url=\(webURL)")
-                #endif
-                return .external(webURL)
-            }
-            #if DEBUG
-            logDebugEvent("link.resolve result=embeddedBrowser(bareHost) url=\(webURL)")
-            #endif
-            return .embeddedBrowser(webURL)
-        }
-
-        guard let fallback = URL(string: trimmed) else {
-            #if DEBUG
-            logDebugEvent("link.resolve result=nil (unparseable)")
-            #endif
-            return nil
-        }
         #if DEBUG
-        logDebugEvent("link.resolve result=external(fallback) url=\(fallback)")
+        logDebugEvent("link.resolve result=nil (schemeless)")
         #endif
-        return .external(fallback)
+        return nil
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -46,7 +46,7 @@ public struct TerminalLinkRouter: Sendable {
             return .external(URL(fileURLWithPath: trimmed))
         }
 
-        if let webURL = schemelessHostPathURL(from: trimmed) {
+        if let webURL = schemelessWebURL(from: trimmed) {
             #if DEBUG
             logDebugEvent("link.resolve result=embeddedBrowser(schemeless) url=\(webURL)")
             #endif
@@ -79,20 +79,33 @@ public struct TerminalLinkRouter: Sendable {
         return nil
     }
 
-    private func schemelessHostPathURL(from trimmed: String) -> URL? {
-        guard trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
-              let slashIndex = trimmed.firstIndex(of: "/"),
-              slashIndex > trimmed.startIndex else {
+    private func schemelessWebURL(from trimmed: String) -> URL? {
+        guard trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else { return nil }
+
+        let hostCandidate: String
+        if let slashIndex = trimmed.firstIndex(of: "/") {
+            guard slashIndex > trimmed.startIndex else { return nil }
+            hostCandidate = String(trimmed[..<slashIndex])
+            guard !hostCandidate.hasSuffix(":") else { return nil }
+        } else if Self.hasNumericPort(trimmed) {
+            hostCandidate = trimmed
+        } else {
             return nil
         }
 
-        let hostCandidate = String(trimmed[..<slashIndex])
-        guard !hostCandidate.hasSuffix(":") else { return nil }
         guard let normalizedHost = hostNormalizer.normalizedHost(hostCandidate),
               let scheme = Self.schemelessWebScheme(for: normalizedHost) else {
             return nil
         }
         return URL(string: "\(scheme)://\(trimmed)")
+    }
+
+    private static func hasNumericPort(_ value: String) -> Bool {
+        guard let colon = value.lastIndex(of: ":"),
+              colon < value.index(before: value.endIndex) else {
+            return false
+        }
+        return value[value.index(after: colon)...].allSatisfy(\.isNumber)
     }
 
     private static func schemelessWebScheme(for normalizedHost: String) -> String? {

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -111,7 +111,15 @@ public struct TerminalLinkRouter: Sendable {
               let colon = value.lastIndex(of: ":"),
               colon < value.index(before: value.endIndex),
               value[value.index(after: colon)...].allSatisfy(\.isNumber),
-              hasKnownFileExtension(value[..<colon]) else {
+              let fileExtension = knownFileExtension(value[..<colon]) else {
+            return false
+        }
+        let fileReference = value[..<colon]
+        if fileReference.contains("/") { return true }
+        if fileReference.contains(where: \.isUppercase) { return true }
+        if Self.commonSourceBasenames.contains(stem(fileReference)) { return true }
+        if Self.fileExtensionTopLevelDomains.contains(fileExtension),
+           isWebLikePort(value[value.index(after: colon)...]) {
             return false
         }
         return true
@@ -135,21 +143,41 @@ public struct TerminalLinkRouter: Sendable {
         } ?? value.endIndex
         let path = value[pathStart..<pathEnd]
         let lastComponentStart = path.lastIndex(of: "/").map(path.index(after:)) ?? path.startIndex
-        return hasKnownFileExtension(path[lastComponentStart...])
+        let lastComponent = path[lastComponentStart...]
+        return knownFileExtension(lastComponent) == "md" && lastComponent.contains("-")
     }
 
-    private static func hasKnownFileExtension(_ value: some StringProtocol) -> Bool {
+    private static func knownFileExtension(_ value: some StringProtocol) -> String? {
         guard let dot = value.lastIndex(of: "."),
               dot < value.index(before: value.endIndex) else {
-            return false
+            return nil
         }
-        switch value[value.index(after: dot)...].lowercased() {
+        let fileExtension = value[value.index(after: dot)...].lowercased()
+        switch fileExtension {
         case "c", "cc", "cpp", "css", "go", "h", "hpp", "html", "java",
              "js", "jsx", "json", "m", "md", "mm", "php", "py", "rb", "rs",
              "sh", "swift", "toml", "ts", "tsx", "txt", "yaml", "yml", "zsh":
-            return true
+            return fileExtension
         default:
-            return false
+            return nil
         }
     }
+
+    private static func stem(_ value: some StringProtocol) -> String {
+        guard let dot = value.lastIndex(of: ".") else { return value.lowercased() }
+        return value[..<dot].lowercased()
+    }
+
+    private static func isWebLikePort(_ value: some StringProtocol) -> Bool {
+        guard let port = Int(value), port > 0, port <= 65_535 else { return false }
+        return port == 80 || port == 443 || port >= 1024
+    }
+
+    private static let commonSourceBasenames: Set<String> = [
+        "app", "config", "index", "lib", "main", "package", "readme", "server", "utils",
+    ]
+
+    private static let fileExtensionTopLevelDomains: Set<String> = [
+        "cc", "md", "mm", "py", "rs", "sh",
+    ]
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -89,15 +89,22 @@ public struct TerminalLinkRouter: Sendable {
         let hostCandidate = String(trimmed[..<slashIndex])
         guard !hostCandidate.hasSuffix(":") else { return nil }
         guard let normalizedHost = hostNormalizer.normalizedHost(hostCandidate),
-              Self.isSchemelessWebHost(normalizedHost) else {
+              let scheme = Self.schemelessWebScheme(for: normalizedHost) else {
             return nil
         }
-        return URL(string: "https://\(trimmed)")
+        return URL(string: "\(scheme)://\(trimmed)")
     }
 
-    private static func isSchemelessWebHost(_ normalizedHost: String) -> Bool {
-        normalizedHost == "localhost"
-            || normalizedHost.contains(".")
-            || normalizedHost.contains(":")
+    private static func schemelessWebScheme(for normalizedHost: String) -> String? {
+        if normalizedHost == "localhost"
+            || normalizedHost == "127.0.0.1"
+            || normalizedHost == "::1"
+            || normalizedHost.hasSuffix(".localhost") {
+            return "http"
+        }
+        if normalizedHost.contains(".") || normalizedHost.contains(":") {
+            return "https"
+        }
+        return nil
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -46,6 +46,13 @@ public struct TerminalLinkRouter: Sendable {
             return .external(URL(fileURLWithPath: trimmed))
         }
 
+        if let webURL = schemelessHostPathURL(from: trimmed) {
+            #if DEBUG
+            logDebugEvent("link.resolve result=embeddedBrowser(schemeless) url=\(webURL)")
+            #endif
+            return .embeddedBrowser(webURL)
+        }
+
         if let parsed = URL(string: trimmed),
            let scheme = parsed.scheme?.lowercased() {
             if scheme == "http" || scheme == "https" {
@@ -66,13 +73,6 @@ public struct TerminalLinkRouter: Sendable {
             return .external(parsed)
         }
 
-        if let webURL = schemelessHostPathURL(from: trimmed) {
-            #if DEBUG
-            logDebugEvent("link.resolve result=embeddedBrowser(schemeless) url=\(webURL)")
-            #endif
-            return .embeddedBrowser(webURL)
-        }
-
         #if DEBUG
         logDebugEvent("link.resolve result=nil (schemeless)")
         #endif
@@ -87,7 +87,17 @@ public struct TerminalLinkRouter: Sendable {
         }
 
         let hostCandidate = String(trimmed[..<slashIndex])
-        guard hostNormalizer.normalizedHost(hostCandidate) != nil else { return nil }
+        guard !hostCandidate.hasSuffix(":") else { return nil }
+        guard let normalizedHost = hostNormalizer.normalizedHost(hostCandidate),
+              Self.isSchemelessWebHost(normalizedHost) else {
+            return nil
+        }
         return URL(string: "https://\(trimmed)")
+    }
+
+    private static func isSchemelessWebHost(_ normalizedHost: String) -> Bool {
+        normalizedHost == "localhost"
+            || normalizedHost.contains(".")
+            || normalizedHost.contains(":")
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -111,14 +111,9 @@ public struct TerminalLinkRouter: Sendable {
               let colon = value.lastIndex(of: ":"),
               colon < value.index(before: value.endIndex),
               value[value.index(after: colon)...].allSatisfy(\.isNumber),
-              let fileExtension = knownFileExtension(value[..<colon]) else {
+              hasKnownFileExtension(value[..<colon]) else {
             return false
         }
-        let fileReference = value[..<colon]
-        if fileReference.contains("/") { return true }
-        if fileReference.contains(where: \.isUppercase) { return true }
-        if Self.commonSourceBasenames.contains(stem(fileReference)) { return true }
-        if Self.fileExtensionTopLevelDomains.contains(fileExtension) { return false }
         return true
     }
 
@@ -140,35 +135,21 @@ public struct TerminalLinkRouter: Sendable {
         } ?? value.endIndex
         let path = value[pathStart..<pathEnd]
         let lastComponentStart = path.lastIndex(of: "/").map(path.index(after:)) ?? path.startIndex
-        return knownFileExtension(path[lastComponentStart...]) != nil
+        return hasKnownFileExtension(path[lastComponentStart...])
     }
 
-    private static func knownFileExtension(_ value: some StringProtocol) -> String? {
+    private static func hasKnownFileExtension(_ value: some StringProtocol) -> Bool {
         guard let dot = value.lastIndex(of: "."),
               dot < value.index(before: value.endIndex) else {
-            return nil
+            return false
         }
-        let fileExtension = value[value.index(after: dot)...].lowercased()
-        switch fileExtension {
+        switch value[value.index(after: dot)...].lowercased() {
         case "c", "cc", "cpp", "css", "go", "h", "hpp", "html", "java",
              "js", "jsx", "json", "m", "md", "mm", "php", "py", "rb", "rs",
              "sh", "swift", "toml", "ts", "tsx", "txt", "yaml", "yml", "zsh":
-            return fileExtension
+            return true
         default:
-            return nil
+            return false
         }
     }
-
-    private static func stem(_ value: some StringProtocol) -> String {
-        guard let dot = value.lastIndex(of: ".") else { return value.lowercased() }
-        return value[..<dot].lowercased()
-    }
-
-    private static let commonSourceBasenames: Set<String> = [
-        "app", "config", "index", "main", "package", "readme", "server",
-    ]
-
-    private static let fileExtensionTopLevelDomains: Set<String> = [
-        "cc", "md", "mm", "py", "rs", "sh",
-    ]
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -117,6 +117,7 @@ public struct TerminalLinkRouter: Sendable {
         if Self.commonSourceBasenames.contains(stem(fileReference)) { return true }
         if Self.fileExtensionTopLevelDomains.contains(fileExtension),
            let port = trailingNumericSuffix(value),
+           hasSingleLocationSuffix(value, after: fileReference),
            isValidPort(port) {
             return false
         }
@@ -187,6 +188,14 @@ public struct TerminalLinkRouter: Sendable {
     private static func trailingNumericSuffix(_ value: String) -> Substring? {
         guard let colon = value.lastIndex(of: ":") else { return nil }
         return value[value.index(after: colon)...]
+    }
+
+    private static func hasSingleLocationSuffix(
+        _ value: String,
+        after fileReference: some StringProtocol
+    ) -> Bool {
+        guard let colon = value.lastIndex(of: ":") else { return false }
+        return value[..<colon].elementsEqual(fileReference)
     }
 
     private static func isValidPort(_ value: some StringProtocol) -> Bool {

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -46,6 +46,13 @@ public struct TerminalLinkRouter: Sendable {
             return .external(URL(fileURLWithPath: trimmed))
         }
 
+        if Self.looksLikeFileLineToken(trimmed) {
+            #if DEBUG
+            logDebugEvent("link.resolve result=nil (fileLine)")
+            #endif
+            return nil
+        }
+
         if let webURL = schemelessWebURL(from: trimmed) {
             #if DEBUG
             logDebugEvent("link.resolve result=embeddedBrowser(schemeless) url=\(webURL)")
@@ -105,7 +112,35 @@ public struct TerminalLinkRouter: Sendable {
               colon < value.index(before: value.endIndex) else {
             return false
         }
-        return value[value.index(after: colon)...].allSatisfy(\.isNumber)
+        guard value[value.index(after: colon)...].allSatisfy(\.isNumber) else {
+            return false
+        }
+        let hostCandidate = String(value[..<colon])
+        return !looksLikeFileLineHost(hostCandidate)
+    }
+
+    private static func looksLikeFileLineToken(_ value: String) -> Bool {
+        guard let colon = value.lastIndex(of: ":"),
+              colon < value.index(before: value.endIndex),
+              value[value.index(after: colon)...].allSatisfy(\.isNumber) else {
+            return false
+        }
+        return looksLikeFileLineHost(String(value[..<colon]))
+    }
+
+    private static func looksLikeFileLineHost(_ hostCandidate: String) -> Bool {
+        guard let dot = hostCandidate.lastIndex(of: "."),
+              dot < hostCandidate.index(before: hostCandidate.endIndex) else {
+            return false
+        }
+        switch hostCandidate[hostCandidate.index(after: dot)...].lowercased() {
+        case "c", "cc", "cpp", "css", "go", "h", "hpp", "html", "java",
+             "js", "jsx", "json", "m", "md", "mm", "php", "py", "rb", "rs",
+             "sh", "swift", "toml", "ts", "tsx", "txt", "yaml", "yml", "zsh":
+            return true
+        default:
+            return false
+        }
     }
 
     private static func schemelessWebScheme(for normalizedHost: String) -> String? {

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -9,6 +9,7 @@ import CMUXDebugLog
 /// Routing precedence: absolute file-system paths open externally; `http` and
 /// `https` URLs open embedded when the injected ``BrowserHostNormalizing``
 /// accepts their host, externally otherwise; other schemes open externally;
+/// accepted scheme-less `host/path` text opens embedded as HTTPS; other
 /// scheme-less text that did not already resolve through the caller's
 /// file-path pass is ignored.
 public struct TerminalLinkRouter: Sendable {
@@ -65,9 +66,28 @@ public struct TerminalLinkRouter: Sendable {
             return .external(parsed)
         }
 
+        if let webURL = schemelessHostPathURL(from: trimmed) {
+            #if DEBUG
+            logDebugEvent("link.resolve result=embeddedBrowser(schemeless) url=\(webURL)")
+            #endif
+            return .embeddedBrowser(webURL)
+        }
+
         #if DEBUG
         logDebugEvent("link.resolve result=nil (schemeless)")
         #endif
         return nil
+    }
+
+    private func schemelessHostPathURL(from trimmed: String) -> URL? {
+        guard trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              let slashIndex = trimmed.firstIndex(of: "/"),
+              slashIndex > trimmed.startIndex else {
+            return nil
+        }
+
+        let hostCandidate = String(trimmed[..<slashIndex])
+        guard hostNormalizer.normalizedHost(hostCandidate) != nil else { return nil }
+        return URL(string: "https://\(trimmed)")
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -9,9 +9,9 @@ import CMUXDebugLog
 /// Routing precedence: absolute file-system paths open externally; `http` and
 /// `https` URLs open embedded when the injected ``BrowserHostNormalizing``
 /// accepts their host, externally otherwise; other schemes open externally;
-/// browser-navigable scheme-less text opens embedded; terminal file references
-/// and path fragments that did not already resolve through the caller's
-/// file-path pass are ignored.
+/// browser-navigable scheme-less text opens embedded; terminal path fragments
+/// that did not already resolve through the caller's file-path pass are
+/// ignored.
 public struct TerminalLinkRouter: Sendable {
     private let hostNormalizer: any BrowserHostNormalizing
 
@@ -59,13 +59,6 @@ public struct TerminalLinkRouter: Sendable {
             }
         }
 
-        if Self.looksLikeTerminalFileReference(trimmed) {
-            #if DEBUG
-            logDebugEvent("link.resolve result=nil (fileReference)")
-            #endif
-            return nil
-        }
-
         if Self.looksLikeSingleLabelPathFragment(trimmed) {
             #if DEBUG
             logDebugEvent("link.resolve result=nil (pathFragment)")
@@ -104,45 +97,6 @@ public struct TerminalLinkRouter: Sendable {
         logDebugEvent("link.resolve result=embeddedBrowser(\(reason)) url=\(url)")
         #endif
         return .embeddedBrowser(url)
-    }
-
-    private static func looksLikeTerminalFileReference(_ value: String) -> Bool {
-        looksLikeFileLineToken(value) || looksLikeBareFileToken(value)
-    }
-
-    private static func looksLikeFileLineToken(_ value: String) -> Bool {
-        guard let colon = value.lastIndex(of: ":"),
-              colon < value.index(before: value.endIndex),
-              value[value.index(after: colon)...].allSatisfy(\.isNumber) else {
-            return false
-        }
-        return looksLikeFileLineHost(String(value[..<colon]))
-    }
-
-    private static func looksLikeBareFileToken(_ value: String) -> Bool {
-        guard value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
-              !value.contains("/") else {
-            return false
-        }
-        let end = value.firstIndex { character in
-            character == "?" || character == "#"
-        } ?? value.endIndex
-        return looksLikeFileLineHost(String(value[..<end]))
-    }
-
-    private static func looksLikeFileLineHost(_ hostCandidate: String) -> Bool {
-        guard let dot = hostCandidate.lastIndex(of: "."),
-              dot < hostCandidate.index(before: hostCandidate.endIndex) else {
-            return false
-        }
-        switch hostCandidate[hostCandidate.index(after: dot)...].lowercased() {
-        case "c", "cc", "cpp", "css", "go", "h", "hpp", "html", "java",
-             "js", "jsx", "json", "m", "md", "mm", "php", "py", "rb", "rs",
-             "sh", "swift", "toml", "ts", "tsx", "txt", "yaml", "yml", "zsh":
-            return true
-        default:
-            return false
-        }
     }
 
     private static func looksLikeSingleLabelPathFragment(_ value: String) -> Bool {

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -111,9 +111,14 @@ public struct TerminalLinkRouter: Sendable {
               let colon = value.lastIndex(of: ":"),
               colon < value.index(before: value.endIndex),
               value[value.index(after: colon)...].allSatisfy(\.isNumber),
-              hasKnownFileExtension(value[..<colon]) else {
+              let fileExtension = knownFileExtension(value[..<colon]) else {
             return false
         }
+        let fileReference = value[..<colon]
+        if fileReference.contains("/") { return true }
+        if fileReference.contains(where: \.isUppercase) { return true }
+        if Self.commonSourceBasenames.contains(stem(fileReference)) { return true }
+        if Self.fileExtensionTopLevelDomains.contains(fileExtension) { return false }
         return true
     }
 
@@ -135,21 +140,35 @@ public struct TerminalLinkRouter: Sendable {
         } ?? value.endIndex
         let path = value[pathStart..<pathEnd]
         let lastComponentStart = path.lastIndex(of: "/").map(path.index(after:)) ?? path.startIndex
-        return hasKnownFileExtension(path[lastComponentStart...])
+        return knownFileExtension(path[lastComponentStart...]) != nil
     }
 
-    private static func hasKnownFileExtension(_ value: some StringProtocol) -> Bool {
+    private static func knownFileExtension(_ value: some StringProtocol) -> String? {
         guard let dot = value.lastIndex(of: "."),
               dot < value.index(before: value.endIndex) else {
-            return false
+            return nil
         }
-        switch value[value.index(after: dot)...].lowercased() {
+        let fileExtension = value[value.index(after: dot)...].lowercased()
+        switch fileExtension {
         case "c", "cc", "cpp", "css", "go", "h", "hpp", "html", "java",
              "js", "jsx", "json", "m", "md", "mm", "php", "py", "rb", "rs",
              "sh", "swift", "toml", "ts", "tsx", "txt", "yaml", "yml", "zsh":
-            return true
+            return fileExtension
         default:
-            return false
+            return nil
         }
     }
+
+    private static func stem(_ value: some StringProtocol) -> String {
+        guard let dot = value.lastIndex(of: ".") else { return value.lowercased() }
+        return value[..<dot].lowercased()
+    }
+
+    private static let commonSourceBasenames: Set<String> = [
+        "app", "config", "index", "main", "package", "readme", "server",
+    ]
+
+    private static let fileExtensionTopLevelDomains: Set<String> = [
+        "cc", "md", "mm", "py", "rs", "sh",
+    ]
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -129,7 +129,8 @@ public struct TerminalLinkRouter: Sendable {
         }
         let hostCandidate = value[..<slash].lowercased()
         guard hostCandidate != "localhost" else { return false }
-        guard hostCandidate.rangeOfCharacter(from: CharacterSet(charactersIn: ".:[]")) == nil else {
+        guard hostCandidate.count == 1,
+              hostCandidate.rangeOfCharacter(from: CharacterSet(charactersIn: ".:[]")) == nil else {
             return false
         }
         let pathStart = value.index(after: slash)

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -9,9 +9,9 @@ import CMUXDebugLog
 /// Routing precedence: absolute file-system paths open externally; `http` and
 /// `https` URLs open embedded when the injected ``BrowserHostNormalizing``
 /// accepts their host, externally otherwise; other schemes open externally;
-/// accepted scheme-less `host/path` text opens embedded as HTTPS; other
-/// scheme-less text that did not already resolve through the caller's
-/// file-path pass is ignored.
+/// browser-navigable scheme-less text opens embedded; terminal file references
+/// and path fragments that did not already resolve through the caller's
+/// file-path pass are ignored.
 public struct TerminalLinkRouter: Sendable {
     private let hostNormalizer: any BrowserHostNormalizing
 
@@ -46,34 +46,41 @@ public struct TerminalLinkRouter: Sendable {
             return .external(URL(fileURLWithPath: trimmed))
         }
 
-        if Self.looksLikeFileLineToken(trimmed) {
+        if let parsed = URL(string: trimmed),
+           let scheme = parsed.scheme?.lowercased() {
+            if scheme == "http" || scheme == "https" {
+                return routeWebURL(parsed, reason: "explicit")
+            }
+            if scheme == "file" || scheme == "mailto" || trimmed.contains("://") {
+                #if DEBUG
+                logDebugEvent("link.resolve result=external(scheme=\(scheme)) url=\(parsed)")
+                #endif
+                return .external(parsed)
+            }
+        }
+
+        if Self.looksLikeTerminalFileReference(trimmed) {
             #if DEBUG
-            logDebugEvent("link.resolve result=nil (fileLine)")
+            logDebugEvent("link.resolve result=nil (fileReference)")
             #endif
             return nil
         }
 
-        if let webURL = schemelessWebURL(from: trimmed) {
+        if Self.looksLikeSingleLabelPathFragment(trimmed) {
             #if DEBUG
-            logDebugEvent("link.resolve result=embeddedBrowser(schemeless) url=\(webURL)")
+            logDebugEvent("link.resolve result=nil (pathFragment)")
             #endif
-            return .embeddedBrowser(webURL)
+            return nil
+        }
+
+        if let webURL = hostNormalizer.navigableWebURL(trimmed),
+           let scheme = webURL.scheme?.lowercased(),
+           scheme == "http" || scheme == "https" {
+            return routeWebURL(webURL, reason: "browser")
         }
 
         if let parsed = URL(string: trimmed),
            let scheme = parsed.scheme?.lowercased() {
-            if scheme == "http" || scheme == "https" {
-                guard hostNormalizer.normalizedHost(parsed.host ?? "") != nil else {
-                    #if DEBUG
-                    logDebugEvent("link.resolve result=external(invalidHost) url=\(parsed)")
-                    #endif
-                    return .external(parsed)
-                }
-                #if DEBUG
-                logDebugEvent("link.resolve result=embeddedBrowser url=\(parsed)")
-                #endif
-                return .embeddedBrowser(parsed)
-            }
             #if DEBUG
             logDebugEvent("link.resolve result=external(scheme=\(scheme)) url=\(parsed)")
             #endif
@@ -81,42 +88,26 @@ public struct TerminalLinkRouter: Sendable {
         }
 
         #if DEBUG
-        logDebugEvent("link.resolve result=nil (schemeless)")
+        logDebugEvent("link.resolve result=nil (unresolved)")
         #endif
         return nil
     }
 
-    private func schemelessWebURL(from trimmed: String) -> URL? {
-        guard trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else { return nil }
-
-        let hostCandidate: String
-        if let slashIndex = trimmed.firstIndex(of: "/") {
-            guard slashIndex > trimmed.startIndex else { return nil }
-            hostCandidate = String(trimmed[..<slashIndex])
-            guard !hostCandidate.hasSuffix(":") else { return nil }
-        } else if Self.hasNumericPort(trimmed) {
-            hostCandidate = trimmed
-        } else {
-            return nil
+    private func routeWebURL(_ url: URL, reason: String) -> TerminalOpenURLTarget {
+        guard hostNormalizer.normalizedHost(url.host ?? "") != nil else {
+            #if DEBUG
+            logDebugEvent("link.resolve result=external(\(reason),invalidHost) url=\(url)")
+            #endif
+            return .external(url)
         }
-
-        guard let normalizedHost = hostNormalizer.normalizedHost(hostCandidate),
-              let scheme = Self.schemelessWebScheme(for: normalizedHost) else {
-            return nil
-        }
-        return URL(string: "\(scheme)://\(trimmed)")
+        #if DEBUG
+        logDebugEvent("link.resolve result=embeddedBrowser(\(reason)) url=\(url)")
+        #endif
+        return .embeddedBrowser(url)
     }
 
-    private static func hasNumericPort(_ value: String) -> Bool {
-        guard let colon = value.lastIndex(of: ":"),
-              colon < value.index(before: value.endIndex) else {
-            return false
-        }
-        guard value[value.index(after: colon)...].allSatisfy(\.isNumber) else {
-            return false
-        }
-        let hostCandidate = String(value[..<colon])
-        return !looksLikeFileLineHost(hostCandidate)
+    private static func looksLikeTerminalFileReference(_ value: String) -> Bool {
+        looksLikeFileLineToken(value) || looksLikeBareFileToken(value)
     }
 
     private static func looksLikeFileLineToken(_ value: String) -> Bool {
@@ -126,6 +117,17 @@ public struct TerminalLinkRouter: Sendable {
             return false
         }
         return looksLikeFileLineHost(String(value[..<colon]))
+    }
+
+    private static func looksLikeBareFileToken(_ value: String) -> Bool {
+        guard value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              !value.contains("/") else {
+            return false
+        }
+        let end = value.firstIndex { character in
+            character == "?" || character == "#"
+        } ?? value.endIndex
+        return looksLikeFileLineHost(String(value[..<end]))
     }
 
     private static func looksLikeFileLineHost(_ hostCandidate: String) -> Bool {
@@ -143,16 +145,14 @@ public struct TerminalLinkRouter: Sendable {
         }
     }
 
-    private static func schemelessWebScheme(for normalizedHost: String) -> String? {
-        if normalizedHost == "localhost"
-            || normalizedHost == "127.0.0.1"
-            || normalizedHost == "::1"
-            || normalizedHost.hasSuffix(".localhost") {
-            return "http"
+    private static func looksLikeSingleLabelPathFragment(_ value: String) -> Bool {
+        guard value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              let slash = value.firstIndex(of: "/"),
+              slash > value.startIndex else {
+            return false
         }
-        if normalizedHost.contains(".") || normalizedHost.contains(":") {
-            return "https"
-        }
-        return nil
+        let hostCandidate = value[..<slash].lowercased()
+        guard hostCandidate != "localhost" else { return false }
+        return hostCandidate.rangeOfCharacter(from: CharacterSet(charactersIn: ".:[]")) == nil
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -108,21 +108,34 @@ public struct TerminalLinkRouter: Sendable {
 
     private static func looksLikeUnresolvedFileLineReference(_ value: String) -> Bool {
         guard value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
-              let colon = value.lastIndex(of: ":"),
-              colon < value.index(before: value.endIndex),
-              value[value.index(after: colon)...].allSatisfy(\.isNumber),
-              let fileExtension = knownFileExtension(value[..<colon]) else {
+              let fileReference = fileReferenceBeforeLocationSuffix(value),
+              let fileExtension = knownFileExtension(fileReference) else {
             return false
         }
-        let fileReference = value[..<colon]
         if fileReference.contains("/") { return true }
         if fileReference.contains(where: \.isUppercase) { return true }
         if Self.commonSourceBasenames.contains(stem(fileReference)) { return true }
         if Self.fileExtensionTopLevelDomains.contains(fileExtension),
-           isWebLikePort(value[value.index(after: colon)...]) {
+           let port = trailingNumericSuffix(value),
+           isWebLikePort(port) {
             return false
         }
         return true
+    }
+
+    private static func fileReferenceBeforeLocationSuffix(_ value: String) -> Substring? {
+        guard let lastColon = value.lastIndex(of: ":"),
+              lastColon < value.index(before: value.endIndex),
+              value[value.index(after: lastColon)...].allSatisfy(\.isNumber) else {
+            return nil
+        }
+        let beforeLastColon = value[..<lastColon]
+        if let lineColon = beforeLastColon.lastIndex(of: ":"),
+           lineColon < beforeLastColon.index(before: beforeLastColon.endIndex),
+           beforeLastColon[beforeLastColon.index(after: lineColon)...].allSatisfy(\.isNumber) {
+            return beforeLastColon[..<lineColon]
+        }
+        return beforeLastColon
     }
 
     private static func looksLikeWrappedFilePathFragment(_ value: String) -> Bool {
@@ -144,6 +157,9 @@ public struct TerminalLinkRouter: Sendable {
         let path = value[pathStart..<pathEnd]
         let lastComponentStart = path.lastIndex(of: "/").map(path.index(after:)) ?? path.startIndex
         let lastComponent = path[lastComponentStart...]
+        // The Ghostty callback gives Swift only selected text, not the click
+        // pin or wrapped logical line. Keep the fail-closed guard to the
+        // reported wrapped suffix shape instead of all one-letter hosts.
         return knownFileExtension(lastComponent) == "md" && lastComponent.contains("-")
     }
 
@@ -166,6 +182,11 @@ public struct TerminalLinkRouter: Sendable {
     private static func stem(_ value: some StringProtocol) -> String {
         guard let dot = value.lastIndex(of: ".") else { return value.lowercased() }
         return value[..<dot].lowercased()
+    }
+
+    private static func trailingNumericSuffix(_ value: String) -> Substring? {
+        guard let colon = value.lastIndex(of: ":") else { return nil }
+        return value[value.index(after: colon)...]
     }
 
     private static func isWebLikePort(_ value: some StringProtocol) -> Bool {

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/LinkRouting/TerminalLinkRouter.swift
@@ -114,6 +114,7 @@ public struct TerminalLinkRouter: Sendable {
               hasKnownFileExtension(value[..<colon]) else {
             return false
         }
+        if value[..<colon].contains("/") { return true }
         guard !value[..<colon].contains(where: \.isUppercase),
               let port = Int(value[value.index(after: colon)...]) else {
             return true

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -3,7 +3,7 @@ import Testing
 import CmuxTerminalCore
 
 /// A deterministic stand-in for the browser domain: hosts containing a dot or
-/// equal to localhost are accepted for explicit web URLs.
+/// equal to localhost are accepted.
 private struct StubHostNormalizer: BrowserHostNormalizing {
     var rejectsEveryHost = false
 
@@ -30,8 +30,15 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.path == "/path")
     }
 
-    @Test func schemelessBareDomainResolvesToNil() {
-        #expect(router.resolveOpenURLTarget("example.com/docs") == nil)
+    @Test func schemelessHostPathResolvesAsEmbeddedBrowser() throws {
+        let target = try #require(router.resolveOpenURLTarget("example.com/docs"))
+        guard case let .embeddedBrowser(url) = target else {
+            Issue.record("Expected host-like schemeless path to route to embedded browser")
+            return
+        }
+        #expect(url.scheme == "https")
+        #expect(url.host == "example.com")
+        #expect(url.path == "/docs")
     }
 
     @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {
@@ -96,9 +103,13 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.host == "example.com")
     }
 
-    @Test func rejectedHostDoesNotAffectSchemelessText() {
+    @Test func rejectedHostLeavesSchemelessTextUnresolved() {
         let rejecting = TerminalLinkRouter(hostNormalizer: StubHostNormalizer(rejectsEveryHost: true))
         #expect(rejecting.resolveOpenURLTarget("example.com/docs") == nil)
+    }
+
+    @Test func schemelessHostWithoutPathResolvesToNil() {
+        #expect(router.resolveOpenURLTarget("example.com") == nil)
     }
 
     @Test func emptyTextResolvesToNil() {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -147,6 +147,9 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("README.md:12") == nil)
         #expect(router.resolveOpenURLTarget("App.swift:42") == nil)
         #expect(router.resolveOpenURLTarget("main.swift:42") == nil)
+        #expect(router.resolveOpenURLTarget("main.swift:443") == nil)
+        #expect(router.resolveOpenURLTarget("index.ts:3000") == nil)
+        #expect(router.resolveOpenURLTarget("server.go:8080") == nil)
         #expect(router.resolveOpenURLTarget("src/main.swift:3000") == nil)
         #expect(router.resolveOpenURLTarget("Sources/App.swift:8080") == nil)
     }
@@ -234,17 +237,6 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
             #expect(url.scheme == expectedScheme)
             #expect(url.host == expectedHost)
         }
-    }
-
-    @Test func schemelessFileLikeHostPortResolvesAsEmbeddedBrowser() throws {
-        let target = try #require(router.resolveOpenURLTarget("example.swift:443"))
-        guard case let .embeddedBrowser(url) = target else {
-            Issue.record("Expected file-like TLD host:port to route through browser normalization")
-            return
-        }
-        #expect(url.scheme == "https")
-        #expect(url.host == "example.swift")
-        #expect(url.port == 443)
     }
 
     @Test func emptyTextResolvesToNil() {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -145,7 +145,6 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
 
     @Test func fileLineTokensDoNotResolveAsHostPorts() {
         #expect(router.resolveOpenURLTarget("README.md:12") == nil)
-        #expect(router.resolveOpenURLTarget("README.md:443") == nil)
         #expect(router.resolveOpenURLTarget("App.swift:42") == nil)
         #expect(router.resolveOpenURLTarget("main.swift:42") == nil)
         #expect(router.resolveOpenURLTarget("main.swift:443") == nil)
@@ -153,23 +152,6 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("server.go:8080") == nil)
         #expect(router.resolveOpenURLTarget("src/main.swift:3000") == nil)
         #expect(router.resolveOpenURLTarget("Sources/App.swift:8080") == nil)
-    }
-
-    @Test func schemelessFileLikeTLDHostPortsResolveAsEmbeddedBrowser() throws {
-        for (rawValue, expectedHost) in [
-            ("docs.rs:443", "docs.rs"),
-            ("bun.sh:443", "bun.sh"),
-            ("example.md:443", "example.md"),
-        ] {
-            let target = try #require(router.resolveOpenURLTarget(rawValue))
-            guard case let .embeddedBrowser(url) = target else {
-                Issue.record("Expected file-like TLD host:port to route through browser normalization")
-                return
-            }
-            #expect(url.scheme == "https")
-            #expect(url.host == expectedHost)
-            #expect(url.port == 443)
-        }
     }
 
     @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -59,6 +59,11 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.port == 8443)
     }
 
+    @Test func fileLineTokensDoNotResolveAsHostPorts() {
+        #expect(router.resolveOpenURLTarget("README.md:12") == nil)
+        #expect(router.resolveOpenURLTarget("App.swift:42") == nil)
+    }
+
     @Test func schemelessLoopbackPathResolvesAsHTTPEmbeddedBrowser() throws {
         for (rawValue, expectedHost, expectedPort, expectedPath) in [
             ("localhost:3000", "localhost", 3000, ""),

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -98,6 +98,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
             ("0.0.0.0.evil.example/docs", "0.0.0.0.evil.example", "/docs"),
             ("grafana/dashboard", "grafana", "/dashboard"),
             ("grafana/dashboard.json", "grafana", "/dashboard.json"),
+            ("s/dashboard.json", "s", "/dashboard.json"),
+            ("x/app.js", "x", "/app.js"),
             ("wiki/docs/intro.md", "wiki", "/docs/intro.md"),
             ("gitlab/group/project/README.md", "gitlab", "/group/project/README.md"),
         ] {
@@ -145,13 +147,34 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
 
     @Test func fileLineTokensDoNotResolveAsHostPorts() {
         #expect(router.resolveOpenURLTarget("README.md:12") == nil)
+        #expect(router.resolveOpenURLTarget("README.md:443") == nil)
         #expect(router.resolveOpenURLTarget("App.swift:42") == nil)
+        #expect(router.resolveOpenURLTarget("utils.py:42") == nil)
+        #expect(router.resolveOpenURLTarget("lib.rs:10") == nil)
         #expect(router.resolveOpenURLTarget("main.swift:42") == nil)
         #expect(router.resolveOpenURLTarget("main.swift:443") == nil)
         #expect(router.resolveOpenURLTarget("index.ts:3000") == nil)
         #expect(router.resolveOpenURLTarget("server.go:8080") == nil)
         #expect(router.resolveOpenURLTarget("src/main.swift:3000") == nil)
         #expect(router.resolveOpenURLTarget("Sources/App.swift:8080") == nil)
+    }
+
+    @Test func fileLikeTLDHostPortsResolveAsEmbeddedBrowser() throws {
+        for (rawValue, expectedHost, expectedPort) in [
+            ("docs.rs:443", "docs.rs", 443),
+            ("bun.sh:443", "bun.sh", 443),
+            ("example.md:443", "example.md", 443),
+            ("docs.md:8123", "docs.md", 8123),
+        ] {
+            let target = try #require(router.resolveOpenURLTarget(rawValue))
+            guard case let .embeddedBrowser(url) = target else {
+                Issue.record("Expected file-like TLD host:port to route through browser normalization")
+                return
+            }
+            #expect(url.scheme == "https")
+            #expect(url.host == expectedHost)
+            #expect(url.port == expectedPort)
+        }
     }
 
     @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -168,6 +168,9 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("Sources/App.swift:42:17") == nil)
         #expect(router.resolveOpenURLTarget("models.py:10:2") == nil)
         #expect(router.resolveOpenURLTarget("docs.rs:12:5") == nil)
+        #expect(router.resolveOpenURLTarget("docs.md:12") == nil)
+        #expect(router.resolveOpenURLTarget("models.py:10") == nil)
+        #expect(router.resolveOpenURLTarget("deploy.sh:2") == nil)
     }
 
     @Test func fileLikeTLDHostPortsResolveAsEmbeddedBrowser() throws {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -2,8 +2,7 @@ import Foundation
 import Testing
 import CmuxTerminalCore
 
-/// A deterministic stand-in for the browser domain: hosts containing a dot or
-/// equal to localhost are accepted.
+/// A deterministic stand-in for the app normalizer, which accepts non-empty hosts.
 private struct StubHostNormalizer: BrowserHostNormalizing {
     var rejectsEveryHost = false
 
@@ -11,7 +10,6 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         guard !rejectsEveryHost else { return nil }
         let trimmed = rawHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !trimmed.isEmpty else { return nil }
-        guard trimmed.contains(".") || trimmed == "localhost" else { return nil }
         return trimmed
     }
 }
@@ -38,6 +36,18 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         }
         #expect(url.scheme == "https")
         #expect(url.host == "example.com")
+        #expect(url.path == "/docs")
+    }
+
+    @Test func schemelessLocalhostPathResolvesAsEmbeddedBrowser() throws {
+        let target = try #require(router.resolveOpenURLTarget("localhost:3000/docs"))
+        guard case let .embeddedBrowser(url) = target else {
+            Issue.record("Expected localhost schemeless path to route to embedded browser")
+            return
+        }
+        #expect(url.scheme == "https")
+        #expect(url.host == "localhost")
+        #expect(url.port == 3000)
         #expect(url.path == "/docs")
     }
 

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -171,7 +171,9 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
     @Test func fileLikeTLDHostPortsResolveAsEmbeddedBrowser() throws {
         for (rawValue, expectedHost, expectedPort) in [
             ("docs.rs:443", "docs.rs", 443),
+            ("docs.rs:808", "docs.rs", 808),
             ("bun.sh:443", "bun.sh", 443),
+            ("example.md:500", "example.md", 500),
             ("example.md:443", "example.md", 443),
             ("docs.md:8123", "docs.md", 8123),
         ] {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -28,9 +28,10 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         guard !trimmed.isEmpty, !trimmed.contains(" ") else { return nil }
         let lower = trimmed.lowercased()
         let bareHost = Self.bareHostCandidate(lower)
-        if bareHost == "localhost" || bareHost == "127.0.0.1" ||
-            bareHost == "0.0.0.0" || lower.hasPrefix("[::1]") ||
-            (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
+        let normalizedBareHost = bareHost.trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        if normalizedBareHost == "localhost" || normalizedBareHost == "127.0.0.1" ||
+            normalizedBareHost == "0.0.0.0" || lower.hasPrefix("[::1]") ||
+            normalizedBareHost.hasSuffix(".localhost") {
             return URL(string: "http://\(trimmed)")
         }
         if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() {
@@ -129,9 +130,11 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         for (rawValue, expectedHost, expectedPort, expectedPath) in [
             ("localhost:3000", "localhost", 3000, ""),
             ("localhost:3000/docs", "localhost", 3000, "/docs"),
+            ("localhost.:3000/docs", "localhost.", 3000, "/docs"),
             ("127.0.0.1:5173/docs", "127.0.0.1", 5173, "/docs"),
             ("0.0.0.0:5173/docs", "0.0.0.0", 5173, "/docs"),
             ("deep.api.localhost/docs", "deep.api.localhost", nil, "/docs"),
+            ("api.localhost.:3000/docs", "api.localhost.", 3000, "/docs"),
         ] {
             let target = try #require(router.resolveOpenURLTarget(rawValue))
             guard case let .embeddedBrowser(url) = target else {
@@ -151,6 +154,10 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("App.swift:42") == nil)
         #expect(router.resolveOpenURLTarget("utils.py:42") == nil)
         #expect(router.resolveOpenURLTarget("lib.rs:10") == nil)
+        #expect(router.resolveOpenURLTarget("foo.py:443") == nil)
+        #expect(router.resolveOpenURLTarget("changelog.md:443") == nil)
+        #expect(router.resolveOpenURLTarget("build.rs:8080") == nil)
+        #expect(router.resolveOpenURLTarget("script.sh:1024") == nil)
         #expect(router.resolveOpenURLTarget("main.swift:42") == nil)
         #expect(router.resolveOpenURLTarget("main.swift:443") == nil)
         #expect(router.resolveOpenURLTarget("index.ts:3000") == nil)

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -145,6 +145,7 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
 
     @Test func fileLineTokensDoNotResolveAsHostPorts() {
         #expect(router.resolveOpenURLTarget("README.md:12") == nil)
+        #expect(router.resolveOpenURLTarget("README.md:443") == nil)
         #expect(router.resolveOpenURLTarget("App.swift:42") == nil)
         #expect(router.resolveOpenURLTarget("main.swift:42") == nil)
         #expect(router.resolveOpenURLTarget("main.swift:443") == nil)
@@ -152,6 +153,23 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("server.go:8080") == nil)
         #expect(router.resolveOpenURLTarget("src/main.swift:3000") == nil)
         #expect(router.resolveOpenURLTarget("Sources/App.swift:8080") == nil)
+    }
+
+    @Test func schemelessFileLikeTLDHostPortsResolveAsEmbeddedBrowser() throws {
+        for (rawValue, expectedHost) in [
+            ("docs.rs:443", "docs.rs"),
+            ("bun.sh:443", "bun.sh"),
+            ("example.md:443", "example.md"),
+        ] {
+            let target = try #require(router.resolveOpenURLTarget(rawValue))
+            guard case let .embeddedBrowser(url) = target else {
+                Issue.record("Expected file-like TLD host:port to route through browser normalization")
+                return
+            }
+            #expect(url.scheme == "https")
+            #expect(url.host == expectedHost)
+            #expect(url.port == 443)
+        }
     }
 
     @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -3,8 +3,7 @@ import Testing
 import CmuxTerminalCore
 
 /// A deterministic stand-in for the browser domain: hosts containing a dot or
-/// equal to localhost are navigable, and scheme-less host-ish text becomes an
-/// HTTPS URL the way the embedded browser's omnibox would treat it.
+/// equal to localhost are accepted for explicit web URLs.
 private struct StubHostNormalizer: BrowserHostNormalizing {
     var rejectsEveryHost = false
 
@@ -14,14 +13,6 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         guard !trimmed.isEmpty else { return nil }
         guard trimmed.contains(".") || trimmed == "localhost" else { return nil }
         return trimmed
-    }
-
-    func navigableWebURL(_ input: String) -> URL? {
-        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, !trimmed.contains(" ") else { return nil }
-        if URL(string: trimmed)?.scheme != nil { return URL(string: trimmed) }
-        guard trimmed.contains(".") || trimmed.lowercased().hasPrefix("localhost") else { return nil }
-        return URL(string: "https://\(trimmed)")
     }
 }
 
@@ -39,15 +30,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.path == "/path")
     }
 
-    @Test func resolvesBareDomainAsEmbeddedBrowser() throws {
-        let target = try #require(router.resolveOpenURLTarget("example.com/docs"))
-        guard case let .embeddedBrowser(url) = target else {
-            Issue.record("Expected bare domain to be normalized as an HTTPS browser URL")
-            return
-        }
-        #expect(url.scheme == "https")
-        #expect(url.host == "example.com")
-        #expect(url.path == "/docs")
+    @Test func schemelessBareDomainResolvesToNil() {
+        #expect(router.resolveOpenURLTarget("example.com/docs") == nil)
     }
 
     @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {
@@ -112,19 +96,9 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.host == "example.com")
     }
 
-    @Test func rejectedHostRoutesBareDomainExternally() throws {
-        let rejecting = TerminalLinkRouter(
-            hostNormalizer: StubHostNormalizer(rejectsEveryHost: true)
-        )
-        // The rejecting stub also refuses navigableWebURL inputs only at the
-        // host check, so build one that still yields a URL but fails the host
-        // gate: navigableWebURL is unaffected by rejectsEveryHost.
-        let target = rejecting.resolveOpenURLTarget("example.com/docs")
-        guard case let .external(url)? = target else {
-            Issue.record("Expected bare domain with rejected host to open externally")
-            return
-        }
-        #expect(url.host == "example.com")
+    @Test func rejectedHostDoesNotAffectSchemelessText() {
+        let rejecting = TerminalLinkRouter(hostNormalizer: StubHostNormalizer(rejectsEveryHost: true))
+        #expect(rejecting.resolveOpenURLTarget("example.com/docs") == nil)
     }
 
     @Test func emptyTextResolvesToNil() {
@@ -132,18 +106,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("   \n") == nil)
     }
 
-    @Test func nonNavigableTokenFallsBackToExternalURL() {
-        // Scheme-less text the browser cannot navigate still becomes an
-        // external URL when Foundation can parse it as a relative URL.
-        // (Multi-word text is deliberately not asserted here: URL(string:)
-        // rejects spaces on macOS 14/15 but percent-encodes them on newer
-        // Foundation, so its routing is OS-dependent.)
-        let target = router.resolveOpenURLTarget("foo_bar")
-        guard case let .external(url)? = target else {
-            Issue.record("Expected non-navigable token to fall back to external routing")
-            return
-        }
-        #expect(url.absoluteString == "foo_bar")
+    @Test func schemelessNonPathTokenResolvesToNil() {
+        #expect(router.resolveOpenURLTarget("foo_bar") == nil)
     }
 
     @Test func openTargetURLAccessorReturnsDestination() throws {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -147,6 +147,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("README.md:12") == nil)
         #expect(router.resolveOpenURLTarget("App.swift:42") == nil)
         #expect(router.resolveOpenURLTarget("main.swift:42") == nil)
+        #expect(router.resolveOpenURLTarget("src/main.swift:3000") == nil)
+        #expect(router.resolveOpenURLTarget("Sources/App.swift:8080") == nil)
     }
 
     @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -48,11 +48,23 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.path == "/docs")
     }
 
+    @Test func schemelessDottedHostPortResolvesAsEmbeddedBrowser() throws {
+        let target = try #require(router.resolveOpenURLTarget("example.com:8443"))
+        guard case let .embeddedBrowser(url) = target else {
+            Issue.record("Expected host:port schemeless token to route to embedded browser")
+            return
+        }
+        #expect(url.scheme == "https")
+        #expect(url.host == "example.com")
+        #expect(url.port == 8443)
+    }
+
     @Test func schemelessLoopbackPathResolvesAsHTTPEmbeddedBrowser() throws {
-        for (rawValue, expectedHost, expectedPort) in [
-            ("localhost:3000/docs", "localhost", 3000),
-            ("127.0.0.1:5173/docs", "127.0.0.1", 5173),
-            ("deep.api.localhost/docs", "deep.api.localhost", nil),
+        for (rawValue, expectedHost, expectedPort, expectedPath) in [
+            ("localhost:3000", "localhost", 3000, ""),
+            ("localhost:3000/docs", "localhost", 3000, "/docs"),
+            ("127.0.0.1:5173/docs", "127.0.0.1", 5173, "/docs"),
+            ("deep.api.localhost/docs", "deep.api.localhost", nil, "/docs"),
         ] {
             let target = try #require(router.resolveOpenURLTarget(rawValue))
             guard case let .embeddedBrowser(url) = target else {
@@ -62,7 +74,7 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
             #expect(url.scheme == "http")
             #expect(url.host == expectedHost)
             #expect(url.port == expectedPort)
-            #expect(url.path == "/docs")
+            #expect(url.path == expectedPath)
         }
     }
 

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -28,9 +28,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         guard !trimmed.isEmpty, !trimmed.contains(" ") else { return nil }
         let lower = trimmed.lowercased()
         let bareHost = Self.bareHostCandidate(lower)
-        if lower.hasPrefix("localhost") ||
-            lower.hasPrefix("127.0.0.1") ||
-            lower.hasPrefix("[::1]") ||
+        if lower.hasPrefix("localhost") || lower.hasPrefix("127.0.0.1") ||
+            lower.hasPrefix("0.0.0.0") || lower.hasPrefix("[::1]") ||
             (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
             return URL(string: "http://\(trimmed)")
         }
@@ -125,6 +124,7 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
             ("localhost:3000", "localhost", 3000, ""),
             ("localhost:3000/docs", "localhost", 3000, "/docs"),
             ("127.0.0.1:5173/docs", "127.0.0.1", 5173, "/docs"),
+            ("0.0.0.0:5173/docs", "0.0.0.0", 5173, "/docs"),
             ("deep.api.localhost/docs", "deep.api.localhost", nil, "/docs"),
         ] {
             let target = try #require(router.resolveOpenURLTarget(rawValue))

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -28,8 +28,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         guard !trimmed.isEmpty, !trimmed.contains(" ") else { return nil }
         let lower = trimmed.lowercased()
         let bareHost = Self.bareHostCandidate(lower)
-        if lower.hasPrefix("localhost") || lower.hasPrefix("127.0.0.1") ||
-            lower.hasPrefix("0.0.0.0") || lower.hasPrefix("[::1]") ||
+        if bareHost == "localhost" || bareHost == "127.0.0.1" ||
+            bareHost == "0.0.0.0" || lower.hasPrefix("[::1]") ||
             (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
             return URL(string: "http://\(trimmed)")
         }
@@ -93,13 +93,13 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
     }
 
     @Test func schemelessHostPathResolvesAsEmbeddedBrowser() throws {
-        let target = try #require(router.resolveOpenURLTarget("example.com/docs"))
+        let target = try #require(router.resolveOpenURLTarget("0.0.0.0.evil.example/docs"))
         guard case let .embeddedBrowser(url) = target else {
             Issue.record("Expected host-like schemeless path to route to embedded browser")
             return
         }
         #expect(url.scheme == "https")
-        #expect(url.host == "example.com")
+        #expect(url.host == "0.0.0.0.evil.example")
         #expect(url.path == "/docs")
     }
 
@@ -112,11 +112,6 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.scheme == "https")
         #expect(url.host == "example.com")
         #expect(url.port == 8443)
-    }
-
-    @Test func fileLineTokensDoNotResolveAsHostPorts() {
-        #expect(router.resolveOpenURLTarget("README.md:12") == nil)
-        #expect(router.resolveOpenURLTarget("App.swift:42") == nil)
     }
 
     @Test func schemelessLoopbackPathResolvesAsHTTPEmbeddedBrowser() throws {
@@ -145,10 +140,7 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
     }
 
     @Test func unresolvedRelativePathDoesNotResolveAsHTTPSURL() {
-        let target = router.resolveOpenURLTarget("README.md")
-        #expect(target == nil)
-        #expect(router.resolveOpenURLTarget("README.md#L12") == nil)
-        #expect(router.resolveOpenURLTarget("README.md?raw=1") == nil)
+        #expect(router.resolveOpenURLTarget("foo_bar") == nil)
     }
 
     @Test func resolvesFileSchemeAsExternal() throws {
@@ -212,6 +204,9 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         for (rawValue, expectedHost, expectedScheme) in [
             ("example.com", "example.com", "https"),
             ("example.com?x=1", "example.com", "https"),
+            ("bun.sh", "bun.sh", "https"),
+            ("docs.rs", "docs.rs", "https"),
+            ("example.md", "example.md", "https"),
             ("localhost", "localhost", "http"),
         ] {
             let target = try #require(router.resolveOpenURLTarget(rawValue))
@@ -222,6 +217,17 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
             #expect(url.scheme == expectedScheme)
             #expect(url.host == expectedHost)
         }
+    }
+
+    @Test func schemelessFileLikeHostPortResolvesAsEmbeddedBrowser() throws {
+        let target = try #require(router.resolveOpenURLTarget("example.swift:443"))
+        guard case let .embeddedBrowser(url) = target else {
+            Issue.record("Expected file-like TLD host:port to route through browser normalization")
+            return
+        }
+        #expect(url.scheme == "https")
+        #expect(url.host == "example.swift")
+        #expect(url.port == 443)
     }
 
     @Test func emptyTextResolvesToNil() {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -50,6 +50,16 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.path == "/docs")
     }
 
+    @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {
+        let target = router.resolveOpenURLTarget("s/pipeline-failure-state-model.md")
+        #expect(target == nil)
+    }
+
+    @Test func unresolvedRelativePathDoesNotResolveAsHTTPSURL() {
+        let target = router.resolveOpenURLTarget("README.md")
+        #expect(target == nil)
+    }
+
     @Test func resolvesFileSchemeAsExternal() throws {
         let target = try #require(router.resolveOpenURLTarget("file:///tmp/cmux.txt"))
         guard case let .external(url) = target else {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -157,6 +157,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("server.go:8080") == nil)
         #expect(router.resolveOpenURLTarget("src/main.swift:3000") == nil)
         #expect(router.resolveOpenURLTarget("Sources/App.swift:8080") == nil)
+        #expect(router.resolveOpenURLTarget("App.swift:42:17") == nil)
+        #expect(router.resolveOpenURLTarget("Sources/App.swift:42:17") == nil)
     }
 
     @Test func fileLikeTLDHostPortsResolveAsEmbeddedBrowser() throws {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -166,6 +166,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(router.resolveOpenURLTarget("Sources/App.swift:8080") == nil)
         #expect(router.resolveOpenURLTarget("App.swift:42:17") == nil)
         #expect(router.resolveOpenURLTarget("Sources/App.swift:42:17") == nil)
+        #expect(router.resolveOpenURLTarget("models.py:10:2") == nil)
+        #expect(router.resolveOpenURLTarget("docs.rs:12:5") == nil)
     }
 
     @Test func fileLikeTLDHostPortsResolveAsEmbeddedBrowser() throws {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -97,6 +97,9 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
             ("example.com/docs", "example.com", "/docs"),
             ("0.0.0.0.evil.example/docs", "0.0.0.0.evil.example", "/docs"),
             ("grafana/dashboard", "grafana", "/dashboard"),
+            ("grafana/dashboard.json", "grafana", "/dashboard.json"),
+            ("wiki/docs/intro.md", "wiki", "/docs/intro.md"),
+            ("gitlab/group/project/README.md", "gitlab", "/group/project/README.md"),
         ] {
             let target = try #require(router.resolveOpenURLTarget(rawValue))
             guard case let .embeddedBrowser(url) = target else {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -93,14 +93,20 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
     }
 
     @Test func schemelessHostPathResolvesAsEmbeddedBrowser() throws {
-        let target = try #require(router.resolveOpenURLTarget("0.0.0.0.evil.example/docs"))
-        guard case let .embeddedBrowser(url) = target else {
-            Issue.record("Expected host-like schemeless path to route to embedded browser")
-            return
+        for (rawValue, expectedHost, expectedPath) in [
+            ("example.com/docs", "example.com", "/docs"),
+            ("0.0.0.0.evil.example/docs", "0.0.0.0.evil.example", "/docs"),
+            ("grafana/dashboard", "grafana", "/dashboard"),
+        ] {
+            let target = try #require(router.resolveOpenURLTarget(rawValue))
+            guard case let .embeddedBrowser(url) = target else {
+                Issue.record("Expected host-like schemeless path to route to embedded browser")
+                return
+            }
+            #expect(url.scheme == "https")
+            #expect(url.host == expectedHost)
+            #expect(url.path == expectedPath)
         }
-        #expect(url.scheme == "https")
-        #expect(url.host == "0.0.0.0.evil.example")
-        #expect(url.path == "/docs")
     }
 
     @Test func schemelessDottedHostPortResolvesAsEmbeddedBrowser() throws {
@@ -132,6 +138,12 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
             #expect(url.port == expectedPort)
             #expect(url.path == expectedPath)
         }
+    }
+
+    @Test func fileLineTokensDoNotResolveAsHostPorts() {
+        #expect(router.resolveOpenURLTarget("README.md:12") == nil)
+        #expect(router.resolveOpenURLTarget("App.swift:42") == nil)
+        #expect(router.resolveOpenURLTarget("main.swift:42") == nil)
     }
 
     @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -21,6 +21,51 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         let dotted = trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "."))
         return dotted.isEmpty ? nil : dotted
     }
+
+    func navigableWebURL(_ input: String) -> URL? {
+        guard !rejectsEveryHost else { return nil }
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains(" ") else { return nil }
+        let lower = trimmed.lowercased()
+        let bareHost = Self.bareHostCandidate(lower)
+        if lower.hasPrefix("localhost") ||
+            lower.hasPrefix("127.0.0.1") ||
+            lower.hasPrefix("[::1]") ||
+            (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
+            return URL(string: "http://\(trimmed)")
+        }
+        if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() {
+            if scheme == "http" || scheme == "https" { return url }
+            if scheme == "file", url.isFileURL, url.path.hasPrefix("/") { return url }
+            if Self.dottedHostWithPortCandidate(trimmed, schemeCandidate: scheme) {
+                return URL(string: "https://\(trimmed)")
+            }
+            return nil
+        }
+        if trimmed.contains(":") || trimmed.contains("/") || trimmed.contains(".") {
+            return URL(string: "https://\(trimmed)")
+        }
+        return nil
+    }
+
+    private static func bareHostCandidate(_ lowercasedInput: String) -> String {
+        let end = lowercasedInput.firstIndex { character in
+            character == ":" || character == "/" || character == "?" || character == "#"
+        } ?? lowercasedInput.endIndex
+        return String(lowercasedInput[..<end])
+    }
+
+    private static func dottedHostWithPortCandidate(_ input: String, schemeCandidate: String) -> Bool {
+        guard schemeCandidate.contains(".") else { return false }
+        guard input.count > schemeCandidate.count else { return false }
+        let afterScheme = input.dropFirst(schemeCandidate.count)
+        guard afterScheme.first == ":" else { return false }
+        let portAndRest = afterScheme.dropFirst()
+        let port = portAndRest.prefix(while: { $0.isNumber })
+        guard !port.isEmpty, UInt16(port) != nil else { return false }
+        let rest = portAndRest.dropFirst(port.count)
+        return rest.isEmpty || rest.first == "/" || rest.first == "?" || rest.first == "#"
+    }
 }
 
 @Suite struct TerminalLinkRouterTests {
@@ -35,6 +80,17 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.scheme == "https")
         #expect(url.host == "example.com")
         #expect(url.path == "/path")
+    }
+
+    @Test func resolvesExplicitFileLikeHTTPSHostAsEmbeddedBrowser() throws {
+        let target = try #require(router.resolveOpenURLTarget("https://example.md:443"))
+        guard case let .embeddedBrowser(url) = target else {
+            Issue.record("Expected explicit HTTPS URL to route before file-line suppression")
+            return
+        }
+        #expect(url.scheme == "https")
+        #expect(url.host == "example.md")
+        #expect(url.port == 443)
     }
 
     @Test func schemelessHostPathResolvesAsEmbeddedBrowser() throws {
@@ -91,6 +147,8 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
     @Test func unresolvedRelativePathDoesNotResolveAsHTTPSURL() {
         let target = router.resolveOpenURLTarget("README.md")
         #expect(target == nil)
+        #expect(router.resolveOpenURLTarget("README.md#L12") == nil)
+        #expect(router.resolveOpenURLTarget("README.md?raw=1") == nil)
     }
 
     @Test func resolvesFileSchemeAsExternal() throws {
@@ -150,8 +208,20 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(rejecting.resolveOpenURLTarget("example.com/docs") == nil)
     }
 
-    @Test func schemelessHostWithoutPathResolvesToNil() {
-        #expect(router.resolveOpenURLTarget("example.com") == nil)
+    @Test func schemelessHostWithoutPathResolvesAsEmbeddedBrowser() throws {
+        for (rawValue, expectedHost, expectedScheme) in [
+            ("example.com", "example.com", "https"),
+            ("example.com?x=1", "example.com", "https"),
+            ("localhost", "localhost", "http"),
+        ] {
+            let target = try #require(router.resolveOpenURLTarget(rawValue))
+            guard case let .embeddedBrowser(url) = target else {
+                Issue.record("Expected browser-navigable host to route to embedded browser")
+                return
+            }
+            #expect(url.scheme == expectedScheme)
+            #expect(url.host == expectedHost)
+        }
     }
 
     @Test func emptyTextResolvesToNil() {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalLinkRouterTests.swift
@@ -8,9 +8,18 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
 
     func normalizedHost(_ rawHost: String) -> String? {
         guard !rejectsEveryHost else { return nil }
-        let trimmed = rawHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var trimmed = rawHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !trimmed.isEmpty else { return nil }
-        return trimmed
+        if trimmed.hasPrefix("["),
+           let closing = trimmed.firstIndex(of: "]") {
+            trimmed = String(trimmed[trimmed.index(after: trimmed.startIndex)..<closing])
+        } else if let colon = trimmed.lastIndex(of: ":"),
+                  trimmed[trimmed.index(after: colon)...].allSatisfy(\.isNumber),
+                  trimmed.filter({ $0 == ":" }).count == 1 {
+            trimmed = String(trimmed[..<colon])
+        }
+        let dotted = trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        return dotted.isEmpty ? nil : dotted
     }
 }
 
@@ -39,16 +48,22 @@ private struct StubHostNormalizer: BrowserHostNormalizing {
         #expect(url.path == "/docs")
     }
 
-    @Test func schemelessLocalhostPathResolvesAsEmbeddedBrowser() throws {
-        let target = try #require(router.resolveOpenURLTarget("localhost:3000/docs"))
-        guard case let .embeddedBrowser(url) = target else {
-            Issue.record("Expected localhost schemeless path to route to embedded browser")
-            return
+    @Test func schemelessLoopbackPathResolvesAsHTTPEmbeddedBrowser() throws {
+        for (rawValue, expectedHost, expectedPort) in [
+            ("localhost:3000/docs", "localhost", 3000),
+            ("127.0.0.1:5173/docs", "127.0.0.1", 5173),
+            ("deep.api.localhost/docs", "deep.api.localhost", nil),
+        ] {
+            let target = try #require(router.resolveOpenURLTarget(rawValue))
+            guard case let .embeddedBrowser(url) = target else {
+                Issue.record("Expected loopback schemeless path to route to embedded browser")
+                return
+            }
+            #expect(url.scheme == "http")
+            #expect(url.host == expectedHost)
+            #expect(url.port == expectedPort)
+            #expect(url.path == "/docs")
         }
-        #expect(url.scheme == "https")
-        #expect(url.host == "localhost")
-        #expect(url.port == 3000)
-        #expect(url.path == "/docs")
     }
 
     @Test func wrappedPathFragmentDoesNotResolveAsHTTPSURL() {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -186,15 +186,11 @@ private func cmuxRuntimeReadClipboardCallback(
 // GhosttyApp.terminalPasteboard composition static below.
 
 /// The app-side conformance injected into ``TerminalLinkRouter``: terminal
-/// links validate hosts and resolve bare domains through the same browser
-/// rules the embedded browser uses.
+/// links validate explicit URL hosts through the same browser rules the
+/// embedded browser uses.
 struct TerminalBrowserHostNormalizer: BrowserHostNormalizing {
     func normalizedHost(_ rawHost: String) -> String? {
         BrowserInsecureHTTPSettings.normalizeHost(rawHost)
-    }
-
-    func navigableWebURL(_ input: String) -> URL? {
-        resolveBrowserNavigableURL(input)
     }
 }
 
@@ -3089,9 +3085,9 @@ class GhosttyApp {
 
             guard let target = resolveTerminalOpenURLTarget(normalizedOpenURLString) else {
                 #if DEBUG
-                cmuxDebugLog("link.openURL resolve failed, returning false")
+                cmuxDebugLog("link.openURL resolve ignored, consumed invalid token")
                 #endif
-                return false
+                return true
             }
             #if DEBUG
             if UITestCaptureSink().appendLineIfConfigured(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -192,6 +192,7 @@ struct TerminalBrowserHostNormalizer: BrowserHostNormalizing {
     func normalizedHost(_ rawHost: String) -> String? {
         BrowserInsecureHTTPSettings.normalizeHost(rawHost)
     }
+    func navigableWebURL(_ input: String) -> URL? { resolveBrowserNavigableURL(input) }
 }
 
 func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6230,8 +6230,8 @@ func resolveBrowserNavigableURL(_ input: String) -> URL? {
     // URL(string: "localhost:3777") treats "localhost" as a scheme.
     let lower = trimmed.lowercased()
     let bareHost = browserBareHostCandidate(lower)
-    if lower.hasPrefix("localhost") || lower.hasPrefix("127.0.0.1") ||
-        lower.hasPrefix("0.0.0.0") || lower.hasPrefix("[::1]") ||
+    if bareHost == "localhost" || bareHost == "127.0.0.1" ||
+        bareHost == "0.0.0.0" || lower.hasPrefix("[::1]") ||
         (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
         return URL(string: "http://\(trimmed)")
     }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6230,9 +6230,10 @@ func resolveBrowserNavigableURL(_ input: String) -> URL? {
     // URL(string: "localhost:3777") treats "localhost" as a scheme.
     let lower = trimmed.lowercased()
     let bareHost = browserBareHostCandidate(lower)
-    if bareHost == "localhost" || bareHost == "127.0.0.1" ||
-        bareHost == "0.0.0.0" || lower.hasPrefix("[::1]") ||
-        (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
+    let normalizedBareHost = bareHost.trimmingCharacters(in: CharacterSet(charactersIn: "."))
+    if normalizedBareHost == "localhost" || normalizedBareHost == "127.0.0.1" ||
+        normalizedBareHost == "0.0.0.0" || lower.hasPrefix("[::1]") ||
+        normalizedBareHost.hasSuffix(".localhost") {
         return URL(string: "http://\(trimmed)")
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6230,9 +6230,8 @@ func resolveBrowserNavigableURL(_ input: String) -> URL? {
     // URL(string: "localhost:3777") treats "localhost" as a scheme.
     let lower = trimmed.lowercased()
     let bareHost = browserBareHostCandidate(lower)
-    if lower.hasPrefix("localhost") ||
-        lower.hasPrefix("127.0.0.1") ||
-        lower.hasPrefix("[::1]") ||
+    if lower.hasPrefix("localhost") || lower.hasPrefix("127.0.0.1") ||
+        lower.hasPrefix("0.0.0.0") || lower.hasPrefix("[::1]") ||
         (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
         return URL(string: "http://\(trimmed)")
     }

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -5298,7 +5298,6 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
     }
 }
 
-
 @Suite struct BrowserNavigableURLResolutionTests {
     @Test func resolvesFileSchemeAsNavigableURL() throws {
         let resolved = try #require(resolveBrowserNavigableURL("file:///tmp/cmux-local-test.html"))
@@ -5307,15 +5306,17 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
     }
 
     @Test func resolvesBareLocalhostSubdomainAsHTTPURL() throws {
-        let resolved = try #require(resolveBrowserNavigableURL("api.localhost:3000"))
-        #expect(resolved.scheme == "http")
-        #expect(resolved.host == "api.localhost")
-        #expect(resolved.port == 3000)
-
-        let nested = try #require(resolveBrowserNavigableURL("deep.api.localhost/path"))
-        #expect(nested.scheme == "http")
-        #expect(nested.host == "deep.api.localhost")
-        #expect(nested.path == "/path")
+        for (rawValue, expectedHost, expectedPort, expectedPath) in [
+            ("api.localhost:3000", "api.localhost", 3000, ""),
+            ("deep.api.localhost/path", "deep.api.localhost", nil, "/path"),
+            ("0.0.0.0:5173/status", "0.0.0.0", 5173, "/status"),
+        ] {
+            let resolved = try #require(resolveBrowserNavigableURL(rawValue))
+            #expect(resolved.scheme == "http")
+            #expect(resolved.host == expectedHost)
+            #expect(resolved.port == expectedPort)
+            #expect(resolved.path == expectedPath)
+        }
     }
 
     @Test func rejectsNonWebNonFileScheme() {
@@ -5348,7 +5349,6 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
         #expect(resolveBrowserNavigableURL("file://example.html") == nil)
     }
 }
-
 
 final class BrowserReadAccessURLTests: XCTestCase {
     func testUsesParentDirectoryForFileURL() throws {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -5338,8 +5338,8 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
         #expect(withPath.scheme == "https")
         #expect(withPath.port == 8443)
         #expect(withPath.path == "/admin")
+        #expect(try #require(resolveBrowserNavigableURL("0.0.0.0.evil.example/path")).scheme == "https")
     }
-
     @Test func keepsRejectingDottedSchemeInputsWithoutNumericPort() {
         #expect(resolveBrowserNavigableURL("example.com:notaport") == nil)
         #expect(resolveBrowserNavigableURL("example.com:99999") == nil)

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -5308,7 +5308,9 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
     @Test func resolvesBareLocalhostSubdomainAsHTTPURL() throws {
         for (rawValue, expectedHost, expectedPort, expectedPath) in [
             ("api.localhost:3000", "api.localhost", 3000, ""),
+            ("api.localhost.:3000", "api.localhost.", 3000, ""),
             ("deep.api.localhost/path", "deep.api.localhost", nil, "/path"),
+            ("localhost.:3000/status", "localhost.", 3000, "/status"),
             ("0.0.0.0:5173/status", "0.0.0.0", 5173, "/status"),
         ] {
             let resolved = try #require(resolveBrowserNavigableURL(rawValue))
@@ -5326,9 +5328,7 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
 
     @Test func resolvesDottedHostWithPortAsHTTPSURL() throws {
         // URL(string: "example.com:8443") parses "example.com" as a scheme, so
-        // the resolver must recover the bare host:port shape instead of
-        // sending it to search (https://github.com/manaflow-ai/cmux/issues/5913:
-        // the omnibar inline completion displays history hosts this way).
+        // the resolver must recover the bare host:port shape instead of search.
         let resolved = try #require(resolveBrowserNavigableURL("example.com:8443"))
         #expect(resolved.scheme == "https")
         #expect(resolved.host == "example.com")

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -5571,16 +5571,8 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
         }
     }
 
-    func testResolvesBareDomainAsEmbeddedBrowser() throws {
-        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("example.com/docs"))
-        switch target {
-        case let .embeddedBrowser(url):
-            XCTAssertEqual(url.scheme, "https")
-            XCTAssertEqual(url.host, "example.com")
-            XCTAssertEqual(url.path, "/docs")
-        default:
-            XCTFail("Expected bare domain to be normalized as an HTTPS browser URL")
-        }
+    func testSchemelessBareDomainResolvesToNil() throws {
+        XCTAssertNil(resolveTerminalOpenURLTarget("example.com/docs"))
     }
 
     func testResolvesFileSchemeAsExternal() throws {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -5571,8 +5571,16 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
         }
     }
 
-    func testSchemelessBareDomainResolvesToNil() throws {
-        XCTAssertNil(resolveTerminalOpenURLTarget("example.com/docs"))
+    func testSchemelessHostPathResolvesAsEmbeddedBrowser() throws {
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("example.com/docs"))
+        switch target {
+        case let .embeddedBrowser(url):
+            XCTAssertEqual(url.scheme, "https")
+            XCTAssertEqual(url.host, "example.com")
+            XCTAssertEqual(url.path, "/docs")
+        default:
+            XCTFail("Expected host-like schemeless path to route to embedded browser")
+        }
     }
 
     func testResolvesFileSchemeAsExternal() throws {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -5580,7 +5580,7 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
         XCTAssertEqual(url.path, "/docs")
     }
     func testWrappedPathFragmentResolvesToNilWithRealNormalizer() {
-        XCTAssertNil(resolveTerminalOpenURLTarget("s/pipeline-failure-state-model.md"))
+        ["s/pipeline-failure-state-model.md", "README.md:12"].forEach { XCTAssertNil(resolveTerminalOpenURLTarget($0)) }
     }
 
     func testResolvesFileSchemeAsExternal() throws {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -5572,15 +5572,15 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
     }
 
     func testSchemelessHostPathResolvesAsEmbeddedBrowser() throws {
-        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("example.com/docs"))
-        switch target {
-        case let .embeddedBrowser(url):
-            XCTAssertEqual(url.scheme, "https")
-            XCTAssertEqual(url.host, "example.com")
-            XCTAssertEqual(url.path, "/docs")
-        default:
-            XCTFail("Expected host-like schemeless path to route to embedded browser")
+        guard case let .embeddedBrowser(url) = try XCTUnwrap(resolveTerminalOpenURLTarget("example.com/docs")) else {
+            return XCTFail("Expected host-like schemeless path to route to embedded browser")
         }
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertEqual(url.host, "example.com")
+        XCTAssertEqual(url.path, "/docs")
+    }
+    func testWrappedPathFragmentResolvesToNilWithRealNormalizer() {
+        XCTAssertNil(resolveTerminalOpenURLTarget("s/pipeline-failure-state-model.md"))
     }
 
     func testResolvesFileSchemeAsExternal() throws {


### PR DESCRIPTION
## Summary
- Reapply the terminal link router regression coverage after the revert in #7499.
- Stop non-host schemeless terminal fragments like `s/pipeline-failure-state-model.md` from being coerced into `https://` URLs.
- Preserve accepted schemeless `host/path` and numeric `host:port` terminal links, while keeping localhost/loopback hosts on `http://` to match the browser resolver.
- Reject common file-line tokens like `README.md:12` before browser routing so compiler/test output is not treated as a host port.
- Consume ignored Ghostty open-url tokens so invalid wrapped path fragments do not fall through to external opening.

Closes #4675

## Tests
- Test-only commit `78c2c279f5` fails `swift test --package-path Packages/macOS/CmuxTerminalCore --filter TerminalLinkRouterTests/wrappedPathFragmentDoesNotResolveAsHTTPSURL` with `https://s/pipeline-failure-state-model.md`.
- `swift test --package-path Packages/macOS/CmuxTerminalCore --filter TerminalLinkRouterTests`
- `swift test --package-path Packages/macOS/CmuxTerminalCore`
- `python3 scripts/swift_file_length_budget.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `git diff --check`
- `./scripts/reload.sh --tag issue-4675-url-fragment`

## Notes
- No Ghostty submodule changes.
- No user-facing strings changed; localization audit found no new localized surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes click-to-open behavior for terminal text with many edge cases; risk is mitigated by broad new tests but real-world link shapes could still be misclassified.
> 
> **Overview**
> **Terminal link routing** is tightened so compiler output and wrapped path suffixes are not coerced into web opens. `TerminalLinkRouter` now returns `nil` for file-line patterns (`README.md:12`, `App.swift:42:17`) and for a narrow wrapped-fragment shape (`s/…-….md`) before browser normalization runs, while still allowing real schemeless `host/path`, `host:port`, and loopback URLs via `navigableWebURL` + host validation. Unresolved schemeless tokens no longer fall back to an external `URL(string:)` open—they resolve to `nil`.
> 
> **Ghostty open-URL handling** treats ignored tokens as consumed (`return true`) so invalid fragments do not propagate to external opening.
> 
> **Browser navigable URL** loopback detection in `resolveBrowserNavigableURL` aligns with normalized bare hosts (including `0.0.0.0` and trailing-dot localhost forms). Tests cover the new rejection and preserved embedded-browser cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da3a4d208caf7a433345c9763d540db8160dc8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined link routing to avoid auto-opening non-URL text as web destinations, including bare domains, path-like fragments, and file-line token patterns.
  * Embedded-browser routing now applies only to validated schemeless host/path and host:port inputs, rewriting to HTTP/HTTPS appropriately.
  * When a target can’t be resolved, the open-URL action is now handled safely without propagating.
* **Tests**
  * Updated and expanded link-resolution tests for the new schemeless-routing and rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->