### PR TITLE
mux: implement the 8 proposed protocol-6 commands (wait-for, run, send-key, copy, ids, notify, list-agents, report-agent)

### DIFF
--- a/mux/Cargo.lock
+++ b/mux/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "libc",
  "mux-cdp",
  "portable-pty",
+ "regex",
  "serde",
  "serde_json",
  "tungstenite",

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -30,6 +30,7 @@ base64 = "0.22"
 libc = "0.2"
 tungstenite = { version = "0.24", default-features = false, features = ["handshake"] }
 uds_windows = "1.2"
+regex = "1"
 
 [profile.release]
 lto = "thin"

--- a/mux/bindings/conformance/fixtures.json
+++ b/mux/bindings/conformance/fixtures.json
@@ -135,6 +135,68 @@
           "timeout_ms": 10000
         }
       ]
+    },
+    {
+      "name": "implemented-verbs-json",
+      "steps": [
+        {
+          "type": "command",
+          "request": { "id": 1, "cmd": "run", "command": "printf 'cmux-run-marker\\n'; cat", "name": "conf-run", "cols": 80, "rows": 24 },
+          "expect": { "id": 1, "ok": true },
+          "match": "partial",
+          "bind": { "surface0": "data.surface" }
+        },
+        {
+          "type": "wait_contains",
+          "request": { "id": 2, "cmd": "copy", "surface": "$surface0", "mode": "screen" },
+          "path": "data.text",
+          "contains": "cmux-run-marker",
+          "timeout_ms": 10000
+        },
+        {
+          "type": "command",
+          "request": { "id": 3, "cmd": "wait-for", "surface": "$surface0", "pattern": "cmux-run-marker", "timeout_ms": 5000 },
+          "expect": { "id": 3, "ok": true, "data": { "matched": true } },
+          "match": "partial"
+        },
+        {
+          "type": "command",
+          "request": { "id": 4, "cmd": "ids", "kind": "surface" },
+          "expect": { "id": 4, "ok": true },
+          "match": "partial"
+        },
+        {
+          "type": "command",
+          "request": { "id": 5, "cmd": "notify", "title": "Build", "body": "ok", "level": "info", "surface": "$surface0" },
+          "expect": { "id": 5, "ok": true },
+          "match": "partial"
+        },
+        {
+          "type": "command",
+          "request": { "id": 6, "cmd": "report-agent", "surface": "$surface0", "state": "working", "source": "socket", "session": "conf" },
+          "expect": { "id": 6, "ok": true, "data": { "state": "working", "source": "socket", "session": "conf" } },
+          "match": "partial"
+        },
+        {
+          "type": "command",
+          "request": { "id": 7, "cmd": "list-agents", "surface": "$surface0", "state": "working" },
+          "expect": { "id": 7, "ok": true, "data": { "agents": [ { "surface": "$surface0", "state": "working", "source": "socket", "session": "conf" } ] } },
+          "match": "partial"
+        },
+        {
+          "type": "command",
+          "request": { "id": 8, "cmd": "send-key", "surface": "$surface0", "keys": ["h", "i", "enter"] },
+          "expect": { "id": 8, "ok": true, "data": {} },
+          "match": "partial"
+        },
+        {
+          "type": "wait_contains",
+          "request": { "id": 9, "cmd": "copy", "surface": "$surface0", "mode": "scrollback" },
+          "path": "data.text",
+          "contains": "hi",
+          "timeout_ms": 10000
+        }
+      ]
     }
   ]
 }

--- a/mux/bindings/conformance/runner.py
+++ b/mux/bindings/conformance/runner.py
@@ -216,6 +216,14 @@ def dispatch(client: CmuxClient, cmd: str, params: Dict[str, Any]) -> Any:
         "move-tab": client.move_tab,
         "move-workspace": client.move_workspace,
         "scroll-surface": client.scroll_surface,
+        "wait-for": lambda **kw: client._request("wait-for", **kw),
+        "run": lambda **kw: client._request("run", **kw),
+        "send-key": lambda **kw: client._request("send-key", **kw),
+        "copy": lambda **kw: client._request("copy", **kw),
+        "ids": lambda **kw: client._request("ids", **kw),
+        "notify": lambda **kw: client._request("notify", **kw),
+        "list-agents": lambda **kw: client._request("list-agents", **kw),
+        "report-agent": lambda **kw: client._request("report-agent", **kw),
     }
     if cmd not in mapping:
         raise FixtureFailure(f"unsupported fixture command {cmd}")

--- a/mux/crates/ghostty-vt/src/key.rs
+++ b/mux/crates/ghostty-vt/src/key.rs
@@ -35,6 +35,132 @@ impl std::ops::BitOr for Mods {
     }
 }
 
