### PR TITLE
fix(settings): merge shortcut edits into cmux.json instead of clobbering other bindings

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/JSONConfigStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/JSONConfigStore.swift
@@ -120,6 +120,31 @@ public actor JSONConfigStore {
         }
     }
 
+    /// Merges `entries` into the dictionary already stored at `key`'s path,
+    /// overwriting only the provided keys and leaving every other on-disk entry
+    /// byte-for-form untouched.
+    ///
+    /// Unlike ``set(_:for:)`` — which replaces the whole object at the leaf —
+    /// this preserves sibling entries the caller did not pass, including entries
+    /// authored in a schema-valid form this process would never emit itself
+    /// (e.g. a hand-written string stroke `"cmd+shift+up"` rather than the
+    /// object form). Use it for user-editable maps like `shortcuts.bindings`,
+    /// passing only the entries that actually changed, so editing one entry can
+    /// never rewrite or silently drop the others.
+    public func merge<Element: SettingCodable>(
+        _ entries: [String: Element],
+        for key: JSONKey<[String: Element]>
+    ) throws {
+        guard !entries.isEmpty else { return }
+        try mutateRoot { root in
+            var existing = (key.path.lookup(in: root) as? [String: Any]) ?? [:]
+            for (entryKey, element) in entries {
+                existing[entryKey] = element.encodeForJSON()
+            }
+            key.path.assign(existing, in: &root)
+        }
+    }
+
     /// Removes the key's entry from the file. Parent objects that become
     /// empty are pruned. The file itself is not deleted even when no entries
     /// remain.

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/StoredShortcut.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/StoredShortcut.swift
@@ -42,11 +42,30 @@ public struct StoredShortcut: Sendable, Equatable, Hashable, Codable, SettingCod
     }
 
     public static func decodeFromJSON(_ raw: Any?) -> StoredShortcut? {
-        guard let raw, !(raw is NSNull) else { return nil }
-        guard let data = try? JSONSerialization.data(withJSONObject: raw, options: .fragmentsAllowed) else {
-            return nil
+        guard let raw else { return nil }
+        // Accept every schema-valid binding form (`$defs.shortcutBinding`) so a
+        // hand-authored string stroke, chord array, or unbind sentinel loads
+        // into the UI model instead of being dropped. Dropping any one entry
+        // makes the all-or-nothing dictionary decode blank the entire bindings
+        // map, which is what left the Settings UI showing no shortcuts. The
+        // grammar mirrors the app target's runtime reader so a UI-loaded binding
+        // and a runtime-resolved one agree on the canonical key form.
+        if raw is NSNull {
+            return .unbound
         }
-        return try? JSONDecoder().decode(StoredShortcut.self, from: data)
+        if let string = raw as? String {
+            return parseConfig(string)
+        }
+        if let strokes = raw as? [String] {
+            return parseConfig(strokes: strokes)
+        }
+        if let object = raw as? [String: Any] {
+            guard let data = try? JSONSerialization.data(withJSONObject: object, options: .fragmentsAllowed) else {
+                return nil
+            }
+            return try? JSONDecoder().decode(StoredShortcut.self, from: data)
+        }
+        return nil
     }
 
     public func encodeForJSON() -> Any {
@@ -55,5 +74,147 @@ public struct StoredShortcut: Sendable, Equatable, Hashable, Codable, SettingCod
             return NSNull()
         }
         return object
+    }
+}
+
+// MARK: - Config string / chord / sentinel parsing
+//
+// Mirrors the app target's `ShortcutStroke.parseConfig` grammar so the Settings
+// UI decodes the same hand-editable forms the runtime resolver accepts, and
+// produces the same canonical `key` tokens (arrows as glyphs, Return as "\r",
+// Tab as "\t", Space as "space", media as "media.*"). This is a lossless
+// *decode* for display/preservation, so modifier-less ("bare") strokes are
+// accepted here even though the recorder rejects them at record time.
+
+extension StoredShortcut {
+    /// Parses a binding value's string form (`"cmd+shift+up"`) or an unbind
+    /// sentinel (`""`, `"none"`, `"clear"`, `"unbound"`, `"disabled"`).
+    static func parseConfig(_ rawValue: String) -> StoredShortcut? {
+        if isUnboundConfigToken(rawValue) { return .unbound }
+        return parseConfig(strokes: [rawValue])
+    }
+
+    /// Parses a one- or two-stroke chord from its string strokes. An empty array
+    /// is the unbind sentinel; more than two strokes is invalid.
+    static func parseConfig(strokes: [String]) -> StoredShortcut? {
+        if strokes.isEmpty { return .unbound }
+        guard strokes.count <= 2 else { return nil }
+        if strokes.count == 1, let only = strokes.first, isUnboundConfigToken(only) {
+            return .unbound
+        }
+        let parsed = strokes.compactMap(ShortcutStroke.parseConfig(_:))
+        guard parsed.count == strokes.count, let first = parsed.first else { return nil }
+        return StoredShortcut(first: first, second: parsed.count == 2 ? parsed[1] : nil)
+    }
+
+    private static func isUnboundConfigToken(_ rawValue: String) -> Bool {
+        if rawValue.isEmpty { return true }
+        if rawValue == " " { return false }
+        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else { return true }
+        return normalized == "none" || normalized == "clear" || normalized == "unbound" || normalized == "disabled"
+    }
+}
+
+extension ShortcutStroke {
+    /// Parses a single stroke string like `"cmd+shift+up"` into a stroke, or
+    /// `nil` when a modifier token or the key token is unrecognized.
+    static func parseConfig(_ rawValue: String) -> ShortcutStroke? {
+        guard !rawValue.isEmpty else { return nil }
+        let rawParts = rawValue.split(separator: "+", omittingEmptySubsequences: false).map(String.init)
+        let parts = rawParts.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        guard !parts.isEmpty, let lastRawPart = rawParts.last, !lastRawPart.isEmpty else {
+            return nil
+        }
+        var command = false
+        var shift = false
+        var option = false
+        var control = false
+        for modifier in parts.dropLast() {
+            switch modifier.lowercased() {
+            case "cmd", "command", "⌘":
+                command = true
+            case "shift", "⇧":
+                shift = true
+            case "opt", "option", "alt", "⌥":
+                option = true
+            case "ctrl", "control", "ctl", "⌃":
+                control = true
+            default:
+                return nil
+            }
+        }
+        guard let key = parseConfigKeyToken(lastRawPart) else { return nil }
+        return ShortcutStroke(key: key, command: command, shift: shift, option: option, control: control)
+    }
+
+    private static func parseConfigKeyToken(_ rawValue: String) -> String? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return rawValue == " " ? "space" : nil
+        }
+        let lowered = trimmed.lowercased()
+        switch lowered {
+        case "left", "arrowleft", "leftarrow", "←":
+            return "←"
+        case "right", "arrowright", "rightarrow", "→":
+            return "→"
+        case "up", "arrowup", "uparrow", "↑":
+            return "↑"
+        case "down", "arrowdown", "downarrow", "↓":
+            return "↓"
+        case "tab":
+            return "\t"
+        case "return", "enter", "↩":
+            return "\r"
+        case "space", "spacebar", "<space>":
+            return "space"
+        case "comma":
+            return ","
+        case "period", "dot":
+            return "."
+        case "slash":
+            return "/"
+        case "backslash":
+            return "\\"
+        case "semicolon":
+            return ";"
+        case "quote", "apostrophe":
+            return "'"
+        case "backtick", "grave":
+            return "`"
+        case "minus", "hyphen":
+            return "-"
+        case "plus", "equals":
+            return "="
+        case "leftbracket", "openbracket":
+            return "["
+        case "rightbracket", "closebracket":
+            return "]"
+        case "volumeup", "mediavolumeup", "media.volumeup":
+            return "media.volumeUp"
+        case "volumedown", "mediavolumedown", "media.volumedown":
+            return "media.volumeDown"
+        case "brightnessup", "mediabrightnessup", "media.brightnessup":
+            return "media.brightnessUp"
+        case "brightnessdown", "mediabrightnessdown", "media.brightnessdown":
+            return "media.brightnessDown"
+        case "mute", "mediamute", "media.mute":
+            return "media.mute"
+        case "playpause", "mediaplaypause", "media.playpause":
+            return "media.playPause"
+        case "nexttrack", "medianext", "media.next", "media.nexttrack":
+            return "media.next"
+        case "previoustrack", "mediaprevious", "media.previous", "media.previoustrack":
+            return "media.previous"
+        default:
+            if lowered.hasPrefix("f"),
+               let number = Int(lowered.dropFirst()),
+               (1...20).contains(number) {
+                return "f\(number)"
+            }
+            guard lowered.count == 1 else { return nil }
+            return lowered
+        }
     }
 }

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SettingCodableTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SettingCodableTests.swift
@@ -37,4 +37,58 @@ struct SettingCodableTests {
         let encoded = value.encodeForJSON()
         #expect([String: Int].decodeFromJSON(encoded) == value)
     }
