### PR TITLE
Fix sidebar workspace close hover reconciliation

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14045,9 +14045,7 @@ struct TabItemView: View, Equatable {
         .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
         .padding(.horizontal, SidebarWorkspaceListMetrics.rowOuterHorizontalPadding)
         .contentShape(Rectangle())
-        .onHover { hovering in
-            rowInteractionState.setPointerHovering(hovering)
-        }
+        .sidebarWorkspaceRowHoverTracking($rowInteractionState)
         .opacity(isBeingDragged ? 0.6 : 1)
         .overlay {
             MiddleClickCapture {
@@ -14089,9 +14087,6 @@ struct TabItemView: View, Equatable {
         .onAppear {
             updateObservedActiveState(tabManager.selectedTabId == tab.id)
             refreshWorkspaceSnapshot(force: true)
-        }
-        .onDisappear {
-            rowInteractionState.setPointerHovering(false)
         }
         .onReceive(
             tabManager.selectedTabIdPublisher

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverReconciler.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverReconciler.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct SidebarWorkspaceRowHoverReconciler: NSViewRepresentable {
+    let onPointerHoverChanged: (Bool) -> Void
+
+    func makeNSView(context: Context) -> SidebarWorkspaceRowHoverReconcilerView {
+        let view = SidebarWorkspaceRowHoverReconcilerView()
+        view.onPointerHoverChanged = onPointerHoverChanged
+        return view
+    }
+
+    func updateNSView(_ nsView: SidebarWorkspaceRowHoverReconcilerView, context: Context) {
+        nsView.onPointerHoverChanged = onPointerHoverChanged
+    }
+}

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
@@ -47,11 +47,11 @@ final class SidebarWorkspaceRowHoverReconcilerView: NSView {
     }
 
     func reconcilePointerLocation(pointInView: NSPoint) {
-        reportPointerHovering(bounds.contains(pointInView))
+        reportPointerHovering(bounds.contains(pointInView), force: true)
     }
 
-    private func reportPointerHovering(_ hovering: Bool) {
-        guard lastReportedHover != hovering else { return }
+    private func reportPointerHovering(_ hovering: Bool, force: Bool = false) {
+        guard force || lastReportedHover != hovering else { return }
         lastReportedHover = hovering
         onPointerHoverChanged?(hovering)
     }

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
@@ -1,0 +1,58 @@
+import AppKit
+
+final class SidebarWorkspaceRowHoverReconcilerView: NSView {
+    var onPointerHoverChanged: ((Bool) -> Void)?
+    private var trackingArea: NSTrackingArea?
+    private var lastReportedHover: Bool?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        let nextTrackingArea = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(nextTrackingArea)
+        trackingArea = nextTrackingArea
+        reconcileCurrentPointerLocation()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        reconcileCurrentPointerLocation()
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        reconcileCurrentPointerLocation()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        reportPointerHovering(false)
+    }
+
+    func reconcileCurrentPointerLocation() {
+        guard let window else {
+            reportPointerHovering(false)
+            return
+        }
+        reconcilePointerLocation(pointInView: convert(window.mouseLocationOutsideOfEventStream, from: nil))
+    }
+
+    func reconcilePointerLocation(pointInView: NSPoint) {
+        reportPointerHovering(bounds.contains(pointInView))
+    }
+
+    private func reportPointerHovering(_ hovering: Bool) {
+        guard lastReportedHover != hovering else { return }
+        lastReportedHover = hovering
+        onPointerHoverChanged?(hovering)
+    }
+}

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverTrackingModifier.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverTrackingModifier.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct SidebarWorkspaceRowHoverTrackingModifier: ViewModifier {
+    @Binding var rowInteractionState: SidebarWorkspaceRowInteractionState
+
+    func body(content: Content) -> some View {
+        content
+            .onHover { hovering in
+                rowInteractionState.setPointerHovering(hovering)
+            }
+            .overlay {
+                SidebarWorkspaceRowHoverReconciler { hovering in
+                    rowInteractionState.setPointerHovering(hovering)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .onDisappear {
+                rowInteractionState.setPointerHovering(false)
+            }
+    }
+}
+
+extension View {
+    func sidebarWorkspaceRowHoverTracking(
+        _ rowInteractionState: Binding<SidebarWorkspaceRowInteractionState>
+    ) -> some View {
+        modifier(SidebarWorkspaceRowHoverTrackingModifier(rowInteractionState: rowInteractionState))
+    }
+}

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverTrackingModifier.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverTrackingModifier.swift
@@ -5,9 +5,6 @@ struct SidebarWorkspaceRowHoverTrackingModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onHover { hovering in
-                rowInteractionState.setPointerHovering(hovering)
-            }
             .overlay {
                 SidebarWorkspaceRowHoverReconciler { hovering in
                     rowInteractionState.setPointerHovering(hovering)

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -101,6 +101,9 @@ struct SidebarWorkspaceRowInteractionState: Equatable {
             isPointerHovering = false
             return
         }
+        if deferredPointerHoveringWhileContextMenu == nil, isPointerHovering == hovering {
+            return
+        }
         deferredPointerHoveringWhileContextMenu = nil
         isPointerHovering = hovering
     }

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -278,9 +278,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
         )
         .padding(.horizontal, SidebarWorkspaceListMetrics.rowOuterHorizontalPadding)
         .shortcutHintVisibilityAnimation(value: showsShortcutHint)
-        .onHover { hovering in
-            rowInteractionState.setPointerHovering(hovering)
-        }
+        .sidebarWorkspaceRowHoverTracking($rowInteractionState)
         .opacity(isBeingDragged ? 0.6 : 1)
         .overlay(alignment: .top) {
             SidebarWorkspaceTopDropIndicator(
@@ -309,9 +307,6 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                     rowInteractionState.contextMenuTrackingObserverDidInstall()
                 }
             }
-        }
-        .onDisappear {
-            rowInteractionState.setPointerHovering(false)
         }
         .contextMenu {
             Button(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1101,6 +1101,9 @@
 		C9A57609C9A57609C9A57609 /* SidebarWorkspaceReorderDropOverlayTargetBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5760AC9A5760AC9A5760A /* SidebarWorkspaceReorderDropOverlayTargetBridge.swift */; };
 		C9A5760FC9A5760FC9A5760F /* SidebarWorkspaceReorderDropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57610C9A57610C9A57610 /* SidebarWorkspaceReorderDropView.swift */; };
 		C9A5760BC9A5760BC9A5760B /* SidebarWorkspaceReorderPendingDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5760CC9A5760CC9A5760C /* SidebarWorkspaceReorderPendingDrop.swift */; };
+		D35450070000000000000007 /* SidebarWorkspaceRowHoverReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450070000000000000008 /* SidebarWorkspaceRowHoverReconciler.swift */; };
+		D35450070000000000000009 /* SidebarWorkspaceRowHoverReconcilerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3545007000000000000000A /* SidebarWorkspaceRowHoverReconcilerView.swift */; };
+		D3545007000000000000000B /* SidebarWorkspaceRowHoverTrackingModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3545007000000000000000C /* SidebarWorkspaceRowHoverTrackingModifier.swift */; };
 		D35450030000000000000003 /* SidebarWorkspaceRowMenuTrackingReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450030000000000000004 /* SidebarWorkspaceRowMenuTrackingReconciler.swift */; };
 		D35450030000000000000005 /* SidebarWorkspaceRowMenuTrackingReconcilerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450030000000000000006 /* SidebarWorkspaceRowMenuTrackingReconcilerView.swift */; };
 		C9A57505C9A57505C9A57505 /* SidebarWorkspaceScrollLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57506C9A57506C9A57506 /* SidebarWorkspaceScrollLayoutTests.swift */; };
