### PR TITLE
CmuxFleet: board UI — right-sidebar mode, store/rows, config sheet, pane-openable

### DIFF
--- a/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Board/FleetBoardColumn.swift
+++ b/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Board/FleetBoardColumn.swift
@@ -1,0 +1,17 @@
+/// Columns used by the Fleet board projection.
+public enum FleetBoardColumn: String, CaseIterable, Codable, Sendable {
+    /// Tasks waiting for scheduler dispatch.
+    case queue
+
+    /// Tasks currently being provisioned, launched, supervised, or retried.
+    case running
+
+    /// Tasks waiting for human input.
+    case needsInput
+
+    /// Tasks waiting for pull request review.
+    case review
+
+    /// Tasks that have reached a terminal state.
+    case done
+}

--- a/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Board/FleetBoardFleetSummary.swift
+++ b/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Board/FleetBoardFleetSummary.swift
@@ -1,0 +1,27 @@
+/// A compact Fleet summary for board fleet pickers.
+public struct FleetBoardFleetSummary: Equatable, Sendable, Identifiable {
+    /// The Fleet identifier.
+    public var id: FleetID
+
+    /// The Fleet display name.
+    public var name: String
+
+    /// The repository root associated with the Fleet.
+    public var repoRoot: String
+
+    /// Indicates whether the Fleet is dispatching tasks.
+    public var isRunning: Bool
+
+    /// Creates a board Fleet summary.
+    /// - Parameters:
+    ///   - id: The Fleet identifier.
+    ///   - name: The Fleet display name.
+    ///   - repoRoot: The repository root associated with the Fleet.
+    ///   - isRunning: Indicates whether the Fleet is dispatching tasks.
+    public init(id: FleetID, name: String, repoRoot: String, isRunning: Bool) {
+        self.id = id
+        self.name = name
+        self.repoRoot = repoRoot
+        self.isRunning = isRunning
+    }
+}

--- a/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Board/FleetBoardProjection.swift
+++ b/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Board/FleetBoardProjection.swift
@@ -1,0 +1,83 @@
+public import Foundation
+
+/// Builds pure board snapshots from Fleet engine values.
+public struct FleetBoardProjection: Sendable {
+    /// Creates a board projection helper.
+    public init() {}
+
+    /// Returns the board column for a Fleet task state.
+    /// - Parameter state: The Fleet task state.
+    public static func column(for state: FleetTaskState) -> FleetBoardColumn {
+        switch state {
+        case .queued:
+            .queue
+        case .provisioning, .launching, .running, .stalled, .retryBackoff:
+            .running
+        case .needsInput:
+            .needsInput
+        case .awaitingReview:
+            .review
+        case .done, .failed, .cancelled:
+            .done
+        }
+    }
+
+    /// Builds a value snapshot for the board.
+    /// - Parameters:
+    ///   - configs: Fleet configurations.
+    ///   - isRunningByID: Running-state values keyed by Fleet identifier.
+    ///   - tasksByFleetID: Tasks keyed by Fleet identifier.
+    ///   - selectedFleetID: The requested selected Fleet.
+    /// - Returns: A board snapshot with rows grouped into columns.
+    public static func makeSnapshot(
+        configs: [FleetConfig],
+        isRunningByID: [FleetID: Bool],
+        tasksByFleetID: [FleetID: [FleetTask]],
+        selectedFleetID: FleetID?
+    ) -> FleetBoardSnapshot {
+        let summaries = configs
+            .map { config in
+                FleetBoardFleetSummary(
+                    id: config.id,
+                    name: config.name,
+                    repoRoot: config.repoRoot,
+                    isRunning: isRunningByID[config.id] ?? false
+                )
+            }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+
+        let selected = summaries.first { $0.id == selectedFleetID } ?? summaries.first
+        guard let selected else { return .empty }
+
+        var columns = Dictionary(uniqueKeysWithValues: FleetBoardColumn.allCases.map { ($0, [FleetBoardRowSnapshot]()) })
+        for task in (tasksByFleetID[selected.id] ?? []) {
+            columns[Self.column(for: task.state), default: []].append(rowSnapshot(for: task))
+        }
+        for column in FleetBoardColumn.allCases {
+            columns[column, default: []].sort { lhs, rhs in
+                if lhs.updatedAt != rhs.updatedAt {
+                    return lhs.updatedAt > rhs.updatedAt
+                }
+                return lhs.id.rawValue < rhs.id.rawValue
+            }
+        }
+
+        return FleetBoardSnapshot(selectedFleet: selected, fleets: summaries, columns: columns)
+    }
+
+    private static func rowSnapshot(for task: FleetTask) -> FleetBoardRowSnapshot {
+        FleetBoardRowSnapshot(
+            id: task.id,
+            title: task.title,
+            state: task.state,
+            attempts: task.attempts,
+            prURL: task.pr?.url,
+            prLabel: task.pr?.number.map { "#\($0)" },
+            lastError: task.lastError,
+            updatedAt: task.updatedAt,
+            canRetry: task.state.canUserRetry,
+            canCancel: task.state.canUserCancel,
+            hasWorkspace: task.workspaceID != nil
+        )
+    }
+}

--- a/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Board/FleetBoardRowSnapshot.swift
+++ b/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Board/FleetBoardRowSnapshot.swift
@@ -1,0 +1,64 @@
+public import Foundation
+
+/// A value snapshot for one Fleet board row.
+public struct FleetBoardRowSnapshot: Equatable, Sendable, Identifiable {
+    /// The Fleet task identifier.
+    public var id: FleetTaskID
+
+    /// The task title.
+    public var title: String
+
+    /// The Fleet supervision state.
+    public var state: FleetTaskState
+
+    /// The number of agent launch attempts.
+    public var attempts: Int
+
+    /// The pull request URL, when available.
+    public var prURL: URL?
+
+    /// A compact pull request label, such as `#123`.
+    public var prLabel: String?
+
+    /// The latest error message, when available.
+    public var lastError: String?
+
+    /// The task's last update timestamp.
+    public var updatedAt: Date
+
+    /// Indicates whether retry is currently valid.
+    public var canRetry: Bool
+
+    /// Indicates whether cancel is currently valid.
+    public var canCancel: Bool
+
+    /// Indicates whether the task has a workspace target to open.
+    public var hasWorkspace: Bool
+
+    /// Creates a Fleet board row snapshot.
+    public init(
+        id: FleetTaskID,
+        title: String,
+        state: FleetTaskState,
+        attempts: Int,
+        prURL: URL?,
+        prLabel: String?,
+        lastError: String?,
+        updatedAt: Date,
+        canRetry: Bool,
+        canCancel: Bool,
+        hasWorkspace: Bool
+    ) {
+        self.id = id
+        self.title = title
+        self.state = state
+        self.attempts = attempts
+        self.prURL = prURL
+        self.prLabel = prLabel
+        self.lastError = lastError
+        self.updatedAt = updatedAt
+        self.canRetry = canRetry
+        self.canCancel = canCancel
+        self.hasWorkspace = hasWorkspace
+    }
+}

--- a/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Board/FleetBoardSnapshot.swift
+++ b/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Board/FleetBoardSnapshot.swift
@@ -1,0 +1,35 @@
+/// Value snapshot rendered by the Fleet board.
+public struct FleetBoardSnapshot: Equatable, Sendable {
+    /// The selected Fleet summary, when one exists.
+    public var selectedFleet: FleetBoardFleetSummary?
+
+    /// Every configured Fleet available to the picker.
+    public var fleets: [FleetBoardFleetSummary]
+
+    /// Rows grouped by board column.
+    public var columns: [FleetBoardColumn: [FleetBoardRowSnapshot]]
+
+    /// Creates a Fleet board snapshot.
+    /// - Parameters:
+    ///   - selectedFleet: The selected Fleet summary, when one exists.
+    ///   - fleets: Every configured Fleet available to the picker.
+    ///   - columns: Rows grouped by board column.
+    public init(
+        selectedFleet: FleetBoardFleetSummary?,
+        fleets: [FleetBoardFleetSummary],
+        columns: [FleetBoardColumn: [FleetBoardRowSnapshot]]
+    ) {
+        self.selectedFleet = selectedFleet
+        self.fleets = fleets
+        self.columns = columns
+    }
+
+    /// An empty board snapshot.
+    public static var empty: FleetBoardSnapshot {
+        FleetBoardSnapshot(
+            selectedFleet: nil,
+            fleets: [],
+            columns: Dictionary(uniqueKeysWithValues: FleetBoardColumn.allCases.map { ($0, []) })
+        )
+    }
+}

--- a/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Engine/FleetEngine+Signals.swift
+++ b/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Engine/FleetEngine+Signals.swift
@@ -80,6 +80,7 @@ extension FleetEngine {
         }
         if next != task {
             persistSnapshot()
+            notifyStateChanged()
         }
         if task.state != next.state {
             dispatchTick()
@@ -129,6 +130,7 @@ extension FleetEngine {
             _ = fleetID
         }
         persistSnapshot()
+        notifyStateChanged()
         dispatchTick()
         scheduleReconcileTimerIfNeeded()
     }

