### PR TITLE
Reconcile sidebar hover after view updates

### DIFF
--- a/Sources/Sidebar/SidebarWorkspaceRowHoverReconciler.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverReconciler.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct SidebarWorkspaceRowHoverReconciler: NSViewRepresentable {
+    let trackedPointerHovering: Bool
     let onPointerHoverChanged: (Bool) -> Void
 
     func makeNSView(context: Context) -> SidebarWorkspaceRowHoverReconcilerView {
@@ -11,6 +12,6 @@ struct SidebarWorkspaceRowHoverReconciler: NSViewRepresentable {
 
     func updateNSView(_ nsView: SidebarWorkspaceRowHoverReconcilerView, context: Context) {
         nsView.onPointerHoverChanged = onPointerHoverChanged
-        nsView.reconcileCurrentPointerLocation()
+        nsView.reconcileCurrentPointerLocation(repairing: trackedPointerHovering)
     }
 }

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverReconciler.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverReconciler.swift
@@ -11,5 +11,6 @@ struct SidebarWorkspaceRowHoverReconciler: NSViewRepresentable {
 
     func updateNSView(_ nsView: SidebarWorkspaceRowHoverReconcilerView, context: Context) {
         nsView.onPointerHoverChanged = onPointerHoverChanged
+        nsView.reconcileCurrentPointerLocation()
     }
 }

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
@@ -38,16 +38,23 @@ final class SidebarWorkspaceRowHoverReconcilerView: NSView {
         reportPointerHovering(false)
     }
 
-    func reconcileCurrentPointerLocation() {
+    func reconcileCurrentPointerLocation(repairing trackedPointerHovering: Bool? = nil) {
         guard let window else {
-            reportPointerHovering(false)
+            reportPointerHovering(false, force: trackedPointerHovering == true)
             return
         }
-        reconcilePointerLocation(pointInView: convert(window.mouseLocationOutsideOfEventStream, from: nil))
+        reconcilePointerLocation(
+            pointInView: convert(window.mouseLocationOutsideOfEventStream, from: nil),
+            repairing: trackedPointerHovering
+        )
     }
 
-    func reconcilePointerLocation(pointInView: NSPoint) {
-        reportPointerHovering(bounds.contains(pointInView), force: true)
+    func reconcilePointerLocation(pointInView: NSPoint, repairing trackedPointerHovering: Bool? = nil) {
+        let pointerHovering = bounds.contains(pointInView)
+        reportPointerHovering(
+            pointerHovering,
+            force: trackedPointerHovering.map { $0 != pointerHovering } ?? false
+        )
     }
 
     private func reportPointerHovering(_ hovering: Bool, force: Bool = false) {

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverTrackingModifier.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverTrackingModifier.swift
@@ -6,7 +6,9 @@ struct SidebarWorkspaceRowHoverTrackingModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .overlay {
-                SidebarWorkspaceRowHoverReconciler { hovering in
+                SidebarWorkspaceRowHoverReconciler(
+                    trackedPointerHovering: rowInteractionState.trackedPointerHovering
+                ) { hovering in
                     rowInteractionState.setPointerHovering(hovering)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -93,6 +93,10 @@ struct SidebarWorkspaceRowInteractionState: Equatable {
     private var contextMenuTrackingObserverInstalled = false
     private var deferredPointerHoveringWhileContextMenu: Bool?
 
+    var trackedPointerHovering: Bool {
+        deferredPointerHoveringWhileContextMenu ?? isPointerHovering
+    }
+
     mutating func setPointerHovering(_ hovering: Bool) {
         if contextMenuVisible {
             if hovering || contextMenuTrackingObserverInstalled {

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -426,6 +426,7 @@ import Testing
 
         state.setPointerHovering(false)
         #expect(!state.shouldShowCloseButton(canCloseWorkspace: true, shortcutHintModeActive: false))
+        view.onPointerHoverChanged = { state.setPointerHovering($0) }
 
         view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
 

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -428,7 +428,7 @@ import Testing
         #expect(!state.shouldShowCloseButton(canCloseWorkspace: true, shortcutHintModeActive: false))
         view.onPointerHoverChanged = { state.setPointerHovering($0) }
 
-        view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+        view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14), repairing: state.trackedPointerHovering)
 
         #expect(
             state.shouldShowCloseButton(


### PR DESCRIPTION
Follow-up to #7545 for #7539. #7545 was merged at c0beaf7b34 while autoreview was still running; this PR carries the remaining structured-review fix so the AppKit hover reconciler also resyncs during NSViewRepresentable updates, not only tracking-area changes.

## Summary
- reconcile current pointer location after updating the AppKit hover callback
- extend the regression test to cover callback replacement after hover state reset

## Test plan
- git diff --check
- python3 scripts/swift_file_length_budget.py
- ./scripts/lint-pbxproj-test-wiring.sh
- ./scripts/check-pbxproj.sh
- ./scripts/reload.sh --tag issue-7539-sidebar-close-hover

## Notes
- Did not launch the dogfood app.
- Local Xcode tests/XCUITests were not run on this Mac per project constraints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sidebar hover/UI interaction logic with a targeted regression test; no auth, data, or core infrastructure changes.
> 
> **Overview**
> Fixes sidebar workspace row close affordance disappearing when SwiftUI clears hover during sidebar updates or row reuse while the pointer is still over the row.
> 
> **`SidebarWorkspaceRowHoverReconciler`** now takes SwiftUI’s **`trackedPointerHovering`** (including deferred hover while a context menu is open) and, on every **`updateNSView`**, re-runs pointer reconciliation—not only on tracking-area or mouse events.
> 
> **`SidebarWorkspaceRowHoverReconcilerView`** adds an optional **repair** path: when tracked hover disagrees with geometry, it **forces** a hover callback so state can be restored without another mouse move.
> 
> **`SidebarWorkspaceRowInteractionState`** exposes **`trackedPointerHovering`** for that repair signal. A regression test covers callback replacement after a deliberate hover reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099e580d616ca02348c526eb8f59e7a86169aa8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar hover handling so pointer state stays accurate after context menus and other hover-state changes.
  * Fixed hover reconciliation to restore the correct row interaction state more reliably, including close-button visibility.
  * Updated related behavior to better preserve the current hover state when the pointer is already over a row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->