### PR TITLE
iOS browser: session restore, share/Safari/security chrome, desktop site toggle

### DIFF
--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSecurityIndicator.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSecurityIndicator.swift
@@ -31,6 +31,10 @@ public enum BrowserSecurityIndicator: Equatable, Sendable {
         self = .insecure
     }
 
+    // These helpers are static members rather than file-scope functions
+    // because scripts/lint-ios-package-conventions.sh forbids top-level
+    // funcs in iOS packages; the enum has cases, so it is a real value
+    // type, not a static namespace.
     private static func isLocalOrPrivateHost(_ host: String) -> Bool {
         let normalized = host.lowercased()
         if normalized == "localhost" || normalized.hasSuffix(".localhost") {

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSecurityIndicator.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSecurityIndicator.swift
@@ -1,0 +1,63 @@
+public import Foundation
+
+/// Computes the address-bar security indicator for a browser URL.
+public struct BrowserSecurityIndicator {
+    /// The visual security state shown next to the address.
+    public enum State: Equatable, Sendable {
+        /// An HTTPS page.
+        case secure
+        /// A public HTTP page.
+        case insecure
+        /// No indicator should be shown.
+        case none
+    }
+
+    private init() {}
+
+    /// Return the security indicator state for a URL.
+    ///
+    /// - Parameter url: The committed browser URL, or `nil` before navigation.
+    /// - Returns: The indicator state for the address bar.
+    public static func state(for url: URL?) -> State {
+        guard let url, let scheme = url.scheme?.lowercased() else { return .none }
+        if scheme == "https" { return .secure }
+        guard scheme == "http" else { return .none }
+        guard let host = url.host(percentEncoded: false), !isLocalOrPrivateHost(host) else {
+            return .none
+        }
+        return .insecure
+    }
+
+    private static func isLocalOrPrivateHost(_ host: String) -> Bool {
+        let normalized = host.lowercased()
+        if normalized == "localhost" || normalized.hasSuffix(".localhost") {
+            return true
+        }
+        if normalized == "::1" || normalized == "0:0:0:0:0:0:0:1" {
+            return true
+        }
+        if isPrivateOrLoopbackIPv4(normalized) {
+            return true
+        }
+        return isPrivateOrLoopbackIPv6(normalized)
+    }
+
+    private static func isPrivateOrLoopbackIPv4(_ host: String) -> Bool {
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4 else { return false }
+        let values = octets.compactMap { Int($0) }
+        guard values.count == 4, values.allSatisfy({ (0...255).contains($0) }) else { return false }
+        if values[0] == 127 { return true }
+        if values[0] == 10 { return true }
+        if values[0] == 192 && values[1] == 168 { return true }
+        if values[0] == 172 && (16...31).contains(values[1]) { return true }
+        return false
+    }
+
+    private static func isPrivateOrLoopbackIPv6(_ host: String) -> Bool {
+        if host.hasPrefix("fc") || host.hasPrefix("fd") {
+            return true
+        }
+        return host.hasPrefix("fe80:")
+    }
+}

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSecurityIndicator.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSecurityIndicator.swift
@@ -1,31 +1,34 @@
 public import Foundation
 
-/// Computes the address-bar security indicator for a browser URL.
-public struct BrowserSecurityIndicator {
-    /// The visual security state shown next to the address.
-    public enum State: Equatable, Sendable {
-        /// An HTTPS page.
-        case secure
-        /// A public HTTP page.
-        case insecure
-        /// No indicator should be shown.
-        case none
-    }
+/// The address-bar security indicator for a browser URL.
+public enum BrowserSecurityIndicator: Equatable, Sendable {
+    /// An HTTPS page.
+    case secure
+    /// A public HTTP page.
+    case insecure
+    /// No indicator should be shown.
+    case none
 
-    private init() {}
-
-    /// Return the security indicator state for a URL.
+    /// Classify the security indicator for a URL.
     ///
     /// - Parameter url: The committed browser URL, or `nil` before navigation.
-    /// - Returns: The indicator state for the address bar.
-    public static func state(for url: URL?) -> State {
-        guard let url, let scheme = url.scheme?.lowercased() else { return .none }
-        if scheme == "https" { return .secure }
-        guard scheme == "http" else { return .none }
-        guard let host = url.host(percentEncoded: false), !isLocalOrPrivateHost(host) else {
-            return .none
+    public init(url: URL?) {
+        guard let url, let scheme = url.scheme?.lowercased() else {
+            self = .none
+            return
         }
-        return .insecure
+        if scheme == "https" {
+            self = .secure
+            return
+        }
+        guard scheme == "http",
+              let host = url.host(percentEncoded: false),
+              !Self.isLocalOrPrivateHost(host)
+        else {
+            self = .none
+            return
+        }
+        self = .insecure
     }
 
     private static func isLocalOrPrivateHost(_ host: String) -> Bool {

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSecurityIndicator.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSecurityIndicator.swift
@@ -54,10 +54,24 @@ public enum BrowserSecurityIndicator: Equatable, Sendable {
         if values[0] == 10 { return true }
         if values[0] == 192 && values[1] == 168 { return true }
         if values[0] == 172 && (16...31).contains(values[1]) { return true }
+        // IPv4 link-local.
+        if values[0] == 169 && values[1] == 254 { return true }
+        // CGNAT 100.64.0.0/10 — Tailscale addresses live here, and Tailscale
+        // is the primary way cmux devices reach each other.
+        if values[0] == 100 && (64...127).contains(values[1]) { return true }
         return false
     }
 
     private static func isPrivateOrLoopbackIPv6(_ host: String) -> Bool {
+        // Only IPv6 literals contain ":" (the port is not part of `URL.host`).
+        // Ordinary DNS names must never match the ULA/link-local prefixes;
+        // e.g. fda.gov is a public host and keeps its HTTP warning.
+        guard host.contains(":") else { return false }
+        // IPv4-mapped IPv6 (`::ffff:127.0.0.1`) classifies by its embedded
+        // IPv4 address.
+        if host.hasPrefix("::ffff:") {
+            return isPrivateOrLoopbackIPv4(String(host.dropFirst("::ffff:".count)))
+        }
         if host.hasPrefix("fc") || host.hasPrefix("fd") {
             return true
         }

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSurfaceState.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSurfaceState.swift
@@ -61,6 +61,16 @@ public final class BrowserSurfaceState: Identifiable {
     /// The page's current committed URL, or `nil` before the first navigation.
     public var currentURL: URL?
 
+    /// The most recent WebKit interaction state for this surface.
+    ///
+    /// `WKWebView` instances are view-lifecycle objects and can be torn down
+    /// during workspace switches. This data lets a fresh web view restore the
+    /// page plus its back/forward list while the in-memory surface survives.
+    public var savedInteractionState: Data?
+
+    /// Whether subsequent page loads should request the desktop site.
+    public var prefersDesktopSite: Bool
+
     /// Whether a navigation is in flight. Drives the progress indicator and the
     /// reload/stop button affordance.
     public var isLoading: Bool
@@ -101,6 +111,8 @@ public final class BrowserSurfaceState: Identifiable {
         self.isAddressEditing = false
         self.title = nil
         self.currentURL = initialURL
+        self.savedInteractionState = nil
+        self.prefersDesktopSite = false
         self.isLoading = false
         self.estimatedProgress = 0
         self.canGoBack = false
@@ -117,6 +129,33 @@ public final class BrowserSurfaceState: Identifiable {
         loadRequest = url
         addressText = url.absoluteString
         lastErrorMessage = nil
+        savedInteractionState = nil
+    }
+
+    /// Store a new WebKit interaction-state snapshot when WebKit provides one.
+    ///
+    /// - Parameter data: The `WKWebView.interactionState` data snapshot, or
+    ///   `nil` when WebKit has no restorable state yet.
+    public func saveInteractionState(_ data: Data?) {
+        guard let data else { return }
+        savedInteractionState = data
+    }
+
+    /// Update the desktop-site preference and request a reload when a page is
+    /// already loaded.
+    ///
+    /// - Parameter value: Whether subsequent loads should prefer desktop mode.
+    public func setPrefersDesktopSite(_ value: Bool) {
+        guard prefersDesktopSite != value else { return }
+        prefersDesktopSite = value
+        if loadRequest == nil, currentURL != nil {
+            request(.reload)
+        }
+    }
+
+    /// Flip the desktop-site preference.
+    public func togglePrefersDesktopSite() {
+        setPrefersDesktopSite(!prefersDesktopSite)
     }
 
     /// Resolve and load whatever is currently in the address bar, returning

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSurfaceState.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSurfaceState.swift
@@ -86,8 +86,23 @@ public final class BrowserSurfaceState: Identifiable {
     /// the user toggles the desktop-site menu item.
     public var contentModePreference: ContentModePreference
 
-    /// Whether subsequent page loads request the desktop site.
-    public var prefersDesktopSite: Bool { contentModePreference == .desktop }
+    /// Whether this device's recommended WebKit content mode is desktop
+    /// (true on iPad, false on iPhone). Injected by the hosting view when the
+    /// web view attaches, so this package stays UIKit-free and the toggle's
+    /// label and first action are correct on iPads, whose default
+    /// ``ContentModePreference/recommended`` mode already loads desktop sites.
+    public var recommendedContentModeIsDesktop: Bool
+
+    /// Whether subsequent page loads request the desktop site, resolving
+    /// ``ContentModePreference/recommended`` to the device default. Drives the
+    /// menu label and the toggle direction.
+    public var prefersDesktopSite: Bool {
+        switch contentModePreference {
+        case .recommended: recommendedContentModeIsDesktop
+        case .mobile: false
+        case .desktop: true
+        }
+    }
 
     /// Whether a navigation is in flight. Drives the progress indicator and the
     /// reload/stop button affordance.
@@ -131,6 +146,7 @@ public final class BrowserSurfaceState: Identifiable {
         self.currentURL = initialURL
         self.savedInteractionState = nil
         self.contentModePreference = .recommended
+        self.recommendedContentModeIsDesktop = false
         self.isLoading = false
         self.estimatedProgress = 0
         self.canGoBack = false
@@ -171,10 +187,11 @@ public final class BrowserSurfaceState: Identifiable {
         }
     }
 
-    /// Flip the desktop-site preference. The first toggle forces the desktop
-    /// site; toggling back forces the mobile site (not the device default, so
-    /// "Request Mobile Site" is honored on iPads whose recommended mode is
-    /// desktop).
+    /// Flip the desktop-site preference relative to the current effective
+    /// mode. On iPhone the first toggle forces the desktop site; on iPad
+    /// (where ``recommendedContentModeIsDesktop`` is true) it forces the
+    /// mobile site. Explicit modes are forced, never the device default, so
+    /// the request is honored regardless of device.
     public func togglePrefersDesktopSite() {
         setContentModePreference(prefersDesktopSite ? .mobile : .desktop)
     }

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSurfaceState.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSurfaceState.swift
@@ -64,12 +64,30 @@ public final class BrowserSurfaceState: Identifiable {
     /// The most recent WebKit interaction state for this surface.
     ///
     /// `WKWebView` instances are view-lifecycle objects and can be torn down
-    /// during workspace switches. This data lets a fresh web view restore the
-    /// page plus its back/forward list while the in-memory surface survives.
-    public var savedInteractionState: Data?
+    /// during workspace switches. This snapshot lets a fresh web view restore
+    /// the page plus its back/forward list while the in-memory surface
+    /// survives. WebKit documents `WKWebView.interactionState` as an opaque
+    /// value, so it is held as-is and only ever handed back to WebKit.
+    public var savedInteractionState: Any?
 
-    /// Whether subsequent page loads should request the desktop site.
-    public var prefersDesktopSite: Bool
+    /// The user's explicit content-mode choice for this surface.
+    public enum ContentModePreference: Equatable, Sendable {
+        /// Follow WebKit's recommended mode for the device (mobile on iPhone,
+        /// desktop on iPad).
+        case recommended
+        /// Force the mobile site.
+        case mobile
+        /// Force the desktop site.
+        case desktop
+    }
+
+    /// The content mode subsequent page loads should request. Starts as
+    /// ``ContentModePreference/recommended`` and becomes an explicit mode once
+    /// the user toggles the desktop-site menu item.
+    public var contentModePreference: ContentModePreference
+
+    /// Whether subsequent page loads request the desktop site.
+    public var prefersDesktopSite: Bool { contentModePreference == .desktop }
 
     /// Whether a navigation is in flight. Drives the progress indicator and the
     /// reload/stop button affordance.
@@ -112,7 +130,7 @@ public final class BrowserSurfaceState: Identifiable {
         self.title = nil
         self.currentURL = initialURL
         self.savedInteractionState = nil
-        self.prefersDesktopSite = false
+        self.contentModePreference = .recommended
         self.isLoading = false
         self.estimatedProgress = 0
         self.canGoBack = false
@@ -134,28 +152,31 @@ public final class BrowserSurfaceState: Identifiable {
 
     /// Store a new WebKit interaction-state snapshot when WebKit provides one.
     ///
-    /// - Parameter data: The `WKWebView.interactionState` data snapshot, or
-    ///   `nil` when WebKit has no restorable state yet.
-    public func saveInteractionState(_ data: Data?) {
-        guard let data else { return }
-        savedInteractionState = data
+    /// - Parameter interactionState: The opaque `WKWebView.interactionState`
+    ///   value, or `nil` when WebKit has no restorable state yet.
+    public func saveInteractionState(_ interactionState: Any?) {
+        guard let interactionState else { return }
+        savedInteractionState = interactionState
     }
 
-    /// Update the desktop-site preference and request a reload when a page is
+    /// Update the content-mode preference and request a reload when a page is
     /// already loaded.
     ///
-    /// - Parameter value: Whether subsequent loads should prefer desktop mode.
-    public func setPrefersDesktopSite(_ value: Bool) {
-        guard prefersDesktopSite != value else { return }
-        prefersDesktopSite = value
+    /// - Parameter preference: The content mode subsequent loads should request.
+    public func setContentModePreference(_ preference: ContentModePreference) {
+        guard contentModePreference != preference else { return }
+        contentModePreference = preference
         if loadRequest == nil, currentURL != nil {
             request(.reload)
         }
     }
 
-    /// Flip the desktop-site preference.
+    /// Flip the desktop-site preference. The first toggle forces the desktop
+    /// site; toggling back forces the mobile site (not the device default, so
+    /// "Request Mobile Site" is honored on iPads whose recommended mode is
+    /// desktop).
     public func togglePrefersDesktopSite() {
-        setPrefersDesktopSite(!prefersDesktopSite)
+        setContentModePreference(prefersDesktopSite ? .mobile : .desktop)
     }
 
     /// Resolve and load whatever is currently in the address bar, returning

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSurfaceStore.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSurfaceStore.swift
@@ -66,10 +66,9 @@ public final class BrowserSurfaceStore {
     ///
     /// If the workspace already has a browser surface, that same surface is
     /// returned so the current page is restored when switching away and back
-    /// (the surface's `currentURL` is reloaded into a fresh web view on
-    /// re-attach). In P1, full back/forward history is not preserved across
-    /// remounts; persisting the live WebKit session and history is P2. A new
-    /// surface loads ``defaultURL``.
+    /// (the surface's saved WebKit interaction state, including the page and
+    /// back/forward stack, is restored into a fresh web view on re-attach, with
+    /// `currentURL` as the fallback). A new surface loads ``defaultURL``.
     ///
     /// - Parameter workspaceID: The workspace's raw identifier string.
     /// - Returns: The active browser surface for the workspace.

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserPane.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserPane.swift
@@ -120,7 +120,7 @@ public struct MobileBrowserPane: View {
 
     @ViewBuilder
     private var securityIndicator: some View {
-        switch BrowserSecurityIndicator.state(for: state.currentURL) {
+        switch BrowserSecurityIndicator(url: state.currentURL) {
         case .secure:
             Image(systemName: "lock.fill")
                 .font(.caption)

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserPane.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserPane.swift
@@ -19,6 +19,9 @@ public struct MobileBrowserPane: View {
     /// the field shows the user's in-progress text rather than the live URL.
     @FocusState private var isAddressFocused: Bool
 
+    /// Opens the current page in Safari when requested from the overflow menu.
+    @Environment(\.openURL) private var openURL
+
     /// Invoked when the user closes the browser pane.
     private let onClose: () -> Void
 
@@ -65,6 +68,8 @@ public struct MobileBrowserPane: View {
 
             reloadOrStopButton
 
+            overflowMenu
+
             Button(action: onClose) {
                 Image(systemName: "xmark")
             }
@@ -77,27 +82,60 @@ public struct MobileBrowserPane: View {
     }
 
     private var addressField: some View {
-        TextField(
-            L10n.string("mobile.browser.addressPlaceholder", defaultValue: "Search or enter address"),
-            text: $state.addressText
-        )
-        .textFieldStyle(.roundedBorder)
-        .textInputAutocapitalization(.never)
-        .autocorrectionDisabled(true)
-        .keyboardType(.webSearch)
-        .submitLabel(.go)
-        .focused($isAddressFocused)
-        .onChange(of: isAddressFocused) { _, focused in
-            // Mirror editing focus into the state so the web view's URL observer
-            // does not overwrite in-progress typing (see `isAddressEditing`).
-            state.isAddressEditing = focused
-        }
-        .onSubmit {
-            if state.submitAddress() {
-                isAddressFocused = false
+        HStack(spacing: 6) {
+            securityIndicator
+
+            TextField(
+                L10n.string("mobile.browser.addressPlaceholder", defaultValue: "Search or enter address"),
+                text: $state.addressText
+            )
+            .textFieldStyle(.plain)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .keyboardType(.webSearch)
+            .submitLabel(.go)
+            .focused($isAddressFocused)
+            .onChange(of: isAddressFocused) { _, focused in
+                // Mirror editing focus into the state so the web view's URL observer
+                // does not overwrite in-progress typing (see `isAddressEditing`).
+                state.isAddressEditing = focused
             }
+            .onSubmit {
+                if state.submitAddress() {
+                    isAddressFocused = false
+                }
+            }
+            .accessibilityIdentifier("MobileBrowserAddressField")
         }
-        .accessibilityIdentifier("MobileBrowserAddressField")
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .frame(minHeight: 36)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color(.separator).opacity(0.35), lineWidth: 0.5)
+        }
+    }
+
+    @ViewBuilder
+    private var securityIndicator: some View {
+        switch BrowserSecurityIndicator.state(for: state.currentURL) {
+        case .secure:
+            Image(systemName: "lock.fill")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel(L10n.string("mobile.browser.security.secure", defaultValue: "Secure connection"))
+                .accessibilityIdentifier("MobileBrowserSecureIndicator")
+        case .insecure:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .accessibilityLabel(L10n.string("mobile.browser.security.insecure", defaultValue: "Not secure"))
+                .accessibilityIdentifier("MobileBrowserInsecureIndicator")
+        case .none:
+            EmptyView()
+        }
     }
 
     @ViewBuilder
@@ -118,6 +156,68 @@ public struct MobileBrowserPane: View {
             }
             .accessibilityLabel(L10n.string("mobile.browser.reload", defaultValue: "Reload"))
             .accessibilityIdentifier("MobileBrowserReloadButton")
+        }
+    }
+
+    private var overflowMenu: some View {
+        Menu {
+            shareMenuItem
+
+            Button {
+                if let url = state.currentURL {
+                    openURL(url)
+                }
+            } label: {
+                menuLabel(
+                    L10n.string("mobile.browser.openInSafari", defaultValue: "Open in Safari"),
+                    systemImage: "safari"
+                )
+            }
+            .disabled(state.currentURL == nil)
+
+            Button {
+                state.togglePrefersDesktopSite()
+            } label: {
+                menuLabel(
+                    state.prefersDesktopSite
+                        ? L10n.string("mobile.browser.requestMobileSite", defaultValue: "Request Mobile Site")
+                        : L10n.string("mobile.browser.requestDesktopSite", defaultValue: "Request Desktop Site"),
+                    systemImage: state.prefersDesktopSite ? "iphone" : "desktopcomputer"
+                )
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .frame(width: 44, height: 44)
+        }
+        .accessibilityLabel(L10n.string("mobile.browser.more", defaultValue: "More"))
+        .accessibilityIdentifier("MobileBrowserOverflowMenu")
+    }
+
+    @ViewBuilder
+    private var shareMenuItem: some View {
+        if let url = state.currentURL {
+            ShareLink(item: url) {
+                menuLabel(
+                    L10n.string("mobile.browser.share", defaultValue: "Share"),
+                    systemImage: "square.and.arrow.up"
+                )
+            }
+        } else {
+            Button {} label: {
+                menuLabel(
+                    L10n.string("mobile.browser.share", defaultValue: "Share"),
+                    systemImage: "square.and.arrow.up"
+                )
+            }
+            .disabled(true)
+        }
+    }
+
+    private func menuLabel(_ title: String, systemImage: String) -> some View {
+        Label {
+            Text(title)
+        } icon: {
+            Image(systemName: systemImage)
         }
     }
 

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserView.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserView.swift
@@ -97,23 +97,39 @@ public struct MobileBrowserView: UIViewRepresentable {
         func attach(webView: WKWebView) {
             self.webView = webView
             observe(webView)
+            // A fresh web view starts idle, but the surface may still carry
+            // `isLoading` from a navigation that was in flight when the old
+            // web view was torn down. Mirror the new web view's state so the
+            // progress line does not persist; the loads below drive it again
+            // through the navigation delegate.
+            state.isLoading = webView.isLoading
+            state.estimatedProgress = webView.estimatedProgress
+
+            // An explicit pending load (first mount's initial URL, or a load
+            // queued while unmounted) wins outright. A command queued before
+            // the remount targeted the old web view's history and would cancel
+            // or no-op against this fresh load, so drop it.
+            if let url = state.consumeLoadRequest() {
+                webView.load(URLRequest(url: url))
+                _ = state.consumeCommand()
+                return
+            }
+
             // A surface can be re-attached to a fresh WKWebView when SwiftUI
             // remounts the representable (switching workspaces, hiding/showing
             // the browser). The surface state survives, but the web view does
-            // not, so restore the saved WebKit interaction state on re-attach
-            // to preserve the page and back/forward stack. If WebKit cannot
-            // restore that state, fall back to the last committed URL. First
-            // mount already has a pending initial-URL load, so guard against a
-            // double-load.
-            let hadPendingLoad = state.loadRequest != nil
-            applyPendingWork()
-            if !hadPendingLoad, webView.url == nil {
-                if restoreInteractionState(on: webView) {
-                    return
-                }
-                if let restore = state.currentURL {
-                    webView.load(URLRequest(url: restore))
-                }
+            // not, so restore the saved WebKit interaction state to preserve
+            // the page and back/forward stack. If WebKit rejects that state,
+            // fall back to the last committed URL.
+            if !restoreInteractionState(on: webView), let restore = state.currentURL {
+                webView.load(URLRequest(url: restore))
+            }
+
+            // Apply a command queued while no web view was attached (e.g. the
+            // desktop-site toggle's reload) after the session is restored so
+            // it acts on the restored page, not an empty web view.
+            if let command = state.consumeCommand() {
+                run(command, on: webView)
             }
         }
 
@@ -130,13 +146,16 @@ public struct MobileBrowserView: UIViewRepresentable {
         }
 
         private func run(_ command: BrowserSurfaceState.NavigationCommand, on webView: WKWebView) {
+            // No interaction-state capture here: right after `goBack()`/
+            // `goForward()` the snapshot still reflects the previous history
+            // position. `didFinish` captures the committed result, and
+            // `detach()` captures whatever WebKit has if the pane is torn
+            // down mid-navigation.
             switch command {
             case .goBack:
                 webView.goBack()
-                captureInteractionState(from: webView)
             case .goForward:
                 webView.goForward()
-                captureInteractionState(from: webView)
             case .reload:
                 webView.reload()
             case .stopLoading:
@@ -197,7 +216,12 @@ public struct MobileBrowserView: UIViewRepresentable {
         private func restoreInteractionState(on webView: WKWebView) -> Bool {
             guard let savedInteractionState = state.savedInteractionState else { return false }
             webView.interactionState = savedInteractionState
-            return webView.url != nil
+            // WebKit populates the back/forward list synchronously when it
+            // accepts a snapshot but may commit the page load asynchronously,
+            // so `webView.url` alone can still be nil for a successful
+            // restore. Only report failure (triggering the `currentURL`
+            // fallback) when WebKit rejected the snapshot outright.
+            return webView.url != nil || webView.backForwardList.currentItem != nil
         }
 
         private func captureInteractionState(from webView: WKWebView) {

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserView.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserView.swift
@@ -97,6 +97,11 @@ public struct MobileBrowserView: UIViewRepresentable {
         func attach(webView: WKWebView) {
             self.webView = webView
             observe(webView)
+            // WebKit's `.recommended` content mode resolves to desktop on
+            // iPad-class devices. Inject that resolution so the desktop-site
+            // menu label and toggle direction are correct on first use.
+            state.recommendedContentModeIsDesktop =
+                UIDevice.current.userInterfaceIdiom == .pad
             // A fresh web view starts idle, but the surface may still carry
             // `isLoading` from a navigation that was in flight when the old
             // web view was torn down. Mirror the new web view's state so the

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserView.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserView.swift
@@ -201,7 +201,9 @@ public struct MobileBrowserView: UIViewRepresentable {
         }
 
         private func captureInteractionState(from webView: WKWebView) {
-            state.saveInteractionState(webView.interactionState as? Data)
+            // `interactionState` is documented as an opaque value; hold it
+            // as-is (no cast) and only ever hand it back to WebKit.
+            state.saveInteractionState(webView.interactionState)
         }
 
         // MARK: - WKNavigationDelegate
@@ -247,7 +249,7 @@ public struct MobileBrowserView: UIViewRepresentable {
             preferences: WKWebpagePreferences,
             decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy, WKWebpagePreferences) -> Void
         ) {
-            preferences.preferredContentMode = state.prefersDesktopSite ? .desktop : .recommended
+            preferences.preferredContentMode = state.contentModePreference.webKitContentMode
             decisionHandler(.allow, preferences)
         }
 
@@ -268,6 +270,17 @@ public struct MobileBrowserView: UIViewRepresentable {
                 webView.load(navigationAction.request)
             }
             return nil
+        }
+    }
+}
+
+extension BrowserSurfaceState.ContentModePreference {
+    /// The WebKit content mode this preference requests for page loads.
+    var webKitContentMode: WKWebpagePreferences.ContentMode {
+        switch self {
+        case .recommended: .recommended
+        case .mobile: .mobile
+        case .desktop: .desktop
         }
     }
 }

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserView.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserView.swift
@@ -272,6 +272,8 @@ public struct MobileBrowserView: UIViewRepresentable {
             state.navigationDidFail(message: error.localizedDescription)
         }
 
+        /// Applies the surface's content-mode preference (mobile/desktop/
+        /// recommended) to every navigation and allows it to proceed.
         public func webView(
             _ webView: WKWebView,
             decidePolicyFor navigationAction: WKNavigationAction,

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserView.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/MobileBrowserView.swift
@@ -100,13 +100,20 @@ public struct MobileBrowserView: UIViewRepresentable {
             // A surface can be re-attached to a fresh WKWebView when SwiftUI
             // remounts the representable (switching workspaces, hiding/showing
             // the browser). The surface state survives, but the web view does
-            // not, so restore the last committed URL on re-attach to honor the
-            // "current page is restored on return" promise. First mount already
-            // has a pending initial-URL load, so guard against a double-load.
+            // not, so restore the saved WebKit interaction state on re-attach
+            // to preserve the page and back/forward stack. If WebKit cannot
+            // restore that state, fall back to the last committed URL. First
+            // mount already has a pending initial-URL load, so guard against a
+            // double-load.
             let hadPendingLoad = state.loadRequest != nil
             applyPendingWork()
-            if !hadPendingLoad, webView.url == nil, let restore = state.currentURL {
-                webView.load(URLRequest(url: restore))
+            if !hadPendingLoad, webView.url == nil {
+                if restoreInteractionState(on: webView) {
+                    return
+                }
+                if let restore = state.currentURL {
+                    webView.load(URLRequest(url: restore))
+                }
             }
         }
 
@@ -126,8 +133,10 @@ public struct MobileBrowserView: UIViewRepresentable {
             switch command {
             case .goBack:
                 webView.goBack()
+                captureInteractionState(from: webView)
             case .goForward:
                 webView.goForward()
+                captureInteractionState(from: webView)
             case .reload:
                 webView.reload()
             case .stopLoading:
@@ -138,6 +147,9 @@ public struct MobileBrowserView: UIViewRepresentable {
         /// Cancels all observations and releases the web view. Called on
         /// dismantle so the surface leaves no dangling KVO registrations.
         func detach() {
+            if let webView {
+                captureInteractionState(from: webView)
+            }
             observations.forEach { $0.invalidate() }
             observations.removeAll()
             webView?.navigationDelegate = nil
@@ -182,6 +194,16 @@ public struct MobileBrowserView: UIViewRepresentable {
             ]
         }
 
+        private func restoreInteractionState(on webView: WKWebView) -> Bool {
+            guard let savedInteractionState = state.savedInteractionState else { return false }
+            webView.interactionState = savedInteractionState
+            return webView.url != nil
+        }
+
+        private func captureInteractionState(from webView: WKWebView) {
+            state.saveInteractionState(webView.interactionState as? Data)
+        }
+
         // MARK: - WKNavigationDelegate
 
         public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
@@ -193,6 +215,7 @@ public struct MobileBrowserView: UIViewRepresentable {
             if let title = webView.title, !title.isEmpty {
                 state.title = title
             }
+            captureInteractionState(from: webView)
         }
 
         public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {
@@ -216,6 +239,16 @@ public struct MobileBrowserView: UIViewRepresentable {
                 return
             }
             state.navigationDidFail(message: error.localizedDescription)
+        }
+
+        public func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            preferences: WKWebpagePreferences,
+            decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy, WKWebpagePreferences) -> Void
+        ) {
+            preferences.preferredContentMode = state.prefersDesktopSite ? .desktop : .recommended
+            decisionHandler(.allow, preferences)
         }
 
         // MARK: - WKUIDelegate

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSecurityIndicatorTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSecurityIndicatorTests.swift
@@ -14,8 +14,16 @@ import Testing
         #expect(BrowserSecurityIndicator(url: url) == .secure)
     }
 
-    @Test func publicHTTPURLIsInsecure() {
-        let url = URL(string: "http://example.com")!
+    @Test(arguments: [
+        "http://example.com",
+        // DNS names that merely start with IPv6 private-prefix text are public.
+        "http://fda.gov",
+        "http://fe80.example.com",
+        // Outside the CGNAT 100.64.0.0/10 range.
+        "http://100.128.0.1",
+    ])
+    func publicHTTPURLIsInsecure(rawURL: String) throws {
+        let url = try #require(URL(string: rawURL))
         #expect(BrowserSecurityIndicator(url: url) == .insecure)
     }
 
@@ -26,6 +34,11 @@ import Testing
         "http://10.0.0.5",
         "http://172.16.0.1",
         "http://192.168.1.10",
+        "http://169.254.169.254",
+        "http://100.100.1.50",
+        "http://[fd00::1]",
+        "http://[fe80::1]",
+        "http://[::ffff:127.0.0.1]",
     ])
     func localAndPrivateHTTPURLsShowNoIndicator(rawURL: String) throws {
         let url = try #require(URL(string: rawURL))

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSecurityIndicatorTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSecurityIndicatorTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileBrowser
+
+/// Pure URL classification for the address-bar security indicator.
+@Suite struct BrowserSecurityIndicatorTests {
+    @Test func nilURLShowsNoIndicator() {
+        #expect(BrowserSecurityIndicator.state(for: nil) == .none)
+    }
+
+    @Test func httpsURLIsSecure() {
+        let url = URL(string: "https://example.com")!
+        #expect(BrowserSecurityIndicator.state(for: url) == .secure)
+    }
+
+    @Test func publicHTTPURLIsInsecure() {
+        let url = URL(string: "http://example.com")!
+        #expect(BrowserSecurityIndicator.state(for: url) == .insecure)
+    }
+
+    @Test(arguments: [
+        "http://localhost:3000",
+        "http://127.0.0.1:8080",
+        "http://[::1]:8080",
+        "http://10.0.0.5",
+        "http://172.16.0.1",
+        "http://192.168.1.10",
+    ])
+    func localAndPrivateHTTPURLsShowNoIndicator(rawURL: String) throws {
+        let url = try #require(URL(string: rawURL))
+        #expect(BrowserSecurityIndicator.state(for: url) == .none)
+    }
+
+    @Test(arguments: [
+        "file:///tmp/index.html",
+        "about:blank",
+    ])
+    func nonWebURLsShowNoIndicator(rawURL: String) throws {
+        let url = try #require(URL(string: rawURL))
+        #expect(BrowserSecurityIndicator.state(for: url) == .none)
+    }
+}

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSecurityIndicatorTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSecurityIndicatorTests.swift
@@ -6,17 +6,17 @@ import Testing
 /// Pure URL classification for the address-bar security indicator.
 @Suite struct BrowserSecurityIndicatorTests {
     @Test func nilURLShowsNoIndicator() {
-        #expect(BrowserSecurityIndicator.state(for: nil) == .none)
+        #expect(BrowserSecurityIndicator(url: nil) == .none)
     }
 
     @Test func httpsURLIsSecure() {
         let url = URL(string: "https://example.com")!
-        #expect(BrowserSecurityIndicator.state(for: url) == .secure)
+        #expect(BrowserSecurityIndicator(url: url) == .secure)
     }
 
     @Test func publicHTTPURLIsInsecure() {
         let url = URL(string: "http://example.com")!
-        #expect(BrowserSecurityIndicator.state(for: url) == .insecure)
+        #expect(BrowserSecurityIndicator(url: url) == .insecure)
     }
 
     @Test(arguments: [
@@ -29,7 +29,7 @@ import Testing
     ])
     func localAndPrivateHTTPURLsShowNoIndicator(rawURL: String) throws {
         let url = try #require(URL(string: rawURL))
-        #expect(BrowserSecurityIndicator.state(for: url) == .none)
+        #expect(BrowserSecurityIndicator(url: url) == .none)
     }
 
     @Test(arguments: [
@@ -38,6 +38,6 @@ import Testing
     ])
     func nonWebURLsShowNoIndicator(rawURL: String) throws {
         let url = try #require(URL(string: rawURL))
-        #expect(BrowserSecurityIndicator.state(for: url) == .none)
+        #expect(BrowserSecurityIndicator(url: url) == .none)
     }
 }

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSurfaceStateTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSurfaceStateTests.swift
@@ -30,6 +30,8 @@ import Testing
         #expect(state.canGoBack == false)
         #expect(state.canGoForward == false)
         #expect(state.isAddressEditing == false)
+        #expect(state.savedInteractionState == nil)
+        #expect(state.prefersDesktopSite == false)
     }
 
     @Test func consumeHelpersAreIdempotentWhenEmpty() {
@@ -50,7 +52,32 @@ import Testing
         state.load(url)
         #expect(state.addressText == "https://cmux.dev")
         #expect(state.lastErrorMessage == nil)
+        #expect(state.savedInteractionState == nil)
         #expect(state.consumeLoadRequest() == url)
+    }
+
+    @Test func saveInteractionStateKeepsLatestNonNilData() {
+        let state = makeState()
+        let first = Data([1, 2, 3])
+        let second = Data([4, 5, 6])
+
+        state.saveInteractionState(first)
+        #expect(state.savedInteractionState == first)
+
+        state.saveInteractionState(nil)
+        #expect(state.savedInteractionState == first)
+
+        state.saveInteractionState(second)
+        #expect(state.savedInteractionState == second)
+    }
+
+    @Test func loadClearsSavedInteractionState() {
+        let state = makeState()
+        state.saveInteractionState(Data([1, 2, 3]))
+
+        state.load(URL(string: "https://cmux.dev")!)
+
+        #expect(state.savedInteractionState == nil)
     }
 
     @Test func submitAddressResolvesAndRequestsLoad() {
@@ -103,5 +130,40 @@ import Testing
         state.request(.goBack)
         state.request(.goForward)
         #expect(state.consumeCommand() == .goForward)
+    }
+
+    @Test func desktopSitePreferenceDefaultsToMobileRecommendedMode() {
+        let state = makeState()
+        #expect(state.prefersDesktopSite == false)
+    }
+
+    @Test func desktopSiteToggleReloadsCurrentPage() {
+        let state = makeState(initialURL: URL(string: "https://example.com")!)
+        _ = state.consumeLoadRequest()
+
+        state.togglePrefersDesktopSite()
+
+        #expect(state.prefersDesktopSite)
+        #expect(state.consumeCommand() == .reload)
+    }
+
+    @Test func desktopSiteToggleBeforeFirstLoadDoesNotDoubleLoad() {
+        let state = makeState(initialURL: URL(string: "https://example.com")!)
+
+        state.togglePrefersDesktopSite()
+
+        #expect(state.prefersDesktopSite)
+        #expect(state.consumeCommand() == nil)
+        #expect(state.consumeLoadRequest()?.absoluteString == "https://example.com")
+    }
+
+    @Test func settingSameDesktopPreferenceIsNoOp() {
+        let state = makeState(initialURL: URL(string: "https://example.com")!)
+        _ = state.consumeLoadRequest()
+
+        state.setPrefersDesktopSite(false)
+
+        #expect(state.prefersDesktopSite == false)
+        #expect(state.consumeCommand() == nil)
     }
 }

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSurfaceStateTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSurfaceStateTests.swift
@@ -139,6 +139,24 @@ import Testing
         #expect(state.prefersDesktopSite == false)
     }
 
+    @Test func recommendedResolvesToDesktopOnPadClassDevices() {
+        // On iPad, WebKit's recommended mode already loads desktop sites, so
+        // the effective preference must report desktop while .recommended and
+        // the first toggle must request the MOBILE site, not no-op to desktop.
+        let state = makeState(initialURL: URL(string: "https://example.com")!)
+        _ = state.consumeLoadRequest()
+        state.recommendedContentModeIsDesktop = true
+
+        #expect(state.contentModePreference == .recommended)
+        #expect(state.prefersDesktopSite)
+
+        state.togglePrefersDesktopSite()
+
+        #expect(state.contentModePreference == .mobile)
+        #expect(state.prefersDesktopSite == false)
+        #expect(state.consumeCommand() == .reload)
+    }
+
     @Test func desktopSiteToggleReloadsCurrentPage() {
         let state = makeState(initialURL: URL(string: "https://example.com")!)
         _ = state.consumeLoadRequest()

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSurfaceStateTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSurfaceStateTests.swift
@@ -31,6 +31,7 @@ import Testing
         #expect(state.canGoForward == false)
         #expect(state.isAddressEditing == false)
         #expect(state.savedInteractionState == nil)
+        #expect(state.contentModePreference == .recommended)
         #expect(state.prefersDesktopSite == false)
     }
 
@@ -56,19 +57,19 @@ import Testing
         #expect(state.consumeLoadRequest() == url)
     }
 
-    @Test func saveInteractionStateKeepsLatestNonNilData() {
+    @Test func saveInteractionStateKeepsLatestNonNilSnapshot() {
         let state = makeState()
         let first = Data([1, 2, 3])
         let second = Data([4, 5, 6])
 
         state.saveInteractionState(first)
-        #expect(state.savedInteractionState == first)
+        #expect(state.savedInteractionState as? Data == first)
 
         state.saveInteractionState(nil)
-        #expect(state.savedInteractionState == first)
+        #expect(state.savedInteractionState as? Data == first)
 
         state.saveInteractionState(second)
-        #expect(state.savedInteractionState == second)
+        #expect(state.savedInteractionState as? Data == second)
     }
 
     @Test func loadClearsSavedInteractionState() {
@@ -132,8 +133,9 @@ import Testing
         #expect(state.consumeCommand() == .goForward)
     }
 
-    @Test func desktopSitePreferenceDefaultsToMobileRecommendedMode() {
+    @Test func contentModeDefaultsToRecommended() {
         let state = makeState()
+        #expect(state.contentModePreference == .recommended)
         #expect(state.prefersDesktopSite == false)
     }
 
@@ -143,7 +145,24 @@ import Testing
 
         state.togglePrefersDesktopSite()
 
+        #expect(state.contentModePreference == .desktop)
         #expect(state.prefersDesktopSite)
+        #expect(state.consumeCommand() == .reload)
+    }
+
+    @Test func toggleBackForcesMobileNotRecommended() {
+        // On iPads the recommended mode is desktop, so "Request Mobile Site"
+        // must force .mobile rather than fall back to the device default.
+        let state = makeState(initialURL: URL(string: "https://example.com")!)
+        _ = state.consumeLoadRequest()
+
+        state.togglePrefersDesktopSite()
+        #expect(state.consumeCommand() == .reload)
+
+        state.togglePrefersDesktopSite()
+
+        #expect(state.contentModePreference == .mobile)
+        #expect(state.prefersDesktopSite == false)
         #expect(state.consumeCommand() == .reload)
     }
 
@@ -157,11 +176,11 @@ import Testing
         #expect(state.consumeLoadRequest()?.absoluteString == "https://example.com")
     }
 
-    @Test func settingSameDesktopPreferenceIsNoOp() {
+    @Test func settingSameContentModePreferenceIsNoOp() {
         let state = makeState(initialURL: URL(string: "https://example.com")!)
         _ = state.consumeLoadRequest()
 
-        state.setPrefersDesktopSite(false)
+        state.setContentModePreference(.recommended)
 
         #expect(state.prefersDesktopSite == false)
         #expect(state.consumeCommand() == nil)

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSurfaceStoreTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserSurfaceStoreTests.swift
@@ -38,8 +38,8 @@ import Testing
         let first = store.openBrowser(for: "ws-1")
         let second = store.openBrowser(for: "ws-1")
         // Same instance, so the current page is restored when switching away and
-        // back (the surface's currentURL is reloaded on re-attach). Full live
-        // WebKit history persistence across remounts is P2.
+        // back. WebKit session snapshots are stored on that surface across
+        // remounts.
         #expect(first === second)
     }
 

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -783,6 +783,23 @@
         }
       }
     },
+    "mobile.browser.more": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "その他"
+          }
+        }
+      }
+    },
     "mobile.browser.new": {
       "extractionState": "manual",
       "localizations": {
@@ -800,6 +817,23 @@
         }
       }
     },
+    "mobile.browser.openInSafari": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in Safari"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Safariで開く"
+          }
+        }
+      }
+    },
     "mobile.browser.reload": {
       "extractionState": "manual",
       "localizations": {
@@ -813,6 +847,91 @@
           "stringUnit": {
             "state": "translated",
             "value": "再読み込み"
+          }
+        }
+      }
+    },
+    "mobile.browser.requestDesktopSite": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request Desktop Site"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デスクトップ用サイトを表示"
+          }
+        }
+      }
+    },
+    "mobile.browser.requestMobileSite": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request Mobile Site"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モバイル用サイトを表示"
+          }
+        }
+      }
+    },
+    "mobile.browser.security.insecure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not secure"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全ではありません"
+          }
+        }
+      }
+    },
+    "mobile.browser.security.secure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secure connection"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全な接続"
+          }
+        }
+      }
+    },
+    "mobile.browser.share": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "共有"
           }
         }
       }


