### PR TITLE
feat(sleepy-mode): keep Mac awake while agents are actively working

### DIFF
--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SleepyModeSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SleepyModeSection.swift
@@ -20,6 +20,18 @@ public struct SleepyModeSection: View {
         Group {
             SettingsSectionHeader(String(localized: "settings.section.sleepyMode", defaultValue: "Sleepy Mode"), section: .sleepyMode)
 
+            // Amphetamine Mode: headless keep-awake driven by agent activity —
+            // a behavior toggle, separate from the screensaver appearance below.
+            SettingsCard {
+                SettingsCardRow(
+                    configurationReview: .settingsOnly,
+                    String(localized: "sleepyMode.settings.keepAwake", defaultValue: "Prevent Mac from sleeping while agents are active"),
+                    subtitle: String(localized: "sleepyMode.settings.keepAwake.subtitle", defaultValue: "Keeps the Mac and display awake while any agent is actively running a command, so long tasks don\u{2019}t stall when the Mac would otherwise sleep. Releases automatically when every agent is idle.")
+                ) {
+                    Toggle("", isOn: $store.keepAwakeWhileAgentsActive).labelsHidden().controlSize(.small)
+                }
+            }
+
             SettingsCard {
                 SettingsCardRow(
                     configurationReview: .settingsOnly,

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeDefaultsKeys.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeDefaultsKeys.swift
@@ -18,6 +18,8 @@ struct SleepyModeDefaultsKeys {
     static let customInk = "sleepyMode.customInk"
     static let customLogo = "sleepyMode.customLogo"
     static let customBackground = "sleepyMode.customBackground"
+    /// Amphetamine Mode: keep the Mac awake while any agent is actively working.
+    static let keepAwakeWhileAgentsActive = "sleepyMode.keepAwakeWhileAgentsActive"
 
     private init() {}
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeSettingsStore.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeSettingsStore.swift
@@ -49,6 +49,13 @@ public final class SleepyModeSettingsStore {
     /// Custom background color ("RRGGBB"), used when `glow == .custom`.
     public var customBackground: String { didSet { persist(customBackground, SleepyModeDefaultsKeys.customBackground) } }
 
+    /// Amphetamine Mode: when on, `SleepyModeController` holds IOKit power
+    /// assertions while any agent is actively working, so the Mac does not
+    /// idle-sleep mid-task. A *behavior* flag read by the controller — not an
+    /// appearance field, so it is deliberately absent from `SleepyModeConfig`
+    /// and `snapshot()` (the per-frame render config).
+    public var keepAwakeWhileAgentsActive: Bool { didSet { persist(keepAwakeWhileAgentsActive, SleepyModeDefaultsKeys.keepAwakeWhileAgentsActive) } }
+
     private let defaults: UserDefaults
 
     /// Loads persisted preferences from `defaults` (inject an isolated
@@ -71,6 +78,8 @@ public final class SleepyModeSettingsStore {
         customInk = defaults.string(forKey: SleepyModeDefaultsKeys.customInk) ?? fallback.customInk
         customLogo = defaults.string(forKey: SleepyModeDefaultsKeys.customLogo) ?? fallback.customLogo
         customBackground = defaults.string(forKey: SleepyModeDefaultsKeys.customBackground) ?? fallback.customBackground
+        // ponytail: default off; behavior flag, no SleepyModeConfig fallback needed.
+        keepAwakeWhileAgentsActive = defaults.object(forKey: SleepyModeDefaultsKeys.keepAwakeWhileAgentsActive) as? Bool ?? false
     }
 
     /// Returns an immutable snapshot of the current preferences for the renderer.

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeSettingsStore.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/SleepyMode/SleepyModeSettingsStore.swift
@@ -78,7 +78,7 @@ public final class SleepyModeSettingsStore {
         customInk = defaults.string(forKey: SleepyModeDefaultsKeys.customInk) ?? fallback.customInk
         customLogo = defaults.string(forKey: SleepyModeDefaultsKeys.customLogo) ?? fallback.customLogo
         customBackground = defaults.string(forKey: SleepyModeDefaultsKeys.customBackground) ?? fallback.customBackground
-        // ponytail: default off; behavior flag, no SleepyModeConfig fallback needed.
+        // Behavior flag, default off; no SleepyModeConfig fallback needed.
         keepAwakeWhileAgentsActive = defaults.object(forKey: SleepyModeDefaultsKeys.keepAwakeWhileAgentsActive) as? Bool ?? false
     }
 

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SleepyModeKeepAwakeSettingTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SleepyModeKeepAwakeSettingTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import CmuxSettingsUI
+
+/// Persistence contract for the Amphetamine Mode toggle
+/// (`keepAwakeWhileAgentsActive`): off by default, survives a store reload, and
+/// writes under the expected UserDefaults key. Isolated `UserDefaults` per test.
+@MainActor
+@Suite
+struct SleepyModeKeepAwakeSettingTests {
+    private func isolatedDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "sleepy-keep-awake-\(UUID().uuidString)")!
+    }
+
+    @Test func defaultsToOff() {
+        let store = SleepyModeSettingsStore(defaults: isolatedDefaults())
+        #expect(store.keepAwakeWhileAgentsActive == false)
+    }
+
+    @Test func persistsAcrossStoreReload() {
+        let defaults = isolatedDefaults()
+        SleepyModeSettingsStore(defaults: defaults).keepAwakeWhileAgentsActive = true
+        // A fresh store reading the same defaults must observe the saved value.
+        let reloaded = SleepyModeSettingsStore(defaults: defaults)
+        #expect(reloaded.keepAwakeWhileAgentsActive == true)
+    }
+
+    @Test func writesUnderExpectedKey() {
+        let defaults = isolatedDefaults()
+        let store = SleepyModeSettingsStore(defaults: defaults)
+        store.keepAwakeWhileAgentsActive = true
+        #expect(defaults.bool(forKey: SleepyModeDefaultsKeys.keepAwakeWhileAgentsActive) == true)
+    }
+
+    @Test func togglingOffPersistsFalse() {
+        let defaults = isolatedDefaults()
+        let store = SleepyModeSettingsStore(defaults: defaults)
+        store.keepAwakeWhileAgentsActive = true
+        store.keepAwakeWhileAgentsActive = false
+        #expect(SleepyModeSettingsStore(defaults: defaults).keepAwakeWhileAgentsActive == false)
+    }
+}

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -12,7 +12,7 @@ enum SettingsSearchAliasIndex {
         case .textBox:
             return localized("settings.search.alias.section.textBox", defaultValue: "textbox text box rich input prompt beta focus composer compose attachments")
         case .sleepyMode:
-            return localized("settings.search.alias.section.sleepyMode", defaultValue: "sleepy mode screensaver caffeinate keep awake do not sleep lock touch id battery wifi clock mascot theme glow pixel night")
+            return localized("settings.search.alias.section.sleepyMode", defaultValue: "sleepy mode screensaver caffeinate keep awake do not sleep lock touch id battery wifi clock mascot theme glow pixel night amphetamine prevent sleep agents busy")
         case .mobile:
             return localized("settings.search.alias.section.mobile", defaultValue: "ios iphone ipad mobile pairing local network permission sync")
         case .sidebarAppearance:

--- a/Sources/SleepyModeController.swift
+++ b/Sources/SleepyModeController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CmuxSettingsUI
+import CmuxWorkspaces
 import IOKit.pwr_mgt
 import SwiftUI
 
@@ -56,7 +57,14 @@ final class SleepyModeController {
     private var hasSystemAssertion = false
     private var hasDisplayAssertion = false
 
-    private init() {}
+    /// Drives Amphetamine Mode: periodically re-evaluates whether the Mac should
+    /// stay awake for a working agent. See `reconcilePowerAssertions()`.
+    private var reconcileTimer: Timer?
+    private let reconcileInterval: TimeInterval = 5
+
+    private init() {
+        startReconcileLoop()
+    }
 
     var isHoldingPowerAssertions: Bool { hasSystemAssertion || hasDisplayAssertion }
 
@@ -73,7 +81,7 @@ final class SleepyModeController {
     func activate() {
         guard !isActive else { return }
         isActive = true
-        beginPowerAssertions()
+        reconcilePowerAssertions()
         installScreenObserver()
         rebuildOverlayWindows()
         NSApp.unhide(nil)
@@ -91,7 +99,7 @@ final class SleepyModeController {
         guard isActive else { return }
         isActive = false
         removeScreenObserver()
-        endPowerAssertions()
+        reconcilePowerAssertions()
         tearDownOverlayWindows()
         onStateChange?()
     }
@@ -160,6 +168,69 @@ final class SleepyModeController {
             NotificationCenter.default.removeObserver(screenObserver)
             self.screenObserver = nil
         }
+    }
+
+    // MARK: - Keep-awake reconciliation
+
+    /// Pure keep-awake decision — the clobber-safe contract. The Mac stays awake
+    /// if the Sleepy Mode screensaver is active OR Amphetamine Mode wants it (the
+    /// setting is on AND an agent is working). The `||` guarantees neither
+    /// hold-reason can release an assertion the other still needs. `nonisolated`
+    /// and total so it is unit-testable without the app or the main actor.
+    nonisolated static func shouldKeepAwake(
+        screensaverActive: Bool,
+        keepAwakeSetting: Bool,
+        anyAgentWorking: Bool
+    ) -> Bool {
+        screensaverActive || (keepAwakeSetting && anyAgentWorking)
+    }
+
+    /// Whether any of the given per-workspace activity-state lists contains a
+    /// running command. Split from the live `anyAgentWorking()` reader so the
+    /// "which agent state counts as busy" rule is unit-testable with plain
+    /// values. An idle-but-open agent (`.promptIdle`) does NOT count.
+    nonisolated static func anyAgentWorking(in workspaceActivityStates: [[PanelShellActivityState]]) -> Bool {
+        workspaceActivityStates.contains { $0.contains(.commandRunning) }
+    }
+
+    /// Live reading of `anyAgentWorking(in:)` across every open workspace —
+    /// `.commandRunning` is the same busy signal the sidebar activity uses.
+    static func anyAgentWorking() -> Bool {
+        guard let app = AppDelegate.shared else { return false }
+        return anyAgentWorking(in: app.openWorkspacesForPetCensus().map { Array($0.panelShellActivityStates.values) })
+    }
+
+    /// Single source of truth for the IOKit power assertions: makes the held
+    /// assertion match `shouldKeepAwake(...)`. Idempotent — the begin/end helpers
+    /// no-op when already in the desired state — so it is safe to call on every
+    /// timer tick and on every state change.
+    func reconcilePowerAssertions() {
+        let desired = Self.shouldKeepAwake(
+            screensaverActive: isActive,
+            keepAwakeSetting: store.keepAwakeWhileAgentsActive,
+            anyAgentWorking: Self.anyAgentWorking()
+        )
+        if desired {
+            beginPowerAssertions()
+        } else {
+            endPowerAssertions()
+        }
+    }
+
+    private func startReconcileLoop() {
+        // ponytail: 5s poll reuses the SleepyAgentCensus sampling pattern and
+        // covers every transition (agent busy/idle, toggle flip, workspace
+        // close) uniformly. 5s latency is trivial vs. OS idle-sleep timers
+        // (minutes). Upgrade path: event-driven reconcile at
+        // Workspace.updatePanelShellActivityState if latency ever matters.
+        reconcileTimer?.invalidate()
+        let timer = Timer(timeInterval: reconcileInterval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.reconcilePowerAssertions()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        reconcileTimer = timer
     }
 
     // MARK: - Power assertions

--- a/Sources/SleepyModeController.swift
+++ b/Sources/SleepyModeController.swift
@@ -2,6 +2,7 @@ import AppKit
 import CmuxSettingsUI
 import CmuxWorkspaces
 import IOKit.pwr_mgt
+import Observation
 import SwiftUI
 
 /// Owns "Sleepy Mode": a cute full-screen keep-awake screensaver. It holds
@@ -64,6 +65,7 @@ final class SleepyModeController {
 
     private init() {
         startReconcileLoop()
+        observeKeepAwakeSetting()
     }
 
     var isHoldingPowerAssertions: Bool { hasSystemAssertion || hasDisplayAssertion }
@@ -205,10 +207,14 @@ final class SleepyModeController {
     /// no-op when already in the desired state — so it is safe to call on every
     /// timer tick and on every state change.
     func reconcilePowerAssertions() {
+        // Short-circuit the O(workspaces × panels) scan: `anyAgentWorking()` only
+        // affects the decision when the screensaver is off and the setting is on,
+        // so users who never enable the feature pay nothing per tick.
+        let agentWorking = (!isActive && store.keepAwakeWhileAgentsActive) ? Self.anyAgentWorking() : false
         let desired = Self.shouldKeepAwake(
             screensaverActive: isActive,
             keepAwakeSetting: store.keepAwakeWhileAgentsActive,
-            anyAgentWorking: Self.anyAgentWorking()
+            anyAgentWorking: agentWorking
         )
         if desired {
             beginPowerAssertions()
@@ -217,12 +223,28 @@ final class SleepyModeController {
         }
     }
 
+    /// Reconcile the instant the setting is toggled, so enabling the feature
+    /// while an agent is already working takes effect immediately rather than on
+    /// the next poll. Re-arms after each change (the Observation callback fires
+    /// once per tracked mutation).
+    private func observeKeepAwakeSetting() {
+        withObservationTracking {
+            _ = store.keepAwakeWhileAgentsActive
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.reconcilePowerAssertions()
+                self.observeKeepAwakeSetting()
+            }
+        }
+    }
+
     private func startReconcileLoop() {
-        // ponytail: 5s poll reuses the SleepyAgentCensus sampling pattern and
-        // covers every transition (agent busy/idle, toggle flip, workspace
-        // close) uniformly. 5s latency is trivial vs. OS idle-sleep timers
-        // (minutes). Upgrade path: event-driven reconcile at
-        // Workspace.updatePanelShellActivityState if latency ever matters.
+        // Safety-net poll. Primary reconciliation is event-driven — on the
+        // setting toggle (observeKeepAwakeSetting) and on agent activity changes
+        // (Workspace.updatePanelShellActivityState) — but the timer catches
+        // anything those miss (e.g. a workspace closing). 5s latency is trivial
+        // vs. OS idle-sleep timers (minutes).
         reconcileTimer?.invalidate()
         let timer = Timer(timeInterval: reconcileInterval, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4582,6 +4582,10 @@ final class Workspace: Identifiable, ObservableObject {
             "panel=\(panelId.uuidString.prefix(5)) from=\(previousState.rawValue) to=\(state.rawValue)"
         )
 #endif
+        // Amphetamine Mode: an agent going busy/idle is exactly when the Mac's
+        // keep-awake state may need to flip, so reconcile now instead of waiting
+        // for the next poll (issue #7537). Cheap: a no-op when the feature is off.
+        SleepyModeController.shared.reconcilePowerAssertions()
     }
 
     func setAgentLifecycle(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1116,6 +1116,7 @@
 		C7B0FACE0000000000000006 /* SleepyEnergyMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0FACE0000000000000007 /* SleepyEnergyMode.swift */; };
 		C7B0000000000000000000B2 /* SleepyFaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0000000000000000000B1 /* SleepyFaceView.swift */; };
 		C7B0000000000000000000A2 /* SleepyModeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0000000000000000000A1 /* SleepyModeController.swift */; };
+		5E27010A0000000000000001 /* SleepyModeKeepAwakeReconcileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E27010A0000000000000002 /* SleepyModeKeepAwakeReconcileTests.swift */; };
 		C7B0FACE0000000000000000 /* SleepyOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0FACE0000000000000001 /* SleepyOverlayWindow.swift */; };
 		C7B0FACE000000000000001C /* SleepyPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0FACE000000000000001D /* SleepyPalette.swift */; };
 		C7B0FACE0000000000000010 /* SleepyPetFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0FACE0000000000000011 /* SleepyPetFrame.swift */; };
@@ -2546,6 +2547,7 @@
 		C7B0FACE0000000000000007 /* SleepyEnergyMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyEnergyMode.swift; sourceTree = "<group>"; };
 		C7B0000000000000000000B1 /* SleepyFaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyFaceView.swift; sourceTree = "<group>"; };
 		C7B0000000000000000000A1 /* SleepyModeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyModeController.swift; sourceTree = "<group>"; };
+		5E27010A0000000000000002 /* SleepyModeKeepAwakeReconcileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SleepyModeKeepAwakeReconcileTests.swift; sourceTree = "<group>"; };
 		C7B0FACE0000000000000001 /* SleepyOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyOverlayWindow.swift; sourceTree = "<group>"; };
 		C7B0FACE000000000000001D /* SleepyPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyPalette.swift; sourceTree = "<group>"; };
 		C7B0FACE0000000000000011 /* SleepyPetFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyPetFrame.swift; sourceTree = "<group>"; };
@@ -4395,6 +4397,7 @@
 				9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */,
 				B8B056D80000000000000002 /* MobileHostIdentityTests.swift */,
 				5E2701030000000000000002 /* SentryEventScrubberTests.swift */,
+				5E27010A0000000000000002 /* SleepyModeKeepAwakeReconcileTests.swift */,
 			);
 			path = cmuxTests;
 			sourceTree = "<group>";
@@ -6117,6 +6120,7 @@
 				C9A57505C9A57505C9A57505 /* SidebarWorkspaceScrollLayoutTests.swift in Sources */,
 				C0DE56010000000000000001 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift in Sources */,
 					62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */,
+				5E27010A0000000000000001 /* SleepyModeKeepAwakeReconcileTests.swift in Sources */,
 				5830CA11BAC0000000000002 /* SocketCallbackAwaiterMainThreadTests.swift in Sources */,
 						F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 				F6724600A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift in Sources */,

--- a/cmuxTests/SleepyModeKeepAwakeReconcileTests.swift
+++ b/cmuxTests/SleepyModeKeepAwakeReconcileTests.swift
@@ -1,0 +1,75 @@
+import CmuxWorkspaces
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Truth table for `SleepyModeController.shouldKeepAwake(...)` and the
+/// `anyAgentWorking(in:)` busy classification. These pin the two-owner
+/// power-assertion contract: the Sleepy Mode screensaver and Amphetamine Mode
+/// are independent hold-reasons, and neither may release an assertion the other
+/// still needs (issue #7537).
+@Suite
+struct SleepyModeKeepAwakeReconcileTests {
+    // MARK: shouldKeepAwake truth table
+
+    @Test func screensaverActiveAlwaysKeepsAwake() {
+        // Screensaver holds even with the setting off and no agent working.
+        #expect(SleepyModeController.shouldKeepAwake(
+            screensaverActive: true, keepAwakeSetting: false, anyAgentWorking: false))
+    }
+
+    @Test func amphetamineKeepsAwakeWhenSettingOnAndAgentWorking() {
+        #expect(SleepyModeController.shouldKeepAwake(
+            screensaverActive: false, keepAwakeSetting: true, anyAgentWorking: true))
+    }
+
+    @Test func idleAgentDoesNotKeepAwake() {
+        #expect(!SleepyModeController.shouldKeepAwake(
+            screensaverActive: false, keepAwakeSetting: true, anyAgentWorking: false))
+    }
+
+    @Test func settingOffDoesNotKeepAwakeEvenIfAgentWorking() {
+        #expect(!SleepyModeController.shouldKeepAwake(
+            screensaverActive: false, keepAwakeSetting: false, anyAgentWorking: true))
+    }
+
+    @Test func nothingActiveReleases() {
+        #expect(!SleepyModeController.shouldKeepAwake(
+            screensaverActive: false, keepAwakeSetting: false, anyAgentWorking: false))
+    }
+
+    /// Regression guard for the clobber bug: an Amphetamine hold must survive the
+    /// screensaver closing while an agent is still working.
+    @Test func amphetamineHoldSurvivesScreensaverClose() {
+        // Screensaver open on top of an active amphetamine hold.
+        #expect(SleepyModeController.shouldKeepAwake(
+            screensaverActive: true, keepAwakeSetting: true, anyAgentWorking: true))
+        // Screensaver closes; agent still working -> STILL awake.
+        #expect(SleepyModeController.shouldKeepAwake(
+            screensaverActive: false, keepAwakeSetting: true, anyAgentWorking: true))
+    }
+
+    // MARK: anyAgentWorking(in:)
+
+    @Test func anyAgentWorkingDetectsCommandRunning() {
+        #expect(SleepyModeController.anyAgentWorking(in: [
+            [.promptIdle],
+            [.commandRunning, .promptIdle],
+        ]))
+    }
+
+    @Test func anyAgentWorkingFalseWhenAllIdleOrUnknown() {
+        #expect(!SleepyModeController.anyAgentWorking(in: [
+            [.promptIdle, .unknown],
+            [],
+        ]))
+    }
+
+    @Test func anyAgentWorkingFalseWhenNoWorkspaces() {
+        #expect(!SleepyModeController.anyAgentWorking(in: []))
+    }
+}


