### PR TITLE
Scan Claude launch options past prompt positionals on resume

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchPositionalScanning.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchPositionalScanning.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+extension AgentLaunchSanitizer {
+    static func preserveOptions(_ args: [String], policy: Policy) -> [String]? {
+        var result: [String] = []
+        var index = 0
+        var consumedFirstPositional = false
+        var sawPositional = false
+        var sawOptionBeforePositional = false
+        var skippingResumePositionals = false
+
+        while index < args.count {
+            let arg = args[index]
+            if arg == "--" {
+                break
+            }
+
+            if !arg.hasPrefix("-") || arg == "-" {
+                let previousIndex = index
+                guard consumePositional(
+                    arg,
+                    policy: policy,
+                    index: &index,
+                    result: &result,
+                    consumedFirstPositional: &consumedFirstPositional,
+                    sawPositional: &sawPositional,
+                    sawOptionBeforePositional: sawOptionBeforePositional,
+                    skippingResumePositionals: &skippingResumePositionals
+                ) else { return nil }
+                if index > previousIndex {
+                    continue
+                }
+                break
+            }
+            sawOptionBeforePositional = true
+
+            if shouldDropOption(arg, droppedOptions: policy.rejectOptions) {
+                return nil
+            }
+
+            if policy.droppedOptionPrefixes.contains(where: { arg.hasPrefix($0) }) {
+                index += 1
+                continue
+            }
+
+            let runtimeOnlyWidth = runtimeOnlyOptionWidth(arg)
+            let width = runtimeOnlyWidth ?? optionWidth(args, index: index, policy: policy)
+            if runtimeOnlyWidth != nil || shouldDropOption(arg, droppedOptions: policy.droppedOptions) {
+                index += width
+                continue
+            }
+
+            if policy.skipClaudeHookSettings,
+               let replacement = claudeHookSettingsReplacement(args, index: index) {
+                result.append(contentsOf: replacement)
+                index += width
+                continue
+            }
+            guard let consumedPromptBoundary = consumePromptBoundaryOption(arg, args: args, index: &index, width: width, policy: policy, result: &result) else { return nil }
+            if consumedPromptBoundary { continue }
+            result.append(contentsOf: args[index..<min(args.count, index + width)])
+            index += width
+        }
+
+        return result
+    }
+
+    /// Applies the Claude prompt trust boundary while preserving legacy positional behavior for every other policy.
+    ///
+    /// Direct Claude launches can resume options after prompt positionals because the CLI honors them. Claude Teams keeps
+    /// its existing post-option prompt boundary so flag-shaped prompt payloads are not promoted during Teams restore.
+    static func consumePositional(
+        _ arg: String,
+        policy: Policy,
+        index: inout Int,
+        result: inout [String],
+        consumedFirstPositional: inout Bool,
+        sawPositional: inout Bool,
+        sawOptionBeforePositional: Bool,
+        skippingResumePositionals: inout Bool
+    ) -> Bool {
+        if policy.scansOptionsPastPositionals {
+            if !policy.promptBoundaryOptions.isEmpty, sawOptionBeforePositional {
+                return true
+            }
+            if !sawPositional, policy.nonRestorableCommands.contains(arg) {
+                return false
+            }
+            sawPositional = true
+            index += 1
+            return true
+        }
+        if policy.preservePositionals { result.append(arg); index += 1; return true }
+        if let resumeSubcommand = policy.resumeSubcommand, arg == resumeSubcommand {
+            skippingResumePositionals = true
+            index += 1
+            return true
+        }
+        if skippingResumePositionals {
+            skippingResumePositionals = false
+            index += 1
+            return true
+        }
+        if policy.nonRestorableCommands.contains(arg) {
+            return false
+        }
+        if policy.preserveFirstPositional, !consumedFirstPositional {
+            result.append(arg)
+            consumedFirstPositional = true
+            index += 1
+            return true
+        }
+        return true
+    }
+
+    static func shouldDropOption(_ arg: String, droppedOptions: Set<String>) -> Bool {
+        if droppedOptions.contains(arg) { return true }
+        guard let equals = arg.firstIndex(of: "=") else { return false }
+        return droppedOptions.contains(String(arg[..<equals]))
+    }
+
+    static func optionWidth(
+        _ args: [String],
+        index: Int,
+        policy: Policy,
+        stopVariadicAtPositionals: Set<String> = []
+    ) -> Int {
+        let arg = args[index]
+        if arg.contains("=") {
+            return 1
+        }
+        if policy.optionalValueOptions.contains(arg) {
+            guard index + 1 < args.count else { return 1 }
+            let value = args[index + 1]
+            if let choices = policy.optionalValueChoices[arg] { return choices.contains(value) ? 2 : 1 }
+            let following = index + 2 < args.count ? args[index + 2] : nil
+            if policy.greedyOptionalValueOptions.contains(arg),
+               looksLikeGreedyOptionalValue(value) { return 2 }
+            guard looksLikeOptionalValue(value, following: following) else { return 1 }
+            return 2
+        }
+        guard policy.valueOptions.contains(arg) else {
+            return unknownOptionWidth(args, index: index, policy: policy)
+        }
+        guard index + 1 < args.count else { return 1 }
+        if policy.variadicOptions.contains(arg) {
+            var end = index + 1
+            while end < args.count,
+                  !args[end].hasPrefix("-"),
+                  !stopVariadicAtPositionals.contains(args[end]),
+                  variadicValueCanContinue(args[end], policy: policy) {
+                end += 1
+            }
+            return max(1, end - index)
+        }
+        return 2
+    }
+
+    /// Infers one value for unknown direct-Claude options only when the value is bounded by another option or comma list.
+    ///
+    /// A trailing single word stays a prompt and is skipped. The deliberate trade-off is that a single-word prompt
+    /// sandwiched between an unknown boolean flag and another flag can be treated as that unknown flag's value.
+    static func unknownOptionWidth(_ args: [String], index: Int, policy: Policy) -> Int {
+        guard policy.scansOptionsPastPositionals,
+              policy.promptBoundaryOptions.isEmpty,
+              index + 1 < args.count else { return 1 }
+        let value = args[index + 1]
+        let following = index + 2 < args.count ? args[index + 2] : nil
+        guard !value.isEmpty,
+              !value.hasPrefix("-"),
+              value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              value.contains(",") || (following?.hasPrefix("-") == true) else {
+            return 1
+        }
+        return 2
+    }
+
+    static func variadicValueCanContinue(_ value: String, policy: Policy) -> Bool {
+        guard policy.scansOptionsPastPositionals else { return true }
+        return looksLikeGreedyOptionalValue(value)
+    }
+
+    static func looksLikeOptionalValue(_ value: String, following: String?) -> Bool {
+        guard !value.isEmpty,
+              !value.hasPrefix("-"),
+              value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else {
+            return false
+        }
+        return following == nil || value.contains(",") || (following?.hasPrefix("-") == true)
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -28,6 +28,8 @@ public enum AgentLaunchSanitizer {
         var resumeSubcommand: String?
         var preserveFirstPositional: Bool = false
         var preservePositionals: Bool = false
+        /// Keeps scanning for top-level option tokens after prompt positionals; only Claude supports this replay boundary.
+        var scansOptionsPastPositionals: Bool = false
         var skipClaudeHookSettings: Bool = false
     }
     public static func sanitizedLaunchArguments(
@@ -374,79 +376,6 @@ public enum AgentLaunchSanitizer {
         return trimmed.unicodeScalars.allSatisfy { allowed.contains($0) } && trimmed.contains("-")
     }
 
-    private static func preserveOptions(_ args: [String], policy: Policy) -> [String]? {
-        var result: [String] = []
-        var index = 0
-        var consumedFirstPositional = false
-        var skippingResumePositionals = false
-
-        while index < args.count {
-            let arg = args[index]
-            if arg == "--" {
-                break
-            }
-
-            if !arg.hasPrefix("-") || arg == "-" {
-                if policy.preservePositionals { result.append(arg); index += 1; continue }
-                if let resumeSubcommand = policy.resumeSubcommand, arg == resumeSubcommand {
-                    skippingResumePositionals = true
-                    index += 1
-                    continue
-                }
-                if skippingResumePositionals {
-                    skippingResumePositionals = false
-                    index += 1
-                    continue
-                }
-                if policy.nonRestorableCommands.contains(arg) {
-                    return nil
-                }
-                if policy.preserveFirstPositional, !consumedFirstPositional {
-                    result.append(arg)
-                    consumedFirstPositional = true
-                    index += 1
-                    continue
-                }
-                break
-            }
-
-            if shouldDropOption(arg, droppedOptions: policy.rejectOptions) {
-                return nil
-            }
-
-            if policy.droppedOptionPrefixes.contains(where: { arg.hasPrefix($0) }) {
-                index += 1
-                continue
-            }
-
-            let runtimeOnlyWidth = runtimeOnlyOptionWidth(arg)
-            let width = runtimeOnlyWidth ?? optionWidth(args, index: index, policy: policy)
-            if runtimeOnlyWidth != nil || shouldDropOption(arg, droppedOptions: policy.droppedOptions) {
-                index += width
-                continue
-            }
-
-            if policy.skipClaudeHookSettings,
-               let replacement = claudeHookSettingsReplacement(args, index: index) {
-                result.append(contentsOf: replacement)
-                index += width
-                continue
-            }
-            guard let consumedPromptBoundary = consumePromptBoundaryOption(arg, args: args, index: &index, width: width, policy: policy, result: &result) else { return nil }
-            if consumedPromptBoundary { continue }
-            result.append(contentsOf: args[index..<min(args.count, index + width)])
-            index += width
-        }
-
-        return result
-    }
-
-    private static func shouldDropOption(_ arg: String, droppedOptions: Set<String>) -> Bool {
-        if droppedOptions.contains(arg) { return true }
-        guard let equals = arg.firstIndex(of: "=") else { return false }
-        return droppedOptions.contains(String(arg[..<equals]))
-    }
-
     private static func normalizedWorkingDirectory(_ value: String?) -> String? {
         guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else {
@@ -462,7 +391,7 @@ public enum AgentLaunchSanitizer {
         return true
     }
 
-    private static func runtimeOnlyOptionWidth(_ arg: String) -> Int? {
+    static func runtimeOnlyOptionWidth(_ arg: String) -> Int? {
         if let width = runtimeOnlyOptionWidths[arg] {
             return width
         }
@@ -470,49 +399,7 @@ public enum AgentLaunchSanitizer {
         return runtimeOnlyOptionWidths[String(arg[..<equals])].map { _ in 1 }
     }
 
-    private static func optionWidth(
-        _ args: [String],
-        index: Int,
-        policy: Policy,
-        stopVariadicAtPositionals: Set<String> = []
-    ) -> Int {
-        let arg = args[index]
-        if arg.contains("=") {
-            return 1
-        }
-        if policy.optionalValueOptions.contains(arg) {
-            guard index + 1 < args.count else { return 1 }
-            let value = args[index + 1]
-            if let choices = policy.optionalValueChoices[arg] { return choices.contains(value) ? 2 : 1 }
-            let following = index + 2 < args.count ? args[index + 2] : nil
-            if policy.greedyOptionalValueOptions.contains(arg),
-               looksLikeGreedyOptionalValue(value) { return 2 }
-            guard looksLikeOptionalValue(value, following: following) else { return 1 }
-            return 2
-        }
-        guard policy.valueOptions.contains(arg), index + 1 < args.count else { return 1 }
-        if policy.variadicOptions.contains(arg) {
-            var end = index + 1
-            while end < args.count,
-                  !args[end].hasPrefix("-"),
-                  !stopVariadicAtPositionals.contains(args[end]) {
-                end += 1
-            }
-            return max(1, end - index)
-        }
-        return 2
-    }
-
-    private static func looksLikeOptionalValue(_ value: String, following: String?) -> Bool {
-        guard !value.isEmpty,
-              !value.hasPrefix("-"),
-              value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else {
-            return false
-        }
-        return following == nil || value.contains(",") || (following?.hasPrefix("-") == true)
-    }
-
-    private static func claudeHookSettingsReplacement(_ args: [String], index: Int) -> [String]? {
+    static func claudeHookSettingsReplacement(_ args: [String], index: Int) -> [String]? {
         let arg = args[index]
         if arg.hasPrefix("--settings=") {
             let value = String(arg.dropFirst("--settings=".count))

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerGrokPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerGrokPolicy.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+extension AgentLaunchSanitizer {
+    static let grokPolicy = Policy(
+        valueOptions: [
+            "--agent",
+            "--agents",
+            "--allow",
+            "--cwd",
+            "--deny",
+            "--disallowed-tools",
+            "--effort",
+            "--max-turns",
+            "--model",
+            "-m",
+            "--permission-mode",
+            "--reasoning-effort",
+            "--resume",
+            "-r",
+            "--rules",
+            "--sandbox",
+            "--system-prompt-override",
+            "--tools",
+            "--worktree",
+            "-w"
+        ],
+        optionalValueOptions: [
+            "--resume",
+            "-r",
+            "--worktree",
+            "-w"
+        ],
+        nonRestorableCommands: [
+            "agent",
+            "help",
+            "import",
+            "inspect",
+            "leader",
+            "login",
+            "mcp",
+            "memory",
+            "models",
+            "sessions",
+            "setup",
+            "share",
+            "ssh",
+            "trace",
+            "update",
+            "version",
+            "v",
+            "worktree"
+        ],
+        droppedOptions: [
+            "--continue",
+            "-c",
+            "--restore-code",
+            "--resume",
+            "-r",
+            "--worktree",
+            "-w"
+        ],
+        droppedOptionPrefixes: [
+            "--resume=",
+            "-r=",
+            "--worktree=",
+            "-w="
+        ],
+        rejectOptions: [
+            "--best-of-n",
+            "--output-format",
+            "--prompt-file",
+            "--prompt-json",
+            "--single",
+            "-p"
+        ]
+    )
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
@@ -51,6 +51,7 @@ extension AgentLaunchSanitizer {
             "--allowedTools",
             "--allowed-tools",
             "--betas",
+            "--dangerously-load-development-channels",
             "--disallowedTools",
             "--disallowed-tools",
             "--file",
@@ -101,6 +102,7 @@ extension AgentLaunchSanitizer {
             "-p",
             "--no-session-persistence"
         ],
+        scansOptionsPastPositionals: true,
         skipClaudeHookSettings: true
     )
 
@@ -165,80 +167,6 @@ extension AgentLaunchSanitizer {
             "--remote-auth-token-env="
         ],
         resumeSubcommand: "resume"
-    )
-
-    static let grokPolicy = Policy(
-        valueOptions: [
-            "--agent",
-            "--agents",
-            "--allow",
-            "--cwd",
-            "--deny",
-            "--disallowed-tools",
-            "--effort",
-            "--max-turns",
-            "--model",
-            "-m",
-            "--permission-mode",
-            "--reasoning-effort",
-            "--resume",
-            "-r",
-            "--rules",
-            "--sandbox",
-            "--system-prompt-override",
-            "--tools",
-            "--worktree",
-            "-w"
-        ],
-        optionalValueOptions: [
-            "--resume",
-            "-r",
-            "--worktree",
-            "-w"
-        ],
-        nonRestorableCommands: [
-            "agent",
-            "help",
-            "import",
-            "inspect",
-            "leader",
-            "login",
-            "mcp",
-            "memory",
-            "models",
-            "sessions",
-            "setup",
-            "share",
-            "ssh",
-            "trace",
-            "update",
-            "version",
-            "v",
-            "worktree"
-        ],
-        droppedOptions: [
-            "--continue",
-            "-c",
-            "--restore-code",
-            "--resume",
-            "-r",
-            "--worktree",
-            "-w"
-        ],
-        droppedOptionPrefixes: [
-            "--resume=",
-            "-r=",
-            "--worktree=",
-            "-w="
-        ],
-        rejectOptions: [
-            "--best-of-n",
-            "--output-format",
-            "--prompt-file",
-            "--prompt-json",
-            "--single",
-            "-p"
-        ]
     )
 
     static let piPolicy = Policy(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeFlagPreservationTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeFlagPreservationTests.swift
@@ -1,0 +1,220 @@
+import CMUXAgentLaunch
+import Testing
+
+@Suite("Claude resume flag preservation")
+struct ClaudeResumeFlagPreservationTests {
+    @Test("Preserves flags after prompt positional")
+    func preservesFlagsAfterPromptPositional() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "claude",
+                    "investigate the flaky test",
+                    "--dangerously-skip-permissions",
+                    "--model",
+                    "claude-fable-5",
+                    "--effort",
+                    "max"
+                ],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == [
+                "claude",
+                "--dangerously-skip-permissions",
+                "--model",
+                "claude-fable-5",
+                "--effort",
+                "max"
+            ]
+        )
+    }
+
+    @Test("Preserves unknown value option and later known options")
+    func preservesUnknownValueOptionAndLaterKnownOptions() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "claude",
+                    "--some-new-flag",
+                    "value",
+                    "--dangerously-skip-permissions",
+                    "--model",
+                    "claude-fable-5"
+                ],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == [
+                "claude",
+                "--some-new-flag",
+                "value",
+                "--dangerously-skip-permissions",
+                "--model",
+                "claude-fable-5"
+            ]
+        )
+    }
+
+    @Test("Preserves all development channel values")
+    func preservesAllDevelopmentChannelValues() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "claude",
+                    "--dangerously-load-development-channels",
+                    "chan-a",
+                    "chan-b",
+                    "--dangerously-skip-permissions"
+                ],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == [
+                "claude",
+                "--dangerously-load-development-channels",
+                "chan-a",
+                "chan-b",
+                "--dangerously-skip-permissions"
+            ]
+        )
+    }
+
+    @Test("Preserves flags before prompt positional")
+    func preservesFlagsBeforePromptPositional() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "claude",
+                    "--model",
+                    "claude-fable-5",
+                    "--dangerously-skip-permissions",
+                    "do the thing"
+                ],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == [
+                "claude",
+                "--model",
+                "claude-fable-5",
+                "--dangerously-skip-permissions"
+            ]
+        )
+    }
+
+    @Test("Drops session binding flags while later flags survive")
+    func dropsSessionBindingFlagsWhileLaterFlagsSurvive() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "claude",
+                    "--resume",
+                    "0195aaaa-bbbb-cccc-dddd-eeeeffff0000",
+                    "--dangerously-skip-permissions",
+                    "prompt here",
+                    "--model",
+                    "opus"
+                ],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == [
+                "claude",
+                "--dangerously-skip-permissions",
+                "--model",
+                "opus"
+            ]
+        )
+    }
+
+    @Test("Does not replay trailing prompt after unknown boolean flag")
+    func doesNotReplayTrailingPromptAfterUnknownBooleanFlag() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "claude",
+                    "--dangerously-skip-permissions",
+                    "investigate"
+                ],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == [
+                "claude",
+                "--dangerously-skip-permissions"
+            ]
+        )
+    }
+
+    @Test("Stops variadic development channels at prompt-shaped token")
+    func stopsVariadicDevelopmentChannelsAtPromptShapedToken() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "claude",
+                    "--dangerously-load-development-channels",
+                    "dev",
+                    "fix the flaky test",
+                    "--model",
+                    "opus"
+                ],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == [
+                "claude",
+                "--dangerously-load-development-channels",
+                "dev",
+                "--model",
+                "opus"
+            ]
+        )
+    }
+
+    @Test("Rejects non-restorable Claude subcommand")
+    func rejectsNonRestorableClaudeSubcommand() {
+        #expect(
+            AgentLaunchSanitizer.preservedArguments(
+                kind: "claude",
+                args: ["doctor", "--model", "opus"]
+            ) == nil
+        )
+    }
+
+    @Test("Stops scanning at double dash")
+    func stopsScanningAtDoubleDash() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "claude",
+                    "--model",
+                    "opus",
+                    "--",
+                    "--dangerously-skip-permissions"
+                ],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == [
+                "claude",
+                "--model",
+                "opus"
+            ]
+        )
+    }
+
+    @Test("Codex still stops scanning at prompt positional")
+    func codexStillStopsScanningAtPromptPositional() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "codex",
+                    "--model",
+                    "gpt-5",
+                    "investigate",
+                    "--sandbox",
+                    "danger-full-access"
+                ],
+                launcher: "codex",
+                fallbackKind: "codex"
+            ) == [
+                "codex",
+                "--model",
+                "gpt-5"
+            ]
+        )
+    }
+}