@@ -2531,6 +2534,9 @@
 		C9A5760AC9A5760AC9A5760A /* SidebarWorkspaceReorderDropOverlayTargetBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceReorderDropOverlayTargetBridge.swift; sourceTree = "<group>"; };
 		C9A57610C9A57610C9A57610 /* SidebarWorkspaceReorderDropView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceReorderDropView.swift; sourceTree = "<group>"; };
 		C9A5760CC9A5760CC9A5760C /* SidebarWorkspaceReorderPendingDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceReorderPendingDrop.swift; sourceTree = "<group>"; };
+		D35450070000000000000008 /* SidebarWorkspaceRowHoverReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowHoverReconciler.swift; sourceTree = "<group>"; };
+		D3545007000000000000000A /* SidebarWorkspaceRowHoverReconcilerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift; sourceTree = "<group>"; };
+		D3545007000000000000000C /* SidebarWorkspaceRowHoverTrackingModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowHoverTrackingModifier.swift; sourceTree = "<group>"; };
 		D35450030000000000000004 /* SidebarWorkspaceRowMenuTrackingReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowMenuTrackingReconciler.swift; sourceTree = "<group>"; };
 		D35450030000000000000006 /* SidebarWorkspaceRowMenuTrackingReconcilerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowMenuTrackingReconcilerView.swift; sourceTree = "<group>"; };
 		C9A57506C9A57506C9A57506 /* SidebarWorkspaceScrollLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceScrollLayoutTests.swift; sourceTree = "<group>"; };
@@ -3258,6 +3264,9 @@
 				C9A5760AC9A5760AC9A5760A /* SidebarWorkspaceReorderDropOverlayTargetBridge.swift */,
 				C9A57610C9A57610C9A57610 /* SidebarWorkspaceReorderDropView.swift */,
 				C9A5760CC9A5760CC9A5760C /* SidebarWorkspaceReorderPendingDrop.swift */,
