### PR TITLE
Add sidebar "agent is working" walking pixel-pet indicator

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13410,6 +13410,22 @@ struct TabItemView: View, Equatable {
                     audioColor: activeSecondaryColor(0.8)
                 )
 
+                // Walking pixel-pet shown while a coding agent is actively
+                // working in this workspace, tinted to the agent's color.
+                if let runningAgentStatusKey = workspaceSnapshot.runningAgentStatusKey {
+                    let workingAgentName = SidebarWorkingAgentPresentation.displayName(forStatusKey: runningAgentStatusKey)
+                    let agentWorkingTooltip = String(
+                        localized: "sidebar.agentWorking.tooltip",
+                        defaultValue: "\(workingAgentName) is working…"
+                    )
+                    SidebarWorkingAgentIndicatorView(
+                        species: PixelAgentPet.Species(agentStatusKey: runningAgentStatusKey),
+                        pointSize: scaledFontSize(11)
+                    )
+                    .safeHelp(agentWorkingTooltip)
+                    .accessibilityLabel(agentWorkingTooltip)
+                }
+
                 if isEditing {
                     SidebarInlineRenameField(
                         initialText: renameDraft,
@@ -14286,8 +14302,25 @@ struct TabItemView: View, Equatable {
             checklistItems: tab.todoState.checklist,
             checklistCompletedCount: checklistProgress.completedCount,
             checklistTotalCount: checklistProgress.totalCount,
-            checklistFirstUncheckedText: checklistProgress.firstUncheckedText
+            checklistFirstUncheckedText: checklistProgress.firstUncheckedText,
+            runningAgentStatusKey: runningAgentStatusKey()
         )
+    }
+
+    /// The agent whose walking pixel-pet the row should show, or nil when no
+    /// agent in the workspace is actively working. Reads the per-panel agent
+    /// lifecycle states reported by agent hooks; the row already refreshes this
+    /// snapshot whenever those states change (`.sidebarAgentRuntimeObservation`).
+    private func runningAgentStatusKey() -> String? {
+        let statesByPanel = tab.agentLifecycleStatesByPanelId
+        guard !statesByPanel.isEmpty else { return nil }
+        var runningKeys: Set<String> = []
+        for (_, statesByAgent) in statesByPanel {
+            for (agentKey, state) in statesByAgent where state == .running {
+                runningKeys.insert(agentKey)
+            }
+        }
+        return SidebarWorkingAgentPresentation.primaryStatusKey(among: runningKeys)
     }
 
     private var sidebarVisibleCustomDescription: String? {

--- a/Sources/PixelAgentPet.swift
+++ b/Sources/PixelAgentPet.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+/// Shared pixel-art "pet": one little walking creature per running coding
+/// agent. Used both by Sleepy Mode (the full-screen scene in `SleepyFaceView`)
+/// and by the sidebar "agent is working" indicator, so the two stay
+/// pixel-for-pixel identical and only have to evolve in one place.
+enum PixelAgentPet {
+    /// Color bucket for a running agent, matching the Sleepy Mode palette.
+    enum Species: String, CaseIterable, Sendable, Equatable {
+        case claude
+        case codex
+        case opencode
+        case pi
+        case ollama
+        case other
+
+        /// Maps an agent-hook status key (e.g. `"claude_code"`) to a species.
+        /// Less-common agents intentionally fall back to `.other` so the palette
+        /// stays small and readable at glyph size.
+        init(agentStatusKey key: String) {
+            switch key {
+            case "claude_code": self = .claude
+            case "codex": self = .codex
+            case "opencode": self = .opencode
+            case "pi": self = .pi
+            case "ollama": self = .ollama
+            default: self = .other
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .claude: return Color(red: 0.96, green: 0.55, blue: 0.26)
+            case .codex: return Color(red: 0.62, green: 0.86, blue: 0.97)
+            case .opencode: return Color(red: 0.45, green: 0.86, blue: 0.55)
+            case .pi: return Color(red: 0.70, green: 0.52, blue: 0.97)
+            case .ollama: return Color(red: 0.93, green: 0.89, blue: 0.80)
+            case .other: return Color(red: 1.0, green: 0.70, blue: 0.80)
+            }
+        }
+    }
+
+    /// Draws one walking pixel pet into `ctx`, its top-left body cell at
+    /// `(x, y)`. The tail nub sits one cell before `x` when `facingRight`, so
+    /// callers should leave a one-cell margin on the leading side.
+    static func draw(
+        in ctx: inout GraphicsContext,
+        x: CGFloat,
+        y: CGFloat,
+        cell: CGFloat,
+        color: Color,
+        step: Int,
+        facingRight: Bool
+    ) {
+        let ink = Color(red: 0.12, green: 0.13, blue: 0.20)
+        func put(_ col: Int, _ row: Int, _ c: Color) {
+            ctx.fill(
+                Path(CGRect(x: x + CGFloat(col) * cell, y: y + CGFloat(row) * cell, width: cell, height: cell)),
+                with: .color(c)
+            )
+        }
+        // Body (rows 1-3, cols 0-6) with softened top corners.
+        for col in 0...6 {
+            for row in 1...3 {
+                if row == 1 && (col == 0 || col == 6) { continue }
+                put(col, row, color)
+            }
+        }
+        // Ears + tail nub.
+        put(1, 0, color)
+        put(5, 0, color)
+        put(facingRight ? -1 : 7, 1, color)
+        // Eye on the leading side.
+        put(facingRight ? 5 : 1, 2, ink)
+        // Legs alternate as it walks.
+        if step == 0 {
+            put(1, 4, color); put(5, 4, color)
+        } else {
+            put(2, 4, color); put(4, 4, color)
+        }
+    }
+}
+
+/// Presentation helpers for the sidebar "agent is working" indicator.
+enum SidebarWorkingAgentPresentation {
+    /// Deterministic priority so a workspace running several agents at once
+    /// still shows a single, stable pet. Claude leads (it is the feature's
+    /// primary case), then the other first-class species; anything else falls
+    /// back to alphabetical order.
+    private static let priorityOrder = ["claude_code", "codex", "opencode", "pi"]
+
+    /// The one agent whose pet the row should show, given every agent key that
+    /// is currently reporting `.running` in the workspace.
+    static func primaryStatusKey(among keys: Set<String>) -> String? {
+        for key in priorityOrder where keys.contains(key) {
+            return key
+        }
+        return keys.sorted().first
+    }
+
+    /// Human-readable brand name for the tooltip. Agent brand names are proper
+    /// nouns and are intentionally not localized; only the surrounding sentence
+    /// (the "… is working" part) is.
+    static func displayName(forStatusKey key: String) -> String {
+        switch key {
+        case "claude_code": return "Claude"
+        case "codex": return "Codex"
+        case "opencode": return "OpenCode"
+        case "pi": return "Pi"
+        case "amp": return "Amp"
+        case "antigravity": return "Antigravity"
+        case "codebuddy": return "CodeBuddy"
+        case "copilot": return "Copilot"
+        case "cursor": return "Cursor"
+        case "factory": return "Factory"
+        case "gemini": return "Gemini"
+        case "grok": return "Grok"
+        case "hermes-agent": return "Hermes Agent"
+        case "kiro": return "Kiro"
+        case "qoder": return "Qoder"
+        case "rovodev": return "Rovo Dev"
+        default:
+            return key
+                .replacingOccurrences(of: "_", with: " ")
+                .replacingOccurrences(of: "-", with: " ")
+                .capitalized
+        }
+    }
+}

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -14,6 +14,7 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
         let checklistTotalCount: Int
         let checklistFirstUncheckedText: String?
         let activeCodingAgentCount: Int
+        let runningAgentStatusKey: String?
     }
 
     var contextMenuImmediateFields: ContextMenuImmediateFields {
@@ -29,7 +30,8 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             checklistCompletedCount: checklistCompletedCount,
             checklistTotalCount: checklistTotalCount,
             checklistFirstUncheckedText: checklistFirstUncheckedText,
-            activeCodingAgentCount: activeCodingAgentCount
+            activeCodingAgentCount: activeCodingAgentCount,
+            runningAgentStatusKey: runningAgentStatusKey
         )
     }
 
