### PR TITLE
Fix + menu Cloud VM row padding

### DIFF
--- a/Sources/Update/MouseDownMenuItemView.swift
+++ b/Sources/Update/MouseDownMenuItemView.swift
@@ -1,0 +1,107 @@
+import AppKit
+
+@MainActor
+final class MouseDownMenuItemView: NSView {
+    private static let defaultWidth: CGFloat = 260
+    private static let labelHorizontalPadding: CGFloat = 14
+    private static let highlightHorizontalInset: CGFloat = 5
+    private static let highlightVerticalInset: CGFloat = 2
+    private static let highlightCornerRadius: CGFloat = 5
+
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let action: () -> Void
+    private var trackingArea: NSTrackingArea?
+    private var isHighlighted = false {
+        didSet {
+            guard oldValue != isHighlighted else { return }
+            needsDisplay = true
+            titleLabel.textColor = isHighlighted ? .selectedMenuItemTextColor : .labelColor
+        }
+    }
+
+    init(title: String, action: @escaping () -> Void) {
+        self.action = action
+        super.init(frame: NSRect(
+            x: 0,
+            y: 0,
+            width: Self.defaultWidth,
+            height: Self.nativeMenuItemRowHeight()
+        ))
+        // NSMenu sizes to its widest item; let this custom view stretch so its
+        // highlight spans the full menu like a native item.
+        autoresizingMask = [.width]
+        wantsLayer = true
+        titleLabel.stringValue = title
+        titleLabel.font = .menuFont(ofSize: 0)
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(titleLabel)
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.labelHorizontalPadding),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.labelHorizontalPadding),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        trackingArea = area
+        addTrackingArea(area)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHighlighted = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHighlighted = false
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        isHighlighted = true
+        enclosingMenuItem?.menu?.cancelTrackingWithoutAnimation()
+        action()
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard isHighlighted else { return }
+        NSColor.selectedContentBackgroundColor.setFill()
+        NSBezierPath(
+            roundedRect: bounds.insetBy(dx: Self.highlightHorizontalInset, dy: Self.highlightVerticalInset),
+            xRadius: Self.highlightCornerRadius,
+            yRadius: Self.highlightCornerRadius
+        ).fill()
+    }
+
+    static func nativeMenuItemRowHeight() -> CGFloat {
+        let oneItemMenu = NSMenu()
+        oneItemMenu.addItem(NSMenuItem(title: "", action: nil, keyEquivalent: ""))
+
+        let twoItemMenu = NSMenu()
+        twoItemMenu.addItem(NSMenuItem(title: "", action: nil, keyEquivalent: ""))
+        twoItemMenu.addItem(NSMenuItem(title: "", action: nil, keyEquivalent: ""))
+
+        let rowHeight = twoItemMenu.size.height - oneItemMenu.size.height
+        guard rowHeight.isFinite, rowHeight > 0 else {
+            let menuFont = NSFont.menuFont(ofSize: 0)
+            return ceil(menuFont.ascender - menuFont.descender + menuFont.leading)
+        }
+        return rowHeight
+    }
+}

