### PR TITLE
feat: broadcast input (pane synchronization) across visible panes

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -15646,6 +15646,7 @@ struct CMUXCLI {
               close-others | close-above | close-below
               mark-read | mark-unread
               set-color | clear-color
+              toggle-sync
 
             Flags:
               --action <name>              Action name (required if not positional)
@@ -15669,6 +15670,7 @@ struct CMUXCLI {
               cmux workspace-action --action set-description --description "Ship checklist"
               cmux workspace-action --action set-description $'Ship checklist\n- verify build\n- post notes'
               cmux workspace-action clear-color
+              cmux workspace-action --action toggle-sync
             """
         case "tab-action":
             return """

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
@@ -102,6 +102,7 @@ extension ShortcutAction {
         case .attachTextBoxFile: return ShortcutStroke(key: "a", command: true, shift: true, option: true)
         case .sendCtrlFToTerminal: return nil
         case .clearScreenKeepScrollback: return ShortcutStroke(key: "k", command: true, shift: true)
+        case .toggleBroadcastInput: return ShortcutStroke(key: "i", command: true, shift: true)
         case .toggleRightSidebar: return ShortcutStroke(key: "b", command: true, option: true)
         case .fileExplorerOpenSelection: return ShortcutStroke(key: "\r")
         case .fileExplorerOpenSelectionFinderAlias: return ShortcutStroke(key: "↓", command: true)

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -77,6 +77,9 @@ public enum ShortcutAction: String, CaseIterable, Sendable, Hashable, SettingCod
     case sendCtrlFToTerminal
     /// Clears the focused terminal's visible screen while preserving scrollback.
     case clearScreenKeepScrollback
+    /// Broadcasts keystrokes typed in the focused pane to every other visible
+    /// pane in the workspace (tmux synchronize-panes / iTerm2 Broadcast Input).
+    case toggleBroadcastInput
 
     // MARK: Panes
     case focusLeft
@@ -190,7 +193,7 @@ extension ShortcutAction {
              .newWorkspaceGroup, .groupSelectedWorkspaces, .toggleFocusedWorkspaceGroupCollapsed,
              .reopenClosedBrowserPanel, .newSurface, .toggleTerminalCopyMode,
              .focusTextBoxInput, .cycleTextBoxSubmitAction, .attachTextBoxFile, .sendCtrlFToTerminal,
-             .clearScreenKeepScrollback:
+             .clearScreenKeepScrollback, .toggleBroadcastInput:
             return .navigation
         case .focusLeft, .focusRight, .focusUp, .focusDown, .splitRight, .splitDown,
              .toggleSplitZoom, .equalizeSplits, .splitBrowserRight, .splitBrowserDown,
@@ -275,7 +278,7 @@ extension ShortcutAction {
             return .atom(.sidebarFocus)
         case .renameTab, .renameWorkspace:
             return .and(.not(.atom(.browserFocus)), .not(.atom(.sidebarFocus)))
-        case .sendCtrlFToTerminal, .clearScreenKeepScrollback:
+        case .sendCtrlFToTerminal, .clearScreenKeepScrollback, .toggleBroadcastInput:
             return .and(.not(.atom(.browserFocus)), .not(.atom(.sidebarFocus)))
         case .browserBack, .browserForward, .browserReload, .browserHardReload,
              .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole, .toggleBrowserFocusMode,
@@ -392,6 +395,8 @@ extension ShortcutAction {
             return String(localized: "shortcut.sendCtrlFToTerminal.label", defaultValue: "Send Ctrl-F to Terminal")
         case .clearScreenKeepScrollback:
             return String(localized: "shortcut.clearScreenKeepScrollback.label", defaultValue: "Clear Screen (Keep Scrollback)")
+        case .toggleBroadcastInput:
+            return String(localized: "shortcut.toggleBroadcastInput.label", defaultValue: "Toggle Broadcast Input")
         case .focusLeft: return "Focus Pane Left"
         case .focusRight: return "Focus Pane Right"
         case .focusUp: return "Focus Pane Up"

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
@@ -79,6 +79,30 @@ extension TerminalSurface {
         }
     }
 
+    /// Replays a fully-formed key event onto this surface as part of
+    /// broadcast-input (pane synchronization): a keystroke typed in the focused
+    /// surface is fanned out to the other visible panes of the same workspace
+    /// (tmux `synchronize-panes` / iTerm2 "Broadcast Input").
+    ///
+    /// Only delivers to a live surface — a cold/hibernated pane is skipped
+    /// rather than started, matching the "visible panes only" broadcast scope.
+    /// The caller passes the same `ghostty_input_key_s` it delivered to the
+    /// focused surface; any `text` pointer it carries must stay valid for this
+    /// synchronous call (callers invoke this from inside the originating
+    /// `withCString` scope, exactly like the desktop `keyDown` send path).
+    ///
+    /// - Returns: Whether libghostty handled the key.
+    @MainActor
+    @discardableResult
+    public func replayBroadcastKeyEvent(_ keyEvent: ghostty_input_key_s) -> Bool {
+        guard let liveSurface = liveSurfaceForSocketWrite(reason: "broadcast.replayKey") else {
+            return false
+        }
+        guard !ghostty_surface_process_exited(liveSurface) else { return false }
+        hibernationRecorder.recordTerminalInput(workspaceId: tabId, panelId: id)
+        return ghostty_surface_key(liveSurface, keyEvent)
+    }
+
     /// Sends a named key (e.g. `"ctrl-c"`, `"enter"`), queueing on a cold
     /// surface.
     @MainActor

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13912,6 +13912,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
             return true
         }
+        if matchConfiguredShortcut(event: event, action: .toggleBroadcastInput) {
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+            if routedManager?.toggleBroadcastInput() == nil {
+                NSSound.beep()
+            }
+            return true
+        }
         if matchConfiguredShortcut(event: event, action: .equalizeSplits) { performEqualizeSplitsShortcut(); return true }
         // Canvas layout actions share one executor with the palette, View
         // menu, and the canvas.* socket verbs.

--- a/Sources/ContentView+RightSidebarCommandPalette.swift
+++ b/Sources/ContentView+RightSidebarCommandPalette.swift
@@ -88,6 +88,8 @@ extension ContentView {
             return .clearScreenKeepScrollback
         case "palette.toggleSplitZoom":
             return .toggleSplitZoom
+        case "palette.toggleBroadcastInput":
+            return .toggleBroadcastInput
         case "palette.equalizeSplits":
             return .equalizeSplits
         case "palette.triggerFlash":

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7407,6 +7407,18 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.toggleBroadcastInput",
+                title: constant(String(localized: "command.toggleBroadcastInput.title", defaultValue: "Toggle Broadcast Input")),
+                subtitle: constant(String(localized: "command.toggleBroadcastInput.subtitle", defaultValue: "Terminal Input")),
+                keywords: ["broadcast", "sync", "synchronize", "panes", "input", "type", "all"],
+                when: { context in
+                    context.bool(CommandPaletteContextKeys.panelIsTerminal) &&
+                    context.bool(CommandPaletteContextKeys.workspaceHasSplits)
+                }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.equalizeSplits",
                 title: constant(String(localized: "command.equalizeSplits.title", defaultValue: "Equalize Splits")),
                 subtitle: workspaceSubtitle,
@@ -8095,6 +8107,11 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.toggleFullWidthTab") {
             if !tabManager.toggleFocusedFullWidthTab() {
+                NSSound.beep()
+            }
+        }
+        registry.register(commandId: "palette.toggleBroadcastInput") {
+            if tabManager.toggleBroadcastInput() == nil {
                 NSSound.beep()
             }
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3418,6 +3418,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     weak var terminalSurface: TerminalSurface?
+    /// Per-`keyDown` gate for broadcast input (pane synchronization). Primed
+    /// once at the top of `keyDown` via `resolveBroadcastInputActive()` and
+    /// reset by that scope's `defer`, so the hot `sendGhosttyKeyToFocusedSurface`
+    /// path only reads a bool. `false` whenever the focused workspace is not in
+    /// broadcast mode — the overwhelmingly common case.
+    var broadcastInputActive: Bool = false
     var scrollbar: GhosttyScrollbar?
     /// Pending scrollbar value written from the action callback thread;
     /// read and cleared on the main thread by `flushPendingScrollbar()`.
@@ -5706,6 +5712,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             dismissNotificationMs = (ProcessInfo.processInfo.systemUptime - dismissNotificationStart) * 1000.0
 #endif
         }
+        // Prime the broadcast-input gate once for this keystroke. Every send
+        // path below reads `broadcastInputActive`; the `defer` clears it so the
+        // flag can never leak into a later, non-keyDown `sendGhosttyKey` caller.
+        broadcastInputActive = resolveBroadcastInputActive()
+        defer { broadcastInputActive = false }
         let flags = ShortcutStroke.normalizedModifierFlags(from: event.modifierFlags)
         if !cmuxFindEventIsPlainEscape(event) { endFindEscapeSuppression() }
         if shouldConsumeSuppressedFindEscape(event) { return }
@@ -5773,7 +5784,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 )
                 ghosttySendMs = (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
                 #else
-                handled = ghostty_surface_key(surface, keyEvent)
+                handled = sendGhosttyKeyToFocusedSurface(surface, keyEvent)
                 #endif
             } else {
                 #if DEBUG
@@ -5782,7 +5793,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 #endif
                 handled = text.withCString { ptr in
                     keyEvent.text = ptr
-                    return ghostty_surface_key(surface, keyEvent)
+                    return sendGhosttyKeyToFocusedSurface(surface, keyEvent)
                 }
                 #if DEBUG
                 ghosttySendMs = (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
@@ -5975,7 +5986,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     )
                     ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
                     #else
-                    _ = ghostty_surface_key(surface, keyEvent)
+                    _ = sendGhosttyKeyToFocusedSurface(surface, keyEvent)
                     #endif
                 }
             }
@@ -5996,7 +6007,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 )
                 ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
 #else
-                _ = ghostty_surface_key(surface, keyEvent)
+                _ = sendGhosttyKeyToFocusedSurface(surface, keyEvent)
 #endif
             }
         } else {
@@ -6057,7 +6068,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     )
                     ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
                     #else
