### PR TITLE
Fix first-attempt Dock pane drops

### DIFF
--- a/Sources/AppDelegate+DockSurfaceMove.swift
+++ b/Sources/AppDelegate+DockSurfaceMove.swift
@@ -97,33 +97,10 @@ extension AppDelegate {
         destination: BonsplitController.ExternalTabDropRequest.Destination
     ) -> Bool {
         guard let source = locateContainerSurface(tabId: sourceTabId) else { return false }
-
-        // Reject moving a workspace's LAST main panel into its OWN Dock. It would
-        // empty the workspace's main area, and every alternative is unsafe: closing
-        // the now-empty workspace tears down that same Dock and destroys the just-
-        // moved surface, while seeding a replacement terminal issues a remote
-        // `tmux new-window` for a remote tmux mirror. The surface stays put — move
-        // it after adding another main terminal, or into a different/window Dock.
-        if case .workspace(_, let workspace, _, _) = source,
-           workspace.panels.count == 1,
-           destinationDock.scope == .workspace,
-           destinationDock.workspaceId == workspace.id {
-            return false
-        }
-
-        // Same class of self-destruction for a window Dock: moving the LAST main
-        // panel of a window's ONLY workspace into that same window's Dock would
-        // close the emptied window (`cleanupEmptySourceWorkspaceAfterSurfaceMove`),
-        // and window close tears down its Dock — destroying the just-moved
-        // surface. A window with more workspaces is fine: only the emptied
-        // workspace closes and the Dock lives on.
-        if case .workspace(let sourceWindowId, let workspace, _, let manager) = source,
-           workspace.panels.count == 1,
-           manager.tabs.count == 1,
-           destinationDock.scope == .global,
-           destinationDock.workspaceId == sourceWindowId {
-            return false
-        }
+        let shouldPreserveSourceWorkspace = shouldPreserveSourceWorkspaceAfterDockMove(
+            source,
+            destinationDock: destinationDock
+        )
 
         let target = resolveDockDropDestination(destination)
         guard destinationDock.containsPane(target.pane.id) else { return false }
@@ -169,12 +146,10 @@ extension AppDelegate {
             window: destinationDockWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
         )
 
-        // A move into the source workspace's own Dock that would empty it was
-        // already rejected above, so any now-empty source workspace here moved its
-        // surface into a DIFFERENT container (another workspace's Dock or a window
-        // Dock) and should be cleaned up as usual (the surface survives at the
-        // destination).
-        cleanupEmptyContainerAfterMove(source)
+        cleanupEmptyContainerAfterMove(
+            source,
+            preserveSourceWorkspace: shouldPreserveSourceWorkspace
+        )
         return true
     }
 
@@ -282,6 +257,23 @@ extension AppDelegate {
         }
     }
 
+    private func shouldPreserveSourceWorkspaceAfterDockMove(
+        _ source: ContainerSurfaceLocation,
+        destinationDock: DockSplitStore
+    ) -> Bool {
+        guard case .workspace(let sourceWindowId, let workspace, _, let manager) = source,
+              workspace.panels.count == 1 else {
+            return false
+        }
+
+        switch destinationDock.scope {
+        case .workspace:
+            return destinationDock.workspaceId == workspace.id
+        case .global:
+            return destinationDock.workspaceId == sourceWindowId && manager.tabs.count == 1
+        }
+    }
+
     private func detachSurfaceFromContainer(
         _ source: ContainerSurfaceLocation
     ) -> Workspace.DetachedSurfaceTransfer? {
@@ -312,18 +304,31 @@ extension AppDelegate {
         }
     }
 
-    private func cleanupEmptyContainerAfterMove(_ source: ContainerSurfaceLocation) {
+    private func cleanupEmptyContainerAfterMove(
+        _ source: ContainerSurfaceLocation,
+        preserveSourceWorkspace: Bool = false
+    ) {
         switch source {
         case .workspace(let windowId, let workspace, _, let manager):
-            cleanupEmptySourceWorkspaceAfterSurfaceMove(
-                sourceWorkspace: workspace,
-                sourceManager: manager,
-                sourceWindowId: windowId
-            )
+            if preserveSourceWorkspace {
+                preserveEmptySourceWorkspaceAfterSurfaceMove(sourceWorkspace: workspace)
+            } else {
+                cleanupEmptySourceWorkspaceAfterSurfaceMove(
+                    sourceWorkspace: workspace,
+                    sourceManager: manager,
+                    sourceWindowId: windowId
+                )
+            }
         case .dock:
             // The Dock auto-closes emptied panes (autoCloseEmptyPanes) and keeps
             // an empty root pane, so there is nothing to tear down.
             break
         }
+    }
+
+    private func preserveEmptySourceWorkspaceAfterSurfaceMove(sourceWorkspace: Workspace) {
+        guard sourceWorkspace.panels.isEmpty else { return }
+        _ = sourceWorkspace.createReplacementTerminalPanel()
+        sourceWorkspace.scheduleTerminalGeometryReconcile()
     }
 }

--- a/Sources/AppDelegate+DockSurfaceMove.swift
+++ b/Sources/AppDelegate+DockSurfaceMove.swift
@@ -37,6 +37,13 @@ extension AppDelegate {
         return nil
     }
 
+    /// Whether a live surface can leave its current owner and be driven from
+    /// `destinationDock`.
+    func canMoveSurfaceIntoDock(sourceTabId: UUID, destinationDock _: DockSplitStore) -> Bool {
+        guard let source = locateContainerSurface(tabId: sourceTabId) else { return false }
+        return canMoveSurfaceIntoDock(source)
+    }
+
     /// Whether the right sidebar (Files / Find / Dock) currently owns input
     /// focus in `workspace`'s window. Lets the workspace's imperative terminal
     /// portal active-state reconcile honor the same focus-exclusivity gate the