--- a/Sources/Update/TitlebarCloudVMButton.swift
+++ b/Sources/Update/TitlebarCloudVMButton.swift
@@ -424,7 +424,7 @@ struct TitlebarCloudVMButton: View {
 
     private static func mouseDownMenuItem(title: String, action: @escaping () -> Void) -> NSMenuItem {
         let item = menuItem(title: title, action: #selector(CloudVMMenuTarget.open))
-        item.view = CloudVMMouseDownMenuItemView(title: title, action: action)
+        item.view = MouseDownMenuItemView(title: title, action: action)
         return item
     }
 
@@ -499,87 +499,5 @@ private final class CloudVMMenuTarget: NSObject {
 
     @objc func handoff() {
         _ = AppDelegate.shared?.performCurrentCloudVMCommand(.handoff, debugSource: "titlebar.cloudVM.menu.handoff")
-    }
-}
-
-@MainActor
-private final class CloudVMMouseDownMenuItemView: NSView {
-    private let titleLabel = NSTextField(labelWithString: "")
-    private let action: () -> Void
-    private var trackingArea: NSTrackingArea?
-    private var isHighlighted = false {
-        didSet {
-            guard oldValue != isHighlighted else { return }
-            needsDisplay = true
-            titleLabel.textColor = isHighlighted ? .selectedMenuItemTextColor : .labelColor
-        }
-    }
-
-    init(title: String, action: @escaping () -> Void) {
-        self.action = action
-        super.init(frame: NSRect(x: 0, y: 0, width: 260, height: 28))
-        // NSMenu sizes to its widest item (e.g. "Checkpoint Cloud VM", the
-        // Advanced submenu row); let this custom view stretch to that width so
-        // its highlight spans the full menu like a native item instead of
-        // stopping at the fixed 260pt frame.
-        autoresizingMask = [.width]
-        wantsLayer = true
-        titleLabel.stringValue = title
-        titleLabel.font = .menuFont(ofSize: 0)
-        titleLabel.lineBreakMode = .byTruncatingTail
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(titleLabel)
-        NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
-            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
-            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-        ])
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override var mouseDownCanMoveWindow: Bool { false }
-
-    override func updateTrackingAreas() {
-        super.updateTrackingAreas()
-        if let trackingArea {
-            removeTrackingArea(trackingArea)
-        }
-        let area = NSTrackingArea(
-            rect: bounds,
-            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
-            owner: self,
-            userInfo: nil
-        )
-        trackingArea = area
-        addTrackingArea(area)
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        isHighlighted = true
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        isHighlighted = false
-    }
-
-    override func mouseDown(with event: NSEvent) {
-        isHighlighted = true
-        enclosingMenuItem?.menu?.cancelTrackingWithoutAnimation()
-        action()
-    }
-
-    override func draw(_ dirtyRect: NSRect) {
-        super.draw(dirtyRect)
-        guard isHighlighted else { return }
-        // Match native menu selection: rounded highlight, not a sharp rect.
-        NSColor.selectedContentBackgroundColor.setFill()
-        NSBezierPath(
-            roundedRect: bounds.insetBy(dx: 5, dy: 2),
-            xRadius: 5,
-            yRadius: 5
-        ).fill()
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -811,6 +811,7 @@
 		00C3AA443F6DA8D94E28CE17 /* MobileWorkspaceListObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */; };
 		D75280030000000000000001 /* MobileWorkspaceObserverSignposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75280030000000000000002 /* MobileWorkspaceObserverSignposts.swift */; };
 		13AB1A2E5DA6AD02DCAE971D /* MockBridgeInputCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3B5F249DECAB446CC71D32 /* MockBridgeInputCapture.swift */; };
+		C75740020000000000000001 /* MouseDownMenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75740020000000000000002 /* MouseDownMenuItemView.swift */; };
 		B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
 		596100000000000000000003 /* NativeNotificationDeliveryHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596100000000000000000004 /* NativeNotificationDeliveryHooks.swift */; };
 		596100000000000000000001 /* NativeNotificationFallbackCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596100000000000000000002 /* NativeNotificationFallbackCommandTests.swift */; };
@@ -2280,6 +2281,7 @@
 		C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileWorkspaceListObserver.swift; sourceTree = "<group>"; };
 		D75280030000000000000002 /* MobileWorkspaceObserverSignposts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileWorkspaceObserverSignposts.swift; sourceTree = "<group>"; };
 		CD3B5F249DECAB446CC71D32 /* MockBridgeInputCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBridgeInputCapture.swift; sourceTree = "<group>"; };
+		C75740020000000000000002 /* MouseDownMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/MouseDownMenuItemView.swift; sourceTree = "<group>"; };
 		B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsUITests.swift; sourceTree = "<group>"; };
 		596100000000000000000004 /* NativeNotificationDeliveryHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeNotificationDeliveryHooks.swift; sourceTree = "<group>"; };
 		596100000000000000000002 /* NativeNotificationFallbackCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeNotificationFallbackCommandTests.swift; sourceTree = "<group>"; };
@@ -3868,6 +3870,7 @@
 				A5001223 /* UpdateLogStore.swift */,
 				A5001218 /* UpdateTitlebarAccessory.swift */,
 				C10D00120000000000000012 /* TitlebarCloudVMButton.swift */,