@@ -62,8 +64,9 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             pullRequestRows: pullRequestRows,
             listeningPorts: listeningPorts,
             finderDirectoryPath: snapshot.finderDirectoryPath,
-            // Media activity drives a leading row glyph, so stale values are
-            // visually worse than ordinary telemetry text while the menu is open.
+            // Media activity and the "agent is working" pet both drive leading
+            // row glyphs, so stale values are visually worse than ordinary
+            // telemetry text while the menu is open.
             mediaActivity: snapshot.mediaActivity,
             // Todo status/checklist are mutated FROM this context menu (Status
             // submenu, Mark as Done, checkbox clicks), so the done-row dim and
@@ -72,7 +75,8 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             checklistItems: snapshot.checklistItems,
             checklistCompletedCount: snapshot.checklistCompletedCount,
             checklistTotalCount: snapshot.checklistTotalCount,
-            checklistFirstUncheckedText: snapshot.checklistFirstUncheckedText
+            checklistFirstUncheckedText: snapshot.checklistFirstUncheckedText,
+            runningAgentStatusKey: snapshot.runningAgentStatusKey
         )
     }
 }

--- a/Sources/SidebarWorkingAgentIndicatorView.swift
+++ b/Sources/SidebarWorkingAgentIndicatorView.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftUI
+
+/// A tiny pixel pet that walks in place while a coding agent is working in a
+/// workspace. Rendered in the sidebar row's status-glyph row, next to the pin
+/// and media-activity indicators.
+///
+/// The view is a fixed size and animates entirely inside a `Canvas`, so it
+/// never changes the row's layout or height while it toggles on and off. This
+/// matters: the sidebar rows live in a `LazyVStack`, where an animated layout
+/// change forces a per-frame re-measure that pegs the main thread (see the
+/// perf notes around `TabItemView` in `ContentView.swift`). The pet only ever
+/// animates within its own frame.
+struct SidebarWorkingAgentIndicatorView: View {
+    let species: PixelAgentPet.Species
+    /// Roughly the point size of the sibling glyphs; the pet is scaled to sit
+    /// on the same visual line.
+    var pointSize: CGFloat = 11
+
+    // Sprite grid: 8 cells wide (leading tail + body), 5 tall, plus one row of
+    // headroom for the little hop.
+    private static let cellsWide: CGFloat = 8
+    private static let cellsTall: CGFloat = 5
+
+    var body: some View {
+        let cell = max(1, (pointSize / Self.cellsTall).rounded())
+        let width = cell * Self.cellsWide
+        let height = cell * (Self.cellsTall + 1)
+        let color = species.color
+        TimelineView(.animation(minimumInterval: 1.0 / 15.0)) { timeline in
+            let t = timeline.date.timeIntervalSinceReferenceDate
+            Canvas { context, size in
+                // Walk in place: legs alternate, with an occasional light hop so
+                // the row reads as "actively working" rather than merely idle.
+                let step = Int(t * 6) % 2
+                let hop: CGFloat = sin(t * 7) > 0.6 ? -cell : 0
+                // Leading tail sits at col -1, so start the body one cell in.
+                let x = cell
+                let y = (size.height - Self.cellsTall * cell) + hop
+                PixelAgentPet.draw(
+                    in: &context,
+                    x: x,
+                    y: y,
+                    cell: cell,
+                    color: color,
+                    step: step,
+                    facingRight: true
+                )
+            }
+        }
+        .frame(width: width, height: height)
+        // The tooltip / accessibility label live on the parent row glyph.
+        .accessibilityHidden(true)
+    }
+}

