### PR TITLE
Fix launch vector glyph crash

### DIFF
--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSidebarEntryRow.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSidebarEntryRow.swift
@@ -18,7 +18,7 @@ struct SettingsSidebarEntryRow: View {
         HStack(spacing: 10) {
             Image(systemName: symbolName)
                 .foregroundStyle(.secondary)
-                .frame(width: 16)
+                .frame(width: 16, height: 16)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)

--- a/Sources/ProBadgeStyle.swift
+++ b/Sources/ProBadgeStyle.swift
@@ -273,8 +273,9 @@ struct ProBadgeView: View {
                 .accessibilityIdentifier("ProBadgeButton")
 
                 // Only mount the dismiss glyph while hovered. A zero-width
-                // Image(systemName:) frame crashes AppKit restoration layout on
-                // macOS 26 (CUINamedVectorGlyph requires targetSize > 0).
+                // Image(systemName:) frame crashes AppKit restoration layout
+                // when CUINamedVectorGlyph requires targetSize > 0 (reproduced on
+                // macOS 27 beta).
                 Group {
                     if isHovered {
                         Button {

--- a/Sources/ProBadgeStyle.swift
+++ b/Sources/ProBadgeStyle.swift
@@ -272,28 +272,33 @@ struct ProBadgeView: View {
                 .accessibilityLabel(helpTitle)
                 .accessibilityIdentifier("ProBadgeButton")
 
-                // The X is always laid out; only its container width animates,
-                // so it's revealed by the widening capsule (clipped) rather
-                // than fading or sliding on its own.
-                Button {
-                    withAnimation(.easeOut(duration: 0.15)) {
-                        ProBadgeStyleStore.shared.isDismissed = true
+                // Only mount the dismiss glyph while hovered. A zero-width
+                // Image(systemName:) frame crashes AppKit restoration layout on
+                // macOS 26 (CUINamedVectorGlyph requires targetSize > 0).
+                Group {
+                    if isHovered {
+                        Button {
+                            withAnimation(.easeOut(duration: 0.15)) {
+                                ProBadgeStyleStore.shared.isDismissed = true
+                            }
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 8, weight: .bold))
+                                .foregroundStyle(foreground)
+                                .opacity(0.75)
+                                .padding(.leading, 4)
+                                .frame(width: 14, alignment: .leading)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .safeHelp(dismissTitle)
+                        .accessibilityLabel(dismissTitle)
+                        .accessibilityIdentifier("ProBadgeDismissButton")
                     }
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 8, weight: .bold))
-                        .foregroundStyle(foreground)
-                        .opacity(0.75)
-                        .padding(.leading, 4)
-                        .frame(width: isHovered ? 14 : 0, alignment: .leading)
-                        .clipped()
-                        .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .frame(width: isHovered ? 14 : 0, alignment: .leading)
+                .clipped()
                 .allowsHitTesting(isHovered)
-                .safeHelp(dismissTitle)
-                .accessibilityLabel(dismissTitle)
-                .accessibilityIdentifier("ProBadgeDismissButton")
             }
             .modifier(ProBadgeCapsule(style: style, isHovered: isHovered))
             .frame(height: 22, alignment: .center)


### PR DESCRIPTION
## Summary

This fixes a crash on macOS 27 described in #7200 

## Testing

I compiled cmux and was able to start it again.

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786003749&installation_id=133855650&pr_number=7507&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7507&signature=3fd6e000b119f3a1f728ea16a5b04695d6c4c6e157363540371a5b3a72128b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only layout changes for crash avoidance; dismiss X behavior shifts slightly (glyph unmounted when not hovered) but hit testing and hover animation are preserved.
> 
> **Overview**
> Fixes a **launch crash on macOS 27 beta** (#7200) when AppKit restores window layout and `Image(systemName:)` is laid out at **zero size**, which trips `CUINamedVectorGlyph`’s `targetSize > 0` requirement.
> 
> In **`ProBadgeView`**, the hover dismiss **xmark** is no longer always in the tree with a width that animates to 0—it is **only created while hovered**, while the surrounding container still animates/clips width so the capsule behavior stays similar.
> 
> In **`SettingsSidebarEntryRow`**, sidebar SF Symbols get an explicit **16×16** frame (height was missing) so glyphs always have a positive target size during layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcabfbfcbca9edc9311c2bddf3b9e85520ecf45f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a launch crash on macOS 27 during window restoration caused by zero‑size SF Symbol glyph layout. Icons no longer render at 0 size, and the Pro badge dismiss glyph only mounts on hover.

- **Bug Fixes**
  - Pro badge: mount the "xmark" button only when hovered; keep a 0/14pt container for animation to avoid `CUINamedVectorGlyph` assertions from zero‑width `Image(systemName:)`.
  - Settings sidebar: set symbol frames to 16×16 to prevent zero‑height glyphs in restored windows.

<sup>Written for commit bcabfbfcbca9edc9311c2bddf3b9e85520ecf45f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar icon sizing and alignment for more consistent row layout.
  * Made the Pro badge dismiss control appear only when hovering, reducing visual clutter and accidental interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->