+
+    // MARK: - StoredShortcut decodes every schema-valid binding form
+
+    @Test func storedShortcutObjectFormRoundTrips() {
+        let value = StoredShortcut(first: ShortcutStroke(key: "n", command: true))
+        #expect(StoredShortcut.decodeFromJSON(value.encodeForJSON()) == value)
+    }
+
+    @Test func storedShortcutDecodesStringStroke() {
+        // The string form must yield the same canonical key ("↓", …) the
+        // runtime resolver uses, so UI-loaded and runtime bindings agree.
+        #expect(
+            StoredShortcut.decodeFromJSON("cmd+shift+down")
+                == StoredShortcut(first: ShortcutStroke(key: "↓", command: true, shift: true))
+        )
+        #expect(
+            StoredShortcut.decodeFromJSON("ctrl+a")
+                == StoredShortcut(first: ShortcutStroke(key: "a", control: true))
+        )
+    }
+
+    @Test func storedShortcutDecodesChordArray() {
+        #expect(
+            StoredShortcut.decodeFromJSON(["ctrl+b", "c"])
+                == StoredShortcut(
+                    first: ShortcutStroke(key: "b", control: true),
+                    second: ShortcutStroke(key: "c")
+                )
+        )
+    }
+
+    @Test func storedShortcutDecodesUnbindSentinels() {
+        for token in ["", "none", "clear", "unbound", "disabled"] {
+            #expect(StoredShortcut.decodeFromJSON(token) == .unbound, "\(token) should decode to unbound")
+        }
+        #expect(StoredShortcut.decodeFromJSON(NSNull()) == .unbound)
+        #expect(StoredShortcut.decodeFromJSON([String]()) == .unbound)
+    }
+
+    @Test func storedShortcutRejectsInvalidString() {
+        #expect(StoredShortcut.decodeFromJSON("cmd+boguskey") == nil)
+        #expect(StoredShortcut.decodeFromJSON("madeupmodifier+a") == nil)
+    }
+
+    @Test func bindingsDictionarySurvivesMixedForms() {
+        // The all-or-nothing dictionary decode must no longer blank the whole
+        // map when one entry is a hand-authored string form and another is the
+        // object form the UI writes — this was the root of the clobber bug.
+        let objectForm = StoredShortcut(first: ShortcutStroke(key: ",", command: true)).encodeForJSON()
+        let raw: [String: Any] = ["focusDown": "cmd+shift+down", "openSettings": objectForm]
+        let decoded = [String: StoredShortcut].decodeFromJSON(raw)
+        #expect(decoded?["focusDown"] == StoredShortcut(first: ShortcutStroke(key: "↓", command: true, shift: true)))
+        #expect(decoded?["openSettings"] == StoredShortcut(first: ShortcutStroke(key: ",", command: true)))
+    }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/ShortcutListModel.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/ShortcutListModel.swift
@@ -67,9 +67,23 @@ final class ShortcutListModel {
     private var latestBindings: [String: StoredShortcut] { pendingBindings ?? bindings }
 
     private func ingestBindings(_ dictionary: [String: StoredShortcut]) {
-        let changedActionIds = Set(bindings.keys).union(dictionary.keys)
-            .filter { bindings[$0] != dictionary[$0] }
-        bindings = dictionary
+        // Only surface bindings the runtime will actually honor. A modifier-less
+        // ("bare") first stroke is honored only for actions that allow it (or
+        // for Space) — mirror that action-aware rule from the runtime reader so
+        // a hand-authored bare binding on a modifier-required action isn't
+        // presented as the active shortcut while the app ignores it and falls
+        // back to the default. The raw entry still stays in cmux.json (merge-on-
+        // save never drops untouched keys); it is just not shown as loaded.
+        let loadable = dictionary.filter { key, shortcut in
+            guard let action = ShortcutAction(rawValue: key) else { return true }
+            if shortcut.isUnbound { return true }
+            return action.allowsBareFirstStroke
+                || shortcut.first.hasAnyModifier
+                || shortcut.first.key == "space"
+        }
+        let changedActionIds = Set(bindings.keys).union(loadable.keys)
+            .filter { bindings[$0] != loadable[$0] }
+        bindings = loadable
         pruneRestoreShortcuts()
         pruneConflictRejections(changedActionIds: Set(changedActionIds))
         pruneNumberedDigitRejections(changedActionIds: Set(changedActionIds))

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/ShortcutListModel.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/ShortcutListModel.swift
@@ -414,18 +414,31 @@ final class ShortcutListModel {
         numberedDigitRejections.removeAll()
         conflictRejections.removeAll()
         rejectedConflictShortcuts.removeAll()
-        await write([:])
+        await write([:], replacingAll: true)
     }
 
     /// Persists `updated` to the bindings store, recording any failure to the
     /// error log.
-    private func write(_ updated: [String: StoredShortcut]) async {
+    ///
+    /// Per-action edits (`replacingAll == false`) merge only the entries that
+    /// actually changed into the on-disk `shortcuts.bindings` object, so bindings
+    /// the UI never loaded — e.g. hand-authored string strokes, or object-form
+    /// entries dropped when a sibling failed to decode — are preserved verbatim
+    /// instead of being clobbered by a full-block rewrite. "Reset Defaults"
+    /// (`replacingAll == true`) intentionally replaces the whole object.
+    private func write(_ updated: [String: StoredShortcut], replacingAll: Bool = false) async {
         pendingWriteGeneration += 1
         let generation = pendingWriteGeneration
+        let previous = bindings
         pendingBindings = updated
         bindings = updated
         do {
-            try await jsonStore.set(updated, for: catalog.shortcuts.bindings)
+            if replacingAll {
+                try await jsonStore.set(updated, for: catalog.shortcuts.bindings)
+            } else {
+                let changed = updated.filter { previous[$0.key] != $0.value }
+                try await jsonStore.merge(changed, for: catalog.shortcuts.bindings)
+            }
             if pendingWriteGeneration == generation {
                 pendingBindings = nil
             }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/GlobalHotkeySection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/GlobalHotkeySection.swift
@@ -164,7 +164,11 @@ public struct GlobalHotkeySection: View {
 
     private func write(_ updated: [String: StoredShortcut]) async {
         do {
-            try await jsonStore.set(updated, for: catalog.shortcuts.bindings)
+            // Merge only the changed entries so this section, which owns just the
+            // global-hotkey binding, never rewrites or drops the other bindings
+            // in cmux.json (including ones authored directly in the file).
+            let changed = updated.filter { bindings[$0.key] != $0.value }
+            try await jsonStore.merge(changed, for: catalog.shortcuts.bindings)
         } catch {
             errorLog.record(error, keyID: catalog.shortcuts.bindings.id)
         }

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/ShortcutListModelTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/ShortcutListModelTests.swift
@@ -481,4 +481,28 @@ import CmuxSettings
         )
         #expect(bindings?["closeWindow"] != nil, "the edited action must be written")
     }
+
+    @Test func handAuthoredStringBindingLoadsIntoModel() async throws {
+        // A binding authored in the file as a string stroke now decodes into the
+        // UI model with the same canonical key the runtime resolver uses —
+        // previously one such entry blanked the whole map, so the UI showed no
+        // shortcuts at all.
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("shortcut-lossless-load-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("cmux.json")
+        let seed = """
+        { "shortcuts": { "bindings": { "focusDown": "cmd+shift+down" } } }
+        """
+        try Data(seed.utf8).write(to: fileURL)
+
+        let store = JSONConfigStore(fileURL: fileURL)
+        let model = ShortcutListModel(jsonStore: store, catalog: SettingCatalog(), errorLog: SettingsErrorLog())
+        model.startObserving()
+        await spin(until: { model.bindings["focusDown"] != nil })
+        #expect(
+            model.bindings["focusDown"]
+                == StoredShortcut(first: ShortcutStroke(key: "↓", command: true, shift: true))
+        )
+    }
 }

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/ShortcutListModelTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/ShortcutListModelTests.swift
@@ -435,4 +435,50 @@ import CmuxSettings
                 )
         )
     }
+
+    @Test func editingOneActionPreservesHandAuthoredStringBinding() async throws {
+        // Regression for the cmux.json clobber bug: a binding authored directly
+        // in the file as a schema-valid *string* stroke (a form the Settings UI
+        // never emits and cannot decode into its typed model) must survive
+        // editing an unrelated action. Before merge-on-save, saving one shortcut
+        // rewrote the whole `shortcuts.bindings` block and silently dropped it.
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("shortcut-clobber-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("cmux.json")
+
+        let seed = """
+        {
+          "shortcuts": {
+            "bindings": {
+              "focusDown": "cmd+shift+down"
+            }
+          }
+        }
+        """
+        try Data(seed.utf8).write(to: fileURL)
+
+        let store = JSONConfigStore(fileURL: fileURL)
+        let catalog = SettingCatalog()
+        let model = ShortcutListModel(jsonStore: store, catalog: catalog, errorLog: SettingsErrorLog())
+        model.startObserving()
+
+        // Edit an unrelated action through the UI model with an exotic,
+        // conflict-free stroke so the write actually lands.
+        await model.assign(
+            stroke: ShortcutStroke(key: "j", command: true, shift: true, option: true, control: true),
+            to: .closeWindow
+        )
+
+        // Read the raw file: BOTH the hand-authored string binding and the newly
+        // edited action must be present. (store.value can't be used here — the
+        // string form makes the all-or-nothing typed decode blank the map.)
+        let raw = try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
+        let bindings = (raw?["shortcuts"] as? [String: Any])?["bindings"] as? [String: Any]
+        #expect(
+            bindings?["focusDown"] as? String == "cmd+shift+down",
+            "hand-authored string binding must be preserved verbatim after editing another action"
+        )
+        #expect(bindings?["closeWindow"] != nil, "the edited action must be written")
+    }
 }

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/ShortcutListModelTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/ShortcutListModelTests.swift
@@ -505,4 +505,31 @@ import CmuxSettings
                 == StoredShortcut(first: ShortcutStroke(key: "↓", command: true, shift: true))
         )
     }
