### PR TITLE
Speed up dashboard navigation and upsell free users on billing

### DIFF
--- a/web/app/[locale]/dashboard/ai-accounts/loading.tsx
+++ b/web/app/[locale]/dashboard/ai-accounts/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "../components/dashboard-skeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/web/app/[locale]/dashboard/ai-accounts/page.tsx
+++ b/web/app/[locale]/dashboard/ai-accounts/page.tsx
@@ -12,8 +12,7 @@ export default async function AiAccountsRedirectPage({
   params: Promise<{ locale: string }>;
   searchParams: Promise<{ team?: string | string[] }>;
 }) {
-  const { locale } = await params;
-  const { team: teamParam } = await searchParams;
+  const [{ locale }, { team: teamParam }] = await Promise.all([params, searchParams]);
   const team = Array.isArray(teamParam) ? teamParam[0] : teamParam;
   const target = getPathname({
     locale,

--- a/web/app/[locale]/dashboard/billing/loading.tsx
+++ b/web/app/[locale]/dashboard/billing/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "../components/dashboard-skeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/web/app/[locale]/dashboard/billing/page.tsx
+++ b/web/app/[locale]/dashboard/billing/page.tsx
@@ -2,8 +2,15 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 
+import { PRO_CHECKOUT_URL, TEAM_CHECKOUT_URL } from "@/app/lib/billing";
 import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
+import {
+  FeatureList,
+  PlanCard,
+  PrimaryLink,
+  visibleProFeatures,
+} from "@/app/components/pricing-shared";
 import { cloudDb } from "@/db/client";
 import { stripeCustomers, stripeSubscriptions } from "@/db/schema";
 import { Link } from "@/i18n/navigation";
@@ -42,8 +49,10 @@ export default async function DashboardBillingPage({
   params: Promise<{ locale: string }>;
   searchParams?: Promise<SearchParams>;
 }) {
-  const { locale } = await params;
-  const query = await searchParams;
+  const [{ locale }, query] = await Promise.all([
+    params,
+    searchParams ?? Promise.resolve(undefined),
+  ]);
 
   if (!isStackConfigured()) {
     redirect("/");
@@ -53,16 +62,28 @@ export default async function DashboardBillingPage({
     redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard/billing")));
   }
 
-  const t = await getTranslations({ locale, namespace: "dashboard.billing" });
-  const status = await resolveProPlanStatus(user);
-  const billingTeam = await billingTeamForUser(user);
-  const [subscription, hasStripeCustomer, teamSubscription, hasTeamStripeCustomer] = await Promise.all([
+  const billingTeamPromise = billingTeamForUser(user);
+  const [
+    t,
+    pricingT,
+    status,
+    billingTeam,
+    subscription,
+    hasStripeCustomer,
+  ] = await Promise.all([
+    getTranslations({ locale, namespace: "dashboard.billing" }),
+    getTranslations({ locale, namespace: "pricing" }),
+    resolveProPlanStatus(user),
+    billingTeamPromise,
     latestActiveStripeSubscription(user.id),
     hasCustomerRow(user.id),
+  ]);
+  const [teamSubscription, hasTeamStripeCustomer] = await Promise.all([
     billingTeam ? latestActiveStripeSubscriptionForTeam(billingTeam.id) : Promise.resolve(null),
     billingTeam ? hasTeamCustomerRow(billingTeam.id) : Promise.resolve(false),
   ]);
   const banner = billingBanner(Array.isArray(query?.billing) ? query?.billing[0] : query?.billing);
+  const isFreePlan = !status.isPro && !teamSubscription;
 
   return (
     <div className="mx-auto w-full max-w-5xl px-3 py-4">
@@ -78,7 +99,9 @@ export default async function DashboardBillingPage({
         </div>
       ) : null}
 
-      {!status.isPro ? (
+      {isFreePlan ? (
+        <FreePlanUpsell t={t} pricingT={pricingT} />
+      ) : !status.isPro ? (
         <FreePlan t={t} />
       ) : subscription ? (
         <StripePlan
@@ -210,6 +233,69 @@ function FreePlan({ t }: { t: Awaited<ReturnType<typeof getTranslations>> }) {
         {t("actions.viewPricing")}
       </Link>
     </section>
+  );
+}
+
+function FreePlanUpsell({
+  t,
+  pricingT,
+}: {
+  t: Awaited<ReturnType<typeof getTranslations>>;
+  pricingT: Awaited<ReturnType<typeof getTranslations>>;
+}) {
+  const proFeatures = visibleProFeatures({
+    base: pricingT.raw("pro.features") as string[],
+    vault: pricingT.raw("pro.vaultFeatures") as string[],
+    hostedNetworking: pricingT.raw("pro.hostedNetworkingFeatures") as string[],
+  });
+  const teamFeatures = pricingT.raw("team.features") as string[];
+
+  return (
+    <div className="space-y-3">
+      <section className="border border-border p-3">
+        <h2 className="text-sm font-medium">{t("free.name")}</h2>
+        <p className="mt-2 max-w-2xl text-muted">{t("free.body")}</p>
+      </section>
+
+      <section>
+        <div className="mb-2">
+          <h2 className="text-sm font-medium">{t("free.upsellTitle")}</h2>
+          <p className="mt-1 max-w-2xl text-muted">{t("free.upsellBody")}</p>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          <PlanCard
+            name={pricingT("pro.name")}
+            price={pricingT("pro.price")}
+            period={pricingT("perMonth")}
+          >
+            <PrimaryLink href={PRO_CHECKOUT_URL}>{pricingT("pro.cta")}</PrimaryLink>
+            <p className="mt-5 text-sm font-medium">{pricingT("pro.featuresLead")}</p>
+            <FeatureList items={proFeatures} />
+          </PlanCard>
+
+          <PlanCard
+            name={pricingT("team.name")}
+            price={pricingT("team.price")}
+            period={pricingT("perUserMonth")}
+          >
+            <PrimaryLink href={TEAM_CHECKOUT_URL}>{pricingT("team.cta")}</PrimaryLink>
+            <p className="mt-5 text-sm font-medium">{pricingT("team.featuresLead")}</p>
+            <FeatureList items={teamFeatures} />
+          </PlanCard>
+        </div>
+      </section>
+
+      <section className="border border-border p-3">
+        <h2 className="text-sm font-medium">{t("free.testflightTitle")}</h2>
+        <p className="mt-2 max-w-2xl text-muted">{t("free.testflightBody")}</p>
+        <Link
+          href="/dashboard/testflight"
+          className="mt-3 inline-block border border-border bg-background px-3 py-1.5 text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground hover:bg-foreground hover:text-background"
+        >
+          {t("free.testflightCta")}
+        </Link>
+      </section>
+    </div>
   );
 }
 

--- a/web/app/[locale]/dashboard/components/dashboard-skeleton.tsx
+++ b/web/app/[locale]/dashboard/components/dashboard-skeleton.tsx
@@ -1,0 +1,53 @@
+type DashboardSkeletonProps = {
+  variant?: "cards" | "rows";
+};
+
+export function DashboardSkeleton({ variant = "cards" }: DashboardSkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className="mx-auto w-full max-w-5xl px-3 py-4"
+    >
+      <div className="mb-4 border-b border-border pb-3">
+        <SkeletonBlock className="h-3 w-16" />
+        <SkeletonBlock className="mt-2 h-4 w-32" />
+        <SkeletonBlock className="mt-2 h-3 w-full max-w-lg" />
+      </div>
+
+      {variant === "rows" ? (
+        <div className="border border-border">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div
+              key={index}
+              className="grid gap-3 border-b border-border p-3 last:border-b-0 md:grid-cols-[1.2fr_1fr_1fr_auto]"
+            >
+              <SkeletonBlock className="h-4 w-28" />
+              <SkeletonBlock className="h-4 w-36" />
+              <SkeletonBlock className="h-4 w-24" />
+              <SkeletonBlock className="h-7 w-16" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <section key={index} className="border border-border p-3">
+              <SkeletonBlock className="h-4 w-24" />
+              <SkeletonBlock className="mt-3 h-3 w-full" />
+              <SkeletonBlock className="mt-2 h-3 w-5/6" />
+              <SkeletonBlock className="mt-4 h-8 w-28" />
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SkeletonBlock({ className }: { className: string }) {
+  return (
+    <div
+      className={`animate-pulse bg-code-bg ${className}`}
+    />
+  );
+}

--- a/web/app/[locale]/dashboard/layout.tsx
+++ b/web/app/[locale]/dashboard/layout.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { StackProvider, StackTheme } from "@stackframe/stack";
 import { redirect } from "next/navigation";
 import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import { DashboardSkeleton } from "./components/dashboard-skeleton";
 import { DashboardShell } from "./dashboard-shell";
 
 // Auth redirects are owned by each page, not this layout: a layout cannot see
@@ -20,12 +21,12 @@ export default async function DashboardLayout({
   }
 
   return (
-    <Suspense>
-      <StackProvider app={getStackServerApp()}>
-        <StackTheme>
-          <DashboardShell>{children}</DashboardShell>
-        </StackTheme>
-      </StackProvider>
-    </Suspense>
+    <StackProvider app={getStackServerApp()}>
+      <StackTheme>
+        <DashboardShell>
+          <Suspense fallback={<DashboardSkeleton />}>{children}</Suspense>
+        </DashboardShell>
+      </StackTheme>
+    </StackProvider>
   );
 }

--- a/web/app/[locale]/dashboard/loading.tsx
+++ b/web/app/[locale]/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "./components/dashboard-skeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/web/app/[locale]/dashboard/subrouter/loading.tsx
+++ b/web/app/[locale]/dashboard/subrouter/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "../components/dashboard-skeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton variant="rows" />;
+}

--- a/web/app/[locale]/dashboard/subrouter/page.tsx
+++ b/web/app/[locale]/dashboard/subrouter/page.tsx
@@ -52,8 +52,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
 }
 
 export default async function SubrouterOverviewPage({ params, searchParams }: PageProps) {
-  const { locale } = await params;
-  const { team: teamParam } = await searchParams;
+  const [{ locale }, { team: teamParam }] = await Promise.all([params, searchParams]);
   const team = Array.isArray(teamParam) ? teamParam[0] : teamParam;
 
   if (!isStackConfigured()) {
@@ -64,8 +63,10 @@ export default async function SubrouterOverviewPage({ params, searchParams }: Pa
     redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard/subrouter")));
   }
 
-  const tPage = await getTranslations({ locale, namespace: "dashboard.subrouter" });
-  const t = await getTranslations({ locale, namespace: "dashboard.aiAccounts" });
+  const [tPage, t] = await Promise.all([
+    getTranslations({ locale, namespace: "dashboard.subrouter" }),
+    getTranslations({ locale, namespace: "dashboard.aiAccounts" }),
+  ]);
   const teams = await dashboardTeams(stackUser, t("personalTeam"));
   const selectedTeam = selectTeam(teams, team);
   const accountState = await loadAccounts(selectedTeam);

--- a/web/app/[locale]/dashboard/testflight/loading.tsx
+++ b/web/app/[locale]/dashboard/testflight/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "../components/dashboard-skeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/web/app/[locale]/dashboard/vault/cli-auth/loading.tsx
+++ b/web/app/[locale]/dashboard/vault/cli-auth/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "../../components/dashboard-skeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/web/app/[locale]/dashboard/vault/loading.tsx
+++ b/web/app/[locale]/dashboard/vault/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "../components/dashboard-skeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/web/app/[locale]/dashboard/vault/sessions/loading.tsx
+++ b/web/app/[locale]/dashboard/vault/sessions/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "../../components/dashboard-skeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton variant="rows" />;
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -82,7 +82,12 @@
       },
       "free": {
         "name": "Free",
-        "body": "You are currently on the Free plan. Upgrade when you need Pro limits and hosted features."
+        "body": "You are currently on the Free plan. Upgrade when you need Pro limits and hosted features.",
+        "upsellTitle": "Upgrade when you need cloud agents or team billing.",
+        "upsellBody": "Choose Pro for personal cloud features, or Team for shared billing and seats.",
+        "testflightTitle": "Get the cmux iOS app",
+        "testflightBody": "The iOS beta is available through TestFlight for active Pro users and Team members.",
+        "testflightCta": "Join the iOS beta"
       },
       "pro": {
         "name": "cmux Pro",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -82,7 +82,12 @@
       },
       "free": {
         "name": "Free",
-        "body": "現在はFreeプランです。Proの上限やホスト型機能が必要になったらアップグレードしてください。"
+        "body": "現在はFreeプランです。Proの上限やホスト型機能が必要になったらアップグレードしてください。",
+        "upsellTitle": "クラウドエージェントやチーム請求が必要になったらアップグレードできます。",
+        "upsellBody": "個人向けクラウド機能にはPro、共有請求とシート管理にはTeamを選択してください。",
+        "testflightTitle": "cmux iOSアプリを入手",
+        "testflightBody": "iOSベータは、有効なProユーザーとTeamメンバーがTestFlightで利用できます。",
+        "testflightCta": "iOSベータに参加"
       },
       "pro": {
         "name": "cmux Pro",

--- a/web/tests/dashboard-billing-page.test.tsx
+++ b/web/tests/dashboard-billing-page.test.tsx
@@ -94,12 +94,18 @@ describe("dashboard billing page", () => {
     proUser.update.mockClear();
   });
 
-  test("renders the Free plan state with a pricing link", async () => {
+  test("renders the Free plan state with pricing cards and TestFlight link", async () => {
     const html = await renderBillingPage();
 
     expect(html).toContain("Free");
     expect(html).toContain("You are currently on the Free plan.");
-    expect(html).toContain('href="/pricing"');
+    expect(html).toContain("Upgrade when you need cloud agents or team billing.");
+    expect(html).toContain('href="/api/billing/checkout?plan=pro&amp;cmux_external_browser=1"');
+    expect(html).toContain('href="/api/billing/checkout?plan=team&amp;cmux_external_browser=1"');
+    expect(html).toContain("Get Pro");
+    expect(html).toContain("Get Teams");
+    expect(html).toContain('href="/dashboard/testflight"');
+    expect(html).toContain("Join the iOS beta");
     expect(html).not.toContain("/api/billing/subscription");
   });
 


### PR DESCRIPTION
Two dashboard improvements.

**Nav feels instant.** Every dashboard route was force-dynamic with sequential per-user awaits and no loading state, and the layout suspended the nav chrome along with the page — so every click blanked the whole screen until a Stack Auth round-trip plus DB queries finished. Now: a shared skeleton + per-route loading.tsx paint immediately, the layout renders the nav shell outside Suspense so only page content streams, and independent awaits on billing/ai-accounts/subrouter run in parallel. force-dynamic stays (data is per-user); streaming is what makes it feel fast.

**Free users get upsold.** /dashboard/billing free-plan state now shows the Pro ($30) and Team ($35) pricing cards with their real checkout links plus an iOS TestFlight pointer. Pro/Team/cancel-pending/legacy states unchanged.

/fable loop: judge APPROVE. Live-verified as a signed-in free user (Free state + both plan cards + checkout buttons + TestFlight link render); 501 web tests green in sorted order, typecheck + flag lint clean, en/ja parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786065789&installation_id=133855650&pr_number=7562&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7562&signature=e09a363ebcba08f33168ee3444ada62ec702af84906a06619650c3f7f2c291fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UX (skeletons, Suspense) and marketing UI on billing; checkout still uses existing billing URLs and paid-plan flows are unchanged.
> 
> **Overview**
> Dashboard navigation should feel immediate: a shared **`DashboardSkeleton`** (card vs row layouts) backs new **`loading.tsx`** files on dashboard routes, and the layout keeps **`DashboardShell`** outside **`Suspense`** so only page content suspends with that skeleton instead of blanking the whole screen.
> 
> Several dashboard pages now **`Promise.all`** independent work (params/searchParams, translations, billing/Stripe lookups) to cut sequential wait time.
> 
> On **`/dashboard/billing`**, users with no Pro and no team subscription see a new **`FreePlanUpsell`**: Pro and Team **`PlanCard`**s with real checkout URLs, plus a TestFlight section—replacing the old “link to pricing” free state. The prior **`FreePlan`** UI remains when a team subscription exists but the user isn’t Pro. **en**/**ja** strings and billing page tests were updated for the new copy and links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5cf426594d767d3ce20821893dc739eed1d67a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make dashboard navigation feel instant by streaming only page content and showing a shared skeleton during loads. Add a free-plan upsell on the billing page with Pro/Team checkout links and an iOS TestFlight link.

- **New Features**
  - Free plan view on `/dashboard/billing` shows Pro and Team cards with checkout links (`PRO_CHECKOUT_URL`, `TEAM_CHECKOUT_URL`) and a TestFlight link to `/dashboard/testflight`.
  - Pro/Team/cancel-pending/legacy billing states are unchanged.

- **Refactors**
  - Added shared `DashboardSkeleton` and `loading.tsx` for all dashboard routes; layout renders the nav shell outside `Suspense` with a skeleton fallback so only page content streams.
  - Parallelized blocking work on billing, AI accounts, and subrouter pages with `Promise.all` (params, search params, translations, billing/team queries); retained `force-dynamic` for per-user data.

<sup>Written for commit bf5cf426594d767d3ce20821893dc739eed1d67a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