--- a/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Engine/FleetEngine.swift
+++ b/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Engine/FleetEngine.swift
@@ -19,6 +19,9 @@ public final class FleetEngine {
 
     var fleets: [FleetID: FleetRuntimeState] = [:]
 
+    /// Callback fired after Fleet runtime state changes.
+    public var onStateChange: (@MainActor () -> Void)?
+
     /// Creates a Fleet engine and restores persisted state, if any exists.
     /// - Parameter dependencies: The dependencies used for all imperative effects.
     public init(dependencies: FleetEngineDependencies) {
@@ -80,6 +83,7 @@ public final class FleetEngine {
             scheduledStallAttemptByTaskID: [:]
         )
         persistSnapshot()
+        notifyStateChanged()
         return .success(config)
     }
 
@@ -92,6 +96,7 @@ public final class FleetEngine {
         runtime.isRunning = true
         fleets[id] = runtime
         persistSnapshot()
+        notifyStateChanged()
         scheduleReconcileTimerIfNeeded()
         dispatchTick()
         return true
@@ -106,6 +111,7 @@ public final class FleetEngine {
         runtime.isRunning = false
         fleets[id] = runtime
         persistSnapshot()
+        notifyStateChanged()
         if !anyFleetRunning {
             dependencies.timers.cancel(key: Self.reconcileTimerKey)
         }
@@ -176,6 +182,7 @@ public final class FleetEngine {
         runtime.tasks[id] = task
         fleets[fleetID] = runtime
         persistSnapshot()
+        notifyStateChanged()
         if runtime.isRunning {
             dispatchTick()
         }
@@ -261,6 +268,10 @@ public final class FleetEngine {
         dependencies.persistence.save(FleetPersistedState(fleets: persisted))
     }
 
+    func notifyStateChanged() {
+        onStateChange?()
+    }
+
     func restore() {
         guard let snapshot = dependencies.persistence.load() else { return }
         fleets.removeAll()
@@ -314,6 +325,7 @@ public final class FleetEngine {
         if after == before {
             return .invalidState(before.state)
         }
+        notifyStateChanged()
         return .ok(after)
     }
 }

--- a/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Engine/FleetTaskState+UserActions.swift
+++ b/Packages/macOS/CmuxFleet/Sources/CmuxFleet/Engine/FleetTaskState+UserActions.swift
@@ -1,0 +1,18 @@
+/// User-initiated action predicates for Fleet task states.
+public extension FleetTaskState {
+    /// Indicates whether Fleet accepts a user retry from this state.
+    var canUserRetry: Bool {
+        switch self {
+        case .failed, .cancelled, .awaitingReview:
+            true
+        case .queued, .provisioning, .launching, .running, .needsInput, .stalled,
+             .retryBackoff, .done:
+            false
+        }
+    }
+
+    /// Indicates whether Fleet accepts a user cancel from this state.
+    var canUserCancel: Bool {
+        !isTerminal
+    }
+}

--- a/Packages/macOS/CmuxFleet/Tests/CmuxFleetTests/FleetBoardProjectionTests.swift
+++ b/Packages/macOS/CmuxFleet/Tests/CmuxFleetTests/FleetBoardProjectionTests.swift
@@ -1,0 +1,94 @@
+import CmuxFleet
+import Foundation
+import Testing
+
+@Suite("Fleet board projection")
+struct FleetBoardProjectionTests {
+    @Test
+    func allTaskStatesMapToOneColumn() {
+        let columns = FleetTaskState.allCases.map { FleetBoardProjection.column(for: $0) }
+
+        #expect(columns.count == FleetTaskState.allCases.count)
+        #expect(columns[0] == .queue)
+        #expect(Set(columns).isSubset(of: Set(FleetBoardColumn.allCases)))
+        #expect(FleetBoardProjection.column(for: .queued) == .queue)
+        #expect(FleetBoardProjection.column(for: .provisioning) == .running)
+        #expect(FleetBoardProjection.column(for: .launching) == .running)
+        #expect(FleetBoardProjection.column(for: .running) == .running)
+        #expect(FleetBoardProjection.column(for: .stalled) == .running)
+        #expect(FleetBoardProjection.column(for: .retryBackoff) == .running)
+        #expect(FleetBoardProjection.column(for: .needsInput) == .needsInput)
+        #expect(FleetBoardProjection.column(for: .awaitingReview) == .review)
+        #expect(FleetBoardProjection.column(for: .done) == .done)
+        #expect(FleetBoardProjection.column(for: .failed) == .done)
+        #expect(FleetBoardProjection.column(for: .cancelled) == .done)
+    }
+
+    @Test
+    func rowOrderingAndActionPredicatesUseEngineRules() {
+        let config = Self.config(id: "fleet-a", name: "Fleet A")
+        let newer = FleetTestSupport.task(
+            idSuffix: "newer",
+            state: .failed,
+            attempts: 2,
+            updatedAt: Date(timeIntervalSince1970: 200),
+            pr: FleetPullRequestStatus(number: 123, url: URL(string: "https://example.com/pull/123")),
+            lastError: "boom"
+        )
+        let older = FleetTestSupport.task(
+            idSuffix: "older",
+            state: .done,
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let snapshot = FleetBoardProjection.makeSnapshot(
+            configs: [config],
+            isRunningByID: [config.id: true],
+            tasksByFleetID: [config.id: [older, newer]],
+            selectedFleetID: config.id
+        )
+        let doneRows = snapshot.columns[.done] ?? []
+
+        #expect(snapshot.selectedFleet?.id == config.id)
+        #expect(snapshot.selectedFleet?.isRunning == true)
+        #expect(doneRows.map(\.id) == [newer.id, older.id])
+        #expect(doneRows.first?.canRetry == true)
+        #expect(doneRows.first?.canCancel == false)
+        #expect(doneRows.first?.prLabel == "#123")
+        #expect(doneRows.first?.hasWorkspace == true)
+    }
+
+    @Test
+    func snapshotBuildsMultipleFleetPickerAndSelectedRows() {
+        let a = Self.config(id: "fleet-a", name: "A Fleet")
+        let b = Self.config(id: "fleet-b", name: "B Fleet")
+        let selectedTask = FleetTestSupport.task(idSuffix: "selected", state: .needsInput)
+        let otherTask = FleetTestSupport.task(idSuffix: "other", state: .queued)
+
+        let snapshot = FleetBoardProjection.makeSnapshot(
+            configs: [b, a],
+            isRunningByID: [a.id: false, b.id: true],
+            tasksByFleetID: [
+                a.id: [otherTask],
+                b.id: [selectedTask],
+            ],
+            selectedFleetID: b.id
+        )
+
+        #expect(snapshot.fleets.map(\.id) == [a.id, b.id])
+        #expect(snapshot.selectedFleet?.id == b.id)
+        #expect(snapshot.selectedFleet?.isRunning == true)
+        #expect(snapshot.columns[.needsInput]?.map(\.id) == [selectedTask.id])
+        #expect(snapshot.columns[.queue]?.isEmpty == true)
+    }
+
+    @Test(arguments: FleetTaskState.allCases)
+    func actionPredicatesMatchUserActionStates(state: FleetTaskState) {
+        #expect(state.canUserRetry == [.failed, .cancelled, .awaitingReview].contains(state))
+        #expect(state.canUserCancel == !state.isTerminal)
+    }
+
+    private static func config(id: FleetID, name: String) -> FleetConfig {
+        FleetConfig(id: id, name: name, repoRoot: "/repo", workspaceRoot: "/repo-fleet")
+    }
+}

--- a/Packages/macOS/CmuxFleet/Tests/CmuxFleetTests/FleetEngineTests.swift
+++ b/Packages/macOS/CmuxFleet/Tests/CmuxFleetTests/FleetEngineTests.swift
@@ -335,6 +335,49 @@ struct FleetEngineTests {
         #expect(harness.actuator.notifications.count == notificationCount)
     }
 
+    @Test
+    func onStateChangeFiresForPublicMutationsAndReducedSignals() async throws {
+        let harness = FleetEngineHarness()
+        let engine = harness.engine()
+        let tempRoot = try Self.tempDirectory()
+        var callbackCount = 0
+        engine.onStateChange = {
+            callbackCount += 1
+        }
+
+        let fleet = try engine.createFleet(name: "Fleet", repoRoot: tempRoot.path, agentCommandTemplate: nil, maxConcurrent: nil).get()
+        let afterCreate = callbackCount
+        #expect(afterCreate > 0)
+
+        let task = try engine.addTask(fleetID: fleet.id, title: "Task", body: nil, priority: nil).get()
+        let afterAdd = callbackCount
+        #expect(afterAdd > afterCreate)
+
+        #expect(engine.startFleet(id: fleet.id))
+        await Task.yield()
+        await Task.yield()
+        let afterStart = callbackCount
+        #expect(afterStart > afterAdd)
+
+        let launching = try #require(try engine.tasks(fleetID: fleet.id, state: .launching).get().first?.task)
+        harness.world.existingWorkspaces.insert(launching.workspaceID!)
+        engine.noteWorkstreamHook(workspaceID: launching.workspaceID!, sessionID: "s1", pid: nil, kind: .sessionStart, at: harness.dateBox.now)
+        let afterSignal = callbackCount
+        #expect(afterSignal > afterStart)
+
+        #expect(engine.stopFleet(id: fleet.id))
+        let afterStop = callbackCount
+        #expect(afterStop > afterSignal)
+
+        #expect(engine.cancelTask(id: task.id).isOK)
+        let afterCancel = callbackCount
+        #expect(afterCancel > afterStop)
+
+        #expect(engine.retryTask(id: task.id).isOK)
+        let afterRetry = callbackCount
+        #expect(afterRetry > afterCancel)
+    }
+
     private static func createFleet(
         _ engine: FleetEngine,
         repoRoot: URL,

--- a/Packages/macOS/CmuxFleet/Tests/CmuxFleetTests/FleetTestSupport.swift
+++ b/Packages/macOS/CmuxFleet/Tests/CmuxFleetTests/FleetTestSupport.swift
@@ -14,6 +14,7 @@ struct FleetTestSupport {
         priority: Int? = nil,
         isBlocked: Bool = false,
         createdAt: Date = baseDate,
+        updatedAt: Date = baseDate,
         pr: FleetPullRequestStatus? = nil,
         lastError: String? = nil
     ) -> FleetTask {
@@ -28,7 +29,7 @@ struct FleetTestSupport {
             sourceState: "open",
             isBlocked: isBlocked,
             createdAt: createdAt,
-            updatedAt: baseDate,
+            updatedAt: updatedAt,
             state: state,
             attempts: attempts,
             workspaceID: "workspace-1",
@@ -46,6 +47,7 @@ struct FleetTestSupport {
         priority: Int? = nil,
         isBlocked: Bool = false,
         createdAt: Date = baseDate,
+        updatedAt: Date = baseDate,
         pr: FleetPullRequestStatus? = nil,
         lastError: String? = nil
     ) -> FleetTask {
@@ -57,6 +59,7 @@ struct FleetTestSupport {
             priority: priority,
             isBlocked: isBlocked,
             createdAt: createdAt,
+            updatedAt: updatedAt,
             pr: pr,
             lastError: lastError
         )

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BetaFeaturesCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BetaFeaturesCatalogSection.swift
@@ -25,6 +25,16 @@ public struct BetaFeaturesCatalogSection: SettingCatalogSection {
         userDefaultsKey: "rightSidebar.beta.dock.enabled"
     )
 
+    /// Right-sidebar Fleet: an experimental board that displays Fleet tasks
+    /// in Queue, Running, Needs Input, Review, and Done sections. Defaults
+    /// off; while off, the Fleet mode is hidden from the right-sidebar
+    /// switcher.
+    public let rightSidebarFleet = DefaultsKey<Bool>(
+        id: "rightSidebar.beta.fleet.enabled",
+        defaultValue: false,
+        userDefaultsKey: "rightSidebar.beta.fleet.enabled"
+    )
+
     /// Extensions: the experimental ExtensionKit sidebar-extension surface
     /// (puzzle button, sidebar-toggle provider menu, installed-extension
     /// host, and the extensions browser). Defaults off; while off, every

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -171,6 +171,7 @@ extension Array where Element == CuratedSettingEntry {
             // Beta
             .init(section: .betaFeatures, id: "feed", title: "Feed", synonyms: "feed right sidebar agent decisions permissions questions approval beta unstable"),
             .init(section: .betaFeatures, id: "dock", title: "Dock", synonyms: "dock right sidebar terminal controls tui beta unstable"),
+            .init(section: .betaFeatures, id: "fleet", title: String(localized: "settings.betaFeatures.fleet", defaultValue: "Fleet"), synonyms: "fleet task board queue running review right sidebar beta unstable"),
             .init(section: .betaFeatures, id: "customSidebars", title: "Custom Sidebars", synonyms: "custom sidebars swift json interpreted vibe beta unstable"),
             .init(section: .betaFeatures, id: "remoteTmux", title: "Remote tmux", synonyms: "remote tmux ssh control mode -CC mirror session window pane sidebar workspace beta unstable"),
 

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BetaFeaturesSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BetaFeaturesSection.swift
@@ -9,6 +9,7 @@ import SwiftUI
 public struct BetaFeaturesSection: View {
     @State private var feed: DefaultsValueModel<Bool>
     @State private var dock: DefaultsValueModel<Bool>
+    @State private var fleet: DefaultsValueModel<Bool>
     @State private var extensions: DefaultsValueModel<Bool>
     @State private var customSidebars: DefaultsValueModel<Bool>
     @State private var remoteTmux: DefaultsValueModel<Bool>
@@ -16,6 +17,7 @@ public struct BetaFeaturesSection: View {
     public init(defaultsStore: UserDefaultsSettingsStore, catalog: SettingCatalog) {
         _feed = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.rightSidebarFeed))
         _dock = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.rightSidebarDock))
+        _fleet = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.rightSidebarFleet))
         _extensions = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.extensions))
         _customSidebars = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.customSidebars))
         _remoteTmux = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.betaFeatures.remoteTmux))
@@ -33,6 +35,8 @@ public struct BetaFeaturesSection: View {
                 SettingsCardDivider()
                 dockRow
                 SettingsCardDivider()
+                fleetRow
+                SettingsCardDivider()
                 extensionsRow
                 SettingsCardDivider()
                 customSidebarsRow
@@ -47,6 +51,7 @@ public struct BetaFeaturesSection: View {
         let models: [any SettingObservationStarting] = [
             feed,
             dock,
+            fleet,
             extensions,
             customSidebars,
             remoteTmux,
@@ -85,6 +90,23 @@ public struct BetaFeaturesSection: View {
                 .labelsHidden()
                 .controlSize(.small)
                 .accessibilityIdentifier("SettingsBetaDockToggle")
+        }
+    }
+
+    @ViewBuilder
+    private var fleetRow: some View {
+        SettingsCardRow(
+            configurationReview: .settingsOnly,
+            searchAnchorID: "setting:betaFeatures:fleet",
+            String(localized: "settings.betaFeatures.fleet", defaultValue: "Fleet"),
+            subtitle: fleet.current
+                ? String(localized: "settings.betaFeatures.fleet.subtitleOn", defaultValue: "Shows Fleet in the right sidebar mode switcher for task board monitoring.")
+                : String(localized: "settings.betaFeatures.fleet.subtitleOff", defaultValue: "Hides Fleet from the right sidebar until you enable it here.")
+        ) {
+            Toggle("", isOn: Binding(get: { fleet.current }, set: { fleet.set($0) }))
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsBetaFleetToggle")
         }
     }
 

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -147,6 +147,7 @@ struct SettingsRowAnchorResolutionTests {
         "setting:mobile:iOSPairingDisplayName",
         "setting:betaFeatures:feed",
         "setting:betaFeatures:dock",
+        "setting:betaFeatures:fleet",
         "setting:betaFeatures:customSidebars",
         "setting:betaFeatures:remoteTmux",
         "setting:customSidebars:enabled",

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -482,9 +482,11 @@ enum AgentHibernationTrackingGate {
 enum RightSidebarBetaFeatureSettings {
     static let feedEnabledKey = "rightSidebar.beta.feed.enabled"
     static let dockEnabledKey = "rightSidebar.beta.dock.enabled"
+    static let fleetEnabledKey = "rightSidebar.beta.fleet.enabled"
 
     static let defaultFeedEnabled = false
     static let defaultDockEnabled = false
+    static let defaultFleetEnabled = false
 
     nonisolated static func isFeedEnabled(defaults: UserDefaults = .standard) -> Bool {
         guard defaults.object(forKey: feedEnabledKey) != nil else { return defaultFeedEnabled }
@@ -494,6 +496,11 @@ enum RightSidebarBetaFeatureSettings {
     nonisolated static func isDockEnabled(defaults: UserDefaults = .standard) -> Bool {
         guard defaults.object(forKey: dockEnabledKey) != nil else { return defaultDockEnabled }
         return defaults.bool(forKey: dockEnabledKey)
+    }
+
+    nonisolated static func isFleetEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: fleetEnabledKey) != nil else { return defaultFleetEnabled }
+        return defaults.bool(forKey: fleetEnabledKey)
     }
 }
 

--- a/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+++ b/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
@@ -749,6 +749,17 @@ enum CommandPaletteSettingsToggleCommands {
                 defaultsKey: RightSidebarBetaFeatureSettings.dockEnabledKey
             ),
             CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "rightSidebarFleet",
+                settingsKey: "betaFeatures.fleet",
+                title: {
+                    String(localized: "settings.betaFeatures.fleet", defaultValue: "Fleet")
+                },
+                sectionTitle: beta,
+                keywords: ["betaFeatures.fleet", "fleet", "right", "sidebar", "beta", "task", "board"],
+                defaultValue: RightSidebarBetaFeatureSettings.defaultFleetEnabled,
+                defaultsKey: RightSidebarBetaFeatureSettings.fleetEnabledKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
                 commandId: commandIdPrefix + "claudeCodeIntegration",
                 settingsKey: "automation.claudeCodeIntegration",
                 title: {

--- a/Sources/ContentView+RightSidebarCommandPalette.swift
+++ b/Sources/ContentView+RightSidebarCommandPalette.swift
@@ -118,8 +118,9 @@ extension ContentView {
             { _ in value }
         }
 
-        return commandPaletteRightSidebarToolPaneCommandDescriptors().map { descriptor in
-            CommandPaletteCommandContribution(
+        return commandPaletteRightSidebarToolPaneCommandDescriptors().compactMap { descriptor in
+            guard descriptor.mode.isAvailable() else { return nil }
+            return CommandPaletteCommandContribution(
                 commandId: descriptor.commandId,
                 title: constant(descriptor.title),
                 subtitle: constant(String(localized: "command.openRightSidebarToolAsPane.subtitle", defaultValue: "Pane")),
@@ -140,6 +141,8 @@ extension ContentView {
             return "palette.showRightSidebarFeed"
         case .dock:
             return "palette.showRightSidebarDock"
+        case .fleet:
+            return "palette.showRightSidebarFleet"
         case .customSidebar:
             return "palette.showRightSidebarCustomSidebar"
         }
@@ -163,6 +166,8 @@ extension ContentView {
             return "palette.openFindPane"
         case .sessions:
             return "palette.openVaultPane"
+        case .fleet:
+            return "palette.openFleetPane"
         case .feed, .dock, .customSidebar:
             return nil
         }
@@ -176,6 +181,8 @@ extension ContentView {
             return String(localized: "command.openFindPane.title", defaultValue: "Open Find as Pane")
         case .sessions:
             return String(localized: "command.openVaultPane.title", defaultValue: "Open Vault as Pane")
+        case .fleet:
+            return String(localized: "command.openFleetPane.title", defaultValue: "Open Fleet as Pane")
         case .feed, .dock, .customSidebar:
             return nil
         }
@@ -199,6 +206,10 @@ extension ContentView {
     }
 
     func handleCommandPaletteRightSidebarToolPane(_ mode: RightSidebarMode) {
+        guard mode.isAvailable() else {
+            NSSound.beep()
+            return
+        }
         openRightSidebarToolPane(mode)
     }
 

--- a/Sources/Fleet/FleetBoardPanelView.swift
+++ b/Sources/Fleet/FleetBoardPanelView.swift
@@ -1,0 +1,181 @@
+import AppKit
+import CmuxFleet
+import SwiftUI
+
+struct FleetBoardPanelView: View {
+    @StateObject private var store = FleetBoardStore.shared
+    @State private var quickTaskTitle = ""
+    @State private var isConfigSheetPresented = false
+
+    private let columnOrder: [FleetBoardColumn] = [.queue, .running, .needsInput, .review, .done]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+            Divider()
+            if store.snapshot.selectedFleet == nil {
+                emptyState
+            } else {
+                quickAdd
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                Divider()
+                board
+            }
+        }
+        .sheet(isPresented: $isConfigSheetPresented) {
+            FleetConfigSheet(store: store)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            if store.snapshot.fleets.count > 1 {
+                Picker("", selection: $store.selectedFleetID) {
+                    ForEach(store.snapshot.fleets) { fleet in
+                        Text(fleet.name).tag(Optional(fleet.id))
+                    }
+                }
+                .labelsHidden()
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(store.snapshot.selectedFleet?.name ?? String(localized: "fleet.board.title", defaultValue: "Fleet"))
+                        .cmuxFont(.headline)
+                        .lineLimit(1)
+                    if let repoRoot = store.snapshot.selectedFleet?.repoRoot {
+                        Text(repoRoot)
+                            .cmuxFont(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+            if let fleet = store.snapshot.selectedFleet {
+                Circle()
+                    .fill(fleet.isRunning ? Color.green : Color.secondary)
+                    .frame(width: 8, height: 8)
+                    .accessibilityLabel(
+                        fleet.isRunning
+                        ? String(localized: "fleet.board.running", defaultValue: "Running")
+                        : String(localized: "fleet.board.stopped", defaultValue: "Stopped")
+                    )
+                Button {
+                    fleet.isRunning ? store.stopSelectedFleet() : store.startSelectedFleet()
+                } label: {
+                    Image(systemName: fleet.isRunning ? "stop.fill" : "play.fill")
+                }
+                .buttonStyle(.borderless)
+                .safeHelp(
+                    fleet.isRunning
+                    ? String(localized: "fleet.board.stop", defaultValue: "Stop")
+                    : String(localized: "fleet.board.start", defaultValue: "Start")
+                )
+            }
+            Button {
+                isConfigSheetPresented = true
+            } label: {
+                Image(systemName: "gearshape")
+            }
+            .buttonStyle(.borderless)
+            .safeHelp(String(localized: "fleet.board.configure", defaultValue: "Configure Fleet"))
+        }
+    }
+
+    private var quickAdd: some View {
+        HStack(spacing: 6) {
+            TextField(
+                String(localized: "fleet.board.addTask.placeholder", defaultValue: "Add a task..."),
+                text: $quickTaskTitle
+            )
+            .textFieldStyle(.roundedBorder)
+            .onSubmit {
+                addQuickTask()
+            }
+            Button {
+                addQuickTask()
+            } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(.borderless)
+            .safeHelp(String(localized: "fleet.board.addTask", defaultValue: "Add Task"))
+        }
+    }
+
+    private var board: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 8) {
+                ForEach(sectionSnapshots) { section in
+                    FleetBoardSectionView(section: section, actions: rowActions)
+                        .equatable()
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Spacer(minLength: 0)
+            Image(systemName: "square.grid.3x1.below.line.grid.1x2")
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(String(localized: "fleet.board.empty.noFleet", defaultValue: "No Fleet configured"))
+                .cmuxFont(.headline)
+            Button(String(localized: "fleet.board.empty.createFleet", defaultValue: "Create Fleet")) {
+                isConfigSheetPresented = true
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    private var rowActions: FleetBoardRowActions {
+        FleetBoardRowActions(
+            onOpen: { store.openTask($0) },
+            onRetry: { store.retryTask($0) },
+            onCancel: { store.cancelTask($0) },
+            onOpenPR: { NSWorkspace.shared.open($0) },
+            onCopyPRURL: { url in
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(url.absoluteString, forType: .string)
+            }
+        )
+    }
+
+    private var sectionSnapshots: [FleetBoardSectionSnapshot] {
+        columnOrder.map { column in
+            FleetBoardSectionSnapshot(
+                column: column,
+                title: title(for: column),
+                rows: store.snapshot.columns[column] ?? []
+            )
+        }
+    }
+
+    private func addQuickTask() {
+        let title = quickTaskTitle
+        store.addTask(title: title)
+        if !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            quickTaskTitle = ""
+        }
+    }
+
+    private func title(for column: FleetBoardColumn) -> String {
+        switch column {
+        case .queue:
+            String(localized: "fleet.board.column.queue", defaultValue: "Queue")
+        case .running:
+            String(localized: "fleet.board.column.running", defaultValue: "Running")
+        case .needsInput:
+            String(localized: "fleet.board.column.needsInput", defaultValue: "Needs input")
+        case .review:
+            String(localized: "fleet.board.column.review", defaultValue: "Review")
+        case .done:
+            String(localized: "fleet.board.column.done", defaultValue: "Done")
+        }
+    }
+}

--- a/Sources/Fleet/FleetBoardRows.swift
+++ b/Sources/Fleet/FleetBoardRows.swift
@@ -1,0 +1,218 @@
+import AppKit
+import CmuxFleet
+import SwiftUI
+
+struct FleetBoardRowActions {
+    let onOpen: @MainActor (FleetTaskID) -> Void
+    let onRetry: @MainActor (FleetTaskID) -> Void
+    let onCancel: @MainActor (FleetTaskID) -> Void
+    let onOpenPR: @MainActor (URL) -> Void
+    let onCopyPRURL: @MainActor (URL) -> Void
+}
+
+struct FleetBoardSectionSnapshot: Equatable, Identifiable {
+    let column: FleetBoardColumn
+    let title: String
+    let rows: [FleetBoardRowSnapshot]
+
+    var id: FleetBoardColumn { column }
+}
+
+struct FleetBoardSectionView: View, Equatable {
+    let section: FleetBoardSectionSnapshot
+    let actions: FleetBoardRowActions
+
+    static func == (lhs: FleetBoardSectionView, rhs: FleetBoardSectionView) -> Bool {
+        lhs.section == rhs.section
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text(section.title)
+                    .cmuxFont(.caption)
+                    .foregroundStyle(.secondary)
+                Text("\(section.rows.count)")
+                    .cmuxFont(.caption)
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(Color.secondary.opacity(0.12)))
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .padding(.top, 8)
+
+            if section.rows.isEmpty {
+                Text(emptyText(for: section.column))
+                    .cmuxFont(.caption)
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 8)
+            } else {
+                ForEach(section.rows) { row in
+                    FleetBoardRowView(row: row, actions: actions)
+                        .equatable()
+                }
+            }
+        }
+    }
+
+    private func emptyText(for column: FleetBoardColumn) -> String {
+        switch column {
+        case .queue:
+            String(localized: "fleet.board.empty.queue", defaultValue: "No queued tasks")
+        case .running:
+            String(localized: "fleet.board.empty.running", defaultValue: "Nothing running")
+        case .needsInput:
+            String(localized: "fleet.board.empty.needsInput", defaultValue: "No tasks need input")
+        case .review:
+            String(localized: "fleet.board.empty.review", defaultValue: "No reviews waiting")
+        case .done:
+            String(localized: "fleet.board.empty.done", defaultValue: "No completed tasks")
+        }
+    }
+}
+
+struct FleetBoardRowView: View, Equatable {
+    let row: FleetBoardRowSnapshot
+    let actions: FleetBoardRowActions
+
+    static func == (lhs: FleetBoardRowView, rhs: FleetBoardRowView) -> Bool {
+        lhs.row == rhs.row
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(alignment: .top, spacing: 8) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(row.title)
+                        .cmuxFont(.caption)
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if row.state == .failed, let lastError = row.lastError, !lastError.isEmpty {
+                        Text(lastError)
+                            .cmuxFont(.caption2)
+                            .foregroundStyle(.red)
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 0)
+                VStack(alignment: .trailing, spacing: 4) {
+                    stateChip
+                    if row.attempts > 1 {
+                        Text(String.localizedStringWithFormat(
+                            String(localized: "fleet.board.attempts", defaultValue: "x%d"),
+                            row.attempts
+                        ))
+                        .cmuxFont(.caption2)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            if let prURL = row.prURL, let label = row.prLabel {
+                Button {
+                    actions.onOpenPR(prURL)
+                } label: {
+                    Label(label, systemImage: "arrow.up.right.square")
+                        .labelStyle(.titleAndIcon)
+                        .cmuxFont(.caption2)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.blue)
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(row.hasWorkspace ? Color.primary.opacity(0.055) : Color.primary.opacity(0.035))
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if row.hasWorkspace {
+                actions.onOpen(row.id)
+            }
+        }
+        .contextMenu {
+            if row.hasWorkspace {
+                Button(String(localized: "fleet.board.context.open", defaultValue: "Open")) {
+                    actions.onOpen(row.id)
+                }
+            }
+            if row.canRetry {
+                Button(String(localized: "fleet.board.context.retry", defaultValue: "Retry")) {
+                    actions.onRetry(row.id)
+                }
+            }
+            if row.canCancel {
+                Button(String(localized: "fleet.board.context.cancel", defaultValue: "Cancel")) {
+                    actions.onCancel(row.id)
+                }
+            }
+            if let prURL = row.prURL {
+                Button(String(localized: "fleet.board.context.copyPRURL", defaultValue: "Copy PR URL")) {
+                    actions.onCopyPRURL(prURL)
+                }
+            }
+        }
+        .padding(.horizontal, 8)
+    }
+
+    private var stateChip: some View {
+        Text(stateLabel(row.state))
+            .cmuxFont(.caption2)
+            .foregroundStyle(stateColor(row.state))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(stateColor(row.state).opacity(0.14)))
+    }
+
+    private func stateLabel(_ state: FleetTaskState) -> String {
+        switch state {
+        case .queued:
+            String(localized: "fleet.taskState.queued", defaultValue: "Queued")
+        case .provisioning:
+            String(localized: "fleet.taskState.provisioning", defaultValue: "Provisioning")
+        case .launching:
+            String(localized: "fleet.taskState.launching", defaultValue: "Launching")
+        case .running:
+            String(localized: "fleet.taskState.running", defaultValue: "Running")
+        case .needsInput:
+            String(localized: "fleet.taskState.needsInput", defaultValue: "Needs input")
+        case .stalled:
+            String(localized: "fleet.taskState.stalled", defaultValue: "Stalled")
+        case .retryBackoff:
+            String(localized: "fleet.taskState.retryBackoff", defaultValue: "Retrying")
+        case .awaitingReview:
+            String(localized: "fleet.taskState.awaitingReview", defaultValue: "Review")
+        case .done:
+            String(localized: "fleet.taskState.done", defaultValue: "Done")
+        case .failed:
+            String(localized: "fleet.taskState.failed", defaultValue: "Failed")
+        case .cancelled:
+            String(localized: "fleet.taskState.cancelled", defaultValue: "Cancelled")
+        }
+    }
+
+    private func stateColor(_ state: FleetTaskState) -> Color {
+        switch state {
+        case .queued:
+            .gray
+        case .provisioning, .launching, .running:
+            .blue
+        case .needsInput, .stalled, .retryBackoff:
+            .orange
+        case .awaitingReview:
+            .purple
+        case .done:
+            .green
+        case .failed:
+            .red
+        case .cancelled:
+            .secondary
+        }
+    }
+}

--- a/Sources/Fleet/FleetBoardStore.swift
+++ b/Sources/Fleet/FleetBoardStore.swift
@@ -1,0 +1,128 @@
+import AppKit
+import CmuxFleet
+import Foundation
+import SwiftUI
+
+@MainActor
+final class FleetBoardStore: ObservableObject {
+    static let shared = FleetBoardStore()
+
+    @Published private(set) var snapshot: FleetBoardSnapshot = .empty
+    @Published var selectedFleetID: FleetID? {
+        didSet {
+            guard oldValue != selectedFleetID else { return }
+            refresh()
+        }
+    }
+
+    private let engine: FleetEngine
+    private var refreshScheduled = false
+    private var needsRefresh = false
+
+    private init() {
+        self.engine = FleetAppHost.shared.engine
+        engine.onStateChange = { [weak self] in
+            self?.scheduleRefresh()
+        }
+        refresh()
+    }
+
+    func scheduleRefresh() {
+        needsRefresh = true
+        guard !refreshScheduled else { return }
+        refreshScheduled = true
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.refreshScheduled = false
+            guard self.needsRefresh else { return }
+            self.needsRefresh = false
+            self.refresh()
+        }
+    }
+
+    func openTask(_ id: FleetTaskID) {
+        switch FleetTaskWorkspaceOpener.openTask(id, engine: engine) {
+        case .opened:
+            break
+        case .workspaceUnavailable, .taskNotFound:
+            NSSound.beep()
+        }
+    }
+
+    func retryTask(_ id: FleetTaskID) {
+        if case .ok = engine.retryTask(id: id) {
+            return
+        }
+        NSSound.beep()
+    }
+
+    func cancelTask(_ id: FleetTaskID) {
+        if case .ok = engine.cancelTask(id: id) {
+            return
+        }
+        NSSound.beep()
+    }
+
+    func addTask(title: String) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let fleetID = snapshot.selectedFleet?.id else { return }
+        if case .failure = engine.addTask(fleetID: fleetID, title: trimmed, body: nil, priority: nil) {
+            NSSound.beep()
+        }
+    }
+
+    func startSelectedFleet() {
+        guard let fleetID = snapshot.selectedFleet?.id, engine.startFleet(id: fleetID) else {
+            NSSound.beep()
+            return
+        }
+    }
+
+    func stopSelectedFleet() {
+        guard let fleetID = snapshot.selectedFleet?.id, engine.stopFleet(id: fleetID) else {
+            NSSound.beep()
+            return
+        }
+    }
+
+    func createFleet(
+        name: String,
+        repoRoot: String,
+        agentCommand: String?,
+        maxConcurrent: Int?
+    ) -> Result<FleetConfig, FleetCreateError> {
+        let result = engine.createFleet(
+            name: name,
+            repoRoot: repoRoot,
+            agentCommandTemplate: agentCommand,
+            maxConcurrent: maxConcurrent
+        )
+        if case .success(let config) = result {
+            selectedFleetID = config.id
+        }
+        return result
+    }
+
+    private func refresh() {
+        let configs = engine.fleetConfigs()
+        if selectedFleetID == nil || !configs.contains(where: { $0.id == selectedFleetID }) {
+            selectedFleetID = configs.first?.id
+            return
+        }
+        var running: [FleetID: Bool] = [:]
+        var tasks: [FleetID: [FleetTask]] = [:]
+        for config in configs {
+            running[config.id] = engine.isFleetRunning(id: config.id) ?? false
+            tasks[config.id] = (try? engine.tasks(fleetID: config.id, state: nil).get().map(\.task)) ?? []
+        }
+        let next = FleetBoardProjection.makeSnapshot(
+            configs: configs,
+            isRunningByID: running,
+            tasksByFleetID: tasks,
+            selectedFleetID: selectedFleetID
+        )
+        if snapshot != next {
+            snapshot = next
+        }
+    }
+}

--- a/Sources/Fleet/FleetConfigSheet.swift
+++ b/Sources/Fleet/FleetConfigSheet.swift
@@ -1,0 +1,109 @@
+import AppKit
+import CmuxFleet
+import SwiftUI
+
+struct FleetConfigSheet: View {
+    @ObservedObject var store: FleetBoardStore
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var repoRoot = ""
+    @State private var agentCommand = FleetConfig(
+        id: "template",
+        name: "",
+        repoRoot: "",
+        workspaceRoot: ""
+    ).agentCommandTemplate
+    @State private var maxConcurrent = 3
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Form {
+                TextField(String(localized: "fleet.config.name", defaultValue: "Name"), text: $name)
+
+                HStack {
+                    TextField(
+                        String(localized: "fleet.config.repoRoot", defaultValue: "Repository root"),
+                        text: $repoRoot
+                    )
+                    Button(String(localized: "fleet.config.choose", defaultValue: "Choose...")) {
+                        chooseRepositoryRoot()
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    TextField(
+                        String(localized: "fleet.config.agentCommand", defaultValue: "Agent command template"),
+                        text: $agentCommand
+                    )
+                    .font(.system(.body, design: .monospaced))
+                    Text(String(localized: "fleet.config.agentCommand.caption", defaultValue: "Use {{PROMPT}} where the task prompt should be inserted. Other placeholders include {{TITLE}}, {{BODY}}, {{TASK_ID}}, {{DIR}}, and {{BRANCH}}."))
+                        .cmuxFont(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Stepper(
+                    String.localizedStringWithFormat(
+                        String(localized: "fleet.config.maxConcurrent", defaultValue: "Max concurrent agents: %d"),
+                        maxConcurrent
+                    ),
+                    value: $maxConcurrent,
+                    in: 1...32
+                )
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .cmuxFont(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 8)
+            }
+
+            HStack {
+                Spacer()
+                Button(String(localized: "fleet.config.cancel", defaultValue: "Cancel")) {
+                    dismiss()
+                }
+                Button(String(localized: "fleet.config.create", defaultValue: "Create")) {
+                    create()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding()
+        }
+        .frame(width: 520)
+    }
+
+    private func chooseRepositoryRoot() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.title = String(localized: "fleet.config.choose.title", defaultValue: "Choose Repository Root")
+        panel.prompt = String(localized: "fleet.config.choose.prompt", defaultValue: "Choose")
+        if panel.runModal() == .OK, let url = panel.url {
+            repoRoot = url.path
+        }
+    }
+
+    private func create() {
+        switch store.createFleet(
+            name: name,
+            repoRoot: repoRoot,
+            agentCommand: agentCommand,
+            maxConcurrent: maxConcurrent
+        ) {
+        case .success:
+            dismiss()
+        case .failure(.invalidConfiguration(let reason)):
+            errorMessage = String.localizedStringWithFormat(
+                String(localized: "fleet.config.error.invalidConfiguration", defaultValue: "Could not create Fleet: %@"),
+                reason
+            )
+        }
+    }
+}

--- a/Sources/Fleet/FleetTaskWorkspaceOpener.swift
+++ b/Sources/Fleet/FleetTaskWorkspaceOpener.swift
@@ -1,0 +1,35 @@
+import AppKit
+import CmuxFleet
+import Foundation
+
+enum FleetTaskWorkspaceOpenResult: Equatable {
+    case opened(workspaceID: UUID)
+    case workspaceUnavailable
+    case taskNotFound(String)
+}
+
+@MainActor
+enum FleetTaskWorkspaceOpener {
+    static func openTask(_ taskID: FleetTaskID, engine: FleetEngine? = nil) -> FleetTaskWorkspaceOpenResult {
+        let engine = engine ?? FleetAppHost.shared.engine
+        switch engine.openTarget(taskID: taskID) {
+        case .workspace(let idString):
+            guard let workspaceID = UUID(uuidString: idString),
+                  let tabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceID),
+                  let workspace = tabManager.tabs.first(where: { $0.id == workspaceID })
+            else { return .workspaceUnavailable }
+            if let windowID = AppDelegate.shared?.windowId(for: tabManager) {
+                _ = AppDelegate.shared?.focusMainWindow(windowId: windowID)
+            }
+            if tabManager.selectedTabId != workspace.id {
+                tabManager.selectWorkspace(workspace)
+            }
+            TerminalController.shared.setActiveTabManager(tabManager)
+            return .opened(workspaceID: workspaceID)
+        case .noWorkspace:
+            return .workspaceUnavailable
+        case .notFound:
+            return .taskNotFound(taskID.rawValue)
+        }
+    }
+}

--- a/Sources/MainWindowFocusController.swift
+++ b/Sources/MainWindowFocusController.swift
@@ -127,7 +127,7 @@ final class MainWindowFocusController {
             fileExplorerHost = host
         case .find:
             fileSearchHost = host
-        case .sessions, .feed, .dock, .customSidebar:
+        case .sessions, .feed, .dock, .fleet, .customSidebar:
             break
         }
         focusRegisteredRightSidebarEndpointIfNeeded(mode: mode)
@@ -712,7 +712,7 @@ final class MainWindowFocusController {
             return .outline
         case .find:
             return .searchField
-        case .sessions, .customSidebar:
+        case .sessions, .fleet, .customSidebar:
             return .host
         case .feed:
             return focusFirstItem ? .firstItem : .host
@@ -730,8 +730,8 @@ final class MainWindowFocusController {
             return fileExplorerHost?.focusOutline() == true
         case .find:
             return fileSearchHost?.focusSearchField() == true
-        case .sessions, .customSidebar:
-            return mode == .customSidebar ? focusFallbackRightSidebarHost() : false
+        case .sessions, .fleet, .customSidebar:
+            return mode == .customSidebar || mode == .fleet ? focusFallbackRightSidebarHost() : false
         case .feed:
             if target == .firstItem {
                 feedHost?.focusFirstItemFromCoordinator()

--- a/Sources/RightSidebarMode+Availability.swift
+++ b/Sources/RightSidebarMode+Availability.swift
@@ -14,6 +14,8 @@ extension RightSidebarMode {
             return .feed
         case "dock":
             return .dock
+        case "fleet":
+            return .fleet
         default:
             return nil
         }
@@ -22,22 +24,30 @@ extension RightSidebarMode {
     static func availableModes(defaults: UserDefaults = .standard) -> [RightSidebarMode] {
         availableModes(
             feedEnabled: RightSidebarBetaFeatureSettings.isFeedEnabled(defaults: defaults),
-            dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults)
+            dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults),
+            fleetEnabled: RightSidebarBetaFeatureSettings.isFleetEnabled(defaults: defaults)
         )
     }
 
-    static func availableModes(feedEnabled: Bool, dockEnabled: Bool) -> [RightSidebarMode] {
-        allCases.filter { $0 != .customSidebar && $0.isAvailable(feedEnabled: feedEnabled, dockEnabled: dockEnabled) }
+    static func availableModes(feedEnabled: Bool, dockEnabled: Bool, fleetEnabled: Bool) -> [RightSidebarMode] {
+        allCases.filter {
+            $0 != .customSidebar && $0.isAvailable(
+                feedEnabled: feedEnabled,
+                dockEnabled: dockEnabled,
+                fleetEnabled: fleetEnabled
+            )
+        }
     }
 
     func isAvailable(defaults: UserDefaults = .standard) -> Bool {
         isAvailable(
             feedEnabled: RightSidebarBetaFeatureSettings.isFeedEnabled(defaults: defaults),
-            dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults)
+            dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults),
+            fleetEnabled: RightSidebarBetaFeatureSettings.isFleetEnabled(defaults: defaults)
         )
     }
 
-    func isAvailable(feedEnabled: Bool, dockEnabled: Bool) -> Bool {
+    func isAvailable(feedEnabled: Bool, dockEnabled: Bool, fleetEnabled: Bool) -> Bool {
         switch self {
         case .files, .find, .sessions:
             return true
@@ -45,6 +55,8 @@ extension RightSidebarMode {
             return feedEnabled
         case .dock:
             return dockEnabled
+        case .fleet:
+            return fleetEnabled
         case .customSidebar:
             return false
         }

--- a/Sources/RightSidebarMode.swift
+++ b/Sources/RightSidebarMode.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Mode shown in the right sidebar (the panel toggled by Command-Option-B).
+nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
+    case files
+    case find
+    case sessions
+    case feed
+    case dock
+    case fleet
+    case customSidebar = "custom-sidebar"
+
+    var label: String {
+        switch self {
+        case .files: return String(localized: "rightSidebar.mode.files", defaultValue: "Files")
+        case .find: return String(localized: "rightSidebar.mode.find", defaultValue: "Find")
+        case .sessions: return String(localized: "rightSidebar.mode.sessions", defaultValue: "Vault")
+        case .feed: return String(localized: "rightSidebar.mode.feed", defaultValue: "Feed")
+        case .dock: return String(localized: "rightSidebar.mode.dock", defaultValue: "Dock")
+        case .fleet: return String(localized: "rightSidebar.mode.fleet", defaultValue: "Fleet")
+        case .customSidebar: return String(localized: "rightSidebar.mode.customSidebar", defaultValue: "Custom")
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .files: return "folder"
+        case .find: return "magnifyingglass"
+        case .sessions: return "books.vertical"
+        case .feed: return "dot.radiowaves.left.and.right"
+        case .dock: return "dock.rectangle"
+        case .fleet: return "square.grid.3x1.below.line.grid.1x2"
+        case .customSidebar: return "wand.and.stars"
+        }
+    }
+
+    var shortcutAction: KeyboardShortcutSettings.Action? {
+        switch self {
+        case .files: return .switchRightSidebarToFiles
+        case .find: return .switchRightSidebarToFind
+        case .sessions: return .switchRightSidebarToSessions
+        case .feed: return .switchRightSidebarToFeed
+        case .dock: return .switchRightSidebarToDock
+        case .fleet: return nil
+        case .customSidebar: return nil
+        }
+    }
+}
+
+extension RightSidebarMode {
+    static let paneModes: [RightSidebarMode] = [.files, .find, .sessions, .fleet]
+
+    var canOpenAsPane: Bool {
+        Self.paneModes.contains(self)
+    }
+}

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -12,57 +12,6 @@ private func rightSidebarDebugResponder(_ responder: NSResponder?) -> String {
     return String(describing: type(of: responder))
 }
 
-/// Mode shown in the right sidebar (the panel toggled by ⌘⌥B).
-nonisolated enum RightSidebarMode: String, CaseIterable, Codable, Sendable {
-    case files
-    case find
-    case sessions
-    case feed
-    case dock
-    case customSidebar = "custom-sidebar"
-
-    var label: String {
-        switch self {
-        case .files: return String(localized: "rightSidebar.mode.files", defaultValue: "Files")
-        case .find: return String(localized: "rightSidebar.mode.find", defaultValue: "Find")
-        case .sessions: return String(localized: "rightSidebar.mode.sessions", defaultValue: "Vault")
-        case .feed: return String(localized: "rightSidebar.mode.feed", defaultValue: "Feed")
-        case .dock: return String(localized: "rightSidebar.mode.dock", defaultValue: "Dock")
-        case .customSidebar: return String(localized: "rightSidebar.mode.customSidebar", defaultValue: "Custom")
-        }
-    }
-
-    var symbolName: String {
-        switch self {
-        case .files: return "folder"
-        case .find: return "magnifyingglass"
-        case .sessions: return "books.vertical"
-        case .feed: return "dot.radiowaves.left.and.right"
-        case .dock: return "dock.rectangle"
-        case .customSidebar: return "wand.and.stars"
-        }
-    }
-
-    var shortcutAction: KeyboardShortcutSettings.Action? {
-        switch self {
-        case .files: return .switchRightSidebarToFiles
-        case .find: return .switchRightSidebarToFind
-        case .sessions: return .switchRightSidebarToSessions
-        case .feed: return .switchRightSidebarToFeed
-        case .dock: return .switchRightSidebarToDock
-        case .customSidebar: return nil
-        }
-    }
-}
-
-extension RightSidebarMode {
-    static let paneModes: [RightSidebarMode] = [.files, .find, .sessions]
-
-    var canOpenAsPane: Bool {
-        Self.paneModes.contains(self)
-    }
-}
-
 nonisolated enum RightSidebarContentMountPolicy {
     static func shouldMountContent(isRightSidebarVisible: Bool, hasMountedContent: Bool) -> Bool {
         isRightSidebarVisible || hasMountedContent
@@ -75,7 +24,7 @@ nonisolated enum FileExplorerRootSyncPolicy {
         switch mode {
         case .files, .find:
             return true
-        case .sessions, .feed, .dock, .customSidebar:
+        case .sessions, .feed, .dock, .fleet, .customSidebar:
             return false
         }
     }
@@ -136,6 +85,8 @@ struct RightSidebarPanelView: View {
     private var feedEnabled = RightSidebarBetaFeatureSettings.defaultFeedEnabled
     @AppStorage(RightSidebarBetaFeatureSettings.dockEnabledKey)
     private var dockEnabled = RightSidebarBetaFeatureSettings.defaultDockEnabled
+    @AppStorage(RightSidebarBetaFeatureSettings.fleetEnabledKey)
+    private var fleetEnabled = RightSidebarBetaFeatureSettings.defaultFleetEnabled
 
     // Re-reading the observable store inside modeBar causes SwiftUI to
     // track the pending count so the badge updates live when hooks push
@@ -145,7 +96,7 @@ struct RightSidebarPanelView: View {
     }
 
     private var availableModes: [RightSidebarMode] {
-        RightSidebarMode.availableModes(feedEnabled: feedEnabled, dockEnabled: dockEnabled)
+        RightSidebarMode.availableModes(feedEnabled: feedEnabled, dockEnabled: dockEnabled, fleetEnabled: fleetEnabled)
     }
 
     private var modeBarItems: [RightSidebarModeBarItem] {
@@ -211,6 +162,7 @@ struct RightSidebarPanelView: View {
         }
         .onChange(of: feedEnabled) { _, _ in refreshModeAvailabilityAndFocusIfNeeded() }
         .onChange(of: dockEnabled) { _, _ in refreshModeAvailabilityAndFocusIfNeeded() }
+        .onChange(of: fleetEnabled) { _, _ in refreshModeAvailabilityAndFocusIfNeeded() }
     }
 
     private var modeBar: some View {
@@ -401,6 +353,8 @@ struct RightSidebarPanelView: View {
                 FeedPanelView()
             case .dock:
                 dockPanel(windowAppearance: windowAppearance)
+            case .fleet:
+                FleetBoardPanelView()
             case .customSidebar:
                 EmptyView()
             }

--- a/Sources/RightSidebarToolPanel.swift
+++ b/Sources/RightSidebarToolPanel.swift
@@ -81,7 +81,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
         case .sessions:
             guard let store = sessionIndexStoreStorage else { return }
             syncSessionIndexRoot(from: workspace, store: store)
-        case .feed, .dock, .customSidebar:
+        case .feed, .dock, .fleet, .customSidebar:
             break
         }
     }
@@ -139,7 +139,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
             guard let anchor = sessionIndexFocusAnchorView,
                   let window = anchor.window else { return }
             _ = window.makeFirstResponder(anchor)
-        case .feed, .dock, .customSidebar:
+        case .feed, .dock, .fleet, .customSidebar:
             break
         }
     }
@@ -161,7 +161,7 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
         case .sessions:
             guard sessionIndexFocusAnchorView?.ownsKeyboardFocus(responder) == true else { return nil }
             return .panel
-        case .feed, .dock, .customSidebar:
+        case .feed, .dock, .fleet, .customSidebar:
             return nil
         }
     }
@@ -290,6 +290,8 @@ struct RightSidebarToolPanelView: View {
             )
         case .feed, .dock, .customSidebar:
             EmptyView()
+        case .fleet:
+            FleetBoardPanelView()
         }
     }
 

--- a/Sources/TerminalController+ControlFleetContext.swift
+++ b/Sources/TerminalController+ControlFleetContext.swift
@@ -114,24 +114,12 @@ extension TerminalController: ControlFleetContext {
     }
 
     func controlFleetTaskOpen(taskID: String) -> ControlFleetTaskOpenResolution {
-        let engine = FleetAppHost.shared.engine
-        switch engine.openTarget(taskID: FleetTaskID(taskID)) {
-        case .workspace(let idString):
-            guard let workspaceID = UUID(uuidString: idString),
-                  let tabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceID),
-                  let workspace = tabManager.tabs.first(where: { $0.id == workspaceID })
-            else { return .workspaceUnavailable }
-            if let windowID = AppDelegate.shared?.windowId(for: tabManager) {
-                _ = AppDelegate.shared?.focusMainWindow(windowId: windowID)
-            }
-            if tabManager.selectedTabId != workspace.id {
-                tabManager.selectWorkspace(workspace)
-            }
-            TerminalController.shared.setActiveTabManager(tabManager)
+        switch FleetTaskWorkspaceOpener.openTask(FleetTaskID(taskID)) {
+        case .opened(let workspaceID):
             return .opened(workspaceID: workspaceID)
-        case .noWorkspace:
+        case .workspaceUnavailable:
             return .workspaceUnavailable
-        case .notFound:
+        case .taskNotFound(let taskID):
             return .taskNotFound(taskID)
         }
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -591,7 +591,12 @@
 		C0DEF1000000000000000032 /* FleetAppPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF1000000000000000031 /* FleetAppPersistence.swift */; };
 		C0DEF1000000000000000042 /* FleetAppTimers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF1000000000000000041 /* FleetAppTimers.swift */; };
 		C0DEF1000000000000000052 /* FleetAppWorldReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF1000000000000000051 /* FleetAppWorldReader.swift */; };
+		C0DE73610000000000000002 /* FleetBoardPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE73610000000000000001 /* FleetBoardPanelView.swift */; };
+		C0DE73610000000000000004 /* FleetBoardRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE73610000000000000003 /* FleetBoardRows.swift */; };
+		C0DE73610000000000000006 /* FleetBoardStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE73610000000000000005 /* FleetBoardStore.swift */; };
+		C0DE73610000000000000008 /* FleetConfigSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE73610000000000000007 /* FleetConfigSheet.swift */; };
 		C0DEF1000000000000000062 /* FleetControlSocketMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF1000000000000000061 /* FleetControlSocketMapping.swift */; };
+		C0DE7361000000000000000A /* FleetTaskWorkspaceOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE73610000000000000009 /* FleetTaskWorkspaceOpener.swift */; };
 		F0C05170000000000000002 /* FocusHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C05170000000000000001 /* FocusHistory.swift */; };
 		C4160A020000000000000001 /* FocusHistoryMenuInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A020000000000000002 /* FocusHistoryMenuInvalidator.swift */; };
 		5E55400000000000000000D1 /* FocusStealingResponderConformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E55400000000000000000D2 /* FocusStealingResponderConformances.swift */; };