@@ -97,6 +104,7 @@ extension AppDelegate {
         destination: BonsplitController.ExternalTabDropRequest.Destination
     ) -> Bool {
         guard let source = locateContainerSurface(tabId: sourceTabId) else { return false }
+        guard canMoveSurfaceIntoDock(source) else { return false }
         let shouldPreserveSourceWorkspace = shouldPreserveSourceWorkspaceAfterDockMove(
             source,
             destinationDock: destinationDock
@@ -255,6 +263,17 @@ extension AppDelegate {
         case .split(let pane, let orientation, let insertFirst):
             return (pane, nil, (orientation, insertFirst))
         }
+    }
+
+    private func canMoveSurfaceIntoDock(_ source: ContainerSurfaceLocation) -> Bool {
+        if case .workspace(_, let workspace, _, _) = source,
+           workspace.isRemoteTmuxMirror {
+            // Remote tmux mirror panes are manually driven by the mirror
+            // workspace. Dock has no mirror-owned I/O routing yet, so moving one
+            // would leave the Dock panel detached from its remote owner.
+            return false
+        }
+        return true
     }
 
     private func shouldPreserveSourceWorkspaceAfterDockMove(

--- a/Sources/AppDelegate+DockSurfaceMove.swift
+++ b/Sources/AppDelegate+DockSurfaceMove.swift
@@ -328,6 +328,7 @@ extension AppDelegate {
 
     private func preserveEmptySourceWorkspaceAfterSurfaceMove(sourceWorkspace: Workspace) {
         guard sourceWorkspace.panels.isEmpty else { return }
+        sourceWorkspace.detachRemoteTmuxMirrorKeptOpenLocallyIfNeeded()
         _ = sourceWorkspace.createReplacementTerminalPanel()
         sourceWorkspace.scheduleTerminalGeometryReconcile()
     }

--- a/Sources/BrowserPaneDropTargetView.swift
+++ b/Sources/BrowserPaneDropTargetView.swift
@@ -117,8 +117,8 @@ final class BrowserPaneDropTargetView: NSView {
         // target and call prepare before perform. Mirrors update/perform. (File
         // URLs over page content already returned via the hosted-WebView branch
         // above, so they are not rejected here.)
-        if AppDelegate.shared?.dockForPane(dropContext.paneId) != nil,
-           liveSurfaceTransfer(for: sender) == nil {
+        if let dock = AppDelegate.shared?.dockForPane(dropContext.paneId),
+           liveSurfaceTransfer(for: sender, destinationDock: dock) == nil {
 #if DEBUG
             cmuxDebugLog(
                 "browser.paneDrop.prepare.dock panel=\(dropContext.panelId.uuidString.prefix(5)) " +
@@ -177,7 +177,7 @@ final class BrowserPaneDropTargetView: NSView {
         // (and, for file previews, consumed) through the workspace handlers, which
         // target a pane the workspace does not own.
         if let dock = AppDelegate.shared?.dockForPane(dropContext.paneId) {
-            guard let transfer = liveSurfaceTransfer(for: sender) else {
+            guard let transfer = liveSurfaceTransfer(for: sender, destinationDock: dock) else {
 #if DEBUG
                 cmuxDebugLog(
                     "browser.paneDrop.perform.dock panel=\(dropContext.panelId.uuidString.prefix(5)) " +
@@ -352,7 +352,7 @@ final class BrowserPaneDropTargetView: NSView {
         // and reject anything else (see performDragOperation). A main-area pane
         // (`dockForPane` is nil) falls through to the workspace handling below.
         if let dock = AppDelegate.shared?.dockForPane(dropContext.paneId) {
-            guard let transfer = liveSurfaceTransfer(for: sender) else {
+            guard let transfer = liveSurfaceTransfer(for: sender, destinationDock: dock) else {
                 clearDragState(phase: "\(phase).reject")
                 return []
             }
@@ -431,19 +431,15 @@ final class BrowserPaneDropTargetView: NSView {
         dropContext
     }
 
-    /// The live container tab a drop would move, or nil when the payload is not a
-    /// supported live-surface tab (registry-backed virtual drags such as
-    /// file-preview own no live surface). Shared by prepare/update/perform so the
-    /// Dock accept/reject decision cannot diverge across the three paths: a
-    /// Dock-hosted browser pane lives in a `DockSplitStore`, not the owning
-    /// workspace's Bonsplit tree, so only a live-surface tab can be routed in;
-    /// anything else must be rejected rather than mis-routed (and, for file
-    /// previews, consumed) through the workspace handlers.
-    private func liveSurfaceTransfer(for sender: any NSDraggingInfo) -> BrowserPaneDragTransfer? {
+    /// The live container tab a Dock drop would move. Registry-backed virtual
+    /// drags and owners without Dock transfer routing return nil. Shared by
+    /// prepare/update/perform so unsupported payloads do not fall through to the
+    /// workspace handlers.
+    private func liveSurfaceTransfer(for sender: any NSDraggingInfo, destinationDock: DockSplitStore) -> BrowserPaneDragTransfer? {
         guard let transfer = BrowserPaneDragTransfer.decode(from: sender.draggingPasteboard),
               transfer.isFromCurrentProcess,
               !transfer.isFilePreview,
-              AppDelegate.shared?.locateContainerSurface(tabId: transfer.tabId) != nil else {
+              AppDelegate.shared?.canMoveSurfaceIntoDock(sourceTabId: transfer.tabId, destinationDock: destinationDock) == true else {
             return nil
         }
         return transfer

--- a/Sources/DragOverlayRoutingPolicy.swift
+++ b/Sources/DragOverlayRoutingPolicy.swift
@@ -376,10 +376,18 @@ enum DragOverlayRoutingPolicy {
         pasteboardTypes: [NSPasteboard.PasteboardType]?,
         eventType: NSEvent.EventType?
     ) -> Bool {
-        guard WindowInputRoutingContext.allowsTerminalPortalDragRouting(eventType: eventType) else { return false }
-        return shouldPassThroughPortalHitTesting(
-            pasteboardTypes: pasteboardTypes,
-            eventType: eventType
-        ) || hasFileURL(pasteboardTypes)
+        let routingContext = WindowInputRoutingContext(eventType: eventType)
+        guard routingContext.allowsTerminalPortalDragRouting else { return false }
+        switch routingContext.eventKind {
+        case .pointerDrag:
+            return shouldPassThroughPortalHitTesting(
+                pasteboardTypes: pasteboardTypes,
+                eventType: eventType
+            ) || hasFileURL(pasteboardTypes)
+        case .pointerUp:
+            return hasBonsplitTabTransfer(pasteboardTypes) || hasFileDropPayload(pasteboardTypes)
+        case .noEvent, .keyboard, .pointerDown, .pointerHover, .scroll, .appKitRouting, .other:
+            return false
+        }
     }
 }

--- a/Sources/DragOverlayRoutingPolicy.swift
+++ b/Sources/DragOverlayRoutingPolicy.swift
@@ -372,10 +372,10 @@ enum DragOverlayRoutingPolicy {
         }
     }
 
-    @MainActor
     static func shouldPassThroughTerminalPortalHitTesting(
         pasteboardTypes: [NSPasteboard.PasteboardType]?,
-        eventType: NSEvent.EventType?
+        eventType: NSEvent.EventType?,
+        hasActiveDropDrag: Bool = false
     ) -> Bool {
         let routingContext = WindowInputRoutingContext(eventType: eventType)
         guard routingContext.allowsTerminalPortalDragRouting else { return false }
@@ -386,8 +386,10 @@ enum DragOverlayRoutingPolicy {
                 eventType: eventType
             ) || hasFileURL(pasteboardTypes)
         case .pointerUp:
-            guard PaneDropRoutingSession.hasActiveDropDrag else { return false }
-            return hasBonsplitTabTransfer(pasteboardTypes) || hasFileDropPayload(pasteboardTypes)
+            guard hasActiveDropDrag else { return false }
+            return hasBonsplitTabTransfer(pasteboardTypes)
+                || hasFilePreviewTransfer(pasteboardTypes)
+                || hasSidebarTabReorder(pasteboardTypes)
         case .noEvent, .keyboard, .pointerDown, .pointerHover, .scroll, .appKitRouting, .other:
             return false
         }

--- a/Sources/DragOverlayRoutingPolicy.swift
+++ b/Sources/DragOverlayRoutingPolicy.swift
@@ -372,6 +372,7 @@ enum DragOverlayRoutingPolicy {
         }
     }
 
+    @MainActor
     static func shouldPassThroughTerminalPortalHitTesting(
         pasteboardTypes: [NSPasteboard.PasteboardType]?,
         eventType: NSEvent.EventType?
@@ -385,6 +386,7 @@ enum DragOverlayRoutingPolicy {
                 eventType: eventType
             ) || hasFileURL(pasteboardTypes)
         case .pointerUp:
+            guard PaneDropRoutingSession.hasActiveDropDrag else { return false }
             return hasBonsplitTabTransfer(pasteboardTypes) || hasFileDropPayload(pasteboardTypes)
         case .noEvent, .keyboard, .pointerDown, .pointerHover, .scroll, .appKitRouting, .other:
             return false

--- a/Sources/DragOverlayRoutingPolicy.swift
+++ b/Sources/DragOverlayRoutingPolicy.swift
@@ -365,13 +365,9 @@ enum DragOverlayRoutingPolicy {
             return hasTabTransfer
                 || hasFilePreviewTransfer(pasteboardTypes)
                 || hasSidebarReorder
-        case .pointerUp:
-            return hasTabTransfer
-                || hasFilePreviewTransfer(pasteboardTypes)
-                || hasSidebarReorder
         case .pointerHover:
             return hasTabTransfer || hasSidebarReorder
-        case .noEvent, .keyboard, .pointerDown, .scroll, .appKitRouting, .other:
+        case .noEvent, .keyboard, .pointerDown, .pointerUp, .scroll, .appKitRouting, .other:
             return false
         }
     }

--- a/Sources/DragOverlayRoutingPolicy.swift
+++ b/Sources/DragOverlayRoutingPolicy.swift
@@ -365,9 +365,13 @@ enum DragOverlayRoutingPolicy {
             return hasTabTransfer
                 || hasFilePreviewTransfer(pasteboardTypes)
                 || hasSidebarReorder
+        case .pointerUp:
+            return hasTabTransfer
+                || hasFilePreviewTransfer(pasteboardTypes)
+                || hasSidebarReorder
         case .pointerHover:
             return hasTabTransfer || hasSidebarReorder
-        case .noEvent, .keyboard, .pointerDown, .pointerUp, .scroll, .appKitRouting, .other:
+        case .noEvent, .keyboard, .pointerDown, .scroll, .appKitRouting, .other:
             return false
         }
     }

--- a/Sources/PaneDropRoutingRegistration.swift
+++ b/Sources/PaneDropRoutingRegistration.swift
@@ -1,0 +1,50 @@
+import AppKit
+
+@MainActor
+final class PaneDropRoutingRegistration {
+    private weak var owner: WindowTerminalHostView?
+    private var sequenceNumber: Int?
+
+    func update(_ sender: any NSDraggingInfo, operation: NSDragOperation, targetView: NSView) {
+        guard let host = targetView.enclosingWindowTerminalHostView else {
+            clear(sender)
+            return
+        }
+
+        if host.updateActivePaneDropRoutingSession(sender, operation: operation) {
+            owner = host
+            sequenceNumber = sender.draggingSequenceNumber
+        } else if sequenceNumber == sender.draggingSequenceNumber {
+            clear(sender)
+        }
+    }
+
+    func clear(_ sender: (any NSDraggingInfo)? = nil) {
+        if let sender {
+            owner?.clearActivePaneDropRoutingSession(sender)
+            if sequenceNumber == sender.draggingSequenceNumber {
+                sequenceNumber = nil
+                owner = nil
+            }
+            return
+        }
+
+        guard let sequenceNumber else { return }
+        owner?.clearActivePaneDropRoutingSession(sequenceNumber: sequenceNumber)
+        self.sequenceNumber = nil
+        owner = nil
+    }
+}
+
+private extension NSView {
+    var enclosingWindowTerminalHostView: WindowTerminalHostView? {
+        var candidate = superview
+        while let view = candidate {
+            if let host = view as? WindowTerminalHostView {
+                return host
+            }
+            candidate = view.superview
+        }
+        return nil
+    }
+}

--- a/Sources/PaneDropRoutingSession.swift
+++ b/Sources/PaneDropRoutingSession.swift
@@ -1,0 +1,31 @@
+import AppKit
+
+@MainActor
+final class PaneDropRoutingSession {
+    private var activeSequenceNumbers: Set<Int> = []
+
+    var hasActiveDropDrag: Bool {
+        !activeSequenceNumbers.isEmpty
+    }
+
+    func updateActiveDropDrag(_ sender: any NSDraggingInfo, operation: NSDragOperation) -> Bool {
+        guard !operation.isEmpty else {
+            clearActiveDropDrag(sender)
+            return false
+        }
+
+        let types = sender.draggingPasteboard.types
+        guard DragOverlayRoutingPolicy.hasBonsplitTabTransfer(types)
+            || DragOverlayRoutingPolicy.hasFileDropPayload(types) else { return false }
+        activeSequenceNumbers.insert(sender.draggingSequenceNumber)
+        return true
+    }
+
+    func clearActiveDropDrag(_ sender: any NSDraggingInfo) {
+        activeSequenceNumbers.remove(sender.draggingSequenceNumber)
+    }
+
+    func clearActiveDropDrag(sequenceNumber: Int) {
+        activeSequenceNumbers.remove(sequenceNumber)
+    }
+}

--- a/Sources/PaneDropRoutingSupport.swift
+++ b/Sources/PaneDropRoutingSupport.swift
@@ -58,7 +58,12 @@ enum PaneDropRoutingSession {
         !activeSequenceNumbers.isEmpty
     }
 
-    static func noteActiveDropDrag(_ sender: any NSDraggingInfo) {
+    static func updateActiveDropDrag(_ sender: any NSDraggingInfo, operation: NSDragOperation) {
+        guard !operation.isEmpty else {
+            clearActiveDropDrag(sender)
+            return
+        }
+
         let types = sender.draggingPasteboard.types
         guard DragOverlayRoutingPolicy.hasBonsplitTabTransfer(types)
             || DragOverlayRoutingPolicy.hasFileDropPayload(types) else { return }

--- a/Sources/PaneDropRoutingSupport.swift
+++ b/Sources/PaneDropRoutingSupport.swift
@@ -50,6 +50,30 @@ struct PaneDragTransfer: Equatable {
 
 typealias TerminalPaneDragTransfer = PaneDragTransfer
 
+@MainActor
+enum PaneDropRoutingSession {
+    private static var activeSequenceNumbers: Set<Int> = []
+
+    static var hasActiveDropDrag: Bool {
+        !activeSequenceNumbers.isEmpty
+    }
+
+    static func noteActiveDropDrag(_ sender: any NSDraggingInfo) {
+        let types = sender.draggingPasteboard.types
+        guard DragOverlayRoutingPolicy.hasBonsplitTabTransfer(types)
+            || DragOverlayRoutingPolicy.hasFileDropPayload(types) else { return }
+        activeSequenceNumbers.insert(sender.draggingSequenceNumber)
+    }
+
+    static func clearActiveDropDrag(_ sender: (any NSDraggingInfo)?) {
+        guard let sender else {
+            activeSequenceNumbers.removeAll()
+            return
+        }
+        activeSequenceNumbers.remove(sender.draggingSequenceNumber)
+    }
+}
+
 enum PaneDropRouting {
     private static func fullPaneSize(for size: CGSize, topChromeHeight: CGFloat) -> CGSize {
         CGSize(width: size.width, height: size.height + max(0, topChromeHeight))

--- a/Sources/PaneDropRoutingSupport.swift
+++ b/Sources/PaneDropRoutingSupport.swift
@@ -51,72 +51,6 @@ struct PaneDragTransfer: Equatable {
 typealias TerminalPaneDragTransfer = PaneDragTransfer
 
 @MainActor
-final class PaneDropRoutingSession {
-    private var activeSequenceNumbers: Set<Int> = []
-
-    var hasActiveDropDrag: Bool {
-        !activeSequenceNumbers.isEmpty
-    }
-
-    func updateActiveDropDrag(_ sender: any NSDraggingInfo, operation: NSDragOperation) -> Bool {
-        guard !operation.isEmpty else {
-            clearActiveDropDrag(sender)
-            return false
-        }
-
-        let types = sender.draggingPasteboard.types
-        guard DragOverlayRoutingPolicy.hasBonsplitTabTransfer(types)
-            || DragOverlayRoutingPolicy.hasFileDropPayload(types) else { return false }
-        activeSequenceNumbers.insert(sender.draggingSequenceNumber)
-        return true
-    }
-
-    func clearActiveDropDrag(_ sender: any NSDraggingInfo) {
-        activeSequenceNumbers.remove(sender.draggingSequenceNumber)
-    }
-
-    func clearActiveDropDrag(sequenceNumber: Int) {
-        activeSequenceNumbers.remove(sequenceNumber)
-    }
-}
-
-@MainActor
-final class PaneDropRoutingRegistration {
-    private weak var owner: WindowTerminalHostView?
-    private var sequenceNumber: Int?
-
-    func update(_ sender: any NSDraggingInfo, operation: NSDragOperation, targetView: NSView) {
-        guard let host = targetView.enclosingWindowTerminalHostView else {
-            clear(sender)
-            return
-        }
-
-        if host.updateActivePaneDropRoutingSession(sender, operation: operation) {
-            owner = host
-            sequenceNumber = sender.draggingSequenceNumber
-        } else if sequenceNumber == sender.draggingSequenceNumber {
-            clear(sender)
-        }
-    }
-
-    func clear(_ sender: (any NSDraggingInfo)? = nil) {
-        if let sender {
-            owner?.clearActivePaneDropRoutingSession(sender)
-            if sequenceNumber == sender.draggingSequenceNumber {
-                sequenceNumber = nil
-                owner = nil
-            }
-            return
-        }
-
-        guard let sequenceNumber else { return }
-        owner?.clearActivePaneDropRoutingSession(sequenceNumber: sequenceNumber)
-        self.sequenceNumber = nil
-        owner = nil
-    }
-}
-
-@MainActor
 extension WindowTerminalHostView {
     var hasActivePaneDropDrag: Bool {
         paneDropRoutingSession.hasActiveDropDrag
@@ -132,19 +66,6 @@ extension WindowTerminalHostView {
 
     func clearActivePaneDropRoutingSession(sequenceNumber: Int) {
         paneDropRoutingSession.clearActiveDropDrag(sequenceNumber: sequenceNumber)
-    }
-}
-
-private extension NSView {
-    var enclosingWindowTerminalHostView: WindowTerminalHostView? {
-        var candidate = superview
-        while let view = candidate {
-            if let host = view as? WindowTerminalHostView {
-                return host
-            }
-            candidate = view.superview
-        }
-        return nil
     }
 }
 

--- a/Sources/PaneDropRoutingSupport.swift
+++ b/Sources/PaneDropRoutingSupport.swift
@@ -51,31 +51,100 @@ struct PaneDragTransfer: Equatable {
 typealias TerminalPaneDragTransfer = PaneDragTransfer
 
 @MainActor
-enum PaneDropRoutingSession {
-    private static var activeSequenceNumbers: Set<Int> = []
+final class PaneDropRoutingSession {
+    private var activeSequenceNumbers: Set<Int> = []
 
-    static var hasActiveDropDrag: Bool {
+    var hasActiveDropDrag: Bool {
         !activeSequenceNumbers.isEmpty
     }
 
-    static func updateActiveDropDrag(_ sender: any NSDraggingInfo, operation: NSDragOperation) {
+    func updateActiveDropDrag(_ sender: any NSDraggingInfo, operation: NSDragOperation) -> Bool {
         guard !operation.isEmpty else {
             clearActiveDropDrag(sender)
-            return
+            return false
         }
 
         let types = sender.draggingPasteboard.types
         guard DragOverlayRoutingPolicy.hasBonsplitTabTransfer(types)
-            || DragOverlayRoutingPolicy.hasFileDropPayload(types) else { return }
+            || DragOverlayRoutingPolicy.hasFileDropPayload(types) else { return false }
         activeSequenceNumbers.insert(sender.draggingSequenceNumber)
+        return true
     }
 
-    static func clearActiveDropDrag(_ sender: (any NSDraggingInfo)?) {
-        guard let sender else {
-            activeSequenceNumbers.removeAll()
+    func clearActiveDropDrag(_ sender: any NSDraggingInfo) {
+        activeSequenceNumbers.remove(sender.draggingSequenceNumber)
+    }
+
+    func clearActiveDropDrag(sequenceNumber: Int) {
+        activeSequenceNumbers.remove(sequenceNumber)
+    }
+}
+
+@MainActor
+final class PaneDropRoutingRegistration {
+    private weak var owner: WindowTerminalHostView?
+    private var sequenceNumber: Int?
+
+    func update(_ sender: any NSDraggingInfo, operation: NSDragOperation, targetView: NSView) {
+        guard let host = targetView.enclosingWindowTerminalHostView else {
+            clear(sender)
             return
         }
-        activeSequenceNumbers.remove(sender.draggingSequenceNumber)
+
+        if host.updateActivePaneDropRoutingSession(sender, operation: operation) {
+            owner = host
+            sequenceNumber = sender.draggingSequenceNumber
+        } else if sequenceNumber == sender.draggingSequenceNumber {
+            clear(sender)
+        }
+    }
+
+    func clear(_ sender: (any NSDraggingInfo)? = nil) {
+        if let sender {
+            owner?.clearActivePaneDropRoutingSession(sender)
+            if sequenceNumber == sender.draggingSequenceNumber {
+                sequenceNumber = nil
+                owner = nil
+            }
+            return
+        }
+
+        guard let sequenceNumber else { return }
+        owner?.clearActivePaneDropRoutingSession(sequenceNumber: sequenceNumber)
+        self.sequenceNumber = nil
+        owner = nil
+    }
+}
+
+@MainActor
+extension WindowTerminalHostView {
+    var hasActivePaneDropDrag: Bool {
+        paneDropRoutingSession.hasActiveDropDrag
+    }
+
+    func updateActivePaneDropRoutingSession(_ sender: any NSDraggingInfo, operation: NSDragOperation) -> Bool {
+        paneDropRoutingSession.updateActiveDropDrag(sender, operation: operation)
+    }
+
+    func clearActivePaneDropRoutingSession(_ sender: any NSDraggingInfo) {
+        paneDropRoutingSession.clearActiveDropDrag(sender)
+    }
+
+    func clearActivePaneDropRoutingSession(sequenceNumber: Int) {
+        paneDropRoutingSession.clearActiveDropDrag(sequenceNumber: sequenceNumber)
+    }
+}
+
+private extension NSView {
+    var enclosingWindowTerminalHostView: WindowTerminalHostView? {
+        var candidate = superview
+        while let view = candidate {
+            if let host = view as? WindowTerminalHostView {
+                return host
+            }
+            candidate = view.superview
+        }
+        return nil
     }
 }
 

--- a/Sources/TerminalPaneDropTargetView.swift
+++ b/Sources/TerminalPaneDropTargetView.swift
@@ -77,13 +77,15 @@ final class PaneDropTargetView: NSView {
     }
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        PaneDropRoutingSession.noteActiveDropDrag(sender)
-        return updateDragState(sender, phase: "entered")
+        let operation = updateDragState(sender, phase: "entered")
+        PaneDropRoutingSession.updateActiveDropDrag(sender, operation: operation)
+        return operation
     }
 
     override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        PaneDropRoutingSession.noteActiveDropDrag(sender)
-        return updateDragState(sender, phase: "updated")
+        let operation = updateDragState(sender, phase: "updated")
+        PaneDropRoutingSession.updateActiveDropDrag(sender, operation: operation)
+        return operation
     }
 
     override func draggingExited(_ sender: (any NSDraggingInfo)?) {
@@ -109,7 +111,7 @@ final class PaneDropTargetView: NSView {
         if let transfer = PaneDragTransfer.decode(from: sender.draggingPasteboard),
            transfer.isFromCurrentProcess,
            let dock = AppDelegate.shared?.dockForPane(dropContext.paneId),
-            // Registry-backed virtual drags reuse this payload without owning a live surface.
+           // Registry-backed virtual drags reuse this payload without owning a live surface.
            AppDelegate.shared?.locateContainerSurface(tabId: transfer.tabId) != nil,
            !DragOverlayRoutingPolicy.shouldRouteFileDropToTextDestination(
                pasteboardTypes: sender.draggingPasteboard.types,

--- a/Sources/TerminalPaneDropTargetView.swift
+++ b/Sources/TerminalPaneDropTargetView.swift
@@ -30,13 +30,11 @@ final class PaneDropTargetView: NSView {
         nil
     }
 
-    deinit { dropRoutingRegistration.clear() }
-
-    override func willMove(toSuperview newSuperview: NSView?) {
+    override func viewWillMove(toSuperview newSuperview: NSView?) {
         if newSuperview == nil {
             dropRoutingRegistration.clear()
         }
-        super.willMove(toSuperview: newSuperview)
+        super.viewWillMove(toSuperview: newSuperview)
     }
 
     override func layout() {

--- a/Sources/TerminalPaneDropTargetView.swift
+++ b/Sources/TerminalPaneDropTargetView.swift
@@ -117,8 +117,7 @@ final class PaneDropTargetView: NSView {
         if let transfer = PaneDragTransfer.decode(from: sender.draggingPasteboard),
            transfer.isFromCurrentProcess,
            let dock = AppDelegate.shared?.dockForPane(dropContext.paneId),
-           // Registry-backed virtual drags reuse this payload without owning a live surface.
-           AppDelegate.shared?.locateContainerSurface(tabId: transfer.tabId) != nil,
+           AppDelegate.shared?.canMoveSurfaceIntoDock(sourceTabId: transfer.tabId, destinationDock: dock) == true,
            !DragOverlayRoutingPolicy.shouldRouteFileDropToTextDestination(
                pasteboardTypes: sender.draggingPasteboard.types,
                modifierFlags: DragOverlayRoutingPolicy.currentModifierFlags,
@@ -236,8 +235,7 @@ final class PaneDropTargetView: NSView {
         if let transfer = PaneDragTransfer.decode(from: sender.draggingPasteboard),
            transfer.isFromCurrentProcess,
            let dock = AppDelegate.shared?.dockForPane(dropContext.paneId),
-           // Registry-backed virtual drags reuse this payload without owning a live surface.
-           AppDelegate.shared?.locateContainerSurface(tabId: transfer.tabId) != nil,
+           AppDelegate.shared?.canMoveSurfaceIntoDock(sourceTabId: transfer.tabId, destinationDock: dock) == true,
            !DragOverlayRoutingPolicy.shouldRouteFileDropToTextDestination(
                pasteboardTypes: sender.draggingPasteboard.types,
                modifierFlags: DragOverlayRoutingPolicy.currentModifierFlags,

--- a/Sources/TerminalPaneDropTargetView.swift
+++ b/Sources/TerminalPaneDropTargetView.swift
@@ -8,6 +8,7 @@ final class PaneDropTargetView: NSView {
     weak var hostedView: GhosttySurfaceScrollView?
     var dropContext: PaneDropContext?
     private var activeZone: DropZone?
+    private let dropRoutingRegistration = PaneDropRoutingRegistration()
     private let dropZoneOverlayView = NSView(frame: .zero)
     private lazy var dropZoneOverlayAnimator = PaneDropZoneOverlayAnimator(overlayView: dropZoneOverlayView)
 #if DEBUG
@@ -29,7 +30,14 @@ final class PaneDropTargetView: NSView {
         nil
     }
 
-    deinit {}
+    deinit { dropRoutingRegistration.clear() }
+
+    override func willMove(toSuperview newSuperview: NSView?) {
+        if newSuperview == nil {
+            dropRoutingRegistration.clear()
+        }
+        super.willMove(toSuperview: newSuperview)
+    }
 
     override func layout() {
         super.layout()
@@ -78,24 +86,24 @@ final class PaneDropTargetView: NSView {
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
         let operation = updateDragState(sender, phase: "entered")
-        PaneDropRoutingSession.updateActiveDropDrag(sender, operation: operation)
+        dropRoutingRegistration.update(sender, operation: operation, targetView: self)
         return operation
     }
 
     override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
         let operation = updateDragState(sender, phase: "updated")
-        PaneDropRoutingSession.updateActiveDropDrag(sender, operation: operation)
+        dropRoutingRegistration.update(sender, operation: operation, targetView: self)
         return operation
     }
 
     override func draggingExited(_ sender: (any NSDraggingInfo)?) {
-        PaneDropRoutingSession.clearActiveDropDrag(sender)
+        dropRoutingRegistration.clear(sender)
         clearDragState(phase: "exited")
     }
 
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
         defer {
-            PaneDropRoutingSession.clearActiveDropDrag(sender)
+            dropRoutingRegistration.clear(sender)
             clearDragState(phase: "perform.clear")
         }
 

--- a/Sources/TerminalPaneDropTargetView.swift
+++ b/Sources/TerminalPaneDropTargetView.swift
@@ -77,19 +77,23 @@ final class PaneDropTargetView: NSView {
     }
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        updateDragState(sender, phase: "entered")
+        PaneDropRoutingSession.noteActiveDropDrag(sender)
+        return updateDragState(sender, phase: "entered")
     }
 
     override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        updateDragState(sender, phase: "updated")
+        PaneDropRoutingSession.noteActiveDropDrag(sender)
+        return updateDragState(sender, phase: "updated")
     }
 
     override func draggingExited(_ sender: (any NSDraggingInfo)?) {
+        PaneDropRoutingSession.clearActiveDropDrag(sender)
         clearDragState(phase: "exited")
     }
 
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
         defer {
+            PaneDropRoutingSession.clearActiveDropDrag(sender)
             clearDragState(phase: "perform.clear")
         }
 
@@ -100,20 +104,12 @@ final class PaneDropTargetView: NSView {
             return false
         }
 
-        // A Bonsplit tab dropped on a Dock pane routes to the Dock's own
-        // controller (move/split inside the Dock, or transfer in from elsewhere)
-        // rather than the owning workspace — otherwise a Dock drag-to-split would
-        // land in the main split area. Skip this when the drop should insert the
-        // dragged item's path as text (e.g. a file-preview drag carries both a
-        // Bonsplit tab-transfer payload AND a file URL): those fall through to the
-        // file-drop-as-text path below, matching the workspace ordering.
+        // Dock panes route real live-surface tab drops to the Dock controller,
+        // unless the same payload should insert its file path as terminal text.
         if let transfer = PaneDragTransfer.decode(from: sender.draggingPasteboard),
            transfer.isFromCurrentProcess,
            let dock = AppDelegate.shared?.dockForPane(dropContext.paneId),
-           // Only divert REAL live container tabs to the Dock. Registry-backed
-           // virtual drags (session-index, file-preview) reuse the same
-           // tab-transfer payload but own no live surface, so let them fall
-           // through to the workspace handlers that consume those registries.
+            // Registry-backed virtual drags reuse this payload without owning a live surface.
            AppDelegate.shared?.locateContainerSurface(tabId: transfer.tabId) != nil,
            !DragOverlayRoutingPolicy.shouldRouteFileDropToTextDestination(
                pasteboardTypes: sender.draggingPasteboard.types,
@@ -228,17 +224,11 @@ final class PaneDropTargetView: NSView {
             return []
         }
 
-        // Dock pane target: show the Dock's own drop zone and accept the move so
-        // the drop routes to the Dock (see performDragOperation). Skipped for
-        // file-drop-as-text drags (e.g. file-preview), which fall through to the
-        // text-drop handling below.
+        // Dock pane target: preview the Dock route unless this is file-drop-as-text.
         if let transfer = PaneDragTransfer.decode(from: sender.draggingPasteboard),
            transfer.isFromCurrentProcess,
            let dock = AppDelegate.shared?.dockForPane(dropContext.paneId),
-           // Only divert REAL live container tabs to the Dock. Registry-backed
-           // virtual drags (session-index, file-preview) reuse the same
-           // tab-transfer payload but own no live surface, so let them fall
-           // through to the workspace handlers that consume those registries.
+           // Registry-backed virtual drags reuse this payload without owning a live surface.
            AppDelegate.shared?.locateContainerSurface(tabId: transfer.tabId) != nil,
            !DragOverlayRoutingPolicy.shouldRouteFileDropToTextDestination(
                pasteboardTypes: sender.draggingPasteboard.types,

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -172,12 +172,12 @@ final class WindowTerminalHostView: NSView {
             }
 
             clearActiveDividerCursor(restoreArrow: true)
-
-            if routingContext.allowsTerminalPortalDragRouting {
+            if routingContext.allowsTerminalPortalDragRouting,
+               routingContext.eventKind != .pointerUp || PaneDropRoutingSession.hasActiveDropDrag {
                 let dragPasteboardTypes = NSPasteboard(name: .drag).types
                 let shouldPassThrough = DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
                     pasteboardTypes: dragPasteboardTypes,
-                    eventType: eventType
+                    eventType: eventType, hasActiveDropDrag: PaneDropRoutingSession.hasActiveDropDrag
                 )
                 if shouldPassThrough {
                     let hitView = super.hitTest(point)

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -11,7 +11,6 @@ private var cmuxWindowTerminalPortalCloseObserverKey: UInt8 = 0
 
 final class WindowTerminalHostView: NSView {
     private typealias DividerRegion = PortalSplitDividerRegion
-
     private enum DividerCursorKind: Equatable {
         case vertical
         case horizontal
@@ -35,6 +34,7 @@ final class WindowTerminalHostView: NSView {
     private var splitDividerResizeObserver: NSObjectProtocol?
     private var trackingArea: NSTrackingArea?
     private var activeDividerCursorKind: DividerCursorKind?
+    let paneDropRoutingSession = PaneDropRoutingSession()
 #if DEBUG
     private var lastDragRouteSignature: String?
 #endif
@@ -173,11 +173,11 @@ final class WindowTerminalHostView: NSView {
 
             clearActiveDividerCursor(restoreArrow: true)
             if routingContext.allowsTerminalPortalDragRouting,
-               routingContext.eventKind != .pointerUp || PaneDropRoutingSession.hasActiveDropDrag {
+               routingContext.eventKind != .pointerUp || hasActivePaneDropDrag {
                 let dragPasteboardTypes = NSPasteboard(name: .drag).types
                 let shouldPassThrough = DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
                     pasteboardTypes: dragPasteboardTypes,
-                    eventType: eventType, hasActiveDropDrag: PaneDropRoutingSession.hasActiveDropDrag
+                    eventType: eventType, hasActiveDropDrag: hasActivePaneDropDrag
                 )
                 if shouldPassThrough {
                     let hitView = super.hitTest(point)

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -173,11 +173,11 @@ final class WindowTerminalHostView: NSView {
 
             clearActiveDividerCursor(restoreArrow: true)
             if routingContext.allowsTerminalPortalDragRouting,
-               routingContext.eventKind != .pointerUp || hasActivePaneDropDrag {
+               routingContext.eventKind != .pointerUp || hasActivePaneDropDrag || AppDelegate.shared?.sidebarWorkspaceDragRegistry.currentWorkspaceId != nil {
                 let dragPasteboardTypes = NSPasteboard(name: .drag).types
                 let shouldPassThrough = DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
                     pasteboardTypes: dragPasteboardTypes,
-                    eventType: eventType, hasActiveDropDrag: hasActivePaneDropDrag
+                    eventType: eventType, hasActiveDropDrag: hasActivePaneDropDrag || AppDelegate.shared?.sidebarWorkspaceDragRegistry.currentWorkspaceId != nil
                 )
                 if shouldPassThrough {
                     let hitView = super.hitTest(point)

--- a/Sources/WindowInputRoutingContext.swift
+++ b/Sources/WindowInputRoutingContext.swift
@@ -92,9 +92,9 @@ struct WindowInputRoutingContext: Equatable {
 
     var allowsBrowserPortalDragRouting: Bool {
         switch eventKind {
-        case .pointerDrag, .pointerUp, .pointerHover:
+        case .pointerDrag, .pointerHover:
             return true
-        case .noEvent, .keyboard, .pointerDown, .scroll, .appKitRouting, .other:
+        case .noEvent, .keyboard, .pointerDown, .pointerUp, .scroll, .appKitRouting, .other:
             return false
         }
     }

--- a/Sources/WindowInputRoutingContext.swift
+++ b/Sources/WindowInputRoutingContext.swift
@@ -100,7 +100,7 @@ struct WindowInputRoutingContext: Equatable {
     }
 
     var allowsTerminalPortalDragRouting: Bool {
-        eventKind == .pointerDrag
+        eventKind == .pointerDrag || eventKind == .pointerUp
     }
 
     static func allowsTabBarPassThroughHitTesting(eventType: NSEvent.EventType?) -> Bool {

--- a/Sources/WindowInputRoutingContext.swift
+++ b/Sources/WindowInputRoutingContext.swift
@@ -92,9 +92,9 @@ struct WindowInputRoutingContext: Equatable {
 
     var allowsBrowserPortalDragRouting: Bool {
         switch eventKind {
-        case .pointerDrag, .pointerHover:
+        case .pointerDrag, .pointerUp, .pointerHover:
             return true
-        case .noEvent, .keyboard, .pointerDown, .pointerUp, .scroll, .appKitRouting, .other:
+        case .noEvent, .keyboard, .pointerDown, .scroll, .appKitRouting, .other:
             return false
         }
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3465,14 +3465,18 @@ final class Workspace: Identifiable, ObservableObject {
 
     func handleRemoteTmuxSessionEndedKeepingWorkspaceOpenIfNeeded() -> Bool {
         guard remoteTmuxKeepWorkspaceOpenAfterSessionEnd else { return false }
-        remoteTmuxKeepWorkspaceOpenAfterSessionEnd = false; isRemoteTmuxMirror = false
         let panelIds = remoteTmuxKeepWorkspaceOpenTabIds.compactMap { panelIdFromSurfaceId($0) }
-        remoteTmuxKeepWorkspaceOpenTabIds.removeAll(); remoteTmuxWindowMirrors.removeAll()
+        remoteTmuxKeepWorkspaceOpenTabIds.removeAll(); detachRemoteTmuxMirrorKeptOpenLocallyIfNeeded()
         for panelId in panelIds { _ = closePanel(panelId, force: true) }
         if panels.isEmpty { _ = createReplacementTerminalPanel() }
         return true
     }
-
+    @discardableResult func detachRemoteTmuxMirrorKeptOpenLocallyIfNeeded() -> Bool {
+        guard isRemoteTmuxMirror else { return false }
+        pendingRemoteDisconnectReplacement = nil; remoteTmuxKeepWorkspaceOpenAfterSessionEnd = false; isRemoteTmuxMirror = false; remoteTmuxWindowMirrors.removeAll()
+        AppDelegate.shared?.remoteTmuxController.detachMirrorWorkspaceKeptOpenLocally(workspaceId: id)
+        return true
+    }
     private func clearRemoteTmuxWorkspaceCloseIntent(tabId: TabID) {
         remoteTmuxWorkspaceCloseButtonByTabId.removeValue(forKey: tabId); remoteTmuxKeepWorkspaceOpenTabIds.remove(tabId)
         if remoteTmuxKeepWorkspaceOpenTabIds.isEmpty { remoteTmuxKeepWorkspaceOpenAfterSessionEnd = false }
@@ -12537,18 +12541,14 @@ extension Workspace: BonsplitDelegate {
             }
 
             if remoteTmuxWorkspaceCloseButton != nil {
-                pendingRemoteDisconnectReplacement = nil; remoteTmuxKeepWorkspaceOpenAfterSessionEnd = false; isRemoteTmuxMirror = false
-                remoteTmuxWindowMirrors.removeAll()
-                AppDelegate.shared?.remoteTmuxController.detachMirrorWorkspaceKeptOpenLocally(workspaceId: id)
+                detachRemoteTmuxMirrorKeptOpenLocallyIfNeeded()
                 let manager = owningTabManager ?? AppDelegate.shared?.tabManagerFor(tabId: id) ?? AppDelegate.shared?.tabManager
                 if let manager, manager.tabs.count > 1 { manager.closeWorkspace(self, recordHistory: false); scheduleTerminalGeometryReconcile(); return }
                 if let manager, let appDelegate = AppDelegate.shared, appDelegate.mainWindowContexts.count > 1,
                    let windowId = appDelegate.windowId(for: manager) { appDelegate.discardMainWindowWithoutClosedHistory(windowId: windowId); scheduleTerminalGeometryReconcile(); return }
             }
             if remoteTmuxKeepWorkspaceOpen {
-                pendingRemoteDisconnectReplacement = nil; remoteTmuxKeepWorkspaceOpenAfterSessionEnd = false; isRemoteTmuxMirror = false
-                remoteTmuxWindowMirrors.removeAll()
-                AppDelegate.shared?.remoteTmuxController.detachMirrorWorkspaceKeptOpenLocally(workspaceId: id)
+                detachRemoteTmuxMirrorKeptOpenLocallyIfNeeded()
             }
 
             #if DEBUG

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -827,6 +827,8 @@
 		ODBG00010000000000000001 /* OpenDiffViewerAgentBaselineLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = ODBG00010000000000000002 /* OpenDiffViewerAgentBaselineLookup.swift */; };
 		ODBG00020000000000000001 /* OpenDiffViewerAgentContextRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ODBG00020000000000000002 /* OpenDiffViewerAgentContextRequest.swift */; };
 		E3B7A4000000000000000021 /* PaneChromeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B7A4000000000000000022 /* PaneChromeSettings.swift */; };
+		D0B752900000000000000002 /* PaneDropRoutingRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B752900000000000000001 /* PaneDropRoutingRegistration.swift */; };
+		D0B752900000000000000004 /* PaneDropRoutingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B752900000000000000003 /* PaneDropRoutingSession.swift */; };
 		D0B1001CA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */; };
 		A5001400 /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001410 /* Panel.swift */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
@@ -2265,6 +2267,8 @@
 		ODBG00010000000000000002 /* OpenDiffViewerAgentBaselineLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenDiffViewerAgentBaselineLookup.swift; sourceTree = "<group>"; };
 		ODBG00020000000000000002 /* OpenDiffViewerAgentContextRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenDiffViewerAgentContextRequest.swift; sourceTree = "<group>"; };
 		E3B7A4000000000000000022 /* PaneChromeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneChromeSettings.swift; sourceTree = "<group>"; };
+		D0B752900000000000000001 /* PaneDropRoutingRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingRegistration.swift; sourceTree = "<group>"; };
+		D0B752900000000000000003 /* PaneDropRoutingSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingSession.swift; sourceTree = "<group>"; };
 		D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingSupport.swift; sourceTree = "<group>"; };
 		A5001410 /* Panel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/Panel.swift; sourceTree = "<group>"; };
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
@@ -3445,6 +3449,8 @@
 				EC010D02 /* GhosttyApp+TerminalCustomUpload.swift */,
 				EC010E02 /* GhosttyNSView+TerminalCustomUpload.swift */,
 				D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */,
+				D0B752900000000000000001 /* PaneDropRoutingRegistration.swift */,
+				D0B752900000000000000003 /* PaneDropRoutingSession.swift */,
 				D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */,
 				A5001531 /* TerminalWindowPortal.swift */,
 				D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */,
@@ -5288,6 +5294,8 @@
 				ODBG00010000000000000001 /* OpenDiffViewerAgentBaselineLookup.swift in Sources */,
 				ODBG00020000000000000001 /* OpenDiffViewerAgentContextRequest.swift in Sources */,
 				E3B7A4000000000000000021 /* PaneChromeSettings.swift in Sources */,
+				D0B752900000000000000002 /* PaneDropRoutingRegistration.swift in Sources */,
+				D0B752900000000000000004 /* PaneDropRoutingSession.swift in Sources */,
 				D0B1001CA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift in Sources */,
 				A5001400 /* Panel.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -535,6 +535,7 @@
 		DCDC1000000000000000B009 /* DockControlDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B00A /* DockControlDefinition.swift */; };
 		DCDC0000000000000000B001 /* DockControlDefinitionDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC0000000000000000B002 /* DockControlDefinitionDecodingTests.swift */; };
 		D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */; };
+		D7529001A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */; };
 		D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */; };
 		DCDC1000000000000000B00B /* DockRemoteBrowserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */; };
 		DCDC1000000000000000C020 /* DockScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000C021 /* DockScope.swift */; };
@@ -1976,6 +1977,7 @@
 		DCDC1000000000000000B00A /* DockControlDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockControlDefinition.swift; sourceTree = "<group>"; };
 		DCDC0000000000000000B002 /* DockControlDefinitionDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockControlDefinitionDecodingTests.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockEmptyView.swift; sourceTree = "<group>"; };
+		D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPaneDropUnfocusedRoutingTests.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPanelView.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockRemoteBrowserSettings.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000C021 /* DockScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockScope.swift; sourceTree = "<group>"; };
@@ -4081,6 +4083,7 @@
 				D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */,
 				C58410010000000000000002 /* RenderableSystemSymbolTests.swift */,
 				DCDC0000000000000000B002 /* DockControlDefinitionDecodingTests.swift */,
+				D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */,
 				D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */,
 				D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */,
 				D6212D0C00000000000000D2 /* WindowDockLifecycleTests.swift */,
@@ -5956,6 +5959,7 @@
 				DE71CE000000000000000002 /* DeviceRegistryClientTests.swift in Sources */,
 				D1FFC0DE000000000000C002 /* DiffCommentStoreTests.swift in Sources */,
 				DCDC0000000000000000B001 /* DockControlDefinitionDecodingTests.swift in Sources */,
+				D7529001A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift in Sources */,
 				D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */,
 				D7054D0C0000000000000001 /* DockTerminalReattachTests.swift in Sources */,
 				D3622100A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift in Sources */,

--- a/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
+++ b/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
@@ -1,0 +1,224 @@
+import AppKit
+import Bonsplit
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+private final class DockPaneDropMockDraggingInfo: NSObject, NSDraggingInfo {
+    let draggingDestinationWindow: NSWindow?
+    let draggingSourceOperationMask: NSDragOperation
+    let draggingLocation: NSPoint
+    let draggedImageLocation: NSPoint
+    let draggedImage: NSImage?
+    // NSDraggingInfo exposes the pasteboard nonisolated; tests mutate it only before construction.
+    nonisolated(unsafe) let draggingPasteboard: NSPasteboard
+    // AppKit exposes the dragging source as an untyped object and this test never mutates it.
+    nonisolated(unsafe) let draggingSource: Any?
+    let draggingSequenceNumber: Int
+    var draggingFormation: NSDraggingFormation = .default
+    var animatesToDestination = false
+    var numberOfValidItemsForDrop = 1
+    let springLoadingHighlight: NSSpringLoadingHighlight = .none
+
+    init(
+        window: NSWindow,
+        location: NSPoint,
+        pasteboard: NSPasteboard,
+        sourceOperationMask: NSDragOperation = .move,
+        draggingSource: Any? = nil,
+        sequenceNumber: Int = 1
+    ) {
+        self.draggingDestinationWindow = window
+        self.draggingSourceOperationMask = sourceOperationMask
+        self.draggingLocation = location
+        self.draggedImageLocation = location
+        self.draggedImage = nil
+        self.draggingPasteboard = pasteboard
+        self.draggingSource = draggingSource
+        self.draggingSequenceNumber = sequenceNumber
+    }
+
+    func slideDraggedImage(to screenPoint: NSPoint) {}
+
+    override func namesOfPromisedFilesDropped(atDestination dropDestination: URL) -> [String]? {
+        nil
+    }
+
+    func enumerateDraggingItems(
+        options enumOpts: NSDraggingItemEnumerationOptions = [],
+        for view: NSView?,
+        classes classArray: [AnyClass],
+        searchOptions: [NSPasteboard.ReadingOptionKey: Any] = [:],
+        using block: (NSDraggingItem, Int, UnsafeMutablePointer<ObjCBool>) -> Void
+    ) {}
+
+    func resetSpringLoading() {}
+}
+
+@Suite("Dock pane drop routing when unfocused", .serialized)
+struct DockPaneDropUnfocusedRoutingTests {
+    @Test("Drop mouse-up uses the same terminal portal route as hover")
+    @MainActor
+    func dropMouseUpUsesSameTerminalPortalRouteAsHover() throws {
+        let tabId = UUID()
+        let sourcePaneId = UUID()
+        let payload = try Self.makePaneDragPayload(tabId: tabId, sourcePaneId: sourcePaneId)
+        let dragPasteboard = NSPasteboard(name: .drag)
+        dragPasteboard.clearContents()
+        dragPasteboard.setData(payload, forType: DragOverlayRoutingPolicy.bonsplitTabTransferType)
+        defer { dragPasteboard.clearContents() }
+
+        let pasteboardTypes = dragPasteboard.types
+        #expect(TerminalPaneDropTargetView.shouldCaptureHitTesting(
+            pasteboardTypes: pasteboardTypes,
+            eventType: .leftMouseDragged
+        ))
+        #expect(TerminalPaneDropTargetView.shouldCaptureHitTesting(
+            pasteboardTypes: pasteboardTypes,
+            eventType: .leftMouseUp
+        ))
+        #expect(WindowInputRoutingContext(eventType: .leftMouseDragged).allowsTerminalPortalDragRouting)
+        #expect(WindowInputRoutingContext(eventType: .leftMouseUp).allowsTerminalPortalDragRouting)
+        #expect(DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
+            pasteboardTypes: pasteboardTypes,
+            eventType: .leftMouseDragged
+        ))
+        #expect(DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
+            pasteboardTypes: pasteboardTypes,
+            eventType: .leftMouseUp
+        ))
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let contentView = try #require(window.contentView)
+        let host = WindowTerminalHostView(frame: contentView.bounds)
+        host.autoresizingMask = [.width, .height]
+        let target = TerminalPaneDropTargetView(frame: host.bounds)
+        target.autoresizingMask = [.width, .height]
+        target.dropContext = PaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: PaneID(id: UUID())
+        )
+        host.addSubview(target)
+        contentView.addSubview(host)
+
+        #expect(!window.isKeyWindow)
+        let pointInWindow = host.convert(NSPoint(x: host.bounds.midX, y: host.bounds.midY), to: nil)
+        let dragEvent = try Self.makeMouseEvent(type: .leftMouseDragged, at: pointInWindow, window: window)
+        let dropEvent = try Self.makeMouseEvent(type: .leftMouseUp, at: pointInWindow, window: window)
+
+        let dragHit = host.performHitTest(
+            at: NSPoint(x: host.bounds.midX, y: host.bounds.midY),
+            currentEvent: dragEvent
+        )
+        let dropHit = host.performHitTest(
+            at: NSPoint(x: host.bounds.midX, y: host.bounds.midY),
+            currentEvent: dropEvent
+        )
+        #expect(dragHit === target)
+        #expect(dropHit === target)
+    }
+
+    @Test("Accepted unfocused Dock pane drop moves a main surface into the Dock")
+    @MainActor
+    func acceptedUnfocusedDockPaneDropMovesMainSurfaceIntoDock() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let previousAppDelegate = AppDelegate.shared
+            let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+            let appDelegate = AppDelegate()
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            AppDelegate.shared = appDelegate
+            appDelegate.tabManager = manager
+            TerminalController.shared.setActiveTabManager(manager)
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                TerminalController.shared.setActiveTabManager(previousManager)
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+                manager.tabs.forEach { $0.teardownAllPanels() }
+                AppDelegate.shared = previousAppDelegate
+            }
+
+            let workspace = try #require(manager.tabs.first)
+            let sourcePane = try #require(workspace.bonsplitController.focusedPaneId ?? workspace.bonsplitController.allPaneIds.first)
+            let sourcePanel = try #require(workspace.newTerminalSurface(inPane: sourcePane, focus: true))
+            let sourceTabId = try #require(workspace.surfaceIdFromPanelId(sourcePanel.id))
+            let dock = workspace.dockSplit
+            let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
+            let existingDockPanelId = try #require(dock.newSurface(kind: .terminal, inPane: dockPane, focus: false))
+
+            let payload = try Self.makePaneDragPayload(tabId: sourceTabId.uuid, sourcePaneId: sourcePane.id)
+            let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7529.\(UUID().uuidString)"))
+            pasteboard.clearContents()
+            pasteboard.setData(payload, forType: DragOverlayRoutingPolicy.bonsplitTabTransferType)
+            defer { pasteboard.clearContents() }
+
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            defer { window.orderOut(nil) }
+            let contentView = try #require(window.contentView)
+            let target = TerminalPaneDropTargetView(frame: NSRect(x: 20, y: 20, width: 260, height: 160))
+            target.dropContext = PaneDropContext(
+                workspaceId: workspace.id,
+                panelId: existingDockPanelId,
+                paneId: dockPane
+            )
+            contentView.addSubview(target)
+
+            #expect(!window.isKeyWindow)
+            #expect(AppDelegate.shared?.dockForPane(dockPane) === dock)
+            #expect(AppDelegate.shared?.locateContainerSurface(tabId: sourceTabId.uuid) != nil)
+            let dropPoint = target.convert(NSPoint(x: target.bounds.midX, y: target.bounds.midY), to: nil)
+            let draggingInfo = DockPaneDropMockDraggingInfo(
+                window: window,
+                location: dropPoint,
+                pasteboard: pasteboard
+            )
+
+            #expect(target.draggingEntered(draggingInfo) == .move)
+            #expect(target.performDragOperation(draggingInfo))
+            #expect(dock.containsPanel(sourcePanel.id))
+            #expect(!workspace.panels.keys.contains(sourcePanel.id))
+        }
+    }
+
+    private static func makePaneDragPayload(tabId: UUID, sourcePaneId: UUID) throws -> Data {
+        try JSONSerialization.data(withJSONObject: [
+            "tab": ["id": tabId.uuidString, "kind": SurfaceKind.terminal.rawValue],
+            "sourcePaneId": sourcePaneId.uuidString,
+            "sourceProcessId": Int(ProcessInfo.processInfo.processIdentifier),
+        ])
+    }
+
+    private static func makeMouseEvent(
+        type: NSEvent.EventType,
+        at locationInWindow: NSPoint,
+        window: NSWindow
+    ) throws -> NSEvent {
+        try #require(NSEvent.mouseEvent(
+            with: type,
+            location: locationInWindow,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+    }
+}

--- a/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
+++ b/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
@@ -88,7 +88,7 @@ struct DockPaneDropUnfocusedRoutingTests {
             pasteboardTypes: pasteboardTypes,
             eventType: .leftMouseDragged
         ))
-        #expect(DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
+        #expect(!DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
             pasteboardTypes: pasteboardTypes,
             eventType: .leftMouseUp
         ))
@@ -117,13 +117,25 @@ struct DockPaneDropUnfocusedRoutingTests {
         let pointInWindow = host.convert(NSPoint(x: host.bounds.midX, y: host.bounds.midY), to: nil)
         let dragEvent = try Self.makeMouseEvent(type: .leftMouseDragged, at: pointInWindow, window: window)
         let dropEvent = try Self.makeMouseEvent(type: .leftMouseUp, at: pointInWindow, window: window)
+        let draggingInfo = DockPaneDropMockDraggingInfo(
+            window: window,
+            location: pointInWindow,
+            pasteboard: dragPasteboard
+        )
+        defer { PaneDropRoutingSession.clearActiveDropDrag(nil) }
 
-        let dragHit = host.performHitTest(
-            at: NSPoint(x: host.bounds.midX, y: host.bounds.midY),
+        _ = target.draggingEntered(draggingInfo)
+        #expect(DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
+            pasteboardTypes: pasteboardTypes,
+            eventType: .leftMouseUp
+        ))
+        let pointInTarget = target.convert(pointInWindow, from: nil)
+        let dragHit = target.performHitTest(
+            at: pointInTarget,
             currentEvent: dragEvent
         )
-        let dropHit = host.performHitTest(
-            at: NSPoint(x: host.bounds.midX, y: host.bounds.midY),
+        let dropHit = target.performHitTest(
+            at: pointInTarget,
             currentEvent: dropEvent
         )
         #expect(dragHit === target)

--- a/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
+++ b/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
@@ -64,82 +64,122 @@ private final class DockPaneDropMockDraggingInfo: NSObject, NSDraggingInfo {
 struct DockPaneDropUnfocusedRoutingTests {
     @Test("Drop mouse-up uses the same terminal portal route as hover")
     @MainActor
-    func dropMouseUpUsesSameTerminalPortalRouteAsHover() throws {
-        let tabId = UUID()
-        let sourcePaneId = UUID()
-        let payload = try Self.makePaneDragPayload(tabId: tabId, sourcePaneId: sourcePaneId)
-        let dragPasteboard = NSPasteboard(name: .drag)
-        dragPasteboard.clearContents()
-        dragPasteboard.setData(payload, forType: DragOverlayRoutingPolicy.bonsplitTabTransferType)
-        defer { dragPasteboard.clearContents() }
+    func dropMouseUpUsesSameTerminalPortalRouteAsHover() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let previousAppDelegate = AppDelegate.shared
+            let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+            let appDelegate = AppDelegate()
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            AppDelegate.shared = appDelegate
+            appDelegate.tabManager = manager
+            TerminalController.shared.setActiveTabManager(manager)
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                PaneDropRoutingSession.clearActiveDropDrag(nil)
+                TerminalController.shared.setActiveTabManager(previousManager)
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+                manager.tabs.forEach { $0.teardownAllPanels() }
+                AppDelegate.shared = previousAppDelegate
+            }
 
-        let pasteboardTypes = dragPasteboard.types
-        #expect(TerminalPaneDropTargetView.shouldCaptureHitTesting(
-            pasteboardTypes: pasteboardTypes,
-            eventType: .leftMouseDragged
-        ))
-        #expect(TerminalPaneDropTargetView.shouldCaptureHitTesting(
-            pasteboardTypes: pasteboardTypes,
-            eventType: .leftMouseUp
-        ))
-        #expect(WindowInputRoutingContext(eventType: .leftMouseDragged).allowsTerminalPortalDragRouting)
-        #expect(WindowInputRoutingContext(eventType: .leftMouseUp).allowsTerminalPortalDragRouting)
-        #expect(DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
-            pasteboardTypes: pasteboardTypes,
-            eventType: .leftMouseDragged
-        ))
-        #expect(!DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
-            pasteboardTypes: pasteboardTypes,
-            eventType: .leftMouseUp
-        ))
+            let workspace = try #require(manager.tabs.first)
+            let targetPanel = try #require(workspace.panels.values.first)
+            let targetPane = try #require(workspace.paneId(forPanelId: targetPanel.id))
+            let sourcePanel = try #require(workspace.newTerminalSurface(inPane: targetPane, focus: true))
+            let sourceTabId = try #require(workspace.surfaceIdFromPanelId(sourcePanel.id))
+            let payload = try Self.makePaneDragPayload(tabId: sourceTabId.uuid, sourcePaneId: targetPane.id)
+            let dragPasteboard = NSPasteboard(name: .drag)
+            dragPasteboard.clearContents()
+            dragPasteboard.setData(payload, forType: DragOverlayRoutingPolicy.bonsplitTabTransferType)
+            defer { dragPasteboard.clearContents() }
 
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        defer { window.orderOut(nil) }
-        let contentView = try #require(window.contentView)
-        let host = WindowTerminalHostView(frame: contentView.bounds)
-        host.autoresizingMask = [.width, .height]
-        let target = TerminalPaneDropTargetView(frame: host.bounds)
-        target.autoresizingMask = [.width, .height]
-        target.dropContext = PaneDropContext(
-            workspaceId: UUID(),
-            panelId: UUID(),
-            paneId: PaneID(id: UUID())
-        )
-        host.addSubview(target)
-        contentView.addSubview(host)
+            let pasteboardTypes = dragPasteboard.types
+            #expect(TerminalPaneDropTargetView.shouldCaptureHitTesting(
+                pasteboardTypes: pasteboardTypes,
+                eventType: .leftMouseDragged
+            ))
+            #expect(TerminalPaneDropTargetView.shouldCaptureHitTesting(
+                pasteboardTypes: pasteboardTypes,
+                eventType: .leftMouseUp
+            ))
+            #expect(WindowInputRoutingContext(eventType: .leftMouseDragged).allowsTerminalPortalDragRouting)
+            #expect(WindowInputRoutingContext(eventType: .leftMouseUp).allowsTerminalPortalDragRouting)
+            #expect(DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
+                pasteboardTypes: pasteboardTypes,
+                eventType: .leftMouseDragged
+            ))
+            #expect(!DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
+                pasteboardTypes: pasteboardTypes,
+                eventType: .leftMouseUp
+            ))
 
-        #expect(!window.isKeyWindow)
-        let pointInWindow = host.convert(NSPoint(x: host.bounds.midX, y: host.bounds.midY), to: nil)
-        let dragEvent = try Self.makeMouseEvent(type: .leftMouseDragged, at: pointInWindow, window: window)
-        let dropEvent = try Self.makeMouseEvent(type: .leftMouseUp, at: pointInWindow, window: window)
-        let draggingInfo = DockPaneDropMockDraggingInfo(
-            window: window,
-            location: pointInWindow,
-            pasteboard: dragPasteboard
-        )
-        defer { PaneDropRoutingSession.clearActiveDropDrag(nil) }
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            defer { window.orderOut(nil) }
+            let contentView = try #require(window.contentView)
+            let host = WindowTerminalHostView(frame: contentView.bounds)
+            host.autoresizingMask = [.width, .height]
+            let target = TerminalPaneDropTargetView(frame: host.bounds)
+            target.autoresizingMask = [.width, .height]
+            target.dropContext = PaneDropContext(
+                workspaceId: workspace.id,
+                panelId: targetPanel.id,
+                paneId: targetPane
+            )
+            host.addSubview(target)
+            contentView.addSubview(host)
 
-        _ = target.draggingEntered(draggingInfo)
-        #expect(DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
-            pasteboardTypes: pasteboardTypes,
-            eventType: .leftMouseUp
-        ))
-        let pointInTarget = target.convert(pointInWindow, from: nil)
-        let dragHit = target.performHitTest(
-            at: pointInTarget,
-            currentEvent: dragEvent
-        )
-        let dropHit = target.performHitTest(
-            at: pointInTarget,
-            currentEvent: dropEvent
-        )
-        #expect(dragHit === target)
-        #expect(dropHit === target)
+            #expect(!window.isKeyWindow)
+            let pointInWindow = host.convert(NSPoint(x: host.bounds.midX, y: host.bounds.midY), to: nil)
+            let dragEvent = try Self.makeMouseEvent(type: .leftMouseDragged, at: pointInWindow, window: window)
+            let dropEvent = try Self.makeMouseEvent(type: .leftMouseUp, at: pointInWindow, window: window)
+            let draggingInfo = DockPaneDropMockDraggingInfo(
+                window: window,
+                location: pointInWindow,
+                pasteboard: dragPasteboard
+            )
+
+            #expect(target.draggingEntered(draggingInfo) == .move)
+            #expect(DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
+                pasteboardTypes: pasteboardTypes,
+                eventType: .leftMouseUp,
+                hasActiveDropDrag: PaneDropRoutingSession.hasActiveDropDrag
+            ))
+            PaneDropRoutingSession.clearActiveDropDrag(draggingInfo)
+            let filePasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7529.file.\(UUID().uuidString)"))
+            filePasteboard.clearContents()
+            filePasteboard.declareTypes([.fileURL], owner: nil)
+            defer { filePasteboard.clearContents() }
+            let fileDraggingInfo = DockPaneDropMockDraggingInfo(
+                window: window,
+                location: pointInWindow,
+                pasteboard: filePasteboard,
+                sequenceNumber: 2
+            )
+            #expect(target.draggingEntered(fileDraggingInfo) == .copy)
+            #expect(!DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
+                pasteboardTypes: filePasteboard.types,
+                eventType: .leftMouseUp,
+                hasActiveDropDrag: PaneDropRoutingSession.hasActiveDropDrag
+            ))
+            PaneDropRoutingSession.clearActiveDropDrag(fileDraggingInfo)
+            #expect(target.draggingEntered(draggingInfo) == .move)
+            let pointInTarget = target.convert(pointInWindow, from: nil)
+            let dragHit = target.performHitTest(
+                at: pointInTarget,
+                currentEvent: dragEvent
+            )
+            let dropHit = target.performHitTest(
+                at: pointInTarget,
+                currentEvent: dropEvent
+            )
+            #expect(dragHit === target)
+            #expect(dropHit === target)
+        }
     }
 
     @Test("Drop mouse-up uses the same browser portal route as hover")

--- a/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
+++ b/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
@@ -130,6 +130,42 @@ struct DockPaneDropUnfocusedRoutingTests {
         #expect(dropHit === target)
     }
 
+    @Test("Drop mouse-up uses the same browser portal route as hover")
+    @MainActor
+    func dropMouseUpUsesSameBrowserPortalRouteAsHover() throws {
+        let tabId = UUID()
+        let sourcePaneId = UUID()
+        let payload = try Self.makePaneDragPayload(tabId: tabId, sourcePaneId: sourcePaneId)
+        let dragPasteboard = NSPasteboard(name: .drag)
+        dragPasteboard.clearContents()
+        dragPasteboard.setData(payload, forType: DragOverlayRoutingPolicy.bonsplitTabTransferType)
+        defer { dragPasteboard.clearContents() }
+
+        let pasteboardTypes = dragPasteboard.types
+        #expect(BrowserPaneDropTargetView.shouldCaptureHitTesting(
+            pasteboardTypes: pasteboardTypes,
+            eventType: .leftMouseDragged
+        ))
+        #expect(BrowserPaneDropTargetView.shouldCaptureHitTesting(
+            pasteboardTypes: pasteboardTypes,
+            eventType: .leftMouseUp
+        ))
+        #expect(WindowInputRoutingContext(eventType: .leftMouseDragged).allowsBrowserPortalDragRouting)
+        #expect(WindowInputRoutingContext(eventType: .leftMouseUp).allowsBrowserPortalDragRouting)
+        #expect(WindowBrowserHostView.shouldPassThroughToDragTargets(
+            pasteboardTypes: pasteboardTypes,
+            eventType: .leftMouseDragged
+        ))
+        #expect(WindowBrowserHostView.shouldPassThroughToDragTargets(
+            pasteboardTypes: pasteboardTypes,
+            eventType: .leftMouseUp
+        ))
+        #expect(!WindowBrowserHostView.shouldPassThroughToDragTargets(
+            pasteboardTypes: [.fileURL],
+            eventType: .leftMouseUp
+        ))
+    }
+
     @Test("Accepted unfocused Dock pane drop moves a main surface into the Dock")
     @MainActor
     func acceptedUnfocusedDockPaneDropMovesMainSurfaceIntoDock() async throws {
@@ -193,6 +229,73 @@ struct DockPaneDropUnfocusedRoutingTests {
             #expect(target.performDragOperation(draggingInfo))
             #expect(dock.containsPanel(sourcePanel.id))
             #expect(!workspace.panels.keys.contains(sourcePanel.id))
+        }
+    }
+
+    @Test("Accepted unfocused main pane drop moves a Dock surface out of the Dock")
+    @MainActor
+    func acceptedUnfocusedMainPaneDropMovesDockSurfaceOutOfDock() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let previousAppDelegate = AppDelegate.shared
+            let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+            let appDelegate = AppDelegate()
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            AppDelegate.shared = appDelegate
+            appDelegate.tabManager = manager
+            TerminalController.shared.setActiveTabManager(manager)
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                TerminalController.shared.setActiveTabManager(previousManager)
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+                manager.tabs.forEach { $0.teardownAllPanels() }
+                AppDelegate.shared = previousAppDelegate
+            }
+
+            let workspace = try #require(manager.tabs.first)
+            let targetPanel = try #require(workspace.panels.values.first)
+            let targetPane = try #require(workspace.paneId(forPanelId: targetPanel.id))
+            let dock = workspace.dockSplit
+            let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
+            let dockPanelId = try #require(dock.newSurface(kind: .terminal, inPane: dockPane, focus: false))
+            let dockTabId = try #require(dock.surfaceId(forPanelId: dockPanelId))
+            let dockSourcePane = try #require(dock.paneId(forPanelId: dockPanelId) ?? dockPane)
+
+            let payload = try Self.makePaneDragPayload(tabId: dockTabId.uuid, sourcePaneId: dockSourcePane.id)
+            let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7529.\(UUID().uuidString)"))
+            pasteboard.clearContents()
+            pasteboard.setData(payload, forType: DragOverlayRoutingPolicy.bonsplitTabTransferType)
+            defer { pasteboard.clearContents() }
+
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            defer { window.orderOut(nil) }
+            let contentView = try #require(window.contentView)
+            let target = TerminalPaneDropTargetView(frame: NSRect(x: 20, y: 20, width: 260, height: 160))
+            target.dropContext = PaneDropContext(
+                workspaceId: workspace.id,
+                panelId: targetPanel.id,
+                paneId: targetPane
+            )
+            contentView.addSubview(target)
+
+            #expect(!window.isKeyWindow)
+            #expect(AppDelegate.shared?.dockForPane(targetPane) == nil)
+            #expect(AppDelegate.shared?.locateDockSurface(tabId: dockTabId.uuid)?.dock === dock)
+            let dropPoint = target.convert(NSPoint(x: target.bounds.midX, y: target.bounds.midY), to: nil)
+            let draggingInfo = DockPaneDropMockDraggingInfo(
+                window: window,
+                location: dropPoint,
+                pasteboard: pasteboard
+            )
+
+            #expect(target.draggingEntered(draggingInfo) == .move)
+            #expect(target.performDragOperation(draggingInfo))
+            #expect(workspace.panels.keys.contains(dockPanelId))
+            #expect(!dock.containsPanel(dockPanelId))
         }
     }
 