+				C75740020000000000000002 /* MouseDownMenuItemView.swift */,
 				C4160A060000000000000002 /* TitlebarChromeGeometryReporting.swift */,
 				C0DE3150A00000000000002 /* MinimalModeSidebarControls.swift */,
 				A5001219 /* WindowToolbarController.swift */,
@@ -5376,6 +5379,7 @@
 				C9CFB398DF94D6DDEAF42D67 /* MobileTerminalRenderObserver.swift in Sources */,
 				00C3AA443F6DA8D94E28CE17 /* MobileWorkspaceListObserver.swift in Sources */,
 				D75280030000000000000001 /* MobileWorkspaceObserverSignposts.swift in Sources */,
+					C75740020000000000000001 /* MouseDownMenuItemView.swift in Sources */,
 				596100000000000000000003 /* NativeNotificationDeliveryHooks.swift in Sources */,
 				C06552010000000000000003 /* NotificationBurstCoalescer.swift in Sources */,
 				7490C00D7490C00D7490C00D /* NotificationCacheMemoryPressureResponder.swift in Sources */,
@@ -5723,10 +5727,10 @@
 				C0DE7B350000000000000001 /* TextBoxSubmitActionSettings.swift in Sources */,
 				C0DE5A420000000000000001 /* TextBoxSubmitAvailability.swift in Sources */,
 				F50030050000000000000001 /* TitlebarAccessoryContainerView.swift in Sources */,
-				F50030060000000000000001 /* TitlebarAccessoryHostingView.swift in Sources */,
-				C4160A060000000000000001 /* TitlebarChromeGeometryReporting.swift in Sources */,
-				C10D00110000000000000011 /* TitlebarCloudVMButton.swift in Sources */,
-				F50030020000000000000001 /* TitlebarInteractiveControlModifier.swift in Sources */,
+					F50030060000000000000001 /* TitlebarAccessoryHostingView.swift in Sources */,
+					C4160A060000000000000001 /* TitlebarChromeGeometryReporting.swift in Sources */,
+					C10D00110000000000000011 /* TitlebarCloudVMButton.swift in Sources */,
+					F50030020000000000000001 /* TitlebarInteractiveControlModifier.swift in Sources */,
 				C4160A070000000000000001 /* TitlebarLayoutDebugWindow.swift in Sources */,
 				E30760030000000000000002 /* TmuxOverlayExperimentSettings.swift in Sources */,
 				E30760040000000000000002 /* TmuxOverlayExperimentTarget.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */; };
 		B900001BA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B900001CA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift */; };
 		C10D00010000000000000001 /* CloudVMActionLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D00020000000000000002 /* CloudVMActionLauncher.swift */; };
+		C75740010000000000000001 /* CloudVMMenuItemMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75740010000000000000002 /* CloudVMMenuItemMetricsTests.swift */; };
 		B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */ = {isa = PBXBuildFile; fileRef = B9000004A1B2C3D4E5F60719 /* cmux */; };
 		C1ADE20002A1B2C3D4E5F719 /* cmux-claude-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */; };
 		C1ADE30002A1B2C3D4E5F719 /* cmux-codex-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE30001A1B2C3D4E5F719 /* cmux-codex-wrapper */; };
@@ -1822,6 +1823,7 @@
 		B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspaceConfirmDialogUITests.swift; sourceTree = "<group>"; };
 		B900001CA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspacesConfirmDialogUITests.swift; sourceTree = "<group>"; };
 		C10D00020000000000000002 /* CloudVMActionLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudVMActionLauncher.swift; sourceTree = "<group>"; };
+		C75740010000000000000002 /* CloudVMMenuItemMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudVMMenuItemMetricsTests.swift; sourceTree = "<group>"; };
 		B9000004A1B2C3D4E5F60719 /* cmux */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cmux; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5001018 /* cmux-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "cmux-Bridging-Header.h"; sourceTree = "<group>"; };
 		C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-claude-wrapper"; sourceTree = SOURCE_ROOT; };
@@ -4121,6 +4123,7 @@
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */,
 				D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */,
 				D5935002A1B2C3D4E5F60718 /* GhosttyDECCKMArrowKeyTests.swift */,
+				C75740010000000000000002 /* CloudVMMenuItemMetricsTests.swift */,
 				F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */,
 				1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */,
 				D3284002A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift */,
