### PR TITLE
Add TestFlight enrollment portal gated on active subscription

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -20,6 +20,16 @@ STRIPE_PRO_MONTHLY_PRICE_ID=
 STRIPE_PRO_YEARLY_PRICE_ID=
 STRIPE_TEAM_MONTHLY_PRICE_ID=
 
+# App Store Connect API for iOS TestFlight enrollment. Leave empty to show the
+# dashboard action as unavailable. ASC_PRIVATE_KEY accepts PEM contents with
+# literal "\n" escapes; ASC_PRIVATE_KEY_PATH is a local-dev fallback.
+ASC_KEY_ID=
+ASC_ISSUER_ID=
+ASC_PRIVATE_KEY=
+ASC_PRIVATE_KEY_PATH=
+CMUX_TESTFLIGHT_APP_ID=6757092429
+CMUX_TESTFLIGHT_GROUP_ID=3ee84bfa-10ad-4f23-a45c-f9a3b037373e
+
 # Server-side error reporting. Optional; no-op when unset.
 SENTRY_DSN=
 

--- a/web/app/[locale]/dashboard/dashboard-shell.tsx
+++ b/web/app/[locale]/dashboard/dashboard-shell.tsx
@@ -47,6 +47,11 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
           label: t("billing"),
           active: pathname.startsWith("/dashboard/billing"),
         },
+        {
+          href: "/dashboard/testflight",
+          label: t("testflight"),
+          active: pathname.startsWith("/dashboard/testflight"),
+        },
       ],
     },
   ];

