### PR TITLE
mux: purge per-surface agent/notification tables on close (follow-up to #7584)

### DIFF
--- a/mux/bindings/conformance/fixtures.json
+++ b/mux/bindings/conformance/fixtures.json
@@ -138,6 +138,9 @@
     },
     {
       "name": "implemented-verbs-json",
+      "requires": {
+        "commands": ["run", "wait-for", "send-key", "copy", "ids", "notify", "list-agents", "report-agent"]
+      },
       "steps": [
         {
           "type": "command",

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -416,6 +416,16 @@ impl Mux {
         record
     }
 
+    /// Drop the per-surface side tables (`agent_records`,
+    /// `surface_notifications`) for a surface that has left the tree.
+    /// `SurfaceId` is monotonic, so without this every closed tab would
+    /// leak an entry forever and `list-agents` would keep reporting dead
+    /// surfaces as live agents.
+    fn purge_surface_side_tables(&self, surface: SurfaceId) {
+        self.agent_records.lock().unwrap().remove(&surface);
+        self.surface_notifications.lock().unwrap().remove(&surface);
+    }
+
     pub fn list_agents(
         &self,
         surface: Option<SurfaceId>,
@@ -928,6 +938,7 @@ impl Mux {
             (remove_surface(&mut state, target), state.workspaces.is_empty())
         };
         if let Some(surface) = removed {
+            self.purge_surface_side_tables(surface.id);
             surface.kill();
             self.emit(MuxEvent::TreeChanged);
         }
@@ -951,6 +962,7 @@ impl Mux {
         };
         if !removed.is_empty() {
             for surface in removed {
+                self.purge_surface_side_tables(surface.id);
                 surface.kill();
             }
             self.emit(MuxEvent::TreeChanged);
@@ -1519,6 +1531,39 @@ mod tests {
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].session.as_deref(), Some("hook-session"));
         assert!(mux.list_agents(Some(surface.id), Some(AgentState::Done)).is_empty());
+    }
+
+    #[test]
+    fn closing_a_surface_purges_agent_and_notification_side_tables() {
+        let mux = test_mux();
+        let first = mux.new_workspace(None, None).unwrap();
+        let pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
+        // A second tab keeps the workspace alive after `first` closes, so we
+        // exercise the per-surface purge rather than a full teardown.
+        let second = mux.new_tab(Some(pane), None, None).unwrap();
+
+        mux.report_agent(
+            first.id,
+            AgentState::Working,
+            AgentSource::Socket,
+            Some("conf".to_string()),
+        );
+        mux.post_notification(
+            "Build".to_string(),
+            "ok".to_string(),
+            NotificationLevel::Warning,
+            Some(first.id),
+        );
+        assert_eq!(mux.list_agents(Some(first.id), None).len(), 1);
+        assert!(mux.surface_notification(first.id).is_some());
+
+        mux.close_surface(first.id);
+
+        // The dead surface must not linger in either side table.
+        assert!(mux.list_agents(Some(first.id), None).is_empty());
+        assert!(mux.list_agents(None, None).is_empty());
+        assert!(mux.surface_notification(first.id).is_none());
+        assert!(mux.with_state(|state| state.surfaces.contains_key(&second.id)));
     }
 
     #[test]

--- a/mux/crates/mux-tui/src/ui/sidebar.rs
+++ b/mux/crates/mux-tui/src/ui/sidebar.rs
@@ -13,12 +13,25 @@ use ratatui::Frame;
 use super::truncate;
 use crate::app::{App, Hit};
 
-fn workspace_has_unread(ws: &crate::session::WorkspaceView) -> bool {
+/// The color of a workspace's unread indicator, or `None` when nothing is
+/// unread. Mirrors the tab-bar severity cue (`error` > `warning` > `info`)
+/// so the sidebar dot carries the same meaning as the per-tab marker.
+fn workspace_unread_color(
+    theme: &crate::config::Theme,
+    ws: &crate::session::WorkspaceView,
+) -> Option<Color> {
     ws.screens
         .iter()
         .flat_map(|screen| screen.panes.iter())
         .flat_map(|pane| pane.tabs.iter())
-        .any(|tab| tab.notification.is_some_and(|notification| notification.unread))
+        .filter_map(|tab| tab.notification.filter(|notification| notification.unread))
+        .map(|notification| match notification.level {
+            "error" => (2u8, theme.notification_error),
+            "warning" => (1, theme.notification_warning),
+            _ => (0, theme.notification_info),
+        })
+        .max_by_key(|(rank, _)| *rank)
+        .map(|(_, color)| color)
 }
 
 pub fn draw(app: &mut App, frame: &mut Frame) {
@@ -83,10 +96,11 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
             buf[(0, y)].set_symbol("▎").set_style(rail_style);
             buf[(0, y + 1)].set_symbol("▎").set_style(rail_style);
         }
-        if workspace_has_unread(ws) && content_w > 1 {
-            let dot_style =
-                style.fg(app.config.theme.notification_info).add_modifier(Modifier::BOLD);
-            buf[(0, y)].set_symbol("•").set_style(dot_style);
+        if content_w > 1 {
+            if let Some(color) = workspace_unread_color(&app.config.theme, ws) {
+                let dot_style = style.fg(color).add_modifier(Modifier::BOLD);
+                buf[(0, y)].set_symbol("•").set_style(dot_style);
+            }
         }
         set_line_from(buf, 1, y, &truncate(&ws.name, content_w - 1), style);
         hits.push((row_rect(y), Hit::Workspace { index: i, id: ws.id }));

--- a/mux/spec/cli.md
+++ b/mux/spec/cli.md
@@ -83,11 +83,11 @@ The generated CLI requires one of `--index` or `--delta` for `select-tab`, `sele
 | `wait-for` | implemented | `--surface <id> --pattern <regex> --timeout-ms <n>` | none | none |
 | `run` | implemented | `-- <argv...>` or `--command <cmd>` | `--pane <id>`, `--new-workspace`, `--cwd <path>`, `--name <name>` | surface id |
 | `send-key` | implemented | `--surface <id> <key>...` | none | none |
-| `copy` | implemented | `--surface <id> --mode screen|selection|scrollback` | none | text |
-| `ids` | implemented | none | `--kind workspace|screen|pane|surface` | id lines |
-| `notify` | implemented | `--title <title> --body <body>` | `--level info|warning|error`, `--surface <id>` | notification id |
+| `copy` | implemented | `--surface <id> --mode screen\|selection\|scrollback` | none | text |
+| `ids` | implemented | none | `--kind workspace\|screen\|pane\|surface` | id lines |
+| `notify` | implemented | `--title <title> --body <body>` | `--level info\|warning\|error`, `--surface <id>` | notification id |
 | `list-agents` | implemented | none | `--surface <id>`, `--state <state>` | agent lines |
-| `report-agent` | implemented | `--surface <id> --state <state> --source socket|hook` | `--session <id>` | none |
+| `report-agent` | implemented | `--surface <id> --state <state> --source socket\|hook` | `--session <id>` | none |
 
 ## Worked Examples
 


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/7584, which merged before its review-bot findings could be folded in.

**Real bug (flagged independently by Greptile P2, Cursor Bugbot, and CodeRabbit):** the new per-surface `agent_records` and `surface_notifications` maps are populated by `report-agent`/`notify` but were never purged when a surface closes or is reaped. Because `SurfaceId` is monotonic, every closed tab leaked an entry for the daemon's whole lifetime, and unfiltered `list-agents` kept returning dead surfaces as live agents. This adds `purge_surface_side_tables`, called from `close_surface`/`close_surfaces`, plus a regression test asserting both side tables drop the surface on close while sibling tabs survive.

Also folds in the smaller review findings:
- Conformance fixture `implemented-verbs-json` gains a `requires` block (the 8 protocol-6 verbs) so it skips gracefully on older servers instead of failing hard, matching the existing `move-tab` fixture convention.
- Sidebar unread dot now colors by notification severity (error > warning > info), matching the tab-bar cue, instead of always using `notification_info`.
- Escape the pipe characters in the `spec/cli.md` verb table so it renders as a table.

`cargo test -p mux-core -p mux-tui` green (104 tests); `cargo fmt --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the surface-close path in mux-core and fixes stale agent/notification state that affected control-socket behavior; UI and doc tweaks are low risk.
> 
> **Overview**
> Fixes a **daemon-lifetime leak** where `agent_records` and `surface_notifications` were never cleared when a tab closed, so `list-agents` could keep reporting dead surfaces and maps grew without bound.
> 
> **mux-core** adds `purge_surface_side_tables` and invokes it from `close_surface` and `close_surfaces`, with a regression test that agent and notification entries disappear while a sibling tab remains.
> 
> **Conformance** `implemented-verbs-json` now declares a `requires.commands` list (protocol-6 verbs) so older servers skip the fixture instead of failing.
> 
> **mux-tui** sidebar unread dots use the highest-severity unread color (error > warning > info), aligned with the tab bar.
> 
> **spec/cli.md** escapes `|` in verb-table cells so Markdown renders correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cbd7d28123a5b1deebb6ae5479b8b5f90a4d9db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786080091&installation_id=133855650&pr_number=7593&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7593&signature=63055b6030efc11807cff6675f41b8c2b9594d0cf846843ecc648e2470ea5877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a leak and stale agent listings by purging per-surface `agent_records` and `surface_notifications` when a surface closes. Also aligns the sidebar unread dot with notification severity, updates the conformance fixture to skip on older servers, and fixes CLI spec table rendering.

- **Bug Fixes**
  - Add `purge_surface_side_tables` and call it from `close_surface`/`close_surfaces` to remove closed surfaces from side tables, preventing unbounded growth and keeping `list-agents` accurate; includes a regression test.
  - Sidebar unread dot now colors by severity (error > warning > info) to match the tab bar.
  - Conformance fixture `implemented-verbs-json` adds a `requires` block for protocol-6 verbs to skip gracefully on older servers; escape `|` in `spec/cli.md` verb table for correct rendering.

<sup>Written for commit 2cbd7d28123a5b1deebb6ae5479b8b5f90a4d9db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace unread indicators now use severity-based colors, highlighting higher-priority notifications more clearly.

* **Bug Fixes**
  * Closing a surface now fully clears its related agent and notification state, preventing stale entries from appearing later.
  * The sidebar only shows unread markers when there’s room to display them.

* **Documentation**
  * Updated CLI command reference formatting for clearer table rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->