### PR TITLE
Fix UserDefaults settings source-less observation

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore+Observation.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore+Observation.swift
@@ -1,0 +1,197 @@
+import Dispatch
+import Foundation
+
+extension UserDefaultsSettingsStore {
+    /// Returns a coalescing stream of the current value and later changes.
+    public nonisolated func values<Value>(for key: DefaultsKey<Value>) -> AsyncStream<Value> {
+        let storage = self.storage
+        let observedMutationWatermarks = self.observedMutationWatermarks
+        let storageKey = key.userDefaultsKey
+        return AsyncStream<Value>(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            let (signals, signalContinuation, storeSignalToken) = storeSignals.makeStream(for: storageKey)
+
+            let observer = storage.addDidChangeObserver { [weak self] isBackingDefaultsNotification, canCarryActiveMutationSource in
+                guard self != nil else { return }
+                let logicalOrder = DispatchTime.now().uptimeNanoseconds
+                _ = observedMutationWatermarks.recordNotification(
+                    logicalOrder: logicalOrder,
+                    isBackingDefaultsNotification: isBackingDefaultsNotification,
+                    canCarryActiveMutationSource: canCarryActiveMutationSource,
+                    for: storageKey
+                )
+                signalContinuation.yield(
+                    UserDefaultsSettingsStoreSignal(
+                        isBackingDefaultsNotification: isBackingDefaultsNotification,
+                        canCarryActiveMutationSource: canCarryActiveMutationSource,
+                        logicalOrder: logicalOrder,
+                        deliveredMutationSource: nil
+                    )
+                )
+            }
+
+            let drainTask = Task { [weak self] in
+                guard let self else {
+                    continuation.finish()
+                    return
+                }
+                var lastYielded = await self.value(for: key)
+                await self.recordKnownValue(lastYielded, for: storageKey)
+                continuation.yield(lastYielded)
+
+                for await signal in signals {
+                    if Task.isCancelled { break }
+                    let current = await self.value(for: key)
+                    if current != lastYielded {
+                        lastYielded = current
+                        await self.recordSourceLessObservedMutation(
+                            value: current,
+                            logicalOrder: signal.logicalOrder,
+                            for: storageKey
+                        )
+                        continuation.yield(current)
+                    }
+                }
+                continuation.finish()
+            }
+
+            continuation.onTermination = { _ in
+                drainTask.cancel()
+                signalContinuation.finish()
+                storeSignalToken.remove()
+                observer.remove()
+            }
+        }
+    }
+
+    /// Returns value changes tagged with one-shot store-owned mutation sources.
+    public func valueEvents<Value>(
+        for key: DefaultsKey<Value>,
+        includingSources includedMutationSources: Set<UserDefaultsSettingsMutationSource> = []
+    ) -> AsyncStream<UserDefaultsSettingsValueEvent<Value>> {
+        let initialConsumedSourceSequence = mutationSourceSequences[key.userDefaultsKey] ?? 0
+        let storage = self.storage
+        let observedMutationWatermarks = self.observedMutationWatermarks
+        let storageKey = key.userDefaultsKey
+        let streamStartLogicalOrder = DispatchTime.now().uptimeNanoseconds
+        recordKnownValue(storage.value(for: key), for: storageKey)
+        return AsyncStream<UserDefaultsSettingsValueEvent<Value>>(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            let (signals, signalContinuation, storeSignalToken) = storeSignals.makeStream(for: storageKey)
+
+            let observer = storage.addDidChangeObserver { [weak self] isBackingDefaultsNotification, canCarryActiveMutationSource in
+                guard self != nil else { return }
+                let logicalOrder = DispatchTime.now().uptimeNanoseconds
+                let deliveredMutationSource = observedMutationWatermarks.recordNotification(
+                    logicalOrder: logicalOrder,
+                    isBackingDefaultsNotification: isBackingDefaultsNotification,
+                    canCarryActiveMutationSource: canCarryActiveMutationSource,
+                    for: storageKey
+                )
+                signalContinuation.yield(
+                    UserDefaultsSettingsStoreSignal(
+                        isBackingDefaultsNotification: isBackingDefaultsNotification,
+                        canCarryActiveMutationSource: canCarryActiveMutationSource,
+                        logicalOrder: logicalOrder,
+                        deliveredMutationSource: deliveredMutationSource
+                    )
+                )
+            }
+
+            let drainTask = Task { [weak self] in
+                guard let self else {
+                    continuation.finish()
+                    return
+                }
+                var consumedSourceSequence = initialConsumedSourceSequence
+                let initialBackingNotification = observedMutationWatermarks.latestBackingNotification(
+                    after: streamStartLogicalOrder,
+                    for: storageKey
+                )
+                let initialSnapshot = await self.valueEvent(
+                    for: key,
+                    consumedSourceSequence: consumedSourceSequence,
+                    includedMutationSources: includedMutationSources,
+                    deliveredMutationSource: initialBackingNotification?.mutationSource,
+                    deliverPendingMutationSourceWhenUnobserved: initialBackingNotification == nil,
+                    supersedesPendingMutationSource: initialBackingNotification != nil
+                        && initialBackingNotification?.mutationSource == nil,
+                    isInitialSnapshot: true
+                )
+                consumedSourceSequence = initialSnapshot.consumedSourceSequence
+                var lastYieldedEvent = initialSnapshot.event
+                if initialSnapshot.event.mutationSource == nil,
+                   initialSnapshot.event.supersededMutationSource != nil {
+                    await self.recordAcceptedMutation(
+                        nil,
+                        logicalOrder: DispatchTime.now().uptimeNanoseconds,
+                        for: key.userDefaultsKey
+                    )
+                }
+                continuation.yieldPreservingSources(initialSnapshot.event)
+
+                for await signal in signals {
+                    if Task.isCancelled { break }
+                    let snapshot = await self.valueEvent(
+                        for: key,
+                        consumedSourceSequence: consumedSourceSequence,
+                        deliveredMutationSource: signal.deliveredMutationSource,
+                        deliverPendingMutationSourceWhenUnobserved: signal.isBackingDefaultsNotification,
+                        deliverPendingMutationSourceWhenValueDiffersFrom: lastYieldedEvent.value,
+                        includeMutationSourceMetadata: signal.isBackingDefaultsNotification
+                            || signal.deliveredMutationSource != nil,
+                        includeMutationSourceMetadataWhenValueDiffersFrom: lastYieldedEvent.value
+                    )
+                    consumedSourceSequence = snapshot.consumedSourceSequence
+                    var currentEvent = snapshot.event
+                    if signal.isBackingDefaultsNotification,
+                       signal.deliveredMutationSource == nil,
+                       currentEvent.value == lastYieldedEvent.value,
+                       currentEvent.mutationSource == nil,
+                       currentEvent.supersededMutationSource == nil,
+                       lastYieldedEvent.mutationSource != nil {
+                        currentEvent = UserDefaultsSettingsValueEvent(
+                            value: currentEvent.value,
+                            supersededMutationSources: lastYieldedEvent.deliveryMutationSources
+                        )
+                    }
+                    let recordsSourceLessFence = signal.isBackingDefaultsNotification && signal.deliveredMutationSource == nil
+                        && currentEvent.value == lastYieldedEvent.value
+                        && currentEvent.mutationSource == nil && currentEvent.supersededMutationSource == nil
+                    if currentEvent.mutationSource == nil,
+                       (currentEvent.value != lastYieldedEvent.value
+                        || currentEvent.supersededMutationSource != nil
+                        || recordsSourceLessFence) {
+                        await self.recordSourceLessObservedMutation(
+                            value: currentEvent.value,
+                            logicalOrder: signal.logicalOrder,
+                            for: key.userDefaultsKey,
+                            recordsAcceptedMutation: currentEvent.supersededMutationSource != nil
+                                || recordsSourceLessFence
+                        )
+                    } else if currentEvent.value != lastYieldedEvent.value {
+                        await self.recordKnownValue(currentEvent.value, for: key.userDefaultsKey)
+                    }
+                    if !signal.isBackingDefaultsNotification {
+                        guard currentEvent.value != lastYieldedEvent.value
+                            || currentEvent.mutationSource != nil
+                            || currentEvent.supersededMutationSource != nil
+                        else { continue }
+                    }
+                    if currentEvent.value != lastYieldedEvent.value
+                        || currentEvent.mutationSource != nil
+                        || currentEvent.supersededMutationSource != nil {
+                        lastYieldedEvent = currentEvent
+                        continuation.yieldPreservingSources(currentEvent)
+                    }
+                }
+                continuation.finish()
+            }
+
+            continuation.onTermination = { _ in
+                drainTask.cancel()
+                signalContinuation.finish()
+                storeSignalToken.remove()
+                observer.remove()
+            }
+        }
+    }
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore.swift
@@ -9,8 +9,9 @@ import Dispatch
 /// ```
 public actor UserDefaultsSettingsStore {
     /// The `UserDefaults` suite this store reads and writes.
-    private let storage: UserDefaultsSettingsStorage
-    private let observedMutationWatermarks = UserDefaultsSettingsObservedMutationWatermarks()
+    let storage: UserDefaultsSettingsStorage
+    let observedMutationWatermarks = UserDefaultsSettingsObservedMutationWatermarks()
+    let storeSignals = UserDefaultsSettingsStoreSignals()
     private var mutationSources: [String: UserDefaultsSettingsMutationSourceRecord] = [:]
     private var supersededMutationSources: [
         String: [(source: UserDefaultsSettingsMutationSource, sequence: UInt64)]
@@ -19,7 +20,7 @@ public actor UserDefaultsSettingsStore {
     private var acceptedMutationSourcesByOwner: [String: [UUID: UserDefaultsSettingsMutationSource]] = [:]
     private var knownValues: [String: any Sendable] = [:]
     private var knownValueLogicalOrders: [String: UInt64] = [:]
-    private var mutationSourceSequences: [String: UInt64] = [:]
+    var mutationSourceSequences: [String: UInt64] = [:]
     private let maximumSupersededMutationSourcesPerKey = 64
 
     /// Creates a store backed by the given `UserDefaults` instance.
@@ -59,6 +60,9 @@ public actor UserDefaultsSettingsStore {
             observedMutationWatermarks.beginMutationSource(source, for: key.userDefaultsKey)
         }
         storage.set(value, for: key)
+        if source == nil {
+            emitStoreOwnedSourceLessMutation(for: key.userDefaultsKey)
+        }
         if let source {
             observedMutationWatermarks.endMutationSource(source, for: key.userDefaultsKey)
         }
@@ -80,6 +84,9 @@ public actor UserDefaultsSettingsStore {
             observedMutationWatermarks.beginMutationSource(source, for: key.userDefaultsKey)
         }
         storage.removeObject(forKey: key.userDefaultsKey)
+        if source == nil {
+            emitStoreOwnedSourceLessMutation(for: key.userDefaultsKey)
+        }
         if let source {
             observedMutationWatermarks.endMutationSource(source, for: key.userDefaultsKey)
         }
@@ -98,10 +105,31 @@ public actor UserDefaultsSettingsStore {
                 defaults = custom
             } else {
                 storage.removeObject(forKey: storageKey)
+                emitStoreOwnedSourceLessMutation(for: storageKey)
                 continue
             }
             defaults.removeObject(forKey: storageKey)
+            emitStoreOwnedSourceLessMutation(for: storageKey)
         }
+    }
+
+    private func emitStoreOwnedSourceLessMutation(for storageKey: String) {
+        let logicalOrder = DispatchTime.now().uptimeNanoseconds
+        let deliveredMutationSource = observedMutationWatermarks.recordNotification(
+            logicalOrder: logicalOrder,
+            isBackingDefaultsNotification: true,
+            canCarryActiveMutationSource: false,
+            for: storageKey
+        )
+        storeSignals.emit(
+            UserDefaultsSettingsStoreSignal(
+                isBackingDefaultsNotification: true,
+                canCarryActiveMutationSource: false,
+                logicalOrder: logicalOrder,
+                deliveredMutationSource: deliveredMutationSource
+            ),
+            for: storageKey
+        )
     }
 
     private func recordMutationSource<Value: SettingCodable>(
@@ -173,7 +201,7 @@ public actor UserDefaultsSettingsStore {
         return true
     }
 
-    private func recordKnownValue<Value: SettingCodable>(
+    func recordKnownValue<Value: SettingCodable>(
         _ value: Value,
         logicalOrder: UInt64 = DispatchTime.now().uptimeNanoseconds,
         for storageKey: String
@@ -182,7 +210,7 @@ public actor UserDefaultsSettingsStore {
         knownValueLogicalOrders[storageKey] = max(knownValueLogicalOrders[storageKey] ?? 0, logicalOrder)
     }
 
-    private func recordSourceLessObservedMutation<Value: SettingCodable>(value: Value, logicalOrder: UInt64, for storageKey: String, recordsAcceptedMutation: Bool = false) {
+    func recordSourceLessObservedMutation<Value: SettingCodable>(value: Value, logicalOrder: UInt64, for storageKey: String, recordsAcceptedMutation: Bool = false) {
         if recordsAcceptedMutation || !knownValue(value, matchesValueFor: storageKey) {
             recordAcceptedMutation(nil, logicalOrder: logicalOrder, for: storageKey)
         }
@@ -197,7 +225,7 @@ public actor UserDefaultsSettingsStore {
         return knownValue == value
     }
 
-    private func recordAcceptedMutation(
+    func recordAcceptedMutation(
         _ source: UserDefaultsSettingsMutationSource?,
         logicalOrder sourceLessLogicalOrder: UInt64? = nil,
         for storageKey: String
@@ -242,7 +270,7 @@ public actor UserDefaultsSettingsStore {
         return nextSequence
     }
 
-    private func valueEvent<Value>(
+    func valueEvent<Value>(
         for key: DefaultsKey<Value>,
         consumedSourceSequence: UInt64,
         includedMutationSources: Set<UserDefaultsSettingsMutationSource> = [],
@@ -306,194 +334,5 @@ public actor UserDefaultsSettingsStore {
             ),
             nextConsumedSourceSequence
         )
-    }
-
-    /// Returns a coalescing stream of the current value and later changes.
-    public nonisolated func values<Value>(for key: DefaultsKey<Value>) -> AsyncStream<Value> {
-        let storage = self.storage
-        let observedMutationWatermarks = self.observedMutationWatermarks
-        let storageKey = key.userDefaultsKey
-        return AsyncStream<Value>(bufferingPolicy: .bufferingNewest(1)) { continuation in
-            typealias Signal = (isBackingDefaultsNotification: Bool, canCarryActiveMutationSource: Bool, logicalOrder: UInt64)
-            let (signals, signalContinuation) = AsyncStream<Signal>.makeStream(bufferingPolicy: .bufferingNewest(1))
-
-            let observer = storage.addDidChangeObserver { [weak self] isBackingDefaultsNotification, canCarryActiveMutationSource in
-                guard self != nil else { return }
-                let logicalOrder = DispatchTime.now().uptimeNanoseconds
-                _ = observedMutationWatermarks.recordNotification(
-                    logicalOrder: logicalOrder,
-                    isBackingDefaultsNotification: isBackingDefaultsNotification,
-                    canCarryActiveMutationSource: canCarryActiveMutationSource,
-                    for: storageKey
-                )
-                signalContinuation.yield((isBackingDefaultsNotification, canCarryActiveMutationSource, logicalOrder))
-            }
-
-            let drainTask = Task { [weak self] in
-                guard let self else {
-                    continuation.finish()
-                    return
-                }
-                var lastYielded = await self.value(for: key)
-                await self.recordKnownValue(lastYielded, for: storageKey)
-                continuation.yield(lastYielded)
-
-                for await signal in signals {
-                    if Task.isCancelled { break }
-                    let current = await self.value(for: key)
-                    if current != lastYielded {
-                        lastYielded = current
-                        await self.recordSourceLessObservedMutation(
-                            value: current,
-                            logicalOrder: signal.logicalOrder,
-                            for: storageKey
-                        )
-                        continuation.yield(current)
-                    }
-                }
-                continuation.finish()
-            }
-
-            continuation.onTermination = { _ in
-                drainTask.cancel()
-                signalContinuation.finish()
-                observer.remove()
-            }
-        }
-    }
-
-    /// Returns value changes tagged with one-shot store-owned mutation sources.
-    public func valueEvents<Value>(
-        for key: DefaultsKey<Value>,
-        includingSources includedMutationSources: Set<UserDefaultsSettingsMutationSource> = []
-    ) -> AsyncStream<UserDefaultsSettingsValueEvent<Value>> {
-        let initialConsumedSourceSequence = mutationSourceSequences[key.userDefaultsKey] ?? 0
-        let storage = self.storage
-        let observedMutationWatermarks = self.observedMutationWatermarks
-        let storageKey = key.userDefaultsKey
-        let streamStartLogicalOrder = DispatchTime.now().uptimeNanoseconds
-        recordKnownValue(storage.value(for: key), for: storageKey)
-        return AsyncStream<UserDefaultsSettingsValueEvent<Value>>(bufferingPolicy: .bufferingNewest(1)) { continuation in
-            typealias Signal = (
-                isBackingDefaultsNotification: Bool,
-                canCarryActiveMutationSource: Bool,
-                logicalOrder: UInt64,
-                deliveredMutationSource: UserDefaultsSettingsMutationSource?
-            )
-            let (signals, signalContinuation) = AsyncStream<Signal>.makeStream(bufferingPolicy: .bufferingNewest(1))
-
-            let observer = storage.addDidChangeObserver { [weak self] isBackingDefaultsNotification, canCarryActiveMutationSource in
-                guard self != nil else { return }
-                let logicalOrder = DispatchTime.now().uptimeNanoseconds
-                let deliveredMutationSource = observedMutationWatermarks.recordNotification(
-                    logicalOrder: logicalOrder,
-                    isBackingDefaultsNotification: isBackingDefaultsNotification,
-                    canCarryActiveMutationSource: canCarryActiveMutationSource,
-                    for: storageKey
-                )
-                signalContinuation.yield((
-                    isBackingDefaultsNotification,
-                    canCarryActiveMutationSource,
-                    logicalOrder,
-                    deliveredMutationSource
-                ))
-            }
-
-            let drainTask = Task { [weak self] in
-                guard let self else {
-                    continuation.finish()
-                    return
-                }
-                var consumedSourceSequence = initialConsumedSourceSequence
-                let initialBackingNotification = observedMutationWatermarks.latestBackingNotification(
-                    after: streamStartLogicalOrder,
-                    for: storageKey
-                )
-                let initialSnapshot = await self.valueEvent(
-                    for: key,
-                    consumedSourceSequence: consumedSourceSequence,
-                    includedMutationSources: includedMutationSources,
-                    deliveredMutationSource: initialBackingNotification?.mutationSource,
-                    deliverPendingMutationSourceWhenUnobserved: initialBackingNotification == nil,
-                    supersedesPendingMutationSource: initialBackingNotification != nil
-                        && initialBackingNotification?.mutationSource == nil,
-                    isInitialSnapshot: true
-                )
-                consumedSourceSequence = initialSnapshot.consumedSourceSequence
-                var lastYieldedEvent = initialSnapshot.event
-                if initialSnapshot.event.mutationSource == nil,
-                   initialSnapshot.event.supersededMutationSource != nil {
-                    await self.recordAcceptedMutation(
-                        nil,
-                        logicalOrder: DispatchTime.now().uptimeNanoseconds,
-                        for: key.userDefaultsKey
-                    )
-                }
-                continuation.yieldPreservingSources(initialSnapshot.event)
-
-                for await signal in signals {
-                    if Task.isCancelled { break }
-                    let snapshot = await self.valueEvent(
-                        for: key,
-                        consumedSourceSequence: consumedSourceSequence,
-                        deliveredMutationSource: signal.deliveredMutationSource,
-                        deliverPendingMutationSourceWhenUnobserved: signal.isBackingDefaultsNotification,
-                        deliverPendingMutationSourceWhenValueDiffersFrom: lastYieldedEvent.value,
-                        includeMutationSourceMetadata: signal.isBackingDefaultsNotification
-                            || signal.deliveredMutationSource != nil,
-                        includeMutationSourceMetadataWhenValueDiffersFrom: lastYieldedEvent.value
-                    )
-                    consumedSourceSequence = snapshot.consumedSourceSequence
-                    var currentEvent = snapshot.event
-                    if signal.isBackingDefaultsNotification,
-                       signal.deliveredMutationSource == nil,
-                       currentEvent.value == lastYieldedEvent.value,
-                       currentEvent.mutationSource == nil,
-                       currentEvent.supersededMutationSource == nil,
-                       lastYieldedEvent.mutationSource != nil {
-                        currentEvent = UserDefaultsSettingsValueEvent(
-                            value: currentEvent.value,
-                            supersededMutationSources: lastYieldedEvent.deliveryMutationSources
-                        )
-                    }
-                    let recordsSourceLessFence = signal.isBackingDefaultsNotification && signal.deliveredMutationSource == nil
-                        && currentEvent.value == lastYieldedEvent.value
-                        && currentEvent.mutationSource == nil && currentEvent.supersededMutationSource == nil
-                    if currentEvent.mutationSource == nil,
-                       (currentEvent.value != lastYieldedEvent.value
-                        || currentEvent.supersededMutationSource != nil
-                        || recordsSourceLessFence) {
-                        await self.recordSourceLessObservedMutation(
-                            value: currentEvent.value,
-                            logicalOrder: signal.logicalOrder,
-                            for: key.userDefaultsKey,
-                            recordsAcceptedMutation: currentEvent.supersededMutationSource != nil
-                                || recordsSourceLessFence
-                        )
-                    } else if currentEvent.value != lastYieldedEvent.value {
-                        await self.recordKnownValue(currentEvent.value, for: key.userDefaultsKey)
-                    }
-                    if !signal.isBackingDefaultsNotification {
-                        guard currentEvent.value != lastYieldedEvent.value
-                            || currentEvent.mutationSource != nil
-                            || currentEvent.supersededMutationSource != nil
-                        else { continue }
-                    }
-                    if currentEvent.value != lastYieldedEvent.value
-                        || currentEvent.mutationSource != nil
-                        || currentEvent.supersededMutationSource != nil {
-                        lastYieldedEvent = currentEvent
-                        continuation.yieldPreservingSources(currentEvent)
-                    }
-                }
-                continuation.finish()
-            }
-
-            continuation.onTermination = { _ in
-                drainTask.cancel()
-                signalContinuation.finish()
-                observer.remove()
-            }
-        }
     }
 }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStoreSignals.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStoreSignals.swift
@@ -1,0 +1,67 @@
+import Foundation
+import os
+
+struct UserDefaultsSettingsStoreSignal: Sendable {
+    let isBackingDefaultsNotification: Bool
+    let canCarryActiveMutationSource: Bool
+    let logicalOrder: UInt64
+    let deliveredMutationSource: UserDefaultsSettingsMutationSource?
+}
+
+final class UserDefaultsSettingsStoreSignalToken: @unchecked Sendable {
+    private let id: UUID
+    private let signals: UserDefaultsSettingsStoreSignals
+
+    init(id: UUID, signals: UserDefaultsSettingsStoreSignals) {
+        self.id = id
+        self.signals = signals
+    }
+
+    func remove() {
+        signals.removeObserver(id: id)
+    }
+}
+
+final class UserDefaultsSettingsStoreSignals: @unchecked Sendable {
+    private struct Observer {
+        let storageKey: String
+        let continuation: AsyncStream<UserDefaultsSettingsStoreSignal>.Continuation
+    }
+
+    private let observers = OSAllocatedUnfairLock(initialState: [UUID: Observer]())
+
+    func makeStream(
+        for storageKey: String,
+        bufferingPolicy: AsyncStream<UserDefaultsSettingsStoreSignal>.Continuation.BufferingPolicy = .bufferingNewest(1)
+    ) -> (
+        stream: AsyncStream<UserDefaultsSettingsStoreSignal>,
+        continuation: AsyncStream<UserDefaultsSettingsStoreSignal>.Continuation,
+        token: UserDefaultsSettingsStoreSignalToken
+    ) {
+        let id = UUID()
+        let (stream, continuation) = AsyncStream<UserDefaultsSettingsStoreSignal>.makeStream(
+            bufferingPolicy: bufferingPolicy
+        )
+        observers.withLock { observers in
+            observers[id] = Observer(storageKey: storageKey, continuation: continuation)
+        }
+        return (stream, continuation, UserDefaultsSettingsStoreSignalToken(id: id, signals: self))
+    }
+
+    func emit(_ signal: UserDefaultsSettingsStoreSignal, for storageKey: String) {
+        let continuations = observers.withLock { observers in
+            observers.values.compactMap { observer in
+                observer.storageKey == storageKey ? observer.continuation : nil
+            }
+        }
+        for continuation in continuations {
+            continuation.yield(signal)
+        }
+    }
+
+    fileprivate func removeObserver(id: UUID) {
+        _ = observers.withLock { observers in
+            observers.removeValue(forKey: id)
+        }
+    }
+}

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsStoreNotificationTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsStoreNotificationTests.swift
@@ -219,9 +219,6 @@ struct UserDefaultsSettingsStoreNotificationTests {
             let stream = await store.valueEvents(for: key)
             for await event in stream {
                 await recorder.append(event)
-                if await recorder.count() >= 3 {
-                    break
-                }
             }
         }
         defer {


### PR DESCRIPTION
Fixes the current main CI `swift-package-tests` failure in `UserDefaultsSettingsStoreTests.valueEventsYieldSupersededSourceWhenSourceLessWriteKeepsLastValue`.

The store previously depended on `UserDefaults.didChangeNotification` to wake value observers after every store-owned write. On the main runner, a same-value source-less write did not reliably deliver a notification, so observers kept the prior tagged mutation source and the test timed out at two events.

This adds a per-key in-process signal channel for source-less store-owned writes. The signal is emitted after the backing value is updated and after the pending source has been recorded as superseded, so observers clear the pending source even when the persisted value is unchanged and `UserDefaults` does not post a notification.

Verification:
- `swift test --package-path Packages/macOS/CmuxSettings --filter 'UserDefaultsSettingsStoreTests/valueEventsYieldSupersededSourceWhenSourceLessWriteKeepsLastValue|UserDefaultsSettingsStoreNotificationTests|UserDefaultsSettingsStoreObservationTests'`
- `swift test --package-path Packages/macOS/CmuxSettings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786067690&installation_id=133855650&pr_number=7571&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7571&signature=2f48e7b23877c7637ca82788487ba035a6c414404759d0fa19c2cc60ec46b4ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes settings observation and mutation-source delivery semantics across async streams and actor-isolated state; behavior is subtle but scoped to source-less store-owned writes with existing test coverage.
> 
> **Overview**
> Fixes **unreliable observation** when the store performs **source-less** writes that leave the persisted value unchanged—`UserDefaults` may not post `didChangeNotification`, so `valueEvents` observers could miss superseded mutation-source metadata (CI failure in `valueEventsYieldSupersededSourceWhenSourceLessWriteKeepsLastValue`).
> 
> Adds **`UserDefaultsSettingsStoreSignals`**, a per-key in-process channel, and **`emitStoreOwnedSourceLessMutation`** after source-less `set`, `reset`, and `resetAll` once the backing write and watermark bookkeeping are done. **`values(for:)`** and **`valueEvents(for:)`** are moved to **`UserDefaultsSettingsStore+Observation`** and now drain a merged stream of these signals plus storage change observers, with token-based cleanup on termination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d515b462853ddd06401b5771ed71427be51e6a7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missed observations for source-less writes in the `UserDefaults` settings store by adding per-key in-process signals and merging them with system notifications. This ensures value and event streams wake and clear superseded mutation sources even on no-op writes, stabilizing CI.

- **Bug Fixes**
  - Added `UserDefaultsSettingsStoreSignals` and `UserDefaultsSettingsStoreSignal`; store now emits per-key signals for source-less writes.
  - Emit a signal after `set`, `remove`, and each key in `resetAll` when `source == nil`, after the write and watermark update.
  - Merged signals with `UserDefaults` notifications in `values(for:)` and `valueEvents(for:)` (moved to `UserDefaultsSettingsStore+Observation.swift`), with token cleanup and required internal API exposure; resolves `UserDefaultsSettingsStoreTests.valueEventsYieldSupersededSourceWhenSourceLessWriteKeepsLastValue`.

<sup>Written for commit d515b462853ddd06401b5771ed71427be51e6a7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live async observation for UserDefaults-backed settings, including a value stream and an event stream with change metadata (optionally including mutation sources).

* **Bug Fixes**
  * Improved delivery of updates for source-less mutations so observers reliably receive the latest value.
  * Refined reset and reset-all notification behavior to keep change events consistent across both standard and custom storage locations.

* **Tests**
  * Updated observation test to continue capturing events until explicitly cancelled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->