### PR TITLE
Fix undo shortcut crash routing

### DIFF
--- a/Sources/App/WindowKeyDownReplayGuard.swift
+++ b/Sources/App/WindowKeyDownReplayGuard.swift
@@ -1,5 +1,16 @@
 import AppKit
 
+extension NSEvent {
+    var cmuxIsUndoRedoCommandEquivalent: Bool {
+        let normalizedFlags = modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+        return type == .keyDown
+            && (normalizedFlags == [.command] || normalizedFlags == [.command, .shift])
+            && KeyboardLayout.normalizedCharacters(for: self) == "z"
+    }
+}
+
 /// Identity of a key event currently being force-dispatched into a responder's
 /// `keyDown(with:)` by `NSWindow.cmux_performKeyEquivalent(with:)`.
 ///

--- a/Sources/App/WindowKeyDownReplayGuard.swift
+++ b/Sources/App/WindowKeyDownReplayGuard.swift
@@ -47,24 +47,47 @@ extension NSWindow {
     func cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit(
         _ event: NSEvent,
         terminalView: GhosttyNSView?,
-        webView: CmuxWebView?
+        webView: CmuxWebView?,
+        browserWebKitKeyDownReentry: Bool
     ) -> Bool {
         guard event.cmuxIsUndoRedoCommandEquivalent,
               !cmuxFirstResponderPreservesLocalUndoRedo else {
             return false
         }
         if let terminalView {
-            _ = terminalView.performKeyEquivalentAfterMenuMiss(with: event)
+            if terminalView.performKeyEquivalentAfterMenuMiss(with: event) {
 #if DEBUG
-            cmuxDebugLog("  -> undo/redo routed to terminal before AppKit menu")
+                cmuxDebugLog("  -> undo/redo routed to terminal before AppKit menu")
 #endif
+                return true
+            }
+            if cmuxForceDispatchKeyDownOnce(event, to: terminalView, reason: "terminal undo/redo") {
+#if DEBUG
+                cmuxDebugLog("  -> undo/redo keyDown fallback routed to terminal")
+#endif
+                return true
+            }
             return true
         }
         if let webView {
-            _ = webView.performKeyEquivalent(with: event)
+            if browserWebKitKeyDownReentry {
 #if DEBUG
-            cmuxDebugLog("  -> undo/redo routed to browser before AppKit menu")
+                cmuxDebugLog("  -> undo/redo browser reentry suppressed before AppKit menu")
 #endif
+                return true
+            }
+            if webView.performKeyEquivalent(with: event) {
+#if DEBUG
+                cmuxDebugLog("  -> undo/redo routed to browser before AppKit menu")
+#endif
+                return true
+            }
+            if cmuxForceDispatchKeyDownOnce(event, to: webView, reason: "browser undo/redo") {
+#if DEBUG
+                cmuxDebugLog("  -> undo/redo keyDown fallback routed to browser")
+#endif
+                return true
+            }
             return true
         }
         return false

--- a/Sources/App/WindowKeyDownReplayGuard.swift
+++ b/Sources/App/WindowKeyDownReplayGuard.swift
@@ -89,6 +89,9 @@ extension NSWindow {
 #endif
                 return true
             }
+            // Do not fall through to AppKit Undo from generic browser focus:
+            // that is the stale NSUndoManager path this router avoids. Focused
+            // editable AppKit responders and Web Inspector are exempted above.
             return true
         }
         return false

--- a/Sources/App/WindowKeyDownReplayGuard.swift
+++ b/Sources/App/WindowKeyDownReplayGuard.swift
@@ -51,7 +51,8 @@ extension NSWindow {
         browserWebKitKeyDownReentry: Bool
     ) -> Bool {
         guard event.cmuxIsUndoRedoCommandEquivalent,
-              !cmuxFirstResponderPreservesLocalUndoRedo else {
+              !cmuxFirstResponderPreservesLocalUndoRedo,
+              !cmuxIsLikelyWebInspectorResponder(firstResponder) else {
             return false
         }
         if let terminalView {

--- a/Sources/App/WindowKeyDownReplayGuard.swift
+++ b/Sources/App/WindowKeyDownReplayGuard.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxTerminal
 
 extension NSEvent {
     var cmuxIsUndoRedoCommandEquivalent: Bool {
@@ -43,6 +44,43 @@ private struct CmuxForceDispatchedKeyEventIdentity: Hashable {
 private var cmuxInFlightForceDispatchedKeyEventIdentities = Set<CmuxForceDispatchedKeyEventIdentity>()
 
 extension NSWindow {
+    func cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit(
+        _ event: NSEvent,
+        terminalView: GhosttyNSView?,
+        webView: CmuxWebView?
+    ) -> Bool {
+        guard event.cmuxIsUndoRedoCommandEquivalent,
+              !cmuxFirstResponderPreservesLocalUndoRedo else {
+            return false
+        }
+        if let terminalView {
+            _ = terminalView.performKeyEquivalentAfterMenuMiss(with: event)
+#if DEBUG
+            cmuxDebugLog("  -> undo/redo routed to terminal before AppKit menu")
+#endif
+            return true
+        }
+        if let webView {
+            _ = webView.performKeyEquivalent(with: event)
+#if DEBUG
+            cmuxDebugLog("  -> undo/redo routed to browser before AppKit menu")
+#endif
+            return true
+        }
+        return false
+    }
+
+    private var cmuxFirstResponderPreservesLocalUndoRedo: Bool {
+        guard let responder = firstResponder else { return false }
+        if let textView = responder as? NSTextView {
+            return textView.isEditable || textView.isFieldEditor
+        }
+        if let textField = responder as? NSTextField {
+            return textField.isEditable
+        }
+        return false
+    }
+
     /// Single chokepoint for every direct `keyDown(with:)` force-dispatch made
     /// by `cmux_performKeyEquivalent(with:)`.
     ///

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -17230,7 +17230,12 @@ private extension NSWindow {
             }
             return false
         }
-        if cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit(event, terminalView: firstResponderGhosttyView, webView: firstResponderWebView) { return true }
+        if cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit(
+            event,
+            terminalView: firstResponderGhosttyView,
+            webView: firstResponderWebView,
+            browserWebKitKeyDownReentry: browserWebKitKeyDownReentry
+        ) { return true }
         if let mode = AppDelegate.shared?.rightSidebarModeShortcut(for: event),
            AppDelegate.shared?.shouldRouteRightSidebarModeShortcut(in: self) == true {
             _ = AppDelegate.shared?.focusRightSidebarInActiveMainWindow(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -17230,22 +17230,7 @@ private extension NSWindow {
             }
             return false
         }
-        if event.cmuxIsUndoRedoCommandEquivalent {
-            if let firstResponderGhosttyView {
-                _ = firstResponderGhosttyView.performKeyEquivalentAfterMenuMiss(with: event)
-#if DEBUG
-                cmuxDebugLog("  -> undo/redo routed to terminal before AppKit menu")
-#endif
-                return true
-            }
-            if let firstResponderWebView {
-                _ = firstResponderWebView.performKeyEquivalent(with: event)
-#if DEBUG
-                cmuxDebugLog("  -> undo/redo routed to browser before AppKit menu")
-#endif
-                return true
-            }
-        }
+        if cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit(event, terminalView: firstResponderGhosttyView, webView: firstResponderWebView) { return true }
         if let mode = AppDelegate.shared?.rightSidebarModeShortcut(for: event),
            AppDelegate.shared?.shouldRouteRightSidebarModeShortcut(in: self) == true {
             _ = AppDelegate.shared?.focusRightSidebarInActiveMainWindow(
@@ -17284,7 +17269,6 @@ private extension NSWindow {
 #endif
             return false
         }
-
         if let ghosttyView = firstResponderGhosttyView {
             // If the IME is composing and the key has no Cmd modifier, don't intercept —
             // let it flow through normal AppKit event dispatch so the input method can

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -17230,12 +17230,7 @@ private extension NSWindow {
             }
             return false
         }
-        if cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit(
-            event,
-            terminalView: firstResponderGhosttyView,
-            webView: firstResponderWebView,
-            browserWebKitKeyDownReentry: browserWebKitKeyDownReentry
-        ) { return true }
+        if cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit(event, terminalView: firstResponderGhosttyView, webView: firstResponderWebView, browserWebKitKeyDownReentry: browserWebKitKeyDownReentry) { return true }
         if let mode = AppDelegate.shared?.rightSidebarModeShortcut(for: event),
            AppDelegate.shared?.shouldRouteRightSidebarModeShortcut(in: self) == true {
             _ = AppDelegate.shared?.focusRightSidebarInActiveMainWindow(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -17230,6 +17230,22 @@ private extension NSWindow {
             }
             return false
         }
+        if event.cmuxIsUndoRedoCommandEquivalent {
+            if let firstResponderGhosttyView {
+                _ = firstResponderGhosttyView.performKeyEquivalentAfterMenuMiss(with: event)
+#if DEBUG
+                cmuxDebugLog("  -> undo/redo routed to terminal before AppKit menu")
+#endif
+                return true
+            }
+            if let firstResponderWebView {
+                _ = firstResponderWebView.performKeyEquivalent(with: event)
+#if DEBUG
+                cmuxDebugLog("  -> undo/redo routed to browser before AppKit menu")
+#endif
+                return true
+            }
+        }
         if let mode = AppDelegate.shared?.rightSidebarModeShortcut(for: event),
            AppDelegate.shared?.shouldRouteRightSidebarModeShortcut(in: self) == true {
             _ = AppDelegate.shared?.focusRightSidebarInActiveMainWindow(

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -741,11 +741,10 @@ final class CmuxWebView: WKWebView {
             _ = super.performKeyEquivalent(with: event)
             return finish(true)
         }
-
-        if !shouldRouteCommandEquivalentDirectlyToMainMenu(event) {
-            return finish(super.performKeyEquivalent(with: event))
+        let routeUndoRedoAwayFromAppKit = event.cmuxIsUndoRedoCommandEquivalent
+        if routeUndoRedoAwayFromAppKit || !shouldRouteCommandEquivalentDirectlyToMainMenu(event) {
+            return finish(super.performKeyEquivalent(with: event) || routeUndoRedoAwayFromAppKit)
         }
-
         if AppDelegate.shared?.handleBrowserSurfaceKeyEquivalentBeforeMainMenu(event) == true {
             return finish(true)
         }

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -741,9 +741,8 @@ final class CmuxWebView: WKWebView {
             _ = super.performKeyEquivalent(with: event)
             return finish(true)
         }
-        let routeUndoRedoAwayFromAppKit = event.cmuxIsUndoRedoCommandEquivalent
-        if routeUndoRedoAwayFromAppKit || !shouldRouteCommandEquivalentDirectlyToMainMenu(event) {
-            return finish(super.performKeyEquivalent(with: event) || routeUndoRedoAwayFromAppKit)
+        if event.cmuxIsUndoRedoCommandEquivalent || !shouldRouteCommandEquivalentDirectlyToMainMenu(event) {
+            return finish(super.performKeyEquivalent(with: event))
         }
         if AppDelegate.shared?.handleBrowserSurfaceKeyEquivalentBeforeMainMenu(event) == true {
             return finish(true)

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -741,7 +741,8 @@ final class CmuxWebView: WKWebView {
             _ = super.performKeyEquivalent(with: event)
             return finish(true)
         }
-        if event.cmuxIsUndoRedoCommandEquivalent || !shouldRouteCommandEquivalentDirectlyToMainMenu(event) {
+        let inspectorOwnsUndoRedo = event.cmuxIsUndoRedoCommandEquivalent && cmuxIsLikelyWebInspectorResponder(window?.firstResponder)
+        if !inspectorOwnsUndoRedo && (event.cmuxIsUndoRedoCommandEquivalent || !shouldRouteCommandEquivalentDirectlyToMainMenu(event)) {
             return finish(super.performKeyEquivalent(with: event))
         }
         if AppDelegate.shared?.handleBrowserSurfaceKeyEquivalentBeforeMainMenu(event) == true {

--- a/cmuxTests/CmuxWebViewKeyDownReentryTests.swift
+++ b/cmuxTests/CmuxWebViewKeyDownReentryTests.swift
@@ -13,7 +13,9 @@ import ObjectiveC.runtime
 private var cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled = false
 private var cmuxUnitTestCmuxWebViewKeyDownHook: ((CmuxWebView, NSEvent) -> Bool)?
 
-private final class FakeWKInspectorUndoResponderView: NSView {}
+private final class FakeWKInspectorUndoResponderView: NSView {
+    override var acceptsFirstResponder: Bool { true }
+}
 
 private final class BrowserUndoMenuActionSpy: NSObject {
     private(set) var invoked = false
@@ -201,7 +203,8 @@ final class CmuxWebViewKeyDownReentryTests: XCTestCase {
             installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
 
             let spy = BrowserUndoMenuActionSpy()
-            installUndoMenu(target: spy)
+            let previousMenu = installUndoMenu(target: spy)
+            defer { NSApp.mainMenu = previousMenu }
 
             guard let webView = window.contentView?.subviews.compactMap({ $0 as? CmuxWebView }).first else {
                 XCTFail("Failed to find hosted CmuxWebView")
@@ -274,7 +277,8 @@ final class CmuxWebViewKeyDownReentryTests: XCTestCase {
         body(window, { keyDownEvents })
     }
 
-    private func installUndoMenu(target: NSObject) {
+    private func installUndoMenu(target: NSObject) -> NSMenu? {
+        let previousMenu = NSApp.mainMenu
         let mainMenu = NSMenu()
         let editItem = NSMenuItem(title: "Edit", action: nil, keyEquivalent: "")
         let editMenu = NSMenu(title: "Edit")
@@ -290,6 +294,7 @@ final class CmuxWebViewKeyDownReentryTests: XCTestCase {
         mainMenu.setSubmenu(editMenu, for: editItem)
         _ = NSApplication.shared
         NSApp.mainMenu = mainMenu
+        return previousMenu
     }
 
     private func makeKeyDownEvent(

--- a/cmuxTests/CmuxWebViewKeyDownReentryTests.swift
+++ b/cmuxTests/CmuxWebViewKeyDownReentryTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+import Carbon.HIToolbox
 import WebKit
 import ObjectiveC.runtime
 
@@ -117,6 +118,68 @@ final class CmuxWebViewKeyDownReentryTests: XCTestCase {
             }
 
             XCTAssertFalse(handled)
+            XCTAssertTrue(keyDownEvents().isEmpty)
+        }
+    }
+
+    @MainActor
+    func testBrowserUndoRedoFallsBackToBrowserKeyDownWhenWebKitDeclines() {
+        withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
+
+            var performKeyEquivalentEvents: [NSEvent] = []
+            cmuxUnitTestWKWebViewPerformKeyEquivalentHook = { currentWebView, event in
+                guard currentWebView.window === window else { return nil }
+                performKeyEquivalentEvents.append(event)
+                return false
+            }
+            defer { cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil }
+
+            guard let event = makeKeyDownEvent(
+                key: "z",
+                modifiers: [.command],
+                keyCode: UInt16(kVK_ANSI_Z),
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct Undo event")
+                return
+            }
+
+            XCTAssertTrue(window.performKeyEquivalent(with: event))
+            XCTAssertEqual(performKeyEquivalentEvents.map(\.keyCode), [UInt16(kVK_ANSI_Z)])
+            XCTAssertEqual(keyDownEvents().map(\.keyCode), [UInt16(kVK_ANSI_Z)])
+        }
+    }
+
+    @MainActor
+    func testBrowserUndoRedoDoesNotRouteDuringWebKitKeyDownReentry() {
+        withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
+
+            var performKeyEquivalentEvents: [NSEvent] = []
+            cmuxUnitTestWKWebViewPerformKeyEquivalentHook = { currentWebView, event in
+                guard currentWebView.window === window else { return nil }
+                performKeyEquivalentEvents.append(event)
+                return false
+            }
+            defer { cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil }
+
+            guard let event = makeKeyDownEvent(
+                key: "z",
+                modifiers: [.command],
+                keyCode: UInt16(kVK_ANSI_Z),
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct Undo event")
+                return
+            }
+
+            let handled = cmuxWithBrowserWebKitKeyDownDispatch {
+                window.performKeyEquivalent(with: event)
+            }
+
+            XCTAssertTrue(handled)
+            XCTAssertTrue(performKeyEquivalentEvents.isEmpty)
             XCTAssertTrue(keyDownEvents().isEmpty)
         }
     }

--- a/cmuxTests/CmuxWebViewKeyDownReentryTests.swift
+++ b/cmuxTests/CmuxWebViewKeyDownReentryTests.swift
@@ -13,6 +13,17 @@ import ObjectiveC.runtime
 private var cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled = false
 private var cmuxUnitTestCmuxWebViewKeyDownHook: ((CmuxWebView, NSEvent) -> Bool)?
 
+private final class FakeWKInspectorUndoResponderView: NSView {}
+
+private final class BrowserUndoMenuActionSpy: NSObject {
+    private(set) var invoked = false
+
+    @objc func didInvoke(_ sender: Any?) {
+        _ = sender
+        invoked = true
+    }
+}
+
 extension CmuxWebView {
     @objc func cmuxUnitTest_keyDown(with event: NSEvent) {
         if cmuxUnitTestCmuxWebViewKeyDownHook?(self, event) == true {
@@ -185,6 +196,47 @@ final class CmuxWebViewKeyDownReentryTests: XCTestCase {
     }
 
     @MainActor
+    func testBrowserUndoRedoDoesNotBypassMenuWhenWebInspectorResponderIsFocused() {
+        withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
+
+            let spy = BrowserUndoMenuActionSpy()
+            installUndoMenu(target: spy)
+
+            guard let webView = window.contentView?.subviews.compactMap({ $0 as? CmuxWebView }).first else {
+                XCTFail("Failed to find hosted CmuxWebView")
+                return
+            }
+            let inspectorView = FakeWKInspectorUndoResponderView(frame: NSRect(x: 0, y: 0, width: 32, height: 20))
+            webView.addSubview(inspectorView)
+
+            var performKeyEquivalentEvents: [NSEvent] = []
+            cmuxUnitTestWKWebViewPerformKeyEquivalentHook = { currentWebView, event in
+                guard currentWebView === webView else { return nil }
+                performKeyEquivalentEvents.append(event)
+                return true
+            }
+            defer { cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil }
+
+            XCTAssertTrue(window.makeFirstResponder(inspectorView))
+            guard let event = makeKeyDownEvent(
+                key: "z",
+                modifiers: [.command],
+                keyCode: UInt16(kVK_ANSI_Z),
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct Undo event")
+                return
+            }
+
+            XCTAssertTrue(window.performKeyEquivalent(with: event))
+            XCTAssertTrue(spy.invoked)
+            XCTAssertTrue(performKeyEquivalentEvents.isEmpty)
+            XCTAssertTrue(keyDownEvents().isEmpty)
+        }
+    }
+
+    @MainActor
     private func withHookedBrowserKeyDownWindow(
         _ body: (NSWindow, () -> [NSEvent]) -> Void
     ) {
@@ -220,6 +272,24 @@ final class CmuxWebViewKeyDownReentryTests: XCTestCase {
 
         XCTAssertTrue(window.makeFirstResponder(webView))
         body(window, { keyDownEvents })
+    }
+
+    private func installUndoMenu(target: NSObject) {
+        let mainMenu = NSMenu()
+        let editItem = NSMenuItem(title: "Edit", action: nil, keyEquivalent: "")
+        let editMenu = NSMenu(title: "Edit")
+        let undoItem = NSMenuItem(
+            title: "Undo",
+            action: #selector(BrowserUndoMenuActionSpy.didInvoke(_:)),
+            keyEquivalent: "z"
+        )
+        undoItem.keyEquivalentModifierMask = [.command]
+        undoItem.target = target
+        editMenu.addItem(undoItem)
+        mainMenu.addItem(editItem)
+        mainMenu.setSubmenu(editMenu, for: editItem)
+        _ = NSApplication.shared
+        NSApp.mainMenu = mainMenu
     }
 
     private func makeKeyDownEvent(

--- a/cmuxTests/CmuxWebViewKeyDownReentryTests.swift
+++ b/cmuxTests/CmuxWebViewKeyDownReentryTests.swift
@@ -1,6 +1,6 @@
-import XCTest
 import AppKit
 import Carbon.HIToolbox
+import Testing
 import WebKit
 import ObjectiveC.runtime
 
@@ -50,94 +50,88 @@ private func installCmuxUnitTestCmuxWebViewKeyDownOverride() {
     cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled = true
 }
 
-final class CmuxWebViewKeyDownReentryTests: XCTestCase {
+@Suite(.serialized)
+final class CmuxWebViewKeyDownReentryTests {
+    @Test
     @MainActor
-    func testPrintableOptionTextRoutesToBrowserKeyDownOnce() {
-        withHookedBrowserKeyDownWindow { window, keyDownEvents in
-            guard let event = makeKeyDownEvent(
+    func printableOptionTextRoutesToBrowserKeyDownOnce() throws {
+        try withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            let event = try #require(makeKeyDownEvent(
                 key: "å",
                 modifiers: [.option],
                 keyCode: 0,
                 windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct printable Option event")
-                return
-            }
+            ))
 
-            XCTAssertTrue(window.performKeyEquivalent(with: event))
-            XCTAssertEqual(keyDownEvents().map(\.keyCode), [0])
+            #expect(window.performKeyEquivalent(with: event))
+            #expect(keyDownEvents().map(\.keyCode) == [0])
         }
     }
 
+    @Test
     @MainActor
-    func testPrintableOptionTextDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
-        withHookedBrowserKeyDownWindow { window, keyDownEvents in
-            guard let event = makeKeyDownEvent(
+    func printableOptionTextDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() throws {
+        try withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            let event = try #require(makeKeyDownEvent(
                 key: "å",
                 modifiers: [.option],
                 keyCode: 0,
                 windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct printable Option event")
-                return
-            }
+            ))
 
             let handled = cmuxWithBrowserWebKitKeyDownDispatch {
                 window.performKeyEquivalent(with: event)
             }
 
-            XCTAssertFalse(handled)
-            XCTAssertTrue(keyDownEvents().isEmpty)
+            #expect(!handled)
+            #expect(keyDownEvents().isEmpty)
         }
     }
 
+    @Test
     @MainActor
-    func testBrowserReturnDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
-        withHookedBrowserKeyDownWindow { window, keyDownEvents in
-            guard let event = makeKeyDownEvent(
+    func browserReturnDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() throws {
+        try withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            let event = try #require(makeKeyDownEvent(
                 key: "\r",
                 modifiers: [],
                 keyCode: 36,
                 windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct Return event")
-                return
-            }
+            ))
 
             let handled = cmuxWithBrowserWebKitKeyDownDispatch {
                 window.performKeyEquivalent(with: event)
             }
 
-            XCTAssertFalse(handled)
-            XCTAssertTrue(keyDownEvents().isEmpty)
+            #expect(!handled)
+            #expect(keyDownEvents().isEmpty)
         }
     }
 
+    @Test
     @MainActor
-    func testBrowserArrowDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
-        withHookedBrowserKeyDownWindow { window, keyDownEvents in
-            guard let event = makeKeyDownEvent(
+    func browserArrowDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() throws {
+        try withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            let event = try #require(makeKeyDownEvent(
                 key: "\u{F701}",
                 modifiers: [],
                 keyCode: 125,
                 windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct Down Arrow event")
-                return
-            }
+            ))
 
             let handled = cmuxWithBrowserWebKitKeyDownDispatch {
                 window.performKeyEquivalent(with: event)
             }
 
-            XCTAssertFalse(handled)
-            XCTAssertTrue(keyDownEvents().isEmpty)
+            #expect(!handled)
+            #expect(keyDownEvents().isEmpty)
         }
     }
 
+    @Test
     @MainActor
-    func testBrowserUndoRedoFallsBackToBrowserKeyDownWhenWebKitDeclines() {
-        withHookedBrowserKeyDownWindow { window, keyDownEvents in
+    func browserUndoRedoFallsBackToBrowserKeyDownWhenWebKitDeclines() throws {
+        try withHookedBrowserKeyDownWindow { window, keyDownEvents in
             installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
 
             var performKeyEquivalentEvents: [NSEvent] = []
@@ -148,25 +142,23 @@ final class CmuxWebViewKeyDownReentryTests: XCTestCase {
             }
             defer { cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil }
 
-            guard let event = makeKeyDownEvent(
+            let event = try #require(makeKeyDownEvent(
                 key: "z",
                 modifiers: [.command],
                 keyCode: UInt16(kVK_ANSI_Z),
                 windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct Undo event")
-                return
-            }
+            ))
 
-            XCTAssertTrue(window.performKeyEquivalent(with: event))
-            XCTAssertEqual(performKeyEquivalentEvents.map(\.keyCode), [UInt16(kVK_ANSI_Z)])
-            XCTAssertEqual(keyDownEvents().map(\.keyCode), [UInt16(kVK_ANSI_Z)])
+            #expect(window.performKeyEquivalent(with: event))
+            #expect(performKeyEquivalentEvents.map(\.keyCode) == [UInt16(kVK_ANSI_Z)])
+            #expect(keyDownEvents().map(\.keyCode) == [UInt16(kVK_ANSI_Z)])
         }
     }
 
+    @Test
     @MainActor
-    func testBrowserUndoRedoDoesNotRouteDuringWebKitKeyDownReentry() {
-        withHookedBrowserKeyDownWindow { window, keyDownEvents in
+    func browserUndoRedoDoesNotRouteDuringWebKitKeyDownReentry() throws {
+        try withHookedBrowserKeyDownWindow { window, keyDownEvents in
             installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
 
             var performKeyEquivalentEvents: [NSEvent] = []
@@ -177,39 +169,34 @@ final class CmuxWebViewKeyDownReentryTests: XCTestCase {
             }
             defer { cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil }
 
-            guard let event = makeKeyDownEvent(
+            let event = try #require(makeKeyDownEvent(
                 key: "z",
                 modifiers: [.command],
                 keyCode: UInt16(kVK_ANSI_Z),
                 windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct Undo event")
-                return
-            }
+            ))
 
             let handled = cmuxWithBrowserWebKitKeyDownDispatch {
                 window.performKeyEquivalent(with: event)
             }
 
-            XCTAssertTrue(handled)
-            XCTAssertTrue(performKeyEquivalentEvents.isEmpty)
-            XCTAssertTrue(keyDownEvents().isEmpty)
+            #expect(handled)
+            #expect(performKeyEquivalentEvents.isEmpty)
+            #expect(keyDownEvents().isEmpty)
         }
     }
 
+    @Test
     @MainActor
-    func testBrowserUndoRedoDoesNotBypassMenuWhenWebInspectorResponderIsFocused() {
-        withHookedBrowserKeyDownWindow { window, keyDownEvents in
+    func browserUndoRedoDoesNotBypassMenuWhenWebInspectorResponderIsFocused() throws {
+        try withHookedBrowserKeyDownWindow { window, keyDownEvents in
             installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
 
             let spy = BrowserUndoMenuActionSpy()
             let previousMenu = installUndoMenu(target: spy)
             defer { NSApp.mainMenu = previousMenu }
 
-            guard let webView = window.contentView?.subviews.compactMap({ $0 as? CmuxWebView }).first else {
-                XCTFail("Failed to find hosted CmuxWebView")
-                return
-            }
+            let webView = try #require(window.contentView?.subviews.compactMap { $0 as? CmuxWebView }.first)
             let inspectorView = FakeWKInspectorUndoResponderView(frame: NSRect(x: 0, y: 0, width: 32, height: 20))
             webView.addSubview(inspectorView)
 
@@ -221,28 +208,25 @@ final class CmuxWebViewKeyDownReentryTests: XCTestCase {
             }
             defer { cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil }
 
-            XCTAssertTrue(window.makeFirstResponder(inspectorView))
-            guard let event = makeKeyDownEvent(
+            #expect(window.makeFirstResponder(inspectorView))
+            let event = try #require(makeKeyDownEvent(
                 key: "z",
                 modifiers: [.command],
                 keyCode: UInt16(kVK_ANSI_Z),
                 windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct Undo event")
-                return
-            }
+            ))
 
-            XCTAssertTrue(window.performKeyEquivalent(with: event))
-            XCTAssertTrue(spy.invoked)
-            XCTAssertTrue(performKeyEquivalentEvents.isEmpty)
-            XCTAssertTrue(keyDownEvents().isEmpty)
+            #expect(window.performKeyEquivalent(with: event))
+            #expect(spy.invoked)
+            #expect(performKeyEquivalentEvents.isEmpty)
+            #expect(keyDownEvents().isEmpty)
         }
     }
 
     @MainActor
     private func withHookedBrowserKeyDownWindow(
-        _ body: (NSWindow, () -> [NSEvent]) -> Void
-    ) {
+        _ body: (NSWindow, () -> [NSEvent]) throws -> Void
+    ) rethrows {
         _ = NSApplication.shared
         AppDelegate.installWindowResponderSwizzlesForTesting()
         installCmuxUnitTestCmuxWebViewKeyDownOverride()
@@ -273,8 +257,8 @@ final class CmuxWebViewKeyDownReentryTests: XCTestCase {
             window.orderOut(nil)
         }
 
-        XCTAssertTrue(window.makeFirstResponder(webView))
-        body(window, { keyDownEvents })
+        #expect(window.makeFirstResponder(webView))
+        try body(window, { keyDownEvents })
     }
 
     private func installUndoMenu(target: NSObject) -> NSMenu? {

--- a/cmuxTests/WindowKeyDownReplayGuardTests.swift
+++ b/cmuxTests/WindowKeyDownReplayGuardTests.swift
@@ -50,6 +50,14 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         }
     }
 
+    private final class EditableUndoProbeTextView: NSTextView {
+        private(set) var undoCallCount = 0
+
+        @objc func undo(_ sender: Any?) {
+            undoCallCount += 1
+        }
+    }
+
     private final class MenuActionProbe: NSObject {
         private(set) var callCount = 0
 
@@ -88,6 +96,26 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         container.addSubview(terminal)
         XCTAssertTrue(window.makeFirstResponder(terminal))
         return (window, terminal)
+    }
+
+    private func makeWindowWithTerminalHostedEditableResponder()
+        -> (NSWindow, TerminalCommandEquivalentProbeView, EditableUndoProbeTextView) {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let terminal = TerminalCommandEquivalentProbeView(frame: NSRect(x: 0, y: 0, width: 128, height: 64))
+        let textView = EditableUndoProbeTextView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        textView.isEditable = true
+        terminal.addSubview(textView)
+        container.addSubview(terminal)
+        XCTAssertTrue(window.makeFirstResponder(textView))
+        return (window, terminal, textView)
     }
 
     private func makeCommandZKeyDownEvent(
@@ -130,6 +158,16 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         redoItem.target = probe
         menu.addItem(redoItem)
 
+        NSApp.mainMenu = menu
+        return previousMenu
+    }
+
+    private func installResponderChainUndoMenu() -> NSMenu? {
+        let previousMenu = NSApp.mainMenu
+        let menu = NSMenu(title: "Main")
+        let undoItem = NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        undoItem.keyEquivalentModifierMask = [.command]
+        menu.addItem(undoItem)
         NSApp.mainMenu = menu
         return previousMenu
     }
@@ -260,5 +298,28 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
             ["z", "z"],
             "Undo/Redo command equivalents should be routed to the terminal shortcut path instead"
         )
+    }
+
+    func testTerminalHostedEditableResponderKeepsLocalUndo() {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let previousMenu = installResponderChainUndoMenu()
+        defer { NSApp.mainMenu = previousMenu }
+
+        let (window, terminal, textView) = makeWindowWithTerminalHostedEditableResponder()
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        guard let event = makeCommandZKeyDownEvent(modifiers: [.command], windowNumber: window.windowNumber) else {
+            XCTFail("Failed to construct Undo key event")
+            return
+        }
+
+        XCTAssertTrue(window.performKeyEquivalent(with: event))
+        XCTAssertEqual(textView.undoCallCount, 1)
+        XCTAssertTrue(terminal.afterMenuMissEvents.isEmpty)
     }
 }

--- a/cmuxTests/WindowKeyDownReplayGuardTests.swift
+++ b/cmuxTests/WindowKeyDownReplayGuardTests.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Carbon.HIToolbox
 import CmuxTerminal
-import XCTest
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -20,7 +20,8 @@ import XCTest
 /// a replay guard at the dispatch chokepoint the event ping-pongs forever and
 /// overflows the main-thread stack.
 @MainActor
-final class WindowKeyDownReplayGuardTests: XCTestCase {
+@Suite(.serialized)
+struct WindowKeyDownReplayGuardTests {
 
     /// First responder stub that models the re-entrant AppKit behavior: an
     /// unhandled keyDown flows back into `NSWindow.performKeyEquivalent` with
@@ -78,7 +79,7 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
 
         let responder = ReplayingKeyDownView(frame: NSRect(x: 0, y: 0, width: 64, height: 32))
         container.addSubview(responder)
-        XCTAssertTrue(window.makeFirstResponder(responder))
+        #expect(window.makeFirstResponder(responder))
         return (window, responder)
     }
 
@@ -94,7 +95,7 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
 
         let terminal = TerminalCommandEquivalentProbeView(frame: NSRect(x: 0, y: 0, width: 64, height: 32))
         container.addSubview(terminal)
-        XCTAssertTrue(window.makeFirstResponder(terminal))
+        #expect(window.makeFirstResponder(terminal))
         return (window, terminal)
     }
 
@@ -114,7 +115,7 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         textView.isEditable = true
         terminal.addSubview(textView)
         container.addSubview(terminal)
-        XCTAssertTrue(window.makeFirstResponder(textView))
+        #expect(window.makeFirstResponder(textView))
         return (window, terminal, textView)
     }
 
@@ -194,20 +195,20 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         )
     }
 
-    func testPrintableOptionTextKeyDownIsForceDispatchedExactlyOncePerEvent() {
+    @Test
+    func printableOptionTextKeyDownIsForceDispatchedExactlyOncePerEvent() {
         _ = NSApplication.shared
         AppDelegate.installWindowResponderSwizzlesForTesting()
 
         let (window, responder) = makeWindowWithReplayingResponder()
         guard let event = makeOptionTextKeyDownEvent(windowNumber: window.windowNumber) else {
-            XCTFail("Failed to construct Option+A key event")
+            Issue.record("Failed to construct Option+A key event")
             return
         }
 
-        XCTAssertTrue(window.performKeyEquivalent(with: event))
-        XCTAssertEqual(
-            responder.keyDownEvents.count,
-            1,
+        #expect(window.performKeyEquivalent(with: event))
+        #expect(
+            responder.keyDownEvents.count == 1,
             "The same in-flight key event must not be force-dispatched into keyDown again " +
             "while the first dispatch is still on the stack; unbounded re-dispatch is the " +
             "infinite key-routing loop from " +
@@ -215,7 +216,8 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         )
     }
 
-    func testDistinctKeyDownEventsAreEachForceDispatched() {
+    @Test
+    func distinctKeyDownEventsAreEachForceDispatched() {
         _ = NSApplication.shared
         AppDelegate.installWindowResponderSwizzlesForTesting()
 
@@ -233,18 +235,19 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
                 timestamp: baseTimestamp + 0.05
             )
         else {
-            XCTFail("Failed to construct Option+A key events")
+            Issue.record("Failed to construct Option+A key events")
             return
         }
 
         // Distinct events (key autorepeat, repeat typing) must each be
         // force-dispatched; the replay guard is per-event, not a throttle.
-        XCTAssertTrue(window.performKeyEquivalent(with: first))
-        XCTAssertTrue(window.performKeyEquivalent(with: second))
-        XCTAssertEqual(responder.keyDownEvents.count, 2)
+        #expect(window.performKeyEquivalent(with: first))
+        #expect(window.performKeyEquivalent(with: second))
+        #expect(responder.keyDownEvents.count == 2)
     }
 
-    func testSameEventIsForceDispatchedAgainAfterPriorDispatchUnwinds() {
+    @Test
+    func sameEventIsForceDispatchedAgainAfterPriorDispatchUnwinds() {
         _ = NSApplication.shared
         AppDelegate.installWindowResponderSwizzlesForTesting()
 
@@ -252,19 +255,20 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         responder.replaysRemaining = 0
 
         guard let event = makeOptionTextKeyDownEvent(windowNumber: window.windowNumber) else {
-            XCTFail("Failed to construct Option+A key event")
+            Issue.record("Failed to construct Option+A key event")
             return
         }
 
         // WebKit legitimately re-sends an unhandled key event through
         // NSApp.sendEvent after the original dispatch has fully unwound. The
         // guard is stack-scoped, so the same event must dispatch again here.
-        XCTAssertTrue(window.performKeyEquivalent(with: event))
-        XCTAssertTrue(window.performKeyEquivalent(with: event))
-        XCTAssertEqual(responder.keyDownEvents.count, 2)
+        #expect(window.performKeyEquivalent(with: event))
+        #expect(window.performKeyEquivalent(with: event))
+        #expect(responder.keyDownEvents.count == 2)
     }
 
-    func testTerminalUndoRedoCommandEquivalentsBypassAppKitUndoMenu() {
+    @Test
+    func terminalUndoRedoCommandEquivalentsBypassAppKitUndoMenu() {
         _ = NSApplication.shared
         AppDelegate.installWindowResponderSwizzlesForTesting()
 
@@ -280,27 +284,26 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
 
         for modifiers in [[.command], [.command, .shift]] as [NSEvent.ModifierFlags] {
             guard let event = makeCommandZKeyDownEvent(modifiers: modifiers, windowNumber: window.windowNumber) else {
-                XCTFail("Failed to construct Undo/Redo key event")
+                Issue.record("Failed to construct Undo/Redo key event")
                 return
             }
 
-            XCTAssertTrue(window.performKeyEquivalent(with: event))
+            #expect(window.performKeyEquivalent(with: event))
         }
 
-        XCTAssertEqual(
-            probe.callCount,
-            0,
+        #expect(
+            probe.callCount == 0,
             "Terminal-focused Cmd+Z/Cmd+Shift+Z must not invoke AppKit menu Undo/Redo; " +
             "that path can dispatch a stale NSUndoManager target and crash in _NSUndoStack.popAndInvoke"
         )
-        XCTAssertEqual(
-            terminal.afterMenuMissEvents.map { $0.charactersIgnoringModifiers },
-            ["z", "z"],
+        #expect(
+            terminal.afterMenuMissEvents.map { $0.charactersIgnoringModifiers } == ["z", "z"],
             "Undo/Redo command equivalents should be routed to the terminal shortcut path instead"
         )
     }
 
-    func testTerminalHostedEditableResponderKeepsLocalUndo() {
+    @Test
+    func terminalHostedEditableResponderKeepsLocalUndo() {
         _ = NSApplication.shared
         AppDelegate.installWindowResponderSwizzlesForTesting()
 
@@ -314,12 +317,12 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         }
 
         guard let event = makeCommandZKeyDownEvent(modifiers: [.command], windowNumber: window.windowNumber) else {
-            XCTFail("Failed to construct Undo key event")
+            Issue.record("Failed to construct Undo key event")
             return
         }
 
-        XCTAssertTrue(window.performKeyEquivalent(with: event))
-        XCTAssertEqual(textView.undoCallCount, 1)
-        XCTAssertTrue(terminal.afterMenuMissEvents.isEmpty)
+        #expect(window.performKeyEquivalent(with: event))
+        #expect(textView.undoCallCount == 1)
+        #expect(terminal.afterMenuMissEvents.isEmpty)
     }
 }

--- a/cmuxTests/WindowKeyDownReplayGuardTests.swift
+++ b/cmuxTests/WindowKeyDownReplayGuardTests.swift
@@ -172,7 +172,11 @@ struct WindowKeyDownReplayGuardTests {
     private func installResponderChainUndoMenu() -> NSMenu? {
         let previousMenu = NSApp.mainMenu
         let menu = NSMenu(title: "Main")
-        let undoItem = NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        let undoItem = NSMenuItem(
+            title: "Undo",
+            action: #selector(EditableUndoProbeTextView.undo(_:)),
+            keyEquivalent: "z"
+        )
         undoItem.keyEquivalentModifierMask = [.command]
         menu.addItem(undoItem)
         NSApp.mainMenu = menu
@@ -215,10 +219,7 @@ struct WindowKeyDownReplayGuardTests {
         #expect(window.performKeyEquivalent(with: event))
         #expect(
             responder.keyDownEvents.count == 1,
-            "The same in-flight key event must not be force-dispatched into keyDown again " +
-            "while the first dispatch is still on the stack; unbounded re-dispatch is the " +
-            "infinite key-routing loop from " +
-            "https://github.com/manaflow-ai/cmux/issues/5887"
+            Comment(rawValue: "The same in-flight key event must not be force-dispatched into keyDown again while the first dispatch is still on the stack; unbounded re-dispatch is the infinite key-routing loop from https://github.com/manaflow-ai/cmux/issues/5887")
         )
     }
 
@@ -299,8 +300,7 @@ struct WindowKeyDownReplayGuardTests {
 
         #expect(
             probe.callCount == 0,
-            "Terminal-focused Cmd+Z/Cmd+Shift+Z must not invoke AppKit menu Undo/Redo; " +
-            "that path can dispatch a stale NSUndoManager target and crash in _NSUndoStack.popAndInvoke"
+            Comment(rawValue: "Terminal-focused Cmd+Z/Cmd+Shift+Z must not invoke AppKit menu Undo/Redo; that path can dispatch a stale NSUndoManager target and crash in _NSUndoStack.popAndInvoke")
         )
         #expect(
             terminal.afterMenuMissEvents.map { $0.charactersIgnoringModifiers } == ["z", "z"],

--- a/cmuxTests/WindowKeyDownReplayGuardTests.swift
+++ b/cmuxTests/WindowKeyDownReplayGuardTests.swift
@@ -1,4 +1,6 @@
 import AppKit
+import Carbon.HIToolbox
+import CmuxTerminal
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -39,6 +41,23 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         }
     }
 
+    private final class TerminalCommandEquivalentProbeView: GhosttyNSView {
+        private(set) var afterMenuMissEvents: [NSEvent] = []
+
+        override func performKeyEquivalentAfterMenuMiss(with event: NSEvent) -> Bool {
+            afterMenuMissEvents.append(event)
+            return true
+        }
+    }
+
+    private final class MenuActionProbe: NSObject {
+        private(set) var callCount = 0
+
+        @objc func perform(_ sender: Any?) {
+            callCount += 1
+        }
+    }
+
     private func makeWindowWithReplayingResponder() -> (NSWindow, ReplayingKeyDownView) {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
@@ -53,6 +72,66 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         container.addSubview(responder)
         XCTAssertTrue(window.makeFirstResponder(responder))
         return (window, responder)
+    }
+
+    private func makeWindowWithTerminalResponder() -> (NSWindow, TerminalCommandEquivalentProbeView) {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let terminal = TerminalCommandEquivalentProbeView(frame: NSRect(x: 0, y: 0, width: 64, height: 32))
+        container.addSubview(terminal)
+        XCTAssertTrue(window.makeFirstResponder(terminal))
+        return (window, terminal)
+    }
+
+    private func makeCommandZKeyDownEvent(
+        modifiers: NSEvent.ModifierFlags,
+        windowNumber: Int
+    ) -> NSEvent? {
+        let characters = modifiers.contains(.shift) ? "Z" : "z"
+        return NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: windowNumber,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: "z",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_Z)
+        )
+    }
+
+    private func installUndoMenu(probe: MenuActionProbe) -> NSMenu? {
+        let previousMenu = NSApp.mainMenu
+        let menu = NSMenu(title: "Main")
+        let undoItem = NSMenuItem(
+            title: "Undo",
+            action: #selector(MenuActionProbe.perform(_:)),
+            keyEquivalent: "z"
+        )
+        undoItem.keyEquivalentModifierMask = [.command]
+        undoItem.target = probe
+        menu.addItem(undoItem)
+
+        let redoItem = NSMenuItem(
+            title: "Redo",
+            action: #selector(MenuActionProbe.perform(_:)),
+            keyEquivalent: "Z"
+        )
+        redoItem.keyEquivalentModifierMask = [.command, .shift]
+        redoItem.target = probe
+        menu.addItem(redoItem)
+
+        NSApp.mainMenu = menu
+        return previousMenu
     }
 
     /// Option+A producing printable text ("å"). The printable-Option-text
@@ -145,5 +224,41 @@ final class WindowKeyDownReplayGuardTests: XCTestCase {
         XCTAssertTrue(window.performKeyEquivalent(with: event))
         XCTAssertTrue(window.performKeyEquivalent(with: event))
         XCTAssertEqual(responder.keyDownEvents.count, 2)
+    }
+
+    func testTerminalUndoRedoCommandEquivalentsBypassAppKitUndoMenu() {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let probe = MenuActionProbe()
+        let previousMenu = installUndoMenu(probe: probe)
+        defer { NSApp.mainMenu = previousMenu }
+
+        let (window, terminal) = makeWindowWithTerminalResponder()
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        for modifiers in [[.command], [.command, .shift]] as [NSEvent.ModifierFlags] {
+            guard let event = makeCommandZKeyDownEvent(modifiers: modifiers, windowNumber: window.windowNumber) else {
+                XCTFail("Failed to construct Undo/Redo key event")
+                return
+            }
+
+            XCTAssertTrue(window.performKeyEquivalent(with: event))
+        }
+
+        XCTAssertEqual(
+            probe.callCount,
+            0,
+            "Terminal-focused Cmd+Z/Cmd+Shift+Z must not invoke AppKit menu Undo/Redo; " +
+            "that path can dispatch a stale NSUndoManager target and crash in _NSUndoStack.popAndInvoke"
+        )
+        XCTAssertEqual(
+            terminal.afterMenuMissEvents.map { $0.charactersIgnoringModifiers },
+            ["z", "z"],
+            "Undo/Redo command equivalents should be routed to the terminal shortcut path instead"
+        )
     }
 }

--- a/cmuxTests/WindowKeyDownReplayGuardTests.swift
+++ b/cmuxTests/WindowKeyDownReplayGuardTests.swift
@@ -44,10 +44,16 @@ struct WindowKeyDownReplayGuardTests {
 
     private final class TerminalCommandEquivalentProbeView: GhosttyNSView {
         private(set) var afterMenuMissEvents: [NSEvent] = []
+        private(set) var keyDownEvents: [NSEvent] = []
+        var performAfterMenuMissResult = true
 
         override func performKeyEquivalentAfterMenuMiss(with event: NSEvent) -> Bool {
             afterMenuMissEvents.append(event)
-            return true
+            return performAfterMenuMissResult
+        }
+
+        override func keyDown(with event: NSEvent) {
+            keyDownEvents.append(event)
         }
     }
 
@@ -324,5 +330,32 @@ struct WindowKeyDownReplayGuardTests {
         #expect(window.performKeyEquivalent(with: event))
         #expect(textView.undoCallCount == 1)
         #expect(terminal.afterMenuMissEvents.isEmpty)
+    }
+
+    @Test
+    func terminalDeclinedUndoCommandFallsBackToTerminalKeyDownWithoutLocalUndo() {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let previousMenu = installResponderChainUndoMenu()
+        defer { NSApp.mainMenu = previousMenu }
+
+        let (window, terminal, textView) = makeWindowWithTerminalHostedEditableResponder()
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+        terminal.performAfterMenuMissResult = false
+        #expect(window.makeFirstResponder(terminal))
+
+        guard let event = makeCommandZKeyDownEvent(modifiers: [.command], windowNumber: window.windowNumber) else {
+            Issue.record("Failed to construct Undo key event")
+            return
+        }
+
+        #expect(window.performKeyEquivalent(with: event))
+        #expect(terminal.afterMenuMissEvents.map { $0.charactersIgnoringModifiers } == ["z"])
+        #expect(terminal.keyDownEvents.map { $0.charactersIgnoringModifiers } == ["z"])
+        #expect(textView.undoCallCount == 0)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/7272

## Summary
- Add a behavior-level regression covering terminal-focused Cmd+Z/Cmd+Shift+Z bypassing the AppKit Undo/Redo menu path.
- Route terminal/browser-focused Cmd+Z and Cmd+Shift+Z before the AppKit main menu can dispatch Undo/Redo to a stale NSUndoManager target.
- Preserve native AppKit text editing Undo/Redo by only intercepting the terminal Ghostty view and cmux browser WebView focus paths.

## Test plan
- `CMUX_TEST_DESTINATION='platform=macOS' ./scripts/test-unit.sh -derivedDataPath /tmp/cmux-issue-7272-undo-segfault CMUX_SKIP_ZIG_BUILD=1 build`
- `git diff --check`
- `python3 scripts/swift_file_length_budget.py`
- `./scripts/reload.sh --tag issue-7272-undo-segfault`

## Notes
- The exact stale Objective-C undo-target EXC_BAD_ACCESS/PAC failure is not deterministic enough to assert directly in a unit test. The regression instead covers the routing condition that allowed terminal Cmd+Z to reach AppKit menu Undo/Redo.
- No local XCUITests or app-hosted test loops were run per issue instructions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786083010&installation_id=133855650&pr_number=7598&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7598&signature=bb19a1a7687160cca64652a824f9c0deeb688002a359069356cc3b73fbec3578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global keyboard routing on the main thread for undo/redo across terminal and WebKit surfaces; mistakes could break undo in browsers, terminals, or native text fields, though behavior is heavily regression-tested.
> 
> **Overview**
> **Fixes undo shortcut crashes** (#7272) by intercepting **Cmd+Z** and **Cmd+Shift+Z** in window key-equivalent handling *before* the AppKit Edit menu can run Undo/Redo against a stale `NSUndoManager` target when focus is on the terminal or in-app browser.
> 
> Adds **`NSEvent.cmuxIsUndoRedoCommandEquivalent`** (layout-normalized **z**) and **`cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit`**, wired from the swizzled **`performKeyEquivalent`** path. Terminal focus uses **`performKeyEquivalentAfterMenuMiss`** with a one-shot **`keyDown`** fallback; browser focus uses **`CmuxWebView.performKeyEquivalent`** / **`keyDown`**, suppresses routing during WebKit **`keyDown`** re-entry, and **does not** fall through to AppKit Undo for generic browser focus. **Editable `NSTextView`/`NSTextField`** and **Web Inspector** first responders are left on native undo paths.
> 
> **`CmuxWebView`** now treats undo/redo like other browser-first command equivalents (WebKit before main menu) except when the inspector should own them. Regression tests move to **Swift Testing** and cover menu bypass, **`keyDown`** fallback, re-entry suppression, inspector menu undo, and terminal-hosted editable undo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf18ae8c925eba998ddde6be79be4d2b67113086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes from Cmd+Z/Cmd+Shift+Z by routing undo/redo to the terminal or in‑app browser when focused, before the AppKit menu can hit a stale undo target (fixes #7272). Native text fields and the Web Inspector keep their own undo/redo, including editable fields inside the terminal.

- **Bug Fixes**
  - Early‑route Cmd+Z/Cmd+Shift+Z in `NSWindow.performKeyEquivalent` via `cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit`; detect with `NSEvent.cmuxIsUndoRedoCommandEquivalent` (layout‑normalized "z"). Preserve local undo for editable `NSTextView`/`NSTextField` and the Web Inspector; send to `GhosttyNSView.performKeyEquivalentAfterMenuMiss` or `CmuxWebView`; suppress during WebKit `keyDown` reentry; fall back to one‑shot `keyDown` when declined. Documented invariant: generic browser focus never falls through to AppKit Undo.
  - In `CmuxWebView`, handle undo/redo before the main menu unless the Web Inspector should own them; fall back to `keyDown` when WebKit declines.  
  - Tests: migrated replay‑guard and browser reentry suites to Swift Testing; added coverage for browser fallback/reentry, inspector menu path, terminal‑hosted editable local undo, and terminal keyDown fallback.

- **Refactors**
  - Moved undo routing helpers into `WindowKeyDownReplayGuard.swift` to keep `AppDelegate` within line budget.

<sup>Written for commit cf18ae8c925eba998ddde6be79be4d2b67113086. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Undo/Redo shortcut routing so Cmd+Z and Cmd+Shift+Z bypass standard app menu handling and are delivered to the active terminal or web content when appropriate.
  * Improved Cmd+Z/Cmd+Shift+Z detection and routing behavior across keyboard layouts.
  * Preserved local undo for editable focused fields; otherwise safely falls back to content key handling (including WebKit key-down reentry).
* **Tests**
  * Expanded regression coverage for terminal and web routing, menu bypass behavior, local undo invocation, and key-down reentry fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->