### PR TITLE
Cloud VM no-card 7-day trial (backend)

### DIFF
--- a/web/app/api/vm/[id]/fork/route.ts
+++ b/web/app/api/vm/[id]/fork/route.ts
@@ -5,7 +5,6 @@ import {
   requestedVmTeamIdFromRequest,
   vmErrorResponse,
   withAuthedVmApiRoute,
-  vmRequiresProResponse,
 } from "../../../../../services/vms/routeHelpers";
 import { setSpanAttributes } from "../../../../../services/telemetry";
 import {
@@ -17,9 +16,9 @@ import {
 } from "../../../../../services/vms/errors";
 import {
   isVmBillingTeamResolutionError,
-  isVmProGateBlocked,
   resolveVmEntitlements,
 } from "../../../../../services/vms/entitlements";
+import { enforceVmProGate } from "../../../../../services/vms/proGate";
 import { forkVm, runVmWorkflow } from "../../../../../services/vms/workflows";
 import { VmTimingRecorder } from "../../../../../services/vms/timings";
 
@@ -59,9 +58,8 @@ export async function POST(
         if (isVmBillingTeamResolutionError(err)) return billingTeamErrorResponse(err);
         throw err;
       }
-      if (isVmProGateBlocked(entitlements)) {
-        return vmRequiresProResponse();
-      }
+      const proGateResponse = await enforceVmProGate({ entitlements, userId: user.id });
+      if (proGateResponse) return proGateResponse;
       const idempotencyKey = idempotencyKeyFromRequest(request);
       const name = stringField(body, "name");
       setSpanAttributes(span, {

--- a/web/app/api/vm/base/routeShared.ts
+++ b/web/app/api/vm/base/routeShared.ts
@@ -3,9 +3,9 @@ import { assertVmCreateEnabled } from "../../../../services/vms/config";
 import { defaultProviderId, type ProviderId } from "../../../../services/vms/drivers";
 import {
   isVmBillingTeamResolutionError,
-  isVmProGateBlocked,
   resolveVmEntitlements,
 } from "../../../../services/vms/entitlements";
+import { enforceVmProGate } from "../../../../services/vms/proGate";
 import {
   isVmCreateCreditsInsufficientError,
   isVmCreateDisabledError,
@@ -24,7 +24,6 @@ import {
   vmBillingTeamErrorResponse,
   vmErrorResponse,
   vmWorkflowErrorResponse,
-  vmRequiresProResponse,
 } from "../../../../services/vms/routeHelpers";
 import { VmTimingRecorder } from "../../../../services/vms/timings";
 import {
@@ -57,9 +56,8 @@ export async function runBaseRoute(input: {
     throw err;
   }
 
-  if (isVmProGateBlocked(entitlements)) {
-    return vmRequiresProResponse();
-  }
+  const proGateResponse = await enforceVmProGate({ entitlements, userId: input.user.id });
+  if (proGateResponse) return proGateResponse;
 
   const provider = parsed.body.provider ?? defaultProviderId();
   let imageSelection;

--- a/web/app/api/vm/restore/route.ts
+++ b/web/app/api/vm/restore/route.ts
@@ -5,7 +5,6 @@ import {
   requestedVmTeamIdFromRequest,
   vmErrorResponse,
   withAuthedVmApiRoute,
-  vmRequiresProResponse,
 } from "../../../../services/vms/routeHelpers";
 import { setSpanAttributes } from "../../../../services/telemetry";
 import {
@@ -17,9 +16,9 @@ import {
 } from "../../../../services/vms/errors";
 import {
   isVmBillingTeamResolutionError,
-  isVmProGateBlocked,
   resolveVmEntitlements,
 } from "../../../../services/vms/entitlements";
+import { enforceVmProGate } from "../../../../services/vms/proGate";
 import { restoreVm, runVmWorkflow } from "../../../../services/vms/workflows";
 import { VmTimingRecorder } from "../../../../services/vms/timings";
 
@@ -76,9 +75,8 @@ export async function POST(request: Request): Promise<Response> {
         if (isVmBillingTeamResolutionError(err)) return billingTeamErrorResponse(err);
         throw err;
       }
-      if (isVmProGateBlocked(entitlements)) {
-        return vmRequiresProResponse();
-      }
+      const proGateResponse = await enforceVmProGate({ entitlements, userId: user.id });
+      if (proGateResponse) return proGateResponse;
       const idempotencyKey = idempotencyKeyFromRequest(request);
       setSpanAttributes(span, {
         "cmux.snapshot.id": snapshotId,

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -21,9 +21,9 @@ import {
 } from "../../../services/vms/errors";
 import {
   isVmBillingTeamResolutionError,
-  isVmProGateBlocked,
   resolveVmEntitlements,
 } from "../../../services/vms/entitlements";
+import { enforceVmProGate } from "../../../services/vms/proGate";
 import {
   imageUsesBakedFreestyleSignedAdmin,
   resolveVmImage,
@@ -36,7 +36,6 @@ import {
   vmErrorResponse,
   vmWorkflowErrorResponse,
   withAuthedVmApiRoute,
-  vmRequiresProResponse,
 } from "../../../services/vms/routeHelpers";
 import {
   createVm,
@@ -289,9 +288,8 @@ export async function POST(request: Request): Promise<Response> {
           "cmux.vm.max_active": entitlements.maxActiveVms,
         });
 
-        if (isVmProGateBlocked(entitlements)) {
-          return vmRequiresProResponse();
-        }
+        const proGateResponse = await enforceVmProGate({ entitlements, userId: user.id });
+        if (proGateResponse) return proGateResponse;
 
         let created;
         try {

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -11,6 +11,8 @@ export type AuthedUser = {
   teamIds: readonly string[];
   userBillingPlanId: string | null;
   billingPlanId: string | null;
+  /** ISO-8601 start of the user's no-card Cloud VM trial, or null. */
+  vmTrialStartedAt: string | null;
 };
 
 export type AuthedTeam = {
@@ -99,6 +101,7 @@ async function authedUserFromStackUser(
     teamIds,
     userBillingPlanId,
     billingPlanId,
+    vmTrialStartedAt: vmTrialStartedAtFromMetadata(user.clientReadOnlyMetadata),
   };
 }
 
@@ -136,6 +139,14 @@ function planIdFromMetadata(metadata: unknown): string | null {
   if (!metadata || typeof metadata !== "object") return null;
   const value = (metadata as { cmuxVmPlan?: unknown; cmuxPlan?: unknown }).cmuxVmPlan ??
     (metadata as { cmuxPlan?: unknown }).cmuxPlan;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export const VM_TRIAL_STARTED_AT_METADATA_KEY = "cmuxVmTrialStartedAt";
+
+function vmTrialStartedAtFromMetadata(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const value = (metadata as Record<string, unknown>)[VM_TRIAL_STARTED_AT_METADATA_KEY];
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 

--- a/web/services/vms/entitlements.ts
+++ b/web/services/vms/entitlements.ts
@@ -7,6 +7,8 @@ export type VmEntitlements = {
   readonly billingCustomerType: BillingCustomerType;
   readonly billingTeamId: string;
   readonly maxActiveVms: number;
+  /** ISO-8601 timestamp the no-card Pro trial started, or null if never started. */
+  readonly vmTrialStartedAt: string | null;
 };
 
 export type VmEntitlementOptions = {
@@ -46,6 +48,7 @@ export function resolveVmEntitlements(
     billingCustomerType: billing.billingCustomerType,
     billingTeamId: billing.billingTeamId,
     maxActiveVms: maxActiveVmsForPlan(planId, env),
+    vmTrialStartedAt: user.vmTrialStartedAt ?? null,
   };
 }
 
@@ -134,16 +137,86 @@ export function isVmProGateEnforced(
   return isVmRequireProFlag(env.CMUX_VM_REQUIRE_PRO);
 }
 
+/** Length of the no-card Pro trial in ms (CMUX_VM_TRIAL_DAYS, default 7). */
+export function vmTrialDurationMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const days = Number.parseInt(env.CMUX_VM_TRIAL_DAYS ?? "", 10);
+  const safeDays = Number.isFinite(days) && days > 0 ? days : 7;
+  return safeDays * 24 * 60 * 60 * 1000;
+}
+
+export type VmTrialState = {
+  /** Whether a trial has ever been started for this user. */
+  readonly started: boolean;
+  /** Within the trial window right now. */
+  readonly active: boolean;
+  /** Started but the window has elapsed. */
+  readonly expired: boolean;
+  /** Whole days remaining while active (0 once expired/never-started). */
+  readonly daysRemaining: number;
+  /** ISO end of the trial window, or null if never started. */
+  readonly endsAt: string | null;
+};
+
+/** Interpret a stored trial-start timestamp against the current instant. */
+export function resolveVmTrialState(
+  vmTrialStartedAt: string | null | undefined,
+  env: Record<string, string | undefined> = process.env,
+  nowMs: number = Date.now(),
+): VmTrialState {
+  const startedMs = vmTrialStartedAt ? Date.parse(vmTrialStartedAt) : NaN;
+  if (!Number.isFinite(startedMs)) {
+    return { started: false, active: false, expired: false, daysRemaining: 0, endsAt: null };
+  }
+  const endMs = startedMs + vmTrialDurationMs(env);
+  const active = nowMs < endMs;
+  const daysRemaining = active ? Math.max(0, Math.ceil((endMs - nowMs) / (24 * 60 * 60 * 1000))) : 0;
+  return {
+    started: true,
+    active,
+    expired: !active,
+    daysRemaining,
+    endsAt: new Date(endMs).toISOString(),
+  };
+}
+
 /**
- * True when the caller's plan may NOT provision Cloud VMs: the gate is
- * enforced and the plan is not paid. Management verbs (list/rm/exec/ssh/
- * attach) must NOT consult this — only provisioning entry points.
+ * Reason-coded provisioning decision for a Cloud VM entry point.
+ * - "allowed": paid plan, active trial, or the gate is not enforced.
+ * - "trial_available": free user with no trial yet — the route should start
+ *   the no-card trial (persist the timestamp) and then proceed.
+ * - "trial_expired": free user whose trial window elapsed — show the upgrade
+ *   wall ("add a card to keep Cloud VMs").
+ */
+export type VmProGateDecision = "allowed" | "trial_available" | "trial_expired";
+
+export function resolveVmProGateDecision(
+  entitlements: Pick<VmEntitlements, "planId" | "vmTrialStartedAt">,
+  env: Record<string, string | undefined> = process.env,
+  nowMs: number = Date.now(),
+): VmProGateDecision {
+  if (!isVmProGateEnforced(env)) return "allowed";
+  if (isPaidVmPlan(entitlements.planId)) return "allowed";
+  const trial = resolveVmTrialState(entitlements.vmTrialStartedAt, env, nowMs);
+  if (trial.active) return "allowed";
+  if (trial.expired) return "trial_expired";
+  return "trial_available";
+}
+
+/**
+ * True when the caller may NOT provision Cloud VMs *without any further action*
+ * — i.e. the trial window has elapsed. "trial_available" is NOT blocked: the
+ * route starts the no-card trial and proceeds. Management verbs
+ * (list/rm/exec/ssh/attach) must NOT consult this — only provisioning entry
+ * points.
  */
 export function isVmProGateBlocked(
-  entitlements: Pick<VmEntitlements, "planId">,
+  entitlements: Pick<VmEntitlements, "planId" | "vmTrialStartedAt">,
   env: Record<string, string | undefined> = process.env,
+  nowMs: number = Date.now(),
 ): boolean {
-  return isVmProGateEnforced(env) && !isPaidVmPlan(entitlements.planId);
+  return resolveVmProGateDecision(entitlements, env, nowMs) === "trial_expired";
 }
 
 function isVmRequireProFlag(value: string | undefined): boolean {

--- a/web/services/vms/proGate.ts
+++ b/web/services/vms/proGate.ts
@@ -1,0 +1,70 @@
+import { getStackServerApp, isStackConfigured } from "../../app/lib/stack";
+import { VM_TRIAL_STARTED_AT_METADATA_KEY } from "./auth";
+import {
+  resolveVmProGateDecision,
+  type VmEntitlements,
+} from "./entitlements";
+import { vmTrialExpiredResponse } from "./routeHelpers";
+
+/** Minimal shape of a mutable Stack user needed to persist the trial start. */
+export type VmTrialMetadataUser = {
+  readonly clientReadOnlyMetadata?: unknown;
+  update(input: { clientReadOnlyMetadata: Record<string, unknown> }): Promise<unknown>;
+};
+
+/**
+ * Persist the no-card trial start on the user's Stack metadata, idempotently.
+ * Never overwrites an existing start (so the window can't be reset by retrying).
+ * Returns the effective start ISO (existing or newly written).
+ */
+export async function ensureVmTrialStarted(
+  user: VmTrialMetadataUser,
+  nowIso: string,
+): Promise<string> {
+  const raw = user.clientReadOnlyMetadata;
+  const metadata: Record<string, unknown> =
+    raw && typeof raw === "object" && !Array.isArray(raw)
+      ? { ...(raw as Record<string, unknown>) }
+      : {};
+  const existing = metadata[VM_TRIAL_STARTED_AT_METADATA_KEY];
+  if (typeof existing === "string" && existing.trim()) return existing.trim();
+  metadata[VM_TRIAL_STARTED_AT_METADATA_KEY] = nowIso;
+  await user.update({ clientReadOnlyMetadata: metadata });
+  return nowIso;
+}
+
+/**
+ * Shared Pro-gate for every Cloud VM provisioning entry point (create, base
+ * open/reset, fork, restore). Returns a Response to short-circuit the route, or
+ * null to proceed:
+ * - "allowed" (paid / active trial / gate off) → null, proceed.
+ * - "trial_available" (free, no trial yet) → start the no-card trial on Stack
+ *   metadata (best-effort; still proceed if the write fails so a Stack blip
+ *   never blocks a first VM), then null.
+ * - "trial_expired" → 402 vm_trial_expired (the upgrade wall).
+ */
+export async function enforceVmProGate(input: {
+  readonly entitlements: Pick<VmEntitlements, "planId" | "vmTrialStartedAt">;
+  readonly userId: string;
+  readonly env?: Record<string, string | undefined>;
+  readonly nowMs?: number;
+}): Promise<Response | null> {
+  const env = input.env ?? process.env;
+  const decision = resolveVmProGateDecision(input.entitlements, env, input.nowMs);
+  if (decision === "trial_expired") return vmTrialExpiredResponse();
+  if (decision === "trial_available" && isStackConfigured()) {
+    try {
+      const serverUser = await getStackServerApp().getUser(input.userId);
+      if (serverUser) {
+        await ensureVmTrialStarted(
+          serverUser as unknown as VmTrialMetadataUser,
+          new Date().toISOString(),
+        );
+      }
+    } catch (err) {
+      // Fail open: never block a user's first Cloud VM on a Stack write hiccup.
+      console.error("[VM] trial start failed", err);
+    }
+  }
+  return null;
+}

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -242,6 +242,15 @@ export function vmRequiresProResponse(): Response {
   });
 }
 
+export function vmTrialExpiredResponse(): Response {
+  return vmErrorResponse({
+    error: "vm_trial_expired",
+    status: 402,
+    message: "Your Cloud VM free trial has ended.",
+    action: "Add a card at https://cmux.com/pricing to keep using Cloud VMs.",
+  });
+}
+
 export function vmWorkflowErrorResponse(err: unknown): Response | null {
   const workflowError = vmWorkflowErrorCause(err) ?? err;
   if (isVmProviderOperationError(workflowError)) {

--- a/web/tests/vm-pro-gate.test.ts
+++ b/web/tests/vm-pro-gate.test.ts
@@ -4,9 +4,16 @@ import {
   isPaidVmPlan,
   isVmProGateBlocked,
   isVmProGateEnforced,
+  resolveVmProGateDecision,
+  resolveVmTrialState,
+  vmTrialDurationMs,
 } from "../services/vms/entitlements";
 
-const ent = (planId: string) => ({ planId });
+const ent = (planId: string, vmTrialStartedAt: string | null = null) => ({ planId, vmTrialStartedAt });
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 1_800_000_000_000; // fixed instant for deterministic trial math
+const iso = (ms: number) => new Date(ms).toISOString();
+const enforce = { CMUX_VM_REQUIRE_PRO: "1" };
 
 describe("Cloud VM Pro gate", () => {
   test("isPaidVmPlan recognizes pro and team, not free", () => {
@@ -27,16 +34,69 @@ describe("Cloud VM Pro gate", () => {
     expect(isVmProGateEnforced({ CMUX_VM_REQUIRE_PRO: "true" })).toBe(true);
     expect(isVmProGateEnforced({ CMUX_VM_REQUIRE_PRO: "ON" })).toBe(true);
   });
+});
 
-  test("enforcement OFF never blocks any plan", () => {
-    expect(isVmProGateBlocked(ent("free"), {})).toBe(false);
-    expect(isVmProGateBlocked(ent("pro"), {})).toBe(false);
+describe("Cloud VM trial state", () => {
+  test("default trial is 7 days, overridable via CMUX_VM_TRIAL_DAYS", () => {
+    expect(vmTrialDurationMs({})).toBe(7 * DAY);
+    expect(vmTrialDurationMs({ CMUX_VM_TRIAL_DAYS: "3" })).toBe(3 * DAY);
+    expect(vmTrialDurationMs({ CMUX_VM_TRIAL_DAYS: "0" })).toBe(7 * DAY); // invalid falls back
+    expect(vmTrialDurationMs({ CMUX_VM_TRIAL_DAYS: "junk" })).toBe(7 * DAY);
   });
 
-  test("enforcement ON blocks free but allows pro/team", () => {
-    const env = { CMUX_VM_REQUIRE_PRO: "1" };
-    expect(isVmProGateBlocked(ent("free"), env)).toBe(true);
-    expect(isVmProGateBlocked(ent("pro"), env)).toBe(false);
-    expect(isVmProGateBlocked(ent("team"), env)).toBe(false);
+  test("never started when no timestamp", () => {
+    const s = resolveVmTrialState(null, {}, NOW);
+    expect(s).toEqual({ started: false, active: false, expired: false, daysRemaining: 0, endsAt: null });
+  });
+
+  test("active within the window, with whole days remaining", () => {
+    const s = resolveVmTrialState(iso(NOW - 2 * DAY), {}, NOW);
+    expect(s.started).toBe(true);
+    expect(s.active).toBe(true);
+    expect(s.expired).toBe(false);
+    expect(s.daysRemaining).toBe(5);
+  });
+
+  test("expired once the window elapses", () => {
+    const s = resolveVmTrialState(iso(NOW - 8 * DAY), {}, NOW);
+    expect(s.active).toBe(false);
+    expect(s.expired).toBe(true);
+    expect(s.daysRemaining).toBe(0);
+  });
+
+  test("malformed timestamp is treated as never started", () => {
+    expect(resolveVmTrialState("not-a-date", {}, NOW).started).toBe(false);
+  });
+});
+
+describe("Cloud VM gate decision", () => {
+  test("gate off → always allowed regardless of plan/trial", () => {
+    expect(resolveVmProGateDecision(ent("free"), {}, NOW)).toBe("allowed");
+    expect(resolveVmProGateDecision(ent("pro"), {}, NOW)).toBe("allowed");
+  });
+
+  test("paid plans are allowed even under enforcement", () => {
+    expect(resolveVmProGateDecision(ent("pro"), enforce, NOW)).toBe("allowed");
+    expect(resolveVmProGateDecision(ent("team"), enforce, NOW)).toBe("allowed");
+  });
+
+  test("free with no trial → trial_available (route auto-starts the trial)", () => {
+    expect(resolveVmProGateDecision(ent("free"), enforce, NOW)).toBe("trial_available");
+  });
+
+  test("free with an active trial → allowed", () => {
+    expect(resolveVmProGateDecision(ent("free", iso(NOW - 2 * DAY)), enforce, NOW)).toBe("allowed");
+  });
+
+  test("free with an elapsed trial → trial_expired (upgrade wall)", () => {
+    expect(resolveVmProGateDecision(ent("free", iso(NOW - 8 * DAY)), enforce, NOW)).toBe("trial_expired");
+  });
+
+  test("isVmProGateBlocked is true only for an expired trial", () => {
+    expect(isVmProGateBlocked(ent("free"), enforce, NOW)).toBe(false); // trial available, not blocked
+    expect(isVmProGateBlocked(ent("free", iso(NOW - 2 * DAY)), enforce, NOW)).toBe(false); // active
+    expect(isVmProGateBlocked(ent("free", iso(NOW - 8 * DAY)), enforce, NOW)).toBe(true); // expired
+    expect(isVmProGateBlocked(ent("pro"), enforce, NOW)).toBe(false);
+    expect(isVmProGateBlocked(ent("free"), {}, NOW)).toBe(false); // gate off
   });
 });

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -316,9 +316,33 @@ describe("VM REST auth", () => {
     }));
   });
 
-  test("blocks a free plan from provisioning when CMUX_VM_REQUIRE_PRO is enforced", async () => {
+  test("auto-starts a no-card trial for a free plan under enforcement (first VM proceeds)", async () => {
     process.env.CMUX_VM_REQUIRE_PRO = "1";
     getUser.mockResolvedValue(freePlanStackUser());
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-trial-start",
+      provider: "freestyle",
+      image: "snapshot-test",
+      imageVersion: null,
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalled();
+  });
+
+  test("blocks a free plan whose trial has expired (upgrade wall)", async () => {
+    process.env.CMUX_VM_REQUIRE_PRO = "1";
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    getUser.mockResolvedValue(freePlanStackUser({ trialStartedAt: eightDaysAgo }));
 
     const response = await POST(
       new Request("https://cmux.test/api/vm", {
@@ -329,7 +353,7 @@ describe("VM REST auth", () => {
     );
 
     expect(response.status).toBe(402);
-    expect((await response.json() as { error: string }).error).toBe("vm_requires_pro");
+    expect((await response.json() as { error: string }).error).toBe("vm_trial_expired");
     expect(createVm).not.toHaveBeenCalled();
   });
 
@@ -1313,11 +1337,14 @@ function authedStackUser() {
   };
 }
 
-function freePlanStackUser() {
+function freePlanStackUser(options: { readonly trialStartedAt?: string } = {}) {
+  const userMetadata: Record<string, unknown> = { cmuxVmPlan: "free" };
+  if (options.trialStartedAt) userMetadata.cmuxVmTrialStartedAt = options.trialStartedAt;
   return {
     id: "user-1",
     displayName: null,
     primaryEmail: "user@example.com",
+    clientReadOnlyMetadata: userMetadata,
     selectedTeam: {
       id: "team-1",
       clientReadOnlyMetadata: { cmuxVmPlan: "free" },
@@ -1326,6 +1353,7 @@ function freePlanStackUser() {
       id: "team-1",
       clientReadOnlyMetadata: { cmuxVmPlan: "free" },
     }],
+    update: async (_input: { clientReadOnlyMetadata: Record<string, unknown> }) => undefined,
   };
 }
 

--- a/web/tests/vm-trial-start.test.ts
+++ b/web/tests/vm-trial-start.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { ensureVmTrialStarted, type VmTrialMetadataUser } from "../services/vms/proGate";
+
+function fakeUser(metadata: unknown) {
+  const calls: Array<{ clientReadOnlyMetadata: Record<string, unknown> }> = [];
+  const user: VmTrialMetadataUser = {
+    clientReadOnlyMetadata: metadata,
+    update(input) {
+      calls.push(input);
+      return Promise.resolve(undefined);
+    },
+  };
+  return { user, calls };
+}
+
+describe("ensureVmTrialStarted", () => {
+  test("writes the start timestamp on first call and returns it", async () => {
+    const { user, calls } = fakeUser({ cmuxPlan: "free" });
+    const now = "2026-07-07T00:00:00.000Z";
+    const result = await ensureVmTrialStarted(user, now);
+    expect(result).toBe(now);
+    expect(calls.length).toBe(1);
+    expect(calls[0].clientReadOnlyMetadata).toEqual({
+      cmuxPlan: "free",
+      cmuxVmTrialStartedAt: now,
+    });
+  });
+
+  test("is idempotent: never overwrites an existing start (no reset by retrying)", async () => {
+    const original = "2026-07-01T00:00:00.000Z";
+    const { user, calls } = fakeUser({ cmuxVmTrialStartedAt: original });
+    const result = await ensureVmTrialStarted(user, "2026-07-07T00:00:00.000Z");
+    expect(result).toBe(original);
+    expect(calls.length).toBe(0);
+  });
+
+  test("handles missing/invalid metadata by starting fresh", async () => {
+    const { user, calls } = fakeUser(null);
+    const now = "2026-07-07T00:00:00.000Z";
+    await ensureVmTrialStarted(user, now);
+    expect(calls[0].clientReadOnlyMetadata).toEqual({ cmuxVmTrialStartedAt: now });
+  });
+});


### PR DESCRIPTION
Backend for the Cloud VM onboarding you asked for: a **7-day free trial, no card**, that starts the moment a signed-in free user first opens a Cloud VM. Builds on the merged Pro-gate.

The four provisioning routes (create, base open/reset, fork, restore) now call one shared `enforceVmProGate` that resolves a reason-coded decision:
- **allowed** — paid plan, active trial, or gate off → proceed
- **trial_available** — free user, no trial yet → persist `cmuxVmTrialStartedAt` on Stack user metadata (idempotent; never reset by retrying; fails open so a Stack hiccup never blocks a first VM), then proceed
- **trial_expired** — window elapsed → `402 vm_trial_expired` with an "Add a card" action (the upgrade wall)

Trial length is `CMUX_VM_TRIAL_DAYS` (default 7). Management verbs (list/rm/exec/ssh/attach) stay ungated so a lapsed user can still wind down existing VMs. Ships dark with the gate — nothing changes until `CMUX_VM_REQUIRE_PRO` is enforced.

The macOS panel states that consume `vm_trial_expired` / 401 / active-trial (sign-in CTA, "N days left", "add a card to keep it") are a stacked follow-up; this PR is the enforcement + persistence foundation and is independently testable.

Verified: `bun run typecheck` clean, focused trial/gate/route tests, full web suite **462 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786060119&installation_id=133855650&pr_number=7543&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7543&signature=86ca0447c9ae5839d5badb1e5b87d39ed094d2074f1eb0903be68dd835bc0da4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing/access rules for VM provisioning and persists trial state in Stack metadata, but behavior stays behind `CMUX_VM_REQUIRE_PRO` and trial-start failures fail open to avoid blocking first-time creates.
> 
> **Overview**
> Adds a **no-card Cloud VM trial** (default **7 days** via `CMUX_VM_TRIAL_DAYS`) that starts on a free user’s **first provisioning** attempt when `CMUX_VM_REQUIRE_PRO` is on. Trial start is stored as `cmuxVmTrialStartedAt` on Stack user metadata and threaded through auth and entitlements.
> 
> Provisioning routes (**create**, **base open/reset**, **fork**, **restore**) now call shared **`enforceVmProGate`** instead of immediately blocking free plans with `vm_requires_pro`. The gate resolves **`allowed`**, **`trial_available`** (persist trial idempotently, then continue), or **`trial_expired`** (**402 `vm_trial_expired`** with an add-card action). Trial metadata writes are **best-effort fail-open** so Stack errors don’t block a first VM.
> 
> **`isVmProGateBlocked`** now means only an **elapsed** trial under enforcement; management routes (e.g. list) stay ungated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b180449f6002bac744037cb1065bc939db0091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 7-day, no-card Cloud VM trial with a shared provisioning gate that auto-starts on a free user’s first VM and blocks after it ends with a 402 `vm_trial_expired`. Management verbs remain ungated, and nothing changes until `CMUX_VM_REQUIRE_PRO` is enforced.

- **New Features**
  - Introduced `enforceVmProGate` for create, base open/reset, fork, and restore routes.
  - Starts the trial by writing `cmuxVmTrialStartedAt` to Stack user metadata (idempotent; fail-open).
  - Outcomes: allowed, trial_available (auto-start), trial_expired (returns 402 `vm_trial_expired` with upgrade action).
  - Trial length via `CMUX_VM_TRIAL_DAYS` (default 7); tests cover trial math and decision paths.

- **Migration**
  - No change until `CMUX_VM_REQUIRE_PRO` is set.
  - Clients should handle 402 `vm_trial_expired` and show an upgrade prompt.

<sup>Written for commit a3b180449f6002bac744037cb1065bc939db0091. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud VM access now supports a free trial before requiring a paid plan.
  * Trial status is tracked automatically, with clearer handling for first-time, active, and expired trials.
  * Users now see a dedicated message when the Cloud VM trial has ended.

* **Bug Fixes**
  * Improved VM access checks so trial users can continue using provisioning until their trial expires.
  * Standardized VM route behavior across create, restore, and fork flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->