### PR TITLE
Turn the Pro success page into a Welcome to Pro next-steps screen

### DIFF
--- a/web/app/billing/success/page.tsx
+++ b/web/app/billing/success/page.tsx
@@ -22,9 +22,23 @@ type BillingSuccessMessages = {
   title: string;
   body: string;
   emailLabel: string;
+  whatUnlockedTitle: string;
   openCmux: string;
   manageBilling: string;
   manageSignInMethods: string;
+  features: Record<BillingSuccessFeatureKey, BillingSuccessFeatureMessage>;
+};
+
+type BillingSuccessFeatureKey =
+  | "cloudAgents"
+  | "modelGateway"
+  | "aiAccounts"
+  | "iosApp";
+
+type BillingSuccessFeatureMessage = {
+  title: string;
+  body: string;
+  action: string;
 };
 
 export const dynamic = "force-dynamic";
@@ -79,23 +93,61 @@ export default async function BillingSuccessPage({
   const { locale, messages } = await billingSuccessMessages(requestHeaders);
   const openCmuxHref = new URL("/handler/after-sign-in", request.nextUrl.origin);
   openCmuxHref.searchParams.set("native_app_return_to", nativeCallbackHrefForScheme(scheme));
+  const featureCards: readonly {
+    key: BillingSuccessFeatureKey;
+    href: string;
+  }[] = [
+    { key: "cloudAgents", href: openCmuxHref.toString() },
+    { key: "modelGateway", href: "/dashboard/subrouter" },
+    { key: "aiAccounts", href: "/dashboard/ai-accounts" },
+    { key: "iosApp", href: "/dashboard/testflight" },
+  ];
 
   return (
-    <main className="min-h-screen bg-[#fafafa] px-6 py-16 text-[#171717]">
-      <div className="mx-auto max-w-xl">
-        <p className="mb-3 text-sm font-medium text-[#5f6368]">{messages.emailLabel}</p>
-        <p className="mb-8 break-words text-base">{email}</p>
-        <h1 className="text-3xl font-medium tracking-tight">{messages.title}</h1>
-        <p className="mt-4 text-base leading-7 text-[#4b5563]">
-          {messages.body.replace("{email}", email)}
-        </p>
-        <div className="mt-8 flex flex-wrap gap-3" lang={locale}>
+    <main className="min-h-screen bg-[#fafafa] px-4 py-10 text-[#171717] sm:px-6 sm:py-16">
+      <div className="mx-auto max-w-5xl" lang={locale}>
+        <section className="border-b border-black/10 pb-8">
+          <p className="mb-3 text-sm font-medium text-[#5f6368]">{messages.emailLabel}</p>
+          <p className="mb-8 break-words text-base">{email}</p>
+          <h1 className="text-3xl font-medium tracking-tight">{messages.title}</h1>
+          <p className="mt-4 max-w-2xl text-base leading-7 text-[#4b5563]">
+            {messages.body.replace("{email}", email)}
+          </p>
           <a
-            className="inline-flex rounded-md bg-[#171717] px-4 py-2 text-sm font-medium text-white"
+            className="mt-8 inline-flex rounded-md bg-[#171717] px-4 py-2 text-sm font-medium text-white"
             href={openCmuxHref.toString()}
           >
             {messages.openCmux}
           </a>
+        </section>
+
+        <section className="py-8">
+          <h2 className="text-xl font-medium tracking-tight">{messages.whatUnlockedTitle}</h2>
+          <div className="mt-5 grid gap-4 md:grid-cols-2">
+            {featureCards.map((card) => {
+              const feature = messages.features[card.key];
+              return (
+                <article
+                  key={card.key}
+                  className="flex min-h-48 flex-col justify-between rounded-lg border border-black/10 bg-white p-5 shadow-sm"
+                >
+                  <div>
+                    <h3 className="text-base font-medium">{feature.title}</h3>
+                    <p className="mt-3 text-sm leading-6 text-[#4b5563]">{feature.body}</p>
+                  </div>
+                  <a
+                    className="mt-5 inline-flex w-fit rounded-md bg-[#171717] px-3 py-2 text-sm font-medium text-white"
+                    href={card.href}
+                  >
+                    {feature.action}
+                  </a>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <div className="flex flex-wrap gap-3 border-t border-black/10 pt-6">
           <a
             className="inline-flex rounded-md border border-black/15 px-4 py-2 text-sm font-medium text-[#171717]"
             href="/api/billing/portal"

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2727,9 +2727,32 @@
     "title": "cmux Pro is active",
     "body": "We created or upgraded your account with {email}. You can open cmux now or add more sign-in methods.",
     "emailLabel": "Purchase email",
+    "whatUnlockedTitle": "What you unlocked",
     "openCmux": "Open cmux",
     "manageBilling": "Manage billing",
-    "manageSignInMethods": "Manage sign-in methods"
+    "manageSignInMethods": "Manage sign-in methods",
+    "features": {
+      "cloudAgents": {
+        "title": "Cloud agents on Cloud VMs",
+        "body": "Run agents in isolated remote sandboxes.",
+        "action": "Open cmux"
+      },
+      "modelGateway": {
+        "title": "Model gateway",
+        "body": "Route across providers with usage and cost analytics, plus 20 compute-hours a month.",
+        "action": "Open model gateway"
+      },
+      "aiAccounts": {
+        "title": "Connect your AI accounts",
+        "body": "Add provider accounts so cmux can route work through them.",
+        "action": "Connect providers"
+      },
+      "iosApp": {
+        "title": "cmux iOS app",
+        "body": "Use cmux on your phone.",
+        "action": "Join the iOS beta"
+      }
+    }
   },
   "landing": {
     "bestTerminal": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -2636,9 +2636,32 @@
     "title": "cmux Pro が有効になりました",
     "body": "{email} のアカウントを作成またはアップグレードしました。cmux を開くか、サインイン方法を追加できます。",
     "emailLabel": "購入メールアドレス",
+    "whatUnlockedTitle": "利用できるようになった機能",
     "openCmux": "cmux を開く",
     "manageBilling": "請求を管理",
-    "manageSignInMethods": "サインイン方法を管理"
+    "manageSignInMethods": "サインイン方法を管理",
+    "features": {
+      "cloudAgents": {
+        "title": "Cloud VM 上のクラウドエージェント",
+        "body": "隔離されたリモートサンドボックスでエージェントを実行できます。",
+        "action": "cmux を開く"
+      },
+      "modelGateway": {
+        "title": "モデルゲートウェイ",
+        "body": "使用量とコスト分析を見ながらプロバイダー間でルーティングし、毎月 20 コンピュート時間を利用できます。",
+        "action": "モデルゲートウェイを開く"
+      },
+      "aiAccounts": {
+        "title": "AI アカウントを接続",
+        "body": "プロバイダーアカウントを追加して、cmux が作業をルーティングできるようにします。",
+        "action": "プロバイダーを接続"
+      },
+      "iosApp": {
+        "title": "cmux iOS アプリ",
+        "body": "スマートフォンで cmux を使用できます。",
+        "action": "iOS ベータに参加"
+      }
+    }
   },
   "landing": {
     "bestTerminal": {

--- a/web/tests/billing-success-page.test.tsx
+++ b/web/tests/billing-success-page.test.tsx
@@ -56,15 +56,32 @@ mock.module("../services/billing/purchase", () => ({
 const { default: BillingSuccessPage } = await import("../app/billing/success/page");
 
 describe("billing success page", () => {
-  test("renders a Manage billing link after an active purchase", async () => {
+  test("renders welcome sections and links after an active purchase", async () => {
     const element = await BillingSuccessPage({
       searchParams: Promise.resolve({ session_id: "cs_123" }),
     });
     const html = renderToStaticMarkup(element);
 
+    expect(html).toContain("cmux Pro is active");
+    expect(html).toContain("buyer@example.com");
+    expect(html).toContain("What you unlocked");
+    expect(html).toContain("Cloud agents on Cloud VMs");
+    expect(html).toContain("Run agents in isolated remote sandboxes.");
+    expect(html).toContain("Model gateway");
+    expect(html).toContain("Route across providers with usage and cost analytics, plus 20 compute-hours a month.");
+    expect(html).toContain("Connect your AI accounts");
+    expect(html).toContain("Add provider accounts so cmux can route work through them.");
+    expect(html).toContain("cmux iOS app");
+    expect(html).toContain("Use cmux on your phone.");
+    expect(html).toContain('href="https://cmux.test/handler/after-sign-in?native_app_return_to=cmux%3A%2F%2Fauth-callback"');
+    expect(html).toContain('href="/dashboard/subrouter"');
+    expect(html).toContain('href="/dashboard/ai-accounts"');
+    expect(html).toContain('href="/dashboard/testflight"');
     expect(html).toContain('href="/api/billing/portal"');
+    expect(html).toContain('href="/handler/account-settings"');
     expect(html).toContain("Manage billing");
     expect(html).toContain("Open cmux");
+    expect(html).toContain("Manage sign-in methods");
     expect(redirect).not.toHaveBeenCalled();
     expect(retrieveSession).toHaveBeenCalledWith("cs_123", {
       expand: ["subscription", "customer"],


### PR DESCRIPTION
New Pro buyers landed on a bare "cmux Pro is active" page and got dropped back into the same terminal they had for free, with nothing showing them what they just paid for. Now /billing/success is a real welcome moment: confirmation plus a "What you unlocked" section with four cards (Cloud agents on Cloud VMs, model gateway, connect AI accounts, iOS app), each with one concrete next-step link to a destination that exists (Open cmux, /dashboard/subrouter, /dashboard/ai-accounts, /dashboard/testflight). Manage billing and Manage sign-in methods stay as secondary actions.

Presentation + copy only: the Stripe config guard, session retrieve + Sentry, scheme validation, active-subscription pending redirect, and the after-sign-in Open cmux href are byte-identical.

/fable loop: judge APPROVE (plus a copy polish on the model-gateway card). 501 web tests green in sorted order, typecheck + flag lint clean, en/ja parity. This is Part A of onboarding; a Swift in-app first-run Pro checklist follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786065927&installation_id=133855650&pr_number=7563&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7563&signature=7238f23790988626b531a27b5ee3264f9db0ab968d4539d0153c90e535de04be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and copy only; Stripe session validation, redirects, and billing guards are unchanged.
> 
> **Overview**
> After a successful Pro purchase, **`/billing/success`** is now a guided welcome screen instead of a minimal confirmation.
> 
> The page keeps the existing purchase confirmation and **Open cmux** CTA, then adds a **What you unlocked** section with four cards—cloud agents, model gateway, AI accounts, and the iOS app—each with copy and a link to a concrete destination (`after-sign-in`, `/dashboard/subrouter`, `/dashboard/ai-accounts`, `/dashboard/testflight`). **Manage billing** and **Manage sign-in methods** remain as secondary footer actions. Layout is widened and sectioned for the card grid.
> 
> New i18n strings for the section title and per-feature title/body/action are added in **en** and **ja**, with typed message keys on the page. Tests assert the new content and hrefs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aadd9cf5db244fef891b760bb62a890896de5038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted `/billing/success` into a “Welcome to Pro” next-steps page that confirms activation and shows what Pro unlocks. Adds four actionable cards; billing/session logic is unchanged.

- **New Features**
  - Added “What you unlocked” with four cards and direct links: Cloud agents on Cloud VMs → Open cmux, Model gateway → `/dashboard/subrouter`, Connect AI accounts → `/dashboard/ai-accounts`, iOS app → `/dashboard/testflight`.
  - Secondary actions remain: Manage billing and Manage sign-in methods. No logic changes to Stripe/Sentry guards, scheme validation, active-subscription redirect, or `after-sign-in` handoff.
  - Localized in `en` and `ja`; tests updated to cover new copy and links.

<sup>Written for commit aadd9cf5db244fef891b760bb62a890896de5038. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