--- a/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
+++ b/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
@@ -219,6 +219,33 @@ struct DockPaneDropUnfocusedRoutingTests {
         ))
     }
 
+    @Test("Sidebar reorder mouse-up routing uses the active sidebar drag registry")
+    @MainActor
+    func sidebarReorderMouseUpRoutingUsesActiveSidebarDragRegistry() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let previousAppDelegate = AppDelegate.shared
+            let appDelegate = AppDelegate()
+            AppDelegate.shared = appDelegate
+            defer { AppDelegate.shared = previousAppDelegate }
+
+            let pasteboardTypes = [DragOverlayRoutingPolicy.sidebarTabReorderType]
+            #expect(!DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
+                pasteboardTypes: pasteboardTypes,
+                eventType: .leftMouseUp,
+                hasActiveDropDrag: appDelegate.sidebarWorkspaceDragRegistry.currentWorkspaceId != nil
+            ))
+
+            let workspaceId = UUID()
+            appDelegate.sidebarWorkspaceDragRegistry.begin(workspaceId: workspaceId)
+            defer { appDelegate.sidebarWorkspaceDragRegistry.end(workspaceId: workspaceId) }
+            #expect(DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
+                pasteboardTypes: pasteboardTypes,
+                eventType: .leftMouseUp,
+                hasActiveDropDrag: appDelegate.sidebarWorkspaceDragRegistry.currentWorkspaceId != nil
+            ))
+        }
+    }
+
     @Test("Nil exit clears only the target view active drag sequence")
     @MainActor
     func nilExitClearsOnlyTargetViewActiveDragSequence() async throws {

--- a/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
+++ b/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
@@ -151,12 +151,14 @@ struct DockPaneDropUnfocusedRoutingTests {
             eventType: .leftMouseUp
         ))
         #expect(WindowInputRoutingContext(eventType: .leftMouseDragged).allowsBrowserPortalDragRouting)