@@ -6032,6 +6035,7 @@
 				C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */,
 				B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */,
 				7375A0037375A0037375A003 /* ClosedMainWindowRoutingTests.swift in Sources */,
+				C75740010000000000000001 /* CloudVMMenuItemMetricsTests.swift in Sources */,
 					0CB4E9797AD54D3BB9CF06F9 /* CMUXCLI+AutoNaming.swift in Sources */,
 					C0DE31390000000000000105 /* CMUXCLIErrorOutputRegressionTests.swift in Sources */,
 					C12985000000000000000004 /* CMUXCLISentryTelemetryRegressionTests.swift in Sources */,

--- a/cmuxTests/CloudVMMenuItemMetricsTests.swift
+++ b/cmuxTests/CloudVMMenuItemMetricsTests.swift
@@ -1,0 +1,30 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+@MainActor
+struct CloudVMMenuItemMetricsTests {
+    @Test func mouseDownCloudVMMenuRowMatchesNativeMenuItemHeight() throws {
+        let menu = TitlebarCloudVMButton.makeCloudVMMenu()
+        let firstView = try #require(menu.items.first?.view)
+
+        #expect(abs(firstView.frame.height - Self.nativeMenuItemRowHeight()) < 0.5)
+    }
+
+    private static func nativeMenuItemRowHeight() -> Double {
+        let oneItemMenu = NSMenu()
+        oneItemMenu.addItem(NSMenuItem(title: "One", action: nil, keyEquivalent: ""))
+
+        let twoItemMenu = NSMenu()
+        twoItemMenu.addItem(NSMenuItem(title: "One", action: nil, keyEquivalent: ""))
+        twoItemMenu.addItem(NSMenuItem(title: "Two", action: nil, keyEquivalent: ""))
+
+        return twoItemMenu.size.height - oneItemMenu.size.height
+    }
+}

