### PR TITLE
Park billing email in claims when it already belongs to another account

### DIFF
--- a/web/services/billing/purchase.ts
+++ b/web/services/billing/purchase.ts
@@ -38,6 +38,11 @@ type StackBillingUser = {
   }): Promise<unknown>;
 };
 
+type StackBillingUserLookup = {
+  readonly id: string;
+  readonly primaryEmail?: string | null;
+};
+
 type StackBillingTeam = {
   readonly id: string;
   readonly clientReadOnlyMetadata?: unknown;
@@ -48,6 +53,12 @@ type StackBillingTeam = {
 
 type StackBillingApp = {
   getUser(id: string): Promise<StackBillingUser | null>;
+  listUsers?(options?: {
+    query?: string;
+    limit?: number;
+    includeAnonymous?: boolean;
+    includeRestricted?: boolean;
+  }): Promise<readonly StackBillingUserLookup[]>;
   getTeam?(id: string): Promise<StackBillingTeam | null>;
 };
 
@@ -121,6 +132,7 @@ export async function recordCheckoutCompletion(
       email,
       stripeCustomerId: customerId,
       stackUserId,
+      stackApp: dependencies.stackApp ?? stackServerApp,
     });
   }
   await syncProPlanMetadata(user, true);
@@ -473,9 +485,20 @@ async function attachPurchaseEmailOrRecordClaim(
     email: string;
     stripeCustomerId: string;
     stackUserId: string;
+    stackApp: StackBillingApp | null | undefined;
   },
 ): Promise<void> {
   if (input.user.primaryEmail) return;
+  let ownerId: string | null = null;
+  try {
+    ownerId = await findUserIdByEmail(input.stackApp, input.email);
+  } catch {
+    ownerId = null;
+  }
+  if (ownerId && ownerId !== input.stackUserId) {
+    await recordBillingEmailClaim(db, input);
+    return;
+  }
   try {
     await input.user.update({
       primaryEmail: input.email,
@@ -483,26 +506,57 @@ async function attachPurchaseEmailOrRecordClaim(
     });
   } catch (error) {
     if (!isEmailAlreadyUsedError(error)) throw error;
-    const existing = await db
-      .select({ id: billingEmailClaims.id })
-      .from(billingEmailClaims)
-      .where(
-        and(
-          eq(billingEmailClaims.email, input.email),
-          eq(billingEmailClaims.stripeCustomerId, input.stripeCustomerId),
-          eq(billingEmailClaims.stackUserId, input.stackUserId),
-          eq(billingEmailClaims.plan, PRO_PLAN_ID),
-        ),
-      )
-      .limit(1);
-    if (existing.length > 0) return;
-    await db.insert(billingEmailClaims).values({
-      email: input.email,
-      stripeCustomerId: input.stripeCustomerId,
-      stackUserId: input.stackUserId,
-      plan: PRO_PLAN_ID,
-    });
+    await recordBillingEmailClaim(db, input);
   }
+}
+
+async function findUserIdByEmail(
+  stackApp: StackBillingApp | null | undefined,
+  email: string,
+): Promise<string | null> {
+  if (!stackApp?.listUsers) {
+    throw new Error("Stack Auth server SDK cannot list users");
+  }
+  const normalizedEmail = email.trim().toLowerCase();
+  const users = await stackApp.listUsers({
+    query: normalizedEmail,
+    limit: 20,
+    includeAnonymous: true,
+    includeRestricted: true,
+  });
+  const owner = users.find(
+    (user) => user.primaryEmail?.trim().toLowerCase() === normalizedEmail,
+  );
+  return owner?.id ?? null;
+}
+
+async function recordBillingEmailClaim(
+  db: BillingDb,
+  input: {
+    email: string;
+    stripeCustomerId: string;
+    stackUserId: string;
+  },
+): Promise<void> {
+  const existing = await db
+    .select({ id: billingEmailClaims.id })
+    .from(billingEmailClaims)
+    .where(
+      and(
+        eq(billingEmailClaims.email, input.email),
+        eq(billingEmailClaims.stripeCustomerId, input.stripeCustomerId),
+        eq(billingEmailClaims.stackUserId, input.stackUserId),
+        eq(billingEmailClaims.plan, PRO_PLAN_ID),
+      ),
+    )
+    .limit(1);
+  if (existing.length > 0) return;
+  await db.insert(billingEmailClaims).values({
+    email: input.email,
+    stripeCustomerId: input.stripeCustomerId,
+    stackUserId: input.stackUserId,
+    plan: PRO_PLAN_ID,
+  });
 }
 
 async function stackUserIdForStripeCustomer(

--- a/web/tests/billing-purchase.test.ts
+++ b/web/tests/billing-purchase.test.ts
@@ -141,6 +141,89 @@ describe("recordCheckoutCompletion", () => {
     });
   });
 