-        #expect(WindowInputRoutingContext(eventType: .leftMouseUp).allowsBrowserPortalDragRouting)
+        #expect(!WindowInputRoutingContext(eventType: .leftMouseUp).allowsBrowserPortalDragRouting)
+        #expect(WindowInputRoutingContext(eventType: .leftMouseUp).allowsPortalPointerHitTesting)
+        #expect(WindowInputRoutingContext(eventType: .leftMouseUp).allowsPaneDropHitTesting)
         #expect(WindowBrowserHostView.shouldPassThroughToDragTargets(
             pasteboardTypes: pasteboardTypes,
             eventType: .leftMouseDragged
         ))
-        #expect(WindowBrowserHostView.shouldPassThroughToDragTargets(
+        #expect(!WindowBrowserHostView.shouldPassThroughToDragTargets(
             pasteboardTypes: pasteboardTypes,
             eventType: .leftMouseUp
         ))

--- a/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
+++ b/cmuxTests/DockPaneDropUnfocusedRoutingTests.swift
@@ -75,7 +75,6 @@ struct DockPaneDropUnfocusedRoutingTests {
             TerminalController.shared.setActiveTabManager(manager)
             let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
             defer {
-                PaneDropRoutingSession.clearActiveDropDrag(nil)
                 TerminalController.shared.setActiveTabManager(previousManager)
                 appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
                 manager.tabs.forEach { $0.teardownAllPanels() }
@@ -147,9 +146,9 @@ struct DockPaneDropUnfocusedRoutingTests {
             #expect(DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
                 pasteboardTypes: pasteboardTypes,
                 eventType: .leftMouseUp,
-                hasActiveDropDrag: PaneDropRoutingSession.hasActiveDropDrag
+                hasActiveDropDrag: host.hasActivePaneDropDrag
             ))
-            PaneDropRoutingSession.clearActiveDropDrag(draggingInfo)
+            target.draggingExited(draggingInfo)
             let filePasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7529.file.\(UUID().uuidString)"))
             filePasteboard.clearContents()
             filePasteboard.declareTypes([.fileURL], owner: nil)
@@ -164,9 +163,9 @@ struct DockPaneDropUnfocusedRoutingTests {
             #expect(!DragOverlayRoutingPolicy.shouldPassThroughTerminalPortalHitTesting(
                 pasteboardTypes: filePasteboard.types,
                 eventType: .leftMouseUp,
-                hasActiveDropDrag: PaneDropRoutingSession.hasActiveDropDrag
+                hasActiveDropDrag: host.hasActivePaneDropDrag
             ))