--- a/cmuxTests/CloudVMMenuItemMetricsTests.swift
+++ b/cmuxTests/CloudVMMenuItemMetricsTests.swift
@@ -13,11 +13,13 @@ struct CloudVMMenuItemMetricsTests {
     @Test func mouseDownCloudVMMenuRowMatchesNativeMenuItemHeight() throws {
         let menu = TitlebarCloudVMButton.makeCloudVMMenu()
         let firstView = try #require(menu.items.first?.view)
+        let nativeRowHeight = MouseDownMenuItemView.nativeMenuItemRowHeight()
 
-        #expect(abs(firstView.frame.height - Self.nativeMenuItemRowHeight()) < 0.5)
+        #expect(abs(firstView.frame.height - nativeRowHeight) < 0.5)
+        #expect(abs(nativeRowHeight - Self.expectedNativeMenuItemRowHeight()) < 0.5)
     }
 
-    private static func nativeMenuItemRowHeight() -> Double {
+    private static func expectedNativeMenuItemRowHeight() -> Double {
         let oneItemMenu = NSMenu()
         oneItemMenu.addItem(NSMenuItem(title: "", action: nil, keyEquivalent: ""))
 

--- a/cmuxTests/CloudVMMenuItemMetricsTests.swift
+++ b/cmuxTests/CloudVMMenuItemMetricsTests.swift
@@ -7,8 +7,8 @@ import Testing
 @testable import cmux
 #endif
 
-@Suite(.serialized)
 @MainActor
+@Suite(.serialized)
 struct CloudVMMenuItemMetricsTests {
     @Test func mouseDownCloudVMMenuRowMatchesNativeMenuItemHeight() throws {
         let menu = TitlebarCloudVMButton.makeCloudVMMenu()
@@ -19,11 +19,11 @@ struct CloudVMMenuItemMetricsTests {
 
     private static func nativeMenuItemRowHeight() -> Double {
         let oneItemMenu = NSMenu()
-        oneItemMenu.addItem(NSMenuItem(title: "One", action: nil, keyEquivalent: ""))
+        oneItemMenu.addItem(NSMenuItem(title: "", action: nil, keyEquivalent: ""))
 
         let twoItemMenu = NSMenu()
-        twoItemMenu.addItem(NSMenuItem(title: "One", action: nil, keyEquivalent: ""))
-        twoItemMenu.addItem(NSMenuItem(title: "Two", action: nil, keyEquivalent: ""))
+        twoItemMenu.addItem(NSMenuItem(title: "", action: nil, keyEquivalent: ""))
+        twoItemMenu.addItem(NSMenuItem(title: "", action: nil, keyEquivalent: ""))
 
         return twoItemMenu.size.height - oneItemMenu.size.height
     }


### PR DESCRIPTION
Closes #7574

## Summary

- Extracts the custom mouse-down Cloud VM menu row into `MouseDownMenuItemView`.
- Replaces the fixed 28pt custom row height with a height derived from AppKit's native `NSMenu` row metric.
- Keeps the existing mouse-down activation path (`cancelTrackingWithoutAnimation()` then action) and hover highlight behavior.

## Visual Evidence

<img src="https://gist.githubusercontent.com/austinywang/488e84a170108b362000bd1738d428c2/raw/f7cd91603c5737f1e9fba242814142c6d506cf58/menu-padding-before-after.svg" alt="Before and after menu padding comparison for issue 7574" width="720">

Evidence SVG: https://gist.githubusercontent.com/austinywang/488e84a170108b362000bd1738d428c2/raw/f7cd91603c5737f1e9fba242814142c6d506cf58/menu-padding-before-after.svg

Metrics note: https://gist.githubusercontent.com/austinywang/488e84a170108b362000bd1738d428c2/raw/c864c1b8bc654bd9f8e5ba47b54de87d695a0810/menu-padding-metrics.txt

Measured by a standalone AppKit harness:

- Native `NSMenu` row height on this host: 24pt
- Old custom row height: 28pt
- New custom row height: native `NSMenu` row height

Local artifact paths:

- `cmux-assets/issue-7574-plus-menu-padding/menu-padding-harness/before-menu-padding-crop.png`
- `cmux-assets/issue-7574-plus-menu-padding/menu-padding-harness/after-menu-padding-crop.png`
- `cmux-assets/issue-7574-plus-menu-padding/menu-padding-harness/menu-padding-before-after.svg`

Cloud Mac note: attempted a cloud Mac GUI run, but the lease did not reach SSH/GUI readiness before I interrupted the stalled provisioner. I used the standalone local AppKit harness above instead; it does not build or launch cmux.

## Tests / Validation

- Added `CloudVMMenuItemMetricsTests.mouseDownCloudVMMenuRowMatchesNativeMenuItemHeight`.
- Red/green commit structure:
  - `2010aa32f9` adds the failing regression test against the old 28pt custom row.
  - `0b447f6aff` applies the fix.
- Review follow-up:
  - `c7de503fbb` clarifies the test by checking both the production helper and an independent AppKit native row measurement.
- `xcrun swiftc -parse Sources/Update/MouseDownMenuItemView.swift`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/swift_file_length_budget.py`
- `git diff --check`

I did not run local `xcodebuild` tests or a local tagged app build, per the issue instructions.

## Localization

No user-facing strings were added or changed. The synthetic `NSMenuItem`s used to measure native row height use empty titles and are never displayed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AppKit menu UI refactor with no changes to Cloud VM commands, auth, or data handling.
> 
> **Overview**
> Fixes oversized vertical padding on the **Open Base** Cloud VM menu row (#7574) by moving the custom mouse-down row into shared **`MouseDownMenuItemView`** and sizing its frame with **`nativeMenuItemRowHeight()`** (derived from AppKit `NSMenu` layout) instead of a fixed **28pt** height.
> 
> **`TitlebarCloudVMButton`** now attaches that view for mouse-down items; hover highlight, full-width stretch, and **`cancelTrackingWithoutAnimation()`** on click are unchanged. **`CloudVMMenuItemMetricsTests`** asserts the Cloud VM menu’s first custom row matches the native row height within **0.5pt**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7de503fbb5543e2d6a25768ef7ba434183a194f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the cloud VM context-menu row with smoother mouse hover highlighting and more reliable click handling.
  * Updated the menu row sizing logic to better match native macOS menu row heights.
* **Tests**
  * Added automated verification that the cloud VM menu’s first row height matches the expected native menu row height (within a small tolerance).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->