### PR DESCRIPTION
## Summary

- **What changed?** Adds an opt-in "Amphetamine Mode" to Sleepy Mode: a `keepAwakeWhileAgentsActive` setting (default off) that holds IOKit system/display sleep-prevention assertions while any open workspace panel is in `commandRunning`, and releases them once all agents go idle. Toggle lives in Settings → Sleepy Mode; persisted in UserDefaults; localized (en/ja) with updated search aliases. `SleepyModeController` routes all assertion begin/end through a single `reconcilePowerAssertions()` using `shouldKeepAwake(screensaver || (setting && agentBusy))`.
- **Why?** Closes #7537. Long-running agents were letting the Mac sleep mid-command. It also fixes an assertion-clobber bug: OR-ing screensaver and agent activity means closing the screensaver no longer drops a still-needed agent hold.

## Testing

- **Automated (Swift Testing):**
  - `SleepyModeKeepAwakeReconcileTests` — full `shouldKeepAwake` truth table (screensaver-only, setting+agent-working, idle agent, setting-off-while-working, nothing-active-releases), the screensaver-close regression (`amphetamineHoldSurvivesScreensaverClose`), and `anyAgentWorking(in:)` classification (command-running detected, idle/unknown/no-workspaces → false).
  - `SleepyModeKeepAwakeSettingTests` — defaults-to-off, persists across store reload, writes under the expected key, toggling off persists false.
- **Manual:** Built the tagged Debug app via `./scripts/reload.sh --tag`, toggled the setting in Settings → Sleepy Mode, confirmed the assertion is held while an agent runs a command and released when idle, and that toggling the setting reconciles immediately (no 5s wait).

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: _TODO_

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved
