### PR TITLE
Dock: register keyboard focus intent on click affordances so creation shortcuts route into the Dock

### DIFF
--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -103,10 +103,22 @@ private struct DockSplitContentView: View {
             dockContent(tab: tab, paneId: paneId)
         } emptyPane: { paneId in
             DockEmptyPaneView(
-                onNewTerminal: { _ = store.newSurface(kind: .terminal, inPane: paneId, focus: true) },
-                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) }
+                onNewTerminal: {
+                    _ = store.newSurfaceFromDockAffordance(
+                        kind: .terminal,
+                        inPane: paneId,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                },
+                onNewBrowser: {
+                    _ = store.newSurfaceFromDockAffordance(
+                        kind: .browser,
+                        inPane: paneId,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                }
             )
-            .onTapGesture { store.bonsplitController.focusPane(paneId) }
+            .onTapGesture { store.focusPaneFromDockClick(paneId, window: NSApp.keyWindow ?? NSApp.mainWindow) }
         }
     }
 
@@ -133,8 +145,7 @@ private struct DockSplitContentView: View {
                 terminalAgentContext: "",
                 paneOwnershipOverride: isVisibleInUI,
                 onFocus: {
-                    store.bonsplitController.focusPane(paneId)
-                    store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow)
+                    store.focusPaneFromDockClick(paneId, window: NSApp.keyWindow ?? NSApp.mainWindow)
                 },
                 onRequestPanelFocus: {
                     store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow)
@@ -144,13 +155,25 @@ private struct DockSplitContentView: View {
                 onAutoResumeAgentHibernation: {},
                 onTriggerFlash: {}
             )
-            .onTapGesture { store.bonsplitController.focusPane(paneId) }
+            .onTapGesture { store.focusPaneFromDockClick(paneId, window: NSApp.keyWindow ?? NSApp.mainWindow) }
         } else {
             DockEmptyPaneView(
-                onNewTerminal: { _ = store.newSurface(kind: .terminal, inPane: paneId, focus: true) },
-                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) }
+                onNewTerminal: {
+                    _ = store.newSurfaceFromDockAffordance(
+                        kind: .terminal,
+                        inPane: paneId,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                },
+                onNewBrowser: {
+                    _ = store.newSurfaceFromDockAffordance(
+                        kind: .browser,
+                        inPane: paneId,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                }
             )
-            .onTapGesture { store.bonsplitController.focusPane(paneId) }
+            .onTapGesture { store.focusPaneFromDockClick(paneId, window: NSApp.keyWindow ?? NSApp.mainWindow) }
         }
     }
 }

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -102,24 +102,31 @@ private struct DockSplitContentView: View {
         BonsplitView(controller: store.bonsplitController) { tab, paneId in
             dockContent(tab: tab, paneId: paneId)
         } emptyPane: { paneId in
-            DockEmptyPaneView(
-                onNewTerminal: {
-                    _ = store.newSurfaceFromDockAffordance(
-                        kind: .terminal,
-                        inPane: paneId,
-                        window: NSApp.keyWindow ?? NSApp.mainWindow
-                    )
-                },
-                onNewBrowser: {
-                    _ = store.newSurfaceFromDockAffordance(
-                        kind: .browser,
-                        inPane: paneId,
-                        window: NSApp.keyWindow ?? NSApp.mainWindow
-                    )
-                }
-            )
-            .onTapGesture { store.focusPaneFromDockClick(paneId, window: NSApp.keyWindow ?? NSApp.mainWindow) }
+            emptyPaneView(paneId: paneId)
         }
+    }
+
+    /// Empty-pane create/click affordances. Both the `BonsplitView` `emptyPane:`
+    /// builder and the panel-less `dockContent` fallback render this one view so
+    /// the Dock focus-intent wiring (#7522) can never drift between the two paths.
+    private func emptyPaneView(paneId: PaneID) -> some View {
+        DockEmptyPaneView(
+            onNewTerminal: {
+                _ = store.newSurfaceFromDockAffordance(
+                    kind: .terminal,
+                    inPane: paneId,
+                    window: NSApp.keyWindow ?? NSApp.mainWindow
+                )
+            },
+            onNewBrowser: {
+                _ = store.newSurfaceFromDockAffordance(
+                    kind: .browser,
+                    inPane: paneId,
+                    window: NSApp.keyWindow ?? NSApp.mainWindow
+                )
+            }
+        )
+        .onTapGesture { store.focusPaneFromDockClick(paneId, window: NSApp.keyWindow ?? NSApp.mainWindow) }
     }
 
     @ViewBuilder