@@ -900,6 +905,7 @@
 		B7F9A604B7F9A604B7F9A604 /* RightSidebarChromeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F9A605B7F9A605B7F9A605 /* RightSidebarChromeStyle.swift */; };
 		C3408A000000000000000003 /* RightSidebarCommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3408A000000000000000004 /* RightSidebarCommandPaletteTests.swift */; };
 		B37A00000000000000000003 /* RightSidebarMode+Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A00000000000000000004 /* RightSidebarMode+Availability.swift */; };
+		C0DE7361000000000000000C /* RightSidebarMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7361000000000000000B /* RightSidebarMode.swift */; };
 		FE003103 /* RightSidebarPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003003 /* RightSidebarPanelView.swift */; };
 		C57570010000000000000002 /* RightSidebarPanelViewTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57570010000000000000001 /* RightSidebarPanelViewTestSupport.swift */; };
 		B37A0000000000000000000D /* RightSidebarRemoteCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A0000000000000000000E /* RightSidebarRemoteCommand.swift */; };
@@ -1916,7 +1922,12 @@
 		C0DEF1000000000000000031 /* FleetAppPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetAppPersistence.swift; sourceTree = "<group>"; };
 		C0DEF1000000000000000041 /* FleetAppTimers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetAppTimers.swift; sourceTree = "<group>"; };
 		C0DEF1000000000000000051 /* FleetAppWorldReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetAppWorldReader.swift; sourceTree = "<group>"; };
+		C0DE73610000000000000001 /* FleetBoardPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetBoardPanelView.swift; sourceTree = "<group>"; };
+		C0DE73610000000000000003 /* FleetBoardRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetBoardRows.swift; sourceTree = "<group>"; };
+		C0DE73610000000000000005 /* FleetBoardStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetBoardStore.swift; sourceTree = "<group>"; };
+		C0DE73610000000000000007 /* FleetConfigSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetConfigSheet.swift; sourceTree = "<group>"; };
 		C0DEF1000000000000000061 /* FleetControlSocketMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetControlSocketMapping.swift; sourceTree = "<group>"; };
+		C0DE73610000000000000009 /* FleetTaskWorkspaceOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetTaskWorkspaceOpener.swift; sourceTree = "<group>"; };
 		F0C05170000000000000001 /* FocusHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusHistory.swift; sourceTree = "<group>"; };
 		C4160A020000000000000002 /* FocusHistoryMenuInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusHistoryMenuInvalidator.swift; sourceTree = "<group>"; };
 		5E55400000000000000000D2 /* FocusStealingResponderConformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusStealingResponderConformances.swift; sourceTree = "<group>"; };
@@ -2221,6 +2232,7 @@
 		B7F9A605B7F9A605B7F9A605 /* RightSidebarChromeStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarChromeStyle.swift; sourceTree = "<group>"; };
 		C3408A000000000000000004 /* RightSidebarCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarCommandPaletteTests.swift; sourceTree = "<group>"; };
 		B37A00000000000000000004 /* RightSidebarMode+Availability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RightSidebarMode+Availability.swift"; sourceTree = "<group>"; };
+		C0DE7361000000000000000B /* RightSidebarMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarMode.swift; sourceTree = "<group>"; };
 		FE003003 /* RightSidebarPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarPanelView.swift; sourceTree = "<group>"; };
 		C57570010000000000000001 /* RightSidebarPanelViewTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarPanelViewTestSupport.swift; sourceTree = "<group>"; };
 		B37A0000000000000000000E /* RightSidebarRemoteCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarRemoteCommand.swift; sourceTree = "<group>"; };
@@ -3590,6 +3602,7 @@
 				B7F9A605B7F9A605B7F9A605 /* RightSidebarChromeStyle.swift */,
 				B7F9A603B7F9A603B7F9A603 /* WindowChromeMetrics.swift */,
 				B37A00000000000000000004 /* RightSidebarMode+Availability.swift */,
