### PR TITLE
Classify transient session-refresh failures as retryable instead of "not signed in"

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -103,9 +103,9 @@
 947	Sources/TerminalNotificationPolicy.swift
 945	Sources/SessionIndexRegisteredAgents.swift
 944	Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+943	Sources/Cloud/VMClient.swift
 942	Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceMacSelectionTests.swift
 937	Sources/TextBoxMentionIndexStore.swift
-932	Sources/Cloud/VMClient.swift
 929	Sources/Panels/TerminalPanel.swift
 918	Sources/Panels/BrowserPopupWindowController.swift
 905	Sources/CmuxSSHURLRequest.swift

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
@@ -93,10 +93,17 @@ extension AuthCoordinator {
     /// refresh-token-only start and report "Not signed in" even though a valid
     /// session becomes available moments later.
     /// - Returns: The access and refresh tokens.
-    /// - Throws: ``AuthError/unauthorized`` when either token is missing.
+    /// - Throws: ``AuthError/networkError`` when the access token is missing
+    ///   but a refresh token survives, meaning the refresh failed transiently;
+    ///   ``AuthError/unauthorized`` when the session is missing either an access
+    ///   token with no refresh token to recover from, or the refresh token
+    ///   required by backend requests.
     public func currentTokens() async throws -> (accessToken: String, refreshToken: String) {
         await awaitBootstrapped()
         guard let access = await client.accessToken(), !access.isEmpty else {
+            if let refresh = await client.refreshToken(), !refresh.isEmpty {
+                throw AuthError.networkError
+            }
             throw AuthError.unauthorized
         }
         guard let refresh = await client.refreshToken(), !refresh.isEmpty else {

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
@@ -435,6 +435,17 @@ import Testing
         }
     }
 
+    @Test func currentTokensThrowsNetworkErrorOnTransientRefreshFailure() async {
+        let client = FakeAuthClient(refresh: "refresh-1")
+        await client.setThrowOnCurrentUser(AuthError.networkError)
+        let (coordinator, _) = makeCoordinator(client: client)
+        coordinator.start()
+
+        await #expect(throws: AuthError.networkError) {
+            _ = try await coordinator.currentTokens()
+        }
+    }
+
     @Test func completeExternalSignInPublishesSeededSession() async throws {
         let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
         let client = FakeAuthClient(user: user)

--- a/Sources/Cloud/AIAccountsClient.swift
+++ b/Sources/Cloud/AIAccountsClient.swift
@@ -4,6 +4,7 @@ import Foundation
 
 enum AIAccountsClientError: Error, CustomStringConvertible {
     case notSignedIn
+    case sessionRefreshFailed
     case httpStatus(Int, String)
     case malformedResponse(String)
     case backendUnreachable(url: String, detail: String)
@@ -12,6 +13,8 @@ enum AIAccountsClientError: Error, CustomStringConvertible {
         switch self {
         case .notSignedIn:
             return "Not signed in. Run `cmux auth login`, then retry."
+        case .sessionRefreshFailed:
+            return "Signed in, but cmux could not refresh your session (network or server issue). Retry in a moment."
         case let .httpStatus(status, body):
             return AIAccountsClient.formatHTTPError(status: status, body: body)
         case let .malformedResponse(message):
@@ -109,6 +112,8 @@ actor AIAccountsClient {
         let tokens: (accessToken: String, refreshToken: String)
         do {
             tokens = try await auth.currentTokens()
+        } catch AuthError.networkError {
+            throw AIAccountsClientError.sessionRefreshFailed
         } catch {
             throw AIAccountsClientError.notSignedIn
         }

--- a/Sources/Cloud/RemotesClient.swift
+++ b/Sources/Cloud/RemotesClient.swift
@@ -7,6 +7,7 @@ import Foundation
 /// CLI can print a clear, actionable line for each failure mode.
 enum RemotesClientError: Error, CustomStringConvertible, Equatable {
     case notSignedIn
+    case sessionRefreshFailed
     case invalidRoute(String)
     case loopbackRoute(host: String)
     case notAttachable(host: String)
@@ -21,6 +22,8 @@ enum RemotesClientError: Error, CustomStringConvertible, Equatable {
         switch self {
         case .notSignedIn:
             return "Not signed in. Run `cmux auth login`, then retry."
+        case .sessionRefreshFailed:
+            return "Signed in, but cmux could not refresh your session (network or server issue). Retry in a moment."
         case let .invalidRoute(value):
             return "Invalid route '\(value)'. Use host:port, e.g. 100.64.1.2:51001 or my-mac.tailnet.ts.net:51001."
         case let .loopbackRoute(host):
@@ -140,6 +143,8 @@ actor RemotesClient {
         // this await `currentUser` reflects the restored session.
         do {
             _ = try await auth.currentTokens()
+        } catch AuthError.networkError {
+            throw RemotesClientError.sessionRefreshFailed
         } catch {
             throw RemotesClientError.notSignedIn
         }
@@ -232,6 +237,8 @@ actor RemotesClient {
         // until the session restores.
         do {
             _ = try await auth.currentTokens()
+        } catch AuthError.networkError {
+            throw RemotesClientError.sessionRefreshFailed
         } catch {
             throw RemotesClientError.notSignedIn
         }
@@ -327,6 +334,8 @@ actor RemotesClient {
         let tokens: (accessToken: String, refreshToken: String)
         do {
             tokens = try await auth.currentTokens()
+        } catch AuthError.networkError {
+            throw RemotesClientError.sessionRefreshFailed
         } catch {
             throw RemotesClientError.notSignedIn
         }

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -3,6 +3,7 @@ import Foundation
 
 enum VMClientError: Error, CustomStringConvertible {
     case notSignedIn
+    case sessionRefreshFailed
     case backendUnreachable(url: String, detail: String)
     case httpStatus(Int, String)
     case malformedResponse(String)
@@ -16,6 +17,14 @@ enum VMClientError: Error, CustomStringConvertible {
                 What to do:
                   cmux auth login
                   cmux auth status
+                """
+        case .sessionRefreshFailed:
+            return """
+                You are signed in, but cmux could not refresh your session (network or server issue).
+
+                What to do:
+                  Retry in a moment.
+                  If it keeps failing, run `cmux auth status` to check your session.
                 """
         case .backendUnreachable(let url, let detail):
             return """
@@ -724,6 +733,8 @@ actor VMClient {
         let tokens: (accessToken: String, refreshToken: String)
         do {
             tokens = try await auth.currentTokens()
+        } catch AuthError.networkError {
+            throw VMClientError.sessionRefreshFailed
         } catch {
             throw VMClientError.notSignedIn
         }


### PR DESCRIPTION
During today's Cloud VM outage the panel showed "You are not signed in to cmux. What to do: cmux auth login" while `cmux auth status` truthfully reported signed in. The misdirection: `AuthCoordinator.currentTokens()` threw `AuthError.unauthorized` whenever the Stack SDK could not hand back an access token, even when the failure was a transient refresh error with a surviving refresh token, and `VMClient`/`RemotesClient`/`AIAccountsClient` blanket-mapped every `currentTokens()` error to their `.notSignedIn` case.

`currentTokens()` now mirrors `accessTokenWithoutStateClear()`'s classification: surviving refresh token → `AuthError.networkError` (retryable), no refresh token → `AuthError.unauthorized`. The three cloud clients map `networkError` to a new `sessionRefreshFailed` case that tells the user they are signed in and should retry; the signed-out path keeps the exact existing copy. No published auth state changes, no state clearing added.

Two-commit structure: commit 1 adds the regression test only (fails with `.unauthorized` thrown instead of `.networkError`), commit 2 adds the fix. Verified locally red then green; full `swift test --package-path Packages/Shared/CmuxAuthRuntime` passes (138 tests). Error strings follow the existing unlocalized plain-text convention of these CLI/socket `CustomStringConvertible` enums.

Outage context (server side, already fixed by applying pending migrations): https://github.com/manaflow-ai/cmux/issues/7553

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786064254&installation_id=133855650&pr_number=7556&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7556&signature=04576e950baec1d8a5acc4c29c933421c0423cb96734da82d2e6937cc63297e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth error classification and user-facing messages on Cloud VM, remotes, and AI accounts paths; behavior is narrow (no auth state clearing) but touches security-sensitive token handling.
> 
> **Overview**
> **`AuthCoordinator.currentTokens()`** now throws **`AuthError.networkError`** when the access token is missing but a refresh token remains, matching **`accessTokenWithoutStateClear()`**; only a session with no refresh path still yields **`AuthError.unauthorized`**.
> 
> **`VMClient`**, **`RemotesClient`**, and **`AIAccountsClient`** catch that case and surface a new **`sessionRefreshFailed`** error with copy that says the user is still signed in and should retry, instead of mapping every token failure to **not signed in**. A regression test covers the transient refresh path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37610722a3d740acceded245153e8991c2231a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies transient session-refresh failures as retryable instead of “not signed in,” so signed-in users see clear retry guidance across Cloud VM, Remotes, and AI Accounts.

- **Bug Fixes**
  - `AuthCoordinator.currentTokens()` now throws `AuthError.networkError` when the access token is missing but a refresh token exists; still throws `AuthError.unauthorized` when no refresh token is available.
  - `VMClient`, `RemotesClient`, and `AIAccountsClient` map `networkError` to a new `sessionRefreshFailed` with messages that say the user is signed in and should retry; the signed-out path is unchanged.
  - Added a regression test to ensure transient refresh failures are not reported as signed-out.
  - Updated `.github/swift-file-length-budget.tsv` to raise the budget for `Sources/Cloud/VMClient.swift` after adding the new error case.

<sup>Written for commit 37610722a3d740acceded245153e8991c2231a94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer session refresh failure messages across cloud sign-in and request flows.

* **Bug Fixes**
  * Improved authentication handling so a missing access token now distinguishes between a true sign-out and a temporary refresh failure.
  * Requests and device setup now report refresh problems separately instead of showing a generic “not signed in” error.
  * Added coverage for the transient refresh failure scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->