--- a/Sources/SidebarWorkspaceSnapshotBuilder.swift
+++ b/Sources/SidebarWorkspaceSnapshotBuilder.swift
@@ -66,5 +66,9 @@ struct SidebarWorkspaceSnapshotBuilder {
         let checklistCompletedCount: Int
         let checklistTotalCount: Int
         let checklistFirstUncheckedText: String?
+        // Agent-hook status key (e.g. "claude_code") of the agent currently
+        // reporting `.running` in this workspace, or nil when none is working.
+        // Drives the walking pixel-pet "agent is working" glyph on the row.
+        let runningAgentStatusKey: String?
     }
 }

--- a/Sources/SleepyFaceView.swift
+++ b/Sources/SleepyFaceView.swift
@@ -269,12 +269,12 @@ struct SleepyFaceView: View {
         func add(_ count: Int, _ color: Color) {
             for _ in 0..<count where colors.count < maxPets { colors.append(color) }
         }
-        add(counts.claude, Color(red: 0.96, green: 0.55, blue: 0.26))
-        add(counts.codex, Color(red: 0.62, green: 0.86, blue: 0.97))
-        add(counts.opencode, Color(red: 0.45, green: 0.86, blue: 0.55))
-        add(counts.pi, Color(red: 0.70, green: 0.52, blue: 0.97))
-        add(counts.ollama, Color(red: 0.93, green: 0.89, blue: 0.80))
-        add(counts.other, Color(red: 1.0, green: 0.70, blue: 0.80))
+        add(counts.claude, PixelAgentPet.Species.claude.color)
+        add(counts.codex, PixelAgentPet.Species.codex.color)
+        add(counts.opencode, PixelAgentPet.Species.opencode.color)
+        add(counts.pi, PixelAgentPet.Species.pi.color)
+        add(counts.ollama, PixelAgentPet.Species.ollama.color)
+        add(counts.other, PixelAgentPet.Species.other.color)
 
         let petW = CGFloat(petWidthCells) * cell
         let left = 2 * cell
@@ -315,29 +315,9 @@ struct SleepyFaceView: View {
     }
 
     private func drawPet(in ctx: inout GraphicsContext, x: CGFloat, y: CGFloat, cell: CGFloat, color: Color, step: Int, facingRight: Bool) {
-        let ink = Color(red: 0.12, green: 0.13, blue: 0.20)
-        func put(_ col: Int, _ row: Int, _ c: Color) {
-            ctx.fill(Path(CGRect(x: x + CGFloat(col) * cell, y: y + CGFloat(row) * cell, width: cell, height: cell)), with: .color(c))
-        }
-        // Body (rows 1-3, cols 0-6) with softened top corners.
-        for col in 0...6 {
-            for row in 1...3 {
-                if row == 1 && (col == 0 || col == 6) { continue }
-                put(col, row, color)
-            }
-        }
-        // Ears + tail nub.
-        put(1, 0, color)
-        put(5, 0, color)
-        put(facingRight ? -1 : 7, 1, color)
-        // Eye on the leading side.
-        put(facingRight ? 5 : 1, 2, ink)
-        // Legs alternate as it walks.
-        if step == 0 {
-            put(1, 4, color); put(5, 4, color)
-        } else {
-            put(2, 4, color); put(4, 4, color)
-        }
+        // Shared with the sidebar "agent is working" indicator so both surfaces
+        // draw the identical creature. See `PixelAgentPet`.
+        PixelAgentPet.draw(in: &ctx, x: x, y: y, cell: cell, color: color, step: step, facingRight: facingRight)
     }
 
     // MARK: - Reaction effects (easter eggs)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1115,6 +1115,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D1F0A00300000000000000C1 /* PhonePushPresenceGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00300000000000000C2 /* PhonePushPresenceGateTests.swift */; };
 		B79500210000000000000001 /* PIDPresence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500210000000000000002 /* PIDPresence.swift */; };
 		B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */; };
