### PR TITLE
Skip terminal close confirmation before tty attach

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+CloseConfirmation.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+CloseConfirmation.swift
@@ -1,0 +1,13 @@
+internal import GhosttyKit
+
+// MARK: - Close confirmation risk model
+
+extension TerminalSurface {
+    func hasCloseConfirmationProcessRisk(_ surface: ghostty_surface_t) -> Bool {
+        if hasDeferredStartupWorkForBackgroundStart() { return true }
+        if ghostty_surface_foreground_pid(surface) > 0 { return true }
+        let exported = ghostty_surface_tty_name(surface)
+        defer { ghostty_string_free(exported) }
+        return exported.ptr != nil && exported.len > 0
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
@@ -16,7 +16,7 @@ extension TerminalSurface {
             return needsConfirmCloseOverrideForTesting
         }
 #endif
-        guard let surface = surface else { return false }
+        guard let surface, hasCloseConfirmationProcessRisk(surface) else { return false }
         return ghostty_surface_needs_confirm_quit(surface)
     }
 

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceCloseConfirmationTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceCloseConfirmationTests.swift
@@ -10,7 +10,7 @@ private func resetGhosttyRuntimeStubs()
 private func setGhosttyCloseState(_ needsConfirm: Bool, _ foregroundPID: UInt64, _ ttyName: UnsafePointer<CChar>?)
 
 @MainActor
-@Suite struct TerminalSurfaceCloseConfirmationTests {
+@Suite(.serialized) struct TerminalSurfaceCloseConfirmationTests {
     @Test func liveSurfaceWithoutPidOrTtyDoesNotRequireConfirmation() {
         let surface = makeSurface()
         let runtimeSurface = fakeRuntimeSurface()

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceCloseConfirmationTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceCloseConfirmationTests.swift
@@ -1,0 +1,102 @@
+import AppKit
+import GhosttyKit
+import Testing
+@testable import CmuxTerminal
+
+@_silgen_name("cmux_test_ghostty_runtime_stubs_reset")
+private func resetGhosttyRuntimeStubs()
+
+@_silgen_name("cmux_test_ghostty_runtime_stubs_set_close_state")
+private func setGhosttyCloseState(_ needsConfirm: Bool, _ foregroundPID: UInt64, _ ttyName: UnsafePointer<CChar>?)
+
+@MainActor
+@Suite struct TerminalSurfaceCloseConfirmationTests {
+    @Test func liveSurfaceWithoutPidOrTtyDoesNotRequireConfirmation() {
+        let surface = makeSurface()
+        let runtimeSurface = fakeRuntimeSurface()
+        surface.installRuntimeSurfaceForTesting(runtimeSurface)
+        resetGhosttyRuntimeStubs()
+        setGhosttyCloseState(true, 0, nil)
+        defer {
+            resetGhosttyRuntimeStubs()
+            surface.releaseSurfaceForTesting()
+        }
+
+        #expect(!surface.needsConfirmClose())
+    }
+
+    @Test func liveSurfaceWithForegroundPidPreservesGhosttyConfirmation() {
+        let surface = makeSurface()
+        let runtimeSurface = fakeRuntimeSurface()
+        surface.installRuntimeSurfaceForTesting(runtimeSurface)
+        resetGhosttyRuntimeStubs()
+        setGhosttyCloseState(true, 42, nil)
+        defer {
+            resetGhosttyRuntimeStubs()
+            surface.releaseSurfaceForTesting()
+        }
+
+        #expect(surface.needsConfirmClose())
+    }
+
+    @Test func liveSurfaceWithTtyPreservesGhosttyConfirmation() {
+        let surface = makeSurface()
+        let runtimeSurface = fakeRuntimeSurface()
+        surface.installRuntimeSurfaceForTesting(runtimeSurface)
+        resetGhosttyRuntimeStubs()
+        "/dev/ttys123".withCString { ttyName in
+            setGhosttyCloseState(true, 0, ttyName)
+            #expect(surface.needsConfirmClose())
+        }
+        resetGhosttyRuntimeStubs()
+        surface.releaseSurfaceForTesting()
+    }
+
+    @Test func pendingStartupCommandPreservesGhosttyConfirmationBeforePidOrTty() {
+        let surface = makeSurface(initialCommand: "sleep 10")
+        let runtimeSurface = fakeRuntimeSurface()
+        surface.installRuntimeSurfaceForTesting(runtimeSurface)
+        resetGhosttyRuntimeStubs()
+        setGhosttyCloseState(true, 0, nil)
+        defer {
+            resetGhosttyRuntimeStubs()
+            surface.releaseSurfaceForTesting()
+        }
+
+        #expect(surface.needsConfirmClose())
+    }
+
+    private func makeSurface(initialCommand: String? = nil) -> TerminalSurface {
+        let nativeView = FakeTerminalSurfaceNativeView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let paneHost = FakeTerminalSurfacePaneHost(surfaceView: nativeView)
+        return TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            initialCommand: initialCommand,
+            dependencies: TerminalSurfaceRuntimeDependencies(
+                registry: FakeSurfaceRegistry(),
+                engine: FakeTerminalEngine(),
+                viewProvider: FakeTerminalSurfaceViewProvider(surfaceView: nativeView, paneHost: paneHost),
+                spawnPolicy: FakeSpawnPolicyProvider(),
+                byteTee: FakeTerminalByteTee(),
+                rendererRealization: FakeRendererRealizationScheduler(),
+                hibernationRecorder: FakeHibernationRecorder(),
+                runtimeTeardown: TerminalSurfaceRuntimeTeardownCoordinator(),
+                restoreSpawnScheduler: TerminalSurfaceRestoreSpawnScheduler(interSpawnDelay: .zero),
+                runtimeFilesystem: TerminalSurfaceRuntimeFilesystem(
+                    claudeCommandShimTemporaryDirectory: URL(fileURLWithPath: "/tmp/cmux-terminal-tests", isDirectory: true),
+                    installClaudeCommandShim: { _, _, _ in nil },
+                    isExecutableFile: { _ in false }
+                ),
+                sessionPortBase: 40_000,
+                sessionPortRangeSize: 100,
+                scrollbackReplayEnvironmentKey: "CMUX_TEST_SCROLLBACK_REPLAY"
+            )
+        )
+    }
+
+    private func fakeRuntimeSurface() -> ghostty_surface_t {
+        UnsafeMutableRawPointer(bitPattern: 0x7540)!
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -1,4 +1,21 @@
 #include "include/GhosttyRuntimeTestStubs.h"
+#include <string.h>
+
+static bool cmux_test_needs_confirm_quit = false;
+static uint64_t cmux_test_foreground_pid = 0;
+static const char* cmux_test_tty_name = NULL;
+
+void cmux_test_ghostty_runtime_stubs_reset(void) {
+    cmux_test_needs_confirm_quit = false;
+    cmux_test_foreground_pid = 0;
+    cmux_test_tty_name = NULL;
+}
+
+void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_t foreground_pid, const char* tty_name) {
+    cmux_test_needs_confirm_quit = needs_confirm;
+    cmux_test_foreground_pid = foreground_pid;
+    cmux_test_tty_name = tty_name;
+}
 
 bool ghostty_surface_clear_selection(void *surface) {
     (void)surface;
@@ -7,23 +24,31 @@ bool ghostty_surface_clear_selection(void *surface) {
 
 void ghostty_config_diagnostics_count(void) {}
 void ghostty_config_get_diagnostic(void) {}
-void ghostty_string_free(void) {}
+void ghostty_string_free(ghostty_string_s string) {
+    (void)string;
+}
 void ghostty_surface_binding_action(void) {}
 void ghostty_surface_config_new(void) {}
 void ghostty_surface_free(void) {}
 void ghostty_surface_free_text(void) {}
 uint64_t ghostty_surface_foreground_pid(void *surface) {
     (void)surface;
-    return 0;
+    return cmux_test_foreground_pid;
 }
 void ghostty_surface_has_selection(void) {}
 void ghostty_surface_key(void) {}
 void ghostty_surface_mouse_button(void) {}
 void ghostty_surface_mouse_pos(void) {}
 void ghostty_surface_mouse_scroll(void) {}
-void ghostty_surface_needs_confirm_quit(void) {}
+bool ghostty_surface_needs_confirm_quit(void *surface) {
+    (void)surface;
+    return cmux_test_needs_confirm_quit;
+}
 void ghostty_surface_new(void) {}
-void ghostty_surface_process_exited(void) {}
+bool ghostty_surface_process_exited(void *surface) {
+    (void)surface;
+    return false;
+}
 void ghostty_surface_process_output(void) {}
 void ghostty_surface_quicklook_font(void) {}
 void ghostty_surface_read_text(void) {}
@@ -40,5 +65,8 @@ void ghostty_surface_text(void) {}
 void ghostty_surface_text_input(void) {}
 ghostty_string_s ghostty_surface_tty_name(void *surface) {
     (void)surface;
-    return (ghostty_string_s){0};
+    if (cmux_test_tty_name == NULL) {
+        return (ghostty_string_s){0};
+    }
+    return (ghostty_string_s){.ptr = cmux_test_tty_name, .len = strlen(cmux_test_tty_name), .sentinel = false};
 }

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -7,9 +7,8 @@
 // Test-only stand-ins for the libghostty symbols referenced by CmuxTerminal
 // and CmuxTerminalCore object files. SwiftPM cannot link the GhosttyKit macOS
 // archive (its binary is not lib-prefixed), so the test runner provides these
-// stubs to satisfy the link. No test ever calls them (tests construct no
-// runtime surface), so only the symbol names matter; C symbols carry no type
-// information for the linker.
+// stubs to satisfy the link. Most tests construct no runtime surface, but close
+// confirmation tests configure the process/tty stubs below.
 typedef struct {
   const char* ptr;
   uintptr_t len;
@@ -20,7 +19,7 @@ bool ghostty_surface_clear_selection(void *surface);
 
 void ghostty_config_diagnostics_count(void);
 void ghostty_config_get_diagnostic(void);
-void ghostty_string_free(void);
+void ghostty_string_free(ghostty_string_s string);
 void ghostty_surface_binding_action(void);
 void ghostty_surface_config_new(void);
 void ghostty_surface_free(void);
@@ -31,9 +30,9 @@ void ghostty_surface_key(void);
 void ghostty_surface_mouse_button(void);
 void ghostty_surface_mouse_pos(void);
 void ghostty_surface_mouse_scroll(void);
-void ghostty_surface_needs_confirm_quit(void);
+bool ghostty_surface_needs_confirm_quit(void *surface);
 void ghostty_surface_new(void);
-void ghostty_surface_process_exited(void);
+bool ghostty_surface_process_exited(void *surface);
 void ghostty_surface_process_output(void);
 void ghostty_surface_quicklook_font(void);
 void ghostty_surface_read_text(void);
@@ -49,5 +48,8 @@ void ghostty_surface_size(void);
 void ghostty_surface_text(void);
 void ghostty_surface_text_input(void);
 ghostty_string_s ghostty_surface_tty_name(void *surface);
+
+void cmux_test_ghostty_runtime_stubs_reset(void);
+void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_t foreground_pid, const char* tty_name);
 
 #endif


### PR DESCRIPTION
Fixes #7540.

## Summary
- Add a regression suite for closing a newly-created terminal surface before tty attachment.
- Treat close confirmation as necessary only when there is real process/session risk: queued startup work, a foreground pid, or a controlling tty.
- Preserve confirmation for running processes and startup commands.

## Verification
- `swift test --package-path Packages/macOS/CmuxTerminal --filter TerminalSurfaceCloseConfirmationTests`
  - Swift Testing reported all 4 tests passed. Local SwiftPM exits nonzero on this package due the existing GhosttyKit binary-name diagnostic: `ghostty-internal.a` is not lib-prefixed.
- `python3 scripts/swift_file_length_budget.py`
- `git diff --check origin/main...HEAD`

## Localization
- No user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786059975&installation_id=133855650&pr_number=7541&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7541&signature=bdea6963ce685b4b44bab6a78128dcaa688c13747722d8347841895dfb2d1916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to close-confirmation gating with dedicated tests; no auth, data, or broad API surface changes.
> 
> **Overview**
> Fixes spurious close prompts on brand-new terminals by **gating** `needsConfirmClose()` on real session risk before honoring Ghostty’s `needs_confirm_quit` flag.
> 
> A new `hasCloseConfirmationProcessRisk` check returns true only when there is **queued startup work** (`hasDeferredStartupWorkForBackgroundStart`), a **non-zero foreground PID**, or a **non-empty TTY name** from `ghostty_surface_tty_name`. If none of those apply, close proceeds without confirmation even when Ghostty would otherwise ask.
> 
> **Regression coverage** adds `TerminalSurfaceCloseConfirmationTests` and extends **Ghostty runtime test stubs** so tests can simulate confirm flag, PID, and TTY without linking GhosttyKit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd11a8d4d58f0c2574737c5fe839381b73578357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips the terminal close confirmation until a foreground process, tty, or queued startup work exists. This removes the prompt on newly created terminals and closes #7540.

- **Bug Fixes**
  - Gate confirmation on real risk: queued startup work, a foreground pid, or a controlling tty.
  - Preserve confirmation for running processes and startup commands; no prompt before tty attach.
  - Add a regression suite, extend test stubs (confirm flag, pid, tty), and serialize the tests to avoid shared stub state races.

<sup>Written for commit fd11a8d4d58f0c2574737c5fe839381b73578357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved close-confirmation behavior for terminal sessions that may still have active work, a foreground process, or an attached TTY.
  * Close prompts now appear more reliably when a session is still at risk of losing running work.

* **Tests**
  * Added coverage for close-confirmation scenarios, including active processes, TTY presence, and pending startup work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->