+
+    @Test func bareFirstStrokeBindingIsNotPresentedForModifierRequiredAction() async throws {
+        // Match the runtime's first-stroke rule: a modifier-less binding on an
+        // action that requires a modifier must not appear as loaded (the app
+        // ignores it and falls back to the default). A valid sibling still loads,
+        // proving ingest ran.
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("shortcut-bare-filter-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("cmux.json")
+        let seed = """
+        { "shortcuts": { "bindings": {
+            "openSettings": "a",
+            "closeWindow": "ctrl+alt+shift+cmd+j"
+        } } }
+        """
+        try Data(seed.utf8).write(to: fileURL)
+
+        let store = JSONConfigStore(fileURL: fileURL)
+        let model = ShortcutListModel(jsonStore: store, catalog: SettingCatalog(), errorLog: SettingsErrorLog())
+        model.startObserving()
+        await spin(until: { model.bindings["closeWindow"] != nil })
+        #expect(
+            model.bindings["openSettings"] == nil,
+            "a bare stroke on a modifier-required action must not be presented as loaded"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Editing **any** keyboard shortcut in Settings (**⌘,** → Keyboard Shortcuts) rewrote the **entire** `shortcuts.bindings` object in `~/.config/cmux/cmux.json`, silently dropping any binding the Settings UI did not load into its typed model — including bindings authored directly in the file in a schema-valid form the UI never emits (e.g. a plain string stroke). Editing action A destroyed unrelated action B.

### Repro (before)

```jsonc
// ~/.config/cmux/cmux.json
{ "shortcuts": { "bindings": { "focusDown": "cmd+shift+down" } } }
```

1. `cmux reload-config` → `focusDown` (⌘⇧↓) works.
2. Settings → change a *different* action (e.g. Global Search). Save.
3. `focusDown` is **gone** from `cmux.json` and falls back to default.

## Root cause

- **Full-block replace on save:** `ShortcutListModel.write` / `GlobalHotkeySection.write` handed the whole in-memory model dict to `JSONConfigStore.set`, which `JSONPath.assign`-replaced the entire `shortcuts.bindings` leaf.
- **Lossy typed model:** the package `StoredShortcut` decoded only the object form, and `Dictionary` decode is all-or-nothing — so a single string/array/sentinel entry dropped the **whole** map from the UI model (the UI showed no shortcuts), which was then written back without it.

## Fix

Both halves, so bindings survive **and** display correctly:

**1. Merge, don't replace (stops the data loss).** Save now merges only the changed entries into the existing on-disk bindings object, preserving every other entry verbatim (any schema-valid form, exact authored shape):
- **`JSONConfigStore.merge(_:for:)`** — per-key merge into the raw on-disk dictionary read by `mutateRoot`, overwriting only the passed keys and leaving untouched siblings byte-for-form intact.
- **`ShortcutListModel.write`** — per-action edits merge only the keys that actually changed; **Reset Defaults** still intentionally replaces the whole object.
- **`GlobalHotkeySection.write`** — merges only the global-hotkey key.

**2. Lossless load (fixes the blank UI).** `StoredShortcut.decodeFromJSON` now parses every schema-valid form — string stroke, chord array, and unbind sentinels (`""`/`none`/`clear`/`unbound`/`disabled`/`null`) — in addition to the object form, so one hand-authored entry no longer blanks the whole map and the binding shows in the UI. The grammar mirrors the app-target runtime reader, so a UI-loaded binding and a runtime-resolved one agree on the canonical key form (arrows as glyphs, Return as `"\r"`, etc.). It's a lenient *decode* (modifier-less strokes decode for display); the recorder still enforces modifier requirements at record time.

## Testing

- `ShortcutListModelTests` (18, incl. new `editingOneActionPreservesHandAuthoredStringBinding` and `handAuthoredStringBindingLoadsIntoModel`; existing `resetAllWritesEmpty`, `failedWriteRollsBackOptimisticBinding`, `consecutiveAssignmentsMergeBeforeObserverEcho` still pass).
- `SettingCodableTests` (12, incl. new StoredShortcut decode of object/string/chord/sentinel/null forms, invalid-string rejection, and mixed-form dictionary survival).
- Full app build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how user keyboard bindings are read and written to `cmux.json`; incorrect merge or decode logic could still corrupt or mis-display shortcuts, though behavior is covered by new regression tests.
> 
> **Overview**
> Fixes a regression where saving **any** keyboard shortcut in Settings replaced the entire `shortcuts.bindings` object in `cmux.json`, silently removing bindings the UI never loaded (e.g. hand-edited string strokes like `"cmd+shift+down"`).
> 
> **Merge-on-save:** Adds `JSONConfigStore.merge(_:for:)` to patch only changed keys into the on-disk map. `ShortcutListModel` and `GlobalHotkeySection` now merge changed entries on normal edits; **Reset Defaults** still replaces the whole bindings object via `replacingAll: true`.
> 
> **Lossless load:** `StoredShortcut.decodeFromJSON` now accepts schema-valid string strokes, chord arrays, unbind sentinels, and `null`, with parsing aligned to the app runtime so mixed-format maps decode instead of failing all-or-nothing and blanking the shortcuts UI.
> 
> **UI ingest:** `ShortcutListModel.ingestBindings` filters out bare first strokes on modifier-required actions (matching runtime) while leaving those keys on disk untouched.
> 
> Regression tests cover clobber preservation, mixed-form decode, and bare-stroke presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d298946ecd9b0bac956bfce15b2d9fce89514f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved shortcut handling to support more on-disk formats, including hand-edited strings, chord shortcuts, and unbound values.
  * Updated shortcut saving to preserve existing entries when only part of the set changes.

* **Bug Fixes**
  * Editing one shortcut no longer overwrites other manually configured shortcuts.
  * Resetting shortcuts now fully clears the saved bindings.

* **Tests**
  * Added regression coverage for mixed shortcut formats and lossless round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->