+		6436E0AD386FDBBD1D33810E /* PixelAgentPet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA258104BB1873CC40785C7B /* PixelAgentPet.swift */; };
 		5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */; };
 		B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */; };
 		D0C658660000000000000004 /* PortalSplitDividerCacheInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */; };
@@ -1443,6 +1444,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F7216006000000000000001 /* SidebarTabItemContextMenuState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7216006000000000000002 /* SidebarTabItemContextMenuState.swift */; };
 		A6AC73F10000000000000001 /* SidebarTitleFirstLineCenterAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73F10000000000000002 /* SidebarTitleFirstLineCenterAlignment.swift */; };
 		CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
+		491B9C2C45D077CF8F730A95 /* SidebarWorkingAgentIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B9BCEA0D88758DC5A8101E /* SidebarWorkingAgentIndicatorView.swift */; };
+		81843B6D4E088EEA316428EA /* SidebarWorkingAgentPetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA325BE3049CBDC4664554DD /* SidebarWorkingAgentPetTests.swift */; };
 		EDA24082C65B4E2A2A03F276 /* SidebarWorkspaceChecklistPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC8DE2AF74EC2C272681A75 /* SidebarWorkspaceChecklistPopover.swift */; };
 		B290FAD92C810ACB2D9CD9C6 /* SidebarWorkspaceChecklistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E7BB6EF7C9F8D2C681999D /* SidebarWorkspaceChecklistView.swift */; };
 		D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */; };
