### PR TITLE
Stabilize TestFlight eligibility tests

### DIFF
--- a/web/tests/dashboard-testflight-page.test.tsx
+++ b/web/tests/dashboard-testflight-page.test.tsx
@@ -148,7 +148,7 @@ async function renderTestflightPage(searchParams: Record<string, string> = {}) {
 
 function testflightUser({ eligible = true }: { eligible?: boolean } = {}) {
   return {
-    id: "",
+    id: "user-pro",
     isAnonymous: false,
     primaryEmail: "Pro@Example.com",
     displayName: "Pro User",

--- a/web/tests/dashboard-testflight-page.test.tsx
+++ b/web/tests/dashboard-testflight-page.test.tsx
@@ -16,6 +16,7 @@ const getUser = mock(async () => currentUser);
 const isTestflightEligible = mock(async (user: unknown) =>
   testflightUserEligibility(user) ?? false,
 );
+const billingProModule = await import("../services/billing/pro");
 const ascFetch = mock(async (path: unknown) => {
   if (String(path).startsWith("/v1/betaTesters?")) {
     return {
@@ -82,6 +83,7 @@ mock.module("../services/errors", () => ({
 }));
 
 mock.module("@/services/billing/pro", () => ({
+  ...billingProModule,
   isTestflightEligible,
 }));
 

--- a/web/tests/dashboard-testflight-page.test.tsx
+++ b/web/tests/dashboard-testflight-page.test.tsx
@@ -2,19 +2,19 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import enMessages from "../messages/en.json";
-import { createTestflightUser } from "./helpers/testflight-user";
+import {
+  createTestflightUser,
+  testflightUserEligibility,
+} from "./helpers/testflight-user";
 
 let stackConfigured = true;
-let currentUser: ReturnType<typeof createPageTestflightUser> | null = null;
+let currentUser: ReturnType<typeof createTestflightUser> | null = null;
 let ascConfigured = true;
 let status = { enrolled: false } as { enrolled: boolean; state?: string };
-const eligibilityByUser = new WeakMap<object, boolean>();
 
 const getUser = mock(async () => currentUser);
 const isTestflightEligible = mock(async (user: unknown) =>
-  user && typeof user === "object"
-    ? eligibilityByUser.get(user) ?? true
-    : true,
+  testflightUserEligibility(user) ?? false,
 );
 const ascFetch = mock(async (path: unknown) => {
   if (String(path).startsWith("/v1/betaTesters?")) {
@@ -90,7 +90,7 @@ const { default: DashboardTestflightPage } = await import("../app/[locale]/dashb
 describe("dashboard TestFlight page", () => {
   beforeEach(() => {
     stackConfigured = true;
-    currentUser = createPageTestflightUser();
+    currentUser = createTestflightUser();
     ascConfigured = true;
     status = { enrolled: false };
     getUser.mockClear();
@@ -100,7 +100,7 @@ describe("dashboard TestFlight page", () => {
   });
 
   test("renders not eligible state with pricing link", async () => {
-    currentUser = createPageTestflightUser({ eligible: false });
+    currentUser = createTestflightUser({ eligible: false });
 
     const html = await renderTestflightPage();
 
@@ -156,14 +156,6 @@ async function renderTestflightPage(searchParams: Record<string, string> = {}) {
     searchParams: Promise.resolve(searchParams),
   });
   return renderToStaticMarkup(element);
-}
-
-function createPageTestflightUser({
-  eligible = true,
-}: { eligible?: boolean } = {}) {
-  const user = createTestflightUser({ eligible });
-  eligibilityByUser.set(user, eligible);
-  return user;
 }
 
 function translator(namespace?: string) {

--- a/web/tests/dashboard-testflight-page.test.tsx
+++ b/web/tests/dashboard-testflight-page.test.tsx
@@ -4,36 +4,9 @@ import { renderToStaticMarkup } from "react-dom/server";
 import enMessages from "../messages/en.json";
 
 let stackConfigured = true;
-let currentUser: typeof testflightUser | null = null;
-let eligible = true;
+let currentUser: ReturnType<typeof testflightUser> | null = null;
 let ascConfigured = true;
 let status = { enrolled: false } as { enrolled: boolean; state?: string };
-
-const testflightUser = {
-  id: "user-pro",
-  isAnonymous: false,
-  primaryEmail: "Pro@Example.com",
-  displayName: "Pro User",
-  clientReadOnlyMetadata: {},
-  listProducts: mock(async () =>
-    Object.assign(
-      eligible
-        ? [
-            {
-              id: "pro",
-              quantity: 1,
-              subscription: {
-                cancelAtPeriodEnd: false,
-                currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
-              },
-            },
-          ]
-        : [],
-      { nextCursor: null },
-    ),
-  ),
-  update: mock(async () => undefined),
-};
 
 const getUser = mock(async () => currentUser);
 const ascFetch = mock(async (path: unknown) => {
@@ -106,19 +79,16 @@ const { default: DashboardTestflightPage } = await import("../app/[locale]/dashb
 describe("dashboard TestFlight page", () => {
   beforeEach(() => {
     stackConfigured = true;
-    currentUser = testflightUser;
-    eligible = true;
+    currentUser = testflightUser();
     ascConfigured = true;
     status = { enrolled: false };
     getUser.mockClear();
-    testflightUser.listProducts.mockClear();
-    testflightUser.update.mockClear();
     ascFetch.mockClear();
     captureAscError.mockClear();
   });
 
   test("renders not eligible state with pricing link", async () => {
-    eligible = false;
+    currentUser = testflightUser({ eligible: false });
 
     const html = await renderTestflightPage();
 
@@ -174,6 +144,34 @@ async function renderTestflightPage(searchParams: Record<string, string> = {}) {
     searchParams: Promise.resolve(searchParams),
   });
   return renderToStaticMarkup(element);
+}
+
+function testflightUser({ eligible = true }: { eligible?: boolean } = {}) {
+  return {
+    id: "",
+    isAnonymous: false,
+    primaryEmail: "Pro@Example.com",
+    displayName: "Pro User",
+    clientReadOnlyMetadata: {},
+    listProducts: mock(async () =>
+      Object.assign(
+        eligible
+          ? [
+              {
+                id: "pro",
+                quantity: 1,
+                subscription: {
+                  cancelAtPeriodEnd: false,
+                  currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
+                },
+              },
+            ]
+          : [],
+        { nextCursor: null },
+      ),
+    ),
+    update: mock(async () => undefined),
+  };
 }
 
 function translator(namespace?: string) {

--- a/web/tests/dashboard-testflight-page.test.tsx
+++ b/web/tests/dashboard-testflight-page.test.tsx
@@ -7,8 +7,14 @@ let stackConfigured = true;
 let currentUser: ReturnType<typeof testflightUser> | null = null;
 let ascConfigured = true;
 let status = { enrolled: false } as { enrolled: boolean; state?: string };
+const eligibilityByUser = new WeakMap<object, boolean>();
 
 const getUser = mock(async () => currentUser);
+const isTestflightEligible = mock(async (user: unknown) =>
+  user && typeof user === "object"
+    ? eligibilityByUser.get(user) ?? true
+    : true,
+);
 const ascFetch = mock(async (path: unknown) => {
   if (String(path).startsWith("/v1/betaTesters?")) {
     return {
@@ -74,6 +80,10 @@ mock.module("../services/errors", () => ({
   captureBillingError: mock(() => undefined),
 }));
 
+mock.module("@/services/billing/pro", () => ({
+  isTestflightEligible,
+}));
+
 const { default: DashboardTestflightPage } = await import("../app/[locale]/dashboard/testflight/page");
 
 describe("dashboard TestFlight page", () => {
@@ -83,6 +93,7 @@ describe("dashboard TestFlight page", () => {
     ascConfigured = true;
     status = { enrolled: false };
     getUser.mockClear();
+    isTestflightEligible.mockClear();
     ascFetch.mockClear();
     captureAscError.mockClear();
   });
@@ -147,7 +158,7 @@ async function renderTestflightPage(searchParams: Record<string, string> = {}) {
 }
 
 function testflightUser({ eligible = true }: { eligible?: boolean } = {}) {
-  return {
+  const user = {
     id: "user-pro",
     isAnonymous: false,
     primaryEmail: "Pro@Example.com",
@@ -172,6 +183,8 @@ function testflightUser({ eligible = true }: { eligible?: boolean } = {}) {
     ),
     update: mock(async () => undefined),
   };
+  eligibilityByUser.set(user, eligible);
+  return user;
 }
 
 function translator(namespace?: string) {

--- a/web/tests/dashboard-testflight-page.test.tsx
+++ b/web/tests/dashboard-testflight-page.test.tsx
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import enMessages from "../messages/en.json";
+import { createTestflightUser } from "./helpers/testflight-user";
 
 let stackConfigured = true;
-let currentUser: ReturnType<typeof testflightUser> | null = null;
+let currentUser: ReturnType<typeof createPageTestflightUser> | null = null;
 let ascConfigured = true;
 let status = { enrolled: false } as { enrolled: boolean; state?: string };
 const eligibilityByUser = new WeakMap<object, boolean>();
@@ -89,7 +90,7 @@ const { default: DashboardTestflightPage } = await import("../app/[locale]/dashb
 describe("dashboard TestFlight page", () => {
   beforeEach(() => {
     stackConfigured = true;
-    currentUser = testflightUser();
+    currentUser = createPageTestflightUser();
     ascConfigured = true;
     status = { enrolled: false };
     getUser.mockClear();
@@ -99,7 +100,7 @@ describe("dashboard TestFlight page", () => {
   });
 
   test("renders not eligible state with pricing link", async () => {
-    currentUser = testflightUser({ eligible: false });
+    currentUser = createPageTestflightUser({ eligible: false });
 
     const html = await renderTestflightPage();
 
@@ -157,32 +158,10 @@ async function renderTestflightPage(searchParams: Record<string, string> = {}) {
   return renderToStaticMarkup(element);
 }
 
-function testflightUser({ eligible = true }: { eligible?: boolean } = {}) {
-  const user = {
-    id: "user-pro",
-    isAnonymous: false,
-    primaryEmail: "Pro@Example.com",
-    displayName: "Pro User",
-    clientReadOnlyMetadata: {},
-    listProducts: mock(async () =>
-      Object.assign(
-        eligible
-          ? [
-              {
-                id: "pro",
-                quantity: 1,
-                subscription: {
-                  cancelAtPeriodEnd: false,
-                  currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
-                },
-              },
-            ]
-          : [],
-        { nextCursor: null },
-      ),
-    ),
-    update: mock(async () => undefined),
-  };
+function createPageTestflightUser({
+  eligible = true,
+}: { eligible?: boolean } = {}) {
+  const user = createTestflightUser({ eligible });
   eligibilityByUser.set(user, eligible);
   return user;
 }

--- a/web/tests/helpers/testflight-user.ts
+++ b/web/tests/helpers/testflight-user.ts
@@ -1,9 +1,11 @@
 import { mock } from "bun:test";
 
+const testflightEligibilityKey = Symbol.for("cmux.tests.testflightEligibility");
+
 export function createTestflightUser({
   eligible = true,
 }: { eligible?: boolean } = {}) {
-  return {
+  const user = {
     id: "user-pro",
     isAnonymous: false,
     primaryEmail: "Pro@Example.com",
@@ -18,7 +20,7 @@ export function createTestflightUser({
                 quantity: 1,
                 subscription: {
                   cancelAtPeriodEnd: false,
-                  currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
+                  currentPeriodEnd: null,
                 },
               },
             ]
@@ -28,4 +30,15 @@ export function createTestflightUser({
     ),
     update: mock(async () => undefined),
   };
+  Object.defineProperty(user, testflightEligibilityKey, {
+    value: eligible,
+    enumerable: false,
+  });
+  return user;
+}
+
+export function testflightUserEligibility(user: unknown): boolean | undefined {
+  if (!user || typeof user !== "object") return undefined;
+  const value = (user as Record<symbol, unknown>)[testflightEligibilityKey];
+  return typeof value === "boolean" ? value : undefined;
 }

--- a/web/tests/helpers/testflight-user.ts
+++ b/web/tests/helpers/testflight-user.ts
@@ -1,0 +1,31 @@
+import { mock } from "bun:test";
+
+export function createTestflightUser({
+  eligible = true,
+}: { eligible?: boolean } = {}) {
+  return {
+    id: "user-pro",
+    isAnonymous: false,
+    primaryEmail: "Pro@Example.com",
+    displayName: "Pro User",
+    clientReadOnlyMetadata: {},
+    listProducts: mock(async () =>
+      Object.assign(
+        eligible
+          ? [
+              {
+                id: "pro",
+                quantity: 1,
+                subscription: {
+                  cancelAtPeriodEnd: false,
+                  currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
+                },
+              },
+            ]
+          : [],
+        { nextCursor: null },
+      ),
+    ),
+    update: mock(async () => undefined),
+  };
+}

--- a/web/tests/testflight-route.test.ts
+++ b/web/tests/testflight-route.test.ts
@@ -1,10 +1,16 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { NextRequest } from "next/server";
+
+const dbClientModule = await import("../db/client");
+const realCloudDb = dbClientModule.cloudDb;
+const realCloseCloudDbForTests = dbClientModule.closeCloudDbForTests;
+const realCreateAwsRdsIamPool = dbClientModule.createAwsRdsIamPool;
 
 let stackConfigured = true;
 let ascConfigured = true;
 let currentUser = testflightUser();
 let user: typeof currentUser | null = currentUser;
+let useStubDb = false;
 
 const getUser = mock(async () => user);
 const ascFetch = mock(async (path: unknown) => {
@@ -43,18 +49,31 @@ mock.module("../services/errors", () => ({
 }));
 
 mock.module("../db/client", () => ({
-  cloudDb: () => ({
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: async () => [],
-        }),
-      }),
-    }),
-  }),
+  createAwsRdsIamPool: realCreateAwsRdsIamPool,
+  closeCloudDbForTests: realCloseCloudDbForTests,
+  cloudDb: (() =>
+    useStubDb
+      ? ({
+          select: () => ({
+            from: () => ({
+              where: () => ({
+                limit: async () => [],
+              }),
+            }),
+          }),
+        } as unknown as ReturnType<typeof realCloudDb>)
+      : realCloudDb()) as typeof realCloudDb,
 }));
 
 const { POST } = await import("../app/api/testflight/route");
+
+beforeAll(() => {
+  useStubDb = true;
+});
+
+afterAll(() => {
+  useStubDb = false;
+});
 
 describe("TestFlight route", () => {
   beforeEach(() => {
@@ -201,7 +220,7 @@ function postAction(
 
 function testflightUser({ eligible = true }: { eligible?: boolean } = {}) {
   return {
-    id: "",
+    id: "user-pro",
     isAnonymous: false,
     primaryEmail: "Pro@Example.com",
     displayName: "Pro User",

--- a/web/tests/testflight-route.test.ts
+++ b/web/tests/testflight-route.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { NextRequest } from "next/server";
 
+import { createTestflightUser } from "./helpers/testflight-user";
+
 const dbClientModule = await import("../db/client");
 const realCloudDb = dbClientModule.cloudDb;
 const realCloseCloudDbForTests = dbClientModule.closeCloudDbForTests;
@@ -8,7 +10,7 @@ const realCreateAwsRdsIamPool = dbClientModule.createAwsRdsIamPool;
 
 let stackConfigured = true;
 let ascConfigured = true;
-let currentUser = testflightUser();
+let currentUser = createTestflightUser();
 let user: typeof currentUser | null = currentUser;
 let useStubDb = false;
 
@@ -79,7 +81,7 @@ describe("TestFlight route", () => {
   beforeEach(() => {
     stackConfigured = true;
     ascConfigured = true;
-    currentUser = testflightUser();
+    currentUser = createTestflightUser();
     user = currentUser;
     getUser.mockClear();
     ascFetch.mockClear();
@@ -120,7 +122,7 @@ describe("TestFlight route", () => {
   });
 
   test("does not enroll ineligible users", async () => {
-    currentUser = testflightUser({ eligible: false });
+    currentUser = createTestflightUser({ eligible: false });
     user = currentUser;
 
     const response = await postAction("join");
@@ -216,34 +218,6 @@ function postAction(
       body: new URLSearchParams({ action }),
     }),
   );
-}
-
-function testflightUser({ eligible = true }: { eligible?: boolean } = {}) {
-  return {
-    id: "user-pro",
-    isAnonymous: false,
-    primaryEmail: "Pro@Example.com",
-    displayName: "Pro User",
-    clientReadOnlyMetadata: {},
-    listProducts: mock(async () =>
-      Object.assign(
-        eligible
-          ? [
-              {
-                id: "pro",
-                quantity: 1,
-                subscription: {
-                  cancelAtPeriodEnd: false,
-                  currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
-                },
-              },
-            ]
-          : [],
-        { nextCursor: null },
-      ),
-    ),
-    update: mock(async () => undefined),
-  };
 }
 
 function callInit(index: number): RequestInit {

--- a/web/tests/testflight-route.test.ts
+++ b/web/tests/testflight-route.test.ts
@@ -1,35 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { NextRequest } from "next/server";
 
-const currentUser = {
-  id: "user-pro",
-  isAnonymous: false,
-  primaryEmail: "Pro@Example.com",
-  displayName: "Pro User",
-  clientReadOnlyMetadata: {},
-  listProducts: mock(async () =>
-    Object.assign(
-      eligible
-        ? [
-            {
-              id: "pro",
-              quantity: 1,
-              subscription: {
-                cancelAtPeriodEnd: false,
-                currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
-              },
-            },
-          ]
-        : [],
-      { nextCursor: null },
-    ),
-  ),
-  update: mock(async () => undefined),
-};
-
 let stackConfigured = true;
 let ascConfigured = true;
-let eligible = true;
+let currentUser = testflightUser();
 let user: typeof currentUser | null = currentUser;
 
 const getUser = mock(async () => user);
@@ -86,11 +60,9 @@ describe("TestFlight route", () => {
   beforeEach(() => {
     stackConfigured = true;
     ascConfigured = true;
-    eligible = true;
+    currentUser = testflightUser();
     user = currentUser;
     getUser.mockClear();
-    currentUser.listProducts.mockClear();
-    currentUser.update.mockClear();
     ascFetch.mockClear();
     captureAscError.mockClear();
     mockImplementation(ascFetch, async (path: unknown) => {
@@ -129,7 +101,8 @@ describe("TestFlight route", () => {
   });
 
   test("does not enroll ineligible users", async () => {
-    eligible = false;
+    currentUser = testflightUser({ eligible: false });
+    user = currentUser;
 
     const response = await postAction("join");
 
@@ -224,6 +197,34 @@ function postAction(
       body: new URLSearchParams({ action }),
     }),
   );
+}
+
+function testflightUser({ eligible = true }: { eligible?: boolean } = {}) {
+  return {
+    id: "",
+    isAnonymous: false,
+    primaryEmail: "Pro@Example.com",
+    displayName: "Pro User",
+    clientReadOnlyMetadata: {},
+    listProducts: mock(async () =>
+      Object.assign(
+        eligible
+          ? [
+              {
+                id: "pro",
+                quantity: 1,
+                subscription: {
+                  cancelAtPeriodEnd: false,
+                  currentPeriodEnd: new Date("2026-12-01T00:00:00Z"),
+                },
+              },
+            ]
+          : [],
+        { nextCursor: null },
+      ),
+    ),
+    update: mock(async () => undefined),
+  };
 }
 
 function callInit(index: number): RequestInit {


### PR DESCRIPTION
## Summary
- isolate TestFlight route/page test users so eligibility does not depend on shared mutable state
- keep the existing ineligible redirect assertion and ASC no-write expectation

## Verification
- cd web && bun test tests/testflight-route.test.ts
- cd web && bun test tests/dashboard-testflight-page.test.tsx
- cd web && bun run typecheck
- cd web && bun test $(ls tests/*.test.ts tests/*.test.tsx | sort)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786063808&installation_id=133855650&pr_number=7555&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7555&signature=6d38f23bd7bc2614a46ba02847e470d665556f9bc6429821d204a46b49bbb2dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test helpers and mocks; production TestFlight and billing code paths are untouched.
> 
> **Overview**
> **Test-only refactor** so TestFlight dashboard and API route specs no longer drive eligibility through a shared mutable `eligible` flag or duplicated inline user objects.
> 
> Adds `tests/helpers/testflight-user.ts` with **`createTestflightUser({ eligible })`**, which still mocks `listProducts` / `update` but also stores eligibility on a non-enumerable **`Symbol.for("cmux.tests.testflightEligibility")`**. Dashboard tests spread the real billing module and replace **`isTestflightEligible`** with a mock that reads that symbol per user. Route tests build users from the same factory and toggle ineligibility by passing `{ eligible: false }` instead of flipping global state.
> 
> The route suite’s **`db/client` mock** now forwards **`createAwsRdsIamPool`**, **`closeCloudDbForTests`**, and the real **`cloudDb`** by default, and only swaps in the stubbed query chain when **`useStubDb`** is set in **`beforeAll`** / cleared in **`afterAll`**. Existing expectations (ineligible redirect, no ASC writes when ineligible) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe9cd6899111afcf18b618994b864dc1e33da34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes TestFlight eligibility tests by using a shared `createTestflightUser` with per-user eligibility stored on a hidden `Symbol`. Existing ineligible redirect and ASC no-write checks remain.

- **Refactors**
  - Added `tests/helpers/testflight-user.ts` with `createTestflightUser({ eligible })` and `testflightUserEligibility` (non-enumerable `Symbol`).
  - Dashboard tests: preserve all `@/services/billing/pro` exports and override only `isTestflightEligible` to read the symbol; reset between tests.
  - Route tests: re-export real `db/client` helpers and default `cloudDb`; enable a stubbed query chain only when `useStubDb` is set in `beforeAll` and cleared in `afterAll`.

<sup>Written for commit 0fe9cd6899111afcf18b618994b864dc1e33da34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored TestFlight route and dashboard tests to use per-user eligibility fixtures instead of a shared global flag.
  * Added a dedicated TestFlight user factory for tests, with mocked product listing and update behavior based on eligibility.
  * Improved eligibility mocking to be user-specific and to default safely when eligibility is unknown.
  * Updated test setup/teardown to reinitialize users and reset only the appropriate mocks.
  * Switched database mocking to a hybrid approach (stubbed query chain when enabled, real client otherwise).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->