-            PaneDropRoutingSession.clearActiveDropDrag(fileDraggingInfo)
+            target.draggingExited(fileDraggingInfo)
             #expect(target.draggingEntered(draggingInfo) == .move)
             let pointInTarget = target.convert(pointInWindow, from: nil)
             let dragHit = target.performHitTest(
@@ -218,6 +217,83 @@ struct DockPaneDropUnfocusedRoutingTests {
             pasteboardTypes: [.fileURL],
             eventType: .leftMouseUp
         ))
+    }
+
+    @Test("Nil exit clears only the target view active drag sequence")
+    @MainActor
+    func nilExitClearsOnlyTargetViewActiveDragSequence() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let previousAppDelegate = AppDelegate.shared
+            let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+            let appDelegate = AppDelegate()
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            AppDelegate.shared = appDelegate
+            appDelegate.tabManager = manager
+            TerminalController.shared.setActiveTabManager(manager)
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                TerminalController.shared.setActiveTabManager(previousManager)
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+                manager.tabs.forEach { $0.teardownAllPanels() }
+                AppDelegate.shared = previousAppDelegate
+            }
+
+            let workspace = try #require(manager.tabs.first)
+            let targetPanel = try #require(workspace.panels.values.first)
+            let targetPane = try #require(workspace.paneId(forPanelId: targetPanel.id))
+            let sourcePanel = try #require(workspace.newTerminalSurface(inPane: targetPane, focus: true))
+            let sourceTabId = try #require(workspace.surfaceIdFromPanelId(sourcePanel.id))
+            let payload = try Self.makePaneDragPayload(tabId: sourceTabId.uuid, sourcePaneId: targetPane.id)
+
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 240, height: 180),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            defer { window.orderOut(nil) }
+            let contentView = try #require(window.contentView)
+            let host = WindowTerminalHostView(frame: contentView.bounds)
+            contentView.addSubview(host)
+            let firstTarget = TerminalPaneDropTargetView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+            let secondTarget = TerminalPaneDropTargetView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+            let dropContext = PaneDropContext(workspaceId: workspace.id, panelId: targetPanel.id, paneId: targetPane)
+            firstTarget.dropContext = dropContext
+            secondTarget.dropContext = dropContext
+            host.addSubview(firstTarget)
+            host.addSubview(secondTarget)
+
+            let firstPasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7529.first.\(UUID().uuidString)"))
+            let secondPasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7529.second.\(UUID().uuidString)"))
+            firstPasteboard.clearContents()
+            secondPasteboard.clearContents()
+            firstPasteboard.setData(payload, forType: DragOverlayRoutingPolicy.bonsplitTabTransferType)
+            secondPasteboard.setData(payload, forType: DragOverlayRoutingPolicy.bonsplitTabTransferType)
+            defer {
+                firstPasteboard.clearContents()
+                secondPasteboard.clearContents()
+            }
+
+            let firstDraggingInfo = DockPaneDropMockDraggingInfo(
+                window: window,
+                location: NSPoint(x: 10, y: 10),
+                pasteboard: firstPasteboard,
+                sequenceNumber: 11
+            )
+            let secondDraggingInfo = DockPaneDropMockDraggingInfo(
+                window: window,
+                location: NSPoint(x: 20, y: 20),
+                pasteboard: secondPasteboard,
+                sequenceNumber: 22
+            )
+
+            #expect(firstTarget.draggingEntered(firstDraggingInfo) == .move)
+            #expect(secondTarget.draggingEntered(secondDraggingInfo) == .move)
+            firstTarget.draggingExited(nil)
+            #expect(host.hasActivePaneDropDrag)
+            secondTarget.draggingExited(nil)
+            #expect(!host.hasActivePaneDropDrag)
+        }
     }
 
     @Test("Accepted unfocused Dock pane drop moves a main surface into the Dock")