@@ -3028,6 +3031,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D1F0A00300000000000000C2 /* PhonePushPresenceGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhonePushPresenceGateTests.swift; sourceTree = "<group>"; };
 		B79500210000000000000002 /* PIDPresence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PIDPresence.swift; sourceTree = "<group>"; };
 		B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiVaultAgentPersistenceTests.swift; sourceTree = "<group>"; };
+		BA258104BB1873CC40785C7B /* PixelAgentPet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelAgentPet.swift; sourceTree = "<group>"; };
 		5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalDividerCursorOcclusionTests.swift; sourceTree = "<group>"; };
 		4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalHitTestingPerformanceTests.swift; sourceTree = "<group>"; };
 		D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerCacheInvalidator.swift; sourceTree = "<group>"; };
@@ -3349,6 +3353,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F7216006000000000000002 /* SidebarTabItemContextMenuState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabItemContextMenuState.swift; sourceTree = "<group>"; };
 		A6AC73F10000000000000002 /* SidebarTitleFirstLineCenterAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarTitleFirstLineCenterAlignment.swift; sourceTree = "<group>"; };
 		EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
+		88B9BCEA0D88758DC5A8101E /* SidebarWorkingAgentIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkingAgentIndicatorView.swift; sourceTree = "<group>"; };
+		DA325BE3049CBDC4664554DD /* SidebarWorkingAgentPetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkingAgentPetTests.swift; sourceTree = "<group>"; };
 		BAC8DE2AF74EC2C272681A75 /* SidebarWorkspaceChecklistPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SidebarWorkspaceChecklistPopover.swift"; sourceTree = "<group>"; };
 		E9E7BB6EF7C9F8D2C681999D /* SidebarWorkspaceChecklistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceChecklistView.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceDropPlannerTests.swift; sourceTree = "<group>"; };
@@ -4660,6 +4666,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7B000000000000000000101 /* SleepyPowerControls.swift */,
 				C7B0000000000000000000F1 /* SleepyAgentCensus.swift */,
 				C7B0000000000000000000B1 /* SleepyFaceView.swift */,
+				BA258104BB1873CC40785C7B /* PixelAgentPet.swift */,
+				88B9BCEA0D88758DC5A8101E /* SidebarWorkingAgentIndicatorView.swift */,
 				C7B0FACE0000000000000021 /* SleepyPowerUIState.swift */,
 				C7B0FACE0000000000000001 /* SleepyOverlayWindow.swift */,
 				C7B0FACE0000000000000003 /* SleepyAgentCounts.swift */,
@@ -5730,6 +5738,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FEEDC0DEC0DEC0DEC0DE0002 /* FeedCoordinatorTests.swift */,
 				1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */,
 				EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */,
