### PR TITLE
Cache mobile workspace list panel order

### DIFF
--- a/Sources/Mobile/MobileWorkspaceListObserver.swift
+++ b/Sources/Mobile/MobileWorkspaceListObserver.swift
@@ -5,6 +5,65 @@ import OSLog
 
 private let mobileWorkspaceObserverLog = Logger(subsystem: "dev.cmux", category: "mobile-workspace-observer")
 
+@MainActor
+struct MobileWorkspaceListSummaryCache {
+    private struct PanelOrderEntry {
+        var paneLayoutVersion: Int
+        var panelIDs: Set<UUID>
+        var orderedPanelIds: [UUID]
+    }
+
+    private var panelOrderByWorkspaceID: [UUID: PanelOrderEntry] = [:]
+
+    #if DEBUG
+    private(set) var panelOrderCacheHits: Int = 0
+    private(set) var panelOrderCacheMisses: Int = 0
+    #endif
+
+    mutating func summaryHash(
+        for tabs: [Workspace],
+        groups: [WorkspaceGroup],
+        selectedTabID: UUID?,
+        previewSignatures: [UUID: Int]
+    ) -> Int {
+        let liveWorkspaceIDs = Set(tabs.map(\.id))
+        panelOrderByWorkspaceID = panelOrderByWorkspaceID.filter { liveWorkspaceIDs.contains($0.key) }
+
+        return MobileWorkspaceListObserver.summaryHash(
+            for: tabs,
+            groups: groups,
+            selectedTabID: selectedTabID,
+            previewSignatures: previewSignatures,
+            panelIDsProvider: { workspace in
+                orderedPanelIds(for: workspace)
+            }
+        )
+    }
+
+    private mutating func orderedPanelIds(for workspace: Workspace) -> [UUID] {
+        let panelIDs = Set(workspace.panels.keys)
+        if let entry = panelOrderByWorkspaceID[workspace.id],
+           entry.paneLayoutVersion == workspace.paneLayoutVersion,
+           entry.panelIDs == panelIDs {
+            #if DEBUG
+            panelOrderCacheHits &+= 1
+            #endif
+            return entry.orderedPanelIds
+        }
+
+        #if DEBUG
+        panelOrderCacheMisses &+= 1
+        #endif
+        let orderedPanelIds = workspace.orderedPanelIds
+        panelOrderByWorkspaceID[workspace.id] = PanelOrderEntry(
+            paneLayoutVersion: workspace.paneLayoutVersion,
+            panelIDs: panelIDs,
+            orderedPanelIds: orderedPanelIds
+        )
+        return orderedPanelIds
+    }
+}
+
 /// Watches `TabManager.tabs` (and each workspace's panels publisher) and emits
 /// `workspace.updated` to subscribed mobile clients whenever the iOS-facing
 /// shape of the workspace list materially changes. Replaces per-RPC emit hooks