+				C0DE7361000000000000000B /* RightSidebarMode.swift */,
 				B37A0000000000000000000E /* RightSidebarRemoteCommand.swift */,
 				FE003003 /* RightSidebarPanelView.swift */,
 				FE0030A3 /* RightSidebarToolPanel.swift */,
@@ -4078,7 +4091,12 @@
 				C0DEF1000000000000000031 /* FleetAppPersistence.swift */,
 				C0DEF1000000000000000041 /* FleetAppTimers.swift */,
 				C0DEF1000000000000000051 /* FleetAppWorldReader.swift */,
+				C0DE73610000000000000001 /* FleetBoardPanelView.swift */,
+				C0DE73610000000000000003 /* FleetBoardRows.swift */,
+				C0DE73610000000000000005 /* FleetBoardStore.swift */,
+				C0DE73610000000000000007 /* FleetConfigSheet.swift */,
 				C0DEF1000000000000000061 /* FleetControlSocketMapping.swift */,
+				C0DE73610000000000000009 /* FleetTaskWorkspaceOpener.swift */,
 			);
 			name = Fleet;
 			path = Fleet;
@@ -4816,7 +4834,12 @@
 				C0DEF1000000000000000032 /* FleetAppPersistence.swift in Sources */,
 				C0DEF1000000000000000042 /* FleetAppTimers.swift in Sources */,
 				C0DEF1000000000000000052 /* FleetAppWorldReader.swift in Sources */,