@@ -157,23 +164,7 @@ private struct DockSplitContentView: View {
             )
             .onTapGesture { store.focusPaneFromDockClick(paneId, window: NSApp.keyWindow ?? NSApp.mainWindow) }
         } else {
-            DockEmptyPaneView(
-                onNewTerminal: {
-                    _ = store.newSurfaceFromDockAffordance(
-                        kind: .terminal,
-                        inPane: paneId,
-                        window: NSApp.keyWindow ?? NSApp.mainWindow
-                    )
-                },
-                onNewBrowser: {
-                    _ = store.newSurfaceFromDockAffordance(
-                        kind: .browser,
-                        inPane: paneId,
-                        window: NSApp.keyWindow ?? NSApp.mainWindow
-                    )
-                }
-            )
-            .onTapGesture { store.focusPaneFromDockClick(paneId, window: NSApp.keyWindow ?? NSApp.mainWindow) }
+            emptyPaneView(paneId: paneId)
         }
     }
 }

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -6,6 +6,24 @@ extension DockSplitStore {
         AppDelegate.shared?.noteRightSidebarKeyboardFocusIntent(mode: .dock, in: window)
     }
 
+    /// Creates a Dock surface from a clicked Dock affordance.
+    ///
+    /// A click on an empty-pane button is explicit Dock interaction, matching the
+    /// Dock intent note from `GhosttyTerminalView.mouseDown` for issue #7522.
+    /// Plain `newSurface` stays intent-neutral for socket-created Dock surfaces.
+    @discardableResult
+    func newSurfaceFromDockAffordance(kind: DockSurfaceKind, inPane paneId: PaneID, window: NSWindow?) -> UUID? {
+        return newSurface(kind: kind, inPane: paneId, focus: true)
+    }
+
+    /// Focuses a Dock pane from a clicked Dock affordance.
+    ///
+    /// A pane-background click is explicit Dock interaction, matching the Dock
+    /// intent note from `GhosttyTerminalView.mouseDown` for issue #7522.
+    func focusPaneFromDockClick(_ paneId: PaneID, window: NSWindow?) {
+        bonsplitController.focusPane(paneId)
+    }
+
     func focusedDockPaneSelection() -> (pane: PaneID?, tab: TabID?) {
         let pane = bonsplitController.focusedPaneId
         return (pane, pane.flatMap { bonsplitController.selectedTab(inPane: $0)?.id })

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -3,20 +3,23 @@ import Bonsplit
 
 extension DockSplitStore {
     func noteKeyboardFocusIntent(window: NSWindow?) {
-        // Resolve through the same chain the creation-shortcut gate uses
-        // (`focusedDockStoreForShortcut` -> `preferredRegisteredMainWindowContext`)
-        // so the note and the gate cannot disagree when the Dock interaction is
-        // windowless; `keyboardFocusCoordinator(for:)` drops nil-window notes.
-        // Deliberately NOT resolved from this store's owning window: the gate
-        // reads intent only through the preferred-window chain, never by store
-        // identity, so a store-owner-bound note would be invisible to the gate
-        // whenever the two resolutions diverge — the exact routing split this
-        // seam closes. Real clicks pass the key window, which is the clicked
-        // store's window (`windowDock(forWindowId:)` renders per-window docks).
-        AppDelegate.shared?
-            .preferredRegisteredMainWindowContext(preferredWindow: window)?
+        guard let appDelegate = AppDelegate.shared else { return }
+        // Bind the note to this store's owning window context first: per-window
+        // docks satisfy `workspaceId == windowId` (`AppDelegate+WindowDock.swift`),
+        // and the Dock UI renders inside its owner, so the owner is the window
+        // the user interacted with regardless of transient key/main-window state
+        // (during a cross-window drag the SOURCE window can still be key; see
+        // the matching owner resolution in `AppDelegate+DockSurfaceMove.swift`).
+        // Workspace-scoped docks have no owning window; for them honor the
+        // caller-resolved window, as the pre-#7522 note did. Never fall back to
+        // ambient key/main/first-context state: noting a context that does not
+        // own the interaction would route the next creation shortcut into a
+        // Dock the user never touched. No owner and no window drops the note.
+        let coordinator = appDelegate.mainWindowContexts.values
+            .first(where: { $0.windowId == workspaceId })?
             .keyboardFocusCoordinator
-            .noteRightSidebarInteraction(mode: .dock)
+            ?? appDelegate.keyboardFocusCoordinator(for: window)
+        coordinator?.noteRightSidebarInteraction(mode: .dock)
     }
 
     /// Creates a Dock surface from a clicked Dock affordance.

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -7,6 +7,12 @@ extension DockSplitStore {
         // (`focusedDockStoreForShortcut` -> `preferredRegisteredMainWindowContext`)
         // so the note and the gate cannot disagree when the Dock interaction is
         // windowless; `keyboardFocusCoordinator(for:)` drops nil-window notes.
+        // Deliberately NOT resolved from this store's owning window: the gate
+        // reads intent only through the preferred-window chain, never by store
+        // identity, so a store-owner-bound note would be invisible to the gate
+        // whenever the two resolutions diverge — the exact routing split this
+        // seam closes. Real clicks pass the key window, which is the clicked
+        // store's window (`windowDock(forWindowId:)` renders per-window docks).
         AppDelegate.shared?
             .preferredRegisteredMainWindowContext(preferredWindow: window)?
             .keyboardFocusCoordinator

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -3,7 +3,14 @@ import Bonsplit
 
 extension DockSplitStore {
     func noteKeyboardFocusIntent(window: NSWindow?) {
-        AppDelegate.shared?.noteRightSidebarKeyboardFocusIntent(mode: .dock, in: window)
+        // Resolve through the same chain the creation-shortcut gate uses
+        // (`focusedDockStoreForShortcut` -> `preferredRegisteredMainWindowContext`)
+        // so the note and the gate cannot disagree when the Dock interaction is
+        // windowless; `keyboardFocusCoordinator(for:)` drops nil-window notes.
+        AppDelegate.shared?
+            .preferredRegisteredMainWindowContext(preferredWindow: window)?
+            .keyboardFocusCoordinator
+            .noteRightSidebarInteraction(mode: .dock)
     }
 
     /// Creates a Dock surface from a clicked Dock affordance.
@@ -13,6 +20,7 @@ extension DockSplitStore {
     /// Plain `newSurface` stays intent-neutral for socket-created Dock surfaces.
     @discardableResult
     func newSurfaceFromDockAffordance(kind: DockSurfaceKind, inPane paneId: PaneID, window: NSWindow?) -> UUID? {
+        noteKeyboardFocusIntent(window: window)
         return newSurface(kind: kind, inPane: paneId, focus: true)
     }
 
@@ -21,6 +29,7 @@ extension DockSplitStore {
     /// A pane-background click is explicit Dock interaction, matching the Dock
     /// intent note from `GhosttyTerminalView.mouseDown` for issue #7522.
     func focusPaneFromDockClick(_ paneId: PaneID, window: NSWindow?) {
+        noteKeyboardFocusIntent(window: window)
         bonsplitController.focusPane(paneId)
     }
 

--- a/cmuxTests/WindowDockLifecycleTests.swift
+++ b/cmuxTests/WindowDockLifecycleTests.swift
@@ -130,6 +130,38 @@ struct WindowDockLifecycleTests {
         }
     }
 
+    @Test("Dock affordance intent binds to the owning window, not ambient focus state")
+    @MainActor
+    func dockAffordanceIntentBindsToOwningWindowContext() throws {
+        try withIsolatedAppDelegate { appDelegate in
+            let firstManager = TabManager(autoWelcomeIfNeeded: false)
+            let secondManager = TabManager(autoWelcomeIfNeeded: false)
+            let firstWindowId = appDelegate.registerMainWindowContextForTesting(tabManager: firstManager)
+            let secondWindowId = appDelegate.registerMainWindowContextForTesting(tabManager: secondManager)
+            defer {
+                firstManager.tabs.forEach { $0.teardownAllPanels() }
+                secondManager.tabs.forEach { $0.teardownAllPanels() }
+            }
+
+            let secondDock = appDelegate.windowDock(forWindowId: secondWindowId)
+            let pane = try #require(secondDock.resolvePane(requestedPaneID: nil))
+            _ = secondDock.newSurfaceFromDockAffordance(kind: .terminal, inPane: pane, window: nil)
+
+            let ownerCoordinator = try #require(
+                appDelegate.mainWindowContexts.values
+                    .first(where: { $0.windowId == secondWindowId })?
+                    .keyboardFocusCoordinator
+            )
+            let otherCoordinator = try #require(
+                appDelegate.mainWindowContexts.values
+                    .first(where: { $0.windowId == firstWindowId })?
+                    .keyboardFocusCoordinator
+            )
+            #expect(ownerCoordinator.activeRightSidebarMode == .dock)
+            #expect(otherCoordinator.activeRightSidebarMode != .dock)
+        }
+    }
+
     @Test("Plain Dock surface creation does not claim shortcut routing")
     @MainActor
     func plainNewSurfaceDoesNotClaimShortcutRouting() throws {

--- a/cmuxTests/WindowDockLifecycleTests.swift
+++ b/cmuxTests/WindowDockLifecycleTests.swift
@@ -139,6 +139,8 @@ struct WindowDockLifecycleTests {
             let firstWindowId = appDelegate.registerMainWindowContextForTesting(tabManager: firstManager)
             let secondWindowId = appDelegate.registerMainWindowContextForTesting(tabManager: secondManager)
             defer {
+                appDelegate.unregisterMainWindowContextForTesting(windowId: secondWindowId)
+                appDelegate.unregisterMainWindowContextForTesting(windowId: firstWindowId)
                 firstManager.tabs.forEach { $0.teardownAllPanels() }
                 secondManager.tabs.forEach { $0.teardownAllPanels() }
             }

--- a/cmuxTests/WindowDockLifecycleTests.swift
+++ b/cmuxTests/WindowDockLifecycleTests.swift
@@ -86,6 +86,69 @@ struct WindowDockLifecycleTests {
         try body(appDelegate)
     }
 
+    @Test("Empty Dock pane affordance routes creation shortcuts to the Dock")
+    @MainActor
+    func emptyPaneAffordanceRoutesCreationShortcutsToDock() throws {
+        try withIsolatedAppDelegate { appDelegate in
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+                manager.tabs.forEach { $0.teardownAllPanels() }
+            }
+
+            let dock = appDelegate.windowDock(forWindowId: windowId)
+            let pane = try #require(dock.resolvePane(requestedPaneID: nil))
+            _ = dock.newSurfaceFromDockAffordance(kind: .terminal, inPane: pane, window: nil)
+
+            #expect(appDelegate.focusedDockStoreForShortcut(preferredWindow: nil) === dock)
+            let routed = try #require(appDelegate.routeCreateToFocusedDock(
+                .terminal,
+                focusAddressBar: false,
+                preferredWindow: nil
+            ))
+            #expect(dock.containsPanel(routed))
+        }
+    }
+
+    @Test("Dock pane click owns creation shortcut routing")
+    @MainActor
+    func dockPaneClickOwnsCreationShortcutRouting() throws {
+        try withIsolatedAppDelegate { appDelegate in
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+                manager.tabs.forEach { $0.teardownAllPanels() }
+            }
+
+            let dock = appDelegate.windowDock(forWindowId: windowId)
+            let pane = try #require(dock.resolvePane(requestedPaneID: nil))
+            dock.focusPaneFromDockClick(pane, window: nil)
+
+            #expect(appDelegate.focusedDockStoreForShortcut(preferredWindow: nil) === dock)
+        }
+    }
+
+    @Test("Plain Dock surface creation does not claim shortcut routing")
+    @MainActor
+    func plainNewSurfaceDoesNotClaimShortcutRouting() throws {
+        try withIsolatedAppDelegate { appDelegate in
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+                manager.tabs.forEach { $0.teardownAllPanels() }
+            }
+
+            let dock = appDelegate.windowDock(forWindowId: windowId)
+            let pane = try #require(dock.resolvePane(requestedPaneID: nil))
+            _ = dock.newSurface(kind: .terminal, inPane: pane, focus: true)
+
+            #expect(appDelegate.focusedDockStoreForShortcut(preferredWindow: nil) == nil)
+        }
+    }
+
     @Test("Each window gets its own independent Dock store")
     @MainActor
     func windowDocksAreIndependentPerWindow() throws {


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/7522

## Problem

Open a window whose Dock is empty, click "New Terminal" in the empty Dock pane, then press Cmd+Shift+L. The browser is created in the main content split tree instead of the Dock. Same failure for Cmd+T and the split shortcuts, and for the "New Browser" button.

## Root cause

Creation-shortcut routing into the Dock is gated on the window coordinator reporting `activeRightSidebarMode == .dock` (`AppDelegate.focusedDockStoreForShortcut`). That state is only set by explicit intent notes. Clicking inside an existing Dock terminal notes it (`GhosttyTerminalView.mouseDown`), but the empty-pane affordance buttons called `DockSplitStore.newSurface(...)` directly, which never records intent, and the `becomeFirstResponder -> onFocus` repair path is suppressed during surface-creation churn. The pane-background tap handlers had the same gap. On top of that, `DockSplitStore.noteKeyboardFocusIntent(window:)` resolved through `keyboardFocusCoordinator(for:)`, which silently drops the note for a nil window.

## Fix

- `DockSplitStore+PaneFocus.swift`: add `newSurfaceFromDockAffordance(kind:inPane:window:)` and `focusPaneFromDockClick(_:window:)`, the shared entry points for every Dock click affordance; both note Dock focus intent first. `noteKeyboardFocusIntent(window:)` now resolves through `preferredRegisteredMainWindowContext(preferredWindow:)`, the exact chain the shortcut gate reads, so the note and the gate cannot disagree.
- `DockPanelView.swift`: both empty-pane button call sites and all three pane tap gestures route through the new methods. No view call site invokes bare `newSurface`/`focusPane` anymore.
- Socket policy preserved: plain `newSurface`/`newSplit` stay intent-neutral, so `surface.create --placement dock` never shifts the user's keyboard focus.

## Tests

Two-commit red/green structure (repo regression policy):

1. Commit 1 adds the seam plus three `WindowDockLifecycleTests` cases; the two positive cases fail because no intent is recorded.
2. Commit 2 adds the intent note; they pass.

- `emptyPaneAffordanceRoutesCreationShortcutsToDock`: affordance click, then `focusedDockStoreForShortcut` resolves the Dock and `routeCreateToFocusedDock` lands the surface in the Dock.
- `dockPaneClickOwnsCreationShortcutRouting`: pane click claims routing.
- `plainNewSurfaceDoesNotClaimShortcutRouting`: socket-path guard, `newSurface` alone must not claim routing.

## Notes for review

- `Sources/DockSplitStore.swift` (882/882) and `Sources/MainWindowFocusController.swift` (834/834) have zero length-budget headroom and are deliberately untouched; the change lives in the untracked extension files. No budget TSV changes. `python3 scripts/swift_file_length_budget.py` passes.
- No new user-facing strings, so no localization changes. Localization audit: the only UI-adjacent diff rewires existing button closures and tap gestures; no string literals added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786044186&installation_id=133855650&pr_number=7526&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7526&signature=04baf0415eb14beaa7b05f493158cb7c2edeeb84506a0c7235eba1452f0953e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes keyboard-focus intent and creation-shortcut routing for Dock interactions; scope is focused but affects multi-window focus edge cases.
> 
> **Overview**
> Fixes **#7522**: after using empty Dock “New Terminal/Browser” or tapping a pane, creation shortcuts (Cmd+T, Cmd+Shift+L, splits) were routed to the **main** split because Dock intent was never recorded.
> 
> **Dock UI** centralizes empty-pane and tap handling in `emptyPaneView` and routes panel `onFocus`/taps through **`newSurfaceFromDockAffordance`** and **`focusPaneFromDockClick`**, which note Dock interaction before creating or focusing. Plain **`newSurface`** stays unchanged for socket/programmatic paths.
> 
> **`noteKeyboardFocusIntent`** now targets the Dock store’s **owning window** keyboard coordinator (`workspaceId == windowId`) when present, then the caller’s window—so intent matches **`focusedDockStoreForShortcut`** and avoids misrouting across windows when `window` is nil or another window is key.
> 
> Adds **`WindowDockLifecycleTests`** for affordance routing, pane-click routing, per-window intent binding, and the socket guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85829783488584222cab473287932741d6cd451c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers Dock keyboard focus intent on Dock click affordances so creation shortcuts (Cmd+T, Cmd+Shift+L, splits) target the Dock. Intent is bound to the Dock’s owning window context to prevent cross-window misrouting, fixing #7522.

- **Bug Fixes**
  - Empty-pane buttons, pane taps, and panel `onFocus` now route through `newSurfaceFromDockAffordance`/`focusPaneFromDockClick` to note Dock intent before acting.
  - Intent notes prefer the Dock store’s owning window context, fall back to the caller-provided window, and never use ambient focus; this matches the shortcut gate and blocks sending shortcuts to another window’s Dock.
  - Sockets stay neutral: `newSurface`/`newSplit` remain intent-agnostic so `surface.create --placement dock` doesn’t shift keyboard focus.

- **Refactors**
  - Extracted `emptyPaneView(paneId:)` so both empty-pane render paths share one view and stay aligned with the focus-intent wiring.
  - Tests: unregister window contexts explicitly in the intent-binding test for deterministic per-window Dock teardown.

<sup>Written for commit 85829783488584222cab473287932741d6cd451c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Dock interactions for the active window: empty-pane “new terminal/browser” creation is consistently routed, and taps on empty Dock panes focus the correct pane.
  * Pane focusing for existing panels now follows the same Dock click routing path, aligning keyboard-focus intent with shortcut routing.
* **Tests**
  * Added per-window Dock lifecycle and routing coverage, including empty-pane affordance routing, pane-click focus routing, and confirming non-affordance Dock surfaces don’t claim shortcut routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->