+				DA325BE3049CBDC4664554DD /* SidebarWorkingAgentPetTests.swift */,
 				C9A57304C9A57304C9A57304 /* SidebarWorkspaceGroupHeaderMetricsTests.swift */,
 				C9A57306C9A57306C9A57306 /* SidebarWorkspaceReorderDropOverlayHitTestingTests.swift */,
 				51D800000000000000000002 /* SidebarIdentifierFormattingTests.swift */,
@@ -6922,6 +6931,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D1F0A00100000000000000A3 /* PhonePushPayload.swift in Sources */,
 				D1F0A00100000000000000A5 /* PhonePushPayloadKind.swift in Sources */,
 				B79500210000000000000001 /* PIDPresence.swift in Sources */,
+				6436E0AD386FDBBD1D33810E /* PixelAgentPet.swift in Sources */,
 				D0C658660000000000000004 /* PortalSplitDividerCacheInvalidator.swift in Sources */,
 				D0C658660000000000000002 /* PortalSplitDividerRegion.swift in Sources */,
 				B79500310000000000000001 /* PortLsofScanResult.swift in Sources */,
@@ -7126,6 +7136,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D7344F010000000000000001 /* SidebarTabDragPayload.swift in Sources */,
 				F7216006000000000000001 /* SidebarTabItemContextMenuState.swift in Sources */,
 				A6AC73F10000000000000001 /* SidebarTitleFirstLineCenterAlignment.swift in Sources */,
+				491B9C2C45D077CF8F730A95 /* SidebarWorkingAgentIndicatorView.swift in Sources */,
 				EDA24082C65B4E2A2A03F276 /* SidebarWorkspaceChecklistPopover.swift in Sources */,
 				B290FAD92C810ACB2D9CD9C6 /* SidebarWorkspaceChecklistView.swift in Sources */,
 				C9A57605C9A57605C9A57605 /* SidebarWorkspaceDropTargetWriters.swift in Sources */,
@@ -8016,6 +8027,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D73440010000000000000001 /* SidebarTabDragPayloadProviderTests.swift in Sources */,
 				D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */,
 				CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,
+				81843B6D4E088EEA316428EA /* SidebarWorkingAgentPetTests.swift in Sources */,
 				D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */,
 				C135190000000000000000B1 /* SidebarWorkspaceGroupConfigOpenerTests.swift in Sources */,
 				C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */,

--- a/cmuxTests/SidebarWorkingAgentPetTests.swift
+++ b/cmuxTests/SidebarWorkingAgentPetTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite
+struct SidebarWorkingAgentPetTests {
+    @Test
+    func speciesMapsKnownAgentStatusKeys() {
+        #expect(PixelAgentPet.Species(agentStatusKey: "claude_code") == .claude)
+        #expect(PixelAgentPet.Species(agentStatusKey: "codex") == .codex)
+        #expect(PixelAgentPet.Species(agentStatusKey: "opencode") == .opencode)
+        #expect(PixelAgentPet.Species(agentStatusKey: "pi") == .pi)
+        #expect(PixelAgentPet.Species(agentStatusKey: "ollama") == .ollama)
+    }
+
+    @Test
+    func speciesFallsBackToOtherForUnmappedKeys() {
+        #expect(PixelAgentPet.Species(agentStatusKey: "grok") == .other)
+        #expect(PixelAgentPet.Species(agentStatusKey: "totally-unknown") == .other)
+    }
+
+    @Test
+    func primaryStatusKeyIsNilWhenNothingRunning() {
+        #expect(SidebarWorkingAgentPresentation.primaryStatusKey(among: []) == nil)
+    }
+
+    @Test
+    func primaryStatusKeyPrefersClaudeThenFirstClassAgents() {
+        // Claude wins whenever it is one of the running agents.
+        #expect(SidebarWorkingAgentPresentation.primaryStatusKey(among: ["codex", "claude_code"]) == "claude_code")
+        // Otherwise the highest remaining first-class agent.
+        #expect(SidebarWorkingAgentPresentation.primaryStatusKey(among: ["pi", "codex"]) == "codex")
+        #expect(SidebarWorkingAgentPresentation.primaryStatusKey(among: ["pi", "opencode"]) == "opencode")
+    }
+
+    @Test
+    func primaryStatusKeyFallsBackToAlphabeticalForUnprioritizedKeys() {
+        #expect(SidebarWorkingAgentPresentation.primaryStatusKey(among: ["grok", "amp"]) == "amp")
+    }
+
+    @Test
+    func displayNameUsesBrandNames() {
+        #expect(SidebarWorkingAgentPresentation.displayName(forStatusKey: "claude_code") == "Claude")
+        #expect(SidebarWorkingAgentPresentation.displayName(forStatusKey: "rovodev") == "Rovo Dev")
+        #expect(SidebarWorkingAgentPresentation.displayName(forStatusKey: "unknown_agent") == "Unknown Agent")
+    }
+}

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -103,6 +103,36 @@ import Testing
         #expect(decision.pendingWorkspaceSnapshot == next)
         #expect(decision.hasDeferredWorkspaceObservationInvalidation)
     }
