### PR TITLE
Fall back to English on the Pro success page for locales without copy

### DIFF
--- a/web/app/billing/success/page.tsx
+++ b/web/app/billing/success/page.tsx
@@ -173,10 +173,20 @@ async function billingSuccessMessages(
   const messages = (await import(`../../../messages/${locale}.json`)).default as {
     billingSuccess?: BillingSuccessMessages;
   };
-  if (!messages.billingSuccess) {
-    throw new Error(`Missing billingSuccess messages for locale ${locale}`);
+  if (messages.billingSuccess) {
+    return { locale, messages: messages.billingSuccess };
   }
-  return { locale, messages: messages.billingSuccess };
+  // Only en and ja carry billingSuccess copy today. A buyer whose browser
+  // resolves to any other locale must still see their post-purchase page
+  // (this is the screen shown right after paying), so fall back to the
+  // English copy rather than throwing a 500.
+  const fallback = (await import("../../../messages/en.json")).default as {
+    billingSuccess?: BillingSuccessMessages;
+  };
+  if (!fallback.billingSuccess) {
+    throw new Error("Missing billingSuccess messages for the default locale");
+  }
+  return { locale: routing.defaultLocale, messages: fallback.billingSuccess };
 }
 
 function preferredLocale(headersList: Headers): Locale {

--- a/web/tests/billing-success-page.test.tsx
+++ b/web/tests/billing-success-page.test.tsx
@@ -21,10 +21,12 @@ mock.module("next/navigation", () => ({
   permanentRedirect: redirect,
 }));
 
+let acceptLanguage = "en";
+
 mock.module("next/headers", () => ({
   headers: async () =>
     new Headers({
-      "accept-language": "en",
+      "accept-language": acceptLanguage,
       host: "cmux.test",
       "x-forwarded-proto": "https",
     }),
@@ -56,6 +58,20 @@ mock.module("../services/billing/purchase", () => ({
 const { default: BillingSuccessPage } = await import("../app/billing/success/page");
 
 describe("billing success page", () => {
+  test("falls back to English copy for a locale without billingSuccess", async () => {
+    acceptLanguage = "fr";
+    try {
+      const element = await BillingSuccessPage({
+        searchParams: Promise.resolve({ session_id: "cs_123" }),
+      });
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain("cmux Pro is active");
+      expect(html).toContain("What you unlocked");
+    } finally {
+      acceptLanguage = "en";
+    }
+  });
+
   test("renders welcome sections and links after an active purchase", async () => {
     const element = await BillingSuccessPage({
       searchParams: Promise.resolve({ session_id: "cs_123" }),


### PR DESCRIPTION
/billing/success threw a 500 for the 18 supported locales that lack a billingSuccess message namespace (only en and ja have it). That page is the screen a buyer lands on immediately after paying, so a browser resolving to fr/de/es/etc. would hit a hard crash right after a successful charge. The message loader now falls back to English copy for any locale missing billingSuccess instead of throwing, with a regression test that a non-en/ja locale renders the page.

Found during the billing-onboarding autoreview (Greptile flagged it as pre-existing on both PRs 7562/7563); fixing it now since the page is post-checkout launch-facing.

502 web tests green in sorted order, typecheck + flag lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786072770&installation_id=133855650&pr_number=7577&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7577&signature=1c482905e9715d316a9314223ad65776e140b7e1eea017047c659b6f1394e74e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 54ea512c6750090f283fc70b5f5d45d03d516362. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pro success page to fall back to English when a locale lacks `billingSuccess` copy, preventing a 500 right after checkout. Non‑en/ja browsers now see the page in English instead of crashing.

- **Bug Fixes**
  - Load English `billingSuccess` messages when the requested locale has no copy; return `routing.defaultLocale` with the fallback.
  - Added a regression test that a non‑en/ja locale (e.g., fr) renders the page and shows key strings.

<sup>Written for commit 54ea512c6750090f283fc70b5f5d45d03d516362. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing success page localization so it now falls back to English when a translated version is unavailable instead of showing an error.
  * Ensured the billing success page still loads correctly for users whose browser language doesn’t have a complete translation.

* **Tests**
  * Expanded billing success page coverage to verify the English fallback behavior for non-English locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->