### PR TITLE
Address link hover review follow-ups

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8082,14 +8082,6 @@ private final class CloudTerminalReconnectOverlayView: NSView {
         return nil
     }
 
-    override func mouseDown(with event: NSEvent) {
-        let pointInButton = reconnectButton.convert(event.locationInWindow, from: nil)
-        if reconnectButton.isHidden == false,
-           reconnectButton.bounds.contains(pointInButton) {
-            onReconnect?()
-        }
-    }
-
     func apply(_ presentation: CloudTerminalReconnectOverlayPolicy.Presentation) {
         guard currentPresentation != presentation else { return }
         currentPresentation = presentation


### PR DESCRIPTION
## Summary

- Complete `cloud.overlay.reconnect.button` for every locale present in the macOS localization catalog.
- Remove the unreachable reconnect overlay `mouseDown(with:)` fallback flagged by CodeRabbit; reconnect still uses the existing button target/action path through `hitTest`.

## Testing

- `git diff --check`
- `python3 scripts/swift_file_length_budget.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-package-resolved-policy.py`
- `./scripts/reload.sh --tag issue-7262-conflict --swift-frontend-workaround`
- Parsed `Resources/Localizable.xcstrings` and verified `cloud.overlay.reconnect.button` covers every catalog locale.

## Demo Video

No video attached. This is a follow-up to #7494 for bot review cleanup and localization completion; it does not change the validated link hover behavior.

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

Follow-up to #7494 / #7262.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786043577&installation_id=133855650&pr_number=7524&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7524&signature=489984bad47ec5279b95f47bba86508b465380f6b19321cf1d8a916469cca143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localization-only plus deletion of unreachable duplicate click handling; reconnect behavior unchanged.
> 
> **Overview**
> Follow-up cleanup after link-hover work: **localizes** the cloud reconnect overlay button string (`cloud.overlay.reconnect.button`) for every locale already in the macOS catalog (ar, bs, da, de, es, fr, it, km, ko, nb, pl, pt-BR, ru, th, tr, uk, zh-Hans, zh-Hant, plus existing en/ja).
> 
> **Removes** the overlay’s custom `mouseDown(with:)` reconnect path in `CloudTerminalReconnectOverlayView`; clicks are already handled via `hitTest` forwarding to `reconnectButton` and its `handleReconnect` target/action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a606b1da1f7690a7f72a3f218c5b4d6d5b31be1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes localization of `cloud.overlay.reconnect.button` across all macOS catalog locales and removes an unreachable `mouseDown(with:)` fallback in the reconnect overlay, keeping the button action via `hitTest`.
Follow-up to #7262 (link hover affordance); no behavior changes.

<sup>Written for commit 1a606b1da1f7690a7f72a3f218c5b4d6d5b31be1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction with the reconnect overlay so clicking the reconnect button responds more reliably.
  * Expanded localized text coverage for the reconnect prompt, adding support for many more languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->