### PR DESCRIPTION
Closes #7599

## Problem

`AgentLaunchSanitizer.preserveOptions` walks the captured argv left-to-right and `break`s at the first positional it does not recognize, silently discarding every argument after it. For Claude resumes this loses launch flags in a whole class of shapes:

1. **Flags after the positional prompt** — `claude "investigate the flaky test" --dangerously-skip-permissions --model claude-fable-5 --effort max` resumed as a bare `claude --resume <id>`; the Claude CLI honors options after a positional prompt (as the `claudeTeamsLaunchHasOption` doc comment already notes).
2. **Any value-taking flag missing from the hardcoded allowlist** — the flag was treated as width-1 boolean, its value became a positional, and the whole tail was dropped.
3. **Multi-value options** (#6235) — the second value of `--dangerously-load-development-channels` parsed as a positional and truncated the tail.

## Fix (class-level, not allowlist widening)

One new claude-only `Policy` knob, `scansOptionsPastPositionals`:

- **Positionals no longer end the scan for Claude.** Prompt positionals are skipped (never replayed) and option scanning continues, mirroring the prompt-boundary semantics `claudeTeamsLaunchHasOption` already uses. Only the *first* positional can still match `nonRestorableCommands` (subcommand position), so a later prompt word like `update` can't nil out the resume.
- **Unknown options are fail-safe.** An option absent from every policy set gets a bounded arity heuristic: it keeps a following single-word value only when that value is bounded by another option (or is a comma list), so an unlisted flag never truncates the tail and a trailing single word is still treated as a prompt and dropped.
- **Variadic values stop at prompt-shaped tokens** for Claude (non-path tokens containing whitespace), so marking `--dangerously-load-development-channels` variadic can't swallow and replay a following prompt.

Trust boundary preserved: session-binding flags (`--resume`, `--session-id`, `--continue`, `--fork-session`, `--tmux`, `--file`, `--from-pr`, `--worktree`) are still dropped, `--` still ends the scan, and Claude Teams keeps its conservative post-option prompt boundary (the `--tmux` post-boundary recovery allowlist is untouched), so flag-shaped tokens spilled from a prompt payload are never promoted to options. All other agents' policies default the knob off; their behavior is unchanged and guarded by a new codex test.

## Commits (red/green regression structure)

1. `Add failing regression tests for Claude resume flag drop` — tests only; 5 of the 10 new tests fail at that commit (the three issue repros plus two more instances of the class).
2. `Scan Claude launch options past prompt positionals on resume` — the fix; full suite green.

## File budgets

All touched budget-tracked files were at exact caps, so the scanner moved to a new `AgentLaunchPositionalScanning.swift` (191 lines) and `grokPolicy` moved verbatim to `AgentLaunchSanitizerGrokPolicy.swift` (77 lines): `AgentLaunchSanitizer.swift` 598→485, `PrimaryPolicies` 601→529, no `.github/swift-file-length-budget.tsv` or warning-budget changes, `python3 scripts/swift_file_length_budget.py` passes.

## Verification

- `swift test --package-path Packages/macOS/CMUXAgentLaunch`: 187 Swift Testing + 6 XCTest tests, 0 failures (177 at baseline).
- Localization audit: pure library change, no user-facing strings touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786084600&installation_id=133855650&pr_number=7602&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7602&signature=f4a1d36e8d89fe1148b6e11b8a2e01e4b3163c76e10470dc65008a44c8ab9438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes argv replay for Claude resumes only, but parsing heuristics for unknown flags and variadic tails could mis-classify edge-case argv shapes; regression tests cover the main scenarios.
> 
> **Overview**
> **Fixes Claude resume losing launch flags** when captured argv had a prompt positional before options, unknown value-taking flags, or multi-value variadic options—the sanitizer used to **stop at the first unrecognized positional** and drop the rest.
> 
> Adds **`scansOptionsPastPositionals`** on `Policy` (enabled for direct **Claude** only). Prompt positionals are **skipped, not replayed**, but option scanning continues. **Unknown flags** get a bounded arity heuristic; **variadic** values stop at prompt-shaped tokens. Session-binding flags, `--`, and **Claude Teams** prompt-boundary behavior stay unchanged; other agents default the knob off.
> 
> Refactors **`preserveOptions`** and related scanning into **`AgentLaunchPositionalScanning.swift`**, moves **`grokPolicy`** to its own file, marks **`--dangerously-load-development-channels`** variadic on Claude, and adds **`ClaudeResumeFlagPreservationTests`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0dd4bc82055b77e232967960a7e45dbea4bae9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude resume so flags after the prompt (and other tail options) are preserved instead of being dropped. Adds a Claude‑only scan that continues past prompt positionals while keeping session and trust boundaries. Closes #7599.

- **Bug Fixes**
  - Claude: continue scanning options after prompt positionals via new policy knob `scansOptionsPastPositionals`; only the first positional can still match non‑restorable subcommands.
  - Unknown options: infer a single value only when bounded by another option or a comma list, preventing tail truncation; a trailing lone word is treated as prompt and skipped.
  - Variadic values: stop at prompt‑shaped tokens for `--dangerously-load-development-channels` so prompts aren’t swallowed.
  - Trust boundary: drop session‑binding flags (`--resume`, `--session-id`, `--continue`, etc.), honor `--` as the end of scan; Claude Teams and other agents remain unchanged.

- **Refactors**
  - Extracted scanning to `AgentLaunchPositionalScanning.swift`; moved Grok policy to `AgentLaunchSanitizerGrokPolicy.swift` to stay within file budgets.
  - Added `ClaudeResumeFlagPreservationTests.swift` and a guard test for non‑Claude agents; all tests pass.

<sup>Written for commit f0dd4bc82055b77e232967960a7e45dbea4bae9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