--- a/web/app/[locale]/dashboard/testflight/page.tsx
+++ b/web/app/[locale]/dashboard/testflight/page.tsx
@@ -1,0 +1,209 @@
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
+import { Link } from "@/i18n/navigation";
+import { isAscConfigured } from "@/services/asc/client";
+import { testerGroupStatus } from "@/services/asc/testflight";
+import { isTestflightEligible } from "@/services/billing/pro";
+import { captureAscError } from "@/services/errors";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = {
+  testflight?: string | string[];
+};
+
+type TestflightStatus = {
+  enrolled: boolean;
+  state?: string;
+  unavailable?: boolean;
+};
+
+export default async function DashboardTestflightPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>;
+  searchParams?: Promise<SearchParams>;
+}) {
+  const { locale } = await params;
+  const query = await searchParams;
+
+  if (!isStackConfigured()) {
+    redirect("/");
+  }
+  const user = await getStackServerApp().getUser({ or: "return-null" });
+  if (!user || user.isAnonymous) {
+    redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard/testflight")));
+  }
+
+  const t = await getTranslations({ locale, namespace: "dashboard.testflight" });
+  const eligible = await isTestflightEligible(user);
+  const email = normalizedEmail(user.primaryEmail);
+  const status = eligible && email
+    ? await loadTestflightStatus(email, user.id)
+    : { enrolled: false };
+  const banner = testflightBanner(
+    Array.isArray(query?.testflight) ? query?.testflight[0] : query?.testflight,
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-3 py-4">
+      <div className="mb-4 border-b border-border pb-3">
+        <p className="text-xs font-medium text-muted">{t("eyebrow")}</p>
+        <h1 className="mt-1 text-sm font-medium">{t("title")}</h1>
+        <p className="mt-1 max-w-2xl text-muted">{t("description")}</p>
+      </div>
+
+      {banner ? (
+        <div className="mb-3 border border-border bg-background p-3 text-sm">
+          {t(`banners.${banner}`)}
+        </div>
+      ) : null}
+
+      {!eligible ? (
+        <NotEligible t={t} />
+      ) : !email ? (
+        <NeedsEmail t={t} />
+      ) : status.unavailable ? (
+        <Unavailable t={t} />
+      ) : status.enrolled ? (
+        <Enrolled t={t} email={email} state={status.state} />
+      ) : (
+        <Join t={t} email={email} />
+      )}
+    </div>
+  );
+}
+
+async function loadTestflightStatus(
+  email: string,
+  stackUserId: string,
+): Promise<TestflightStatus> {
+  if (!isAscConfigured()) return { enrolled: false, unavailable: true };
+  try {
+    return await testerGroupStatus(email);
+  } catch (error) {
+    captureAscError(error, {
+      page: "/dashboard/testflight",
+      stackUserId,
+      email,
+    });
+    return { enrolled: false, unavailable: true };
+  }
+}
+
+function NotEligible({ t }: { t: Awaited<ReturnType<typeof getTranslations>> }) {
+  return (
+    <section className="border border-border p-3">
+      <h2 className="text-sm font-medium">{t("notEligible.title")}</h2>
+      <p className="mt-2 max-w-2xl text-muted">{t("notEligible.body")}</p>
+      <Link
+        href="/pricing"
+        className="mt-3 inline-block border border-border bg-background px-3 py-1.5 text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground hover:bg-foreground hover:text-background"
+      >
+        {t("actions.viewPricing")}
+      </Link>
+    </section>
+  );
+}
+
+function NeedsEmail({ t }: { t: Awaited<ReturnType<typeof getTranslations>> }) {
+  return (
+    <section className="border border-border p-3">
+      <h2 className="text-sm font-medium">{t("needsEmail.title")}</h2>
+      <p className="mt-2 max-w-2xl text-muted">{t("needsEmail.body")}</p>
+    </section>
+  );
+}
+
+function Unavailable({ t }: { t: Awaited<ReturnType<typeof getTranslations>> }) {
+  return (
+    <section className="border border-border p-3">
+      <h2 className="text-sm font-medium">{t("unavailable.title")}</h2>
+      <p className="mt-2 max-w-2xl text-muted">{t("unavailable.body")}</p>
+    </section>
+  );
+}
+
+function Join({
+  t,
+  email,
+}: {
+  t: Awaited<ReturnType<typeof getTranslations>>;
+  email: string;
+}) {
+  return (
+    <section className="border border-border p-3">
+      <h2 className="text-sm font-medium">{t("join.title")}</h2>
+      <p className="mt-2 max-w-2xl text-muted">{t("join.body", { email })}</p>
+      <form method="post" action="/api/testflight" className="mt-4">
+        <input type="hidden" name="action" value="join" />
+        <button
+          type="submit"
+          className="border border-border bg-foreground px-3 py-1.5 text-background focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground"
+        >
+          {t("actions.join")}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+function Enrolled({
+  t,
+  email,
+  state,
+}: {
+  t: Awaited<ReturnType<typeof getTranslations>>;
+  email: string;
+  state?: string;
+}) {
+  return (
+    <section className="border border-border p-3">
+      <h2 className="text-sm font-medium">{t("enrolled.title")}</h2>
+      <p className="mt-2 max-w-2xl text-muted">{t("enrolled.body", { email })}</p>
+      <div className="mt-4 grid border border-border sm:grid-cols-2">
+        <TestflightMetric label={t("details.email")} value={email} />
+        <TestflightMetric label={t("details.status")} value={state ?? t("details.enrolled")} />
+      </div>
+      <p className="mt-3 max-w-2xl text-muted">{t("enrolled.lapseNote")}</p>
+      <form method="post" action="/api/testflight" className="mt-4">
+        <input type="hidden" name="action" value="leave" />
+        <button
+          type="submit"
+          className="border border-border bg-background px-3 py-1.5 text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground hover:bg-foreground hover:text-background"
+        >
+          {t("actions.leave")}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+function TestflightMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border-b border-border p-3 sm:border-b-0 sm:border-r">
+      <p className="text-xs text-muted">{label}</p>
+      <p className="mt-2 font-mono text-xs tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function normalizedEmail(email: string | null | undefined): string | null {
+  const normalized = email?.trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+function testflightBanner(value: string | undefined) {
+  return value === "joined" ||
+    value === "left" ||
+    value === "error" ||
+    value === "ineligible" ||
+    value === "needs_email" ||
+    value === "unavailable"
+    ? value
+    : null;
+}

--- a/web/app/api/testflight/route.ts
+++ b/web/app/api/testflight/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { localizedVaultPath, vaultSignInHref } from "../../lib/vault-auth";
+import { getStackServerApp, isStackConfigured } from "../../lib/stack";
+import { locales, routing } from "../../../i18n/routing";
+import { enrollTester, removeTester } from "../../../services/asc/testflight";
+import { isAscConfigured } from "../../../services/asc/client";
+import { isTestflightEligible } from "../../../services/billing/pro";
+import { captureAscError } from "../../../services/errors";
+import { browserMutationOriginAllowed } from "../../../services/vms/routeHelpers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type TestflightAction = "join" | "leave";
+
+export async function POST(request: NextRequest) {
+  let stackUserId: string | undefined;
+  let action: TestflightAction | null = null;
+
+  if (!browserMutationOriginAllowed(request)) {
+    return testflightRedirect(request, "error");
+  }
+
+  try {
+    const formData = await request.formData();
+    action = testflightAction(formData);
+    if (!action) return testflightRedirect(request, "error");
+
+    if (!isStackConfigured()) {
+      return testflightRedirect(request, "unavailable");
+    }
+
+    const user = await getStackServerApp().getUser({ or: "return-null" });
+    if (!user || user.isAnonymous) {
+      return NextResponse.redirect(
+        new URL(vaultSignInHref(localizedVaultPath(requestLocale(request), "/dashboard/testflight")), request.url),
+        303,
+      );
+    }
+    stackUserId = user.id;
+
+    if (!isAscConfigured()) {
+      return testflightRedirect(request, "unavailable");
+    }
+
+    const email = normalizedEmail(user.primaryEmail);
+    if (!email) return testflightRedirect(request, "needs_email");
+
+    if (action === "join") {
+      if (!(await isTestflightEligible(user))) {
+        return testflightRedirect(request, "ineligible");
+      }
+      const name = splitDisplayName(user.displayName);
+      await enrollTester(email, name.firstName, name.lastName);
+      return testflightRedirect(request, "joined");
+    }
+
+    await removeTester(email);
+    return testflightRedirect(request, "left");
+  } catch (error) {
+    captureAscError(error, {
+      route: "/api/testflight",
+      stackUserId,
+      action,
+    });
+    return testflightRedirect(request, "error");
+  }
+}
+
+function testflightAction(formData: FormData): TestflightAction | null {
+  const action = formData.get("action");
+  return action === "join" || action === "leave" ? action : null;
+}
+
+function normalizedEmail(email: string | null | undefined): string | null {
+  const normalized = email?.trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+function splitDisplayName(displayName: string | null | undefined): {
+  firstName?: string;
+  lastName?: string;
+} {
+  const parts = displayName?.trim().split(/\s+/).filter(Boolean) ?? [];
+  if (parts.length === 0) return {};
+  if (parts.length === 1) return { firstName: parts[0] };
+  return {
+    firstName: parts[0],
+    lastName: parts.slice(1).join(" "),
+  };
+}
+
+function testflightRedirect(
+  request: NextRequest,
+  testflight:
+    | "joined"
+    | "left"
+    | "error"
+    | "ineligible"
+    | "needs_email"
+    | "unavailable",
+) {
+  const url = new URL(localizedTestflightPath(request), request.url);
+  url.searchParams.set("testflight", testflight);
+  return NextResponse.redirect(url, 303);
+}
+
+function localizedTestflightPath(request: NextRequest): string {
+  const locale = requestLocale(request);
+  return locale === routing.defaultLocale
+    ? "/dashboard/testflight"
+    : `/${locale}/dashboard/testflight`;
+}
+
+function requestLocale(request: NextRequest): string {
+  const referer = request.headers.get("referer");
+  if (referer) {
+    try {
+      const firstSegment = new URL(referer).pathname.split("/").filter(Boolean)[0];
+      if (locales.includes(firstSegment as (typeof locales)[number])) {
+        return firstSegment;
+      }
+    } catch {
+      // Ignore malformed referers and fall back to the default locale.
+    }
+  }
+  return routing.defaultLocale;
+}

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -69,6 +69,16 @@ export const env = createEnv({
     STRIPE_PRO_MONTHLY_PRICE_ID: z.string().min(1).optional(),
     STRIPE_PRO_YEARLY_PRICE_ID: z.string().min(1).optional(),
     STRIPE_TEAM_MONTHLY_PRICE_ID: z.string().min(1).optional(),
+    // App Store Connect API for server-side TestFlight enrollment. Optional:
+    // the dashboard shows enrollment unavailable until these credentials are set.
+    // ASC_PRIVATE_KEY accepts PEM contents with literal "\n" escapes;
+    // ASC_PRIVATE_KEY_PATH is a local-dev fallback path.
+    ASC_KEY_ID: z.string().min(1).optional(),
+    ASC_ISSUER_ID: z.string().min(1).optional(),
+    ASC_PRIVATE_KEY: z.string().min(1).optional(),
+    ASC_PRIVATE_KEY_PATH: z.string().min(1).optional(),
+    CMUX_TESTFLIGHT_APP_ID: z.string().min(1).optional(),
+    CMUX_TESTFLIGHT_GROUP_ID: z.string().min(1).optional(),
     SENTRY_DSN: z.string().url().optional(),
     // Slack Incoming Webhook for the #website-waitlist channel. Optional: the
     // /api/waitlist route silently skips the Slack ping when it is unset.
@@ -101,6 +111,12 @@ export const env = createEnv({
     STRIPE_PRO_MONTHLY_PRICE_ID: trimEnv(process.env.STRIPE_PRO_MONTHLY_PRICE_ID),
     STRIPE_PRO_YEARLY_PRICE_ID: trimEnv(process.env.STRIPE_PRO_YEARLY_PRICE_ID),
     STRIPE_TEAM_MONTHLY_PRICE_ID: trimEnv(process.env.STRIPE_TEAM_MONTHLY_PRICE_ID),
+    ASC_KEY_ID: trimEnv(process.env.ASC_KEY_ID),
+    ASC_ISSUER_ID: trimEnv(process.env.ASC_ISSUER_ID),
+    ASC_PRIVATE_KEY: trimEnv(process.env.ASC_PRIVATE_KEY),
+    ASC_PRIVATE_KEY_PATH: trimEnv(process.env.ASC_PRIVATE_KEY_PATH),
+    CMUX_TESTFLIGHT_APP_ID: trimEnv(process.env.CMUX_TESTFLIGHT_APP_ID),
+    CMUX_TESTFLIGHT_GROUP_ID: trimEnv(process.env.CMUX_TESTFLIGHT_GROUP_ID),
     SENTRY_DSN: trimEnv(process.env.SENTRY_DSN),
     SLACK_WAITLIST_WEBHOOK_URL: trimEnv(process.env.SLACK_WAITLIST_WEBHOOK_URL),
     SLACK_ENTERPRISE_WEBHOOK_URL: trimEnv(process.env.SLACK_ENTERPRISE_WEBHOOK_URL),

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -53,7 +53,8 @@
       "subrouterGroup": "subrouter",
       "subrouterOverview": "overview",
       "accountGroup": "account",
-      "billing": "billing"
+      "billing": "billing",
+      "testflight": "iOS TestFlight"
     },
     "home": {
       "title": "dashboard",
@@ -118,6 +119,50 @@
         "cancelSummary": "Cancel plan",
         "confirmCancel": "Confirm cancellation",
         "resume": "Resume plan"
+      }
+    },
+    "testflight": {
+      "eyebrow": "account",
+      "title": "iOS TestFlight",
+      "description": "join the cmux iOS beta from your active subscription.",
+      "banners": {
+        "joined": "Apple will email your TestFlight invite shortly.",
+        "left": "You have left the iOS TestFlight group.",
+        "error": "TestFlight could not be updated. Try again shortly.",
+        "ineligible": "An active Pro or Team subscription is required for iOS TestFlight.",
+        "needs_email": "Add a verified primary email before joining iOS TestFlight.",
+        "unavailable": "TestFlight enrollment is not available right now."
+      },
+      "notEligible": {
+        "title": "Subscription required",
+        "body": "iOS TestFlight access is available to active Pro users and members of a Team subscription."
+      },
+      "needsEmail": {
+        "title": "Verified email required",
+        "body": "Add a verified primary email to your account so Apple can send the TestFlight invite."
+      },
+      "unavailable": {
+        "title": "Enrollment unavailable",
+        "body": "TestFlight enrollment is not configured for this environment. Try again later."
+      },
+      "join": {
+        "title": "Join the iOS beta",
+        "body": "Apple will send a TestFlight invite to {email}. Install TestFlight on your iPhone, then accept the invite."
+      },
+      "enrolled": {
+        "title": "You are enrolled",
+        "body": "{email} is in the cmux iOS TestFlight group.",
+        "lapseNote": "Access ends automatically if your subscription lapses."
+      },
+      "details": {
+        "email": "Email",
+        "status": "Status",
+        "enrolled": "Enrolled"
+      },
+      "actions": {
+        "viewPricing": "View pricing",
+        "join": "Join iOS TestFlight",
+        "leave": "Leave TestFlight"
       }
     },
     "aiAccounts": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -53,7 +53,8 @@
       "subrouterGroup": "subrouter",
       "subrouterOverview": "概要",
       "accountGroup": "アカウント",
-      "billing": "請求"
+      "billing": "請求",
+      "testflight": "iOS TestFlight"
     },
     "home": {
       "title": "ダッシュボード",
@@ -118,6 +119,50 @@
         "cancelSummary": "プランをキャンセル",
         "confirmCancel": "キャンセルを確定",
         "resume": "プランを再開"
+      }
+    },
+    "testflight": {
+      "eyebrow": "アカウント",
+      "title": "iOS TestFlight",
+      "description": "有効なサブスクリプションでcmux iOSベータに参加します。",
+      "banners": {
+        "joined": "AppleからTestFlightの招待メールがまもなく届きます。",
+        "left": "iOS TestFlightグループから退出しました。",
+        "error": "TestFlightを更新できませんでした。しばらくしてから再試行してください。",
+        "ineligible": "iOS TestFlightには有効なProまたはTeamサブスクリプションが必要です。",
+        "needs_email": "iOS TestFlightに参加する前に、確認済みのメインメールを追加してください。",
+        "unavailable": "現在、TestFlight登録は利用できません。"
+      },
+      "notEligible": {
+        "title": "サブスクリプションが必要です",
+        "body": "iOS TestFlightアクセスは、有効なProユーザーとTeamサブスクリプションのメンバーが利用できます。"
+      },
+      "needsEmail": {
+        "title": "確認済みメールが必要です",
+        "body": "AppleがTestFlight招待を送信できるよう、アカウントに確認済みのメインメールを追加してください。"
+      },
+      "unavailable": {
+        "title": "登録を利用できません",
+        "body": "この環境ではTestFlight登録が設定されていません。しばらくしてから再試行してください。"
+      },
+      "join": {
+        "title": "iOSベータに参加",
+        "body": "Appleが{email}にTestFlight招待を送信します。iPhoneにTestFlightをインストールして、招待を承認してください。"
+      },
+      "enrolled": {
+        "title": "登録済みです",
+        "body": "{email}はcmux iOS TestFlightグループに登録されています。",
+        "lapseNote": "サブスクリプションが失効すると、アクセスは自動的に終了します。"
+      },
+      "details": {
+        "email": "メール",
+        "status": "ステータス",
+        "enrolled": "登録済み"
+      },
+      "actions": {
+        "viewPricing": "料金を見る",
+        "join": "iOS TestFlightに参加",
+        "leave": "TestFlightから退出"
       }
     },
     "aiAccounts": {

--- a/web/services/asc/client.ts
+++ b/web/services/asc/client.ts
@@ -1,0 +1,175 @@
+import { readFile } from "node:fs/promises";
+import { createPrivateKey, sign } from "node:crypto";
+
+import { env } from "../../app/env";
+
+const ASC_BASE_URL = "https://api.appstoreconnect.apple.com";
+const ASC_JWT_AUDIENCE = "appstoreconnect-v1";
+const ASC_JWT_TTL_SECONDS = 19 * 60;
+const ASC_TIMEOUT_MS = 10_000;
+
+export class AscApiError extends Error {
+  readonly name = "AscApiError";
+
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly details?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+export class AscConfigurationError extends Error {
+  readonly name = "AscConfigurationError";
+}
+
+export class AscNetworkError extends Error {
+  readonly name = "AscNetworkError";
+
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+  }
+}
+
+export function isAscConfigured(): boolean {
+  return Boolean(
+    env.ASC_KEY_ID &&
+      env.ASC_ISSUER_ID &&
+      (env.ASC_PRIVATE_KEY || env.ASC_PRIVATE_KEY_PATH),
+  );
+}
+
+export async function ascFetch<T = unknown>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  if (!isAscConfigured()) {
+    throw new AscConfigurationError("App Store Connect is not configured");
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ASC_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${ASC_BASE_URL}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+        ...init.headers,
+        authorization: `Bearer ${await ascJwt()}`,
+      },
+    });
+
+    if (!response.ok) {
+      const details = await responseJson(response);
+      throw new AscApiError(
+        `App Store Connect request failed with ${response.status}`,
+        response.status,
+        details,
+      );
+    }
+
+    if (response.status === 204) return null as T;
+    return (await responseJson(response)) as T;
+  } catch (error) {
+    if (error instanceof AscApiError || error instanceof AscConfigurationError) {
+      throw error;
+    }
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new AscNetworkError("App Store Connect request timed out", error);
+    }
+    throw new AscNetworkError("App Store Connect request failed", error);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function ascJwt(): Promise<string> {
+  if (!env.ASC_KEY_ID || !env.ASC_ISSUER_ID) {
+    throw new AscConfigurationError("App Store Connect credentials are incomplete");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "ES256", kid: env.ASC_KEY_ID, typ: "JWT" };
+  const payload = {
+    iss: env.ASC_ISSUER_ID,
+    iat: now,
+    exp: now + ASC_JWT_TTL_SECONDS,
+    aud: ASC_JWT_AUDIENCE,
+  };
+  const input = `${base64UrlJson(header)}.${base64UrlJson(payload)}`;
+  const key = createPrivateKey(await ascPrivateKey());
+  const derSignature = sign("sha256", Buffer.from(input), key);
+  return `${input}.${base64Url(derToJoseSignature(derSignature, 32))}`;
+}
+
+async function ascPrivateKey(): Promise<string> {
+  if (env.ASC_PRIVATE_KEY) {
+    return env.ASC_PRIVATE_KEY.replaceAll("\\n", "\n");
+  }
+  if (env.ASC_PRIVATE_KEY_PATH) {
+    return readFile(env.ASC_PRIVATE_KEY_PATH, "utf8");
+  }
+  throw new AscConfigurationError("App Store Connect private key is missing");
+}
+
+async function responseJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { body: text };
+  }
+}
+
+function base64UrlJson(value: unknown): string {
+  return base64Url(Buffer.from(JSON.stringify(value)));
+}
+
+function base64Url(value: Buffer): string {
+  return value
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+function derToJoseSignature(signature: Buffer, partLength: number): Buffer {
+  let offset = 0;
+  if (signature[offset++] !== 0x30) throw new Error("Invalid ECDSA signature");
+  offset = readDerLength(signature, offset).offset;
+  if (signature[offset++] !== 0x02) throw new Error("Invalid ECDSA signature");
+  const rLength = readDerLength(signature, offset);
+  offset = rLength.offset;
+  const r = signature.subarray(offset, offset + rLength.length);
+  offset += rLength.length;
+  if (signature[offset++] !== 0x02) throw new Error("Invalid ECDSA signature");
+  const sLength = readDerLength(signature, offset);
+  offset = sLength.offset;
+  const s = signature.subarray(offset, offset + sLength.length);
+  return Buffer.concat([leftPadUnsigned(r, partLength), leftPadUnsigned(s, partLength)]);
+}
+
+function readDerLength(
+  buffer: Buffer,
+  offset: number,
+): { length: number; offset: number } {
+  const first = buffer[offset++];
+  if (first < 0x80) return { length: first, offset };
+  const bytes = first & 0x7f;
+  let length = 0;
+  for (let index = 0; index < bytes; index++) {
+    length = (length << 8) | buffer[offset++];
+  }
+  return { length, offset };
+}
+
+function leftPadUnsigned(value: Buffer, length: number): Buffer {
+  const unsigned = value[0] === 0 ? value.subarray(1) : value;
+  if (unsigned.length === length) return unsigned;
+  if (unsigned.length > length) return unsigned.subarray(unsigned.length - length);
+  return Buffer.concat([Buffer.alloc(length - unsigned.length), unsigned]);
+}

--- a/web/services/asc/testflight.ts
+++ b/web/services/asc/testflight.ts
@@ -1,0 +1,147 @@
+import {
+  AscApiError,
+  ascFetch,
+} from "./client";
+import { env } from "../../app/env";
+
+export const TESTFLIGHT_APP_ID =
+  env.CMUX_TESTFLIGHT_APP_ID || "6757092429";
+export const TESTFLIGHT_GROUP_ID =
+  env.CMUX_TESTFLIGHT_GROUP_ID ||
+  "3ee84bfa-10ad-4f23-a45c-f9a3b037373e";
+
+type JsonApiResource = {
+  readonly id: string;
+  readonly type: string;
+  readonly attributes?: Record<string, unknown>;
+};
+
+type JsonApiList = {
+  readonly data?: readonly JsonApiResource[];
+};
+
+export type TestFlightGroupStatus = {
+  readonly enrolled: boolean;
+  readonly state?: string;
+};
+
+export async function findBetaTesterByEmail(
+  email: string,
+): Promise<{ id: string; state?: string } | null> {
+  const response = await ascFetch<JsonApiList>(
+    `/v1/betaTesters?filter[email]=${encodeURIComponent(normalizeEmail(email))}&limit=1`,
+  );
+  const tester = response.data?.[0];
+  return tester ? { id: tester.id, state: testerState(tester) } : null;
+}
+
+export async function testerGroupStatus(
+  email: string,
+): Promise<TestFlightGroupStatus> {
+  const tester = await findBetaTesterByEmail(email);
+  if (!tester) return { enrolled: false };
+
+  const response = await ascFetch<JsonApiList>(
+    `/v1/betaTesters/${encodeURIComponent(tester.id)}/betaGroups?limit=200`,
+  );
+  const enrolled = Boolean(
+    response.data?.some((group) => group.id === TESTFLIGHT_GROUP_ID),
+  );
+  return {
+    enrolled,
+    state: tester.state,
+  };
+}
+
+export async function enrollTester(
+  email: string,
+  firstName?: string,
+  lastName?: string,
+): Promise<void> {
+  const normalizedEmail = normalizeEmail(email);
+  try {
+    await ascFetch("/v1/betaTesters", {
+      method: "POST",
+      body: JSON.stringify({
+        data: {
+          type: "betaTesters",
+          attributes: {
+            email: normalizedEmail,
+            firstName: optionalString(firstName),
+            lastName: optionalString(lastName),
+          },
+          relationships: {
+            betaGroups: {
+              data: [{ type: "betaGroups", id: TESTFLIGHT_GROUP_ID }],
+            },
+          },
+        },
+      }),
+    });
+    return;
+  } catch (error) {
+    if (!isAlreadyExistsError(error)) throw error;
+  }
+
+  const tester = await findBetaTesterByEmail(normalizedEmail);
+  if (!tester) throw new AscApiError("Existing beta tester could not be found", 409);
+  await addTesterToGroup(tester.id);
+}
+
+export async function removeTester(email: string): Promise<void> {
+  const tester = await findBetaTesterByEmail(email);
+  if (!tester) return;
+  try {
+    await ascFetch(`/v1/betaGroups/${encodeURIComponent(TESTFLIGHT_GROUP_ID)}/relationships/betaTesters`, {
+      method: "DELETE",
+      body: JSON.stringify({
+        data: [{ type: "betaTesters", id: tester.id }],
+      }),
+    });
+  } catch (error) {
+    if (isMissingRelationshipError(error)) return;
+    throw error;
+  }
+}
+
+async function addTesterToGroup(testerId: string): Promise<void> {
+  try {
+    await ascFetch(`/v1/betaGroups/${encodeURIComponent(TESTFLIGHT_GROUP_ID)}/relationships/betaTesters`, {
+      method: "POST",
+      body: JSON.stringify({
+        data: [{ type: "betaTesters", id: testerId }],
+      }),
+    });
+  } catch (error) {
+    if (isAlreadyExistsError(error)) return;
+    throw error;
+  }
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function optionalString(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function testerState(tester: JsonApiResource): string | undefined {
+  const attributes = tester.attributes;
+  const state =
+    attributes?.state ??
+    attributes?.betaTesterState ??
+    attributes?.inviteType;
+  return typeof state === "string" && state.trim() ? state.trim() : undefined;
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  if (!(error instanceof AscApiError)) return false;
+  if (error.status === 409) return true;
+  return JSON.stringify(error.details ?? "").toLowerCase().includes("already");
+}
+
+function isMissingRelationshipError(error: unknown): boolean {
+  return error instanceof AscApiError && (error.status === 404 || error.status === 409);
+}

--- a/web/services/billing/pro.ts
+++ b/web/services/billing/pro.ts
@@ -125,6 +125,15 @@ export type ProReconcileUser = ProductsCustomer & ProMetadataCustomer & {
 export type ActiveStripeSubscriptionQuery = (stackUserId: string) => Promise<boolean>;
 export type BillingManagementKind = "stripe" | "external" | "none";
 
+type BillingTeamUserLike = {
+  readonly selectedTeam?: unknown;
+  readonly listTeams?: () => Promise<readonly unknown[]>;
+};
+
+type BillingTeamLike = {
+  readonly id?: string;
+};
+
 export type ProPlanStatus = {
   readonly planId: typeof FREE_PLAN_ID | typeof PRO_PLAN_ID;
   readonly isPro: boolean;
@@ -239,6 +248,15 @@ export async function hasActiveTeamSubscriptionForTeam(
   }
 }
 
+export async function isTestflightEligible(
+  user: ProReconcileUser & BillingTeamUserLike,
+): Promise<boolean> {
+  const status = await resolveProPlanStatus(user);
+  if (status.isPro) return true;
+  const team = await billingTeamForUser(user);
+  return team?.id ? hasActiveTeamSubscriptionForTeam(team.id) : false;
+}
+
 export function metadataPlanId(raw: unknown): string | null {
   return planIdFromMetadata(proMetadataRecord(raw));
 }
@@ -303,6 +321,21 @@ function hasManualVmOverride(metadata: Record<string, unknown>): boolean {
 function planIdFromMetadata(metadata: Record<string, unknown>): string | null {
   const value = metadata.cmuxPlan;
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+async function billingTeamForUser(user: BillingTeamUserLike): Promise<BillingTeamLike | null> {
+  const selected = teamFromUnknown(user.selectedTeam);
+  if (selected) return selected;
+  const teams = typeof user.listTeams === "function"
+    ? (await user.listTeams()).map(teamFromUnknown).filter((team): team is BillingTeamLike => !!team)
+    : [];
+  return teams.length === 1 ? teams[0] : null;
+}
+
+function teamFromUnknown(value: unknown): BillingTeamLike | null {
+  if (!value || typeof value !== "object") return null;
+  const id = (value as { id?: unknown }).id;
+  return typeof id === "string" && id ? { id } : null;
 }
 
 function isMissingDatabaseConfig(error: unknown): boolean {

--- a/web/services/billing/purchase.ts
+++ b/web/services/billing/purchase.ts
@@ -15,6 +15,9 @@ import {
   syncProPlanMetadata,
   syncTeamPlanMetadata,
 } from "./pro";
+import { isAscConfigured } from "../asc/client";
+import { removeTester } from "../asc/testflight";
+import { captureAscError } from "../errors";
 
 export const ACTIVE_STRIPE_SUBSCRIPTION_STATUSES = new Set([
   "active",
@@ -51,6 +54,14 @@ type StackBillingApp = {
 type BillingPurchaseDependencies = {
   db?: BillingDb;
   stackApp?: StackBillingApp | null;
+  testflight?: {
+    isAscConfigured?: () => boolean;
+    removeTester?: (email: string) => Promise<void>;
+    captureAscError?: (
+      error: unknown,
+      context?: Record<string, string | number | boolean | null | undefined>,
+    ) => void;
+  };
 };
 
 export type CheckoutCompletionInput = {
@@ -172,6 +183,9 @@ export async function applySubscriptionUpdate(
   const isActive = isActiveStripeSubscriptionStatus(subscription.status);
   const user = await loadStackUser(stackUserId, dependencies.stackApp);
   await syncProPlanMetadata(user, isActive);
+  if (!isActive) {
+    await removeUserFromTestflightOnLapse(user, stackUserId, dependencies);
+  }
   return { scope: "user", stackUserId, isActive };
 }
 
@@ -228,6 +242,26 @@ async function loadStackTeam(
     throw new Error("Stack Auth server SDK cannot update team metadata");
   }
   return team as StackBillingTeam;
+}
+
+async function removeUserFromTestflightOnLapse(
+  user: StackBillingUser,
+  stackUserId: string,
+  dependencies: BillingPurchaseDependencies,
+): Promise<void> {
+  const configured = dependencies.testflight?.isAscConfigured ?? isAscConfigured;
+  if (!configured()) return;
+  if (!user.primaryEmail) return;
+
+  try {
+    await (dependencies.testflight?.removeTester ?? removeTester)(user.primaryEmail);
+  } catch (error) {
+    (dependencies.testflight?.captureAscError ?? captureAscError)(error, {
+      route: "/api/stripe/webhook",
+      stackUserId,
+      email: user.primaryEmail,
+    });
+  }
 }
 
 async function recordTeamCheckoutCompletion(input: {

--- a/web/services/errors.ts
+++ b/web/services/errors.ts
@@ -15,6 +15,19 @@ export function captureBillingError(
   });
 }
 
+export function captureAscError(
+  error: unknown,
+  context: Record<string, string | number | boolean | null | undefined> = {},
+): void {
+  if (!env.SENTRY_DSN) return;
+  Sentry.captureException(error, {
+    tags: {
+      subsystem: "app-store-connect",
+    },
+    extra: cleanContext(context),
+  });
+}
+
 function cleanContext(
   context: Record<string, string | number | boolean | null | undefined>,
 ): Record<string, string | number | boolean> {

--- a/web/tests/billing-purchase.test.ts
+++ b/web/tests/billing-purchase.test.ts
@@ -339,6 +339,137 @@ describe("recordCheckoutCompletion", () => {
     });
   });
 
+  test("removes a user from TestFlight when a user Pro subscription lapses", async () => {
+    const update = mock(async () => undefined);
+    const removeTester = mock(async () => undefined);
+    const user = {
+      id: "user_123",
+      primaryEmail: "buyer@example.com",
+      clientReadOnlyMetadata: { cmuxPlan: "pro" },
+      update,
+    };
+
+    const result = await applySubscriptionUpdate(
+      userSubscriptionUpdate({ status: "canceled" }) as never,
+      {
+        db: fakeDb() as never,
+        stackApp: { getUser: async () => user } as never,
+        testflight: {
+          isAscConfigured: () => true,
+          removeTester,
+        },
+      },
+    );
+
+    expect(result).toEqual({ scope: "user", stackUserId: "user_123", isActive: false });
+    expect(removeTester).toHaveBeenCalledWith("buyer@example.com");
+    expect(update).toHaveBeenCalledWith({ clientReadOnlyMetadata: {} });
+  });
+
+  test("does not fail the webhook when TestFlight removal fails", async () => {
+    const captureAscError = mock(() => undefined);
+    const user = {
+      id: "user_123",
+      primaryEmail: "buyer@example.com",
+      clientReadOnlyMetadata: { cmuxPlan: "pro" },
+      update: mock(async () => undefined),
+    };
+
+    const result = await applySubscriptionUpdate(
+      userSubscriptionUpdate({ status: "canceled" }) as never,
+      {
+        db: fakeDb() as never,
+        stackApp: { getUser: async () => user } as never,
+        testflight: {
+          isAscConfigured: () => true,
+          removeTester: async () => {
+            throw new Error("ASC down");
+          },
+          captureAscError,
+        },
+      },
+    );
+
+    expect(result).toEqual({ scope: "user", stackUserId: "user_123", isActive: false });
+    expect(captureAscError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "ASC down" }),
+      expect.objectContaining({
+        route: "/api/stripe/webhook",
+        stackUserId: "user_123",
+        email: "buyer@example.com",
+      }),
+    );
+  });
+
+  test("does not remove TestFlight access when ASC is unconfigured", async () => {
+    const removeTester = mock(async () => undefined);
+    const user = {
+      id: "user_123",
+      primaryEmail: "buyer@example.com",
+      clientReadOnlyMetadata: { cmuxPlan: "pro" },
+      update: mock(async () => undefined),
+    };
+
+    await applySubscriptionUpdate(
+      userSubscriptionUpdate({ status: "canceled" }) as never,
+      {
+        db: fakeDb() as never,
+        stackApp: { getUser: async () => user } as never,
+        testflight: {
+          isAscConfigured: () => false,
+          removeTester,
+        },
+      },
+    );
+
+    expect(removeTester).not.toHaveBeenCalled();
+  });
+
+  test("does not remove TestFlight access when a Team subscription lapses", async () => {
+    const removeTester = mock(async () => undefined);
+    const team = {
+      id: "team_123",
+      clientReadOnlyMetadata: { cmuxPlan: "team" },
+      update: mock(async () => undefined),
+    };
+    selectResults = [[{ stackUserId: "owner_123" }], []];
+
+    const result = await applySubscriptionUpdate(
+      {
+        id: "sub_team",
+        customer: "cus_team",
+        status: "canceled",
+        metadata: { stackTeamId: "team_123", plan: "team", app: "cmux" },
+        cancel_at_period_end: false,
+        items: {
+          data: [
+            {
+              quantity: 7,
+              current_period_end: 1_800_000_000,
+              price: { id: "price_team" },
+            },
+          ],
+        },
+      } as never,
+      {
+        db: fakeDb() as never,
+        stackApp: {
+          getUser: async () => {
+            throw new Error("should not load Stack user for Team subscription");
+          },
+          getTeam: async () => team,
+        } as never,
+        testflight: {
+          isAscConfigured: () => true,
+          removeTester,
+        },
+      },
+    );
+
+    expect(result).toEqual({ scope: "team", stackTeamId: "team_123", isActive: false });
+    expect(removeTester).not.toHaveBeenCalled();
+  });
+
   test("skips foreign subscription updates even when they carry a stackUserId", async () => {
     const result = await applySubscriptionUpdate(
       {
@@ -362,3 +493,21 @@ describe("recordCheckoutCompletion", () => {
     expect(updates).toHaveLength(0);
   });
 });
+
+function userSubscriptionUpdate({ status }: { status: string }) {
+  return {
+    id: "sub_user",
+    customer: "cus_user",
+    status,
+    metadata: { stackUserId: "user_123", plan: "pro", app: "cmux" },
+    cancel_at_period_end: false,
+    items: {
+      data: [
+        {
+          current_period_end: 1_800_000_000,
+          price: { id: "price_123" },
+        },
+      ],
+    },
+  };
+}

--- a/web/tests/dashboard-testflight-page.test.tsx
+++ b/web/tests/dashboard-testflight-page.test.tsx
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import enMessages from "../messages/en.json";
+
+let stackConfigured = true;
+let currentUser: typeof testflightUser | null = null;
+let eligible = true;
+let ascConfigured = true;
+let status = { enrolled: false } as { enrolled: boolean; state?: string };
+
+const testflightUser = {
+  id: "user-pro",
+  isAnonymous: false,
+  primaryEmail: "Pro@Example.com",
+  displayName: "Pro User",
+  clientReadOnlyMetadata: {},
+  listProducts: mock(async () =>
+    Object.assign(
+      eligible
+        ? [
+            {
+              id: "pro",
+              quantity: 1,
+              subscription: {
+                cancelAtPeriodEnd: false,
+                currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
+              },
+            },
+          ]
+        : [],
+      { nextCursor: null },
+    ),
+  ),
+  update: mock(async () => undefined),
+};
+
+const getUser = mock(async () => currentUser);
+const ascFetch = mock(async (path: unknown) => {
+  if (String(path).startsWith("/v1/betaTesters?")) {
+    return {
+      data: [
+        {
+          type: "betaTesters",
+          id: "tester_123",
+          attributes: status.state ? { state: status.state } : {},
+        },
+      ],
+    };
+  }
+  if (String(path).includes("/betaGroups")) {
+    return {
+      data: status.enrolled
+        ? [
+            {
+              type: "betaGroups",
+              id: "3ee84bfa-10ad-4f23-a45c-f9a3b037373e",
+            },
+          ]
+        : [],
+    };
+  }
+  return {};
+});
+const captureAscError = mock(() => undefined);
+
+mock.module("next-intl/server", () => ({
+  getTranslations: async (input?: string | { namespace?: string }) =>
+    translator(typeof input === "string" ? input : input?.namespace),
+  setRequestLocale: () => undefined,
+}));
+
+mock.module("@/i18n/navigation", () => ({
+  Link: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  redirect: () => undefined,
+  usePathname: () => "/dashboard/testflight",
+  useRouter: () => ({}),
+  getPathname: () => "/dashboard/testflight",
+}));
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => stackConfigured,
+  stackServerApp: stackConfigured ? { getUser } : null,
+}));
+
+mock.module("../services/asc/client", () => ({
+  AscApiError: class AscApiError extends Error {},
+  AscConfigurationError: class AscConfigurationError extends Error {},
+  AscNetworkError: class AscNetworkError extends Error {},
+  ascFetch,
+  isAscConfigured: () => ascConfigured,
+}));
+
+mock.module("../services/errors", () => ({
+  captureAscError,
+  captureBillingError: mock(() => undefined),
+}));
+
+const { default: DashboardTestflightPage } = await import("../app/[locale]/dashboard/testflight/page");
+
+describe("dashboard TestFlight page", () => {
+  beforeEach(() => {
+    stackConfigured = true;
+    currentUser = testflightUser;
+    eligible = true;
+    ascConfigured = true;
+    status = { enrolled: false };
+    getUser.mockClear();
+    testflightUser.listProducts.mockClear();
+    testflightUser.update.mockClear();
+    ascFetch.mockClear();
+    captureAscError.mockClear();
+  });
+
+  test("renders not eligible state with pricing link", async () => {
+    eligible = false;
+
+    const html = await renderTestflightPage();
+
+    expect(html).toContain("Subscription required");
+    expect(html).toContain("active Pro users and members of a Team subscription");
+    expect(html).toContain('href="/pricing"');
+    expect(html).not.toContain("/api/testflight");
+    expect(ascFetch).not.toHaveBeenCalled();
+  });
+
+  test("renders eligible not enrolled state with join form", async () => {
+    const html = await renderTestflightPage();
+
+    expect(html).toContain("Join the iOS beta");
+    expect(html).toContain("Apple will send a TestFlight invite to pro@example.com");
+    expect(html).toContain('action="/api/testflight"');
+    expect(html).toContain('name="action" value="join"');
+    expect(ascFetch).toHaveBeenCalledWith(
+      "/v1/betaTesters?filter[email]=pro%40example.com&limit=1",
+    );
+  });
+
+  test("renders enrolled state with status and leave form", async () => {
+    status = { enrolled: true, state: "INVITED" };
+
+    const html = await renderTestflightPage();
+
+    expect(html).toContain("You are enrolled");
+    expect(html).toContain("INVITED");
+    expect(html).toContain("Access ends automatically if your subscription lapses.");
+    expect(html).toContain('name="action" value="leave"');
+  });
+
+  for (const [testflight, message] of [
+    ["joined", "Apple will email your TestFlight invite shortly."],
+    ["left", "You have left the iOS TestFlight group."],
+    ["error", "TestFlight could not be updated. Try again shortly."],
+    ["ineligible", "An active Pro or Team subscription is required for iOS TestFlight."],
+    ["needs_email", "Add a verified primary email before joining iOS TestFlight."],
+    ["unavailable", "TestFlight enrollment is not available right now."],
+  ] as const) {
+    test(`renders ${testflight} banner`, async () => {
+      const html = await renderTestflightPage({ testflight });
+
+      expect(html).toContain(message);
+    });
+  }
+});
+
+async function renderTestflightPage(searchParams: Record<string, string> = {}) {
+  const element = await DashboardTestflightPage({
+    params: Promise.resolve({ locale: "en" }),
+    searchParams: Promise.resolve(searchParams),
+  });
+  return renderToStaticMarkup(element);
+}
+
+function translator(namespace?: string) {
+  const root = namespace ? valueAtPath(enMessages, namespace) : enMessages;
+  const t = (key: string, values?: Record<string, unknown>) => {
+    const message = String(valueAtPath(root, key));
+    return interpolate(message, values);
+  };
+  t.raw = (key: string) => valueAtPath(root, key);
+  t.rich = (key: string, values?: Record<string, unknown>) =>
+    interpolate(String(valueAtPath(root, key)), values);
+  return t;
+}
+
+function valueAtPath(root: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((value, part) => {
+    if (value && typeof value === "object" && part in value) {
+      return (value as Record<string, unknown>)[part];
+    }
+    return path;
+  }, root);
+}
+
+function interpolate(message: string, values?: Record<string, unknown>) {
+  if (!values) return message;
+  return Object.entries(values).reduce(
+    (result, [key, value]) => result.replaceAll(`{${key}}`, String(value)),
+    message,
+  );
+}

--- a/web/tests/testflight-route.test.ts
+++ b/web/tests/testflight-route.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+const currentUser = {
+  id: "user-pro",
+  isAnonymous: false,
+  primaryEmail: "Pro@Example.com",
+  displayName: "Pro User",
+  clientReadOnlyMetadata: {},
+  listProducts: mock(async () =>
+    Object.assign(
+      eligible
+        ? [
+            {
+              id: "pro",
+              quantity: 1,
+              subscription: {
+                cancelAtPeriodEnd: false,
+                currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
+              },
+            },
+          ]
+        : [],
+      { nextCursor: null },
+    ),
+  ),
+  update: mock(async () => undefined),
+};
+
+let stackConfigured = true;
+let ascConfigured = true;
+let eligible = true;
+let user: typeof currentUser | null = currentUser;
+
+const getUser = mock(async () => user);
+const ascFetch = mock(async (path: unknown) => {
+  if (String(path).startsWith("/v1/betaTesters?")) {
+    return {
+      data: [
+        {
+          type: "betaTesters",
+          id: "tester_123",
+          attributes: {},
+        },
+      ],
+    };
+  }
+  return {};
+});
+const captureAscError = mock(() => undefined);
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => stackConfigured,
+  stackServerApp: stackConfigured ? { getUser } : null,
+}));
+
+mock.module("../services/asc/client", () => ({
+  AscApiError: class AscApiError extends Error {},
+  AscConfigurationError: class AscConfigurationError extends Error {},
+  AscNetworkError: class AscNetworkError extends Error {},
+  ascFetch,
+  isAscConfigured: () => ascConfigured,
+}));
+
+mock.module("../services/errors", () => ({
+  captureAscError,
+  captureBillingError: mock(() => undefined),
+}));
+
+const { POST } = await import("../app/api/testflight/route");
+
+describe("TestFlight route", () => {
+  beforeEach(() => {
+    stackConfigured = true;
+    ascConfigured = true;
+    eligible = true;
+    user = currentUser;
+    getUser.mockClear();
+    currentUser.listProducts.mockClear();
+    currentUser.update.mockClear();
+    ascFetch.mockClear();
+    captureAscError.mockClear();
+    mockImplementation(ascFetch, async (path: unknown) => {
+      if (String(path).startsWith("/v1/betaTesters?")) {
+        return {
+          data: [
+            {
+              type: "betaTesters",
+              id: "tester_123",
+              attributes: {},
+            },
+          ],
+        };
+      }
+      return {};
+    });
+  });
+
+  test("joins an eligible user and redirects with joined", async () => {
+    const response = await postAction("join");
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/testflight?testflight=joined",
+    );
+    expect(ascFetch).toHaveBeenCalledWith(
+      "/v1/betaTesters",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(String(callInit(0).body));
+    expect(body.data.attributes).toMatchObject({
+      email: "pro@example.com",
+      firstName: "Pro",
+      lastName: "User",
+    });
+  });
+
+  test("does not enroll ineligible users", async () => {
+    eligible = false;
+
+    const response = await postAction("join");
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/testflight?testflight=ineligible",
+    );
+    expect(ascFetch).not.toHaveBeenCalled();
+  });
+
+  test("leaves by removing the current user's email", async () => {
+    const response = await postAction("leave");
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/testflight?testflight=left",
+    );
+    expect(ascFetch).toHaveBeenCalledWith(
+      "/v1/betaGroups/3ee84bfa-10ad-4f23-a45c-f9a3b037373e/relationships/betaTesters",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  test("redirects anonymous users to sign in", async () => {
+    user = null;
+
+    const response = await postAction("join", {
+      referer: "https://cmux.test/ja/dashboard/testflight",
+    });
+    const location = new URL(response.headers.get("location")!);
+    const afterSignIn = new URL(
+      location.searchParams.get("after_auth_return_to")!,
+      "https://cmux.test",
+    );
+
+    expect(response.status).toBe(303);
+    expect(location.pathname).toBe("/handler/sign-in");
+    expect(afterSignIn.searchParams.get("after_auth_return_to")).toBe(
+      "/ja/dashboard/testflight",
+    );
+    expect(ascFetch).not.toHaveBeenCalled();
+  });
+
+  test("rejects cross-site posts before auth or ASC writes", async () => {
+    const response = await postAction("join", {
+      origin: "https://evil.example",
+      secFetchSite: "cross-site",
+    });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/testflight?testflight=error",
+    );
+    expect(getUser).not.toHaveBeenCalled();
+    expect(ascFetch).not.toHaveBeenCalled();
+  });
+
+  test("redirects unavailable when ASC is not configured", async () => {
+    ascConfigured = false;
+
+    const response = await postAction("join");
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://cmux.test/dashboard/testflight?testflight=unavailable",
+    );
+    expect(ascFetch).not.toHaveBeenCalled();
+  });
+});
+
+function postAction(
+  action: string,
+  options: {
+    referer?: string;
+    origin?: string;
+    secFetchSite?: string;
+  } = {},
+) {
+  const headers = new Headers({
+    "content-type": "application/x-www-form-urlencoded",
+    origin: options.origin ?? "https://cmux.test",
+    referer: options.referer ?? "https://cmux.test/dashboard/testflight",
+  });
+  if (options.secFetchSite) {
+    headers.set("sec-fetch-site", options.secFetchSite);
+  }
+
+  return POST(
+    new NextRequest("https://cmux.test/api/testflight", {
+      method: "POST",
+      headers,
+      body: new URLSearchParams({ action }),
+    }),
+  );
+}
+
+function callInit(index: number): RequestInit {
+  return (ascFetch as unknown as { mock: { calls: unknown[][] } }).mock.calls[index][1] as RequestInit;
+}
+
+function mockImplementation(
+  fn: unknown,
+  implementation: (...args: unknown[]) => unknown,
+) {
+  (fn as { mockImplementation(next: typeof implementation): void }).mockImplementation(
+    implementation,
+  );
+}

--- a/web/tests/testflight-service.test.ts
+++ b/web/tests/testflight-service.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+class MockAscApiError extends Error {
+  readonly name = "AscApiError";
+
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly details?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+const ascFetch = mock(async () => ({}));
+
+mock.module("../services/asc/client", () => ({
+  AscApiError: MockAscApiError,
+  AscConfigurationError: class AscConfigurationError extends Error {},
+  AscNetworkError: class AscNetworkError extends Error {},
+  ascFetch,
+  isAscConfigured: () => true,
+}));
+
+const {
+  enrollTester,
+  findBetaTesterByEmail,
+  removeTester,
+  testerGroupStatus,
+} = await import("../services/asc/testflight");
+
+describe("TestFlight ASC service", () => {
+  beforeEach(() => {
+    ascFetch.mockClear();
+    mockImplementation(ascFetch, async () => ({}));
+  });
+
+  test("enrolls a new email with a beta group relationship", async () => {
+    await enrollTester("New@Example.com", "New", "Tester");
+
+    expect(ascFetch).toHaveBeenCalledTimes(1);
+    expect(ascFetch).toHaveBeenCalledWith(
+      "/v1/betaTesters",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(String(callInit(0).body));
+    expect(body).toEqual({
+      data: {
+        type: "betaTesters",
+        attributes: {
+          email: "new@example.com",
+          firstName: "New",
+          lastName: "Tester",
+        },
+        relationships: {
+          betaGroups: {
+            data: [
+              {
+                type: "betaGroups",
+                id: "3ee84bfa-10ad-4f23-a45c-f9a3b037373e",
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
+
+  test("falls back to adding an existing tester to the group", async () => {
+    mockImplementation(ascFetch, async (path: unknown, init?: unknown) => {
+      if (path === "/v1/betaTesters" && (init as { method?: string })?.method === "POST") {
+        throw new MockAscApiError("exists", 409);
+      }
+      if (String(path).startsWith("/v1/betaTesters?")) {
+        return betaTesterList("tester_123");
+      }
+      return {};
+    });
+
+    await enrollTester("exists@example.com");
+
+    expect(ascFetch).toHaveBeenCalledWith(
+      "/v1/betaGroups/3ee84bfa-10ad-4f23-a45c-f9a3b037373e/relationships/betaTesters",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(String(callInit(2).body));
+    expect(body).toEqual({
+      data: [{ type: "betaTesters", id: "tester_123" }],
+    });
+  });
+
+  test("double-enroll is a no-op when the group relationship already exists", async () => {
+    mockImplementation(ascFetch, async (path: unknown, init?: unknown) => {
+      if (path === "/v1/betaTesters" && (init as { method?: string })?.method === "POST") {
+        throw new MockAscApiError("exists", 409);
+      }
+      if (String(path).startsWith("/v1/betaTesters?")) {
+        return betaTesterList("tester_123");
+      }
+      throw new MockAscApiError("already related", 409);
+    });
+
+    await expect(enrollTester("exists@example.com")).resolves.toBeUndefined();
+  });
+
+  test("removes a tester from the configured group", async () => {
+    mockImplementation(ascFetch, async (path: unknown) => {
+      if (String(path).startsWith("/v1/betaTesters?")) {
+        return betaTesterList("tester_123");
+      }
+      return {};
+    });
+
+    await removeTester("Leave@Example.com");
+
+    expect(ascFetch).toHaveBeenCalledWith(
+      "/v1/betaGroups/3ee84bfa-10ad-4f23-a45c-f9a3b037373e/relationships/betaTesters",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    const body = JSON.parse(String(callInit(1).body));
+    expect(body).toEqual({
+      data: [{ type: "betaTesters", id: "tester_123" }],
+    });
+  });
+
+  test("looks up tester group status", async () => {
+    mockImplementation(ascFetch, async (path: unknown) => {
+      if (String(path).startsWith("/v1/betaTesters?")) {
+        return betaTesterList("tester_123", "INVITED");
+      }
+      return {
+        data: [
+          { type: "betaGroups", id: "other" },
+          {
+            type: "betaGroups",
+            id: "3ee84bfa-10ad-4f23-a45c-f9a3b037373e",
+          },
+        ],
+      };
+    });
+
+    await expect(testerGroupStatus("status@example.com")).resolves.toEqual({
+      enrolled: true,
+      state: "INVITED",
+    });
+  });
+
+  test("findBetaTesterByEmail returns null when ASC has no tester", async () => {
+    mockImplementation(ascFetch, async () => ({ data: [] }));
+
+    await expect(findBetaTesterByEmail("none@example.com")).resolves.toBeNull();
+  });
+});
+
+function betaTesterList(id: string, state?: string) {
+  return {
+    data: [
+      {
+        type: "betaTesters",
+        id,
+        attributes: state ? { state } : {},
+      },
+    ],
+  };
+}
+
+function callInit(index: number): RequestInit {
+  return (ascFetch as unknown as { mock: { calls: unknown[][] } }).mock.calls[index][1] as RequestInit;
+}
+
+function mockImplementation(
+  fn: unknown,
+  implementation: (...args: unknown[]) => unknown,
+) {
+  (fn as { mockImplementation(next: typeof implementation): void }).mockImplementation(
+    implementation,
+  );
+}


### PR DESCRIPTION
Paying subscribers can manage their iOS TestFlight access from /dashboard/testflight. Eligibility = active Pro (user) or an active Team subscription (their billing team). Opt-in "Join iOS TestFlight" enrolls their email into the existing cmux BETA "founders edition" group through the App Store Connect API (Apple sends the invite); the page shows enrollment status and a Leave action. When a user's Pro subscription lapses, the Stripe webhook best-effort removes them from the group so access is subscription-gated; team lapses do not remove individual testers.

Design: all App Store Connect calls are server-side via a short-lived ES256 JWT (node:crypto, DER->JOSE raw signature) — no ASC secrets reach the client. No new DB tables; TestFlight state is read live from ASC. Unconfigured environments (all of CI) degrade to "unavailable".

Decisions (locked with the user): existing cmux BETA group, dashboard opt-in (not auto-enroll), remove on lapse.

/fable loop: coder + inline judge (fable-judge subagent hit an auth error mid-review; I ran the full rubric). Verified the ES256 JWT + betaTesters API against the LIVE ASC account before and after coding (200, real testers listed) using the coder's exact signature converter. 455 web tests green in sorted order; typecheck + db:check (no schema change) clean; en/ja parity.

Env to set for prod (optional; unset = feature shows "unavailable"): ASC_KEY_ID, ASC_ISSUER_ID, ASC_PRIVATE_KEY, CMUX_TESTFLIGHT_APP_ID (default 6757092429), CMUX_TESTFLIGHT_GROUP_ID (default the founders group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786002780&installation_id=133855650&pr_number=7506&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7506&signature=aec26564c4dfd08f9cb1fb6631c2b6a2991545ace5a89b7be426acfddf53ac9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing webhooks and external App Store Connect writes with server-held API keys; join is gated on subscription and CSRF-style origin checks, but ASC misconfiguration or partial webhook failures could leave testers enrolled after lapse.
> 
> **Overview**
> Adds a **dashboard TestFlight portal** so paying users can opt into the cmux iOS beta without manual ASC work. A new **account nav item** links to `/dashboard/testflight`, which shows eligibility (active Pro or Team), live enrollment from App Store Connect, and **join/leave** forms that POST to `/api/testflight`.
> 
> Server-side **App Store Connect integration** signs ES256 JWTs and calls the beta tester APIs to enroll or remove the user’s normalized email in a configured beta group. Optional env vars gate the feature; when ASC is unset, the UI shows **unavailable** instead of failing hard.
> 
> **Billing hooks:** `isTestflightEligible` extends Pro/Team checks for join; when a **user** Pro Stripe subscription becomes inactive, the webhook path **best-effort removes** that user from TestFlight (team lapses do not). ASC failures are reported via `captureAscError` without breaking billing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ddee83e98e9ecf23737367ffe95c8664a08812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a subscription-gated TestFlight portal where eligible users can join or leave the cmux iOS beta, with server-side App Store Connect integration and automatic removal on Pro plan lapse.

- **New Features**
  - New dashboard page at /dashboard/testflight with join/leave actions and status.
  - Eligibility: active Pro user, or member of a team with an active Team subscription.
  - Server-side App Store Connect calls with ES256 JWT; no ASC secrets in the client.
  - Shows banners for joined/left/errors and degrades to “unavailable” when ASC is unconfigured.
  - Stripe webhook removes a user from the beta when their Pro subscription lapses; team lapses do not remove individual testers.
  - No DB changes; TestFlight state is read live from App Store Connect. Navigation now includes “iOS TestFlight”.

- **Migration**
  - Set ASC_KEY_ID, ASC_ISSUER_ID, and either ASC_PRIVATE_KEY (supports “\n”) or ASC_PRIVATE_KEY_PATH. Optional: CMUX_TESTFLIGHT_APP_ID and CMUX_TESTFLIGHT_GROUP_ID (defaults provided).
  - If unset, the dashboard shows TestFlight as unavailable.

<sup>Written for commit b6ddee83e98e9ecf23737367ffe95c8664a08812. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an iOS TestFlight section to the dashboard with a dedicated page for checking eligibility, joining, or leaving the beta program.
  * Added localized TestFlight messaging and navigation entries in English and Japanese.

* **Bug Fixes**
  * Improved handling for sign-in, missing email, unavailable service, and enrollment status states.
  * Automatically removes beta access when a qualifying subscription is no longer active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->