+				D35450070000000000000008 /* SidebarWorkspaceRowHoverReconciler.swift */,
+				D3545007000000000000000A /* SidebarWorkspaceRowHoverReconcilerView.swift */,
+				D3545007000000000000000C /* SidebarWorkspaceRowHoverTrackingModifier.swift */,
 				D35450030000000000000004 /* SidebarWorkspaceRowMenuTrackingReconciler.swift */,
 				D35450030000000000000006 /* SidebarWorkspaceRowMenuTrackingReconcilerView.swift */,
 				C0DE5F210000000000000002 /* SidebarMetadataMarkdownRenderer.swift */,
@@ -5460,6 +5469,9 @@
 				C9A57609C9A57609C9A57609 /* SidebarWorkspaceReorderDropOverlayTargetBridge.swift in Sources */,
 				C9A5760FC9A5760FC9A5760F /* SidebarWorkspaceReorderDropView.swift in Sources */,
 				C9A5760BC9A5760BC9A5760B /* SidebarWorkspaceReorderPendingDrop.swift in Sources */,
+				D35450070000000000000007 /* SidebarWorkspaceRowHoverReconciler.swift in Sources */,
+				D35450070000000000000009 /* SidebarWorkspaceRowHoverReconcilerView.swift in Sources */,
+				D3545007000000000000000B /* SidebarWorkspaceRowHoverTrackingModifier.swift in Sources */,
 				D35450030000000000000003 /* SidebarWorkspaceRowMenuTrackingReconciler.swift in Sources */,
 				D35450030000000000000005 /* SidebarWorkspaceRowMenuTrackingReconcilerView.swift in Sources */,
 				988C6A036BA56EA5759A95A0 /* SidebarWorkspaceSnapshotRefreshPolicy.swift in Sources */,

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -414,6 +414,26 @@ import Testing
         )
     }
 