@@ -355,7 +431,7 @@ struct DockPaneDropUnfocusedRoutingTests {
 
     private static func makePaneDragPayload(tabId: UUID, sourcePaneId: UUID) throws -> Data {
         try JSONSerialization.data(withJSONObject: [
-            "tab": ["id": tabId.uuidString, "kind": SurfaceKind.terminal.rawValue],
+            "tab": ["id": tabId.uuidString, "kind": "terminal"],
             "sourcePaneId": sourcePaneId.uuidString,
             "sourceProcessId": Int(ProcessInfo.processInfo.processIdentifier),
         ])

--- a/cmuxTests/WindowDockLifecycleTests.swift
+++ b/cmuxTests/WindowDockLifecycleTests.swift
@@ -288,6 +288,38 @@ struct WindowDockLifecycleTests {
         #expect(appDelegate.existingWindowDock(forWindowId: windowId) === dock)
     }
 
+    @Test("External drop clears remote tmux mirror state before replacing last main panel")
+    @MainActor
+    func externalDropIntoOwnWindowDockDetachesRemoteTmuxMirrorLocally() throws {
+        let appDelegate = try #require(AppDelegate.shared)
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+        defer {
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            manager.tabs.forEach { $0.teardownAllPanels() }
+        }
+
+        let workspace = try #require(manager.tabs.first)
+        workspace.isRemoteTmuxMirror = true
+        let panelId = try #require(workspace.panels.keys.first)
+        let bonsplitTabId = try #require(workspace.surfaceIdFromPanelId(panelId))
+        let sourcePane = try #require(workspace.paneId(forPanelId: panelId))
+        let dock = appDelegate.windowDock(forWindowId: windowId)
+        let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
+
+        let moved = dock.bonsplitController.onExternalTabDrop?(.init(
+            tabId: bonsplitTabId,
+            sourcePaneId: sourcePane,
+            destination: .insert(targetPane: dockPane, targetIndex: nil)
+        )) ?? false
+
+        #expect(moved)
+        #expect(dock.containsPanel(panelId))
+        #expect(workspace.panels[panelId] == nil)
+        #expect(!workspace.isRemoteTmuxMirror)
+        #expect(workspace.panels.count == 1)
+    }
+
     @Test("Docks in two windows render simultaneously without render-host gating")
     @MainActor
     func windowDocksRenderSimultaneouslyInBothWindows() throws {

--- a/cmuxTests/WindowDockLifecycleTests.swift
+++ b/cmuxTests/WindowDockLifecycleTests.swift
@@ -288,9 +288,9 @@ struct WindowDockLifecycleTests {
         #expect(appDelegate.existingWindowDock(forWindowId: windowId) === dock)
     }
 
-    @Test("External drop clears remote tmux mirror state before replacing last main panel")
+    @Test("External drop keeps remote tmux mirror panes out of Dock")
     @MainActor
-    func externalDropIntoOwnWindowDockDetachesRemoteTmuxMirrorLocally() throws {
+    func externalDropIntoOwnWindowDockRejectsRemoteTmuxMirrorPanel() throws {
         let appDelegate = try #require(AppDelegate.shared)
         let manager = TabManager(autoWelcomeIfNeeded: false)
         let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
@@ -313,10 +313,10 @@ struct WindowDockLifecycleTests {
             destination: .insert(targetPane: dockPane, targetIndex: nil)
         )) ?? false
 
-        #expect(moved)
-        #expect(dock.containsPanel(panelId))
-        #expect(workspace.panels[panelId] == nil)
-        #expect(!workspace.isRemoteTmuxMirror)
+        #expect(!moved)
+        #expect(!dock.containsPanel(panelId))
+        #expect(workspace.panels[panelId] != nil)
+        #expect(workspace.isRemoteTmuxMirror)
         #expect(workspace.panels.count == 1)
     }
 

--- a/cmuxTests/WindowDockLifecycleTests.swift
+++ b/cmuxTests/WindowDockLifecycleTests.swift
@@ -250,9 +250,9 @@ struct WindowDockLifecycleTests {
         }
     }
 
-    @Test("Moving a window's last main panel into its own Dock is rejected")
+    @Test("External drop can move a window's last main panel into its own Dock")
     @MainActor
-    func lastPanelMoveIntoOwnWindowDockIsRejected() throws {
+    func externalDropMovesLastMainPanelIntoOwnWindowDock() throws {
         let appDelegate = try #require(AppDelegate.shared)
         let manager = TabManager(autoWelcomeIfNeeded: false)
         let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
@@ -266,20 +266,25 @@ struct WindowDockLifecycleTests {
         #expect(workspace.panels.count == 1)
         let panelId = try #require(workspace.panels.keys.first)
         let bonsplitTabId = try #require(workspace.surfaceIdFromPanelId(panelId))
+        let sourcePane = try #require(workspace.paneId(forPanelId: panelId))
         let dock = appDelegate.windowDock(forWindowId: windowId)
         let dockPane = try #require(dock.bonsplitController.allPaneIds.first)
 
-        // Accepting the move would empty the window's only workspace, close the
-        // window, and tear down the destination Dock with the moved surface in
-        // it — so the move is rejected and the surface stays put.
-        let moved = appDelegate.moveSurfaceIntoDock(
-            sourceTabId: bonsplitTabId.uuid,
-            destinationDock: dock,
+        // Mirrors Bonsplit's external drop callback after a Dock pane has
+        // already accepted hover for a tab dragged from the main split area.
+        let moved = dock.bonsplitController.onExternalTabDrop?(.init(
+            tabId: bonsplitTabId,
+            sourcePaneId: sourcePane,
             destination: .insert(targetPane: dockPane, targetIndex: nil)
-        )
-        #expect(!moved)
-        #expect(workspace.panels[panelId] != nil)
-        #expect(!dock.containsPanel(panelId))
+        )) ?? false
+
+        #expect(moved)
+        #expect(workspace.panels[panelId] == nil)
+        #expect(dock.containsPanel(panelId))
+        #expect(workspace.panels.count == 1)
+        let replacementPanelId = try #require(workspace.panels.keys.first)
+        #expect(replacementPanelId != panelId)
+        #expect(workspace.surfaceIdFromPanelId(replacementPanelId) != nil)
         #expect(appDelegate.existingWindowDock(forWindowId: windowId) === dock)
     }
 

--- a/cmuxTests/WindowDockLifecycleTests.swift
+++ b/cmuxTests/WindowDockLifecycleTests.swift
@@ -88,8 +88,8 @@ struct WindowDockLifecycleTests {
 
     @Test("Each window gets its own independent Dock store")
     @MainActor
-    func windowDocksAreIndependentPerWindow() throws {
-        try withIsolatedAppDelegate { appDelegate in
+    func windowDocksAreIndependentPerWindow() {
+        withIsolatedAppDelegate { appDelegate in
             let firstManager = TabManager(autoWelcomeIfNeeded: false)
             let secondManager = TabManager(autoWelcomeIfNeeded: false)
             let firstWindowId = appDelegate.registerMainWindowContextForTesting(tabManager: firstManager)


### PR DESCRIPTION
Fixes #7529

## Summary
- route terminal portal drop mouse-up through the same accepted drop-target session that produced hover/drop-zone feedback
- cover unfocused main-to-Dock and Dock-to-main pane drops through the real pane drop target and shared Dock move paths
- keep external Finder file URL drops out of the terminal portal mouse-up pass-through path while preserving file-preview/pane/sidebar drag routing
- keep browser raw file URL drops in WebKit; browser pane drops continue through the normal pane drop target path

## Testing
- `python3 scripts/swift_file_length_budget.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `scripts/check-pbxproj.sh`
- `git diff --check`
- `./scripts/reload.sh --tag issue-7529-dock-drop` after the final pushed commit
- Not run locally: unit-test suites, XCUITests, simulators, or bare xcodebuild per the issue plan; CI owns heavy test execution.

## Demo Video
- Not applicable for this routing/state fix. A tagged Debug build is provided for local dogfood.

## Review Trigger
- Addressed CodeRabbit/Cursor feedback on pointer-up drag pasteboard routing and raw file URL drop handling; review bots are rerunning on the latest pushed commit.

## Checklist
- [x] Regression tests added in their own file and wired into `cmuxTests`
- [x] Drop mouse-up routing is gated by an accepted active drop session, not stale pasteboard state
- [x] Raw external file URL mouse-up drops do not use the terminal portal pass-through path
- [x] No `.github/*.tsv` edits and no submodule edits
- [x] Swift file length budget passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Drag-and-drop portal routing now aligns pointer-up behavior with hover/drag, with capture and pass-through gated by active drop-drag state and pasteboard types.
  * Unfocused Dock/pane drops now consistently dock and undock surfaces in both directions.
  * Dock and browser-pane live-surface transfers are more accurately validated per destination; Dock moves no longer leave the source workspace broken—an empty replacement panel is created when needed.
* **Tests**
  * Added/expanded automated coverage for terminal and browser portal routing (including restricted file URL negative cases) and unfocused Dock/pane docking side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches drag hit-testing, Dock surface moves, and workspace empty-state preservation; wrong gating could break drops or leave workspaces in an inconsistent state, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **first-attempt Dock pane drops** (including unfocused windows) by tracking an **active pane drop session** on `WindowTerminalHostView` and routing **terminal portal mouse-up** through the same path as hover, gated on that session (and sidebar reorder drags) instead of stale pasteboard state. **Raw Finder file URL** mouse-up no longer uses terminal portal pass-through; tab/file-preview/sidebar payloads still do when a drop was accepted.
> 
> **Dock moves** use shared `canMoveSurfaceIntoDock` (blocks **remote tmux mirror** panels); moving the last main panel into the **same** workspace/window Dock is **allowed** and **preserves** the emptied workspace via a **replacement terminal** instead of tearing it down. Browser/terminal pane targets call the same eligibility check for Dock routing.
> 
> Adds **`DockPaneDropUnfocusedRoutingTests`** and updates window Dock lifecycle expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 002b2d91f7eb7e51aae36461577e703072b8e6b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->