### PR TITLE
ci: SDK publish workflows (OIDC trusted publishing, tag-gated)

### DIFF
--- a/.github/workflows/sdk-publish-crates.yml
+++ b/.github/workflows/sdk-publish-crates.yml
@@ -1,0 +1,135 @@
+name: sdk publish crates
+
+on:
+  push:
+    tags:
+      - "mux-sdk-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SDK version to validate/publish, for example 0.1.0"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: sdk-publish-crates-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate tag and package versions
+        id: version
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            [[ "$GITHUB_REF_NAME" =~ ^mux-sdk-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "tag must match mux-sdk-vX.Y.Z" >&2
+              exit 1
+            }
+            version="${GITHUB_REF_NAME#mux-sdk-v}"
+          else
+            version="$DISPATCH_VERSION"
+            [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "workflow_dispatch version must match X.Y.Z" >&2
+              exit 1
+            }
+          fi
+          python3 - "$version" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+          root = pathlib.Path.cwd()
+          versions = {
+              "typescript package.json": json.loads((root / "mux/bindings/typescript/package.json").read_text())["version"],
+              "python pyproject.toml": tomllib.loads((root / "mux/bindings/python/pyproject.toml").read_text())["project"]["version"],
+              "rust Cargo.toml": tomllib.loads((root / "mux/bindings/rust/Cargo.toml").read_text())["package"]["version"],
+          }
+          mismatches = {name: got for name, got in versions.items() if got != expected}
+          if mismatches:
+              for name, got in mismatches.items():
+                  print(f"{name}: expected {expected}, got {got}", file=sys.stderr)
+              raise SystemExit(1)
+          print(f"All package versions match {expected}")
+          PY
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  bindings-e2e-rust:
+    needs: version
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev pkg-config
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Rust version
+        run: |
+          rustc --version || true
+          if ! command -v cargo >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Build mux server
+        working-directory: mux
+        run: cargo build -p mux-tui
+
+      - name: Python conformance fixtures
+        run: python3 mux/bindings/conformance/runner.py
+
+      - name: Rust binding e2e
+        run: bash mux/bindings/conformance/e2e.sh --require rust
+
+  publish:
+    needs: bindings-e2e-rust
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: crates-io
+      url: https://crates.io/crates/cmux-client
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Authenticate with crates.io trusted publishing
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish cmux-client
+        working-directory: mux
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p cmux-client --locked

--- a/.github/workflows/sdk-publish-crates.yml
+++ b/.github/workflows/sdk-publish-crates.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     outputs:
@@ -112,7 +112,7 @@ jobs:
 
   publish:
     needs: bindings-e2e-rust
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/sdk-publish-go.yml
+++ b/.github/workflows/sdk-publish-go.yml
@@ -1,0 +1,137 @@
+name: sdk publish go
+
+on:
+  push:
+    tags:
+      - "mux-sdk-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SDK version to validate, for example 0.1.0"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: sdk-publish-go-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate tag and package versions
+        id: version
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            [[ "$GITHUB_REF_NAME" =~ ^mux-sdk-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "tag must match mux-sdk-vX.Y.Z" >&2
+              exit 1
+            }
+            version="${GITHUB_REF_NAME#mux-sdk-v}"
+          else
+            version="$DISPATCH_VERSION"
+            [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "workflow_dispatch version must match X.Y.Z" >&2
+              exit 1
+            }
+          fi
+          python3 - "$version" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+          root = pathlib.Path.cwd()
+          versions = {
+              "typescript package.json": json.loads((root / "mux/bindings/typescript/package.json").read_text())["version"],
+              "python pyproject.toml": tomllib.loads((root / "mux/bindings/python/pyproject.toml").read_text())["project"]["version"],
+              "rust Cargo.toml": tomllib.loads((root / "mux/bindings/rust/Cargo.toml").read_text())["package"]["version"],
+          }
+          mismatches = {name: got for name, got in versions.items() if got != expected}
+          if mismatches:
+              for name, got in mismatches.items():
+                  print(f"{name}: expected {expected}, got {got}", file=sys.stderr)
+              raise SystemExit(1)
+          print(f"All package versions match {expected}")
+          PY
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  bindings-e2e-go:
+    needs: version
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev pkg-config
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Rust version
+        run: |
+          rustc --version || true
+          if ! command -v cargo >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.22.x"
+
+      - name: Build mux server
+        working-directory: mux
+        run: cargo build -p mux-tui
+
+      - name: Python conformance fixtures
+        run: python3 mux/bindings/conformance/runner.py
+
+      - name: Go binding e2e
+        run: bash mux/bindings/conformance/e2e.sh --require go
+
+  validate-go-module:
+    needs: bindings-e2e-go
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.22.x"
+
+      - name: Validate Go module
+        working-directory: mux/bindings/go
+        run: |
+          go build ./...
+          go vet ./...

--- a/.github/workflows/sdk-publish-go.yml
+++ b/.github/workflows/sdk-publish-go.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     outputs:
@@ -117,7 +117,7 @@ jobs:
 
   validate-go-module:
     needs: bindings-e2e-go
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/sdk-publish-java.yml
+++ b/.github/workflows/sdk-publish-java.yml
@@ -1,0 +1,130 @@
+name: sdk publish java
+
+on:
+  push:
+    tags:
+      - "mux-sdk-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SDK version to validate, for example 0.1.0"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: sdk-publish-java-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate tag and package versions
+        id: version
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            [[ "$GITHUB_REF_NAME" =~ ^mux-sdk-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "tag must match mux-sdk-vX.Y.Z" >&2
+              exit 1
+            }
+            version="${GITHUB_REF_NAME#mux-sdk-v}"
+          else
+            version="$DISPATCH_VERSION"
+            [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "workflow_dispatch version must match X.Y.Z" >&2
+              exit 1
+            }
+          fi
+          python3 - "$version" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+          root = pathlib.Path.cwd()
+          versions = {
+              "typescript package.json": json.loads((root / "mux/bindings/typescript/package.json").read_text())["version"],
+              "python pyproject.toml": tomllib.loads((root / "mux/bindings/python/pyproject.toml").read_text())["project"]["version"],
+              "rust Cargo.toml": tomllib.loads((root / "mux/bindings/rust/Cargo.toml").read_text())["package"]["version"],
+          }
+          mismatches = {name: got for name, got in versions.items() if got != expected}
+          if mismatches:
+              for name, got in mismatches.items():
+                  print(f"{name}: expected {expected}, got {got}", file=sys.stderr)
+              raise SystemExit(1)
+          print(f"All package versions match {expected}")
+          PY
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  bindings-e2e-java:
+    needs: version
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev pkg-config
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Rust version
+        run: |
+          rustc --version || true
+          if ! command -v cargo >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Java version
+        run: |
+          echo "JAVA_HOME_17_X64=$JAVA_HOME_17_X64"
+          echo "$JAVA_HOME_17_X64/bin" >> "$GITHUB_PATH"
+          export PATH="$JAVA_HOME_17_X64/bin:$PATH"
+          java -version
+          javac -version
+
+      - name: Build mux server
+        working-directory: mux
+        run: cargo build -p mux-tui
+
+      - name: Python conformance fixtures
+        run: python3 mux/bindings/conformance/runner.py
+
+      - name: Java binding e2e
+        run: bash mux/bindings/conformance/e2e.sh --require java
+
+  maven-central-todo:
+    needs: bindings-e2e-java
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Maven Central publish not implemented
+        run: |
+          echo "Java publishing is intentionally not automated yet."
+          echo "TODO: add Maven Central publishing after com.cmux namespace verification, project metadata, and signing/provenance setup are complete."

--- a/.github/workflows/sdk-publish-java.yml
+++ b/.github/workflows/sdk-publish-java.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     outputs:
@@ -120,7 +120,7 @@ jobs:
 
   maven-central-todo:
     needs: bindings-e2e-java
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/sdk-publish-npm.yml
+++ b/.github/workflows/sdk-publish-npm.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     outputs:
@@ -121,7 +121,7 @@ jobs:
     # action, so tag pushes never publish to npm and manual runs must opt in.
     if: github.event_name == 'workflow_dispatch'
     needs: bindings-e2e-typescript
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/sdk-publish-npm.yml
+++ b/.github/workflows/sdk-publish-npm.yml
@@ -1,0 +1,156 @@
+name: sdk publish npm
+
+on:
+  push:
+    tags:
+      - "mux-sdk-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SDK version to validate/publish, for example 0.1.0"
+        required: true
+        type: string
+      confirm_npm_cmux:
+        description: "Set true only for the coordinated npm cmux SDK publish"
+        required: true
+        default: false
+        type: boolean
+
+permissions: {}
+
+concurrency:
+  group: sdk-publish-npm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate tag and package versions
+        id: version
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            [[ "$GITHUB_REF_NAME" =~ ^mux-sdk-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "tag must match mux-sdk-vX.Y.Z" >&2
+              exit 1
+            }
+            version="${GITHUB_REF_NAME#mux-sdk-v}"
+          else
+            version="$DISPATCH_VERSION"
+            [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "workflow_dispatch version must match X.Y.Z" >&2
+              exit 1
+            }
+          fi
+          python3 - "$version" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+          root = pathlib.Path.cwd()
+          versions = {
+              "typescript package.json": json.loads((root / "mux/bindings/typescript/package.json").read_text())["version"],
+              "python pyproject.toml": tomllib.loads((root / "mux/bindings/python/pyproject.toml").read_text())["project"]["version"],
+              "rust Cargo.toml": tomllib.loads((root / "mux/bindings/rust/Cargo.toml").read_text())["package"]["version"],
+          }
+          mismatches = {name: got for name, got in versions.items() if got != expected}
+          if mismatches:
+              for name, got in mismatches.items():
+                  print(f"{name}: expected {expected}, got {got}", file=sys.stderr)
+              raise SystemExit(1)
+          print(f"All package versions match {expected}")
+          PY
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  bindings-e2e-typescript:
+    needs: version
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev pkg-config
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Rust version
+        run: |
+          rustc --version || true
+          if ! command -v cargo >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Build mux server
+        working-directory: mux
+        run: cargo build -p mux-tui
+
+      - name: Python conformance fixtures
+        run: python3 mux/bindings/conformance/runner.py
+
+      - name: TypeScript binding e2e
+        run: bash mux/bindings/conformance/e2e.sh --require typescript
+
+  publish:
+    # The npm package name "cmux" is currently a different live package
+    # (the cloud-VM CLI). Publishing the SDK there is a coordinated breaking
+    # action, so tag pushes never publish to npm and manual runs must opt in.
+    if: github.event_name == 'workflow_dispatch'
+    needs: bindings-e2e-typescript
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/cmux
+    steps:
+      - name: Require npm cmux confirmation
+        if: inputs.confirm_npm_cmux != true
+        run: |
+          echo "Refusing to publish npm package cmux without confirm_npm_cmux=true." >&2
+          exit 1
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22.14.0"
+          registry-url: https://registry.npmjs.org
+
+      - name: Build package
+        working-directory: mux/bindings/typescript
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Publish package to npm
+        working-directory: mux/bindings/typescript
+        run: npm publish --provenance

--- a/.github/workflows/sdk-publish-python.yml
+++ b/.github/workflows/sdk-publish-python.yml
@@ -1,0 +1,156 @@
+name: sdk publish python
+
+on:
+  push:
+    tags:
+      - "mux-sdk-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SDK version to validate/publish, for example 0.1.0"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: sdk-publish-python-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate tag and package versions
+        id: version
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            [[ "$GITHUB_REF_NAME" =~ ^mux-sdk-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "tag must match mux-sdk-vX.Y.Z" >&2
+              exit 1
+            }
+            version="${GITHUB_REF_NAME#mux-sdk-v}"
+          else
+            version="$DISPATCH_VERSION"
+            [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "workflow_dispatch version must match X.Y.Z" >&2
+              exit 1
+            }
+          fi
+          python3 - "$version" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+          root = pathlib.Path.cwd()
+          versions = {
+              "typescript package.json": json.loads((root / "mux/bindings/typescript/package.json").read_text())["version"],
+              "python pyproject.toml": tomllib.loads((root / "mux/bindings/python/pyproject.toml").read_text())["project"]["version"],
+              "rust Cargo.toml": tomllib.loads((root / "mux/bindings/rust/Cargo.toml").read_text())["package"]["version"],
+          }
+          mismatches = {name: got for name, got in versions.items() if got != expected}
+          if mismatches:
+              for name, got in mismatches.items():
+                  print(f"{name}: expected {expected}, got {got}", file=sys.stderr)
+              raise SystemExit(1)
+          print(f"All package versions match {expected}")
+          PY
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  bindings-e2e-python:
+    needs: version
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev pkg-config
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Rust version
+        run: |
+          rustc --version || true
+          if ! command -v cargo >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Build mux server
+        working-directory: mux
+        run: cargo build -p mux-tui
+
+      - name: Python conformance fixtures
+        run: python3 mux/bindings/conformance/runner.py
+
+      - name: Python binding e2e
+        run: bash mux/bindings/conformance/e2e.sh --require python
+
+  build:
+    needs: bindings-e2e-python
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build sdist and wheel
+        working-directory: mux/bindings/python
+        run: |
+          python3 -m pip install --upgrade build
+          python3 -m build --sdist --wheel
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cmux-python-dist
+          path: mux/bindings/python/dist/*
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cmux
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: cmux-python-dist
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist
+          attestations: true

--- a/.github/workflows/sdk-publish-python.yml
+++ b/.github/workflows/sdk-publish-python.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     outputs:
@@ -112,7 +112,7 @@ jobs:
 
   build:
     needs: bindings-e2e-python
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     steps:
@@ -135,7 +135,7 @@ jobs:
 
   publish:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       id-token: write

--- a/mux/bindings/RELEASING.md
+++ b/mux/bindings/RELEASING.md
@@ -1,0 +1,70 @@
+# cmux mux SDK releases
+
+The mux SDKs share one version and one tag:
+
+```bash
+mux-sdk-vX.Y.Z
+```
+
+These tags are separate from app release tags such as `vX.Y.Z`. Current SDK
+package versions are `0.1.0`.
+
+## One-time registry setup
+
+- PyPI: create or claim the `cmux` project, then add a trusted publisher for
+  `manaflow-ai/cmux`, workflow `.github/workflows/sdk-publish-python.yml`, and
+  environment `pypi`. The workflow uses OIDC trusted publishing and PyPI
+  attestations, so no PyPI token is stored in GitHub.
+- crates.io: publish or claim the first `cmux-client` crate release manually if
+  crates.io still requires an initial release, then add a trusted publisher for
+  owner `manaflow-ai`, repo `cmux`, workflow
+  `.github/workflows/sdk-publish-crates.yml`, and environment `crates-io`. The
+  workflow exchanges GitHub OIDC for a short-lived crates.io token via
+  `rust-lang/crates-io-auth-action`.
+- npm: configure trusted publishing and required 2FA policy for package `cmux`,
+  workflow `.github/workflows/sdk-publish-npm.yml`, and environment `npm`.
+  Warning: the live npm package name `cmux` is currently a different cloud-VM CLI
+  package. Publishing the SDK to that name is a deliberate coordinated breaking
+  move; the npm workflow never publishes on tag push and requires manual
+  `workflow_dispatch` with `confirm_npm_cmux: true`.
+- Maven Central: verify the `com.cmux` namespace in Central Portal, add complete
+  Maven metadata, configure GPG signing, and decide the Central publishing
+  workflow. Java publishing is intentionally a CI stub until those prerequisites
+  are done.
+- Go: there is no registry publish step. Once the tag exists, users can install
+  with `go get github.com/manaflow-ai/cmux/mux/bindings/go@mux-sdk-vX.Y.Z`.
+
+## Cutting a release
+
+1. Update all SDK manifests to the same version:
+   `mux/bindings/typescript/package.json`,
+   `mux/bindings/python/pyproject.toml`, and
+   `mux/bindings/rust/Cargo.toml`.
+2. Run the mux binding tests locally or wait for `.github/workflows/mux.yml` on
+   the release PR. The publish workflows also run the language conformance gate
+   before publishing.
+3. Merge the version bump.
+4. Create and push the namespaced SDK tag:
+
+   ```bash
+   git tag mux-sdk-vX.Y.Z
+   git push origin mux-sdk-vX.Y.Z
+   ```
+
+5. Watch the SDK workflows. Python and Rust publish automatically after their
+   conformance gates pass. Go validates only. Java reports the Maven Central
+   TODO. npm validates on tag push but does not publish until a maintainer runs
+   `sdk publish npm` manually with `confirm_npm_cmux: true`.
+
+## Safety checks
+
+Each SDK workflow is triggered only by `mux-sdk-v*` tag pushes or
+`workflow_dispatch`. The version guard extracts `X.Y.Z` from the tag, or uses the
+manual `version` input, and fails unless the TypeScript, Python, and Rust package
+manifest versions all match.
+
+Publish jobs use least-privilege permissions. OIDC-capable registries use
+`id-token: write` only on the publish job. No long-lived registry tokens are
+committed or required for PyPI, crates.io, or npm trusted publishing. PyPI uses
+PEP 740 attestations; npm publishes with provenance. All GitHub Actions `uses:`
+entries are pinned to full commit SHAs.

--- a/mux/bindings/rust/Cargo.toml
+++ b/mux/bindings/rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "cmux-client"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Sets up the release pipeline for the cmux-mux SDKs. **Publishes nothing** — every workflow triggers only on a `mux-sdk-v*` tag or manual dispatch (never push/PR), so nothing ships until a maintainer configures trusted publishers and pushes a tag.

| Workflow | Target | Mechanism |
|---|---|---|
| `sdk-publish-python.yml` | PyPI `cmux` | OIDC trusted publishing + PEP 740 attestations |
| `sdk-publish-crates.yml` | crates.io `cmux-client` | short-lived OIDC token, `cargo publish -p cmux-client` |
| `sdk-publish-npm.yml` | npm `cmux` | `npm publish --provenance`, gated behind an explicit confirm input (npm `cmux` is currently the live cloud-VM CLI) |
| `sdk-publish-go.yml` | (tag-only) | build/vet gate; `go get ...@mux-sdk-vX.Y.Z` |
| `sdk-publish-java.yml` | Maven Central | TODO stub (needs GPG + `com.cmux` namespace verification) |

Each job validates the tag version matches every package manifest and runs that language's binding e2e as a gate, so a broken or stale binding can't publish. All `uses:` are SHA-pinned, per-job least-privilege `permissions:`, `actionlint` clean. `mux/bindings/RELEASING.md` documents the one-time registry trusted-publisher setup, the tag scheme, and the security posture. Marks the rust binding `publish = true`.

Meta/CI-only; no app or runtime behavior changes. First real publish still requires: registry trusted-publisher config (maintainer, out-of-band), a version bump, and a deliberate tag push.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786084362&installation_id=133855650&pr_number=7601&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7601&signature=fbfdcf1a90919a66063671d074e7581331557a6988e82da7219b8cd497d27c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only, but tag pushes can ship to PyPI and crates.io once trusted publishers are configured; npm is gated, yet mistaken registry setup or a bad tag could still publish public packages.
> 
> **Overview**
> Adds **tag-gated CI** for mux SDK releases on `mux-sdk-v*` (or manual `workflow_dispatch`), with a shared version guard that requires TypeScript, Python, and Rust manifests to match before any publish path runs.
> 
> **Python** and **crates.io** (`cmux-client`) publish via OIDC trusted publishing after language-specific binding e2e gates; PyPI uses attestations, Rust uses `crates-io-auth-action`. **Go** and **Java** only validate (Go `build`/`vet`; Java ends in a Maven Central TODO stub). **npm** runs e2e on tags but **never publishes on tag push**—publish requires manual dispatch plus `confirm_npm_cmux: true` because the `cmux` name is a live unrelated package.
> 
> `mux/bindings/RELEASING.md` documents registry setup, the `mux-sdk-vX.Y.Z` tag scheme, and safety posture. `cmux-client` is set to **`publish = true`** explicitly (overriding workspace `publish = false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd396f12e28c24d863dfc7e1ad8a9d2af5d86bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tag-gated CI to validate and publish the `cmux` SDKs via OIDC trusted publishing. Nothing publishes on push/PR; only `mux-sdk-v*` tags or manual runs can release.

- **New Features**
  - Workflows for Python (PyPI `cmux`), Rust (crates.io `cmux-client`), npm (`cmux`), Go (validate only), and Java (publish stub).
  - Guards: ensure tag version matches TS/Python/Rust manifests; run per-language e2e as a gate before publish.
  - Security: OIDC trusted publishing (no stored tokens), provenance/attestations where supported, SHA-pinned actions, least-privilege perms; runners routed via `vars.LINUX_RUNNER` with a safe default.
  - Enables Rust crate publishing (`publish = true`) and adds `mux/bindings/RELEASING.md`.

- **Migration**
  - Set up trusted publishers for PyPI `cmux`, crates.io `cmux-client`, and npm `cmux`.
  - Bump all SDK versions, merge, then push `mux-sdk-vX.Y.Z` to trigger; Go is tag-consumed (e.g., `go get ...@mux-sdk-vX.Y.Z`).
  - npm requires a manual dispatch with `confirm_npm_cmux: true`; Java publish remains TODO until `com.cmux` verification and signing are ready.

<sup>Written for commit 2c3d626fa68338685277922f813082317212d821. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated SDK release workflows for Rust, Go, Java, TypeScript (npm), and Python, including cross-language version alignment checks, end-to-end validation, and publishing steps.
  * Added manual-approval gating for npm publishing.
* **Documentation**
  * Added an SDK release guide covering version consistency, workflow triggering rules, and publishing safety practices.
* **Bug Fixes**
  * Ensured the Rust `cmux-client` crate is explicitly marked for publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->