### PR TITLE
Budget checker: evaluate the speculative merge with current main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BEFORE_SHA: ${{ github.event.before }}
         run: |
@@ -226,7 +227,7 @@ jobs:
             python3 scripts/swift_file_length_budget.py \
               --budget .github/swift-file-length-budget.tsv \
               --base-ref "$BASE_REF" \
-              --merge-ref origin/main \
+              --merge-ref "origin/${BASE_BRANCH:-main}" \
               --merge-head "$HEAD_SHA"
           elif [ "$EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && ! [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
             python3 scripts/swift_file_length_budget.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,9 @@ jobs:
             fi
             python3 scripts/swift_file_length_budget.py \
               --budget .github/swift-file-length-budget.tsv \
-              --base-ref "$BASE_REF"
+              --base-ref "$BASE_REF" \
+              --merge-ref origin/main \
+              --merge-head "$HEAD_SHA"
           elif [ "$EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && ! [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
             python3 scripts/swift_file_length_budget.py \
               --budget .github/swift-file-length-budget.tsv \

--- a/scripts/swift_file_length_budget.py
+++ b/scripts/swift_file_length_budget.py
@@ -51,6 +51,90 @@ def collect_file_lengths(repo_root: pathlib.Path, roots: tuple[str, ...]) -> Fil
     return budget
 
 
+def is_in_roots(rel_path: str, roots: tuple[str, ...]) -> bool:
+    return any(rel_path == root or rel_path.startswith(f"{root}/") for root in roots)
+
+
+def count_blob_lines(content: bytes) -> int:
+    return content.count(b"\n") + (0 if content.endswith(b"\n") or not content else 1)
+
+
+def list_tree_swift_paths(repo_root: pathlib.Path, tree: str, roots: tuple[str, ...]) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-tree", "-r", "--name-only", "-z", tree],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.decode("utf-8", errors="replace").strip())
+
+    paths: list[str] = []
+    for raw_path in result.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        rel_path = raw_path.decode("utf-8", errors="surrogateescape")
+        if not rel_path.endswith(".swift"):
+            continue
+        if not is_in_roots(rel_path, roots):
+            continue
+        if is_ignored_path(pathlib.Path(rel_path)):
+            continue
+        paths.append(rel_path)
+    return sorted(paths)
+
+
+def collect_file_lengths_at_ref(repo_root: pathlib.Path, ref: str, roots: tuple[str, ...]) -> FileLengthBudget:
+    paths = list_tree_swift_paths(repo_root, ref, roots)
+    if not paths:
+        return {}
+
+    batch_input = "".join(f"{ref}:{rel_path}\n" for rel_path in paths).encode(
+        "utf-8",
+        errors="surrogateescape",
+    )
+    try:
+        process = subprocess.run(
+            ["git", "-C", str(repo_root), "cat-file", "--batch"],
+            input=batch_input,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    if process.returncode != 0:
+        raise RuntimeError(process.stderr.decode("utf-8", errors="replace").strip())
+
+    budget: FileLengthBudget = {}
+    offset = 0
+    stdout = process.stdout
+    for rel_path in paths:
+        header_end = stdout.find(b"\n", offset)
+        if header_end == -1:
+            raise RuntimeError(f"missing git cat-file header for {rel_path}")
+        header = stdout[offset:header_end]
+        header_parts = header.split()
+        if len(header_parts) == 2 and header_parts[1] == b"missing":
+            raise RuntimeError(f"missing object for {ref}:{rel_path}")
+        if len(header_parts) != 3:
+            raise RuntimeError(f"unexpected git cat-file header for {rel_path}: {header!r}")
+        try:
+            size = int(header_parts[2])
+        except ValueError as exc:
+            raise RuntimeError(f"invalid git cat-file size for {rel_path}: {header!r}") from exc
+        content_start = header_end + 1
+        content_end = content_start + size
+        if content_end > len(stdout):
+            raise RuntimeError(f"truncated git cat-file content for {rel_path}")
+        budget[rel_path] = count_blob_lines(stdout[content_start:content_end])
+        offset = content_end
+        if offset < len(stdout) and stdout[offset : offset + 1] == b"\n":
+            offset += 1
+    return budget
+
+
 def tracked_file_lengths(file_lengths: FileLengthBudget, threshold: int) -> FileLengthBudget:
     return {
         rel_path: line_count
@@ -72,7 +156,7 @@ def count_lines_at_ref(repo_root: pathlib.Path, ref: str, rel_path: str) -> int 
 
     if result.returncode != 0:
         return None
-    return result.stdout.count(b"\n") + (0 if result.stdout.endswith(b"\n") or not result.stdout else 1)
+    return count_blob_lines(result.stdout)
 
 
 def parse_budget(text: str, source: str) -> FileLengthBudget:
@@ -141,6 +225,51 @@ def write_budget(path: pathlib.Path, budget: FileLengthBudget) -> None:
 def print_file_summary(label: str, file_lengths: FileLengthBudget) -> None:
     total = sum(file_lengths.values())
     print(f"{label}: {total} line(s) across {len(file_lengths)} Swift file(s)")
+
+
+def speculative_merge_tree(repo_root: pathlib.Path, merge_ref: str, merge_head: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "merge-tree", "--write-tree", merge_ref, merge_head],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        print(
+            f"Speculative merge of {merge_ref} and {merge_head} could not run; "
+            "falling back to working-tree evaluation.",
+        )
+        print(str(exc), file=sys.stderr)
+        return None
+
+    if result.returncode == 0:
+        tree = result.stdout.splitlines()[0] if result.stdout.splitlines() else ""
+        if tree:
+            return tree
+        print(
+            f"Speculative merge of {merge_ref} and {merge_head} did not produce a tree; "
+            "falling back to working-tree evaluation.",
+        )
+        if result.stderr.strip():
+            print(result.stderr.strip(), file=sys.stderr)
+        return None
+
+    if result.returncode == 1:
+        print(
+            f"Speculative merge of {merge_ref} and {merge_head} conflicts; "
+            "falling back to working-tree evaluation.",
+        )
+        return None
+
+    print(
+        f"Speculative merge of {merge_ref} and {merge_head} failed; "
+        "falling back to working-tree evaluation.",
+    )
+    if result.stderr.strip():
+        print(result.stderr.strip(), file=sys.stderr)
+    return None
 
 
 def compare_budget(
@@ -305,6 +434,15 @@ def main(argv: list[str]) -> int:
         help="git ref used to allow small PR-local growth in files already over budget",
     )
     parser.add_argument(
+        "--merge-ref",
+        help="git ref to speculatively merge with --merge-head before evaluating the budget",
+    )
+    parser.add_argument(
+        "--merge-head",
+        default="HEAD",
+        help="git ref for the PR side of a speculative merge",
+    )
+    parser.add_argument(
         "--incidental-growth",
         default=DEFAULT_INCIDENTAL_GROWTH,
         type=int,
@@ -327,9 +465,59 @@ def main(argv: list[str]) -> int:
     if args.hard_cap < args.threshold:
         print("--hard-cap must be at least --threshold", file=sys.stderr)
         return 2
+    if args.write_budget and args.merge_ref:
+        print("--write-budget cannot be used with --merge-ref", file=sys.stderr)
+        return 2
 
     repo_root = args.repo_root.resolve(strict=False)
     budget_path = args.budget if args.budget.is_absolute() else repo_root / args.budget
+
+    merged_tree: str | None = None
+    if args.merge_ref:
+        merged_tree = speculative_merge_tree(repo_root, args.merge_ref, args.merge_head)
+
+    if merged_tree:
+        print(
+            f"Evaluating speculative merge of {args.merge_ref} and {args.merge_head} "
+            f"(tree {merged_tree})."
+        )
+        try:
+            file_lengths = collect_file_lengths_at_ref(repo_root, merged_tree, tuple(args.roots))
+        except RuntimeError as exc:
+            print(f"Error reading Swift files from merged tree: {exc}", file=sys.stderr)
+            return 2
+        actual = tracked_file_lengths(file_lengths, args.threshold)
+        print_file_summary("All scanned cmux-owned Swift files", file_lengths)
+        print_file_summary(f"Tracked Swift files >= {args.threshold} lines", actual)
+
+        budget_ref_path = repo_relative_path(repo_root, budget_path)
+        try:
+            allowed = load_budget_at_ref(repo_root, merged_tree, budget_ref_path) if budget_ref_path else None
+        except ValueError as exc:
+            print(f"Error reading Swift file length budget: {exc}", file=sys.stderr)
+            return 2
+        if allowed is None:
+            print(f"Missing Swift file length budget: {budget_path}", file=sys.stderr)
+            return 2
+        base_allowed: FileLengthBudget | None = None
+        try:
+            base_allowed = load_budget_at_ref(repo_root, args.merge_ref, budget_ref_path)
+        except ValueError as exc:
+            print(f"Error reading base Swift file length budget: {exc}", file=sys.stderr)
+            return 2
+        print_file_summary("Allowed Swift file length budget", allowed)
+        return compare_budget(
+            actual,
+            allowed,
+            base_allowed,
+            args.threshold,
+            file_lengths,
+            repo_root,
+            args.merge_ref,
+            args.incidental_growth,
+            args.hard_cap,
+        )
+
     file_lengths = collect_file_lengths(repo_root, tuple(args.roots))
     actual = tracked_file_lengths(file_lengths, args.threshold)
     print_file_summary("All scanned cmux-owned Swift files", file_lengths)

--- a/tests/test_ci_swift_file_length_budget.sh
+++ b/tests/test_ci_swift_file_length_budget.sh
@@ -339,3 +339,154 @@ if ! grep -Fq 'duplicate entry' "$TMP_DIR/duplicate.out"; then
   cat "$TMP_DIR/duplicate.out" >&2
   exit 1
 fi
+
+if ! git merge-tree --write-tree HEAD HEAD >/dev/null 2>&1; then
+  echo "Skipping speculative merge-tree budget tests: git merge-tree --write-tree is unsupported by this git."
+  exit 0
+fi
+
+RACE_FIXTURE="$TMP_DIR/race-repo"
+
+python3 - "$RACE_FIXTURE" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+
+def write_lines(path: pathlib.Path, count: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(f"line {index}\n" for index in range(count)), encoding="utf-8")
+
+write_lines(root / "Sources" / "Racy.swift", 40)
+(root / ".github").mkdir(parents=True, exist_ok=True)
+(root / ".github" / "test-budget.tsv").write_text("40\tSources/Racy.swift\n", encoding="utf-8")
+(root / ".gitattributes").write_text("Sources/Racy.swift merge=keepFeature\n", encoding="utf-8")
+(root / "README.md").write_text("base readme\n", encoding="utf-8")
+PY
+
+git -C "$RACE_FIXTURE" init -q
+git -C "$RACE_FIXTURE" config merge.keepFeature.name 'keep feature side for race fixture'
+git -C "$RACE_FIXTURE" config merge.keepFeature.driver 'cp %B %A'
+git -C "$RACE_FIXTURE" add .
+git -C "$RACE_FIXTURE" -c user.name='cmux CI' -c user.email='ci@example.invalid' commit -qm baseline
+git -C "$RACE_FIXTURE" branch -M main
+RACE_BASE="$(git -C "$RACE_FIXTURE" rev-parse HEAD)"
+
+git -C "$RACE_FIXTURE" checkout -q -b feature
+python3 - "$RACE_FIXTURE/Sources/Racy.swift" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_text(
+    "".join(f"line {index}\n" for index in range(40))
+    + "feature line 40\n"
+    + "feature line 41\n",
+    encoding="utf-8",
+)
+PY
+git -C "$RACE_FIXTURE" add Sources/Racy.swift
+git -C "$RACE_FIXTURE" -c user.name='cmux CI' -c user.email='ci@example.invalid' commit -qm 'grow racy file'
+
+git -C "$RACE_FIXTURE" checkout -q main
+python3 - "$RACE_FIXTURE" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+(root / "Sources" / "Racy.swift").write_text(
+    "".join(f"split line {index}\n" for index in range(6)),
+    encoding="utf-8",
+)
+(root / ".github" / "test-budget.tsv").write_text("6\tSources/Racy.swift\n", encoding="utf-8")
+(root / "README.md").write_text("main readme\n", encoding="utf-8")
+PY
+git -C "$RACE_FIXTURE" add Sources/Racy.swift .github/test-budget.tsv README.md
+git -C "$RACE_FIXTURE" -c user.name='cmux CI' -c user.email='ci@example.invalid' commit -qm 'split racy file and lower budget'
+
+git -C "$RACE_FIXTURE" checkout -q feature
+RACE_MERGE_BASE="$(git -C "$RACE_FIXTURE" merge-base main feature)"
+python3 scripts/swift_file_length_budget.py \
+  --repo-root "$RACE_FIXTURE" \
+  --budget .github/test-budget.tsv \
+  --threshold 5 \
+  --base-ref "$RACE_MERGE_BASE" \
+  --incidental-growth 3 \
+  --hard-cap 100 >"$TMP_DIR/race-old-behavior.out"
+
+if python3 scripts/swift_file_length_budget.py \
+  --repo-root "$RACE_FIXTURE" \
+  --budget .github/test-budget.tsv \
+  --threshold 5 \
+  --base-ref "$RACE_MERGE_BASE" \
+  --merge-ref main \
+  --merge-head feature \
+  --incidental-growth 3 \
+  --hard-cap 100 >"$TMP_DIR/race-merge-ref.out" 2>&1; then
+  echo "expected speculative merge budget check to catch racy growth" >&2
+  cat "$TMP_DIR/race-merge-ref.out" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'Sources/Racy.swift' "$TMP_DIR/race-merge-ref.out"; then
+  echo "expected speculative merge failure to name Racy.swift" >&2
+  cat "$TMP_DIR/race-merge-ref.out" >&2
+  exit 1
+fi
+
+if python3 scripts/swift_file_length_budget.py \
+  --repo-root "$RACE_FIXTURE" \
+  --budget .github/test-budget.tsv \
+  --threshold 5 \
+  --merge-ref main \
+  --write-budget >"$TMP_DIR/race-write-budget.out" 2>&1; then
+  echo "expected --write-budget with --merge-ref to fail" >&2
+  exit 1
+fi
+
+if ! grep -Fq -- '--write-budget cannot be used with --merge-ref' "$TMP_DIR/race-write-budget.out"; then
+  echo "expected --write-budget merge-ref argument error" >&2
+  cat "$TMP_DIR/race-write-budget.out" >&2
+  exit 1
+fi
+
+git -C "$RACE_FIXTURE" checkout -q -b conflict "$RACE_BASE"
+printf 'feature readme\n' >"$RACE_FIXTURE/README.md"
+git -C "$RACE_FIXTURE" add README.md
+git -C "$RACE_FIXTURE" -c user.name='cmux CI' -c user.email='ci@example.invalid' commit -qm 'conflict on readme'
+
+CONFLICT_MERGE_BASE="$(git -C "$RACE_FIXTURE" merge-base main conflict)"
+set +e
+python3 scripts/swift_file_length_budget.py \
+  --repo-root "$RACE_FIXTURE" \
+  --budget .github/test-budget.tsv \
+  --threshold 5 \
+  --base-ref "$CONFLICT_MERGE_BASE" \
+  --incidental-growth 3 \
+  --hard-cap 100 >"$TMP_DIR/conflict-plain.out" 2>&1
+PLAIN_CONFLICT_STATUS=$?
+python3 scripts/swift_file_length_budget.py \
+  --repo-root "$RACE_FIXTURE" \
+  --budget .github/test-budget.tsv \
+  --threshold 5 \
+  --base-ref "$CONFLICT_MERGE_BASE" \
+  --merge-ref main \
+  --merge-head conflict \
+  --incidental-growth 3 \
+  --hard-cap 100 >"$TMP_DIR/conflict-merge-ref.out" 2>&1
+MERGE_REF_CONFLICT_STATUS=$?
+set -e
+
+if [ "$PLAIN_CONFLICT_STATUS" -ne "$MERGE_REF_CONFLICT_STATUS" ]; then
+  echo "conflict fallback should produce the same exit code as plain base-ref evaluation" >&2
+  echo "plain status: $PLAIN_CONFLICT_STATUS" >&2
+  echo "merge-ref status: $MERGE_REF_CONFLICT_STATUS" >&2
+  cat "$TMP_DIR/conflict-merge-ref.out" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'falling back to working-tree evaluation' "$TMP_DIR/conflict-merge-ref.out"; then
+  echo "expected conflict fallback notice" >&2
+  cat "$TMP_DIR/conflict-merge-ref.out" >&2
+  exit 1
+fi


### PR DESCRIPTION
The Swift file length budget check on `pull_request` compared the PR tree against its own merge-base, i.e. main as of the PR's last push. Two PRs racing on the same file could each pass and still turn main red after both merged. Canonical case: PR A splits a god object and lowers its budget line in `.github/swift-file-length-budget.tsv`; PR B, branched earlier, still grows the old big file; no textual conflict, both green, main red.

Fix: `scripts/swift_file_length_budget.py` gains `--merge-ref`/`--merge-head`. It runs `git merge-tree --write-tree origin/main <head>` (in-memory merge, no worktree changes), measures Swift file lengths from the merged tree with a single `git cat-file --batch`, reads the budget TSV from the merged tree, and attributes growth against current main. The check now answers "would the budget hold if this PR merged into main right now?" on every CI run, shrinking the exposure window from the PR's lifetime to last-CI-run-to-merge. On merge conflict or old git it prints a notice and falls back to the exact pre-change behavior (`--base-ref` working-tree evaluation); the conflicted tree is never used. `ci.yml` passes the new flags on `pull_request` only; push and dispatch lanes are unchanged (the dispatch lane already evaluates against current main, which is what `scripts/merge-gate.sh` in cmuxterm-hq relies on).

Two-commit structure: the first commit adds the failing regression test only (the race scenario passes with old flags, documenting the blind spot, and must fail with the new ones), the second adds the fix, so `workflow-guard-tests` goes red then green in the Commits tab. Verified locally: `./tests/test_ci_swift_file_length_budget.sh` fails at the first commit (exit 1) and passes at head, and `python3 -m py_compile` is clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786077615&installation_id=133855650&pr_number=7587&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7587&signature=2c4f6fb6d7446f5e4fe4d41c918ec7617058077d8aa3fe6d7e9e42af41e21595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI guard scripting and workflow wiring for the Swift length budget, with explicit fallback to prior behavior on merge conflicts or unsupported git.
> 
> **Overview**
> **Pull request Swift file length checks now answer whether the budget would hold if the branch merged into current `origin/main`**, closing a race where two green PRs could both pass against stale merge-base state and still break `main` after merge.
> 
> `scripts/swift_file_length_budget.py` adds `--merge-ref` / `--merge-head`. When set, it runs `git merge-tree --write-tree`, measures Swift line counts from that tree via `git ls-tree` + `git cat-file --batch`, loads the budget TSV from the merged tree, and runs `compare_budget` with growth attributed to `--merge-ref` (current main). On merge conflict, missing `merge-tree`, or other failure it logs a notice and **falls back** to the prior working-tree / `--base-ref` path; `--write-budget` is rejected alongside `--merge-ref`.
> 
> `.github/workflows/ci.yml` passes `--merge-ref "origin/${BASE_BRANCH:-main}"` and `--merge-head "$HEAD_SHA"` on `pull_request` only; push and dispatch paths are unchanged.
> 
> `tests/test_ci_swift_file_length_budget.sh` adds a two-PR race fixture (main lowers budget while a feature branch still grows the old file), conflict fallback parity, and the write-budget guard, skipping when `git merge-tree --write-tree` is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4ff9ff97eaeaf4d875bba3132f283ea9881ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Swift file length budget check to evaluate a speculative merge with the PR’s base branch (not hard-coded `main`), preventing two green PRs from turning `main` red. Adds CI wiring and regression tests with a safe fallback on conflicts or old Git.

- **New Features**
  - Add `--merge-ref`/`--merge-head` to `scripts/swift_file_length_budget.py`; build an in-memory merge via `git merge-tree --write-tree` and read Swift lengths and the TSV budget from that tree with `git cat-file --batch`.
  - CI: on `pull_request`, pass `--merge-ref origin/${BASE_BRANCH:-main} --merge-head $HEAD_SHA` in `.github/workflows/ci.yml`; push and dispatch lanes unchanged.
  - Fallback and safety: on merge conflicts or missing `merge-tree`, log a notice and fall back to the previous `--base-ref` working-tree evaluation; reject `--write-budget` with `--merge-ref`. Tests cover the race regression, conflict fallback (exit-code parity and notice), and `--write-budget` rejection, skipping if `git merge-tree --write-tree` is unsupported.

<sup>Written for commit 5e4ff9ff97eaeaf4d875bba3132f283ea9881ed0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swift file length checks now evaluate against a speculative merged view when merge context is available, making budget results more accurate for pull requests.

* **Bug Fixes**
  * Improved handling of merge conflicts and fallback behavior so checks continue to run reliably when merged-tree evaluation isn’t available.
  * Added validation to prevent combining budget-writing with merge-based checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->