+				C0DE73610000000000000002 /* FleetBoardPanelView.swift in Sources */,
+				C0DE73610000000000000004 /* FleetBoardRows.swift in Sources */,
+				C0DE73610000000000000006 /* FleetBoardStore.swift in Sources */,
+				C0DE73610000000000000008 /* FleetConfigSheet.swift in Sources */,
 				C0DEF1000000000000000062 /* FleetControlSocketMapping.swift in Sources */,
+				C0DE7361000000000000000A /* FleetTaskWorkspaceOpener.swift in Sources */,
 				F0C05170000000000000002 /* FocusHistory.swift in Sources */,
 				C4160A020000000000000001 /* FocusHistoryMenuInvalidator.swift in Sources */,
 				5E55400000000000000000D1 /* FocusStealingResponderConformances.swift in Sources */,
@@ -5018,6 +5041,7 @@
 				B7F9A600B7F9A600B7F9A600 /* RightSidebarChromeGeometryReporting.swift in Sources */,
 				B7F9A604B7F9A604B7F9A604 /* RightSidebarChromeStyle.swift in Sources */,
 				B37A00000000000000000003 /* RightSidebarMode+Availability.swift in Sources */,
+				C0DE7361000000000000000C /* RightSidebarMode.swift in Sources */,
 				FE003103 /* RightSidebarPanelView.swift in Sources */,
 				B37A0000000000000000000D /* RightSidebarRemoteCommand.swift in Sources */,
 				FE0031A3 /* RightSidebarToolPanel.swift in Sources */,