+  test("records an email claim instead of attaching an email owned by a different Stack user", async () => {
+    const update = mock(async () => undefined);
+    const listUsers = mock(async () => [
+      { id: "other_user", primaryEmail: "BUYER@example.com" },
+    ]);
+    const user = { id: "user_123", primaryEmail: null, clientReadOnlyMetadata: {}, update };
+
+    await recordCheckoutCompletion(checkoutInput() as never, {
+      db: fakeDb() as never,
+      stackApp: { getUser: async () => user, listUsers } as never,
+    });
+
+    expect(listUsers).toHaveBeenCalledWith({
+      query: "buyer@example.com",
+      limit: 20,
+      includeAnonymous: true,
+      includeRestricted: true,
+    });
+    expect(update).not.toHaveBeenCalledWith({
+      primaryEmail: "buyer@example.com",
+      primaryEmailAuthEnabled: true,
+    });
+    expect(
+      inserts.some(
+        (insert) =>
+          insert.table === billingEmailClaims &&
+          insert.values.email === "buyer@example.com" &&
+          insert.values.stripeCustomerId === "cus_123" &&
+          insert.values.stackUserId === "user_123" &&
+          insert.values.plan === "pro",
+      ),
+    ).toBe(true);
+    expect(
+      inserts.some(
+        (insert) =>
+          insert.table === stripeSubscriptions &&
+          insert.values.stackUserId === "user_123" &&
+          insert.values.plan === "pro",
+      ),
+    ).toBe(true);
+    expect(update).toHaveBeenCalledWith({
+      clientReadOnlyMetadata: { cmuxPlan: "pro" },
+    });
+  });
+
+  test("attaches Stripe email when the ownership lookup finds no exact owner", async () => {
+    const update = mock(async () => undefined);
+    const listUsers = mock(async () => [
+      { id: "fuzzy_user", primaryEmail: "not-buyer@example.com" },
+    ]);
+    const user = { id: "user_123", primaryEmail: null, clientReadOnlyMetadata: {}, update };
+
+    await recordCheckoutCompletion(checkoutInput() as never, {
+      db: fakeDb() as never,
+      stackApp: { getUser: async () => user, listUsers } as never,
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      primaryEmail: "buyer@example.com",
+      primaryEmailAuthEnabled: true,
+    });
+    expect(inserts.some((insert) => insert.table === billingEmailClaims)).toBe(false);
+  });
+
+  test("does not record an email claim when the email is owned by the purchaser", async () => {
+    const update = mock(async () => undefined);
+    const listUsers = mock(async () => [
+      { id: "user_123", primaryEmail: "buyer@example.com" },
+    ]);
+    const user = { id: "user_123", primaryEmail: null, clientReadOnlyMetadata: {}, update };
+
+    await recordCheckoutCompletion(checkoutInput() as never, {
+      db: fakeDb() as never,
+      stackApp: { getUser: async () => user, listUsers } as never,
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      primaryEmail: "buyer@example.com",
+      primaryEmailAuthEnabled: true,
+    });
+    expect(inserts.some((insert) => insert.table === billingEmailClaims)).toBe(false);
+  });
+
   test("records an email claim when Stack reports the email is already used", async () => {
     const update = mock(async (options: unknown) => {
       if ("primaryEmail" in (options as Record<string, unknown>)) {
@@ -167,23 +250,61 @@ describe("recordCheckoutCompletion", () => {
     });
   });
 
-  test("does not duplicate an existing email claim on retry", async () => {
+  test("falls back to update/catch when the ownership lookup throws", async () => {
     const update = mock(async (options: unknown) => {
-      if ("primaryEmail" in (options as Record<string, unknown>)) throw new Error("email already used");
+      if ("primaryEmail" in (options as Record<string, unknown>)) {
+        throw new Error("CONTACT_CHANNEL_ALREADY_USED_FOR_AUTH_BY_SOMEONE_ELSE");
+      }
     });
+    const listUsers = mock(async () => {
+      throw new Error("Stack lookup failed");
+    });
+    const user = { id: "user_123", primaryEmail: null, clientReadOnlyMetadata: {}, update };
+
+    await recordCheckoutCompletion(checkoutInput() as never, {
+      db: fakeDb() as never,
+      stackApp: { getUser: async () => user, listUsers } as never,
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      primaryEmail: "buyer@example.com",
+      primaryEmailAuthEnabled: true,
+    });
+    expect(
+      inserts.some(
+        (insert) =>
+          insert.table === billingEmailClaims &&
+          insert.values.email === "buyer@example.com" &&
+          insert.values.stackUserId === "user_123",
+      ),
+    ).toBe(true);
+    expect(update).toHaveBeenCalledWith({
+      clientReadOnlyMetadata: { cmuxPlan: "pro" },
+    });
+  });
+
+  test("does not duplicate an existing email claim on retry", async () => {
+    const update = mock(async () => undefined);
+    const listUsers = mock(async () => [
+      { id: "other_user", primaryEmail: "buyer@example.com" },
+    ]);
     const user = { id: "user_123", primaryEmail: null, clientReadOnlyMetadata: {}, update };
     selectResults = [[], [], [], [{ id: "claim_1" }]];
 
     await recordCheckoutCompletion(checkoutInput() as never, {
       db: fakeDb() as never,
-      stackApp: { getUser: async () => user } as never,
+      stackApp: { getUser: async () => user, listUsers } as never,
     });
     await recordCheckoutCompletion(checkoutInput() as never, {
       db: fakeDb() as never,
-      stackApp: { getUser: async () => user } as never,
+      stackApp: { getUser: async () => user, listUsers } as never,
     });
 
     expect(inserts.filter((insert) => insert.table === billingEmailClaims)).toHaveLength(1);
+    expect(update).not.toHaveBeenCalledWith({
+      primaryEmail: "buyer@example.com",
+      primaryEmailAuthEnabled: true,
+    });
   });
 
   test("updates the Stripe customer id when the same Stack user repurchases", async () => {


### PR DESCRIPTION
Found while running the anonymous-purchase edge-case tests. The purchase recorder attached the Stripe email to the anonymous purchaser and only recorded a `billing_email_claims` row inside a `catch` for a thrown "email already used" error. Stack does not throw when a primary email is already owned by another user, so a purchase using an already-registered email silently created two Stack accounts sharing one primary email and recorded no claim. The pre-existing account never received Pro (that path was already safe), but the duplicate-email account plus missing claim is a data-integrity bug.

The recorder now looks up the email's owner before attaching: if a different Stack user already owns it (exact, case-insensitive primaryEmail match), it records the claim and skips the primary-email update. Unowned emails attach as before; a same-owner match is a safe no-op. The lookup is bounded and defensive: if it throws or the SDK capability is absent, it falls back to the prior try/update/catch path so the webhook never fails, and the `isEmailAlreadyUsedError` guard is retained for the check-then-claim race.

**Verified live** (test mode) against the exact repro that exposed the bug: a purchase with an already-registered email now creates a `billing_email_claims` row, only the original account holds the email as primary (no duplicate), the original account stays free, and the purchaser still gets Pro bound to their own id. Plus unit coverage for owned/unowned/self/lookup-throws/dedup. fable-judge APPROVE. 506 web tests green, typecheck + db:check + flag lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786075882&installation_id=133855650&pr_number=7582&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7582&signature=31af371d8087f72638a2ffd9a9b11a7f55756599ac292bb8864d788c1edfa2c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe checkout email attachment and billing identity integrity; behavior is defensive with lookup fallback but still affects who gets primary email vs a claim row.
> 
> **Overview**
> Fixes a checkout path where Stripe’s email was attached to an anonymous purchaser even when that address was already another account’s **primary email**, because Stack did not throw on that case—only the error-handler path wrote **`billing_email_claims`**.
> 
> **`attachPurchaseEmailOrRecordClaim`** now calls **`findUserIdByEmail`** (via optional **`listUsers`**, case-insensitive exact match) before updating the purchaser. If a **different** user owns the email, it records a claim and **skips** setting `primaryEmail`; unowned or self-owned emails still attach as before. Lookup failures fall back to the prior update + **`isEmailAlreadyUsedError`** catch so webhooks keep succeeding. Claim insert logic is centralized in **`recordBillingEmailClaim`**.
> 
> Unit tests cover cross-account claim, fuzzy lookup miss, same purchaser, lookup throw + catch, and claim dedup on retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3db356f8edee581b3867f61cd4f897987125402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate primary emails on purchase by checking ownership first. If the Stripe billing email already belongs to someone else, we park it in `billing_email_claims` instead of attaching it.

- **Bug Fixes**
  - Look up the email owner via `stackApp.listUsers` (exact, case-insensitive) before updating `primaryEmail`.
  - If a different user owns it, record a `billing_email_claims` row and skip the email update; self-match is a no-op; unowned emails attach as before.
  - Fallback to the existing try/update/catch path when lookup fails or is unavailable; keep `isEmailAlreadyUsedError` to handle races.
  - Added unit tests for owned, unowned, self-owned, lookup-throws, and claim de-duplication.

<sup>Written for commit f3db356f8edee581b3867f61cd4f897987125402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