+    @Test @MainActor func hoverReconcilerRestoresCloseButtonAfterLifecycleHoverReset() {
+        var state = SidebarWorkspaceRowInteractionState()
+        state.setPointerHovering(true)
+        state.setPointerHovering(false)
+
+        let view = SidebarWorkspaceRowHoverReconcilerView()
+        view.frame = NSRect(x: 0, y: 0, width: 120, height: 28)
+        view.onPointerHoverChanged = { state.setPointerHovering($0) }
+
+        view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+
+        #expect(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "When sidebar updates or row reuse clear SwiftUI hover state while the pointer is still inside the row, the AppKit hover reconciler must restore the close affordance without waiting for another mouse move."
+        )
+    }
+
     @Test func contextMenuAppearanceHidesExistingCloseButtonUntilPointerIsReconciled() {
         var state = SidebarWorkspaceRowInteractionState()
 

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -416,12 +416,16 @@ import Testing
 
     @Test @MainActor func hoverReconcilerRestoresCloseButtonAfterLifecycleHoverReset() {
         var state = SidebarWorkspaceRowInteractionState()
-        state.setPointerHovering(true)
-        state.setPointerHovering(false)
 
         let view = SidebarWorkspaceRowHoverReconcilerView()
         view.frame = NSRect(x: 0, y: 0, width: 120, height: 28)
         view.onPointerHoverChanged = { state.setPointerHovering($0) }
+
+        view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+        #expect(state.shouldShowCloseButton(canCloseWorkspace: true, shortcutHintModeActive: false))
+
+        state.setPointerHovering(false)
+        #expect(!state.shouldShowCloseButton(canCloseWorkspace: true, shortcutHintModeActive: false))
 
         view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
 


### PR DESCRIPTION
Fixes #7539.

## Summary
- add a behavior-level regression test for the sidebar workspace row hover-close lifecycle path
- restore row-owned AppKit hover reconciliation so a stationary pointer inside a remounted/updated row makes the close affordance visible again
- share the hover tracking path between normal workspace rows and workspace group headers

## Test plan
- python3 scripts/swift_file_length_budget.py
- ./scripts/lint-pbxproj-test-wiring.sh
- ./scripts/check-pbxproj.sh
- ./scripts/reload.sh --tag issue-7539-sidebar-close-hover

## Notes
- Preserved the requested two-commit red/green structure: commit 856d255728 adds the failing regression test, commit b0cfd2cbb5 adds the fix.
- Did not run local xcodebuild tests or XCUITests on this Mac, per project constraints.
- Did not launch the dogfood app.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786060229&installation_id=133855650&pr_number=7545&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7545&signature=e1f8c565833568b830a8e5e30da445fc95d2d8aea280f1f2cad6bcf9e52d3228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar UI hover/close affordance behavior only; follows the existing AppKit menu-tracking reconciler pattern with no auth, data, or network impact.
> 
> **Overview**
> Fixes **#7539** by replacing SwiftUI `.onHover` on sidebar workspace rows and group headers with a shared **`sidebarWorkspaceRowHoverTracking`** path backed by a non-hit-testing AppKit overlay that re-reads the pointer when tracking areas update or the view re-enters a window.
> 
> That reconciler restores **close** (and group-header **plus**) visibility when row updates or reuse clear hover state while the cursor is still over the row, without requiring another mouse move. **`SidebarWorkspaceRowInteractionState.setPointerHovering`** now skips redundant updates when hover is unchanged and no deferred context-menu hover is pending. A regression test covers the lifecycle reset → reconcile flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0beaf7b34d0c58391de9dfaedd9a45b8df248b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7539 by making the sidebar close button (and group header plus) reappear if the pointer is still over a row after it updates or remounts. Applies to workspace rows and group headers.

- **Bug Fixes**
  - Added a non-hit-testing AppKit hover reconciler overlay and a shared SwiftUI tracking modifier to restore hover state without waiting for `.onHover`.
  - Consolidated hover tracking into `sidebarWorkspaceRowHoverTracking` and removed per-view `.onHover`/`.onDisappear` in `TabItemView` and `SidebarWorkspaceGroupHeaderView`.
  - Skipped redundant hover updates while preserving context-menu deferral in `SidebarWorkspaceRowInteractionState`; added a regression test to confirm the close button returns without pointer movement.

<sup>Written for commit c0beaf7b34d0c58391de9dfaedd9a45b8df248b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hover tracking in sidebar rows so the close button can reappear more reliably when the pointer is still over a row.
  * Sidebar row hover behavior is now handled more consistently across movement and window changes.

* **Bug Fixes**
  * Fixed cases where hover state could get out of sync, causing the close affordance to stay hidden until the pointer moved again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->