+
+    @Test func contextMenuRunningAgentChangeUpdatesDisplayedGlyphImmediately() {
+        let current = Self.snapshot(
+            latestConversationMessage: "old message",
+            listeningPorts: [3000],
+            runningAgentStatusKey: nil
+        )
+        let next = Self.snapshot(
+            latestConversationMessage: "new message",
+            listeningPorts: [3000, 4000],
+            runningAgentStatusKey: "claude_code"
+        )
+
+        let decision = SidebarWorkspaceSnapshotRefreshPolicy().decision(
+            current: current,
+            next: next,
+            force: false,
+            contextMenuVisible: true
+        )
+
+        // The working-agent pet is a leading row glyph, so it must update
+        // immediately even while the context menu is open…
+        #expect(decision.workspaceSnapshotStorage?.runningAgentStatusKey == "claude_code")
+        // …while telemetry-heavy fields stay frozen until the menu closes.
+        #expect(decision.workspaceSnapshotStorage?.latestConversationMessage == "old message")
+        #expect(decision.workspaceSnapshotStorage?.listeningPorts == [3000])
+        #expect(decision.pendingWorkspaceSnapshot == next)
+        #expect(decision.hasDeferredWorkspaceObservationInvalidation)
+    }
+
     @Test func closedContextMenuStoresNextAndClearsPending() {
         let current = Self.snapshot(title: "old", isPinned: false)
         let next = Self.snapshot(title: "new", isPinned: true)
@@ -130,7 +160,8 @@ import Testing
         listeningPorts: [Int] = [],
         finderDirectoryPath: String? = nil,
         mediaActivity: BrowserMediaActivity = BrowserMediaActivity(),
-        activeCodingAgentCount: Int = 0
+        activeCodingAgentCount: Int = 0,
+        runningAgentStatusKey: String? = nil
     ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
             presentationKey: presentationKey ?? Self.presentationKey(),
@@ -162,7 +193,8 @@ import Testing
             checklistItems: [],
             checklistCompletedCount: 0,
             checklistTotalCount: 0,
-            checklistFirstUncheckedText: nil
+            checklistFirstUncheckedText: nil,
+            runningAgentStatusKey: runningAgentStatusKey
         )
     }
 


### PR DESCRIPTION
## Summary

While an agent is actively working in a workspace, its sidebar row now shows a tiny pixel pet walking in place — next to the existing pin / audio / mic / camera glyphs — so you can tell at a glance which of your parallel workspaces are busy vs. idle/waiting. The pet is tinted to the working agent's color (Claude orange, Codex, OpenCode, pi, others); the tooltip reads e.g. "Claude is working…".

It reuses the app's own Sleepy Mode pet — the sprite and per-agent colors are extracted into a shared `PixelAgentPet` so the full-screen scene and the sidebar indicator draw the identical creature.