--- a/cmuxTests/FileExplorerStateModePersistenceTests.swift
+++ b/cmuxTests/FileExplorerStateModePersistenceTests.swift
@@ -12,6 +12,7 @@ final class FileExplorerStateModePersistenceTests: XCTestCase {
     private let customSidebarNameKey = "rightSidebar.customSidebarName"
     private let feedEnabledKey = RightSidebarBetaFeatureSettings.feedEnabledKey
     private let dockEnabledKey = RightSidebarBetaFeatureSettings.dockEnabledKey
+    private let fleetEnabledKey = RightSidebarBetaFeatureSettings.fleetEnabledKey
 
     func testDisabledFeedStoredModeFallsBackToFiles() {
         withSavedRightSidebarModeDefaults {
@@ -44,6 +45,7 @@ final class FileExplorerStateModePersistenceTests: XCTestCase {
             let defaults = UserDefaults.standard
             defaults.set(false, forKey: feedEnabledKey)
             defaults.set(false, forKey: dockEnabledKey)
+            defaults.set(false, forKey: fleetEnabledKey)
             let state = FileExplorerState()
 
             state.mode = .feed
@@ -56,6 +58,16 @@ final class FileExplorerStateModePersistenceTests: XCTestCase {
             XCTAssertEqual(defaults.string(forKey: modeKey), RightSidebarMode.dock.rawValue)
 
             defaults.set(false, forKey: dockEnabledKey)
+            state.refreshModeAvailability()
+            XCTAssertEqual(state.mode, .files)
+            XCTAssertEqual(defaults.string(forKey: modeKey), RightSidebarMode.files.rawValue)
+
+            defaults.set(true, forKey: fleetEnabledKey)
+            state.mode = .fleet
+            XCTAssertEqual(state.mode, .fleet)
+            XCTAssertEqual(defaults.string(forKey: modeKey), RightSidebarMode.fleet.rawValue)
+
+            defaults.set(false, forKey: fleetEnabledKey)
             state.refreshModeAvailability()
             XCTAssertEqual(state.mode, .files)
             XCTAssertEqual(defaults.string(forKey: modeKey), RightSidebarMode.files.rawValue)
@@ -82,6 +94,7 @@ final class FileExplorerStateModePersistenceTests: XCTestCase {
         XCTAssertEqual(RightSidebarMode.from(cliArgument: "sessions"), .sessions)
         XCTAssertEqual(RightSidebarMode.from(cliArgument: "feed"), .feed)
         XCTAssertEqual(RightSidebarMode.from(cliArgument: "dock"), .dock)
+        XCTAssertEqual(RightSidebarMode.from(cliArgument: "fleet"), .fleet)
         XCTAssertEqual(RightSidebarMode.from(cliArgument: " Vault "), .sessions)
         XCTAssertNil(RightSidebarMode.from(cliArgument: "custom-sidebar"))
         XCTAssertNil(RightSidebarMode.from(cliArgument: "custom"))
@@ -94,11 +107,13 @@ final class FileExplorerStateModePersistenceTests: XCTestCase {
         let previousCustomSidebarName = defaults.object(forKey: customSidebarNameKey)
         let previousFeedEnabled = defaults.object(forKey: feedEnabledKey)
         let previousDockEnabled = defaults.object(forKey: dockEnabledKey)
+        let previousFleetEnabled = defaults.object(forKey: fleetEnabledKey)
         defer {
             restore(previousMode, forKey: modeKey)
             restore(previousCustomSidebarName, forKey: customSidebarNameKey)
             restore(previousFeedEnabled, forKey: feedEnabledKey)
             restore(previousDockEnabled, forKey: dockEnabledKey)
+            restore(previousFleetEnabled, forKey: fleetEnabledKey)
         }
         body()
     }

--- a/cmuxTests/RightSidebarCommandPaletteTests.swift
+++ b/cmuxTests/RightSidebarCommandPaletteTests.swift
@@ -14,6 +14,7 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
             let defaults = UserDefaults.standard
             defaults.removeObject(forKey: RightSidebarBetaFeatureSettings.feedEnabledKey)
             defaults.removeObject(forKey: RightSidebarBetaFeatureSettings.dockEnabledKey)
+            defaults.removeObject(forKey: RightSidebarBetaFeatureSettings.fleetEnabledKey)
             let contributions = ContentView.commandPaletteRightSidebarModeCommandContributions()
             let contributionsByID = Dictionary(uniqueKeysWithValues: contributions.map { ($0.commandId, $0) })
             let context = CommandPaletteContextSnapshot()
@@ -40,6 +41,7 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
             XCTAssertEqual(contributions.count, 3)
             XCTAssertNil(contributionsByID[ContentView.commandPaletteRightSidebarModeCommandID(.feed)])
             XCTAssertNil(contributionsByID[ContentView.commandPaletteRightSidebarModeCommandID(.dock)])
+            XCTAssertNil(contributionsByID[ContentView.commandPaletteRightSidebarModeCommandID(.fleet)])
         }
     }
 
@@ -48,6 +50,7 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
             let defaults = UserDefaults.standard
             defaults.set(true, forKey: RightSidebarBetaFeatureSettings.feedEnabledKey)
             defaults.set(true, forKey: RightSidebarBetaFeatureSettings.dockEnabledKey)
+            defaults.set(true, forKey: RightSidebarBetaFeatureSettings.fleetEnabledKey)
 
             for mode in RightSidebarMode.allCases {
                 XCTAssertEqual(
@@ -57,6 +60,31 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
                     mode.shortcutAction
                 )
             }
+        }
+    }
+
+    func testCommandPaletteRightSidebarToolPaneContributionsRespectFleetBetaGate() throws {
+        try withSavedBetaFeatureDefaults {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: RightSidebarBetaFeatureSettings.fleetEnabledKey)
+
+            var contributionsByID = Dictionary(
+                uniqueKeysWithValues: ContentView.commandPaletteRightSidebarToolPaneCommandContributions()
+                    .map { ($0.commandId, $0) }
+            )
+            XCTAssertNil(contributionsByID["palette.openFleetPane"])
+
+            defaults.set(true, forKey: RightSidebarBetaFeatureSettings.fleetEnabledKey)
+            contributionsByID = Dictionary(
+                uniqueKeysWithValues: ContentView.commandPaletteRightSidebarToolPaneCommandContributions()
+                    .map { ($0.commandId, $0) }
+            )
+            let contribution = try XCTUnwrap(contributionsByID["palette.openFleetPane"])
+            let context = CommandPaletteContextSnapshot()
+            XCTAssertEqual(
+                contribution.title(context),
+                String(localized: "command.openFleetPane.title", defaultValue: "Open Fleet as Pane")
+            )
         }
     }
 
@@ -75,9 +103,11 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
         let defaults = UserDefaults.standard
         let previousFeed = defaults.object(forKey: RightSidebarBetaFeatureSettings.feedEnabledKey)
         let previousDock = defaults.object(forKey: RightSidebarBetaFeatureSettings.dockEnabledKey)
+        let previousFleet = defaults.object(forKey: RightSidebarBetaFeatureSettings.fleetEnabledKey)
         defer {
             restore(previousFeed, forKey: RightSidebarBetaFeatureSettings.feedEnabledKey)
             restore(previousDock, forKey: RightSidebarBetaFeatureSettings.dockEnabledKey)
+            restore(previousFleet, forKey: RightSidebarBetaFeatureSettings.fleetEnabledKey)
         }
         try body()
     }

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -1189,6 +1189,7 @@ final class RightSidebarModeShortcutHintTests: XCTestCase {
         XCTAssertEqual(RightSidebarMode.sessions.shortcutAction, .switchRightSidebarToSessions)
         XCTAssertEqual(RightSidebarMode.feed.shortcutAction, .switchRightSidebarToFeed)
         XCTAssertEqual(RightSidebarMode.dock.shortcutAction, .switchRightSidebarToDock)
+        XCTAssertNil(RightSidebarMode.fleet.shortcutAction)
     }
 
     func testModeShortcutsUsePrivateControlDigitDefaults() {


### PR DESCRIPTION
Fleet PR 4 of the chain in #7361 (stacks on #7418).

## What

- **`RightSidebarMode.fleet`** (beta-gated, default off): new board panel in the right-sidebar mode switcher, also openable as a pane like Files/Find/Sessions. Enabled via Settings → Beta Features → Fleet, CLI arg `fleet`, and the command palette (all respecting the gate).
- **Board**: five fixed sections — Queue / Running / Needs input / Review / Done — with counts. Rows show title, colored state chip, attempt badge, PR link, and last error; context menu offers Open / Retry / Cancel / Copy PR URL. Quick-add field enqueues tasks; header has fleet picker, running dot, Start/Stop, and gear.
- **Config sheet**: create a fleet (name, repo root with directory picker, agent command template with placeholder help, max concurrent agents), inline validation errors.
- **`FleetBoardProjection`** (CmuxFleet package): pure state→column mapping with exhaustive no-default switches, row snapshots, and `canUserRetry`/`canUserCancel` predicates mirroring the reducer rules.
- **`FleetEngine.onStateChange`**: single notification chokepoint after every public mutation and signal-driven state change; `FleetBoardStore` coalesces refreshes to one rebuild per runloop tick and only publishes on `Equatable` change.
- **Shared open path**: board row click and socket `fleet.task.open` both call the extracted `FleetTaskWorkspaceOpener.openTask` — clicking a row is the only focus-changing action.
- **`RightSidebarMode` extracted** to its own file so `RightSidebarPanelView.swift` lands at 507 lines (was at its 553 cap); no new file exceeds 218 lines; the length-budget TSV is untouched.

## Snapshot boundary

Nothing below the board's `LazyVStack`/`ForEach` holds an ObservableObject: sections and rows receive immutable `FleetBoardRowSnapshot` values plus a closure action bundle, and row views are `Equatable` with `.equatable()` (per the #2586 rule).

## Localization audit

All 52 new user-facing keys (mode label, column headers, chips, context menus, config sheet, empty state, Settings row, palette subtitle) have both `en` and `ja` entries in `Resources/Localizable.xcstrings` / the settings catalog; parity was script-checked. No existing keys modified.

## Tests

- CmuxFleet package: 67 tests pass (projection mapping/ordering/predicates, `onStateChange` coverage for every mutation and reduced signals).
- CmuxSettingsUI package: 78 tests pass.
- cmuxTests (cmux-unit): `RightSidebarCommandPaletteTests` (incl. new beta-gate regression test for the pane command), `FileExplorerStateModePersistenceTests`, `RightSidebarModeShortcutHintTests` — all pass. Note: the shortcut-hint suite has a pre-existing environment dependency (expects the feed beta default enabled in the host defaults domain); verified the 3 affected tests fail identically without this diff and pass with the gate on.
- Lints: pbxproj test wiring, workspace package groups, Package.resolved policy all pass. Tagged Debug build (`fleet-board-ui`) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 014809100f0ebcb67776362cc9092ffc0f84f1f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786089340&installation_id=133855650&pr_number=7612&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7612&signature=40afa236d4b2f494ebaa120b5ff8f26cccb00afebfb3494ea797006056a50084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a beta-gated Fleet board to the right sidebar (also openable as a pane) to track tasks across Queue, Running, Needs Input, Review, and Done. Keeps the UI live with a new `FleetEngine.onStateChange` and a lightweight projection/store.

- **New Features**
  - Right-sidebar `fleet` mode and pane command, hidden behind the Beta Features toggle; shows column counts and rows with title, state, attempts, PR link, and last error.
  - Row actions: Open, Retry, Cancel, Copy PR URL; clicking a row focuses the task’s workspace.
  - Header with fleet picker, running indicator, Start/Stop, gear; quick-add input; config sheet to create fleets (name, repo root, agent command template, max concurrent) with inline validation.
  - Command palette and Settings wiring respect the gate; new strings added in `en` and `ja`.

- **Refactors**
  - `CmuxFleet`: added `FleetBoardProjection` plus `FleetBoardSnapshot`/`FleetBoardRowSnapshot`; `FleetTaskState` now exposes `canUserRetry`/`canUserCancel`.
  - Engine/UI sync: new `FleetEngine.onStateChange`; `FleetBoardStore` coalesces rebuilds and publishes only on `Equatable` change.
  - Shared task open path via `FleetTaskWorkspaceOpener`; extracted `RightSidebarMode` to its own file and updated availability gating.

<sup>Written for commit 014809100f0ebcb67776362cc9092ffc0f84f1f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