### PR DESCRIPTION
Improves the phone-local iOS browser (`Packages/iOS/CmuxMobileBrowser`), from Mitchell Hashimoto feedback on mobile browsing gaps.

**What changed**

1. **Session persistence across remounts.** Previously only the last committed URL survived a remount; the WebKit back/forward stack was silently dropped whenever you switched workspaces and back. The coordinator now captures `WKWebView.interactionState` on navigation finish, back/forward, and detach, and `attach` restores it into the fresh web view (URL load remains the fallback when absent or restore fails).
2. **Overflow menu**: Share, Open in Safari, Request Desktop/Mobile Site — all ≥44pt targets, disabled correctly when no page is loaded.
3. **Security indicator** in the address field: lock for https, warning for public http; loopback/private hosts and non-web schemes show nothing. Derivation is a pure function (`BrowserSecurityIndicator`) with unit tests.
4. **Desktop-site toggle** via `WKWebpagePreferences.preferredContentMode`, per-surface, reloads on flip, survives remounts. Related: https://github.com/manaflow-ai/cmux/issues/1614

**Out of scope (deliberately):** tabs, Mac↔phone browser sync, back/forward edge gestures (https://github.com/manaflow-ai/cmux/issues/6634 conflict).

**Testing:** `swift test --package-path Packages/iOS/CmuxMobileBrowser` (45 tests, 4 suites) and iOS-simulator-triple package build both pass. New strings localized EN+JA in `ios/cmux/Resources/Localizable.xcstrings`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local in-app browser UI and WebKit session handling only; no auth, sync, or server changes. Main risk is WebKit restore edge cases on workspace remounts.
> 
> **Overview**
> Expands the phone-local iOS browser with **session restore**, **address-bar security**, an **overflow menu**, and a **per-surface desktop/mobile site** toggle.
> 
> **Session restore:** `BrowserSurfaceState` keeps opaque `WKWebView.interactionState`; the coordinator captures it on navigation finish and detach, restores it on re-attach (with `currentURL` as fallback), and clears it on explicit loads. Re-attach also syncs loading/progress, prioritizes pending loads, drops stale commands from the old web view, and applies queued reloads after restore.
> 
> **Chrome:** New `BrowserSecurityIndicator` drives lock vs warning for HTTPS vs public HTTP (private/loopback/CGNAT hosts and non-web schemes show nothing). The address field is restyled with that indicator. An overflow menu adds Share, Open in Safari, and Request Desktop/Mobile Site (iPad-aware via `recommendedContentModeIsDesktop`).
> 
> **WebKit:** `decidePolicyFor` sets `WKWebpagePreferences.preferredContentMode` from per-surface `ContentModePreference`; toggling reloads when a page is already loaded. EN+JA strings added for the new UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e17302f6be5b966bf5a24fbdd8c17c89a65a866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786065115&installation_id=133855650&pr_number=7557&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7557&signature=44ec93d058409d07a56bd154be1979783ccec472d565848d3e2c41cc8e8ca4c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the iOS in‑app browser with reliable session restore, an overflow menu (Share, Safari, desktop/mobile), and a clearer security indicator. Also fixes the desktop-site toggle on iPad so the menu starts at “Request Mobile Site” and the first toggle forces mobile; adds DocC for the navigation policy hook.

- **New Features**
  - Restores full session across remounts by saving and restoring `WKWebView.interactionState` (falls back to last URL if restore fails).
  - Adds overflow menu: Share, Open in Safari, and Request Desktop/Mobile Site (disabled with no page, ≥44pt targets).
  - Shows a security indicator in the address bar: lock for https, warning for public http; none for loopback/private/non‑web (`BrowserSecurityIndicator` is pure and tested).
  - Desktop/mobile site control per surface via `WKWebpagePreferences.preferredContentMode`; models recommended/mobile/desktop, reloads on toggle, persists across remounts. On iPad, `.recommended` resolves to desktop so the menu initially shows “Request Mobile Site,” and the first toggle forces mobile. DocC added on the navigation policy hook.

- **Bug Fixes**
  - More robust session restore: accept restores when `backForwardList.currentItem` is present (even before `url` commits), sync loading/progress on reattach, prioritize pending loads, drop stale commands, and apply queued commands after restore; capture interaction state on `didFinish` and `detach` only.
  - Security indicator classification tightened: only apply IPv6 private prefixes to true IPv6 literals, classify IPv4‑mapped IPv6 by embedded IPv4, and treat 169.254/16 and 100.64/10 (CGNAT/Tailscale) as private; tests added.

<sup>Written for commit 7e17302f6be5b966bf5a24fbdd8c17c89a65a866. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an address bar security indicator (secure, not secure, or unavailable).
  * Added an overflow menu with “Open in Safari,” request desktop/mobile site, and sharing (when available).
  * Introduced per-surface content-mode control to request desktop vs mobile pages.
* **Bug Fixes**
  * Improved restoration of browsing session state across reattachment, including navigation context and reliable fallback loading.
* **Tests**
  * Added unit tests for security indicator classification and interaction/content-mode persistence.
* **Documentation**
  * Added localized UI strings for the new mobile browser controls and security/share labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->