-                    _ = ghostty_surface_key(surface, keyEvent)
+                    _ = sendGhosttyKeyToFocusedSurface(surface, keyEvent)
                     #endif
                 }
             } else {
@@ -6073,7 +6084,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 )
                 ghosttySendMs += (ProcessInfo.processInfo.systemUptime - ghosttySendStart) * 1000.0
                 #else
-                _ = ghostty_surface_key(surface, keyEvent)
+                _ = sendGhosttyKeyToFocusedSurface(surface, keyEvent)
                 #endif
             }
         }
@@ -6086,7 +6097,58 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #if DEBUG
         Self.debugGhosttySurfaceKeyEventObserver?(keyEvent)
 #endif
-        return ghostty_surface_key(surface, keyEvent)
+        return sendGhosttyKeyToFocusedSurface(surface, keyEvent)
+    }
+
+    /// Delivers a key event to the focused surface and, when broadcast input
+    /// (pane synchronization) is active for this workspace, fans the identical
+    /// event out to the other visible panes. This is the single choke point for
+    /// the fan-out: every keyDown send path funnels through here (directly or
+    /// via `sendGhosttyKey`).
+    ///
+    /// Kept distinct from `sendGhosttyKey` so the DEBUG key-event observer's
+    /// call count is unchanged for the raw `ghostty_surface_key` fast paths —
+    /// many IME/forwarding tests assert on that observer, and only
+    /// `sendGhosttyKey` should invoke it.
+    @discardableResult
+    private func sendGhosttyKeyToFocusedSurface(
+        _ surface: ghostty_surface_t,
+        _ keyEvent: ghostty_input_key_s
+    ) -> Bool {
+        let handled = ghostty_surface_key(surface, keyEvent)
+        if broadcastInputActive {
+            broadcastKeyEventToVisibleSiblings(keyEvent)
+        }
+        return handled
+    }
+
+    /// Resolves whether broadcast input is enabled for the focused surface's
+    /// workspace. Called once at the top of `keyDown` to prime
+    /// `broadcastInputActive`; the O(1) `workspacesById` lookup keeps the hot
+    /// path free of per-keystroke `tabs` scans.
+    private func resolveBroadcastInputActive() -> Bool {
+        guard let source = terminalSurface,
+              let manager = AppDelegate.shared?.tabManagerFor(tabId: source.tabId) else {
+            return false
+        }
+        return manager.isBroadcastInputEnabled(forTabId: source.tabId)
+    }
+
+    /// Fans `keyEvent` out to every visible pane in the focused surface's
+    /// workspace except the source. Runs only while `broadcastInputActive`, so
+    /// the per-pane walk never touches the common (broadcast-off) keystroke.
+    /// The `keyEvent`'s `text` pointer is still valid here because callers
+    /// invoke this synchronously from inside the originating `withCString`
+    /// scope.
+    private func broadcastKeyEventToVisibleSiblings(_ keyEvent: ghostty_input_key_s) {
+        guard let source = terminalSurface,
+              let manager = AppDelegate.shared?.tabManagerFor(tabId: source.tabId),
+              let workspace = manager.workspace(withId: source.tabId) else {
+            return
+        }
+        for panel in workspace.visibleTerminalPanels where panel.surface.id != source.id {
+            _ = panel.surface.replayBroadcastKeyEvent(keyEvent)
+        }
     }
 
 #if DEBUG

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6179,6 +6179,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             super.keyUp(with: event)
             return
         }
