### PR TITLE
Fix Cloud VM panel text readability across all terminal themes

### DIFF
--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -179,6 +179,16 @@ private struct CloudVMLoadingPanelView: View {
     @ObservedObject var panel: CloudVMLoadingPanel
 
     var body: some View {
+        // The panel paints the terminal theme's background (any color from the
+        // user's Ghostty config), but the text uses SwiftUI semantic colors
+        // (.primary/.secondary/.tertiary/.orange) that resolve against the
+        // *system* light/dark appearance, not this background. On a dark theme
+        // under a light system appearance (or vice versa) that renders dark
+        // text on a dark panel — unreadable. Pin the panel's color scheme to
+        // whichever contrasts better with the actual background so every theme
+        // stays legible.
+        let backgroundColor = GhosttyApp.shared.defaultBackgroundColor
+        let readableScheme = WindowChromeColorResolver().readableColorScheme(for: backgroundColor)
         let schedule: PeriodicTimelineSchedule = .periodic(from: panel.startedAt, by: 1)
         TimelineView(schedule) { context in
             let elapsedSeconds = max(0, Int(context.date.timeIntervalSince(panel.startedAt).rounded(.down)))
@@ -237,7 +247,8 @@ private struct CloudVMLoadingPanelView: View {
             }
             .padding(32)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(nsColor: GhosttyApp.shared.defaultBackgroundColor))
+            .background(Color(nsColor: backgroundColor))
+            .environment(\.colorScheme, readableScheme)
         }
     }
 }


### PR DESCRIPTION
The Cloud VM loading/error panel (`CloudVMLoadingPanelView`) paints the terminal theme's background color from the user's Ghostty config, but rendered its text with SwiftUI semantic colors (`.primary`/`.secondary`/`.tertiary`/`.orange`) that resolve against the *system* light/dark appearance rather than the actual background. On a dark theme under a light system appearance (and the reverse), the "Base unavailable" message rendered dark-on-dark and was unreadable — the reported bug.

Fix: derive the panel's color scheme from the background's luminance using the existing `WindowChromeColorResolver.readableColorScheme(for:)` (the same helper cmux already uses for readable chrome text over terminal backgrounds) and pin it with `.environment(\.colorScheme,)`. Text now contrasts with the panel on every theme, light or dark.

Scope: presentational only, no string or logic changes. No new user-facing strings, so localization is unaffected. Principled fix (reuses the established readable-scheme helper rather than hardcoding colors).

Verified: cloud Release-capable Debug build compiles (tag `cvmerr`). The live failed-panel visual is best confirmed in dogfood since forcing the `.failed` phase requires a real provisioning failure and this CLI build has no panel-screenshot verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786057628&installation_id=133855650&pr_number=7538&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7538&signature=a9eba5544ff623973486f9609ae0d5bce2bffda3f26c81a25aeef7c362e8c092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational SwiftUI change only; reuses an existing contrast helper with no auth, provisioning, or logic changes.
> 
> **Overview**
> Fixes **unreadable text** on the Cloud VM loading/error panel when the terminal theme background disagrees with the system light/dark appearance.
> 
> `CloudVMLoadingPanelView` still uses the Ghostty default background, but it now derives a **readable** `ColorScheme` via `WindowChromeColorResolver.readableColorScheme(for:)` (same approach as window chrome) and applies `.environment(\.colorScheme, readableScheme)` so `.primary`/`.secondary`/`.tertiary` resolve against the panel, not macOS appearance alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29cb166eba1938ca9c1ca64774507299b2f4826b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable text in the Cloud VM loading/error panel when the terminal theme and system appearance don’t match. The panel now derives a readable color scheme from the terminal background and pins it via `.environment(\.colorScheme)`, so text keeps contrast across themes.

- Reuses `WindowChromeColorResolver.readableColorScheme(for:)`, the same helper used for window chrome text.
- Presentational only; no changes to strings, localization, or VM provisioning logic.

<sup>Written for commit 1b6d9a14ef5784a93f1d8c814593de02ae7358a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal loading screen readability by matching text colors to the terminal’s background.
  * Loading screen appearance now remains visually consistent regardless of the system light or dark mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->