### PR TITLE
Resolve billing team for multi-team users so paid teams are not shown as free

### DIFF
--- a/web/app/[locale]/dashboard/billing/page.tsx
+++ b/web/app/[locale]/dashboard/billing/page.tsx
@@ -20,6 +20,7 @@ import {
   TEAM_PLAN_ID,
   resolveProPlanStatus,
 } from "@/services/billing/pro";
+import { resolveBillingTeam, type BillingTeamLike } from "@/services/billing/teamResolution";
 
 export const dynamic = "force-dynamic";
 
@@ -35,11 +36,6 @@ type StripeSubscriptionRow = {
   currentPeriodEnd: Date | null;
   cancelAtPeriodEnd: boolean;
   raw: Record<string, unknown> | null;
-};
-
-type BillingTeam = {
-  id: string;
-  displayName: string | null;
 };
 
 export default async function DashboardBillingPage({
@@ -62,7 +58,7 @@ export default async function DashboardBillingPage({
     redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard/billing")));
   }
 
-  const billingTeamPromise = billingTeamForUser(user);
+  const billingTeamPromise = resolveBillingTeam(user);
   const [
     t,
     pricingT,
@@ -193,32 +189,6 @@ async function hasTeamCustomerRow(stackTeamId: string): Promise<boolean> {
     .where(eq(stripeCustomers.stackTeamId, stackTeamId))
     .limit(1);
   return rows.length > 0;
-}
-
-async function billingTeamForUser(user: unknown): Promise<BillingTeam | null> {
-  const stackUser = user as {
-    selectedTeam?: unknown;
-    listTeams?: () => Promise<readonly unknown[]>;
-  };
-  const selected = teamFromUnknown(stackUser.selectedTeam);
-  if (selected) return selected;
-  const teams = typeof stackUser.listTeams === "function"
-    ? (await stackUser.listTeams()).map(teamFromUnknown).filter((team): team is BillingTeam => !!team)
-    : [];
-  return teams.length === 1 ? teams[0] : null;
-}
-
-function teamFromUnknown(value: unknown): BillingTeam | null {
-  if (!value || typeof value !== "object") return null;
-  const id = (value as { id?: unknown }).id;
-  if (typeof id !== "string" || !id) return null;
-  const displayName = (value as { displayName?: unknown }).displayName;
-  return {
-    id,
-    displayName: typeof displayName === "string" && displayName.trim()
-      ? displayName
-      : null,
-  };
 }
 
 function FreePlan({ t }: { t: Awaited<ReturnType<typeof getTranslations>> }) {
@@ -391,7 +361,7 @@ function TeamPlan({
 }: {
   t: Awaited<ReturnType<typeof getTranslations>>;
   locale: string;
-  team: BillingTeam;
+  team: BillingTeamLike;
   subscription: StripeSubscriptionRow;
   canManageBilling: boolean;
 }) {

--- a/web/app/api/billing/plan/route.ts
+++ b/web/app/api/billing/plan/route.ts
@@ -9,6 +9,10 @@ import {
   resolveProPlanStatus,
   type BillingManagementKind,
 } from "../../../../services/billing/pro";
+import {
+  resolveBillingTeam,
+  type BillingTeamUserLike,
+} from "../../../../services/billing/teamResolution";
 
 export const dynamic = "force-dynamic";
 
@@ -80,18 +84,8 @@ type TeamPlanStatus = {
   readonly billingManagement: BillingManagementKind;
 };
 
-type BillingTeamLike = {
-  readonly id?: string;
-  readonly clientReadOnlyMetadata?: unknown;
-};
-
-type BillingTeamUserLike = {
-  readonly selectedTeam?: unknown;
-  readonly listTeams?: () => Promise<readonly unknown[]>;
-};
-
 async function resolveTeamPlanStatus(user: BillingTeamUserLike): Promise<TeamPlanStatus> {
-  const team = await billingTeamForUser(user);
+  const team = await resolveBillingTeam(user);
   if (!team?.id) {
     return { planId: FREE_PLAN_ID, billingManagement: "none" };
   }
@@ -104,23 +98,4 @@ async function resolveTeamPlanStatus(user: BillingTeamUserLike): Promise<TeamPla
     return { planId: TEAM_PLAN_ID, billingManagement: "external" };
   }
   return { planId: FREE_PLAN_ID, billingManagement: "none" };
-}
-
-async function billingTeamForUser(user: BillingTeamUserLike): Promise<BillingTeamLike | null> {
-  const selected = teamFromUnknown(user.selectedTeam);
-  if (selected) return selected;
-  const teams = typeof user.listTeams === "function"
-    ? (await user.listTeams()).map(teamFromUnknown).filter((team): team is BillingTeamLike => !!team)
-    : [];
-  return teams.length === 1 ? teams[0] : null;
-}
-
-function teamFromUnknown(value: unknown): BillingTeamLike | null {
-  if (!value || typeof value !== "object") return null;
-  const id = (value as { id?: unknown }).id;
-  if (typeof id !== "string" || !id) return null;
-  return {
-    id,
-    clientReadOnlyMetadata: (value as { clientReadOnlyMetadata?: unknown }).clientReadOnlyMetadata,
-  };
 }

--- a/web/app/api/billing/portal/route.ts
+++ b/web/app/api/billing/portal/route.ts
@@ -10,6 +10,7 @@ import {
   isStripeBillingConfigured,
   stripe,
 } from "../../../../services/billing/stripe";
+import { resolveBillingTeam } from "../../../../services/billing/teamResolution";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -30,7 +31,7 @@ export async function GET(request: NextRequest) {
     stackUserId = user.id;
 
     const requestedScope = billingPortalScope(request.nextUrl.searchParams.get("scope"));
-    const team = requestedScope === "team" ? await billingTeamForUser(user) : null;
+    const team = requestedScope === "team" ? await resolveBillingTeam(user) : null;
     const customerId = team?.id
       ? await stripeCustomerIdForStackTeam(team.id)
       : await stripeCustomerIdForStackUser(user.id);
@@ -98,27 +99,6 @@ async function stripeCustomerIdForStackTeam(stackTeamId: string): Promise<string
 
 function billingPortalScope(raw: string | null): "user" | "team" {
   return raw === "team" ? "team" : "user";
-}
-
-type BillingTeamLike = { readonly id?: string };
-type BillingTeamUserLike = {
-  readonly selectedTeam?: unknown;
-  readonly listTeams?: () => Promise<readonly unknown[]>;
-};
-
-async function billingTeamForUser(user: BillingTeamUserLike): Promise<BillingTeamLike | null> {
-  const selected = teamFromUnknown(user.selectedTeam);
-  if (selected) return selected;
-  const teams = typeof user.listTeams === "function"
-    ? (await user.listTeams()).map(teamFromUnknown).filter((team): team is BillingTeamLike => !!team)
-    : [];
-  return teams.length === 1 ? teams[0] : null;
-}
-
-function teamFromUnknown(value: unknown): BillingTeamLike | null {
-  if (!value || typeof value !== "object") return null;
-  const id = (value as { id?: unknown }).id;
-  return typeof id === "string" && id ? { id } : null;
 }
 
 function pricingRedirect(request: NextRequest, billing: "unavailable" | "external" | "error") {

--- a/web/app/api/billing/subscription/route.ts
+++ b/web/app/api/billing/subscription/route.ts
@@ -15,6 +15,10 @@ import {
   isStripeBillingConfigured,
   stripe,
 } from "../../../../services/billing/stripe";
+import {
+  resolveBillingTeam,
+  type BillingTeamUserLike,
+} from "../../../../services/billing/teamResolution";
 import { captureBillingError } from "../../../../services/errors";
 import { browserMutationOriginAllowed } from "../../../../services/vms/routeHelpers";
 
@@ -101,7 +105,7 @@ function billingScope(formData: FormData): BillingScope {
 }
 
 async function verifiedBillingTeamId(user: unknown, formData: FormData): Promise<string> {
-  const team = await billingTeamForUser(user as BillingTeamUserLike);
+  const team = await resolveBillingTeam(user as BillingTeamUserLike);
   const clientTeamId = formData.get("teamId");
   if (
     typeof clientTeamId === "string" &&
@@ -162,27 +166,6 @@ async function updateSubscriptionSnapshot(
       updatedAt: sql`now()`,
     })
     .where(eq(stripeSubscriptions.id, subscriptionId));
-}
-
-type BillingTeamLike = { readonly id?: string };
-type BillingTeamUserLike = {
-  readonly selectedTeam?: unknown;
-  readonly listTeams?: () => Promise<readonly unknown[]>;
-};
-
-async function billingTeamForUser(user: BillingTeamUserLike): Promise<BillingTeamLike | null> {
-  const selected = teamFromUnknown(user.selectedTeam);
-  if (selected) return selected;
-  const teams = typeof user.listTeams === "function"
-    ? (await user.listTeams()).map(teamFromUnknown).filter((team): team is BillingTeamLike => !!team)
-    : [];
-  return teams.length === 1 ? teams[0] : null;
-}
-
-function teamFromUnknown(value: unknown): BillingTeamLike | null {
-  if (!value || typeof value !== "object") return null;
-  const id = (value as { id?: unknown }).id;
-  return typeof id === "string" && id ? { id } : null;
 }
 
 function billingRedirect(

--- a/web/services/billing/pro.ts
+++ b/web/services/billing/pro.ts
@@ -14,6 +14,7 @@ import { inArray, eq, and } from "drizzle-orm";
 
 import { cloudDb } from "../../db/client";
 import { stripeSubscriptions } from "../../db/schema";
+import { resolveBillingTeam, type BillingTeamUserLike } from "./teamResolution";
 
 export const PRO_PRODUCT_ID = "pro";
 export const TEAM_PRODUCT_ID = process.env.CMUX_TEAM_PRODUCT_ID?.trim() || "team";
@@ -124,15 +125,6 @@ export type ProReconcileUser = ProductsCustomer & ProMetadataCustomer & {
 
 export type ActiveStripeSubscriptionQuery = (stackUserId: string) => Promise<boolean>;
 export type BillingManagementKind = "stripe" | "external" | "none";
-
-type BillingTeamUserLike = {
-  readonly selectedTeam?: unknown;
-  readonly listTeams?: () => Promise<readonly unknown[]>;
-};
-
-type BillingTeamLike = {
-  readonly id?: string;
-};
 
 export type ProPlanStatus = {
   readonly planId: typeof FREE_PLAN_ID | typeof PRO_PLAN_ID;
@@ -253,7 +245,7 @@ export async function isTestflightEligible(
 ): Promise<boolean> {
   const status = await resolveProPlanStatus(user);
   if (status.isPro) return true;
-  const team = await billingTeamForUser(user);
+  const team = await resolveBillingTeam(user);
   return team?.id ? hasActiveTeamSubscriptionForTeam(team.id) : false;
 }
 
@@ -321,21 +313,6 @@ function hasManualVmOverride(metadata: Record<string, unknown>): boolean {
 function planIdFromMetadata(metadata: Record<string, unknown>): string | null {
   const value = metadata.cmuxPlan;
   return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-async function billingTeamForUser(user: BillingTeamUserLike): Promise<BillingTeamLike | null> {
-  const selected = teamFromUnknown(user.selectedTeam);
-  if (selected) return selected;
-  const teams = typeof user.listTeams === "function"
-    ? (await user.listTeams()).map(teamFromUnknown).filter((team): team is BillingTeamLike => !!team)
-    : [];
-  return teams.length === 1 ? teams[0] : null;
-}
-
-function teamFromUnknown(value: unknown): BillingTeamLike | null {
-  if (!value || typeof value !== "object") return null;
-  const id = (value as { id?: unknown }).id;
-  return typeof id === "string" && id ? { id } : null;
 }
 
 function isMissingDatabaseConfig(error: unknown): boolean {

--- a/web/services/billing/teamResolution.ts
+++ b/web/services/billing/teamResolution.ts
@@ -30,7 +30,17 @@ export function resolveBillingTeamFromTeams(
 
   const paidTeams = teams
     .filter((team) => hasActiveBillingPlan(team.clientReadOnlyMetadata))
-    .toSorted((left, right) => compareBillingTeamId(left.id, right.id));
+    .toSorted((left, right) => {
+      // Every billing surface (dashboard, portal, subscription, plan, TestFlight)
+      // reads the real Stripe subscription by team id and never honors the
+      // operator-set cmuxVmPlan override. So a team paid only through a
+      // cmuxVmPlan override must not shadow a team holding a real cmuxPlan
+      // subscription, or the real subscription is masked as free.
+      const leftReal = hasRealSubscriptionPlan(left.clientReadOnlyMetadata);
+      const rightReal = hasRealSubscriptionPlan(right.clientReadOnlyMetadata);
+      if (leftReal !== rightReal) return leftReal ? -1 : 1;
+      return compareBillingTeamId(left.id, right.id);
+    });
   return paidTeams[0] ?? null;
 }
 
@@ -58,6 +68,15 @@ export function billingPlanIdFromMetadata(metadata: unknown): string | null {
 
 function hasActiveBillingPlan(metadata: unknown): boolean {
   const planId = billingPlanIdFromMetadata(metadata);
+  return !!planId && planId !== "free";
+}
+
+// A real Stripe subscription is reflected only by cmuxPlan (written from active
+// subscription state); cmuxVmPlan is a manual override decoupled from billing.
+function hasRealSubscriptionPlan(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== "object") return false;
+  const value = (metadata as { cmuxPlan?: unknown }).cmuxPlan;
+  const planId = typeof value === "string" && value.trim() ? value.trim() : null;
   return !!planId && planId !== "free";
 }
 

--- a/web/services/billing/teamResolution.ts
+++ b/web/services/billing/teamResolution.ts
@@ -28,9 +28,13 @@ export function resolveBillingTeamFromTeams(
   if (teams.length === 1) return teams[0];
   if (teams.length < 2) return null;
 
+  // filter() returns a fresh array, so sorting it in place mutates nothing
+  // shared. Avoid Array.prototype.toSorted here: this resolver runs on billing
+  // and VM auth server paths, and toSorted is not guaranteed on every Node
+  // runtime targeted by ES2017.
   const paidTeams = teams
     .filter((team) => hasActiveBillingPlan(team.clientReadOnlyMetadata))
-    .toSorted((left, right) => {
+    .sort((left, right) => {
       // Every billing surface (dashboard, portal, subscription, plan, TestFlight)
       // reads the real Stripe subscription by team id and never honors the
       // operator-set cmuxVmPlan override. So a team paid only through a

--- a/web/services/billing/teamResolution.ts
+++ b/web/services/billing/teamResolution.ts
@@ -1,0 +1,68 @@
+export type BillingTeamLike = {
+  readonly id: string;
+  readonly displayName: string | null;
+  readonly clientReadOnlyMetadata?: unknown;
+};
+
+export type BillingTeamUserLike = {
+  readonly selectedTeam?: unknown;
+  readonly listTeams?: () => Promise<readonly unknown[]>;
+};
+
+export async function resolveBillingTeam(
+  user: BillingTeamUserLike,
+): Promise<BillingTeamLike | null> {
+  const selected = billingTeamFromUnknown(user.selectedTeam);
+  if (selected) return selected;
+
+  const teams = typeof user.listTeams === "function"
+    ? (await user.listTeams()).map(billingTeamFromUnknown).filter((team): team is BillingTeamLike => !!team)
+    : [];
+
+  return resolveBillingTeamFromTeams(teams);
+}
+
+export function resolveBillingTeamFromTeams(
+  teams: readonly BillingTeamLike[],
+): BillingTeamLike | null {
+  if (teams.length === 1) return teams[0];
+  if (teams.length < 2) return null;
+
+  const paidTeams = teams
+    .filter((team) => hasActiveBillingPlan(team.clientReadOnlyMetadata))
+    .toSorted((left, right) => compareBillingTeamId(left.id, right.id));
+  return paidTeams[0] ?? null;
+}
+
+export function billingTeamFromUnknown(value: unknown): BillingTeamLike | null {
+  if (!value || typeof value !== "object") return null;
+  const id = (value as { id?: unknown }).id;
+  if (typeof id !== "string" || !id) return null;
+  const displayName = (value as { displayName?: unknown; name?: unknown }).displayName ??
+    (value as { name?: unknown }).name;
+  return {
+    id,
+    displayName: typeof displayName === "string" && displayName.trim()
+      ? displayName.trim()
+      : null,
+    clientReadOnlyMetadata: (value as { clientReadOnlyMetadata?: unknown }).clientReadOnlyMetadata,
+  };
+}
+
+export function billingPlanIdFromMetadata(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const value = (metadata as { cmuxVmPlan?: unknown }).cmuxVmPlan ??
+    (metadata as { cmuxPlan?: unknown }).cmuxPlan;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function hasActiveBillingPlan(metadata: unknown): boolean {
+  const planId = billingPlanIdFromMetadata(metadata);
+  return !!planId && planId !== "free";
+}
+
+function compareBillingTeamId(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -1,4 +1,10 @@
 import { getStackServerApp, isStackConfigured } from "../../app/lib/stack";
+import {
+  billingPlanIdFromMetadata,
+  billingTeamFromUnknown,
+  resolveBillingTeam,
+  type BillingTeamLike,
+} from "../billing/teamResolution";
 
 export type AuthedUser = {
   id: string;
@@ -67,22 +73,25 @@ async function authedUserFromStackUser(
   user: StackUserLike,
   options: { readonly requestedTeamId?: string | null },
 ): Promise<AuthedUser> {
-  const selectedTeam = teamLike(user.selectedTeam);
+  const selectedTeam = billingTeamFromUnknown(user.selectedTeam);
   const requestedTeamId = normalizedOptionalString(options.requestedTeamId);
   // When the selected team is enough, entitlements resolve from it before any
   // multi-team guard needs a full team list.
   const needsListedTeams = !selectedTeam || (!!requestedTeamId && requestedTeamId !== selectedTeam.id);
   const listedTeams = needsListedTeams && typeof user.listTeams === "function"
-    ? (await user.listTeams()).map(teamLike).filter((team): team is TeamLike => !!team)
+    ? (await user.listTeams()).map(billingTeamFromUnknown).filter((team): team is BillingTeamLike => !!team)
     : [];
   const teamIds = uniqueStrings([
     selectedTeam?.id,
     ...listedTeams.map((team) => team.id),
   ]);
   const teams = uniqueTeams([selectedTeam, ...listedTeams]);
-  const billingTeam = selectedTeam ?? (teams.length === 1 ? teams[0] : null);
-  const userBillingPlanId = planIdFromMetadata(user.clientReadOnlyMetadata) ?? null;
-  const billingPlanId = planIdFromMetadata(billingTeam?.clientReadOnlyMetadata) ?? userBillingPlanId;
+  const billingTeam = await resolveBillingTeam({
+    selectedTeam,
+    listTeams: async () => listedTeams,
+  });
+  const userBillingPlanId = billingPlanIdFromMetadata(user.clientReadOnlyMetadata) ?? null;
+  const billingPlanId = billingPlanIdFromMetadata(billingTeam?.clientReadOnlyMetadata) ?? userBillingPlanId;
 
   return {
     id: user.id,
@@ -94,7 +103,7 @@ async function authedUserFromStackUser(
     teams: teams.map((team) => ({
       id: team.id,
       displayName: team.displayName,
-      billingPlanId: planIdFromMetadata(team.clientReadOnlyMetadata),
+      billingPlanId: billingPlanIdFromMetadata(team.clientReadOnlyMetadata),
     })),
     teamIds,
     userBillingPlanId,
@@ -111,40 +120,12 @@ type StackUserLike = {
   readonly listTeams?: () => Promise<readonly unknown[]>;
 };
 
-type TeamLike = {
-  readonly id: string;
-  readonly displayName: string | null;
-  readonly clientReadOnlyMetadata?: unknown;
-};
-
-function teamLike(value: unknown): TeamLike | null {
-  if (!value || typeof value !== "object") return null;
-  const id = (value as { id?: unknown }).id;
-  if (typeof id !== "string" || !id) return null;
-  const displayName = (value as { displayName?: unknown; name?: unknown }).displayName ??
-    (value as { name?: unknown }).name;
-  return {
-    id,
-    displayName: typeof displayName === "string" && displayName.trim()
-      ? displayName.trim()
-      : null,
-    clientReadOnlyMetadata: (value as { clientReadOnlyMetadata?: unknown }).clientReadOnlyMetadata,
-  };
-}
-
-function planIdFromMetadata(metadata: unknown): string | null {
-  if (!metadata || typeof metadata !== "object") return null;
-  const value = (metadata as { cmuxVmPlan?: unknown; cmuxPlan?: unknown }).cmuxVmPlan ??
-    (metadata as { cmuxPlan?: unknown }).cmuxPlan;
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
 function uniqueStrings(values: readonly (string | undefined)[]): readonly string[] {
   return [...new Set(values.filter((value): value is string => typeof value === "string" && value.length > 0))];
 }
 
-function uniqueTeams(values: readonly (TeamLike | null | undefined)[]): readonly TeamLike[] {
-  const teams: TeamLike[] = [];
+function uniqueTeams(values: readonly (BillingTeamLike | null | undefined)[]): readonly BillingTeamLike[] {
+  const teams: BillingTeamLike[] = [];
   const seen = new Set<string>();
   for (const team of values) {
     if (!team || seen.has(team.id)) continue;

--- a/web/tests/billing-team-resolution.test.ts
+++ b/web/tests/billing-team-resolution.test.ts
@@ -62,12 +62,32 @@ describe("billing team resolution", () => {
     })).resolves.toMatchObject({ id: "team-override" });
   });
 
-  test("picks the first team id deterministically when multiple teams are paid", async () => {
+  test("prefers a real cmuxPlan subscription over a cmuxVmPlan override even with a larger id", async () => {
     await expect(resolveBillingTeam({
       selectedTeam: null,
       listTeams: async () => [
         { id: "team-z", clientReadOnlyMetadata: { cmuxPlan: "team" } },
         { id: "team-a", clientReadOnlyMetadata: { cmuxVmPlan: "pro" } },
+      ],
+    })).resolves.toMatchObject({ id: "team-z" });
+  });
+
+  test("picks the first team id deterministically when multiple teams have real subscriptions", async () => {
+    await expect(resolveBillingTeam({
+      selectedTeam: null,
+      listTeams: async () => [
+        { id: "team-z", clientReadOnlyMetadata: { cmuxPlan: "team" } },
+        { id: "team-a", clientReadOnlyMetadata: { cmuxPlan: "team" } },
+      ],
+    })).resolves.toMatchObject({ id: "team-a" });
+  });
+
+  test("falls back to a cmuxVmPlan override team deterministically when no team has a real subscription", async () => {
+    await expect(resolveBillingTeam({
+      selectedTeam: null,
+      listTeams: async () => [
+        { id: "team-z", clientReadOnlyMetadata: { cmuxVmPlan: "pro" } },
+        { id: "team-a", clientReadOnlyMetadata: { cmuxVmPlan: "enterprise" } },
       ],
     })).resolves.toMatchObject({ id: "team-a" });
   });

--- a/web/tests/billing-team-resolution.test.ts
+++ b/web/tests/billing-team-resolution.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { resolveBillingTeam } from "../services/billing/teamResolution";
+
+describe("billing team resolution", () => {
+  test("selectedTeam wins without listing teams", async () => {
+    const listTeams = mock(async () => [
+      paidTeam("team-paid"),
+    ]);
+
+    await expect(resolveBillingTeam({
+      selectedTeam: freeTeam("team-selected"),
+      listTeams,
+    })).resolves.toMatchObject({ id: "team-selected" });
+    expect(listTeams).not.toHaveBeenCalled();
+  });
+
+  test("uses the single listed team", async () => {
+    await expect(resolveBillingTeam({
+      selectedTeam: null,
+      listTeams: async () => [freeTeam("team-only")],
+    })).resolves.toMatchObject({ id: "team-only" });
+  });
+
+  test("returns null for multiple teams with no paid metadata", async () => {
+    await expect(resolveBillingTeam({
+      selectedTeam: null,
+      listTeams: async () => [
+        freeTeam("team-free"),
+        { id: "team-empty", clientReadOnlyMetadata: { cmuxPlan: "" } },
+      ],
+    })).resolves.toBeNull();
+  });
+
+  test("preserves raw cmuxVmPlan masking before checking cmuxPlan", async () => {
+    await expect(resolveBillingTeam({
+      selectedTeam: null,
+      listTeams: async () => [
+        freeTeam("team-free"),
+        { id: "team-masked", clientReadOnlyMetadata: { cmuxVmPlan: "", cmuxPlan: "team" } },
+      ],
+    })).resolves.toBeNull();
+  });
+
+  test("uses the only team paid through cmuxPlan", async () => {
+    await expect(resolveBillingTeam({
+      selectedTeam: null,
+      listTeams: async () => [
+        freeTeam("team-free"),
+        { id: "team-paid", clientReadOnlyMetadata: { cmuxPlan: "team" } },
+      ],
+    })).resolves.toMatchObject({ id: "team-paid" });
+  });
+
+  test("uses the only team paid through cmuxVmPlan", async () => {
+    await expect(resolveBillingTeam({
+      selectedTeam: null,
+      listTeams: async () => [
+        freeTeam("team-free"),
+        { id: "team-override", clientReadOnlyMetadata: { cmuxVmPlan: "pro" } },
+      ],
+    })).resolves.toMatchObject({ id: "team-override" });
+  });
+
+  test("picks the first team id deterministically when multiple teams are paid", async () => {
+    await expect(resolveBillingTeam({
+      selectedTeam: null,
+      listTeams: async () => [
+        { id: "team-z", clientReadOnlyMetadata: { cmuxPlan: "team" } },
+        { id: "team-a", clientReadOnlyMetadata: { cmuxVmPlan: "pro" } },
+      ],
+    })).resolves.toMatchObject({ id: "team-a" });
+  });
+
+  test("returns null for zero teams", async () => {
+    await expect(resolveBillingTeam({
+      selectedTeam: null,
+      listTeams: async () => [],
+    })).resolves.toBeNull();
+  });
+});
+
+function paidTeam(id: string) {
+  return { id, clientReadOnlyMetadata: { cmuxPlan: "team" } };
+}
+
+function freeTeam(id: string) {
+  return { id, clientReadOnlyMetadata: { cmuxPlan: "free" } };
+}

--- a/web/tests/dashboard-billing-page.test.tsx
+++ b/web/tests/dashboard-billing-page.test.tsx
@@ -20,8 +20,8 @@ const proUser = {
   isAnonymous: false,
   primaryEmail: "pro@example.com",
   clientReadOnlyMetadata: {},
-  selectedTeam: null as null | { id: string; displayName?: string },
-  listTeams: mock(async () => [] as Array<{ id: string; displayName?: string }>),
+  selectedTeam: null as null | { id: string; displayName?: string; clientReadOnlyMetadata?: unknown },
+  listTeams: mock(async () => [] as Array<{ id: string; displayName?: string; clientReadOnlyMetadata?: unknown }>),
   listProducts: mock(async () =>
     Object.assign(
       stackProductsActive
@@ -90,6 +90,7 @@ describe("dashboard billing page", () => {
     customerRows = [];
     proUser.selectedTeam = null;
     proUser.listTeams.mockClear();
+    mockImplementation(proUser.listTeams, async () => []);
     proUser.listProducts.mockClear();
     proUser.update.mockClear();
   });
@@ -160,6 +161,33 @@ describe("dashboard billing page", () => {
     expect(html).toContain("$35/seat/month");
     expect(html).toContain('name="scope" value="team"');
     expect(html).toContain('href="/api/billing/portal?scope=team"');
+  });
+
+  test("renders active Stripe Team for a paid team when no team is selected", async () => {
+    mockImplementation(proUser.listTeams, async () => [
+      { id: "team-free", displayName: "Team Free", clientReadOnlyMetadata: { cmuxPlan: "free" } },
+      { id: "team-pro", displayName: "Team Pro", clientReadOnlyMetadata: { cmuxPlan: "team" } },
+    ]);
+    subscriptionResults = [
+      [],
+      [],
+      [
+        stripeSubscriptionRow({
+          cancelAtPeriodEnd: false,
+          plan: "team",
+          scope: "team",
+          seats: 4,
+        }),
+      ],
+    ];
+    customerRows = [{ id: "cus_team" }];
+
+    const html = await renderBillingPage();
+
+    expect(html).toContain("cmux Team");
+    expect(html).toContain("Team Pro renews on");
+    expect(html).toContain('name="scope" value="team"');
+    expect(html).not.toContain("Upgrade when you need cloud agents or team billing.");
   });
 
   test("renders legacy Stack Pro without Stripe self-serve actions", async () => {
@@ -272,5 +300,14 @@ function interpolate(message: string, values?: Record<string, unknown>) {
   return Object.entries(values).reduce(
     (result, [key, value]) => result.replaceAll(`{${key}}`, String(value)),
     message,
+  );
+}
+
+function mockImplementation(
+  fn: unknown,
+  implementation: (...args: never[]) => unknown,
+) {
+  (fn as { mockImplementation(next: typeof implementation): void }).mockImplementation(
+    implementation,
   );
 }

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -654,15 +654,55 @@ describe("VM REST auth", () => {
     expect(runVmWorkflow).not.toHaveBeenCalled();
   });
 
-  test("rejects VM create when Stack Auth returns multiple teams but no selected/requested team", async () => {
+  test("uses the paid Stack team when multiple teams have no selected/requested team", async () => {
     getUser.mockResolvedValue({
       id: "user-1",
       displayName: null,
       primaryEmail: "user@example.com",
+      clientReadOnlyMetadata: { cmuxPlan: "free" },
       selectedTeam: null,
       listTeams: async () => [
         { id: "team-1", clientReadOnlyMetadata: { cmuxVmPlan: "free" } },
-        { id: "team-2", clientReadOnlyMetadata: { cmuxVmPlan: "pro" } },
+        { id: "team-2", clientReadOnlyMetadata: { cmuxPlan: "team" } },
+      ],
+    });
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-team-paid",
+      provider: "freestyle",
+      image: "snapshot-test",
+      imageVersion: null,
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
+      userId: "user-1",
+      billingCustomerType: "team",
+      billingTeamId: "team-2",
+      billingPlanId: "team",
+      maxActiveVms: 10,
+    }));
+    expect(runVmWorkflow).toHaveBeenCalled();
+  });
+
+  test("rejects VM create when multiple Stack teams have no paid metadata and no selected/requested team", async () => {
+    getUser.mockResolvedValue({
+      id: "user-1",
+      displayName: null,
+      primaryEmail: "user@example.com",
+      clientReadOnlyMetadata: { cmuxPlan: "free" },
+      selectedTeam: null,
+      listTeams: async () => [
+        { id: "team-1", clientReadOnlyMetadata: { cmuxVmPlan: "free" } },
+        { id: "team-2", clientReadOnlyMetadata: { cmuxPlan: "" } },
       ],
     });
 


### PR DESCRIPTION
A user who belongs to 2+ teams with no selected team resolved to `billingTeam = null`, so `/dashboard/billing` showed the free-plan upsell and VM auth fell back to their personal (free) plan even when one of their teams had an active Team subscription. Found while sanity-checking the billing entitlement flow.

Both the dashboard and VM auth (plus the plan/portal/subscription routes and pro.ts, which had the same duplicated logic) now share one `resolveBillingTeam` helper: selected team wins, then a sole team, then, for multi-team users, a team whose metadata carries an active plan, chosen deterministically. Single-team and selected-team users are byte-identical, no-paid-team users still resolve free, and the metadata read preserves the existing `cmuxVmPlan ?? cmuxPlan` raw-value semantics so a present-but-invalid override still masks the fallback.

/fable loop: coder + fable-judge (REVISE round 1 caught a real semantic drift + a dropped 409 test; round 2 fixed both, APPROVE). 512 web tests green in sorted order, typecheck + db:check + flag lint clean. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786077032&installation_id=133855650&pr_number=7586&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7586&signature=46dbbb8c45cd78a25912c01635fdafc14e5c54fa5c9a833a96b63ee52a92566c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared billing/entitlement resolution across dashboard, Stripe routes, and VM provisioning; incorrect team choice could mis-bill or grant wrong VM limits, though behavior is heavily tested and single-team/selected-team paths are unchanged.
> 
> **Overview**
> Fixes a bug where users in **two or more** Stack teams with **no selected team** got `billingTeam = null`, so billing UI looked free and VM auth used personal limits even when a team had an active Team plan.
> 
> Introduces **`resolveBillingTeam`** in `services/billing/teamResolution` and wires it through the billing dashboard, plan/portal/subscription APIs, `pro.ts` (e.g. TestFlight), and VM auth—removing duplicated `billingTeamForUser` helpers. Resolution order: **selected team**, then **sole team**, then among multiple teams a **paid** team from metadata (`cmuxVmPlan` then `cmuxPlan`, with empty override masking), preferring teams with real **`cmuxPlan`** subscriptions over **`cmuxVmPlan`-only** overrides, with deterministic id tie-breaks.
> 
> VM create now **succeeds** against the inferred paid team when appropriate; users with multiple unpaid teams still hit **`vm_billing_team_required`**. Tests cover the resolver, dashboard team billing without selection, and the updated VM path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0fe789e4314286145f07bb7e24bbe4cea84f69c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing team resolution for multi-team users so paid teams are chosen correctly, preferring real `cmuxPlan` subscriptions over `cmuxVmPlan` overrides. Centralizes selection in `resolveBillingTeam` across the dashboard, billing APIs, and VM auth to prevent paid teams showing as free.

- **Bug Fixes**
  - For users with 2+ teams and no selected team, pick a paid team from metadata; `cmuxPlan` beats `cmuxVmPlan`, with deterministic id tiebreakers within each tier.
  - Dashboard billing and VM auth now use the correct team; if no team has paid metadata, return null and keep the “select a team” path. Preserves `cmuxVmPlan ?? cmuxPlan` masking semantics.
  - VM create now succeeds on the paid team in that scenario; still 409 when no team qualifies.

- **Refactors**
  - Introduced `resolveBillingTeam` in `services/billing/teamResolution` and used it in the billing page, `plan`, `portal`, `subscription`, `pro.ts`, and VM auth; removed duplicated helpers and added focused tests.
  - Replaced `toSorted` with `Array.sort` in the resolver for wider Node compatibility.

<sup>Written for commit c0fe789e4314286145f07bb7e24bbe4cea84f69c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Billing pages and API flows now automatically pick the most relevant team when a user has multiple teams, including paid-team prioritization.
  * Team billing and portal actions now work more consistently across dashboard, subscription, and VM-related flows.

* **Bug Fixes**
  * Improved handling when no team is selected, reducing billing and access errors.
  * Fixed cases where paid team details were not being recognized correctly.

* **Tests**
  * Added and updated coverage for team selection, billing page behavior, and VM route billing handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->