@@ -26,6 +85,7 @@ final class MobileWorkspaceListObserver {
     private var unreadIndicatorsCancellable: AnyCancellable?
     private var perWorkspaceCancellables: [UUID: AnyCancellable] = [:]
     private var lastSummaryHash: Int = 0
+    private var summaryCache = MobileWorkspaceListSummaryCache()
     /// Throttle window with `latest: true`. First event in a burst emits
     /// immediately (iPhone gets the change in milliseconds), subsequent
     /// events within the window collapse to one trailing emit carrying the
@@ -46,7 +106,7 @@ final class MobileWorkspaceListObserver {
         // Initial snapshot. Every observer's first emit is unconditional so
         // freshly-paired clients see the current state without waiting for
         // the first mutation.
-        let initial = Self.summaryHash(
+        let initial = summaryCache.summaryHash(
             for: tabManager.tabs,
             groups: tabManager.workspaceGroups,
             selectedTabID: tabManager.selectedTabId,
@@ -204,7 +264,7 @@ final class MobileWorkspaceListObserver {
 
     private func emitIfNeeded(force: Bool) {
         guard let tabManager else { return }
-        let hash = Self.summaryHash(
+        let hash = summaryCache.summaryHash(
             for: tabManager.tabs,
             groups: tabManager.workspaceGroups,
             selectedTabID: tabManager.selectedTabId,
@@ -239,11 +299,12 @@ final class MobileWorkspaceListObserver {
     /// preview (notification id + timestamp). Folding it in means a new notification
     /// (or a cleared one) re-emits to the phone, which renders the preview + relative
     /// time. Workspaces with no notification are simply absent from the map.
-    private static func summaryHash(
+    fileprivate static func summaryHash(
         for tabs: [Workspace],
         groups: [WorkspaceGroup],
         selectedTabID: UUID?,
-        previewSignatures: [UUID: Int]
+        previewSignatures: [UUID: Int],
+        panelIDsProvider: (Workspace) -> [UUID]
     ) -> Int {
         var hasher = Hasher()
         hasher.combine(tabs.count)
@@ -274,7 +335,7 @@ final class MobileWorkspaceListObserver {
             hasher.combine(previewSignatures[workspace.id])
             // Spatial order is significant: hash the ordered id sequence so a
             // reorder of the same panel set changes the hash.
-            let panelIDs = workspace.orderedPanelIds
+            let panelIDs = panelIDsProvider(workspace)
             hasher.combine(panelIDs)
             for id in panelIDs {
                 hasher.combine(workspace.panelTitle(panelId: id))
@@ -305,7 +366,8 @@ final class MobileWorkspaceListObserver {
             for: tabs,
             groups: groups,
             selectedTabID: selectedTabID,
-            previewSignatures: previewSignatures
+            previewSignatures: previewSignatures,
+            panelIDsProvider: { $0.orderedPanelIds }
         )
     }
     #endif

--- a/cmuxTests/MobileWorkspaceListFidelityTests.swift
+++ b/cmuxTests/MobileWorkspaceListFidelityTests.swift
@@ -202,6 +202,90 @@ struct MobileWorkspaceListFidelityTests {
         #expect(after != changed, "a newer notification must change the mobile summary hash")
     }
 
+    #if DEBUG
+    @Test func summaryHashCacheReusesPanelOrderForNonLayoutChanges() throws {
+        let (workspace, ordered) = try makeWorkspaceWithTabTerminals(count: 3)
+        let panelId = try #require(ordered.first)
+        var cache = MobileWorkspaceListSummaryCache()
+
+        let initial = cache.summaryHash(
+            for: [workspace],
+            groups: [],
+            selectedTabID: workspace.id,
+            previewSignatures: [:]
+        )
+        #expect(cache.panelOrderCacheMisses == 1)
+        #expect(cache.panelOrderCacheHits == 0)
+
+        workspace.setCustomTitle("Renamed Workspace")
+        let renamedWorkspace = cache.summaryHash(
+            for: [workspace],
+            groups: [],
+            selectedTabID: workspace.id,
+            previewSignatures: [:]
+        )
+        #expect(initial != renamedWorkspace, "workspace title changes must still change the mobile summary hash")
+        #expect(cache.panelOrderCacheMisses == 1)
+        #expect(
+            cache.panelOrderCacheHits == 1,
+            "title-only changes must not re-derive bonsplit panel order on the main actor"
+        )
+
+        workspace.setPanelCustomTitle(panelId: panelId, title: "Renamed Terminal")
+        let renamedTerminal = cache.summaryHash(
+            for: [workspace],
+            groups: [],
+            selectedTabID: workspace.id,
+            previewSignatures: [:]
+        )
+        #expect(renamedWorkspace != renamedTerminal, "terminal title changes must still change the mobile summary hash")
+        #expect(cache.panelOrderCacheMisses == 1)
+        #expect(
+            cache.panelOrderCacheHits == 2,
+            "terminal title changes must reuse the cached panel order while hashing the updated title"
+        )
+    }
+
+    @Test func summaryHashCacheInvalidatesPanelOrderOnLayoutChange() throws {
+        let (workspace, ordered) = try makeWorkspaceWithTabTerminals(count: 3)
+        var cache = MobileWorkspaceListSummaryCache()
+
+        let before = cache.summaryHash(
+            for: [workspace],
+            groups: [],
+            selectedTabID: workspace.id,
+            previewSignatures: [:]
+        )
+        #expect(cache.panelOrderCacheMisses == 1)
+
+        let firstTabId = try #require(workspace.surfaceIdFromPanelId(ordered[0]))
+        #expect(workspace.bonsplitController.reorderTab(firstTabId, toIndex: 2))
+        #expect(workspace.orderedPanelIds != ordered)
+
+        let after = cache.summaryHash(
+            for: [workspace],
+            groups: [],
+            selectedTabID: workspace.id,
+            previewSignatures: [:]
+        )
+        #expect(before != after, "a real tab reorder must still change the mobile summary hash")
+        #expect(
+            cache.panelOrderCacheMisses == 2,
+            "paneLayoutVersion changes must invalidate cached panel order"
+        )
+        #expect(cache.panelOrderCacheHits == 0)
+
+        _ = cache.summaryHash(
+            for: [workspace],
+            groups: [],
+            selectedTabID: workspace.id,
+            previewSignatures: [:]
+        )
+        #expect(cache.panelOrderCacheMisses == 2)
+        #expect(cache.panelOrderCacheHits == 1)
+    }
+    #endif
+
     @Test func remoteDirectoryTrustChangesObserverHashAndPayload() throws {
         let localDirectory = "/Users/alice/development"
         let remoteDirectory = "/home/seepine/workspace"


### PR DESCRIPTION
## Summary
- cache mobile workspace-list panel order per workspace between layout/panel-set changes
- keep title, directory, group, preview, and selected-workspace changes in the summary hash without rewalking bonsplit order
- add mobile workspace-list tests for non-layout cache reuse and layout invalidation

## Why
A 2026-07-07 hang sample from cmux NIGHTLY showed main-thread time inside MobileWorkspaceListObserver.summaryHash while it repeatedly read workspace.orderedPanelIds. That path can traverse bonsplit order and the panel registry for every mobile-list signal.

## Verification
- git diff --check
- ./scripts/lint-pbxproj-test-wiring.sh
- ./scripts/reload.sh --tag mhcach

Local xcodebuild test was not run because this repo bans local XCTest runs; CI should run the cmuxTests target.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786042693&installation_id=133855650&pr_number=7523&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7523&signature=9fc8f90b5c737e3ad3745c34919af27825e6e3caf59fe75e21f961933ba149f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only caching on the main actor with explicit invalidation on layout and panel-set changes; hash semantics for reorders and renames are covered by new DEBUG tests.
> 
> **Overview**
> Adds **`MobileWorkspaceListSummaryCache`** so `MobileWorkspaceListObserver` no longer calls `workspace.orderedPanelIds` (bonsplit traversal) on every mobile-list signal when only titles, directories, groups, or previews change.
> 
> The observer keeps a per-workspace cache keyed by **`paneLayoutVersion`** and the panel ID set; **`summaryHash`** now takes a **`panelIDsProvider`** so production uses the cache while tests still hash live order via **`summaryHashForTesting`**. Stale entries are dropped when workspaces disappear from the tab list.
> 
> DEBUG tests assert cache **reuse** on workspace/terminal renames and **invalidation** (plus a follow-up hit) after a real tab reorder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1eba82f30114e6385d67761951148b05d9ebcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches the mobile workspace list panel order and uses it when computing the summary hash to avoid re-walking bonsplit on every signal. This reduces main-thread work and prevents the mobile list hang observed in `MobileWorkspaceListObserver.summaryHash`.

- **Bug Fixes**
  - Added `MobileWorkspaceListSummaryCache` keyed by workspace ID, `paneLayoutVersion`, and panel set; prunes stale entries.
  - Updated `summaryHash` to accept a `panelIDsProvider` and use the cache, while still hashing title, directory, group, preview, and selection changes.
  - Invalidates cache on layout or panel-set changes; reuses cache for non-layout updates.
  - Added DEBUG counters and tests validating reuse and invalidation.

<sup>Written for commit 0b1eba82f30114e6385d67761951148b05d9ebcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile workspace list updates so changes are detected more efficiently and consistently.
  * Reduced unnecessary recomputation when workspace details change without affecting layout, helping keep updates responsive.
  * Ensured layout changes still invalidate cached ordering so the workspace list stays accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->