### PR TITLE
Active Cloud VM uptime probe + liveness watchdog

### DIFF
--- a/.github/workflows/vm-probe-liveness.yml
+++ b/.github/workflows/vm-probe-liveness.yml
@@ -1,0 +1,26 @@
+name: Cloud VM probe liveness
+
+on:
+  schedule:
+    - cron: "13,43 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  freshness:
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    steps:
+      - name: Check production probe freshness
+        run: |
+          set -euo pipefail
+          endpoint="https://cmux.com/api/cron/vm-probe?mode=freshness"
+          body="$(curl --fail --silent --show-error --max-time 20 "$endpoint")"
+          echo "Freshness response: $body"
+          stale="$(printf '%s' "$body" | jq -r 'if has("stale") then .stale else "missing" end')"
+          last_success="$(printf '%s' "$body" | jq -r '.lastSuccessAt // "null"')"
+          if [ "$stale" != "false" ]; then
+            echo "::error::Cloud VM synthetic probe is stale or freshness payload is invalid. lastSuccessAt=$last_success stale=$stale"
+            exit 1
+          fi

--- a/web/app/api/cron/vm-probe/route.ts
+++ b/web/app/api/cron/vm-probe/route.ts
@@ -1,0 +1,41 @@
+import { getVmProbeFreshness, runVmProbe } from "../../../../services/observability/vmProbe";
+import { jsonResponse } from "../../../../services/vms/routeHelpers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 360;
+
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.searchParams.get("mode") === "freshness") {
+    try {
+      return jsonResponse(await getVmProbeFreshness());
+    } catch {
+      return jsonResponse({ lastSuccessAt: null, stale: true });
+    }
+  }
+
+  const cronSecret = process.env.CRON_SECRET?.trim();
+  if (!cronSecret) {
+    return jsonResponse({ error: "cron_not_configured" }, 503);
+  }
+
+  const expected = `Bearer ${cronSecret}`;
+  if (request.headers.get("authorization") !== expected) {
+    return jsonResponse({ error: "unauthorized" }, 401);
+  }
+
+  try {
+    const probe = await runVmProbe();
+    if ("skipped" in probe) return jsonResponse(probe);
+    return jsonResponse({ probe });
+  } catch (error) {
+    return jsonResponse({
+      probe: {
+        status: "failure",
+        error: "vm_probe_internal_error",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+}

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -621,3 +621,17 @@ export const cloudVmNotificationDeliveries = pgTable(
       .on(table.eventId, table.status),
   ],
 );
+
+export const cloudVmProbeState = pgTable(
+  "cloud_vm_probe_state",
+  {
+    key: text("key").primaryKey(),
+    lastRunAt: timestamp("last_run_at", { withTimezone: true }),
+    lastSuccessAt: timestamp("last_success_at", { withTimezone: true }),
+    consecutiveFailures: integer("consecutive_failures").notNull().default(0),
+    lastErrorCode: text("last_error_code"),
+    lastErrorMessage: text("last_error_message"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+);

--- a/web/services/observability/vmProbe.ts
+++ b/web/services/observability/vmProbe.ts
@@ -1,0 +1,860 @@
+import { and, eq, inArray, isNotNull, like, lt } from "drizzle-orm";
+import { cloudDb } from "../../db/client";
+import { cloudVmProbeState, cloudVms } from "../../db/schema";
+import { assertVmCreateEnabled } from "../vms/config";
+import { defaultProviderId, type ExecResult, type ProviderId } from "../vms/drivers";
+import { maxActiveVmsForPlan } from "../vms/entitlements";
+import {
+  isVmCreateCreditsInsufficientError,
+  isVmCreateDisabledError,
+  vmWorkflowErrorCause,
+} from "../vms/errors";
+import {
+  imageUsesBakedFreestyleSignedAdmin,
+  resolveVmImage,
+} from "../vms/images/resolver";
+import {
+  createVm,
+  destroyVm,
+  execVm,
+  getVm,
+  runVmWorkflow,
+  type VmEntry,
+} from "../vms/workflows";
+import { sendAlert, type AlertFetch, type AlertInput, type AlertResult } from "./alerts";
+
+const PROBE_STATE_KEY = "default";
+const PROBE_IDEMPOTENCY_PREFIX = "cmux-probe-";
+const PROBE_OK = "cmux-probe-ok";
+const ERROR_MESSAGE_MAX_LENGTH = 300;
+const ERROR_SECRET_PATTERNS = [
+  /Bearer\s+\S+/g,
+  /srt_[A-Za-z0-9_-]+/g,
+  /sk-[A-Za-z0-9_-]{8,}/g,
+  /eyJ[A-Za-z0-9_-]{10,}/g,
+] as const;
+
+type ProbeStepName = "create" | "status" | "exec" | "destroy";
+type ProbeStepOutcome = "ok" | "error";
+
+export type VmProbeAlertInput = AlertInput;
+
+export type VmProbeStepSummary = {
+  readonly step: ProbeStepName;
+  readonly outcome: ProbeStepOutcome;
+  readonly ms: number;
+  readonly budgetMs: number;
+  readonly budgetExceeded: boolean;
+  readonly errorCode?: string;
+  readonly errorMessage?: string;
+};
+
+export type VmProbeRunSummary =
+  | { readonly skipped: "probe_not_configured" }
+  | { readonly skipped: "create_disabled"; readonly reason: string }
+  | {
+      readonly status: "success" | "failure";
+      readonly startedAt: string;
+      readonly finishedAt: string;
+      readonly provider: ProviderId | null;
+      readonly imageVersion: string | null;
+      readonly billingTeamId: string | null;
+      readonly vmId: string | null;
+      readonly steps: readonly VmProbeStepSummary[];
+      readonly staleReap: VmProbeStaleReapSummary;
+      readonly state: {
+        readonly lastRunAt: string;
+        readonly lastSuccessAt: string | null;
+        readonly consecutiveFailures: number;
+      };
+      readonly stateWriteError?: {
+        readonly code: string;
+        readonly message: string;
+      };
+    };
+
+export type VmProbeFreshness = {
+  readonly lastSuccessAt: string | null;
+  readonly stale: boolean;
+};
+
+export type VmProbePersistedState = {
+  readonly key: string;
+  readonly lastRunAt: Date | null;
+  readonly lastSuccessAt: Date | null;
+  readonly consecutiveFailures: number;
+  readonly lastErrorCode: string | null;
+  readonly lastErrorMessage: string | null;
+};
+
+type VmProbeStaleVm = {
+  readonly id: string;
+  readonly providerVmId: string;
+};
+
+export type VmProbeStaleReapSummary = {
+  readonly checkedBefore: string;
+  readonly found: number;
+  readonly destroyed: readonly string[];
+  readonly failed: readonly { readonly vmId: string; readonly errorCode: string; readonly errorMessage: string }[];
+};
+
+type VmProbeStore = {
+  readonly getState: () => Promise<VmProbePersistedState | null>;
+  readonly recordResult: (input: {
+    readonly now: Date;
+    readonly success: boolean;
+    readonly errorCode: string | null;
+    readonly errorMessage: string | null;
+    readonly previousState: VmProbePersistedState | null;
+  }) => Promise<VmProbePersistedState>;
+  readonly listStaleProbeVms: (input: {
+    readonly userId: string;
+    readonly billingTeamId: string;
+    readonly before: Date;
+  }) => Promise<readonly VmProbeStaleVm[]>;
+};
+
+type VmProbeWorkflows = {
+  readonly create: (input: Parameters<typeof createVm>[0]) => Promise<VmEntry>;
+  readonly get: (input: Parameters<typeof getVm>[0]) => Promise<VmEntry>;
+  readonly exec: (input: Parameters<typeof execVm>[0]) => Promise<ExecResult>;
+  readonly destroy: (input: Parameters<typeof destroyVm>[0]) => Promise<void>;
+};
+
+type VmProbeClock = {
+  readonly now: () => Date;
+  readonly delay: (ms: number) => Promise<void>;
+};
+
+type SendProbeAlert = (input: VmProbeAlertInput) => Promise<AlertResult>;
+
+export async function runVmProbe(options: {
+  readonly db?: ReturnType<typeof cloudDb>;
+  readonly env?: Record<string, string | undefined>;
+  readonly fetch?: AlertFetch;
+  readonly sendAlert?: SendProbeAlert;
+  readonly store?: VmProbeStore;
+  readonly workflows?: VmProbeWorkflows;
+  readonly clock?: VmProbeClock;
+} = {}): Promise<VmProbeRunSummary> {
+  const env = options.env ?? process.env;
+  const clock = options.clock ?? systemClock;
+  const store = options.store ?? makeVmProbeStore(options.db ?? cloudDb());
+  const workflows = options.workflows ?? defaultWorkflows;
+  const send = options.sendAlert ?? ((input) => sendAlert(input, { fetch: options.fetch, env }));
+  const startedAt = clock.now();
+  const previousState = await safeGetState(store);
+  const steps: VmProbeStepSummary[] = [];
+  let configured: ProbeConfig;
+  try {
+    const config = probeConfig(env);
+    if (!config) return { skipped: "probe_not_configured" };
+    configured = config;
+  } catch (error) {
+    if (isVmCreateDisabledError(error)) {
+      return { skipped: "create_disabled", reason: error.reason };
+    }
+    return finishEarlyFailure({
+      phase: "config",
+      error,
+      store,
+      previousState,
+      send,
+      clock,
+      startedAt,
+      steps,
+      staleReap: emptyStaleReap(startedAt),
+      configured: null,
+    });
+  }
+
+  let staleReap: VmProbeStaleReapSummary;
+  try {
+    staleReap = await reapStaleProbeVms({
+      config: configured,
+      store,
+      workflows,
+      send,
+      clock,
+    });
+  } catch (error) {
+    return finishEarlyFailure({
+      phase: "stale_reap",
+      error,
+      store,
+      previousState,
+      send,
+      clock,
+      startedAt,
+      steps,
+      staleReap: emptyStaleReap(startedAt),
+      configured,
+    });
+  }
+
+  let vmId: string | null = null;
+  let failure: { code: string; message: string; step: ProbeStepName } | null = null;
+  let createCreditsExhausted = false;
+  let leakAlertSent = false;
+
+  try {
+    const created = await runStep("create", configured.createBudgetMs, clock, steps, () =>
+      workflows.create({
+        userId: configured.userId,
+        billingCustomerType: configured.billingCustomerType,
+        billingTeamId: configured.billingTeamId,
+        billingPlanId: configured.billingPlanId,
+        maxActiveVms: configured.maxActiveVms,
+        provider: configured.provider,
+        image: configured.image,
+        imageVersion: configured.imageVersion,
+        idempotencyKey: `${PROBE_IDEMPOTENCY_PREFIX}${startedAt.toISOString()}`,
+        bakedFreestyleSignedAdmin: imageUsesBakedFreestyleSignedAdmin(configured.provider, configured.image),
+      })
+    );
+    vmId = created.providerVmId;
+    recordBudgetFailure(steps.at(-1), "create");
+
+    await runStep("status", configured.statusBudgetMs, clock, steps, () =>
+      pollUntilRunning({
+        workflows,
+        clock,
+        config: configured,
+        vmId: created.providerVmId,
+      })
+    );
+    recordBudgetFailure(steps.at(-1), "status");
+
+    const execResult = await runStep("exec", configured.execBudgetMs, clock, steps, () =>
+      workflows.exec({
+        userId: configured.userId,
+        billingTeamId: configured.billingTeamId,
+        providerVmId: created.providerVmId,
+        command: `echo ${PROBE_OK}`,
+        timeoutMs: configured.execBudgetMs,
+      })
+    );
+    if (execResult.exitCode !== 0 || execResult.stdout.trim() !== PROBE_OK) {
+      throw probeStepError("exec", "vm_probe_exec_unexpected_output", [
+        `exitCode=${execResult.exitCode}`,
+        `stdout=${singleLine(execResult.stdout)}`,
+        `stderr=${singleLine(execResult.stderr)}`,
+      ].join(" "));
+    }
+    recordBudgetFailure(steps.at(-1), "exec");
+  } catch (error) {
+    const summary = errorSummary(error);
+    const step = stepFromError(error) ?? stepFromLastError(steps) ?? "create";
+    failure = { ...summary, step };
+    createCreditsExhausted = step === "create" && isVmCreateCreditsInsufficientError(vmWorkflowErrorCause(error) ?? error);
+    if (steps.length === 0 || steps.at(-1)?.outcome !== "error") {
+      steps.push({
+        step,
+        outcome: "error",
+        ms: 0,
+        budgetMs: budgetForStep(configured, step),
+        budgetExceeded: false,
+        errorCode: summary.code,
+        errorMessage: summary.message,
+      });
+    }
+  } finally {
+    if (vmId) {
+      const destroyVmId = vmId;
+      try {
+        await runStep("destroy", configured.destroyBudgetMs, clock, steps, () =>
+          workflows.destroy({
+            userId: configured.userId,
+            billingTeamId: configured.billingTeamId,
+            providerVmId: destroyVmId,
+          })
+        );
+        recordBudgetFailure(steps.at(-1), "destroy");
+      } catch (error) {
+        const summary = errorSummary(error);
+        if (!failure) {
+          failure = { ...summary, step: "destroy" };
+        }
+        await sendLeakAlert(send, summary, destroyVmId, stepMs(steps, "destroy"));
+        leakAlertSent = true;
+      }
+    }
+  }
+
+  const budgetFailure = steps.find((step) => step.budgetExceeded);
+  if (!failure && budgetFailure) {
+    failure = {
+      step: budgetFailure.step,
+      code: "vm_probe_budget_exceeded",
+      message: `${budgetFailure.step} took ${budgetFailure.ms}ms; budget is ${budgetFailure.budgetMs}ms`,
+    };
+  }
+
+  if (failure) {
+    if (createCreditsExhausted) {
+      await sendCreditsAlert(send, failure, stepMs(steps, "create"));
+    } else if (failure.step !== "destroy" || !leakAlertSent) {
+      await sendStepAlert(send, failure, vmId, stepMs(steps, failure.step));
+    }
+  }
+
+  const finishedAt = clock.now();
+  const success = !failure;
+  const persistedResult = await recordProbeResultSafely(store, {
+    now: finishedAt,
+    success,
+    errorCode: failure?.code ?? null,
+    errorMessage: failure?.message ?? null,
+    previousState,
+  });
+  if (success && persistedResult.ok && (previousState?.consecutiveFailures ?? 0) > 0) {
+    await send({
+      key: "vm-probe-recovered",
+      title: "Cloud VM synthetic probe recovered",
+      body: `The active Cloud VM probe succeeded after ${previousState?.consecutiveFailures ?? 0} consecutive failure(s).`,
+      severity: "warning",
+    });
+  }
+  const persisted = persistedResult.state;
+
+  return {
+    status: success ? "success" : "failure",
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    provider: configured.provider,
+    imageVersion: configured.imageVersion,
+    billingTeamId: configured.billingTeamId,
+    vmId,
+    steps,
+    staleReap,
+    state: {
+      lastRunAt: isoOrNow(persisted.lastRunAt, finishedAt),
+      lastSuccessAt: persisted.lastSuccessAt?.toISOString() ?? null,
+      consecutiveFailures: persisted.consecutiveFailures,
+    },
+    ...(persistedResult.ok ? {} : { stateWriteError: persistedResult.error }),
+  };
+
+  function recordBudgetFailure(step: VmProbeStepSummary | undefined, stepName: ProbeStepName) {
+    if (!step?.budgetExceeded || failure) return;
+    failure = {
+      step: stepName,
+      code: "vm_probe_budget_exceeded",
+      message: `${stepName} took ${step.ms}ms; budget is ${step.budgetMs}ms`,
+    };
+  }
+}
+
+export async function getVmProbeFreshness(options: {
+  readonly db?: ReturnType<typeof cloudDb>;
+  readonly env?: Record<string, string | undefined>;
+  readonly now?: Date;
+  readonly store?: Pick<VmProbeStore, "getState">;
+} = {}): Promise<VmProbeFreshness> {
+  const env = options.env ?? process.env;
+  const now = options.now ?? new Date();
+  const staleMs = positiveIntegerEnv(env.CMUX_VM_PROBE_FRESHNESS_STALE_MS, 45 * 60 * 1000);
+  const store = options.store ?? makeVmProbeStore(options.db ?? cloudDb());
+  const state = await store.getState();
+  const lastSuccessAt = state?.lastSuccessAt ?? null;
+  return {
+    lastSuccessAt: lastSuccessAt?.toISOString() ?? null,
+    stale: !lastSuccessAt || now.getTime() - lastSuccessAt.getTime() > staleMs,
+  };
+}
+
+async function finishEarlyFailure(input: {
+  readonly phase: "config" | "stale_reap";
+  readonly error: unknown;
+  readonly store: VmProbeStore;
+  readonly previousState: VmProbePersistedState | null;
+  readonly send: SendProbeAlert;
+  readonly clock: VmProbeClock;
+  readonly startedAt: Date;
+  readonly steps: readonly VmProbeStepSummary[];
+  readonly staleReap: VmProbeStaleReapSummary;
+  readonly configured: ProbeConfig | null;
+}): Promise<VmProbeRunSummary> {
+  const summary = errorSummary(input.error);
+  await sendRunFailureAlert(input.send, input.phase, summary);
+  const finishedAt = input.clock.now();
+  const persistedResult = await recordProbeResultSafely(input.store, {
+    now: finishedAt,
+    success: false,
+    errorCode: summary.code,
+    errorMessage: summary.message,
+    previousState: input.previousState,
+  });
+  const persisted = persistedResult.state;
+  return {
+    status: "failure",
+    startedAt: input.startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    provider: input.configured?.provider ?? null,
+    imageVersion: input.configured?.imageVersion ?? null,
+    billingTeamId: input.configured?.billingTeamId ?? null,
+    vmId: null,
+    steps: input.steps,
+    staleReap: input.staleReap,
+    state: {
+      lastRunAt: isoOrNow(persisted.lastRunAt, finishedAt),
+      lastSuccessAt: persisted.lastSuccessAt?.toISOString() ?? null,
+      consecutiveFailures: persisted.consecutiveFailures,
+    },
+    ...(persistedResult.ok ? {} : { stateWriteError: persistedResult.error }),
+  };
+}
+
+async function recordProbeResultSafely(
+  store: VmProbeStore,
+  input: {
+    readonly now: Date;
+    readonly success: boolean;
+    readonly errorCode: string | null;
+    readonly errorMessage: string | null;
+    readonly previousState: VmProbePersistedState | null;
+  },
+): Promise<
+  | { readonly ok: true; readonly state: VmProbePersistedState }
+  | {
+      readonly ok: false;
+      readonly state: VmProbePersistedState;
+      readonly error: { readonly code: string; readonly message: string };
+    }
+> {
+  try {
+    return {
+      ok: true,
+      state: await store.recordResult(input),
+    };
+  } catch (error) {
+    const summary = errorSummary(error);
+    const previous = input.previousState;
+    return {
+      ok: false,
+      state: {
+        key: PROBE_STATE_KEY,
+        lastRunAt: input.now,
+        lastSuccessAt: input.success ? previous?.lastSuccessAt ?? null : previous?.lastSuccessAt ?? null,
+        consecutiveFailures: input.success
+          ? previous?.consecutiveFailures ?? 0
+          : (previous?.consecutiveFailures ?? 0) + 1,
+        lastErrorCode: input.success ? previous?.lastErrorCode ?? null : input.errorCode,
+        lastErrorMessage: input.success ? previous?.lastErrorMessage ?? null : input.errorMessage,
+      },
+      error: summary,
+    };
+  }
+}
+
+function emptyStaleReap(now: Date): VmProbeStaleReapSummary {
+  return {
+    checkedBefore: now.toISOString(),
+    found: 0,
+    destroyed: [],
+    failed: [],
+  };
+}
+
+function makeVmProbeStore(db: ReturnType<typeof cloudDb>): VmProbeStore {
+  return {
+    getState: async () => {
+      const [row] = await db
+        .select()
+        .from(cloudVmProbeState)
+        .where(eq(cloudVmProbeState.key, PROBE_STATE_KEY))
+        .limit(1);
+      return row ?? null;
+    },
+    recordResult: async (input) => {
+      const lastSuccessAt = input.success
+        ? input.now
+        : input.previousState?.lastSuccessAt ?? null;
+      const consecutiveFailures = input.success
+        ? 0
+        : (input.previousState?.consecutiveFailures ?? 0) + 1;
+      const values = {
+        key: PROBE_STATE_KEY,
+        lastRunAt: input.now,
+        lastSuccessAt,
+        consecutiveFailures,
+        lastErrorCode: input.success ? null : input.errorCode,
+        lastErrorMessage: input.success ? null : input.errorMessage,
+        updatedAt: input.now,
+      };
+      const [row] = await db
+        .insert(cloudVmProbeState)
+        .values(values)
+        .onConflictDoUpdate({
+          target: cloudVmProbeState.key,
+          set: values,
+        })
+        .returning();
+      if (!row) throw new Error("cloud_vm_probe_state upsert returned no row");
+      return row;
+    },
+    listStaleProbeVms: async (input) => {
+      return db
+        .select({
+          id: cloudVms.id,
+          providerVmId: cloudVms.providerVmId,
+        })
+        .from(cloudVms)
+        .where(and(
+          eq(cloudVms.userId, input.userId),
+          eq(cloudVms.billingTeamId, input.billingTeamId),
+          like(cloudVms.idempotencyKey, `${PROBE_IDEMPOTENCY_PREFIX}%`),
+          inArray(cloudVms.status, ["provisioning", "running", "paused"]),
+          isNotNull(cloudVms.providerVmId),
+          lt(cloudVms.createdAt, input.before),
+        ))
+        .limit(20) as Promise<readonly VmProbeStaleVm[]>;
+    },
+  };
+}
+
+const defaultWorkflows: VmProbeWorkflows = {
+  create: (input) => runVmWorkflow(createVm(input)),
+  get: (input) => runVmWorkflow(getVm(input)),
+  exec: (input) => runVmWorkflow(execVm(input)),
+  destroy: (input) => runVmWorkflow(destroyVm(input)),
+};
+
+const systemClock: VmProbeClock = {
+  now: () => new Date(),
+  delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+async function runStep<A>(
+  step: ProbeStepName,
+  budgetMs: number,
+  clock: VmProbeClock,
+  steps: VmProbeStepSummary[],
+  run: () => Promise<A>,
+): Promise<A> {
+  const start = clock.now().getTime();
+  try {
+    const result = await run();
+    const ms = Math.max(0, clock.now().getTime() - start);
+    steps.push({ step, outcome: "ok", ms, budgetMs, budgetExceeded: ms > budgetMs });
+    return result;
+  } catch (error) {
+    const ms = Math.max(0, clock.now().getTime() - start);
+    const summary = errorSummary(error);
+    steps.push({
+      step,
+      outcome: "error",
+      ms,
+      budgetMs,
+      budgetExceeded: ms > budgetMs,
+      errorCode: summary.code,
+      errorMessage: summary.message,
+    });
+    throw error;
+  }
+}
+
+async function pollUntilRunning(input: {
+  readonly workflows: VmProbeWorkflows;
+  readonly clock: VmProbeClock;
+  readonly config: ProbeConfig;
+  readonly vmId: string;
+}): Promise<VmEntry> {
+  const deadline = input.clock.now().getTime() + input.config.statusBudgetMs;
+  let last: VmEntry | null = null;
+  for (;;) {
+    last = await input.workflows.get({
+      userId: input.config.userId,
+      billingTeamId: input.config.billingTeamId,
+      providerVmId: input.vmId,
+    });
+    if (last.status === "running") return last;
+    if (input.clock.now().getTime() >= deadline) {
+      throw probeStepError("status", "vm_probe_status_timeout", `status stayed ${last.status}`);
+    }
+    await input.clock.delay(Math.min(input.config.statusPollMs, Math.max(1, deadline - input.clock.now().getTime())));
+  }
+}
+
+async function reapStaleProbeVms(input: {
+  readonly config: ProbeConfig;
+  readonly store: VmProbeStore;
+  readonly workflows: VmProbeWorkflows;
+  readonly send: SendProbeAlert;
+  readonly clock: VmProbeClock;
+}): Promise<VmProbeStaleReapSummary> {
+  const before = new Date(input.clock.now().getTime() - input.config.staleReapMs);
+  const stale = await input.store.listStaleProbeVms({
+    userId: input.config.userId,
+    billingTeamId: input.config.billingTeamId,
+    before,
+  });
+  const destroyed: string[] = [];
+  const failed: { vmId: string; errorCode: string; errorMessage: string }[] = [];
+  for (const vm of stale) {
+    try {
+      await input.workflows.destroy({
+        userId: input.config.userId,
+        billingTeamId: input.config.billingTeamId,
+        providerVmId: vm.providerVmId,
+      });
+      destroyed.push(vm.providerVmId);
+    } catch (error) {
+      const summary = errorSummary(error);
+      failed.push({ vmId: vm.providerVmId, errorCode: summary.code, errorMessage: summary.message });
+    }
+  }
+  if (stale.length > 0 || failed.length > 0) {
+    await input.send({
+      key: "vm-probe-stale-reap",
+      title: "Cloud VM probe reaped stale synthetic VMs",
+      body: [
+        `Found ${stale.length} stale probe VM(s) older than ${input.config.staleReapMs}ms.`,
+        `Destroyed: ${destroyed.length ? destroyed.join(", ") : "none"}.`,
+        failed.length ? `Failed: ${failed.map((item) => `${item.vmId}:${item.errorCode}`).join(", ")}.` : "",
+      ].filter(Boolean).join(" "),
+      severity: failed.length ? "critical" : "warning",
+    });
+  }
+  return {
+    checkedBefore: before.toISOString(),
+    found: stale.length,
+    destroyed,
+    failed,
+  };
+}
+
+async function safeGetState(store: VmProbeStore): Promise<VmProbePersistedState | null> {
+  try {
+    return await store.getState();
+  } catch {
+    return null;
+  }
+}
+
+function sendStepAlert(
+  send: SendProbeAlert,
+  failure: { readonly step: ProbeStepName; readonly code: string; readonly message: string },
+  vmId: string | null,
+  latencyMs: number,
+) {
+  return send({
+    key: "vm-probe-step-failed",
+    title: "Cloud VM synthetic probe failed",
+    body: [
+      `Step: ${failure.step}.`,
+      `Code: ${failure.code}.`,
+      `Message: ${failure.message}.`,
+      `Latency: ${latencyMs}ms.`,
+      `VM id: ${vmId ?? "none"}.`,
+    ].join(" "),
+    severity: "critical",
+  });
+}
+
+function sendCreditsAlert(
+  send: SendProbeAlert,
+  failure: { readonly code: string; readonly message: string },
+  latencyMs: number,
+) {
+  return send({
+    key: "vm-probe-credits-exhausted",
+    title: "Cloud VM probe credits exhausted",
+    body: [
+      "The synthetic probe could not create a VM because monitor account credits are exhausted.",
+      `Code: ${failure.code}.`,
+      `Message: ${failure.message}.`,
+      `Latency: ${latencyMs}ms.`,
+    ].join(" "),
+    severity: "warning",
+  });
+}
+
+function sendLeakAlert(
+  send: SendProbeAlert,
+  failure: { readonly code: string; readonly message: string },
+  vmId: string,
+  latencyMs: number,
+) {
+  return send({
+    key: "vm-probe-destroy-failed",
+    title: "Cloud VM synthetic probe leaked a VM",
+    body: [
+      "Destroy failed after the synthetic probe created a VM.",
+      `VM id: ${vmId}.`,
+      `Code: ${failure.code}.`,
+      `Message: ${failure.message}.`,
+      `Latency: ${latencyMs}ms.`,
+    ].join(" "),
+    severity: "critical",
+  });
+}
+
+function sendRunFailureAlert(
+  send: SendProbeAlert,
+  phase: "config" | "stale_reap",
+  failure: { readonly code: string; readonly message: string },
+) {
+  return send({
+    key: "vm-probe-run-failed",
+    title: "Cloud VM synthetic probe could not start",
+    body: [
+      `Phase: ${phase}.`,
+      `Code: ${failure.code}.`,
+      `Message: ${failure.message}.`,
+    ].join(" "),
+    severity: "critical",
+  });
+}
+
+type ProbeConfig = {
+  readonly userId: string;
+  readonly billingTeamId: string;
+  readonly billingCustomerType: "team" | "user";
+  readonly billingPlanId: string;
+  readonly maxActiveVms: number;
+  readonly provider: ProviderId;
+  readonly image: string;
+  readonly imageVersion: string | null;
+  readonly createBudgetMs: number;
+  readonly statusBudgetMs: number;
+  readonly execBudgetMs: number;
+  readonly destroyBudgetMs: number;
+  readonly statusPollMs: number;
+  readonly staleReapMs: number;
+};
+
+function probeConfig(env: Record<string, string | undefined>): ProbeConfig | null {
+  const userId = env.CMUX_VM_PROBE_USER_ID?.trim();
+  if (!userId) return null;
+  const billingTeamId = env.CMUX_VM_PROBE_TEAM_ID?.trim() || userId;
+  const billingCustomerType = env.CMUX_VM_PROBE_TEAM_ID?.trim() ? "team" : "user";
+  const billingPlanId = env.CMUX_VM_PROBE_PLAN_ID?.trim() || env.CMUX_VM_DEFAULT_PLAN?.trim() || "free";
+  const provider = providerEnv(env.CMUX_VM_PROBE_PROVIDER) ?? defaultProviderId();
+  assertVmCreateEnabled(provider, env);
+  const imageSelection = resolveVmImage(provider, env.CMUX_VM_PROBE_IMAGE, env);
+  return {
+    userId,
+    billingTeamId,
+    billingCustomerType,
+    billingPlanId,
+    maxActiveVms: positiveIntegerEnv(env.CMUX_VM_PROBE_MAX_ACTIVE_VMS, maxActiveVmsForPlan(billingPlanId, env)),
+    provider,
+    image: imageSelection.image,
+    imageVersion: imageSelection.imageVersion,
+    createBudgetMs: positiveIntegerEnv(env.CMUX_VM_PROBE_CREATE_TIMEOUT_MS, 120_000),
+    statusBudgetMs: positiveIntegerEnv(env.CMUX_VM_PROBE_STATUS_TIMEOUT_MS, 60_000),
+    execBudgetMs: positiveIntegerEnv(env.CMUX_VM_PROBE_EXEC_TIMEOUT_MS, 30_000),
+    destroyBudgetMs: positiveIntegerEnv(env.CMUX_VM_PROBE_DESTROY_TIMEOUT_MS, 60_000),
+    statusPollMs: positiveIntegerEnv(env.CMUX_VM_PROBE_STATUS_POLL_MS, 5_000),
+    staleReapMs: positiveIntegerEnv(env.CMUX_VM_PROBE_STALE_REAP_MS, 60 * 60 * 1000),
+  };
+}
+
+function providerEnv(value: string | undefined): ProviderId | null {
+  const trimmed = value?.trim();
+  return trimmed === "e2b" || trimmed === "freestyle" || trimmed === "daytona" ? trimmed : null;
+}
+
+function positiveIntegerEnv(value: string | undefined, fallback: number): number {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) return fallback;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function budgetForStep(config: ProbeConfig, step: ProbeStepName): number {
+  switch (step) {
+    case "create":
+      return config.createBudgetMs;
+    case "status":
+      return config.statusBudgetMs;
+    case "exec":
+      return config.execBudgetMs;
+    case "destroy":
+      return config.destroyBudgetMs;
+  }
+}
+
+function errorSummary(error: unknown): { readonly code: string; readonly message: string } {
+  const workflowError = vmWorkflowErrorCause(error) ?? error;
+  if (workflowError && typeof workflowError === "object") {
+    const tag = (workflowError as { _tag?: unknown })._tag;
+    if (typeof tag === "string") {
+      return { code: errorCodeForTag(tag), message: sanitizeErrorMessage(workflowErrorMessage(workflowError)) };
+    }
+    const code = (workflowError as { code?: unknown }).code;
+    if (typeof code === "string") {
+      return { code, message: sanitizeErrorMessage(errorMessage(workflowError)) };
+    }
+  }
+  return { code: "vm_probe_error", message: sanitizeErrorMessage(errorMessage(error)) };
+}
+
+function errorCodeForTag(tag: string): string {
+  switch (tag) {
+    case "VmCreateCreditsInsufficientError":
+      return "vm_create_credits_insufficient";
+    case "VmProviderOperationError":
+      return "vm_cloud_service_unavailable";
+    case "VmCreateFailedError":
+      return "vm_create_failed";
+    case "VmDatabaseError":
+      return "vm_cloud_state_unavailable";
+    case "VmBillingError":
+      return "vm_billing_unavailable";
+    default:
+      return tag.replace(/^Vm/, "vm_").replace(/Error$/, "").replace(/[A-Z]/g, (char) => `_${char.toLowerCase()}`).replace(/__+/g, "_");
+  }
+}
+
+function workflowErrorMessage(error: object): string {
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause) return errorMessage(cause);
+  const message = (error as { message?: unknown }).message;
+  return typeof message === "string" && message ? message : String((error as { _tag?: unknown })._tag ?? "unknown error");
+}
+
+function probeStepError(step: ProbeStepName, code: string, message: string): Error {
+  const error = new Error(message) as Error & { code: string; step: ProbeStepName };
+  error.code = code;
+  error.step = step;
+  return error;
+}
+
+function stepFromError(error: unknown): ProbeStepName | null {
+  const step = (error as { step?: unknown } | null)?.step;
+  return step === "create" || step === "status" || step === "exec" || step === "destroy" ? step : null;
+}
+
+function stepFromLastError(steps: readonly VmProbeStepSummary[]): ProbeStepName | null {
+  const step = steps.at(-1);
+  return step?.outcome === "error" ? step.step : null;
+}
+
+function stepMs(steps: readonly VmProbeStepSummary[], step: ProbeStepName): number {
+  return steps.findLast((candidate) => candidate.step === step && candidate.ms > 0)?.ms ??
+    steps.findLast((candidate) => candidate.step === step)?.ms ??
+    0;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sanitizeErrorMessage(message: string): string {
+  let redacted = message;
+  for (const pattern of ERROR_SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern, "[redacted]");
+  }
+  return redacted.slice(0, ERROR_MESSAGE_MAX_LENGTH);
+}
+
+function singleLine(value: string): string {
+  return value.replace(/\s+/g, " ").trim().slice(0, 200);
+}
+
+function isoOrNow(date: Date | null, now: Date): string {
+  return (date ?? now).toISOString();
+}

--- a/web/tests/vm-probe.test.ts
+++ b/web/tests/vm-probe.test.ts
@@ -1,0 +1,459 @@
+import { describe, expect, test } from "bun:test";
+import { VmCreateCreditsInsufficientError, VmProviderOperationError } from "../services/vms/errors";
+import {
+  getVmProbeFreshness,
+  runVmProbe,
+  type VmProbeAlertInput,
+  type VmProbePersistedState,
+} from "../services/observability/vmProbe";
+import type { ExecResult, ProviderId } from "../services/vms/drivers";
+import type { VmEntry } from "../services/vms/workflows";
+
+const baseEnv = {
+  CMUX_VM_PROBE_USER_ID: "probe-user",
+  CMUX_VM_PROBE_TEAM_ID: "probe-team",
+  CMUX_VM_PROBE_PLAN_ID: "free",
+  CMUX_VM_PROBE_PROVIDER: "e2b",
+  CMUX_VM_PROBE_IMAGE: "cmuxd-ws:tooling-20260509f",
+  CMUX_VM_PROBE_CREATE_TIMEOUT_MS: "120000",
+  CMUX_VM_PROBE_STATUS_TIMEOUT_MS: "60000",
+  CMUX_VM_PROBE_EXEC_TIMEOUT_MS: "30000",
+  CMUX_VM_PROBE_DESTROY_TIMEOUT_MS: "60000",
+  CMUX_VM_PROBE_STATUS_POLL_MS: "1000",
+};
+
+describe("Cloud VM synthetic probe", () => {
+  test("happy path updates state without alerting", async () => {
+    const harness = makeHarness();
+    const summary = await harness.run();
+
+    expect(summary).toMatchObject({ status: "success", vmId: "provider-probe-1" });
+    if ("skipped" in summary) throw new Error("unexpected skip");
+    expect(summary.steps.map((step) => [step.step, step.outcome])).toEqual([
+      ["create", "ok"],
+      ["status", "ok"],
+      ["exec", "ok"],
+      ["destroy", "ok"],
+    ]);
+    expect(harness.alerts).toEqual([]);
+    expect(harness.store.state?.lastSuccessAt?.toISOString()).toBe(summary.finishedAt);
+    expect(harness.store.state?.consecutiveFailures).toBe(0);
+  });
+
+  test("exec failure alerts with the exec step and still destroys the VM", async () => {
+    const harness = makeHarness({
+      exec: async () => {
+        throw new VmProviderOperationError({
+          provider: "e2b",
+          operation: "exec",
+          cause: new Error("exec gateway down"),
+        });
+      },
+    });
+    const summary = await harness.run();
+
+    if ("skipped" in summary) throw new Error("unexpected skip");
+    expect(summary.status).toBe("failure");
+    expect(harness.destroyed).toEqual(["provider-probe-1"]);
+    expect(harness.alerts).toHaveLength(1);
+    expect(harness.alerts[0]).toMatchObject({
+      key: "vm-probe-step-failed",
+      severity: "critical",
+    });
+    expect(harness.alerts[0]?.body).toContain("Step: exec.");
+    expect(harness.alerts[0]?.body).toContain("Code: vm_cloud_service_unavailable.");
+  });
+
+  test("exec failure redacts provider secrets from alerts and persisted state", async () => {
+    const harness = makeHarness({
+      exec: async () => {
+        throw new VmProviderOperationError({
+          provider: "e2b",
+          operation: "exec",
+          cause: new Error("exec denied with Bearer srt_secret123token and api key sk-liveSecret123"),
+        });
+      },
+    });
+    const summary = await harness.run();
+
+    if ("skipped" in summary) throw new Error("unexpected skip");
+    expect(summary.status).toBe("failure");
+    expect(harness.alerts).toHaveLength(1);
+    const alertBody = harness.alerts[0]?.body ?? "";
+    const persistedMessage = harness.store.state?.lastErrorMessage ?? "";
+
+    expect(alertBody).toContain("Step: exec.");
+    expect(alertBody).toContain("Code: vm_cloud_service_unavailable.");
+    expect(alertBody).toContain("[redacted]");
+    expect(alertBody).not.toContain("Bearer srt_secret123token");
+    expect(alertBody).not.toContain("srt_secret123token");
+    expect(alertBody).not.toContain("sk-liveSecret123");
+    expect(harness.store.state?.lastErrorCode).toBe("vm_cloud_service_unavailable");
+    expect(persistedMessage).toContain("[redacted]");
+    expect(persistedMessage).not.toContain("Bearer srt_secret123token");
+    expect(persistedMessage).not.toContain("srt_secret123token");
+    expect(persistedMessage).not.toContain("sk-liveSecret123");
+  });
+
+  test("exec failure followed by destroy failure keeps the original outage as the persisted root cause", async () => {
+    const harness = makeHarness({
+      exec: async () => {
+        throw new VmProviderOperationError({
+          provider: "e2b",
+          operation: "exec",
+          cause: new Error("exec gateway down"),
+        });
+      },
+      destroy: async () => {
+        throw new VmProviderOperationError({
+          provider: "e2b",
+          operation: "destroy",
+          cause: new Error("destroy also down"),
+        });
+      },
+    });
+    const summary = await harness.run();
+
+    if ("skipped" in summary) throw new Error("unexpected skip");
+    expect(summary.status).toBe("failure");
+    expect(harness.alerts.map((alert) => alert.key)).toEqual([
+      "vm-probe-destroy-failed",
+      "vm-probe-step-failed",
+    ]);
+    expect(harness.alerts[1]?.body).toContain("Step: exec.");
+    expect(harness.alerts[1]?.body).toContain("Code: vm_cloud_service_unavailable.");
+    expect(harness.store.state?.lastErrorCode).toBe("vm_cloud_service_unavailable");
+    expect(harness.store.state?.lastErrorMessage).toContain("exec gateway down");
+  });
+
+  test("create credits failure sends the distinct credits alert", async () => {
+    const harness = makeHarness({
+      create: async () => {
+        throw new VmCreateCreditsInsufficientError({
+          itemId: "credit-item",
+          billingCustomerId: "probe-team",
+          amount: 1,
+        });
+      },
+    });
+    const summary = await harness.run();
+
+    if ("skipped" in summary) throw new Error("unexpected skip");
+    expect(summary.status).toBe("failure");
+    expect(harness.destroyed).toEqual([]);
+    expect(harness.alerts.map((alert) => alert.key)).toEqual(["vm-probe-credits-exhausted"]);
+    expect(harness.alerts[0]?.severity).toBe("warning");
+    expect(harness.alerts[0]?.body).toContain("vm_create_credits_insufficient");
+  });
+
+  test("budget breach alerts even when the step succeeds", async () => {
+    const harness = makeHarness({
+      create: async (input) => {
+        harness.clock.advance(121_000);
+        return vmEntry({ providerVmId: "provider-probe-1", provider: input.provider });
+      },
+    });
+    const summary = await harness.run();
+
+    if ("skipped" in summary) throw new Error("unexpected skip");
+    expect(summary.status).toBe("failure");
+    expect(summary.steps[0]).toMatchObject({
+      step: "create",
+      outcome: "ok",
+      budgetExceeded: true,
+    });
+    expect(harness.destroyed).toEqual(["provider-probe-1"]);
+    expect(harness.alerts[0]).toMatchObject({
+      key: "vm-probe-step-failed",
+      severity: "critical",
+    });
+    expect(harness.alerts[0]?.body).toContain("vm_probe_budget_exceeded");
+  });
+
+  test("destroy failure sends a leak alert and records failure state", async () => {
+    const harness = makeHarness({
+      destroy: async () => {
+        throw new VmProviderOperationError({
+          provider: "e2b",
+          operation: "destroy",
+          cause: new Error("destroy failed"),
+        });
+      },
+    });
+    const summary = await harness.run();
+
+    if ("skipped" in summary) throw new Error("unexpected skip");
+    expect(summary.status).toBe("failure");
+    expect(harness.alerts.map((alert) => alert.key)).toEqual(["vm-probe-destroy-failed"]);
+    expect(harness.store.state?.consecutiveFailures).toBe(1);
+    expect(harness.store.state?.lastErrorCode).toBe("vm_cloud_service_unavailable");
+  });
+
+  test("successful destroy budget breach sends a step alert", async () => {
+    const harness = makeHarness({
+      destroy: async () => {
+        harness.clock.advance(61_000);
+      },
+    });
+    const summary = await harness.run();
+
+    if ("skipped" in summary) throw new Error("unexpected skip");
+    expect(summary.status).toBe("failure");
+    expect(summary.steps.find((step) => step.step === "destroy")).toMatchObject({
+      outcome: "ok",
+      budgetExceeded: true,
+    });
+    expect(harness.alerts.map((alert) => alert.key)).toEqual(["vm-probe-step-failed"]);
+    expect(harness.alerts[0]?.body).toContain("Step: destroy.");
+    expect(harness.alerts[0]?.body).toContain("vm_probe_budget_exceeded");
+  });
+
+  test("first success after failure sends one recovery alert", async () => {
+    const previousFailure: VmProbePersistedState = {
+      key: "default",
+      lastRunAt: new Date("2026-07-05T10:00:00.000Z"),
+      lastSuccessAt: null,
+      consecutiveFailures: 2,
+      lastErrorCode: "vm_cloud_service_unavailable",
+      lastErrorMessage: "exec failed",
+    };
+    const harness = makeHarness({ initialState: previousFailure });
+
+    const first = await harness.run();
+    const second = await harness.run();
+
+    if ("skipped" in first || "skipped" in second) throw new Error("unexpected skip");
+    expect(first.status).toBe("success");
+    expect(second.status).toBe("success");
+    expect(harness.alerts.map((alert) => alert.key)).toEqual(["vm-probe-recovered"]);
+    expect(harness.alerts[0]?.severity).toBe("warning");
+  });
+
+  test("success state write failure suppresses recovery until the state is persisted", async () => {
+    const previousFailure: VmProbePersistedState = {
+      key: "default",
+      lastRunAt: new Date("2026-07-05T10:00:00.000Z"),
+      lastSuccessAt: null,
+      consecutiveFailures: 2,
+      lastErrorCode: "vm_cloud_service_unavailable",
+      lastErrorMessage: "exec failed",
+    };
+    const harness = makeHarness({ initialState: previousFailure, failRecordResult: true });
+
+    const first = await harness.run();
+    const second = await harness.run();
+
+    if ("skipped" in first || "skipped" in second) throw new Error("unexpected skip");
+    expect(first.status).toBe("success");
+    expect(first.stateWriteError?.message).toBe("probe state write failed");
+    expect(second.status).toBe("success");
+    expect(harness.alerts.map((alert) => alert.key)).toEqual(["vm-probe-recovered"]);
+    expect(harness.store.state?.consecutiveFailures).toBe(0);
+  });
+
+  test("unconfigured env skips without workflow calls or alerts", async () => {
+    const harness = makeHarness({ env: {} });
+    const summary = await harness.run();
+
+    expect(summary).toEqual({ skipped: "probe_not_configured" });
+    expect(harness.workflowCalls).toEqual([]);
+    expect(harness.alerts).toEqual([]);
+  });
+
+  test("configuration failure alerts, records failure, and does not throw", async () => {
+    const harness = makeHarness({
+      env: {
+        ...baseEnv,
+        VERCEL_ENV: "production",
+        CMUX_VM_PROBE_IMAGE: "missing-image",
+      },
+    });
+    const summary = await harness.run();
+
+    if ("skipped" in summary) throw new Error("unexpected skip");
+    expect(summary.status).toBe("failure");
+    expect(summary.provider).toBeNull();
+    expect(summary.steps).toEqual([]);
+    expect(harness.workflowCalls).toEqual([]);
+    expect(harness.alerts).toHaveLength(1);
+    expect(harness.alerts[0]).toMatchObject({
+      key: "vm-probe-run-failed",
+      severity: "critical",
+    });
+    expect(harness.alerts[0]?.body).toContain("Phase: config.");
+    expect(harness.store.state?.consecutiveFailures).toBe(1);
+    expect(harness.store.state?.lastErrorCode).toBe("vm_image_config");
+  });
+
+  test("create-disabled configuration skips without alerting or incrementing failures", async () => {
+    const harness = makeHarness({
+      env: {
+        ...baseEnv,
+        CMUX_VM_CREATE_ENABLED: "0",
+      },
+    });
+    const summary = await harness.run();
+
+    expect(summary).toEqual({
+      skipped: "create_disabled",
+      reason: "Cloud VM creation is disabled",
+    });
+    expect(harness.workflowCalls).toEqual([]);
+    expect(harness.alerts).toEqual([]);
+    expect(harness.store.state).toBeNull();
+  });
+
+  test("freshness reports stale versus fresh and leaks no details", async () => {
+    const fresh = await getVmProbeFreshness({
+      now: new Date("2026-07-05T12:30:00.000Z"),
+      env: { CMUX_VM_PROBE_FRESHNESS_STALE_MS: "2700000" },
+      store: {
+        getState: async () => ({
+          key: "default",
+          lastRunAt: new Date("2026-07-05T12:00:00.000Z"),
+          lastSuccessAt: new Date("2026-07-05T12:00:00.000Z"),
+          consecutiveFailures: 7,
+          lastErrorCode: "secret-code",
+          lastErrorMessage: "secret-message",
+        }),
+      },
+    });
+    const stale = await getVmProbeFreshness({
+      now: new Date("2026-07-05T13:00:01.000Z"),
+      env: { CMUX_VM_PROBE_FRESHNESS_STALE_MS: "2700000" },
+      store: {
+        getState: async () => ({
+          key: "default",
+          lastRunAt: new Date("2026-07-05T12:00:00.000Z"),
+          lastSuccessAt: new Date("2026-07-05T12:00:00.000Z"),
+          consecutiveFailures: 7,
+          lastErrorCode: "secret-code",
+          lastErrorMessage: "secret-message",
+        }),
+      },
+    });
+
+    expect(fresh).toEqual({ lastSuccessAt: "2026-07-05T12:00:00.000Z", stale: false });
+    expect(stale).toEqual({ lastSuccessAt: "2026-07-05T12:00:00.000Z", stale: true });
+    expect(Object.keys(fresh).sort()).toEqual(["lastSuccessAt", "stale"]);
+    expect(JSON.stringify(fresh)).not.toContain("secret");
+  });
+});
+
+function makeHarness(overrides: {
+  readonly env?: Record<string, string | undefined>;
+  readonly initialState?: VmProbePersistedState | null;
+  readonly failRecordResult?: boolean;
+  readonly create?: (input: Parameters<typeof runVmProbe>[0] extends never ? never : {
+    readonly provider: ProviderId;
+  }) => Promise<VmEntry>;
+  readonly get?: () => Promise<VmEntry>;
+  readonly exec?: () => Promise<ExecResult>;
+  readonly destroy?: () => Promise<void>;
+} = {}) {
+  const alerts: VmProbeAlertInput[] = [];
+  const destroyed: string[] = [];
+  const workflowCalls: string[] = [];
+  const clock = fakeClock(new Date("2026-07-05T12:00:00.000Z"));
+  const store = fakeStore(overrides.initialState ?? null, overrides.failRecordResult ?? false);
+  const workflows = {
+    create: async (input: { provider: ProviderId }) => {
+      workflowCalls.push("create");
+      return overrides.create
+        ? overrides.create(input)
+        : vmEntry({ providerVmId: "provider-probe-1", provider: input.provider });
+    },
+    get: async () => {
+      workflowCalls.push("get");
+      return overrides.get ? overrides.get() : vmEntry({ providerVmId: "provider-probe-1", status: "running" });
+    },
+    exec: async () => {
+      workflowCalls.push("exec");
+      return overrides.exec ? overrides.exec() : { exitCode: 0, stdout: "cmux-probe-ok\n", stderr: "" };
+    },
+    destroy: async (input: { providerVmId: string }) => {
+      workflowCalls.push("destroy");
+      if (overrides.destroy) return overrides.destroy();
+      destroyed.push(input.providerVmId);
+    },
+  };
+  return {
+    alerts,
+    destroyed,
+    workflowCalls,
+    clock,
+    store,
+    run: () =>
+      runVmProbe({
+        env: overrides.env ?? baseEnv,
+        clock,
+        store,
+        workflows,
+        sendAlert: async (input) => {
+          alerts.push(input);
+          return { sent: true, status: 200 };
+        },
+      }),
+  };
+}
+
+function fakeClock(initial: Date) {
+  let current = initial.getTime();
+  return {
+    now: () => new Date(current),
+    delay: async (ms: number) => {
+      current += ms;
+    },
+    advance: (ms: number) => {
+      current += ms;
+    },
+  };
+}
+
+function fakeStore(initialState: VmProbePersistedState | null, failRecordResult: boolean) {
+  const store = {
+    state: initialState,
+    failRecordResult,
+    getState: async () => store.state,
+    recordResult: async (input: {
+      now: Date;
+      success: boolean;
+      errorCode: string | null;
+      errorMessage: string | null;
+      previousState: VmProbePersistedState | null;
+    }) => {
+      if (store.failRecordResult) {
+        store.failRecordResult = false;
+        throw new Error("probe state write failed");
+      }
+      const previous = input.previousState ?? store.state;
+      const next: VmProbePersistedState = {
+        key: "default",
+        lastRunAt: input.now,
+        lastSuccessAt: input.success ? input.now : previous?.lastSuccessAt ?? null,
+        consecutiveFailures: input.success ? 0 : (previous?.consecutiveFailures ?? 0) + 1,
+        lastErrorCode: input.success ? null : input.errorCode,
+        lastErrorMessage: input.success ? null : input.errorMessage,
+      };
+      store.state = next;
+      return next;
+    },
+    listStaleProbeVms: async () => [],
+  };
+  return store;
+}
+
+function vmEntry(input: {
+  readonly providerVmId: string;
+  readonly provider?: ProviderId;
+  readonly status?: VmEntry["status"];
+}): VmEntry {
+  return {
+    providerVmId: input.providerVmId,
+    provider: input.provider ?? "e2b",
+    image: "cmuxd-ws:tooling-20260509f",
+    imageVersion: "e2b-tooling-20260509f",
+    status: input.status ?? "running",
+    createdAt: Date.parse("2026-07-05T12:00:00.000Z"),
+  };
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/vm-alerts",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron/vm-probe",
+      "schedule": "7,22,37,52 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Active-monitoring half of the Cloud VM observability work, re-ported onto fresh main after https://github.com/manaflow-ai/cmux/pull/7518 (passive alerting) merged. Stacks the synthetic probe on top of that.

`web/services/observability/vmProbe.ts` runs create → status poll → exec → destroy every 15 min (off the :00/:30 marks) through the real user workflows under a dedicated monitor account (`CMUX_VM_PROBE_USER_ID`, inert when unset), with per-step latency budgets, alert classification (outage / credits-exhausted / recovery / leak), guaranteed cleanup + stale-probe reaping, and a secret-free `?mode=freshness` endpoint. `/api/cron/vm-probe` is CRON_SECRET-authed; `.github/workflows/vm-probe-liveness.yml` is the out-of-band GHA watchdog. Adds the `cloud_vm_probe_state` schema table and the Vercel cron entry.

**Draft — one step remaining before merge:** the `cloud_vm_probe_state` drizzle migration must be generated interactively (it needs a TTY, which the agent shell doesn't provide):
```
cd web && bunx drizzle-kit generate --name cloud_vm_probe_state
```
Everything else is verified: `bun test tests/vm-probe.test.ts` 14 pass (injected DB), `bun run typecheck` clean, schema table + cron + watchdog in place.

Deploy after merge: set `CMUX_VM_PROBE_USER_ID`/`CMUX_VM_PROBE_TEAM_ID` (monitor account with Cloud VM credits) + `CRON_SECRET` on Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786046993&installation_id=133855650&pr_number=7531&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7531&signature=8a7df911bce49f04321acdf4f107def66cd0865178e5ef93d03dc381504a479f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an active Cloud VM probe that creates → polls → execs → destroys a VM on a monitor account, with per-step budgets and alerts for outages, credits exhaustion, leaks, and recovery. Includes a `CRON_SECRET`-guarded cron endpoint and a GitHub Actions liveness watchdog with a secret-free freshness check.

- **New Features**
  - Synthetic probe in `web/services/observability/vmProbe.ts` with budgets, guaranteed cleanup, and stale VM reaping.
  - New endpoint `/api/cron/vm-probe` (requires `Authorization: Bearer <CRON_SECRET>`); `?mode=freshness` returns `{ lastSuccessAt, stale }`.
  - Vercel cron set to `7,22,37,52 * * * *`; liveness workflow `.github/workflows/vm-probe-liveness.yml` checks freshness and fails if stale.
  - Persists run state in `cloud_vm_probe_state`; alerts redact secrets; inert unless `CMUX_VM_PROBE_USER_ID` is set.

- **Migration**
  - Generate the migration: `cd web && bunx drizzle-kit generate --name cloud_vm_probe_state`.
  - After deploy, set `CMUX_VM_PROBE_USER_ID`/`CMUX_VM_PROBE_TEAM_ID` (monitor account with Cloud VM credits) and `CRON_SECRET` in Vercel.

<sup>Written for commit 61185be8d6373f0e96e65359d1dba879db53cda2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

