### PR TITLE
Preserve sidebar scroll when closing workspaces

### DIFF
--- a/Sources/Sidebar/SidebarState.swift
+++ b/Sources/Sidebar/SidebarState.swift
@@ -70,6 +70,10 @@ enum SidebarSelectedWorkspaceScrollPolicy {
             return true
         }
 
+        guard oldWorkspaceIds.count == newWorkspaceIds.count else {
+            return false
+        }
+
         guard oldIndex != newIndex else {
             return false
         }

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -220,6 +220,9 @@ import Testing
         ))
     }
 
+    @Test func skipsScrollWhenWorkspaceBeforeSelectedWorkspaceCloses() {
+        #expect(!SidebarSelectedWorkspaceScrollPolicy.shouldScrollSelectedWorkspace(selectedWorkspaceId: "d", oldWorkspaceIds: ["a", "b", "c", "d"], newWorkspaceIds: ["a", "c", "d"]))
+    }
     @Test func skipsScrollWhenReorderLeavesSelectedWorkspaceIndexUnchanged() {
         #expect(!SidebarSelectedWorkspaceScrollPolicy.shouldScrollSelectedWorkspace(
             selectedWorkspaceId: "a",


### PR DESCRIPTION
## Summary

Fixes a sidebar jump when closing a workspace row above the currently selected workspace. The selected workspace remained the same, but its index changed after the removal, so `SidebarSelectedWorkspaceScrollPolicy` treated the list mutation as a reason to `scrollTo` the selected workspace. If the user had manually scrolled to a middle row while the selected workspace was lower in the list, closing the visible row snapped the sidebar back down.

The policy now only scrolls the selected workspace when the selected workspace first appears or when a same-size reorder moves it. Insertions/deletions around an already-selected workspace preserve the user's current scroll position.

## Verification

- Reproduced the bad behavior on the previous `geom7` build by selecting a bottom workspace, manually scrolling to a middle row, and closing a visible row above the selection.
  - Before bad close: `out/sidebar-close-scroll-jump/before-geom7-manual-mid-close.png`
  - After bad close: `out/sidebar-close-scroll-jump/after-geom7-manual-mid-close.png`
- Added a regression test for closing a workspace before the selected workspace.
- `git diff --check`
- `./tests/test_ci_pbxproj_test_wiring.sh`
- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv --base-ref origin/main`
- `./scripts/reload.sh --tag wsjmp`

Note: the fixed `wsjmp` app built and launched locally, but macOS window capture started returning `could not create image from window` for the tagged debug window after the scroll-position setup. The local screenshot evidence is available under `out/sidebar-close-scroll-jump/`; the fixed behavior is covered by the policy regression test and final tagged build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786081198&installation_id=133855650&pr_number=7594&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7594&signature=5935d084bd67d513e17d1c3015b57df633cfa1b25b1e93559ba60b4030489e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves sidebar scroll position when closing or inserting workspaces around the selected workspace. Prevents the jump that snapped back to the selected row.

- **Bug Fixes**
  - Updated `SidebarSelectedWorkspaceScrollPolicy` to skip scrolling when the workspace list size changes; only scrolls on same-size reorders or first appearance.
  - Added a regression test for closing a workspace before the selected one.

<sup>Written for commit 29fac937ac23770cf97529fd3a94b175d54eaa99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small policy tweak in sidebar scroll behavior with a targeted unit test; no auth, data, or security impact.
> 
> **Overview**
> Fixes the sidebar **jumping** when you close a workspace row above the current selection while scrolled to a different part of the list.
> 
> `SidebarSelectedWorkspaceScrollPolicy.shouldScrollSelectedWorkspace` now **returns false when the workspace id list length changes**, so removals (and other insert/delete mutations) no longer trigger `scrollTo` just because the selected item’s index shifted. Auto-scroll still runs when the selection is new to the list or when a **same-length reorder** moves the selected workspace.
> 
> Adds a regression test for closing a workspace immediately before the selected one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29fac937ac23770cf97529fd3a94b175d54eaa99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar behavior so the selected workspace no longer auto-scrolls when the workspace list changes size unexpectedly.
  * Fixed a case where removing a workspace before the selected one could cause the selection to shift and trigger an unwanted scroll.

* **Tests**
  * Added coverage for workspace-closing behavior to verify the selected workspace stays in place when a prior item is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->