+fn physical_key_for_char(c: char) -> sys::GhosttyKey {
+    match c.to_ascii_lowercase() {
+        'a' => sys::GHOSTTY_KEY_A,
+        'b' => sys::GHOSTTY_KEY_B,
+        'c' => sys::GHOSTTY_KEY_C,
+        'd' => sys::GHOSTTY_KEY_D,
+        'e' => sys::GHOSTTY_KEY_E,
+        'f' => sys::GHOSTTY_KEY_F,
+        'g' => sys::GHOSTTY_KEY_G,
+        'h' => sys::GHOSTTY_KEY_H,
+        'i' => sys::GHOSTTY_KEY_I,
+        'j' => sys::GHOSTTY_KEY_J,
+        'k' => sys::GHOSTTY_KEY_K,
+        'l' => sys::GHOSTTY_KEY_L,
+        'm' => sys::GHOSTTY_KEY_M,
+        'n' => sys::GHOSTTY_KEY_N,
+        'o' => sys::GHOSTTY_KEY_O,
+        'p' => sys::GHOSTTY_KEY_P,
+        'q' => sys::GHOSTTY_KEY_Q,
+        'r' => sys::GHOSTTY_KEY_R,
+        's' => sys::GHOSTTY_KEY_S,
+        't' => sys::GHOSTTY_KEY_T,
+        'u' => sys::GHOSTTY_KEY_U,
+        'v' => sys::GHOSTTY_KEY_V,
+        'w' => sys::GHOSTTY_KEY_W,
+        'x' => sys::GHOSTTY_KEY_X,
+        'y' => sys::GHOSTTY_KEY_Y,
+        'z' => sys::GHOSTTY_KEY_Z,
+        '0' => sys::GHOSTTY_KEY_DIGIT_0,
+        '1' => sys::GHOSTTY_KEY_DIGIT_1,
+        '2' => sys::GHOSTTY_KEY_DIGIT_2,
+        '3' => sys::GHOSTTY_KEY_DIGIT_3,
+        '4' => sys::GHOSTTY_KEY_DIGIT_4,
+        '5' => sys::GHOSTTY_KEY_DIGIT_5,
+        '6' => sys::GHOSTTY_KEY_DIGIT_6,
+        '7' => sys::GHOSTTY_KEY_DIGIT_7,
+        '8' => sys::GHOSTTY_KEY_DIGIT_8,
+        '9' => sys::GHOSTTY_KEY_DIGIT_9,
+        ' ' => sys::GHOSTTY_KEY_SPACE,
+        '`' => sys::GHOSTTY_KEY_BACKQUOTE,
+        '\\' => sys::GHOSTTY_KEY_BACKSLASH,
+        '[' => sys::GHOSTTY_KEY_BRACKET_LEFT,
+        ']' => sys::GHOSTTY_KEY_BRACKET_RIGHT,
+        ',' => sys::GHOSTTY_KEY_COMMA,
+        '=' => sys::GHOSTTY_KEY_EQUAL,
+        '-' => sys::GHOSTTY_KEY_MINUS,
+        '.' => sys::GHOSTTY_KEY_PERIOD,
+        '\'' => sys::GHOSTTY_KEY_QUOTE,
+        ';' => sys::GHOSTTY_KEY_SEMICOLON,
+        '/' => sys::GHOSTTY_KEY_SLASH,
+        _ => sys::GHOSTTY_KEY_UNIDENTIFIED,
+    }
+}
+
+/// Parse a lower-case socket/CLI key chord into a Ghostty encoder input.
+pub fn key_input_from_chord(chord: &str) -> Option<KeyInput> {
+    let mut mods = Mods::default();
+    let mut key_name = None;
+    for part in chord.split('+') {
+        match part {
+            "ctrl" | "control" => mods = mods | Mods::CTRL,
+            "alt" | "option" => mods = mods | Mods::ALT,
+            "shift" => mods = mods | Mods::SHIFT,
+            "" => return None,
+            other => {
+                if key_name.is_some() {
+                    return None;
+                }
+                key_name = Some(other);
+            }
+        }
+    }
+    let key_name = key_name?;
+    let mut input = KeyInput { mods, action: Some(KeyAction::Press), ..Default::default() };
+    match key_name {
+        "enter" | "return" => input.key = sys::GHOSTTY_KEY_ENTER,
+        "tab" => input.key = sys::GHOSTTY_KEY_TAB,
+        "backtab" => {
+            input.key = sys::GHOSTTY_KEY_TAB;
+            input.mods = input.mods | Mods::SHIFT;
+        }
+        "escape" | "esc" => input.key = sys::GHOSTTY_KEY_ESCAPE,
+        "backspace" => input.key = sys::GHOSTTY_KEY_BACKSPACE,
+        "delete" => input.key = sys::GHOSTTY_KEY_DELETE,
+        "insert" => input.key = sys::GHOSTTY_KEY_INSERT,
+        "up" => input.key = sys::GHOSTTY_KEY_ARROW_UP,
+        "down" => input.key = sys::GHOSTTY_KEY_ARROW_DOWN,
+        "left" => input.key = sys::GHOSTTY_KEY_ARROW_LEFT,
+        "right" => input.key = sys::GHOSTTY_KEY_ARROW_RIGHT,
+        "home" => input.key = sys::GHOSTTY_KEY_HOME,
+        "end" => input.key = sys::GHOSTTY_KEY_END,
+        "pageup" => input.key = sys::GHOSTTY_KEY_PAGE_UP,
+        "pagedown" => input.key = sys::GHOSTTY_KEY_PAGE_DOWN,
+        "space" => {
+            input.key = sys::GHOSTTY_KEY_SPACE;
+            input.unshifted_codepoint = ' ' as u32;
+            if !mods.contains(Mods::CTRL) {
+                input.utf8 = " ".to_string();
+            }
+        }
+        name if name.len() == 1 => {
+            let c = name.chars().next()?;
+            input.key = physical_key_for_char(c);
+            if input.key == sys::GHOSTTY_KEY_UNIDENTIFIED {
+                return None;
+            }
+            input.unshifted_codepoint = c.to_ascii_lowercase() as u32;
+            if !mods.contains(Mods::CTRL) {
+                input.utf8 = c.to_string();
+                if mods.contains(Mods::SHIFT) {
+                    input.consumed_mods = Mods::SHIFT;
+                }
+            }
+        }
+        name if name.starts_with('f') => {
+            let n = name[1..].parse::<u32>().ok()?;
+            if !(1..=24).contains(&n) {
+                return None;
+            }
+            input.key = sys::GHOSTTY_KEY_F1 + (n as sys::GhosttyKey - 1);
+        }
+        _ => return None,
+    }
+    Some(input)
+}
+
 /// A single key event to encode.
 #[derive(Debug, Clone, Default)]
 pub struct KeyInput {
@@ -151,7 +277,28 @@ impl Drop for KeyEncoder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Callbacks;
+    use crate::{Callbacks, Terminal};
+
+    #[test]
+    fn chord_parser_encodes_common_keys() {
+        let term = Terminal::new(80, 24, 100, Callbacks::default()).unwrap();
+        let mut encoder = KeyEncoder::new().unwrap();
+        encoder.sync_from_terminal(&term);
+
+        let mut out = Vec::new();
+        encoder.encode(&key_input_from_chord("ctrl+c").unwrap(), &mut out).unwrap();
+        assert_eq!(out, vec![0x03]);
+
+        out.clear();
+        encoder.encode(&key_input_from_chord("enter").unwrap(), &mut out).unwrap();
+        assert_eq!(out, b"\r");
+
+        out.clear();
+        encoder.encode(&key_input_from_chord("up").unwrap(), &mut out).unwrap();
+        assert!(!out.is_empty());
+
+        assert!(key_input_from_chord("not-a-key").is_none());
+    }
 
     #[test]
     fn encodes_ctrl_c() {

--- a/mux/crates/ghostty-vt/src/lib.rs
+++ b/mux/crates/ghostty-vt/src/lib.rs
@@ -11,7 +11,7 @@ mod terminal;
 /// Raw bindings, re-exported for key/mode constants.
 pub use ghostty_vt_sys as sys;
 
-pub use key::{KeyAction, KeyEncoder, KeyInput, Mods};
+pub use key::{key_input_from_chord, KeyAction, KeyEncoder, KeyInput, Mods};
 pub use render::{Cell, ColorSpec, CursorInfo, CursorShape, Dirty, RenderState};
 pub use terminal::{Callbacks, NotifyFn, PtyWriteFn, Rgb, Screen, Scrollbar, Terminal};
 

--- a/mux/crates/mux-core/Cargo.toml
+++ b/mux/crates/mux-core/Cargo.toml
@@ -15,6 +15,7 @@ serde_json.workspace = true
 anyhow.workspace = true
 base64.workspace = true
 libc.workspace = true
+regex.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 uds_windows.workspace = true

--- a/mux/crates/mux-core/src/browser.rs
+++ b/mux/crates/mux-core/src/browser.rs
@@ -284,7 +284,7 @@ pub(crate) fn new_surface(
     let capture_scale = capture_scale_for(pixel_w, pixel_h, capture_options);
     let capture_pixels = scaled_pixels(pixel_w, pixel_h, capture_scale);
     Arc::new(Surface::Browser(BrowserSurface {
-        meta: SurfaceMeta { id, name: Mutex::new(None) },
+        meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
         session: Mutex::new(None),
         state: Mutex::new(BrowserState {
             latest_frame: None,

--- a/mux/crates/mux-core/src/lib.rs
+++ b/mux/crates/mux-core/src/lib.rs
@@ -24,7 +24,10 @@ pub use layout::{
     SplitEdge, SplitResize,
 };
 pub use model::{Node, Pane, Screen, State, Workspace};
-pub use mux::{Mux, MuxEvent};
+pub use mux::{
+    AgentRecord, AgentSource, AgentState, Mux, MuxEvent, NotificationEvent, NotificationLevel,
+    RunPlacement, SurfaceNotification,
+};
 pub use short_id::assign_short_ids;
 pub use surface::{
     AttachFrame, AttachStream, BrowserAttachState, BrowserFrame, BrowserFrameStream, BrowserSource,

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::browser::{self, BrowserBootstrap, BrowserRuntime};
 use crate::model::{Node, Pane, Screen, State, Workspace};
@@ -27,6 +28,7 @@ pub enum MuxEvent {
     SurfaceExited(SurfaceId),
     TitleChanged(SurfaceId),
     Bell(SurfaceId),
+    Notification(NotificationEvent),
     Status(String),
     /// The workspace/screen/pane/tab tree changed (from any frontend or
     /// the control socket).
@@ -35,16 +37,107 @@ pub enum MuxEvent {
     Empty,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotificationLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+impl NotificationLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NotificationLevel::Info => "info",
+            NotificationLevel::Warning => "warning",
+            NotificationLevel::Error => "error",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NotificationEvent {
+    pub notification: u64,
+    pub title: String,
+    pub body: String,
+    pub level: NotificationLevel,
+    pub surface: Option<SurfaceId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentState {
+    Working,
+    Blocked,
+    Idle,
+    Done,
+    Unknown,
+}
+
+impl AgentState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AgentState::Working => "working",
+            AgentState::Blocked => "blocked",
+            AgentState::Idle => "idle",
+            AgentState::Done => "done",
+            AgentState::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentSource {
+    Detected,
+    Socket,
+    Hook,
+}
+
+impl AgentSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AgentSource::Detected => "detected",
+            AgentSource::Socket => "socket",
+            AgentSource::Hook => "hook",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentRecord {
+    pub surface: SurfaceId,
+    pub state: AgentState,
+    pub source: AgentSource,
+    pub session: Option<String>,
+    pub updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SurfaceNotification {
+    pub notification: u64,
+    pub level: NotificationLevel,
+    pub unread: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RunPlacement {
+    pub surface: SurfaceId,
+    pub pane: PaneId,
+    pub screen: ScreenId,
+    pub workspace: WorkspaceId,
+}
+
 /// The multiplexer. Shared by frontends and the control socket server.
 pub struct Mux {
     state: Mutex<State>,
     subscribers: Mutex<Vec<Sender<MuxEvent>>>,
     next_id: AtomicU64,
+    next_notification_id: AtomicU64,
     next_active_at: AtomicU64,
     surface_options: SurfaceOptions,
     browser_runtime: Mutex<Option<Arc<BrowserRuntime>>>,
     cell_pixels: Mutex<(u16, u16)>,
     default_colors: Mutex<DefaultColors>,
+    agent_records: Mutex<HashMap<SurfaceId, AgentRecord>>,
+    surface_notifications: Mutex<HashMap<SurfaceId, SurfaceNotification>>,
     #[cfg(test)]
     test_surface_runtime: bool,
     pub session: String,
@@ -72,11 +165,14 @@ impl Mux {
             }),
             subscribers: Mutex::new(Vec::new()),
             next_id: AtomicU64::new(1),
+            next_notification_id: AtomicU64::new(1),
             next_active_at: AtomicU64::new(1),
             surface_options,
             browser_runtime: Mutex::new(None),
             cell_pixels: Mutex::new((8, 16)),
             default_colors: Mutex::new(DefaultColors::default()),
+            agent_records: Mutex::new(HashMap::new()),
+            surface_notifications: Mutex::new(HashMap::new()),
             #[cfg(test)]
             test_surface_runtime,
             session,
@@ -99,6 +195,10 @@ impl Mux {
         self.next_active_at.fetch_add(1, Ordering::Relaxed)
     }
 
+    fn next_notification_id(&self) -> u64 {
+        self.next_notification_id.fetch_add(1, Ordering::Relaxed)
+    }
+
     pub fn subscribe(&self) -> Receiver<MuxEvent> {
         let (tx, rx) = channel();
         self.subscribers.lock().unwrap().push(tx);
@@ -110,15 +210,19 @@ impl Mux {
         subs.retain(|tx| tx.send(event.clone()).is_ok());
     }
 
-    fn spawn_surface(
+    fn spawn_surface_with_command(
         self: &Arc<Self>,
         cwd: Option<String>,
         size: Option<(u16, u16)>,
+        command: Option<Vec<String>>,
     ) -> anyhow::Result<Arc<Surface>> {
         let id = self.next_id();
         let mut opts = self.surface_options.clone();
         if cwd.is_some() {
             opts.cwd = cwd;
+        }
+        if command.is_some() {
+            opts.command = command;
         }
         // Spawn at the final size when the frontend knows it: starting at
         // the default 80x24 and resizing a frame later makes shells emit
@@ -137,6 +241,14 @@ impl Mux {
         let surface = Surface::spawn(id, opts, Arc::downgrade(self))?;
         self.state.lock().unwrap().surfaces.insert(id, surface.clone());
         Ok(surface)
+    }
+
+    fn spawn_surface(
+        self: &Arc<Self>,
+        cwd: Option<String>,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<Arc<Surface>> {
+        self.spawn_surface_with_command(cwd, size, None)
     }
 
     fn spawn_browser_surface(
@@ -224,6 +336,100 @@ impl Mux {
         self.state.lock().unwrap().surfaces.len()
     }
 
+    pub fn surface_notification(&self, surface: SurfaceId) -> Option<SurfaceNotification> {
+        self.surface_notifications.lock().unwrap().get(&surface).copied()
+    }
+
+    pub fn surface_notifications(&self) -> HashMap<SurfaceId, SurfaceNotification> {
+        self.surface_notifications.lock().unwrap().clone()
+    }
+
+    pub fn clear_surface_notification(&self, surface: SurfaceId) -> bool {
+        let cleared = self.surface_notifications.lock().unwrap().remove(&surface).is_some();
+        if cleared {
+            self.emit(MuxEvent::TreeChanged);
+        }
+        cleared
+    }
+
+    fn active_surface_in_state(state: &State) -> Option<SurfaceId> {
+        let pane = state.active_pane()?;
+        state.panes.get(&pane)?.active_surface()
+    }
+
+    pub fn active_surface(&self) -> Option<SurfaceId> {
+        self.with_state(Self::active_surface_in_state)
+    }
+
+    fn clear_viewed_notification(&self, surface: Option<SurfaceId>) {
+        if let Some(surface) = surface {
+            let _ = self.surface_notifications.lock().unwrap().remove(&surface);
+        }
+    }
+
+    pub fn post_notification(
+        &self,
+        title: String,
+        body: String,
+        level: NotificationLevel,
+        surface: Option<SurfaceId>,
+    ) -> u64 {
+        let id = self.next_notification_id();
+        let mut unread_changed = false;
+        if let Some(surface) = surface {
+            if self.active_surface() != Some(surface) {
+                self.surface_notifications
+                    .lock()
+                    .unwrap()
+                    .insert(surface, SurfaceNotification { notification: id, level, unread: true });
+                unread_changed = true;
+            }
+        }
+        self.emit(MuxEvent::Notification(NotificationEvent {
+            notification: id,
+            title,
+            body,
+            level,
+            surface,
+        }));
+        if unread_changed {
+            self.emit(MuxEvent::TreeChanged);
+        }
+        id
+    }
+
+    pub fn report_agent(
+        &self,
+        surface: SurfaceId,
+        state: AgentState,
+        source: AgentSource,
+        session: Option<String>,
+    ) -> AgentRecord {
+        let mut records = self.agent_records.lock().unwrap();
+        if let Some(existing) = records.get(&surface) {
+            if existing.source == AgentSource::Hook && source == AgentSource::Socket {
+                return existing.clone();
+            }
+        }
+        let record = AgentRecord { surface, state, source, session, updated_at_ms: now_ms() };
+        records.insert(surface, record.clone());
+        record
+    }
+
+    pub fn list_agents(
+        &self,
+        surface: Option<SurfaceId>,
+        state: Option<AgentState>,
+    ) -> Vec<AgentRecord> {
+        let mut records = self.agent_records.lock().unwrap().values().cloned().collect::<Vec<_>>();
+        records.sort_by_key(|record| record.surface);
+        records
+            .into_iter()
+            .filter(|record| surface.is_none_or(|surface| record.surface == surface))
+            .filter(|record| state.is_none_or(|state| record.state == state))
+            .collect()
+    }
+
     pub fn shutdown(&self) {
         let surfaces = self.state.lock().unwrap().surfaces.values().cloned().collect::<Vec<_>>();
         for surface in surfaces {
@@ -309,6 +515,101 @@ impl Mux {
         self.emit(MuxEvent::TreeChanged);
         self.reap_if_dead(&surface);
         Ok(surface)
+    }
+
+    pub fn run_command_surface(
+        self: &Arc<Self>,
+        argv: Vec<String>,
+        pane: Option<PaneId>,
+        new_workspace: bool,
+        cwd: Option<String>,
+        name: Option<String>,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<RunPlacement> {
+        if new_workspace {
+            let surface = self.spawn_surface_with_command(cwd, size, Some(argv))?;
+            if let Some(name) = name.as_ref() {
+                surface.set_name(Some(name.clone()));
+            }
+            let (pane_id, pane) = self.make_pane(surface.id);
+            let screen_id = self.next_id();
+            let ws_id = self.next_id();
+            {
+                let mut state = self.state.lock().unwrap();
+                let workspace_name =
+                    name.unwrap_or_else(|| format!("{}", state.workspaces.len() + 1));
+                state.panes.insert(pane_id, pane);
+                state.workspaces.push(Workspace {
+                    id: ws_id,
+                    name: workspace_name,
+                    screens: vec![Screen {
+                        id: screen_id,
+                        name: None,
+                        root: Node::Leaf(pane_id),
+                        active_pane: pane_id,
+                    }],
+                    active_screen: 0,
+                });
+                state.active_workspace = state.workspaces.len() - 1;
+            }
+            self.emit(MuxEvent::TreeChanged);
+            self.reap_if_dead(&surface);
+            return Ok(RunPlacement {
+                surface: surface.id,
+                pane: pane_id,
+                screen: screen_id,
+                workspace: ws_id,
+            });
+        }
+
+        let target = {
+            let state = self.state.lock().unwrap();
+            match pane {
+                Some(id) => {
+                    if !state.panes.contains_key(&id) {
+                        anyhow::bail!("unknown pane {id}");
+                    }
+                    Some(id)
+                }
+                None => state.active_pane(),
+            }
+        };
+        let Some(target) = target else {
+            return self.run_command_surface(argv, None, true, cwd, name, size);
+        };
+
+        let cwd = cwd.or_else(|| self.pane_cwd(target));
+        let size = size.or_else(|| self.pane_size(target));
+        let surface = self.spawn_surface_with_command(cwd, size, Some(argv))?;
+        if let Some(name) = name {
+            surface.set_name(Some(name));
+        }
+        let active_at = self.next_active_at();
+        let placement = {
+            let mut state = self.state.lock().unwrap();
+            let Some((wi, si)) = state.screen_of(target) else {
+                state.surfaces.remove(&surface.id);
+                surface.kill();
+                anyhow::bail!("pane disappeared while creating tab");
+            };
+            let Some(pane) = state.panes.get_mut(&target) else {
+                state.surfaces.remove(&surface.id);
+                surface.kill();
+                anyhow::bail!("pane disappeared while creating tab");
+            };
+            pane.tabs.push(surface.id);
+            pane.active_tab = pane.tabs.len() - 1;
+            pane.active_at = active_at;
+            RunPlacement {
+                surface: surface.id,
+                pane: target,
+                screen: state.workspaces[wi].screens[si].id,
+                workspace: state.workspaces[wi].id,
+            }
+        };
+        self.emit(MuxEvent::TreeChanged);
+        self.reap_if_dead(&surface);
+        Ok(placement)
     }
 
     /// Create a screen in a workspace (default: the active one) with one
@@ -791,7 +1092,7 @@ impl Mux {
     /// workspace active).
     pub fn focus_pane(&self, pane: PaneId) -> bool {
         let active_at = self.next_active_at();
-        let found = {
+        let (found, viewed) = {
             let mut state = self.state.lock().unwrap();
             match state.screen_of(pane) {
                 Some((wi, si)) => {
@@ -800,12 +1101,13 @@ impl Mux {
                     ws.active_screen = si;
                     ws.screens[si].active_pane = pane;
                     stamp_pane(&mut state, pane, active_at);
-                    true
+                    (true, Self::active_surface_in_state(&state))
                 }
-                None => false,
+                None => (false, None),
             }
         };
         if found {
+            self.clear_viewed_notification(viewed);
             self.emit(MuxEvent::TreeChanged);
         }
         found
@@ -877,7 +1179,7 @@ impl Mux {
     /// relative delta.
     pub fn select_tab(&self, pane: Option<PaneId>, index: Option<usize>, delta: Option<isize>) {
         let active_at = self.next_active_at();
-        {
+        let viewed = {
             let mut state = self.state.lock().unwrap();
             let Some(target) = pane.or_else(|| state.active_pane()) else { return };
             let Some(pane) = state.panes.get_mut(&target) else { return };
@@ -894,14 +1196,16 @@ impl Mux {
                     ((pane.active_tab as isize + delta).rem_euclid(len as isize)) as usize;
             }
             stamp_pane(&mut state, target, active_at);
-        }
+            state.panes.get(&target).and_then(|pane| pane.active_surface())
+        };
+        self.clear_viewed_notification(viewed);
         self.emit(MuxEvent::TreeChanged);
     }
 
     /// Select a screen in the active workspace by index or relative delta.
     pub fn select_screen(&self, index: Option<usize>, delta: Option<isize>) {
         let active_at = self.next_active_at();
-        {
+        let viewed = {
             let mut state = self.state.lock().unwrap();
             let active = state.active_workspace;
             let Some(ws) = state.workspaces.get_mut(active) else { return };
@@ -920,14 +1224,16 @@ impl Mux {
             if let Some(pane) = ws.active_screen_ref().map(|screen| screen.active_pane) {
                 stamp_pane(&mut state, pane, active_at);
             }
-        }
+            Self::active_surface_in_state(&state)
+        };
+        self.clear_viewed_notification(viewed);
         self.emit(MuxEvent::TreeChanged);
     }
 
     /// Select a workspace by index or relative delta.
     pub fn select_workspace(&self, index: Option<usize>, delta: Option<isize>) {
         let active_at = self.next_active_at();
-        {
+        let viewed = {
             let mut state = self.state.lock().unwrap();
             let len = state.workspaces.len();
             if len == 0 {
@@ -948,9 +1254,18 @@ impl Mux {
             {
                 stamp_pane(&mut state, pane, active_at);
             }
-        }
+            Self::active_surface_in_state(&state)
+        };
+        self.clear_viewed_notification(viewed);
         self.emit(MuxEvent::TreeChanged);
     }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 impl Drop for Mux {
@@ -1167,6 +1482,92 @@ mod tests {
 
     fn test_mux() -> Arc<Mux> {
         Mux::new_for_test("test", SurfaceOptions::default())
+    }
+
+    #[test]
+    fn agent_reports_apply_hook_authority() {
+        let mux = test_mux();
+        let surface = mux.new_workspace(None, None).unwrap();
+        let socket = mux.report_agent(
+            surface.id,
+            AgentState::Working,
+            AgentSource::Socket,
+            Some("socket-session".to_string()),
+        );
+        assert_eq!(socket.state, AgentState::Working);
+        assert_eq!(socket.source, AgentSource::Socket);
+
+        let hook = mux.report_agent(
+            surface.id,
+            AgentState::Blocked,
+            AgentSource::Hook,
+            Some("hook-session".to_string()),
+        );
+        assert_eq!(hook.state, AgentState::Blocked);
+        assert_eq!(hook.source, AgentSource::Hook);
+
+        let ignored_socket = mux.report_agent(
+            surface.id,
+            AgentState::Done,
+            AgentSource::Socket,
+            Some("late-socket".to_string()),
+        );
+        assert_eq!(ignored_socket.state, AgentState::Blocked);
+        assert_eq!(ignored_socket.source, AgentSource::Hook);
+
+        let filtered = mux.list_agents(Some(surface.id), Some(AgentState::Blocked));
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].session.as_deref(), Some("hook-session"));
+        assert!(mux.list_agents(Some(surface.id), Some(AgentState::Done)).is_empty());
+    }
+
+    #[test]
+    fn notification_sets_unread_and_clears_when_tab_is_viewed() {
+        let mux = test_mux();
+        let first = mux.new_workspace(None, None).unwrap();
+        let pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
+        let second = mux.new_tab(Some(pane), None, None).unwrap();
+        let notification = mux.post_notification(
+            "Build".to_string(),
+            "ok".to_string(),
+            NotificationLevel::Warning,
+            Some(first.id),
+        );
+
+        let state = mux.surface_notification(first.id).unwrap();
+        assert_eq!(state.notification, notification);
+        assert_eq!(state.level, NotificationLevel::Warning);
+        assert!(state.unread);
+
+        mux.select_tab(Some(pane), Some(1), None);
+        assert!(mux.surface_notification(first.id).is_some());
+        mux.select_tab(Some(pane), Some(0), None);
+        assert!(mux.surface_notification(first.id).is_none());
+        assert!(mux.surface_notification(second.id).is_none());
+    }
+
+    #[test]
+    fn notification_to_active_surface_does_not_set_unread() {
+        let mux = test_mux();
+        let events = mux.subscribe();
+        let surface = mux.new_workspace(None, None).unwrap();
+        assert_eq!(mux.active_surface(), Some(surface.id));
+
+        let notification = mux.post_notification(
+            "Build".to_string(),
+            "ok".to_string(),
+            NotificationLevel::Info,
+            Some(surface.id),
+        );
+
+        assert!(mux.surface_notification(surface.id).is_none());
+        assert!(events.try_iter().any(|event| {
+            matches!(
+                event,
+                MuxEvent::Notification(note)
+                    if note.notification == notification && note.surface == Some(surface.id)
+            )
+        }));
     }
 
     fn seed_split_ratio_tree(mux: &Mux) -> (PaneId, PaneId, PaneId) {

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -22,16 +22,20 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use base64::Engine;
+use ghostty_vt::{key_input_from_chord, KeyEncoder};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::model::{Screen, State};
 use crate::platform::{self, transport};
 use crate::{
-    assign_short_ids, AttachFrame, DefaultColors, Mux, MuxEvent, Node, PaneId, Rgb, ScreenId,
-    SplitDir, SurfaceId, SurfaceKind, WorkspaceId,
+    assign_short_ids, AgentRecord, AgentSource, AgentState, AttachFrame, DefaultColors, Mux,
+    MuxEvent, Node, NotificationLevel, PaneId, Rgb, ScreenId, SplitDir, SurfaceId, SurfaceKind,
+    SurfaceNotification, WorkspaceId,
 };
 
 pub const PROTOCOL_VERSION: u32 = 6;
@@ -63,6 +67,63 @@ enum Command {
     },
     ReadScreen {
         surface: SurfaceId,
+    },
+    WaitFor {
+        surface: SurfaceId,
+        pattern: String,
+        #[serde(alias = "timeout_ms")]
+        timeout_ms: u64,
+    },
+    Run {
+        #[serde(default)]
+        argv: Option<Vec<String>>,
+        #[serde(default)]
+        command: Option<String>,
+        #[serde(default)]
+        cwd: Option<String>,
+        #[serde(default)]
+        pane: Option<PaneId>,
+        #[serde(default)]
+        new_workspace: bool,
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        cols: Option<u16>,
+        #[serde(default)]
+        rows: Option<u16>,
+    },
+    SendKey {
+        surface: SurfaceId,
+        keys: Vec<String>,
+    },
+    Copy {
+        surface: SurfaceId,
+        mode: String,
+    },
+    Ids {
+        #[serde(default)]
+        kind: Option<String>,
+    },
+    Notify {
+        title: String,
+        body: String,
+        #[serde(default)]
+        level: Option<String>,
+        #[serde(default)]
+        surface: Option<SurfaceId>,
+    },
+    ListAgents {
+        #[serde(default)]
+        surface: Option<SurfaceId>,
+        #[serde(default)]
+        state: Option<String>,
+    },
+    ReportAgent {
+        surface: SurfaceId,
+        state: String,
+        source: String,
+        #[serde(default)]
+        session: Option<String>,
     },
     /// One-shot VT replay of the surface's current state (base64).
     VtState {
@@ -370,7 +431,12 @@ fn node_json(node: &Node) -> Value {
     }
 }
 
-fn pane_json(state: &State, id: PaneId, short_ids: &HashMap<u64, String>) -> Value {
+fn pane_json(
+    state: &State,
+    id: PaneId,
+    short_ids: &HashMap<u64, String>,
+    notifications: &HashMap<SurfaceId, SurfaceNotification>,
+) -> Value {
     let Some(pane) = state.panes.get(&id) else {
         return json!({ "id": id, "dead": true });
     };
@@ -389,6 +455,13 @@ fn pane_json(state: &State, id: PaneId, short_ids: &HashMap<u64, String>) -> Val
                 "browser_status": surface.and_then(|s| s.browser_status().map(|status| status.as_str())),
                 "browser_error": surface.and_then(|s| s.browser_status().and_then(|status| status.error())),
                 "browser_frames_stalled": surface.and_then(|s| s.browser_frames_stalled()),
+                "notification": notifications.get(sid).copied().map(|n| {
+                    json!({
+                        "notification": n.notification,
+                        "unread": n.unread,
+                        "level": n.level.as_str(),
+                    })
+                }),
                 "name": surface.and_then(|s| s.name()),
                 "title": surface.map(|s| s.title()).unwrap_or_default(),
                 "size": surface.map(|s| {
@@ -406,6 +479,7 @@ fn screen_json(
     screen: &Screen,
     active: bool,
     short_ids: &HashMap<u64, String>,
+    notifications: &HashMap<SurfaceId, SurfaceNotification>,
 ) -> Value {
     let mut pane_ids = Vec::new();
     screen.root.pane_ids(&mut pane_ids);
@@ -416,11 +490,14 @@ fn screen_json(
         "active": active,
         "active_pane": screen.active_pane,
         "layout": node_json(&screen.root),
-        "panes": pane_ids.iter().map(|id| pane_json(state, *id, short_ids)).collect::<Vec<_>>(),
+        "panes": pane_ids.iter().map(|id| pane_json(state, *id, short_ids, notifications)).collect::<Vec<_>>(),
     })
 }
 
-fn workspaces_json(state: &State) -> Value {
+fn workspaces_json(
+    state: &State,
+    notifications: &HashMap<SurfaceId, SurfaceNotification>,
+) -> Value {
     let ids = state
         .workspaces
         .iter()
@@ -442,11 +519,45 @@ fn workspaces_json(state: &State) -> Value {
                 "name": ws.name,
                 "active": i == state.active_workspace,
                 "screens": ws.screens.iter().enumerate().map(|(s, screen)| {
-                    screen_json(state, screen, s == ws.active_screen, &short_ids)
+                    screen_json(state, screen, s == ws.active_screen, &short_ids, notifications)
                 }).collect::<Vec<_>>(),
             })
         }).collect::<Vec<_>>(),
     })
+}
+
+fn ids_json(state: &State, kind: Option<&str>) -> anyhow::Result<Value> {
+    let allowed = ["workspace", "screen", "pane", "surface"];
+    if let Some(kind) = kind {
+        if !allowed.contains(&kind) {
+            anyhow::bail!("bad kind {kind}");
+        }
+    }
+    let mut raw = Vec::new();
+    for ws in &state.workspaces {
+        raw.push(("workspace", ws.id));
+        for screen in &ws.screens {
+            raw.push(("screen", screen.id));
+            let mut panes = Vec::new();
+            screen.root.pane_ids(&mut panes);
+            for pane in panes {
+                raw.push(("pane", pane));
+            }
+        }
+    }
+    raw.extend(state.surfaces.keys().copied().map(|id| ("surface", id)));
+    let short_ids = assign_short_ids(raw.iter().map(|(_, id)| *id));
+    Ok(json!({
+        "ids": raw
+            .into_iter()
+            .filter(|(item_kind, _)| kind.is_none_or(|kind| kind == *item_kind))
+            .map(|(kind, id)| json!({
+                "kind": kind,
+                "id": id,
+                "short_id": short_ids.get(&id).cloned().unwrap_or_default(),
+            }))
+            .collect::<Vec<_>>()
+    }))
 }
 
 fn get_surface(mux: &Mux, id: SurfaceId) -> anyhow::Result<Arc<crate::Surface>> {
@@ -467,6 +578,44 @@ fn require_browser(surface: &crate::Surface) -> anyhow::Result<()> {
     } else {
         anyhow::bail!("PTY surface is not a browser surface")
     }
+}
+
+fn parse_notification_level(level: &str) -> anyhow::Result<NotificationLevel> {
+    match level {
+        "info" => Ok(NotificationLevel::Info),
+        "warning" => Ok(NotificationLevel::Warning),
+        "error" => Ok(NotificationLevel::Error),
+        other => anyhow::bail!("bad level {other}"),
+    }
+}
+
+fn parse_agent_state(state: &str) -> anyhow::Result<AgentState> {
+    match state {
+        "working" => Ok(AgentState::Working),
+        "blocked" => Ok(AgentState::Blocked),
+        "idle" => Ok(AgentState::Idle),
+        "done" => Ok(AgentState::Done),
+        "unknown" => Ok(AgentState::Unknown),
+        other => anyhow::bail!("bad state {other}"),
+    }
+}
+
+fn parse_agent_source(source: &str) -> anyhow::Result<AgentSource> {
+    match source {
+        "socket" => Ok(AgentSource::Socket),
+        "hook" => Ok(AgentSource::Hook),
+        other => anyhow::bail!("bad source {other}"),
+    }
+}
+
+fn agent_json(record: &AgentRecord) -> Value {
+    json!({
+        "surface": record.surface,
+        "state": record.state.as_str(),
+        "source": record.source.as_str(),
+        "session": record.session,
+        "updated_at_ms": record.updated_at_ms,
+    })
 }
 
 fn parse_hex_color(value: &str) -> anyhow::Result<Rgb> {
@@ -518,6 +667,38 @@ fn browser_state_json(
     value
 }
 
+fn spawn_attach_notification_stream(
+    mux: Arc<Mux>,
+    surface_id: SurfaceId,
+    writer: LineWriter,
+) -> std::io::Result<()> {
+    let events = mux.subscribe();
+    std::thread::Builder::new()
+        .name("mux-attach-notifications".into())
+        .spawn(move || {
+            while let Ok(event) = events.recv() {
+                let MuxEvent::Notification(notification) = event else {
+                    continue;
+                };
+                if notification.surface != Some(surface_id) {
+                    continue;
+                }
+                let value = json!({
+                    "event": "notification",
+                    "notification": notification.notification,
+                    "title": notification.title,
+                    "body": notification.body,
+                    "level": notification.level.as_str(),
+                    "surface": notification.surface,
+                });
+                if writer.send(&value).is_err() {
+                    break;
+                }
+            }
+        })
+        .map(|_| ())
+}
+
 fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::Result<Value> {
     match cmd {
         Command::Identify => Ok(json!({
@@ -527,7 +708,10 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             "session": mux.session,
             "pid": std::process::id(),
         })),
-        Command::ListWorkspaces => Ok(mux.with_state(workspaces_json)),
+        Command::ListWorkspaces => {
+            let notifications = mux.surface_notifications();
+            Ok(mux.with_state(|state| workspaces_json(state, &notifications)))
+        }
         Command::Send { surface, text, bytes } => {
             let surface = get_surface(mux, surface)?;
             require_pty(&surface)?;
@@ -545,6 +729,153 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             require_pty(&surface)?;
             let text = surface.try_with_terminal(|t| t.viewport_text())??;
             Ok(json!({ "text": text }))
+        }
+        Command::WaitFor { surface, pattern, timeout_ms } => {
+            let surface = get_surface(mux, surface)?;
+            require_pty(&surface)?;
+            let regex = Regex::new(&pattern).map_err(|err| anyhow::anyhow!("bad regex: {err}"))?;
+            let start = Instant::now();
+            let check = || -> anyhow::Result<Option<String>> {
+                let text = surface.try_with_terminal(|t| t.viewport_text())??;
+                Ok(regex.is_match(&text).then_some(text))
+            };
+            if timeout_ms == 0 {
+                if let Some(text) = check()? {
+                    return Ok(json!({
+                        "matched": true,
+                        "text": text,
+                        "elapsed_ms": start.elapsed().as_millis() as u64,
+                    }));
+                }
+                anyhow::bail!("timeout waiting for pattern");
+            }
+            let deadline = start + std::time::Duration::from_millis(timeout_ms);
+            let attach = surface.attach_stream()?;
+            if let Some(text) = check()? {
+                return Ok(json!({
+                    "matched": true,
+                    "text": text,
+                    "elapsed_ms": start.elapsed().as_millis() as u64,
+                }));
+            }
+            loop {
+                let now = Instant::now();
+                if now >= deadline {
+                    anyhow::bail!("timeout waiting for pattern");
+                }
+                let remaining = deadline.saturating_duration_since(now);
+                match attach.stream.recv_timeout(remaining) {
+                    Ok(_) => {
+                        if let Some(text) = check()? {
+                            return Ok(json!({
+                                "matched": true,
+                                "text": text,
+                                "elapsed_ms": start.elapsed().as_millis() as u64,
+                            }));
+                        }
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                        anyhow::bail!("timeout waiting for pattern");
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                        anyhow::bail!("timeout waiting for pattern");
+                    }
+                }
+            }
+        }
+        Command::Run { argv, command, cwd, pane, new_workspace, name, cols, rows } => {
+            if argv.is_some() && command.is_some() {
+                anyhow::bail!("argv and command are mutually exclusive");
+            }
+            let argv = match (argv, command) {
+                (Some(argv), None) if !argv.is_empty() => argv,
+                (None, Some(command)) if !command.is_empty() => {
+                    vec![platform::default_shell(), "-lc".to_string(), command]
+                }
+                _ => anyhow::bail!("argv or command is required"),
+            };
+            if new_workspace && pane.is_some() {
+                anyhow::bail!("pane and new_workspace are mutually exclusive");
+            }
+            let placement =
+                mux.run_command_surface(argv, pane, new_workspace, cwd, name, cols.zip(rows))?;
+            Ok(json!({
+                "surface": placement.surface,
+                "pane": placement.pane,
+                "screen": placement.screen,
+                "workspace": placement.workspace,
+            }))
+        }
+        Command::SendKey { surface, keys } => {
+            let surface = get_surface(mux, surface)?;
+            require_pty(&surface)
+                .map_err(|_| anyhow::anyhow!("surface does not support key input"))?;
+            if keys.is_empty() {
+                anyhow::bail!("bad request: keys must be non-empty");
+            }
+            let mut encoder = KeyEncoder::new()?;
+            let mut encoded = Vec::new();
+            surface.try_with_terminal(|term| {
+                term.scroll_to_bottom();
+                encoder.sync_from_terminal(term);
+                for key in &keys {
+                    let Some(input) = key_input_from_chord(key) else {
+                        return Err(anyhow::anyhow!("unknown key {key}"));
+                    };
+                    encoder.encode(&input, &mut encoded).map_err(anyhow::Error::from)?;
+                }
+                Ok::<(), anyhow::Error>(())
+            })??;
+            surface.write_bytes(&encoded)?;
+            Ok(json!({}))
+        }
+        Command::Copy { surface, mode } => {
+            let surface = get_surface(mux, surface)?;
+            require_pty(&surface)?;
+            let text = match mode.as_str() {
+                "screen" => surface.try_with_terminal(|t| t.viewport_text())??,
+                "scrollback" => surface.try_with_terminal(|t| t.plain_text())??,
+                "selection" => {
+                    surface.selection_text().ok_or_else(|| anyhow::anyhow!("no selection"))?
+                }
+                other => anyhow::bail!("bad mode {other}"),
+            };
+            Ok(json!({ "text": text, "mode": mode }))
+        }
+        Command::Ids { kind } => mux.with_state(|state| ids_json(state, kind.as_deref())),
+        Command::Notify { title, body, level, surface } => {
+            if title.is_empty() {
+                anyhow::bail!("title is required");
+            }
+            let level = parse_notification_level(level.as_deref().unwrap_or("info"))?;
+            if let Some(surface) = surface {
+                get_surface(mux, surface)?;
+            }
+            let notification = mux.post_notification(title, body, level, surface);
+            Ok(json!({ "notification": notification }))
+        }
+        Command::ListAgents { surface, state } => {
+            if let Some(surface) = surface {
+                get_surface(mux, surface)?;
+            }
+            let state = match state {
+                Some(state) => Some(parse_agent_state(&state)?),
+                None => None,
+            };
+            let agents = mux.list_agents(surface, state).iter().map(agent_json).collect::<Vec<_>>();
+            Ok(json!({ "agents": agents }))
+        }
+        Command::ReportAgent { surface, state, source, session } => {
+            get_surface(mux, surface)?;
+            let state = parse_agent_state(&state)?;
+            let source = parse_agent_source(&source)?;
+            let record = mux.report_agent(surface, state, source, session);
+            Ok(json!({
+                "surface": record.surface,
+                "state": record.state.as_str(),
+                "source": record.source.as_str(),
+                "session": record.session,
+            }))
         }
         Command::VtState { surface } => {
             let surface = get_surface(mux, surface)?;
@@ -812,6 +1143,14 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
                             json!({"event": "title-changed", "surface": id})
                         }
                         MuxEvent::Bell(id) => json!({"event": "bell", "surface": id}),
+                        MuxEvent::Notification(notification) => json!({
+                            "event": "notification",
+                            "notification": notification.notification,
+                            "title": notification.title,
+                            "body": notification.body,
+                            "level": notification.level.as_str(),
+                            "surface": notification.surface,
+                        }),
                         MuxEvent::Status(message) => {
                             json!({"event": "status", "message": message})
                         }
@@ -827,6 +1166,7 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
         }
         Command::AttachSurface { surface: surface_id } => {
             let surface = get_surface(mux, surface_id)?;
+            spawn_attach_notification_stream(mux.clone(), surface_id, writer.clone())?;
             if surface.kind() == SurfaceKind::Browser {
                 let (state, frames) = surface.attach_frames()?;
                 writer.send(&browser_state_json(surface_id, &state, true))?;

--- a/mux/crates/mux-core/src/surface.rs
+++ b/mux/crates/mux-core/src/surface.rs
@@ -119,6 +119,7 @@ pub struct SurfaceMeta {
     pub id: SurfaceId,
     /// User-assigned tab name (rename tab); shared by every surface kind.
     pub(crate) name: Mutex<Option<String>>,
+    pub(crate) selection: Mutex<Option<String>>,
 }
 
 /// A pane tab runtime.
@@ -238,7 +239,7 @@ impl Surface {
             term.set_default_colors(colors.fg, colors.bg);
         }
         let surface = Arc::new(Surface::Pty(PtySurface {
-            meta: SurfaceMeta { id, name: Mutex::new(None) },
+            meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
             term: Mutex::new(term),
             writer: Mutex::new(writer),
             master: Mutex::new(pty.master),
@@ -336,7 +337,7 @@ impl Surface {
         }
 
         Ok(Arc::new(Surface::Pty(PtySurface {
-            meta: SurfaceMeta { id, name: Mutex::new(None) },
+            meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
             term: Mutex::new(term),
             writer: Mutex::new(Box::new(std::io::sink())),
             master: Mutex::new(Box::new(TestMasterPty {
@@ -420,6 +421,14 @@ impl Surface {
 
     pub fn name(&self) -> Option<String> {
         self.name.lock().unwrap().clone()
+    }
+
+    pub fn set_selection_text(&self, text: Option<String>) {
+        *self.selection.lock().unwrap() = text;
+    }
+
+    pub fn selection_text(&self) -> Option<String> {
+        self.selection.lock().unwrap().clone()
     }
 
     /// Snapshot the terminal into `rs` (holds the terminal lock only for

--- a/mux/crates/mux-core/tests/pty.rs
+++ b/mux/crates/mux-core/tests/pty.rs
@@ -351,6 +351,53 @@ fn control_socket_read_screen_reports_rendered_viewport_after_scrollback_clear()
 }
 
 #[test]
+fn control_socket_wait_for_matches_one_shot_output_already_on_screen() {
+    let mux = Mux::new(
+        unique_session("test-wait-for-one-shot"),
+        shell_opts("printf 'one-shot-ready\\n'; sleep 30"),
+    );
+    let surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+
+    let sock_path = mux_core::server::serve(mux.clone(), None).unwrap();
+    let stream = connect(&sock_path);
+    let mut writer = stream.try_clone_box().unwrap();
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+
+    let appeared = wait_for(
+        || {
+            line.clear();
+            writeln!(writer, r#"{{"id":1,"cmd":"read-screen","surface":{}}}"#, surface.id).unwrap();
+            reader.read_line(&mut line).unwrap();
+            let value: serde_json::Value = serde_json::from_str(&line).unwrap();
+            assert_eq!(value["ok"], true, "read-screen failed: {line}");
+            value["data"]["text"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("one-shot-ready")
+                .then_some(())
+        },
+        Duration::from_secs(10),
+    );
+    assert!(appeared.is_some(), "one-shot output never appeared");
+
+    line.clear();
+    writeln!(
+        writer,
+        r#"{{"id":2,"cmd":"wait-for","surface":{},"pattern":"one-shot-ready","timeout_ms":1000}}"#,
+        surface.id
+    )
+    .unwrap();
+    reader.read_line(&mut line).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(value["ok"], true, "wait-for failed after one-shot output: {line}");
+    assert_eq!(value["data"]["matched"], true);
+
+    mux.close_surface(surface.id);
+    mux_core::server::cleanup(&sock_path);
+}
+
+#[test]
 fn control_socket_set_default_colors_merges_fields() {
     let opts = SurfaceOptions { command: Some(vec!["/bin/cat".to_string()]), ..Default::default() };
     let mux = Mux::new(format!("test-colors-{}", std::process::id()), opts);

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -2266,6 +2266,9 @@ impl App {
         if text.is_empty() {
             return;
         }
+        if let SurfaceHandle::Local(local) = &surface {
+            local.set_selection_text(Some(text.clone()));
+        }
         self.copy_text_to_clipboard(&text);
         self.show_toast("Copied".to_string());
     }
@@ -2653,10 +2656,21 @@ fn browser_key_mapping(
 #[cfg(test)]
 mod tests {
     use super::{
-        browser_content_size_for_rect, browser_hover_forward_allowed, pane_parts_for_rect,
+        browser_content_size_for_rect, browser_hover_forward_allowed, pane_parts_for_rect, App,
+        PaneArea,
     };
-    use crate::config::ScrollbarPosition;
-    use mux_core::{BrowserStatus, Rect};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use ghostty_vt::{KeyEncoder, RenderState};
+    use mux_core::{BrowserStatus, Mux, Node, Rect, SurfaceKind, SurfaceOptions};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    use crate::browser_input::BrowserInputDispatcher;
+    use crate::config::{Config, ScrollbarPosition};
+    use crate::session::tree::{PaneView, ScreenView, TabNotificationView, TabView, WorkspaceView};
+    use crate::session::{Session, TreeView};
 
     #[test]
     fn browser_omnibar_reduces_content_rect_for_graphics_and_input() {
@@ -2693,5 +2707,136 @@ mod tests {
             false
         ));
         assert!(!browser_hover_forward_allowed(None, false));
+    }
+
+    #[test]
+    fn notify_unread_indicators_render_and_clear() {
+        let mux = Mux::new(
+            "notify-render-test",
+            SurfaceOptions {
+                command: Some(vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    "sleep 30".to_string(),
+                ]),
+                ..Default::default()
+            },
+        );
+        let surface = mux.new_workspace(Some("work".to_string()), Some((20, 8))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_width = 12;
+        app.tree = notify_tree(surface.id, true);
+        app.pane_areas.push(PaneArea {
+            pane: 2,
+            surface: surface.id,
+            rect: Rect { x: 12, y: 1, width: 26, height: 8 },
+            bar: Some(Rect { x: 12, y: 1, width: 26, height: 1 }),
+            omnibar: None,
+            content: Rect { x: 13, y: 2, width: 23, height: 6 },
+            track: None,
+        });
+
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        terminal
+            .draw(|frame| {
+                crate::ui::draw(&mut app, frame);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(12, 2)].symbol(), "│");
+        assert_eq!(buffer[(12, 2)].style().fg, Some(app.config.theme.notification_warning));
+        assert!(row_contains(buffer, 1, "•"), "tab bar should contain unread dot");
+        assert_eq!(buffer[(0, 2)].symbol(), "•", "sidebar should contain unread dot");
+
+        app.tree = notify_tree(surface.id, false);
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        terminal
+            .draw(|frame| {
+                crate::ui::draw(&mut app, frame);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(12, 2)].style().fg, Some(app.config.theme.border_active));
+        assert!(!row_contains(buffer, 1, "•"), "tab bar dot should clear");
+        assert_ne!(buffer[(0, 2)].symbol(), "•", "sidebar dot should clear");
+
+        mux.close_surface(surface.id);
+    }
+
+    fn test_app(session: Session) -> App {
+        App {
+            session,
+            config: Config::default(),
+            tree: TreeView::default(),
+            render_states: HashMap::<u64, RenderState>::new(),
+            graphics_writer: None,
+            graphics_supported: false,
+            stdout_lock: Arc::new(Mutex::new(())),
+            pane_areas: Vec::new(),
+            prefix_armed: false,
+            session_label: "test".to_string(),
+            sidebar_visible: true,
+            sidebar_width: 0,
+            sidebar_width_override: None,
+            content_area: Rect::default(),
+            hits: Vec::new(),
+            tab_scroll: HashMap::new(),
+            hover: None,
+            menu: None,
+            prompt: None,
+            omnibar: None,
+            toast: None,
+            shake_frames: 0,
+            selection: None,
+            status_message: None,
+            cell_pixels: (8, 16),
+            pointer_shape: false,
+            last_browser_hover: None,
+            browser_input: BrowserInputDispatcher::spawn().unwrap(),
+            drag: None,
+            encoder: KeyEncoder::new().unwrap(),
+            encode_buf: Vec::new(),
+            quit: false,
+        }
+    }
+
+    fn notify_tree(surface: u64, unread: bool) -> TreeView {
+        TreeView {
+            active_workspace: 0,
+            workspaces: vec![WorkspaceView {
+                id: 4,
+                short_id: "000004".to_string(),
+                name: "work".to_string(),
+                active_screen: 0,
+                screens: vec![ScreenView {
+                    id: 3,
+                    short_id: "000003".to_string(),
+                    name: None,
+                    layout: Node::Leaf(2),
+                    active_pane: 2,
+                    panes: vec![PaneView {
+                        id: 2,
+                        short_id: "000002".to_string(),
+                        name: None,
+                        active_tab: 0,
+                        tabs: vec![TabView {
+                            surface,
+                            short_id: "000001".to_string(),
+                            name: Some("tab".to_string()),
+                            title: "shell".to_string(),
+                            kind: SurfaceKind::Pty,
+                            browser_source: None,
+                            browser_frames_stalled: false,
+                            notification: unread
+                                .then_some(TabNotificationView { unread: true, level: "warning" }),
+                        }],
+                    }],
+                }],
+            }],
+        }
+    }
+
+    fn row_contains(buffer: &ratatui::buffer::Buffer, y: u16, needle: &str) -> bool {
+        (0..buffer.area.width).any(|x| buffer[(x, y)].symbol() == needle)
     }
 }

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -29,6 +29,7 @@ struct GlobalArgs {
 #[derive(Default)]
 struct FlagMap {
     values: BTreeMap<String, String>,
+    positionals: Vec<String>,
 }
 
 struct VerbSpec {
@@ -66,6 +67,56 @@ const VERBS: &[VerbSpec] = &[
         allowed: &["surface"],
         build: build_surface,
         print: print_read_screen,
+        stream: false,
+    },
+    VerbSpec {
+        name: "wait-for",
+        allowed: &["surface", "pattern", "timeout-ms"],
+        build: build_wait_for,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "run",
+        allowed: &["pane", "new-workspace", "cwd", "name", "command"],
+        build: build_run,
+        print: print_surface,
+        stream: false,
+    },
+    VerbSpec {
+        name: "send-key",
+        allowed: &["surface"],
+        build: build_send_key,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "copy",
+        allowed: &["surface", "mode"],
+        build: build_copy,
+        print: print_read_screen,
+        stream: false,
+    },
+    VerbSpec { name: "ids", allowed: &["kind"], build: build_ids, print: print_ids, stream: false },
+    VerbSpec {
+        name: "notify",
+        allowed: &["title", "body", "level", "surface"],
+        build: build_notify,
+        print: print_notification,
+        stream: false,
+    },
+    VerbSpec {
+        name: "list-agents",
+        allowed: &["surface", "state"],
+        build: build_list_agents,
+        print: print_agents,
+        stream: false,
+    },
+    VerbSpec {
+        name: "report-agent",
+        allowed: &["surface", "state", "source", "session"],
+        build: build_report_agent,
+        print: print_empty,
         stream: false,
     },
     VerbSpec {
@@ -319,12 +370,30 @@ fn parse(args: &[String]) -> Result<Parsed, UsageError> {
                 i += 2;
             }
             "--session" => {
-                global.session = Some(value_after(args, i, "--session")?);
-                i += 2;
+                if verb.is_some_and(|spec| spec.allowed.contains(&"session")) {
+                    let value = value_after(args, i, "--session")?;
+                    if flags.values.insert("session".to_string(), value).is_some() {
+                        return Err(UsageError(format!("duplicate flag {arg:?}")));
+                    }
+                    i += 2;
+                } else {
+                    global.session = Some(value_after(args, i, "--session")?);
+                    i += 2;
+                }
             }
             _ if verb.is_none() && verb_by_name(arg).is_some() => {
                 verb = verb_by_name(arg);
                 i += 1;
+            }
+            "--" => {
+                let Some(spec) = verb else {
+                    return Err(UsageError("missing verb before --".to_string()));
+                };
+                if spec.name != "run" {
+                    return Err(UsageError(format!("unexpected argument {arg:?}")));
+                }
+                flags.positionals.extend(args[i + 1..].iter().cloned());
+                break;
             }
             _ if arg.starts_with("--") => {
                 let Some(spec) = verb else {
@@ -334,6 +403,13 @@ fn parse(args: &[String]) -> Result<Parsed, UsageError> {
                 if !spec.allowed.contains(&name) {
                     return Err(UsageError(format!("unknown flag {arg:?} for {}", spec.name)));
                 }
+                if spec.name == "run" && name == "new-workspace" {
+                    if flags.values.insert(name.to_string(), "true".to_string()).is_some() {
+                        return Err(UsageError(format!("duplicate flag {arg:?}")));
+                    }
+                    i += 1;
+                    continue;
+                }
                 let value = value_after(args, i, arg)?;
                 if flags.values.insert(name.to_string(), value).is_some() {
                     return Err(UsageError(format!("duplicate flag {arg:?}")));
@@ -341,7 +417,13 @@ fn parse(args: &[String]) -> Result<Parsed, UsageError> {
                 i += 2;
             }
             _ if verb.is_some() => {
-                return Err(UsageError(format!("unexpected argument {arg:?}")));
+                let spec = verb.unwrap();
+                if spec.name == "send-key" {
+                    flags.positionals.push(arg.to_string());
+                    i += 1;
+                } else {
+                    return Err(UsageError(format!("unexpected argument {arg:?}")));
+                }
             }
             _ => return Err(UsageError(format!("unknown argument {arg:?}"))),
         }
@@ -569,6 +651,113 @@ fn build_send(flags: &FlagMap) -> Result<Value, UsageError> {
             .map_err(|err| UsageError(format!("failed to read stdin: {err}")))?;
         value["text"] = json!(text);
     }
+    Ok(value)
+}
+
+fn build_wait_for(flags: &FlagMap) -> Result<Value, UsageError> {
+    Ok(json!({
+        "surface": flags.required_u64("surface")?,
+        "pattern": flags.required("pattern")?,
+        "timeout_ms": flags.required_u64("timeout-ms")?,
+    }))
+}
+
+fn build_run(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_u64(&mut value, "pane")?;
+    flags.insert_optional_string(&mut value, "cwd");
+    flags.insert_optional_string(&mut value, "name");
+    if flags.optional("new-workspace").is_some() {
+        value["new_workspace"] = json!(true);
+    }
+    match (flags.optional("command"), flags.positionals.is_empty()) {
+        (Some(command), true) => value["command"] = json!(command),
+        (Some(_), false) => {
+            return Err(UsageError("--command and argv are mutually exclusive".to_string()));
+        }
+        (None, false) => value["argv"] = json!(flags.positionals),
+        (None, true) => return Err(UsageError("argv or --command is required".to_string())),
+    }
+    Ok(value)
+}
+
+fn build_send_key(flags: &FlagMap) -> Result<Value, UsageError> {
+    if flags.positionals.is_empty() {
+        return Err(UsageError("at least one key is required".to_string()));
+    }
+    Ok(json!({
+        "surface": flags.required_u64("surface")?,
+        "keys": flags.positionals,
+    }))
+}
+
+fn build_copy(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mode = flags.required("mode")?;
+    if !matches!(mode.as_str(), "screen" | "selection" | "scrollback") {
+        return Err(UsageError("--mode must be screen, selection, or scrollback".to_string()));
+    }
+    Ok(json!({ "surface": flags.required_u64("surface")?, "mode": mode }))
+}
+
+fn build_ids(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    if let Some(kind) = flags.optional("kind") {
+        if !matches!(kind.as_str(), "workspace" | "screen" | "pane" | "surface") {
+            return Err(UsageError(
+                "--kind must be workspace, screen, pane, or surface".to_string(),
+            ));
+        }
+        value["kind"] = json!(kind);
+    }
+    Ok(value)
+}
+
+fn build_notify(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({
+        "title": flags.required("title")?,
+        "body": flags.required("body")?,
+    });
+    if let Some(level) = flags.optional("level") {
+        if !matches!(level.as_str(), "info" | "warning" | "error") {
+            return Err(UsageError("--level must be info, warning, or error".to_string()));
+        }
+        value["level"] = json!(level);
+    }
+    flags.insert_optional_u64(&mut value, "surface")?;
+    Ok(value)
+}
+
+fn build_list_agents(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_u64(&mut value, "surface")?;
+    if let Some(state) = flags.optional("state") {
+        if !matches!(state.as_str(), "working" | "blocked" | "idle" | "done" | "unknown") {
+            return Err(UsageError(
+                "--state must be working, blocked, idle, done, or unknown".to_string(),
+            ));
+        }
+        value["state"] = json!(state);
+    }
+    Ok(value)
+}
+
+fn build_report_agent(flags: &FlagMap) -> Result<Value, UsageError> {
+    let state = flags.required("state")?;
+    if !matches!(state.as_str(), "working" | "blocked" | "idle" | "done" | "unknown") {
+        return Err(UsageError(
+            "--state must be working, blocked, idle, done, or unknown".to_string(),
+        ));
+    }
+    let source = flags.required("source")?;
+    if !matches!(source.as_str(), "socket" | "hook") {
+        return Err(UsageError("--source must be socket or hook".to_string()));
+    }
+    let mut value = json!({
+        "surface": flags.required_u64("surface")?,
+        "state": state,
+        "source": source,
+    });
+    flags.insert_optional_string(&mut value, "session");
     Ok(value)
 }
 
@@ -810,6 +999,39 @@ fn print_vt_state(data: &Value, out: &mut dyn Write) -> io::Result<()> {
 
 fn print_surface(data: &Value, out: &mut dyn Write) -> io::Result<()> {
     writeln!(out, "{}", data.get("surface").and_then(Value::as_u64).unwrap_or(0))
+}
+
+fn print_notification(data: &Value, out: &mut dyn Write) -> io::Result<()> {
+    writeln!(out, "{}", data.get("notification").and_then(Value::as_u64).unwrap_or(0))
+}
+
+fn print_ids(data: &Value, out: &mut dyn Write) -> io::Result<()> {
+    let Some(ids) = data.get("ids").and_then(Value::as_array) else { return Ok(()) };
+    for item in ids {
+        writeln!(
+            out,
+            "{} {} {}",
+            item.get("kind").and_then(Value::as_str).unwrap_or(""),
+            item.get("id").and_then(Value::as_u64).unwrap_or(0),
+            item.get("short_id").and_then(Value::as_str).unwrap_or("")
+        )?;
+    }
+    Ok(())
+}
+
+fn print_agents(data: &Value, out: &mut dyn Write) -> io::Result<()> {
+    let Some(agents) = data.get("agents").and_then(Value::as_array) else { return Ok(()) };
+    for agent in agents {
+        writeln!(
+            out,
+            "{} {} {} {}",
+            agent.get("surface").and_then(Value::as_u64).unwrap_or(0),
+            agent.get("state").and_then(Value::as_str).unwrap_or(""),
+            agent.get("source").and_then(Value::as_str).unwrap_or(""),
+            agent.get("session").and_then(Value::as_str).unwrap_or("-")
+        )?;
+    }
+    Ok(())
 }
 
 fn print_tree(data: &Value, out: &mut dyn Write) -> io::Result<()> {

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -13,7 +13,10 @@
 //!     "tab_bg": 236,
 //!     "tab_active_bg": null,
 //!     "border_active": "#87afd7",
-//!     "border_inactive": "#444444"
+//!     "border_inactive": "#444444",
+//!     "notification_info": "#87afd7",
+//!     "notification_warning": "#d7af5f",
+//!     "notification_error": "#d75f5f"
 //!   },
 //!   "tabs": {
 //!     "min_width": 7,
@@ -110,6 +113,9 @@ struct RawTheme {
     tab_active_bg: Option<ColorValue>,
     border_active: Option<ColorValue>,
     border_inactive: Option<ColorValue>,
+    notification_info: Option<ColorValue>,
+    notification_warning: Option<ColorValue>,
+    notification_error: Option<ColorValue>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -196,6 +202,9 @@ pub struct Theme {
     pub tab_active_bg: Option<Color>,
     pub border_active: Color,
     pub border_inactive: Color,
+    pub notification_info: Color,
+    pub notification_warning: Color,
+    pub notification_error: Color,
 }
 
 impl Default for Theme {
@@ -211,6 +220,9 @@ impl Default for Theme {
             tab_active_bg: None,
             border_active: Color::Indexed(110),
             border_inactive: Color::Indexed(238),
+            notification_info: Color::Indexed(110),
+            notification_warning: Color::Indexed(179),
+            notification_error: Color::Indexed(167),
         }
     }
 }
@@ -652,6 +664,15 @@ pub fn load() -> Config {
     }
     if let Some(c) = t.border_inactive.as_ref().and_then(ColorValue::to_color) {
         config.theme.border_inactive = c;
+    }
+    if let Some(c) = t.notification_info.as_ref().and_then(ColorValue::to_color) {
+        config.theme.notification_info = c;
+    }
+    if let Some(c) = t.notification_warning.as_ref().and_then(ColorValue::to_color) {
+        config.theme.notification_warning = c;
+    }
+    if let Some(c) = t.notification_error.as_ref().and_then(ColorValue::to_color) {
+        config.theme.notification_error = c;
     }
     if let Some(w) = raw.tabs.min_width {
         config.tabs.min_width = w.clamp(3, 40);

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -79,7 +79,8 @@ CLI VERBS
   close-workspace, rename-pane, rename-surface, rename-screen,
   rename-workspace, resize-surface, focus-pane, select-tab,
   select-screen, select-workspace, move-tab, move-workspace,
-  scroll-surface, subscribe, attach-surface
+  scroll-surface, subscribe, attach-surface, wait-for, run,
+  send-key, copy, ids, notify, list-agents, report-agent
 ";
 
 struct Args {

--- a/mux/crates/mux-tui/src/session/mod.rs
+++ b/mux/crates/mux-tui/src/session/mod.rs
@@ -8,7 +8,7 @@
 //! queries then work identically in both cases.
 
 mod remote;
-mod tree;
+pub(crate) mod tree;
 
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::Receiver;
@@ -22,7 +22,7 @@ use mux_core::{
 use serde_json::json;
 
 pub use remote::{RemoteSession, RemoteSurface};
-pub use tree::TreeView;
+pub use tree::{TabNotificationView, TreeView, WorkspaceView};
 
 pub enum Session {
     Local(Arc<Mux>),
@@ -95,7 +95,12 @@ impl Session {
 
     pub fn tree(&self) -> TreeView {
         match self {
-            Session::Local(mux) => mux.with_state(tree::tree_from_state),
+            Session::Local(mux) => {
+                let notifications = mux.surface_notifications();
+                mux.with_state(|state| {
+                    tree::tree_from_state_with_notifications(state, &notifications)
+                })
+            }
             Session::Remote(remote) => remote.tree().unwrap_or_default(),
         }
     }

--- a/mux/crates/mux-tui/src/session/remote.rs
+++ b/mux/crates/mux-tui/src/session/remote.rs
@@ -360,6 +360,10 @@ impl RemoteSession {
                     self.emit(MuxEvent::Bell(id));
                 }
             }
+            Some("notification") => {
+                self.tree_stale.store(true, Ordering::Release);
+                self.emit(MuxEvent::TreeChanged);
+            }
             Some("status") => {
                 if let Some(message) = value.get("message").and_then(|v| v.as_str()) {
                     self.emit(MuxEvent::Status(message.to_string()));

--- a/mux/crates/mux-tui/src/session/tree.rs
+++ b/mux/crates/mux-tui/src/session/tree.rs
@@ -1,9 +1,11 @@
 //! Read-only tree snapshots shared by the renderer and input handling,
 //! plus the JSON parser for the remote `list-workspaces` shape.
 
+use std::collections::HashMap;
+
 use mux_core::{
     assign_short_ids, BrowserSource, Node, PaneId, ScreenId, SplitDir, State, SurfaceId,
-    SurfaceKind, WorkspaceId,
+    SurfaceKind, SurfaceNotification, WorkspaceId,
 };
 use serde_json::Value;
 
@@ -54,6 +56,13 @@ pub struct TabView {
     pub kind: SurfaceKind,
     pub browser_source: Option<BrowserSource>,
     pub browser_frames_stalled: bool,
+    pub notification: Option<TabNotificationView>,
+}
+
+#[derive(Clone, Copy)]
+pub struct TabNotificationView {
+    pub unread: bool,
+    pub level: &'static str,
 }
 
 impl TreeView {
@@ -132,8 +141,10 @@ impl PaneView {
     }
 }
 
-/// Snapshot a local mux state into a TreeView.
-pub fn tree_from_state(state: &State) -> TreeView {
+pub fn tree_from_state_with_notifications(
+    state: &State,
+    notifications: &HashMap<SurfaceId, SurfaceNotification>,
+) -> TreeView {
     let ids = state
         .workspaces
         .iter()
@@ -168,6 +179,10 @@ pub fn tree_from_state(state: &State) -> TreeView {
                         .get(sid)
                         .and_then(|s| s.browser_frames_stalled())
                         .unwrap_or(false),
+                    notification: notifications.get(sid).map(|notification| TabNotificationView {
+                        unread: notification.unread,
+                        level: notification.level.as_str(),
+                    }),
                 })
                 .collect(),
         })
@@ -262,11 +277,24 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                                 .get("browser_frames_stalled")
                                 .and_then(|v| v.as_bool())
                                 .unwrap_or(false),
+                            notification: tab.get("notification").and_then(parse_notification),
                         })
                     })
                     .collect()
             })
             .unwrap_or_default(),
+    })
+}
+
+fn parse_notification(value: &Value) -> Option<TabNotificationView> {
+    let level = match value.get("level").and_then(|v| v.as_str()).unwrap_or("info") {
+        "warning" => "warning",
+        "error" => "error",
+        _ => "info",
+    };
+    Some(TabNotificationView {
+        unread: value.get("unread").and_then(|v| v.as_bool()).unwrap_or(false),
+        level,
     })
 }
 

--- a/mux/crates/mux-tui/src/ui/pane.rs
+++ b/mux/crates/mux-tui/src/ui/pane.rs
@@ -14,6 +14,7 @@ use ratatui::Frame;
 use super::{thumb_geometry, truncate};
 use crate::app::{App, Hit, PaneArea, PaneEdge, Selection};
 use crate::config::{tab_label, Theme};
+use crate::session::TabNotificationView;
 
 /// Border style for a pane box: active gets the accent color, idle
 /// stays dim. Notification flashing will slot in here as another state
@@ -24,6 +25,14 @@ fn border_style(theme: &Theme, focused: bool) -> Style {
         Style::default().fg(theme.border_active)
     } else {
         Style::default().fg(theme.border_inactive)
+    }
+}
+
+fn notification_color(theme: &Theme, notification: TabNotificationView) -> Color {
+    match notification.level {
+        "warning" => theme.notification_warning,
+        "error" => theme.notification_error,
+        _ => theme.notification_info,
     }
 }
 
@@ -58,7 +67,15 @@ fn draw_box(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool) {
     let screen = frame.area();
     let theme = app.config.theme;
     let buf = frame.buffer_mut();
-    let style = border_style(&theme, focused);
+    let notification = app
+        .tree
+        .pane(area.pane)
+        .and_then(|pane| pane.tabs.get(pane.active_tab))
+        .and_then(|tab| tab.notification)
+        .filter(|notification| notification.unread);
+    let style = notification
+        .map(|notification| Style::default().fg(notification_color(&theme, notification)))
+        .unwrap_or_else(|| border_style(&theme, focused));
     let (x0, y0) = (rect.x, rect.y);
     let (x1, y1) = (rect.x + rect.width - 1, rect.y + rect.height - 1);
     if x1 >= screen.width || y1 >= screen.height {
@@ -89,7 +106,13 @@ fn draw_tab_bar(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
         .tabs
         .iter()
         .enumerate()
-        .map(|(i, t)| tab_label(&tab_cfg, i, &t.title, t.name.as_deref()))
+        .map(|(i, t)| {
+            let mut label = tab_label(&tab_cfg, i, &t.title, t.name.as_deref());
+            if t.notification.is_some_and(|notification| notification.unread) {
+                label.push_str(" •");
+            }
+            label
+        })
         .collect();
     let active_tab = pane.active_tab;
     let pane_id = area.pane;
@@ -204,6 +227,11 @@ fn draw_tab_bar(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
         }
         let is_active = i == active_tab;
         let mut style = if is_active { active_style } else { base };
+        if let Some(notification) =
+            pane.tabs[i].notification.filter(|notification| notification.unread)
+        {
+            style = style.fg(notification_color(&theme, notification));
+        }
         if tab_drag.is_some_and(|drag| pane.tabs[i].surface == drag.surface) {
             style = style.add_modifier(Modifier::DIM);
         }

--- a/mux/crates/mux-tui/src/ui/sidebar.rs
+++ b/mux/crates/mux-tui/src/ui/sidebar.rs
@@ -13,6 +13,14 @@ use ratatui::Frame;
 use super::truncate;
 use crate::app::{App, Hit};
 
+fn workspace_has_unread(ws: &crate::session::WorkspaceView) -> bool {
+    ws.screens
+        .iter()
+        .flat_map(|screen| screen.panes.iter())
+        .flat_map(|pane| pane.tabs.iter())
+        .any(|tab| tab.notification.is_some_and(|notification| notification.unread))
+}
+
 pub fn draw(app: &mut App, frame: &mut Frame) {
     let area = frame.area();
     let width = app.sidebar_width;
@@ -74,6 +82,11 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
             let rail_style = active_style.fg(rail);
             buf[(0, y)].set_symbol("▎").set_style(rail_style);
             buf[(0, y + 1)].set_symbol("▎").set_style(rail_style);
+        }
+        if workspace_has_unread(ws) && content_w > 1 {
+            let dot_style =
+                style.fg(app.config.theme.notification_info).add_modifier(Modifier::BOLD);
+            buf[(0, y)].set_symbol("•").set_style(dot_style);
         }
         set_line_from(buf, 1, y, &truncate(&ws.name, content_w - 1), style);
         hits.push((row_rect(y), Hit::Workspace { index: i, id: ws.id }));

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -87,6 +87,42 @@ fn cli_verbs_cover_command_output_errors_and_streams() {
     let screen = wait_for_screen(&server, surface, &marker);
     assert!(screen.contains(&marker), "screen did not contain marker; got {screen:?}");
 
+    let ids_json = cli(&server, &["--json", "ids", "--kind", "surface"]);
+    assert_success(&ids_json);
+    let ids: serde_json::Value = serde_json::from_slice(&ids_json.stdout).unwrap();
+    assert!(ids["ids"].as_array().unwrap().iter().any(|item| item["id"].as_u64() == Some(surface)));
+
+    let copied = cli(&server, &["copy", "--surface", &surface.to_string(), "--mode", "screen"]);
+    assert_success(&copied);
+    assert!(String::from_utf8_lossy(&copied.stdout).contains(&marker));
+
+    let notify = cli(&server, &["notify", "--title", "Build", "--body", "ok"]);
+    assert_success(&notify);
+    assert!(String::from_utf8_lossy(&notify.stdout).trim().parse::<u64>().unwrap() > 0);
+
+    let report = cli(
+        &server,
+        &[
+            "report-agent",
+            "--surface",
+            &surface.to_string(),
+            "--state",
+            "working",
+            "--source",
+            "socket",
+            "--session",
+            "cli",
+        ],
+    );
+    assert_success(&report);
+    let agents = cli(&server, &["--json", "list-agents", "--surface", &surface.to_string()]);
+    assert_success(&agents);
+    let agents: serde_json::Value = serde_json::from_slice(&agents.stdout).unwrap();
+    assert_eq!(agents["agents"][0]["state"].as_str(), Some("working"));
+
+    let send_key = cli(&server, &["send-key", "--surface", &surface.to_string(), "enter"]);
+    assert_success(&send_key);
+
     let select_bare = cli(&server, &["select-tab"]);
     assert_eq!(select_bare.status.code(), Some(2));
 

--- a/mux/docs/configuration.md
+++ b/mux/docs/configuration.md
@@ -19,6 +19,9 @@ Selection colors are resolved in this order: explicit `mux.json`, Ghostty config
 | `theme.tab_active_bg` | color or null | `null` | Overrides the focused and unfocused active-tab chip backgrounds |
 | `theme.border_active` | color | `110` | Focused pane border |
 | `theme.border_inactive` | color | `238` | Unfocused pane border |
+| `theme.notification_info` | color | `110` | Info notification attention dot and border |
+| `theme.notification_warning` | color | `179` | Warning notification attention dot and border |
+| `theme.notification_error` | color | `167` | Error notification attention dot and border |
 
 ## Tabs
 
@@ -114,7 +117,10 @@ Chord strings can be single characters or a key name with optional `ctrl`, `cont
     "tab_bg": 236,
     "tab_active_bg": null,
     "border_active": "#87afd7",
-    "border_inactive": "#444444"
+    "border_inactive": "#444444",
+    "notification_info": "#87afd7",
+    "notification_warning": "#d7af5f",
+    "notification_error": "#d75f5f"
   },
   "tabs": {
     "min_width": 9,

--- a/mux/spec/cli.md
+++ b/mux/spec/cli.md
@@ -80,14 +80,14 @@ The generated CLI requires one of `--index` or `--delta` for `select-tab`, `sele
 | `scroll-surface` | implemented | `--surface <id> --delta <n>` | none | none |
 | `subscribe` | implemented | none | none in v5 | event JSON lines |
 | `attach-surface` | implemented | `--surface <id>` | none | event JSON lines |
-| `wait-for` | proposed | `--surface <id> --pattern <regex> --timeout-ms <n>` | none | none |
-| `run` | proposed | `-- <argv...>` or `--command <cmd>` | `--pane <id>`, `--new-workspace`, `--cwd <path>`, `--name <name>` | surface id |
-| `send-key` | proposed | `--surface <id> <key>...` | none | none |
-| `copy` | proposed | `--surface <id> --mode screen|selection|scrollback` | none | text |
-| `ids` | proposed | none | `--kind workspace|screen|pane|surface` | id lines |
-| `notify` | proposed | `--title <title> --body <body>` | `--level info|warning|error`, `--surface <id>` | notification id |
-| `list-agents` | proposed | none | `--surface <id>`, `--state <state>` | agent lines |
-| `report-agent` | proposed | `--surface <id> --state <state> --source socket|hook` | `--session <id>` | none |
+| `wait-for` | implemented | `--surface <id> --pattern <regex> --timeout-ms <n>` | none | none |
+| `run` | implemented | `-- <argv...>` or `--command <cmd>` | `--pane <id>`, `--new-workspace`, `--cwd <path>`, `--name <name>` | surface id |
+| `send-key` | implemented | `--surface <id> <key>...` | none | none |
+| `copy` | implemented | `--surface <id> --mode screen|selection|scrollback` | none | text |
+| `ids` | implemented | none | `--kind workspace|screen|pane|surface` | id lines |
+| `notify` | implemented | `--title <title> --body <body>` | `--level info|warning|error`, `--surface <id>` | notification id |
+| `list-agents` | implemented | none | `--surface <id>`, `--state <state>` | agent lines |
+| `report-agent` | implemented | `--surface <id> --state <state> --source socket|hook` | `--session <id>` | none |
 
 ## Worked Examples
 

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -1524,8 +1524,8 @@ Example:
 | Field | Value |
 | --- | --- |
 | name | `wait-for` |
-| status | proposed |
-| since | proposed protocol 6 |
+| status | implemented |
+| since | protocol 6 |
 
 Blocks until a regular expression matches the current plain-text screen for a PTY surface. The server polls the same text source as `read-screen` and returns as soon as a match is found or the timeout expires. This is the primary automation synchronization primitive.
 
@@ -1575,8 +1575,8 @@ Example:
 | Field | Value |
 | --- | --- |
 | name | `run` |
-| status | proposed |
-| since | proposed protocol 6 |
+| status | implemented |
+| since | protocol 6 |
 
 Spawns a command in a new PTY tab and returns the new surface id. `argv` executes directly without a shell. `command` executes through the session shell as `shell -lc <command>`. Exactly one of `argv` or `command` is required. By default the tab is created in the active pane. With `pane`, it is created in that pane. With `new_workspace:true`, a new workspace is created instead.
 
@@ -1605,6 +1605,7 @@ Errors:
 | --- | --- |
 | `argv or command is required` | Neither is supplied |
 | `argv and command are mutually exclusive` | Both are supplied |
+| `pane and new_workspace are mutually exclusive` | Both placement options are supplied by a raw socket caller |
 | `unknown pane <id>` | Supplied pane does not exist |
 | spawn or PTY error string | PTY creation or child spawn fails |
 | `bad request: ...` | Wrong JSON type |
@@ -1631,8 +1632,8 @@ Example:
 | Field | Value |
 | --- | --- |
 | name | `send-key` |
-| status | proposed |
-| since | proposed protocol 6 |
+| status | implemented |
+| since | protocol 6 |
 
 Sends named key chords to a surface without requiring callers to hand-encode escape sequences. PTY surfaces use the same Ghostty key encoder as the TUI, synced to the surface terminal modes. Browser surfaces translate supported keys to CDP keyboard input when the browser runtime is local.
 
@@ -1683,8 +1684,8 @@ Example:
 | Field | Value |
 | --- | --- |
 | name | `copy` |
-| status | proposed |
-| since | proposed protocol 6 |
+| status | implemented |
+| since | protocol 6 |
 
 Extracts text from a surface. `screen` returns the current plain-text viewport. `selection` returns the current mux-owned selection. `scrollback` returns available scrollback followed by the current viewport.
 
@@ -1734,10 +1735,10 @@ Example:
 | Field | Value |
 | --- | --- |
 | name | `ids` |
-| status | proposed |
-| since | proposed protocol 6 |
+| status | implemented |
+| since | protocol 6 |
 
-Returns the session id mapping and establishes the short-id scheme. Every workspace, screen, pane, and surface has a numeric id and a stable short id for the lifetime of the session. Short ids are content-independent, collision-checked per session, and usable anywhere an `IdRef` is accepted.
+Returns the session id mapping. Every workspace, screen, pane, and surface has a numeric id and a stable short id for the lifetime of the session. Short ids are content-independent and collision-checked per session. Accepting short ids anywhere an `IdRef` is accepted remains proposed; implemented command parameters currently accept numeric ids only.
 
 Params:
 
@@ -1751,9 +1752,9 @@ Short id format:
 [a-z0-9]{6}
 ```
 
-Generation rule: the server derives a candidate from a per-session random seed plus numeric id, encodes it base36, and checks for collisions across all live ids. On collision, it rehashes with an incrementing salt. Short ids never depend on names, titles, command text, cwd, or layout position. A short id is not reused while the session is alive.
+Generation rule: implemented short ids are stable six-character base36 ids collision-checked across live ids. The proposed future scheme derives a candidate from a per-session random seed plus numeric id, encodes it base36, and checks for collisions across all live ids. On collision, it rehashes with an incrementing salt. Short ids never depend on names, titles, command text, cwd, or layout position.
 
-Resolution rule: numeric JSON ids resolve first. String ids matching `[0-9]+` are rejected as ambiguous. String ids matching the short-id format resolve by exact short id. Unknown or ambiguous strings error.
+Resolution rule: short-id / `IdRef` string resolution across commands is still proposed and not yet accepted by the implementation. Implemented commands currently deserialize id parameters as numeric JSON ids. Proposed behavior is: numeric JSON ids resolve first; string ids matching `[0-9]+` are rejected as ambiguous; string ids matching the short-id format resolve by exact short id; unknown or ambiguous strings error.
 
 Result:
 
@@ -1790,8 +1791,8 @@ Example:
 | Field | Value |
 | --- | --- |
 | name | `notify` |
-| status | proposed |
-| since | proposed protocol 6 |
+| status | implemented |
+| since | protocol 6 |
 
 Posts a notification into the mux notification area. This is a telemetry command and must not change app focus or pane selection.
 
@@ -1841,8 +1842,8 @@ Example:
 | Field | Value |
 | --- | --- |
 | name | `list-agents` |
-| status | proposed |
-| since | proposed protocol 6 |
+| status | implemented |
+| since | protocol 6 |
 
 Returns known agent status records. Records may come from detection, explicit reports, or hooks. Explicit hook-authority reports override detection for the same surface until another explicit report changes the state or the surface closes.
 
@@ -1897,8 +1898,8 @@ Example:
 | Field | Value |
 | --- | --- |
 | name | `report-agent` |
-| status | proposed |
-| since | proposed protocol 6 |
+| status | implemented |
+| since | protocol 6 |
 
 Reports agent state for a surface. This is a telemetry command and must not change focus. Reports with `source:"hook"` have hook authority and override detector-derived state. Reports with `source:"socket"` override detector-derived state but are lower priority than a newer hook report.
 

--- a/mux/spec/events.md
+++ b/mux/spec/events.md
@@ -6,7 +6,7 @@ Implemented event lines can appear on two stream types:
 
 | Stream | How to start | Event names |
 | --- | --- | --- |
-| Subscribe stream | `subscribe` command | `tree-changed`, `surface-output`, `surface-resized`, `surface-exited`, `title-changed`, `bell`, `empty` |
+| Subscribe stream | `subscribe` command | `tree-changed`, `surface-output`, `surface-resized`, `surface-exited`, `title-changed`, `bell`, `notification`, `empty` |
 | Attach stream v5 | `attach-surface` command | `vt-state`, `output`, `detached` |
 | Attach stream v6 | `attach-surface` command | `vt-state`, `resized`, `output`, `detached` |
 
@@ -160,6 +160,28 @@ Example:
 
 ```json
 {"event":"bell","surface":1}
+```
+
+### notification
+
+| Field | Value |
+| --- | --- |
+| event | `notification` |
+| status | implemented |
+| since | protocol 6 |
+
+Payload:
+
+```text
+object{event:"notification",notification:Id,title:string,body:string,level:"info"|"warning"|"error",surface:Id|null}
+```
+
+Meaning: A notification was posted. If `surface` is present, clients should mark that surface as unread/attention until the user views it.
+
+Example:
+
+```json
+{"event":"notification","notification":44,"title":"Build failed","body":"api tests failed","level":"error","surface":1}
 ```
 
 ### empty


### PR DESCRIPTION
Implements the eight commands that were marked `proposed` in `mux/spec/commands.md`, server-side in mux-core with CLI verbs and full tests, and flips their spec status to implemented. Protocol stays v6 (additive).

- **wait-for** `--surface --pattern --timeout-ms`: blocks on the surface's output stream (attach-then-check ordering, so a one-shot match that lands before the wait is never missed), regex match with a real deadline, no busy-spin.
- **run** `-- <argv>` / `--command`: spawns a surface running an explicit command (vs the login shell), with `--pane`/`--new-workspace`/`--cwd`/`--name` placement.
- **send-key** `<key>...`: encodes named keys/chords (enter, ctrl+c, arrows, alt+…) through the ghostty key encoder synced from the terminal's modes.
- **copy** `--mode screen|selection|scrollback`: viewport / current selection / full scrollback text.
- **ids** `--kind`: tree ids (with short ids).
- **notify** `--title --body [--level] [--surface]`: per-surface unread state + a `notification` event. The mux TUI renders the user-requested UX — an attention **border** on the selected tab/pane in the level color, an unread **dot** in the tab bar, and a workspace **sidebar** dot — cleared when the tab is focused, never stealing focus, and skipped for the already-active surface. A Ratatui `TestBackend` test asserts all three indicators appear and clear.
- **report-agent** / **list-agents**: a per-surface agent-state store with **hook > socket** authority (a newer hook wins; a socket report never clobbers a hook). This is the explicit-report path; auto-detection is separate (#7412).

Tests: per-command mux-core behavior tests, a CLI integration subset, the Ratatui render test, and a new conformance fixture so the commands run (not SKIP). Reviewed via a 2-round plan/code/judge loop (APPROVE). Verified locally: cargo fmt/clippy/test (130), conformance 6/6, smoke-tui, and a live CLI transcript exercising every verb (incl. agent-authority ordering and wait-for match/timeout).

Note: this and #7412 (agent state machine) both touch per-surface agent state; whichever lands second reconciles the store.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786076346&installation_id=133855650&pr_number=7584&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7584&signature=51ec4b25a6034f524c4ab462f3d06c21e3b9be0783de4f012c4280c95e362592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds blocking `wait-for` on the control socket and new PTY spawn paths via `run`, plus agent/notification state that must stay consistent with related work (#7412); scope is large but covered by conformance and integration tests.
> 
> **Overview**
> Implements the eight **proposed** protocol-6 control socket commands (`wait-for`, `run`, `send-key`, `copy`, `ids`, `notify`, `list-agents`, `report-agent`) end-to-end: **mux-core** handlers, **mux-tui** CLI verbs, specs marked **implemented**, plus a conformance fixture that exercises the full flow.
> 
> **Automation:** `wait-for` regex-matches viewport text on the surface attach stream; `run` spawns PTY tabs with explicit `argv` or shell `command` and placement options; `send-key` uses new `key_input_from_chord` in **ghostty-vt**; `copy` reads screen, scrollback, or mux-stored selection text.
> 
> **Telemetry & UI:** `notify` drives per-surface unread state, `notification` events on subscribe/attach, and unread metadata in `list-workspaces`. The TUI shows level-colored pane borders, tab-bar dots, and sidebar dots (theme keys added), cleared when the user views the tab without stealing focus. `report-agent` / `list-agents` store agent state with **hook over socket** authority.
> 
> Adds **`regex`** dependency, mux unit/integration tests, and selection persistence when copying from the TUI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bdfc73b5b1061bb95f8daa490e54d8f485f00ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the eight proposed protocol‑6 commands across `mux-core` and the CLI, adds a notification event with TUI indicators, and keeps the protocol at v6. This enables automation sync, explicit command spawns, key injection, text copy, id listing with short ids, notifications, and agent state APIs.

- **New Features**
  - Implemented v6 commands: wait-for, run, send-key, copy, ids, notify, list-agents, report-agent.
    - wait-for: regex match on viewport text with attach‑then‑check ordering and real deadlines.
    - run: spawn a PTY with `-- <argv>` or `--command`, place in `--pane` or `--new-workspace`, set `--cwd`/`--name`; returns surface/pane/screen/workspace.
    - send-key: named chords via `ghostty-vt` encoder synced to terminal modes.
    - copy: `screen` | `selection` | `scrollback` text.
    - ids: list workspace/screen/pane/surface with stable six-char short ids.
    - notify: posts a notification event; per-surface unread state that doesn’t steal focus and is skipped for the active surface.
    - list-agents/report-agent: per-surface agent store with hook authority over socket; filterable listing.
  - CLI verbs added for all commands; subscribe/attach streams include `notification` events.
  - TUI: attention border on the selected tab/pane in level color, unread dot in tab bar, and workspace sidebar dot; cleared on focus.
  - Spec updated to mark these commands “implemented” in protocol 6.

- **Dependencies**
  - Added `regex` to `mux` and `mux-core`.

<sup>Written for commit 6bdfc73b5b1061bb95f8daa490e54d8f485f00ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new control-socket and CLI commands for waiting on screen text, sending keys, copying content, listing IDs, posting notifications, and reporting/listing agent status.
  * Added unread notification indicators in the tab bar, sidebar, and pane borders, with configurable notification colors.
  * Added keyboard chord parsing for common shortcuts and function keys.

* **Bug Fixes**
  * Improved handling of selection state and notification clearing when switching views.
  * `wait-for` now supports timeout-based matching more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->