+        // Broadcast key releases too, so sibling panes see matching up events
+        // and never get stuck modifier/held-key state under pane sync.
+        broadcastInputActive = resolveBroadcastInputActive()
+        defer { broadcastInputActive = false }
         if event.keyCode != 53 {
             endFindEscapeSuppression()
         }
@@ -6212,6 +6216,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             super.flagsChanged(with: event)
             return
         }
+        // Modifier changes broadcast to sibling panes as well, keeping their
+        // modifier state consistent with the focused pane under pane sync.
+        broadcastInputActive = resolveBroadcastInputActive()
+        defer { broadcastInputActive = false }
 
         if !hasMarkedText(),
            let action = ghostty_input_action_e.modifierActionForFlagsChanged(

--- a/Sources/KeyboardShortcutActionContext.swift
+++ b/Sources/KeyboardShortcutActionContext.swift
@@ -138,7 +138,8 @@ extension KeyboardShortcutSettings.Action {
              .switchRightSidebarToFeed, .switchRightSidebarToDock, .fileExplorerOpenSelection,
              .fileExplorerOpenSelectionFinderAlias:
             return .rightSidebarFocus
-        case .renameTab, .renameWorkspace, .sendCtrlFToTerminal, .clearScreenKeepScrollback:
+        case .renameTab, .renameWorkspace, .sendCtrlFToTerminal, .clearScreenKeepScrollback,
+             .toggleBroadcastInput:
             return .nonBrowserPanel
         case .browserBack, .browserForward, .browserReload, .browserHardReload,
              .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole, .toggleBrowserFocusMode:

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -120,6 +120,7 @@ enum KeyboardShortcutSettings {
         case focusTextBoxInput, cycleTextBoxSubmitAction, attachTextBoxFile
         case sendCtrlFToTerminal
         case clearScreenKeepScrollback
+        case toggleBroadcastInput
 
         // Panes / splits
         case focusLeft
@@ -245,6 +246,7 @@ enum KeyboardShortcutSettings {
             case .attachTextBoxFile: return String(localized: "shortcut.attachTextBoxFile.label", defaultValue: "Attach File to TextBox Input")
             case .sendCtrlFToTerminal: return String(localized: "shortcut.sendCtrlFToTerminal.label", defaultValue: "Send Ctrl-F to Terminal")
             case .clearScreenKeepScrollback: return String(localized: "shortcut.clearScreenKeepScrollback.label", defaultValue: "Clear Screen (Keep Scrollback)")
+            case .toggleBroadcastInput: return String(localized: "shortcut.toggleBroadcastInput.label", defaultValue: "Toggle Broadcast Input")
             case .focusLeft: return String(localized: "shortcut.focusPaneLeft.label", defaultValue: "Focus Pane Left")
             case .focusRight: return String(localized: "shortcut.focusPaneRight.label", defaultValue: "Focus Pane Right")
             case .focusUp: return String(localized: "shortcut.focusPaneUp.label", defaultValue: "Focus Pane Up")
@@ -439,6 +441,7 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "d", command: true, shift: false, option: false, control: false)
             case .splitDown: return StoredShortcut(key: "d", command: true, shift: true, option: false, control: false)
             case .toggleSplitZoom: return StoredShortcut(key: "\r", command: true, shift: true, option: false, control: false)
+            case .toggleBroadcastInput: return StoredShortcut(key: "i", command: true, shift: true, option: false, control: false)
             case .equalizeSplits: return StoredShortcut(key: "=", command: true, shift: false, option: false, control: true)
             case .splitBrowserRight:
                 return StoredShortcut(key: "d", command: true, shift: false, option: true, control: false)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -223,7 +223,7 @@ class TabManager: ObservableObject {
     func toggleBroadcastInput(forTabId tabId: UUID? = nil) -> Bool? {
         guard let targetId = tabId ?? selectedTabId,
               let workspace = workspacesById[targetId] else { return nil }
-        workspace.broadcastInputEnabled.toggle()
+        workspace.setBroadcastInputEnabled(!workspace.broadcastInputEnabled)
         return workspace.broadcastInputEnabled
     }
 
@@ -233,7 +233,7 @@ class TabManager: ObservableObject {
     func setBroadcastInputEnabled(_ enabled: Bool, forTabId tabId: UUID? = nil) -> Bool? {
         guard let targetId = tabId ?? selectedTabId,
               let workspace = workspacesById[targetId] else { return nil }
-        workspace.broadcastInputEnabled = enabled
+        workspace.setBroadcastInputEnabled(enabled)
         return enabled
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -198,6 +198,45 @@ class TabManager: ObservableObject {
         get { workspaces.tabs }
         set { workspaces.tabs = newValue }
     }
+
+    /// O(1) workspace lookup by id. Backs the broadcast-input hot path
+    /// (`GhosttyNSView.keyDown`), which must not scan `tabs` per keystroke.
+    func workspace(withId id: UUID) -> Workspace? {
+        workspacesById[id]
+    }
+
+    /// Whether broadcast input (pane synchronization) is enabled for the given
+    /// workspace. Cheap enough to consult per keystroke.
+    func isBroadcastInputEnabled(forTabId tabId: UUID) -> Bool {
+        workspacesById[tabId]?.broadcastInputEnabled ?? false
+    }
+
+    /// Shared writer for broadcast input (pane synchronization). Every
+    /// entrypoint — keyboard shortcut, command palette, menu, and the
+    /// `workspace-action toggle-sync` CLI — routes through here (or
+    /// ``setBroadcastInputEnabled(_:forTabId:)``) so the state has a single
+    /// mutation path. `tabId` defaults to the selected workspace.
+    ///
+    /// - Returns: The resulting enabled state, or `nil` when no target
+    ///   workspace could be resolved.
+    @discardableResult
+    func toggleBroadcastInput(forTabId tabId: UUID? = nil) -> Bool? {
+        guard let targetId = tabId ?? selectedTabId,
+              let workspace = workspacesById[targetId] else { return nil }
+        workspace.broadcastInputEnabled.toggle()
+        return workspace.broadcastInputEnabled
+    }
+
+    /// Sets broadcast input to an explicit state on the given (or selected)
+    /// workspace. See ``toggleBroadcastInput(forTabId:)``.
+    @discardableResult
+    func setBroadcastInputEnabled(_ enabled: Bool, forTabId tabId: UUID? = nil) -> Bool? {
+        guard let targetId = tabId ?? selectedTabId,
+              let workspace = workspacesById[targetId] else { return nil }
+        workspace.broadcastInputEnabled = enabled
+        return enabled
+    }
+
     /// Named groupings of workspaces shown as collapsible sections in the sidebar.
     /// Group order in this array defines section order in the sidebar.
     /// Each member workspace stores its `groupId` on the `Workspace` model.

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4441,7 +4441,8 @@ class TerminalController {
             "move_up", "move_down", "move_top",
             "close_others", "close_above", "close_below",
             "mark_read", "mark_unread",
-            "set_color", "clear_color"
+            "set_color", "clear_color",
+            "toggle_sync"
         ]
 
         var result: V2CallResult = .err(code: "invalid_params", message: "Unknown workspace action", data: [
@@ -4496,6 +4497,16 @@ class TerminalController {
             case "unpin":
                 tabManager.setPinned(workspace, pinned: false)
                 finish(["pinned": false])
+
+            case "toggle_sync":
+                // Broadcast input (pane synchronization): fan keystrokes typed
+                // in the focused pane out to every other visible pane in the
+                // workspace. Routes through the shared `TabManager` writer so
+                // the CLI, keyboard shortcut, command palette, and menu all
+                // mutate one source of truth.
+                let enabled = tabManager.toggleBroadcastInput(forTabId: workspace.id)
+                    ?? workspace.broadcastInputEnabled
+                finish(["broadcast_input": enabled])
 
             case "rename":
                 guard let titleRaw = v2String(params, "title"),

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1960,10 +1960,12 @@ final class Workspace: Identifiable, ObservableObject {
     /// When enabled, keystrokes typed in the focused pane are broadcast to every
     /// other visible pane in this workspace (tmux `synchronize-panes` / iTerm2
     /// "Broadcast Input"). Scoped per workspace and deliberately not persisted,
-    /// so a broadcast session never outlives the window. Mutate through the
-    /// shared `setBroadcastInputEnabled(_:)` / `toggleBroadcastInput()` path so
-    /// every entrypoint (shortcut, command palette, menu, CLI) stays in sync.
-    @Published var broadcastInputEnabled: Bool = false
+    /// so a broadcast session never outlives the window. Write-protected outside
+    /// `Workspace`: mutate only through ``setBroadcastInputEnabled(_:)`` (which
+    /// `TabManager`'s shared toggle/set path calls) so every entrypoint —
+    /// shortcut, command palette, menu, CLI — stays on one mutation path and
+    /// cannot drift out of sync.
+    @Published private(set) var broadcastInputEnabled: Bool = false
     /// Identifier of the WorkspaceGroup this workspace belongs to, or nil if ungrouped.
     /// The group entity itself lives in `TabManager.workspaceGroups`.
     @Published var groupId: UUID?
@@ -2172,6 +2174,13 @@ final class Workspace: Identifiable, ObservableObject {
             return nil
         }
         return panel
+    }
+
+    /// The only writer for ``broadcastInputEnabled``. `TabManager`'s shared
+    /// `toggleBroadcastInput()` / `setBroadcastInputEnabled(_:)` route here so
+    /// the state has a single mutation path.
+    func setBroadcastInputEnabled(_ enabled: Bool) {
+        broadcastInputEnabled = enabled
     }
 
     /// One terminal panel per currently-visible pane: the selected surface in

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1957,6 +1957,13 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var customTitleSource: CustomTitleSource?
     @Published var customDescription: String?
     @Published var isPinned: Bool = false
+    /// When enabled, keystrokes typed in the focused pane are broadcast to every
+    /// other visible pane in this workspace (tmux `synchronize-panes` / iTerm2
+    /// "Broadcast Input"). Scoped per workspace and deliberately not persisted,
+    /// so a broadcast session never outlives the window. Mutate through the
+    /// shared `setBroadcastInputEnabled(_:)` / `toggleBroadcastInput()` path so
+    /// every entrypoint (shortcut, command palette, menu, CLI) stays in sync.
+    @Published var broadcastInputEnabled: Bool = false
     /// Identifier of the WorkspaceGroup this workspace belongs to, or nil if ungrouped.
     /// The group entity itself lives in `TabManager.workspaceGroups`.
     @Published var groupId: UUID?
@@ -2165,6 +2172,23 @@ final class Workspace: Identifiable, ObservableObject {
             return nil
         }
         return panel
+    }
+
+    /// One terminal panel per currently-visible pane: the selected surface in
+    /// each split pane of the main area. These are the fan-out targets for
+    /// broadcast input (see ``broadcastInputEnabled``). Background surface-tabs
+    /// and the right-Dock tree are intentionally excluded — broadcast is
+    /// "visible panes only". Mirrors the pane-walk in
+    /// ``backgroundPrimeTerminalPanels``.
+    var visibleTerminalPanels: [TerminalPanel] {
+        var seenPanelIds = Set<UUID>()
+        return bonsplitController.allPaneIds.compactMap { paneId -> TerminalPanel? in
+            guard let surfaceId = bonsplitController.selectedTab(inPane: paneId)?.id
+                    ?? bonsplitController.tabs(inPane: paneId).first?.id,
+                  let panelId = panelIdFromSurfaceId(surfaceId),
+                  seenPanelIds.insert(panelId).inserted else { return nil }
+            return panels[panelId] as? TerminalPanel
+        }
     }
 
     /// Forwards to

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2175,16 +2175,23 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     /// One terminal panel per currently-visible pane: the selected surface in
-    /// each split pane of the main area. These are the fan-out targets for
-    /// broadcast input (see ``broadcastInputEnabled``). Background surface-tabs
-    /// and the right-Dock tree are intentionally excluded — broadcast is
-    /// "visible panes only". Mirrors the pane-walk in
-    /// ``backgroundPrimeTerminalPanels``.
+    /// each on-screen split pane of the main area. These are the fan-out targets
+    /// for broadcast input (see ``broadcastInputEnabled``). Background
+    /// surface-tabs and the right-Dock tree are intentionally excluded —
+    /// broadcast is strictly "visible panes only":
+    ///
+    /// - While split-zoom is active only the zoomed pane is rendered, so that is
+    ///   the sole target (matches the app's `renderedPaneIds` definition). This
+    ///   prevents keystrokes from leaking into off-screen panes.
+    /// - A pane with no selected tab (transient split/tab churn) is skipped
+    ///   rather than falling back to its first tab, so input never lands in a
+    ///   hidden/background terminal.
     var visibleTerminalPanels: [TerminalPanel] {
+        let renderedPaneIds = bonsplitController.zoomedPaneId.map { [$0] }
+            ?? bonsplitController.allPaneIds
         var seenPanelIds = Set<UUID>()
-        return bonsplitController.allPaneIds.compactMap { paneId -> TerminalPanel? in
-            guard let surfaceId = bonsplitController.selectedTab(inPane: paneId)?.id
-                    ?? bonsplitController.tabs(inPane: paneId).first?.id,
+        return renderedPaneIds.compactMap { paneId -> TerminalPanel? in
+            guard let surfaceId = bonsplitController.selectedTab(inPane: paneId)?.id,
                   let panelId = panelIdFromSurfaceId(surfaceId),
                   seenPanelIds.insert(panelId).inserted else { return nil }
             return panels[panelId] as? TerminalPanel

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -108,6 +108,18 @@ final class TmuxWorkspacePaneOverlayModel {
 }
 
 /// View that renders a Workspace's content using BonsplitView
+/// The highlight drawn around each visible terminal pane while broadcast input
+/// (pane synchronization) is enabled for the workspace. A distinct warm accent —
+/// deliberately not the blue focus ring — so it's unmistakable that keystrokes
+/// fan out to every pane.
+private struct BroadcastInputPaneBorder: View {
+    var body: some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .strokeBorder(Color.orange, lineWidth: 2)
+            .padding(1)
+    }
+}
+
 struct WorkspaceContentView: View {
     private struct DeferredThemeRefresh {
         let reason: String
@@ -166,6 +178,11 @@ struct WorkspaceContentView: View {
         let usesWorkspacePaneOverlay = TmuxOverlayExperimentSettings.target().usesWorkspacePaneOverlay
         let isWorkspaceManuallyUnread = notificationStore.hasManualUnread(forTabId: workspace.id)
         let workspaceManualUnreadPanelId = workspace.representativePanelIdForWorkspaceManualUnread()
+        // Broadcast input (pane synchronization): read in `body` so toggling it
+        // re-renders the split tree and the per-pane broadcast border below
+        // tracks the state. Cheap — it only changes on an explicit toggle, and
+        // live typing flows through AppKit (`GhosttyNSView`), not this body.
+        let broadcastInputOn = workspace.broadcastInputEnabled
 
         // Inactive workspaces are kept alive in a ZStack (for state preservation) but their
         // AppKit-backed views can still intercept drags. Disable drop acceptance for them.
@@ -273,6 +290,15 @@ struct WorkspaceContentView: View {
                         },
                         onTriggerFlash: { workspace.triggerDebugFlash(panelId: panel.id) }
                     )
+                    .overlay {
+                        // Broadcast input: highlight every visible terminal pane
+                        // that receives fanned-out keystrokes, so it's always
+                        // obvious the workspace is in synchronize-panes mode.
+                        if broadcastInputOn, panel is TerminalPanel {
+                            BroadcastInputPaneBorder()
+                                .allowsHitTesting(false)
+                        }
+                    }
                     .onTapGesture {
                         workspace.bonsplitController.focusPane(paneId)
                     }

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -4005,3 +4005,67 @@ final class CrossWindowWorkspaceMoveTests: XCTestCase {
         XCTAssertTrue(destination.tabs.contains { $0.id == moving.id })
     }
 }
+
+@MainActor
+final class TabManagerBroadcastInputTests: XCTestCase {
+    func testBroadcastInputDefaultsDisabled() {
+        let manager = TabManager()
+        let workspace = manager.tabs[0]
+        XCTAssertFalse(workspace.broadcastInputEnabled)
+        XCTAssertFalse(manager.isBroadcastInputEnabled(forTabId: workspace.id))
+    }
+
+    func testToggleBroadcastInputFlipsSelectedWorkspace() {
+        let manager = TabManager()
+        let workspace = manager.tabs[0]
+        manager.selectWorkspace(workspace)
+
+        XCTAssertEqual(manager.toggleBroadcastInput(), true)
+        XCTAssertTrue(workspace.broadcastInputEnabled)
+        XCTAssertTrue(manager.isBroadcastInputEnabled(forTabId: workspace.id))
+
+        XCTAssertEqual(manager.toggleBroadcastInput(), false)
+        XCTAssertFalse(workspace.broadcastInputEnabled)
+        XCTAssertFalse(manager.isBroadcastInputEnabled(forTabId: workspace.id))
+    }
+
+    func testToggleBroadcastInputTargetsSpecificWorkspaceNotSelection() {
+        let manager = TabManager()
+        let first = manager.tabs[0]
+        let second = manager.addWorkspace()
+        manager.selectWorkspace(first)
+
+        // Toggling a workspace by id must not touch the selected one.
+        XCTAssertEqual(manager.toggleBroadcastInput(forTabId: second.id), true)
+        XCTAssertTrue(second.broadcastInputEnabled)
+        XCTAssertFalse(first.broadcastInputEnabled)
+    }
+
+    func testSetBroadcastInputEnabledIsIdempotent() {
+        let manager = TabManager()
+        let workspace = manager.tabs[0]
+
+        XCTAssertEqual(manager.setBroadcastInputEnabled(true, forTabId: workspace.id), true)
+        XCTAssertTrue(workspace.broadcastInputEnabled)
+        // Re-setting the same value keeps it enabled (no spurious flip).
+        XCTAssertEqual(manager.setBroadcastInputEnabled(true, forTabId: workspace.id), true)
+        XCTAssertTrue(workspace.broadcastInputEnabled)
+
+        XCTAssertEqual(manager.setBroadcastInputEnabled(false, forTabId: workspace.id), false)
+        XCTAssertFalse(workspace.broadcastInputEnabled)
+    }
+
+    func testBroadcastInputActionsReturnNilForUnknownWorkspace() {
+        let manager = TabManager()
+        XCTAssertNil(manager.toggleBroadcastInput(forTabId: UUID()))
+        XCTAssertNil(manager.setBroadcastInputEnabled(true, forTabId: UUID()))
+    }
+
+    func testVisibleTerminalPanelsIncludesSinglePaneTerminal() {
+        let manager = TabManager()
+        let workspace = manager.tabs[0]
+        let visible = workspace.visibleTerminalPanels
+        XCTAssertEqual(visible.count, 1, "A fresh single-pane workspace has exactly one broadcast target")
+        XCTAssertEqual(visible.first?.id, workspace.focusedPanelId)
+    }
+}

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -286,6 +286,7 @@ export const shortcutCategories: ShortcutCategory[] = [
       { id: "splitBrowserRight", combos: [["⌥", "⌘", "D"]], description: { en: "Split browser right", ja: "右にブラウザ分割" } },
       { id: "splitBrowserDown", combos: [["⌥", "⌘", "⇧", "D"]], description: { en: "Split browser down", ja: "下にブラウザ分割" } },
       { id: "toggleSplitZoom", combos: [["⌘", "⇧", "↩"]], description: { en: "Toggle pane zoom", ja: "ペインズームを切り替え" } },
+      { id: "toggleBroadcastInput", combos: [["⌘", "⇧", "I"]], description: { en: "Toggle broadcast input to all panes", ja: "全ペインへの入力ブロードキャストを切り替え" } },
       { id: "equalizeSplits", combos: [["⌃", "⌘", "="]], description: { en: "Equalize split sizes", ja: "分割サイズを均等にする" } },
     ],
   },


### PR DESCRIPTION
## Summary

Implements broadcast input / pane synchronization (requested in #2336) — the tmux `synchronize-panes` / iTerm2 "Broadcast Input" feature. When enabled for a workspace, keystrokes typed in the focused pane are fanned out to every other **visible** pane in that workspace.

Closes #2336

## Behavior

- Toggle per workspace with **⌘⇧I** (`⌘⇧I` was free — no default-shortcut conflict). The shortcut is gated to terminal focus (`.nonBrowserPanel`) so it never shadows browser shortcuts.
- While active, every broadcasting terminal pane shows an orange border, so it is unmistakable the workspace is in synchronize mode.
- Scope: the selected surface in each split pane of the current workspace. Background surface-tabs and the right-Dock tree are excluded. Not persisted — a broadcast session never outlives the window.

## Entry points (one shared writer)

All routes go through `TabManager.toggleBroadcastInput()` / `setBroadcastInputEnabled()`:

- Keyboard shortcut `⌘⇧I`
- Command palette: "Toggle Broadcast Input"
- CLI: `cmux workspace-action --action toggle-sync`
- Settings → Keyboard Shortcuts + `~/.config/cmux/cmux.json` (via `CmuxSettings.ShortcutAction`)

## Implementation notes

- Fan-out lives at a single choke point, `GhosttyNSView.sendGhosttyKeyToFocusedSurface`, gated per-`keyDown` by an O(1) `workspacesById` lookup so the broadcast-off path (the overwhelming common case) is a single bool read — no per-keystroke `tabs` scan. When active, the same `ghostty_input_key_s` is replayed to sibling surfaces via `TerminalSurface.replayBroadcastKeyEvent`, called synchronously inside the originating `withCString` scope so the `text` pointer stays valid. Siblings receive the key directly on their surface — no re-entry into `keyDown`, no recursion.
- The DEBUG `debugGhosttySurfaceKeyEventObserver` call count is deliberately preserved (broadcast is added in a sibling of `sendGhosttyKey`, not by rerouting the raw fast-path sends), so the existing IME / command-shift forwarding tests are unaffected.
- App `shortcutContext` (`.nonBrowserPanel`) and the `CmuxSettings` package `defaultFocusWhenClause` are kept consistent, so the `KeyboardShortcutContextTests` parity test stays green.

## Testing

- New `cmuxTests/TabManagerBroadcastInputTests` (6 tests): default disabled, toggle/set semantics + return values, per-workspace targeting (does not touch the selected workspace), unknown-workspace → nil, and `visibleTerminalPanels` enumeration.
- Full app + `CmuxSettings` package + CLI build: green (Debug, macOS).
- Regression: `KeyboardShortcutContextTests` (24, incl. the runtime↔package parity check) and `ShortcutWhenClauseTests` (9) pass.

## Localization

`en` + `ja` added for the shortcut label and the palette title/subtitle; web shortcut docs (`web/data/cmux-shortcuts.ts`) updated. No new source files, so no `project.pbxproj` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786002716&installation_id=133855650&pr_number=7505&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7505&signature=3fb2ba204cb756d18194ac8939c25844609cede313ed79f674a14ac517a49f9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core terminal key-delivery path and duplicates input to multiple panes when enabled; mistakes could misroute keystrokes or desync modifier state across panes.
> 
> **Overview**
> Adds **broadcast input** (tmux `synchronize-panes` / iTerm2-style) per workspace: keystrokes in the focused terminal pane are replayed to every other **visible** pane in that workspace.
> 
> Toggle via **⌘⇧I**, command palette **Toggle Broadcast Input**, keyboard settings / `cmux.json`, and CLI `workspace-action toggle-sync`. All paths use `TabManager.toggleBroadcastInput()` / `setBroadcastInputEnabled()`; `Workspace.broadcastInputEnabled` is session-only (not persisted).
> 
> While active, visible terminal panes get an **orange border**. Fan-out runs through `GhosttyNSView.sendGhosttyKeyToFocusedSurface` (key down/up and modifier changes), gated by an O(1) workspace lookup; siblings receive keys via `TerminalSurface.replayBroadcastKeyEvent` (live surfaces only). `visibleTerminalPanels` defines targets (respects split zoom; skips background tabs / dock).
> 
> Includes unit tests, `en`/`ja` strings, and web shortcut docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98f5afd03378ec6188c9b3180edc11ae7467a50b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Broadcast Input (pane sync) to send keystrokes from the focused pane to all other visible panes in the workspace, like tmux “synchronize-panes” / iTerm2 “Broadcast Input”. Type once, act in every visible pane.

- **New Features**
  - Toggle per workspace with ⌘⇧I, gated to terminal focus.
  - Targets only rendered panes; respects split zoom; skips hidden and cold/hibernated panes; not persisted.
  - Clear UI: orange border highlights panes receiving broadcast input.
  - Entrypoints: keyboard shortcut, Command Palette (“Toggle Broadcast Input”), CLI (`cmux workspace-action --action toggle-sync`), and `CmuxSettings` shortcuts.
  - Single send choke point with an O(1) workspace lookup; replays the same `ghostty_input_key_s` to sibling surfaces. Single writer via `TabManager.toggleBroadcastInput`/`setBroadcastInputEnabled`; `Workspace.broadcastInputEnabled` is `private(set)` and set through `Workspace.setBroadcastInputEnabled`. Tests, `en`/`ja` localization, and web shortcut docs updated.

- **Bug Fixes**
  - Broadcast now includes key-up and modifier-only changes to keep modifier state aligned across panes.

<sup>Written for commit 98f5afd03378ec6188c9b3180edc11ae7467a50b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Toggle Broadcast Input” across shortcut settings, command palette, and terminal workspace actions, defaulting to Cmd+Shift+I.
  * When enabled, keyboard input syncs to visible split panes and highlights them with an orange pane border.
  * Introduced workspace-scoped enable/disable and automatic targeting of visible terminal panels.
* **Bug Fixes**
  * Improved broadcast synchronization across key down/up and modifier changes to keep pane state consistent.
* **Tests**
  * Added unit tests covering toggling behavior and visible panel selection.
* **Documentation**
  * Updated CLI help to include the new `toggle-sync` workspace action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->