- Shown whenever any panel reports the `.running` agent-hook lifecycle state (`agentLifecycleStatesByPanelId`); multiple agents → one deterministic pet (Claude first).
- `SidebarWorkingAgentIndicatorView` is fixed-size and animates entirely inside a `Canvas`/`TimelineView`, so toggling it never changes row height — respecting the LazyVStack re-measure rules around `TabItemView`.
- Derived into the row's value `Snapshot` (already refreshed on lifecycle changes via `.sidebarAgentRuntimeObservation`); handled as a context-menu "immediate field" like the media-activity glyphs. No store reference crosses the snapshot boundary.
- Tooltip localized (en + ja).

## Testing

- `cmux-unit` tests green: `SidebarWorkingAgentPetTests` + `SidebarWorkspaceSnapshotRefreshPolicyTests` (species mapping, multi-agent priority, immediate-field behavior).
- Debug app builds green.
- *Local-build note:* on macOS 26 the native Ghostty CLI helper phase can't link under the pinned zig 0.15.2 (pre-existing toolchain limitation, unrelated to this change; the repo's mitigations target macOS 15). Built/tested with `CMUX_SKIP_ZIG_BUILD=1`; live visual dogfood still pending on my side.

## Demo Video

*Pending.*

## Checklist

- [x] I tested the change locally (build + unit tests; live visual dogfood pending)
- [x] I added or updated tests for the behavior change
- [ ] Docs/changelog — n/a (changelog handled at release)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786020909&installation_id=133855650&pr_number=7514&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7514&signature=7966bc093b52057d53278aab10ed8e04445a329fe44964dfbd81df44454ddda8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar indicator with isolated drawing helpers and existing lifecycle observation; no auth, data, or store boundary changes beyond snapshot fields.
> 
> **Overview**
> Sidebar workspace rows now show a **fixed-size walking pixel pet** beside pin and media glyphs whenever any panel reports a **`.running`** agent-hook lifecycle state, so parallel workspaces read busy vs idle at a glance. The pet uses agent-tinted colors and a localized tooltip (e.g. “Claude is working…”); multiple running agents collapse to one pet via deterministic priority (Claude first).
> 
> **`PixelAgentPet`** centralizes sprite drawing and species colors; **Sleepy Mode** (`SleepyFaceView`) now calls it instead of duplicating pet art. **`SidebarWorkingAgentIndicatorView`** animates in a `Canvas`/`TimelineView` at 15fps without changing row height. **`runningAgentStatusKey`** is derived from `agentLifecycleStatesByPanelId` into the row snapshot (refreshed via existing agent-runtime observation) and treated as a **context-menu immediate field** like media activity. Unit tests cover species mapping, priority, display names, and refresh policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d79d76a06dd383aa3fc7706af279bd80f63d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a walking pixel‑pet indicator in each sidebar row while an agent is actively working, tinted to the agent’s color. This makes busy workspaces obvious at a glance without changing row layout.

- **New Features**
  - Shows an animated pet when any panel reports `.running`; if multiple agents run, one is chosen deterministically (Claude > Codex > OpenCode > Pi > others).
  - Localized tooltip “%@ is working…” (`en`, `ja`) and matching accessibility label.
  - Fixed-size `Canvas` with `TimelineView`, so appearing/disappearing never reflows the `LazyVStack`.

- **Refactors**
  - Extracted shared sprite and colors into `PixelAgentPet`, used by Sleepy Mode and the sidebar indicator.
  - Added `runningAgentStatusKey` to the sidebar row `Snapshot` and treated it as a context‑menu immediate field; tests cover species mapping, agent priority, display names, and refresh behavior.

<sup>Written for commit 845818f2a9fc0302a3b710e10cfc9a9b834fd03e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new sidebar activity indicator with an animated pixel-pet and matching tooltip/accessibility text.
  * Improved agent status display with clearer names and localized tooltip text in English and Japanese.

* **Bug Fixes**
  * Sidebar agent activity now updates more reliably while a context menu is open, without refreshing unrelated live data.
  * Unknown agent statuses now fall back to a consistent generic display and avatar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->