### PR TITLE
fix: prefer Ghostty inherited cwd for terminal creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -977,17 +977,34 @@ jobs:
             CMUXAgentLaunch
           )
           run_swift_package_tests() {
-            local pkgdir="$1"
-            shift
+            local pkg="$1"
+            local pkgdir="$2"
+            shift 2
             local test_status=0
-            local tolerated_diagnostics='unexpected binary|doesn.t contain a version for the current architecture|incompatible architecture|dlopen_preflight'
             local output
             output="$(swift test --package-path "$pkgdir" "$@" 2>&1)" || test_status=$?
             printf '%s\n' "$output"
             if [ "$test_status" -eq 0 ]; then
               return 0
             fi
-            if printf '%s\n' "$output" | grep -Eq 'Test run with [0-9]+ tests( in [0-9]+ suites)? passed' \
+
+            local expected_summary
+            local tolerated_diagnostics
+            case "$pkg" in
+            CMUXAuthCore)
+              expected_summary='Test run with 15 tests in 2 suites passed'
+              tolerated_diagnostics='CMUXAuthCorePackageTests\.xctest|doesn.t contain a version for the current architecture|incompatible architecture|dlopen_preflight'
+              ;;
+            CmuxTerminal|CmuxTerminalCore)
+              expected_summary='Test run with [0-9]+ tests( in [0-9]+ suites)? passed'
+              tolerated_diagnostics='unexpected binary'
+              ;;
+            *)
+              return "$test_status"
+              ;;
+            esac
+
+            if printf '%s\n' "$output" | grep -Eq "$expected_summary" \
               && ! printf '%s\n' "$output" | grep -Eq 'with [1-9][0-9]* failures?' \
               && printf '%s\n' "$output" | grep -Eq "$tolerated_diagnostics" \
               && ! printf '%s\n' "$output" | grep -E '(^|[^a-zA-Z])error:' | grep -Ev "$tolerated_diagnostics"; then
@@ -999,9 +1016,9 @@ jobs:
           # SwiftPM emits an error-severity diagnostic while planning the
           # GhosttyKit binaryTarget (the xcframework's static archive is not
           # lib-prefixed: "unexpected binary name"/"unexpected binary
-          # framework"). SwiftPM/XCTest can also emit an incompatible-architecture
-          # bundle diagnostic after Swift Testing already reports all tests
-          # passed. Tolerate only those known nonzero runner diagnostics.
+          # framework"). CMUXAuthCore can also emit a known x86_64 XCTest bundle
+          # probe diagnostic after Swift Testing reports its exact full suite.
+          # Tolerate only those scoped nonzero runner diagnostics.
           for pkg in "${PACKAGES[@]}"; do
             # Packages live under group folders (Packages/{Shared,iOS,macOS}/);
             # resolve the actual directory so this list stays group-agnostic.
@@ -1025,11 +1042,11 @@ jobs:
               while IFS= read -r suite; do
                 [ -n "$suite" ] || continue
                 echo "swift test $pkgdir --filter $suite"
-                run_swift_package_tests "$pkgdir" --filter "$suite"
+                run_swift_package_tests "$pkg" "$pkgdir" --filter "$suite"
               done <<< "$suite_list"
               ;;
             *)
-              run_swift_package_tests "$pkgdir"
+              run_swift_package_tests "$pkg" "$pkgdir"
               ;;
             esac
             echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -976,16 +976,31 @@ jobs:
             CmuxUpdater
             CMUXAgentLaunch
           )
+          run_swift_package_tests() {
+            local pkgdir="$1"
+            shift
+            local test_status=0
+            local output
+            output="$(swift test --package-path "$pkgdir" "$@" 2>&1)" || test_status=$?
+            printf '%s\n' "$output"
+            if [ "$test_status" -eq 0 ]; then
+              return 0
+            fi
+            if printf '%s\n' "$output" | grep -Eq 'Test run with [0-9]+ tests( in [0-9]+ suites)? passed' \
+              && ! printf '%s\n' "$output" | grep -Eq 'with [1-9][0-9]* failures?' \
+              && printf '%s\n' "$output" | grep -Eq 'unexpected binary|doesn.t contain a version for the current architecture|incompatible architecture|dlopen_preflight' \
+              && ! printf '%s\n' "$output" | grep -v 'unexpected binary' | grep -Eq '(^|[^a-zA-Z])error:'; then
+              echo "Tolerated cosmetic SwiftPM runner diagnostic; all tests passed."
+              return 0
+            fi
+            return "$test_status"
+          }
           # SwiftPM emits an error-severity diagnostic while planning the
           # GhosttyKit binaryTarget (the xcframework's static archive is not
           # lib-prefixed: "unexpected binary name"/"unexpected binary
-          # framework"). The build and every test still succeed, but the
-          # diagnostic poisons the process exit code on a fresh .build. For
-          # the GhosttyKit-referencing packages only, tolerate exactly that
-          # case: a nonzero exit passes only when the all-tests-passed summary
-          # is present, no test failures are reported, and the only error
-          # lines are that known diagnostic. Everything else (compile errors,
-          # test failures, crashes) still fails the job.
+          # framework"). SwiftPM/XCTest can also emit an incompatible-architecture
+          # bundle diagnostic after Swift Testing already reports all tests
+          # passed. Tolerate only those known nonzero runner diagnostics.
           for pkg in "${PACKAGES[@]}"; do
             # Packages live under group folders (Packages/{Shared,iOS,macOS}/);
             # resolve the actual directory so this list stays group-agnostic.
@@ -1009,25 +1024,11 @@ jobs:
               while IFS= read -r suite; do
                 [ -n "$suite" ] || continue
                 echo "swift test $pkgdir --filter $suite"
-                swift test --package-path "$pkgdir" --filter "$suite"
+                run_swift_package_tests "$pkgdir" --filter "$suite"
               done <<< "$suite_list"
               ;;
-            CmuxTerminal|CmuxTerminalCore)
-              test_status=0
-              output="$(swift test --package-path "$pkgdir" 2>&1)" || test_status=$?
-              printf '%s\n' "$output"
-              if [ "$test_status" -ne 0 ]; then
-                if printf '%s\n' "$output" | grep -Eq 'Test run with [0-9]+ tests( in [0-9]+ suites)? passed' \
-                  && ! printf '%s\n' "$output" | grep -Eq 'with [1-9][0-9]* failures?' \
-                  && ! printf '%s\n' "$output" | grep -v 'unexpected binary' | grep -Eq '(^|[^a-zA-Z])error:'; then
-                  echo "Tolerated cosmetic GhosttyKit binaryTarget diagnostic; all tests passed."
-                else
-                  exit "$test_status"
-                fi
-              fi
-              ;;
             *)
-              swift test --package-path "$pkgdir"
+              run_swift_package_tests "$pkgdir"
               ;;
             esac
             echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1004,10 +1004,10 @@ jobs:
               ;;
             esac
 
-            if printf '%s\n' "$output" | grep -Eq "$expected_summary" \
-              && ! printf '%s\n' "$output" | grep -Eq 'with [1-9][0-9]* failures?' \
-              && printf '%s\n' "$output" | grep -Eq "$tolerated_diagnostics" \
-              && ! printf '%s\n' "$output" | grep -E '(^|[^a-zA-Z])error:' | grep -Ev "$tolerated_diagnostics"; then
+            if grep -Eq "$expected_summary" <<< "$output" \
+              && ! grep -Eq 'with [1-9][0-9]* failures?' <<< "$output" \
+              && grep -Eq "$tolerated_diagnostics" <<< "$output" \
+              && ! grep -E '(^|[^a-zA-Z])error:' <<< "$output" | grep -Ev "$tolerated_diagnostics"; then
               echo "Tolerated cosmetic SwiftPM runner diagnostic; all tests passed."
               return 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -980,6 +980,7 @@ jobs:
             local pkgdir="$1"
             shift
             local test_status=0
+            local tolerated_diagnostics='unexpected binary|doesn.t contain a version for the current architecture|incompatible architecture|dlopen_preflight'
             local output
             output="$(swift test --package-path "$pkgdir" "$@" 2>&1)" || test_status=$?
             printf '%s\n' "$output"
@@ -988,8 +989,8 @@ jobs:
             fi
             if printf '%s\n' "$output" | grep -Eq 'Test run with [0-9]+ tests( in [0-9]+ suites)? passed' \
               && ! printf '%s\n' "$output" | grep -Eq 'with [1-9][0-9]* failures?' \
-              && printf '%s\n' "$output" | grep -Eq 'unexpected binary|doesn.t contain a version for the current architecture|incompatible architecture|dlopen_preflight' \
-              && ! printf '%s\n' "$output" | grep -v 'unexpected binary' | grep -Eq '(^|[^a-zA-Z])error:'; then
+              && printf '%s\n' "$output" | grep -Eq "$tolerated_diagnostics" \
+              && ! printf '%s\n' "$output" | grep -E '(^|[^a-zA-Z])error:' | grep -Ev "$tolerated_diagnostics"; then
               echo "Tolerated cosmetic SwiftPM runner diagnostic; all tests passed."
               return 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -993,7 +993,7 @@ jobs:
             case "$pkg" in
             CMUXAuthCore)
               expected_summary='Test run with 15 tests in 2 suites passed'
-              tolerated_diagnostics='CMUXAuthCorePackageTests\.xctest|doesn.t contain a version for the current architecture|incompatible architecture|dlopen_preflight'
+              tolerated_diagnostics='CMUXAuthCorePackageTests\.xctest.*(doesn.t contain a version for the current architecture|incompatible architecture|dlopen_preflight)|(doesn.t contain a version for the current architecture|incompatible architecture|dlopen_preflight).*CMUXAuthCorePackageTests\.xctest'
               ;;
             CmuxTerminal|CmuxTerminalCore)
               expected_summary='Test run with [0-9]+ tests( in [0-9]+ suites)? passed'

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -353,9 +353,13 @@ jobs:
             # section is not always flushed into the tee'd log, and without the
             # ✘ patterns a real Swift Testing failure exiting 65 was
             # misclassified as a runner cleanup failure and turned the job green.
-            grep -Eq "Test Suite 'Selected tests' passed|Test Suite 'cmuxUITests' passed" "$log_path" &&
+            if grep -Eq "Test Suite 'Selected tests' passed|Test Suite 'cmuxUITests' passed" "$log_path" &&
               grep -Eq "Executed [1-9][0-9]* tests, with 0 failures \\(0 unexpected\\)" "$log_path" &&
-              ! grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|Failing tests:|with [1-9][0-9]* failures|with [0-9]+ failures \\([1-9][0-9]* unexpected\\)|✘ Test|✘ Suite" "$log_path"
+              ! grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|Failing tests:|with [1-9][0-9]* failures|with [0-9]+ failures \\([1-9][0-9]* unexpected\\)|✘ Test|✘ Suite" "$log_path"; then
+              return 0
+            fi
+            grep -Eq "✔ Test run with [1-9][0-9]* tests? in .* passed" "$log_path" &&
+              ! grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|with [1-9][0-9]* failures|with [0-9]+ failures \\([1-9][0-9]* unexpected\\)|✘ Test|✘ Suite" "$log_path"
           }
           for attempt in 1 2; do
             LOG_PATH="$IOS_DERIVED_DATA/logs/attempt-${attempt}.log"
@@ -369,7 +373,7 @@ jobs:
             fi
             status="${PIPESTATUS[0]}"
             if selected_tests_passed_despite_xcodebuild_status "$LOG_PATH"; then
-              echo "xcodebuild exited $status after XCTest reported the selected tests passed with zero failures; treating this as a runner cleanup failure."
+              echo "xcodebuild exited $status after the selected tests passed with zero failures; treating this as a runner cleanup failure."
               exit 0
             fi
             if [ "$attempt" -lt 2 ] && grep -Eq "Timed out while launching application via Xcode|Failed to send signal 19|DTXMessage" "$LOG_PATH"; then

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -381,9 +381,6 @@ jobs:
             # section is not always flushed into the tee'd log, and without the
             # ✘ patterns a real Swift Testing failure exiting 65 was
             # misclassified as a runner cleanup failure and turned the job green.
-            if tests_log_reports_success "$log_path" && tests_log_has_no_failures "$log_path"; then
-              return 0
-            fi
             local timeout_prefix="${log_path}.before-diagnostics-timeout"
             write_log_before_diagnostics_timeout "$log_path" "$timeout_prefix" || {
               rm -f "$timeout_prefix"
@@ -409,7 +406,7 @@ jobs:
             fi
             status="${PIPESTATUS[0]}"
             if selected_tests_passed_despite_xcodebuild_status "$LOG_PATH"; then
-              echo "xcodebuild exited $status after the selected tests passed with zero failures; treating this as a runner cleanup failure."
+              echo "xcodebuild exited $status after tests passed before simulator diagnostics timed out; treating this as a runner cleanup failure."
               exit 0
             fi
             if [ "$attempt" -lt 2 ] && grep -Eq "Timed out while launching application via Xcode|Failed to send signal 19|DTXMessage" "$LOG_PATH"; then

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -346,6 +346,34 @@ jobs:
             XCODEBUILD_ARGS+=(-skip-testing:cmuxUITests)
           fi
           XCODEBUILD_ARGS+=(test)
+          write_log_before_diagnostics_timeout() {
+            local log_path="$1"
+            local output_path="$2"
+            awk '
+              /Failure collecting diagnostics from simulator: Timed out after/ { found = 1; exit }
+              { print }
+              END { if (!found) exit 1 }
+            ' "$log_path" > "$output_path"
+          }
+          latest_xcresult_tests_passed() {
+            local result_bundle
+            result_bundle="$(ls -td "$IOS_DERIVED_DATA"/Logs/Test/*.xcresult 2>/dev/null | head -n 1 || true)"
+            [ -n "$result_bundle" ] || return 1
+            xcrun xcresulttool get test-results summary --path "$result_bundle" --compact 2>/dev/null |
+              python3 -c 'import json, sys; s = json.load(sys.stdin); sys.exit(0 if s.get("result") == "Passed" and int(s.get("totalTestCount") or 0) > 0 and int(s.get("failedTests") or 0) == 0 else 1)'
+          }
+          tests_log_reports_success() {
+            local log_path="$1"
+            if grep -Eq "Test Suite 'Selected tests' passed|Test Suite 'cmuxUITests' passed" "$log_path" &&
+              grep -Eq "Executed [1-9][0-9]* tests, with 0 failures \\(0 unexpected\\)" "$log_path"; then
+              return 0
+            fi
+            grep -Eq "Test run with [1-9][0-9]* tests? in [1-9][0-9]* suites? passed" "$log_path"
+          }
+          tests_log_has_no_failures() {
+            local log_path="$1"
+            ! grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|Failing tests:|with [1-9][0-9]* failures|with [0-9]+ failures \\([1-9][0-9]* unexpected\\)|✘ Test|✘ Suite" "$log_path"
+          }
           selected_tests_passed_despite_xcodebuild_status() {
             local log_path="$1"
             # The negative grep must catch BOTH XCTest failure output and Swift
@@ -353,13 +381,21 @@ jobs:
             # section is not always flushed into the tee'd log, and without the
             # ✘ patterns a real Swift Testing failure exiting 65 was
             # misclassified as a runner cleanup failure and turned the job green.
-            if grep -Eq "Test Suite 'Selected tests' passed|Test Suite 'cmuxUITests' passed" "$log_path" &&
-              grep -Eq "Executed [1-9][0-9]* tests, with 0 failures \\(0 unexpected\\)" "$log_path" &&
-              ! grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|Failing tests:|with [1-9][0-9]* failures|with [0-9]+ failures \\([1-9][0-9]* unexpected\\)|✘ Test|✘ Suite" "$log_path"; then
+            if tests_log_reports_success "$log_path" && tests_log_has_no_failures "$log_path"; then
               return 0
             fi
-            grep -Eq "✔ Test run with [1-9][0-9]* tests? in .* passed" "$log_path" &&
-              ! grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|with [1-9][0-9]* failures|with [0-9]+ failures \\([1-9][0-9]* unexpected\\)|✘ Test|✘ Suite" "$log_path"
+            local timeout_prefix="${log_path}.before-diagnostics-timeout"
+            write_log_before_diagnostics_timeout "$log_path" "$timeout_prefix" || {
+              rm -f "$timeout_prefix"
+              return 1
+            }
+            local cleanup_status=1
+            if tests_log_has_no_failures "$timeout_prefix" &&
+              (latest_xcresult_tests_passed || tests_log_reports_success "$timeout_prefix"); then
+              cleanup_status=0
+            fi
+            rm -f "$timeout_prefix"
+            return "$cleanup_status"
           }
           for attempt in 1 2; do
             LOG_PATH="$IOS_DERIVED_DATA/logs/attempt-${attempt}.log"

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
@@ -233,12 +233,17 @@ extension MobileShellComposite {
     }
 
     private func deliverTerminalOutput(
-        _ delivery: TerminalOutputDelivery,
+        _ incomingDelivery: TerminalOutputDelivery,
         surfaceID: String,
         bypassReplayBarrier: Bool = false
     ) -> Bool {
         guard let continuation = terminalByteContinuationsBySurfaceID[surfaceID],
               let streamToken = terminalOutputStreamTokensBySurfaceID[surfaceID] else { return false }
+        var delivery = incomingDelivery
+        if bypassReplayBarrier,
+           let replayBarrierToken = terminalReplayBarrierTokensBySurfaceID[surfaceID] {
+            delivery.replayBarrierAckToken = replayBarrierToken
+        }
         if let replayBarrierToken = terminalReplayBarrierTokensBySurfaceID[surfaceID],
            !bypassReplayBarrier {
             terminalReplayBarrierDroppedOutputSurfaceIDs.insert(surfaceID)
@@ -301,7 +306,10 @@ extension MobileShellComposite {
     public func terminalOutputDidProcess(surfaceID: String, streamToken: UUID) {
         guard terminalOutputStreamTokensBySurfaceID[surfaceID] == streamToken,
               var queue = terminalOutputQueuesBySurfaceID[surfaceID] else { return }
-        let next = queue.completeInFlight()
+        let next = terminalOutputAfterDroppingStaleQueuedFrames(
+            from: &queue,
+            surfaceID: surfaceID
+        )
         terminalOutputQueuesBySurfaceID[surfaceID] = queue
         if terminalReplayBarrierAckStreamTokensBySurfaceID[surfaceID] == streamToken {
             let replayBarrierToken = terminalReplayBarrierTokensBySurfaceID[surfaceID]
@@ -371,6 +379,11 @@ extension MobileShellComposite {
               terminalOutputStreamTokensBySurfaceID[surfaceID] == streamToken else {
             return
         }
+        prepareQueuedReplayBarrierAckIfNeeded(
+            for: next,
+            surfaceID: surfaceID,
+            streamToken: streamToken
+        )
         continuation.yield(MobileTerminalOutputChunk(
             data: next.bytes,
             streamToken: streamToken,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputQueueDrain.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputQueueDrain.swift
@@ -1,0 +1,56 @@
+internal import CmuxMobileDiagnostics
+import Foundation
+
+extension MobileShellComposite {
+    func terminalOutputAfterDroppingStaleQueuedFrames(
+        from queue: inout TerminalOutputDeliveryQueue,
+        surfaceID: String
+    ) -> TerminalOutputDelivery? {
+        var next = queue.completeInFlight()
+        while let candidate = next,
+              shouldDropQueuedTerminalOutput(candidate, surfaceID: surfaceID) {
+            next = queue.completeInFlight()
+        }
+        return next
+    }
+
+    func prepareQueuedReplayBarrierAckIfNeeded(
+        for delivery: TerminalOutputDelivery,
+        surfaceID: String,
+        streamToken: UUID
+    ) {
+        guard let replayBarrierToken = delivery.replayBarrierAckToken,
+              terminalReplayBarrierTokensBySurfaceID[surfaceID] == replayBarrierToken else {
+            return
+        }
+        terminalReplayBarrierAckStreamTokensBySurfaceID[surfaceID] = streamToken
+    }
+
+    private func shouldDropQueuedTerminalOutput(
+        _ delivery: TerminalOutputDelivery,
+        surfaceID: String
+    ) -> Bool {
+        guard let renderGrid = delivery.renderGridFrame else { return false }
+        let deliveredSeq = deliveredTerminalByteEndSeqBySurfaceID[surfaceID] ?? 0
+        let preBarrierFloorSeq = terminalPreBarrierDeliveredEndSeqBySurfaceID[surfaceID]
+        let deliveredFloor = max(deliveredSeq, preBarrierFloorSeq ?? 0)
+        let isStale = deliveredSeq > renderGrid.stateSeq
+            || (preBarrierFloorSeq.map { $0 >= renderGrid.stateSeq } ?? false)
+        guard isStale else { return false }
+        if let replayBarrierToken = delivery.replayBarrierAckToken {
+            consumeTerminalReplayFailureRetryAfterNoProgress(
+                surfaceID: surfaceID,
+                reason: "stale_queued_render_grid"
+            )
+            clearTerminalReplayBarrierIfCurrent(
+                surfaceID: surfaceID,
+                token: replayBarrierToken,
+                reason: "stale_queued_render_grid"
+            )
+        }
+        MobileDebugLog.anchormux(
+            "terminal.output.drop_stale_queued_render_grid surface=\(surfaceID) delivered=\(deliveredFloor) frame=\(renderGrid.stateSeq)"
+        )
+        return true
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
@@ -16,6 +16,7 @@ struct TerminalOutputDelivery: Equatable, Sendable {
     }
 
     private var payload: Payload
+    var replayBarrierAckToken: UUID?
     var replacementScope: ReplacementScope?
     var viewportPolicy: MobileTerminalOutputViewportPolicy?
 
@@ -51,6 +52,15 @@ struct TerminalOutputDelivery: Equatable, Sendable {
             bytes
         case .renderGrid(let frame):
             frame.vtPatchBytes()
+        }
+    }
+
+    var renderGridFrame: MobileTerminalRenderGridFrame? {
+        switch payload {
+        case .bytes:
+            return nil
+        case .renderGrid(let frame):
+            return frame
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalQueuedRenderGridStalenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalQueuedRenderGridStalenessTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+@Test func queuedRenderGridOlderThanDeliveredHighWaterIsSkipped() async throws {
+    let store = MobileShellComposite.preview()
+    let surfaceID = "terminal"
+    var iterator = store.terminalOutputStream(surfaceID: surfaceID).makeAsyncIterator()
+
+    store.deliverTerminalBytes(Data("blocked".utf8), surfaceID: surfaceID)
+    let blockedChunk = try #require(await iterator.next())
+    let staleFrame = try renderGridFrame(surfaceID: surfaceID, seq: 4, text: "old")
+    #expect(store.deliverTerminalRenderGrid(staleFrame, surfaceID: surfaceID))
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.pendingCount == 1)
+
+    store.markTerminalBytesDelivered(surfaceID: surfaceID, endSeq: 12, fullReplacement: true)
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: blockedChunk.streamToken)
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
+
+    let currentFrame = try renderGridFrame(surfaceID: surfaceID, seq: 12, text: "current")
+    #expect(store.deliverTerminalRenderGrid(currentFrame, surfaceID: surfaceID))
+    let currentChunk = try #require(await iterator.next())
+    let currentText = try #require(String(data: currentChunk.data, encoding: .utf8))
+    #expect(currentText.contains("current"))
+    #expect(!currentText.contains("old"))
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: currentChunk.streamToken)
+}
+
+@MainActor
+@Test func staleQueuedReplayRenderGridClearsBarrierWithoutPaintingOldFrame() async throws {
+    let store = MobileShellComposite.preview()
+    let surfaceID = "terminal"
+    var iterator = store.terminalOutputStream(surfaceID: surfaceID).makeAsyncIterator()
+
+    let barrierToken = store.beginTerminalReplayBarrier(surfaceID: surfaceID)
+    let currentFrame = try renderGridFrame(surfaceID: surfaceID, seq: 12, text: "current")
+    #expect(store.deliverTerminalRenderGrid(
+        currentFrame,
+        surfaceID: surfaceID,
+        bypassReplayBarrier: true
+    ))
+    store.markTerminalBytesDelivered(surfaceID: surfaceID, endSeq: 12, fullReplacement: true)
+    let currentChunk = try #require(await iterator.next())
+    let currentText = try #require(String(data: currentChunk.data, encoding: .utf8))
+    #expect(currentText.contains("current"))
+
+    let staleFrame = try renderGridFrame(surfaceID: surfaceID, seq: 4, text: "old")
+    #expect(store.deliverTerminalRenderGrid(
+        staleFrame,
+        surfaceID: surfaceID,
+        bypassReplayBarrier: true
+    ))
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.pendingCount == 1)
+
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: currentChunk.streamToken)
+
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
+    #expect(store.terminalReplayBarrierTokensBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalReplayBarrierTokensBySurfaceID[surfaceID] != barrierToken)
+
+    let afterFrame = try renderGridFrame(surfaceID: surfaceID, seq: 13, text: "after")
+    #expect(store.deliverTerminalRenderGrid(afterFrame, surfaceID: surfaceID))
+    let afterChunk = try #require(await iterator.next())
+    let afterText = try #require(String(data: afterChunk.data, encoding: .utf8))
+    #expect(afterText.contains("after"))
+    #expect(!afterText.contains("old"))
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: afterChunk.streamToken)
+}

--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -40,11 +40,13 @@ enum CommandClickFileOpenRouter {
            !dir.isEmpty {
             return dir
         }
-        if let dir = workspace.terminalPanel(for: surfaceId)?
-            .requestedWorkingDirectory?
+        if let dir = workspace.terminalRequestedWorkingDirectoryForLocalFallback(panelId: surfaceId)?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !dir.isEmpty {
             return dir
+        }
+        if workspace.usesRemoteDirectoryProvenance {
+            return nil
         }
         let dir = workspace.currentDirectory
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9484,7 +9484,7 @@ struct ContentView: View {
                 if let directory = workspace.reportedPanelDirectory(panelId: focusedPanelId) {
                     return directory
                 }
-                if let requestedDirectory = workspace.terminalPanel(for: focusedPanelId)?.requestedWorkingDirectory {
+                if let requestedDirectory = workspace.terminalRequestedWorkingDirectoryForLocalFallback(panelId: focusedPanelId) {
                     return requestedDirectory
                 }
             }

--- a/Sources/TabManager+WindowTitle.swift
+++ b/Sources/TabManager+WindowTitle.swift
@@ -99,7 +99,7 @@ extension TabManager {
         if let focusedPanelId = tab.focusedPanelId,
            tab.allowsLocalDirectoryFallback(panelId: focusedPanelId) {
             return trimmedWindowTitleDirectory(tab.reportedPanelDirectory(panelId: focusedPanelId))
-                ?? trimmedWindowTitleDirectory(tab.terminalPanel(for: focusedPanelId)?.requestedWorkingDirectory)
+                ?? trimmedWindowTitleDirectory(tab.terminalRequestedWorkingDirectoryForLocalFallback(panelId: focusedPanelId))
                 ?? (tab.isRemoteWorkspace ? "" : trimmedWindowTitleDirectory(tab.presentedCurrentDirectory) ?? "")
         }
         return trimmedWindowTitleDirectory(tab.presentedCurrentDirectory) ?? ""

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -695,7 +695,7 @@ class TabManager: ObservableObject {
         // still probe git metadata before OSC 7 has reported a live cwd.
         if let directory = workspace.reportedPanelDirectory(panelId: panelId) { return normalizedWorkingDirectory(directory) }
         guard workspace.allowsLocalDirectoryFallback(panelId: panelId) else { return nil }
-        let rawDirectory = workspace.terminalPanel(for: panelId)?.requestedWorkingDirectory ?? (!workspace.usesRemoteDirectoryProvenance && workspace.focusedPanelId == panelId ? workspace.currentDirectory : nil)
+        let rawDirectory = workspace.terminalRequestedWorkingDirectoryForLocalFallback(panelId: panelId) ?? (!workspace.usesRemoteDirectoryProvenance && workspace.focusedPanelId == panelId ? workspace.currentDirectory : nil)
         return rawDirectory.flatMap(normalizedWorkingDirectory)
     }
 

--- a/Sources/TerminalController+ControlSurfaceContext.swift
+++ b/Sources/TerminalController+ControlSurfaceContext.swift
@@ -106,10 +106,52 @@ extension TerminalController: ControlSurfaceContext {
         }
         guard let ws = resolveSurfaceWorkspace(routing: routing, tabManager: tabManager) else { return nil }
 
+        var paneByPanelId: [UUID: UUID] = [:]
+        var indexInPaneByPanelId: [UUID: Int] = [:]
+        var selectedInPaneByPanelId: [UUID: Bool] = [:]
+        for paneId in ws.bonsplitController.allPaneIds {
+            let tabs = ws.bonsplitController.tabs(inPane: paneId)
+            let selected = ws.bonsplitController.selectedTab(inPane: paneId)
+            for (idx, tab) in tabs.enumerated() {
+                guard let panelId = ws.panelIdFromSurfaceId(tab.id) else { continue }
+                paneByPanelId[panelId] = paneId.id
+                indexInPaneByPanelId[panelId] = idx
+                selectedInPaneByPanelId[panelId] = (tab.id == selected?.id)
+            }
+        }
+
+        let focusedSurfaceId = ws.focusedPanelId
+        let surfaces: [ControlSurfaceSummary] = orderedPanels(in: ws).map { panel in
+            let terminalPanel = panel as? TerminalPanel
+            return ControlSurfaceSummary(
+                surfaceID: panel.id,
+                typeRawValue: panel.panelType.rawValue,
+                title: ws.panelTitle(panelId: panel.id) ?? panel.displayTitle,
+                isFocused: panel.id == focusedSurfaceId,
+                paneID: paneByPanelId[panel.id],
+                indexInPane: indexInPaneByPanelId[panel.id],
+                selectedInPane: selectedInPaneByPanelId[panel.id],
+                developerToolsVisible: (panel as? BrowserPanel)?.isDeveloperToolsVisible(),
+                requestedWorkingDirectory: terminalPanel == nil
+                    ? nil
+                    : v2NonEmptyString(ws.terminalRequestedWorkingDirectoryForLocalFallback(panelId: panel.id)),
+                initialCommand: terminalPanel.flatMap {
+                    v2NonEmptyString($0.surface.debugInitialCommand())
+                },
+                tmuxStartCommand: terminalPanel.flatMap {
+                    v2NonEmptyString($0.surface.debugTmuxStartCommand())
+                },
+                isTerminal: terminalPanel != nil,
+                resumeBinding: terminalPanel != nil
+                    ? controlResumeBinding(from: ws.surfaceResumeBinding(panelId: panel.id))
+                    : nil
+            )
+        }
+
         return ControlSurfaceListSnapshot(
             workspaceID: ws.id,
             windowID: v2ResolveWindowId(tabManager: tabManager),
-            surfaces: controlSurfaceSummaries(workspace: ws)
+            surfaces: surfaces
         )
     }
 

--- a/Sources/TerminalController+MobileWorkspaceList.swift
+++ b/Sources/TerminalController+MobileWorkspaceList.swift
@@ -198,7 +198,7 @@ extension TerminalController {
             }
             let terminalDirectory = workspace.effectivePanelDirectory(
                 panelId: terminal.id,
-                localFallback: mobileNonEmpty(terminal.directory) ?? mobileNonEmpty(terminal.requestedWorkingDirectory)
+                localFallback: mobileNonEmpty(terminal.directory) ?? workspace.terminalRequestedWorkingDirectoryForLocalFallback(panelId: terminal.id)
             )
             return [
                 "id": terminal.id.uuidString,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5020,7 +5020,7 @@ class TerminalController {
                 let treeVisible = mapped?.bonsplitTabId != nil && paneId != nil
                 let ttyName = workspace?.surfaceTTYNames[panelId]
                 let currentDirectory = workspace.map { $0.effectivePanelDirectory(panelId: panelId, localFallback: nonEmpty(mapped?.terminalPanel.directory)) } ?? nonEmpty(mapped?.terminalPanel.directory)
-                let requestedWorkingDirectory = workspace?.allowsLocalDirectoryFallback(panelId: panelId) == false ? nil : nonEmpty(terminalSurface.requestedWorkingDirectory)
+                let requestedWorkingDirectory = workspace?.terminalRequestedWorkingDirectoryForLocalFallback(panelId: panelId) ?? (workspace == nil ? nonEmpty(terminalSurface.requestedWorkingDirectory) : nil)
                 let teardownRequest = terminalSurface.debugTeardownRequest()
                 let lastKnownWorkspaceId = terminalSurface.debugLastKnownWorkspaceId()
 

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -2478,12 +2478,10 @@ struct TextBoxInputContainer: View {
            !directory.isEmpty {
             return directory
         }
-        if let directory = workspace.terminalPanel(for: surface.id)?
-            .requestedWorkingDirectory?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-           !directory.isEmpty {
+        if let directory = workspace.terminalRequestedWorkingDirectoryForLocalFallback(panelId: surface.id) {
             return directory
         }
+        if workspace.usesRemoteDirectoryProvenance { return nil }
         let directory = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
         return directory.isEmpty ? nil : directory
     }

--- a/Sources/Workspace+LayoutCapture.swift
+++ b/Sources/Workspace+LayoutCapture.swift
@@ -176,7 +176,7 @@ extension Workspace {
         let candidates = [
             panelDirectories[panelId],
             terminalPanel(for: panelId)?.directory,
-            terminalPanel(for: panelId)?.requestedWorkingDirectory,
+            terminalRequestedWorkingDirectoryForLocalFallback(panelId: panelId),
         ]
         for candidate in candidates {
             let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/Sources/Workspace+SidebarDirectories.swift
+++ b/Sources/Workspace+SidebarDirectories.swift
@@ -63,7 +63,16 @@ extension Workspace {
         }
         guard allowsLocalDirectoryFallback(panelId: panelId) else { return nil }
         return normalizedSidebarDirectory(localFallback)
-            ?? normalizedSidebarDirectory(terminalPanel(for: panelId)?.requestedWorkingDirectory)
+            ?? terminalRequestedWorkingDirectoryForLocalFallback(panelId: panelId)
+    }
+
+    func terminalRequestedWorkingDirectoryForLocalFallback(panelId: UUID?) -> String? {
+        guard let panelId,
+              allowsLocalDirectoryFallback(panelId: panelId),
+              !isRemoteTerminalSurface(panelId) else {
+            return nil
+        }
+        return normalizedSidebarDirectory(terminalPanel(for: panelId)?.requestedWorkingDirectory)
     }
 
     func allowsLocalDirectoryFallback(panelId: UUID) -> Bool {
@@ -99,8 +108,7 @@ extension Workspace {
     private func demotedRemoteDirectoryReplacement(excluding excludedPanelIds: Set<UUID>) -> String? {
         for panelId in sidebarOrderedPanelIds() where !excludedPanelIds.contains(panelId) {
             if let directory = normalizedSidebarDirectory(panelDirectories[panelId]) { return directory }
-            if allowsLocalDirectoryFallback(panelId: panelId),
-               let directory = normalizedSidebarDirectory(terminalPanel(for: panelId)?.requestedWorkingDirectory) {
+            if let directory = terminalRequestedWorkingDirectoryForLocalFallback(panelId: panelId) {
                 return directory
             }
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7161,26 +7161,15 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
 
-        let ghosttyInheritedWd = inheritedConfig?
-            .workingDirectory?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let ghosttyInheritedNonEmpty: String? = {
-            guard let ghosttyInheritedWd, !ghosttyInheritedWd.isEmpty else { return nil }
-            return ghosttyInheritedWd
-        }()
-
-        // Prefer libghostty's inherited working directory (same source as standalone Ghostty
-        // when splitting). cmux's explicit TerminalSurface `workingDirectory` wins over
-        // configTemplate in TerminalSurface.createSurface; a stale sidebar cache or workspace
-        // `currentDirectory` must not clobber the live cwd Ghostty already tracks on the source
-        // surface when shell integration events lag or do not run.
-        let splitWorkingDirectory = ghosttyInheritedNonEmpty ?? resolvedTerminalStartupWorkingDirectory(
-            requestedWorkingDirectory: workingDirectory,
-            sourcePanelId: panelId
-        )
+        // Explicit caller cwd is intent; Ghostty inherited cwd only outranks cached Workspace fallback.
+        let requestedWorkingDirectory = Self.normalizedTerminalWorkingDirectory(workingDirectory)
+        let ghosttyInheritedWorkingDirectory = Self.normalizedTerminalWorkingDirectory(inheritedConfig?.workingDirectory)
+        let splitWorkingDirectory = requestedWorkingDirectory
+            ?? ghosttyInheritedWorkingDirectory
+            ?? resolvedTerminalStartupWorkingDirectory(requestedWorkingDirectory: nil, sourcePanelId: panelId)
 #if DEBUG
         cmuxDebugLog(
-            "split.cwd panelId=\(panelId.uuidString.prefix(5)) panelDir=\(panelDirectories[panelId] ?? "nil") requestedDir=\(terminalPanel(for: panelId)?.requestedWorkingDirectory ?? "nil") currentDir=\(currentDirectory) inherited=\(ghosttyInheritedNonEmpty ?? "nil") resolved=\(splitWorkingDirectory ?? "nil")"
+            "split.cwd panelId=\(panelId.uuidString.prefix(5)) panelDir=\(panelDirectories[panelId] ?? "nil") requestedDir=\(terminalPanel(for: panelId)?.requestedWorkingDirectory ?? "nil") currentDir=\(currentDirectory) requested=\(requestedWorkingDirectory ?? "nil") inherited=\(ghosttyInheritedWorkingDirectory ?? "nil") resolved=\(splitWorkingDirectory ?? "nil")"
         )
 #endif
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6760,7 +6760,7 @@ final class Workspace: Identifiable, ObservableObject {
             panelDirectoryForTerminalStartup(sourcePanelId: sourcePanelId),
             liveForegroundWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId),
             sourcePanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
-            currentDirectory,
+            currentDirectoryForTerminalStartup(sourcePanelId: sourcePanelId),
         ].lazy.compactMap(Self.normalizedTerminalWorkingDirectory).first
     }
 
@@ -7133,8 +7133,9 @@ final class Workspace: Identifiable, ObservableObject {
             base: startupEnvironmentWithRemoteSession,
             remoteStartupCommand: remoteStartupCommandForEnvironment
         )
+        let suppressInheritedStartupWorkingDirectory = isRemoteStartupCommand || (explicitInitialCommand != nil && isRemoteTerminalSurface(panelId))
         if startupCommand != nil {
-            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: isRemoteStartupCommand)
+            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: suppressInheritedStartupWorkingDirectory)
         }
 #if DEBUG
         dlog(
@@ -7149,7 +7150,7 @@ final class Workspace: Identifiable, ObservableObject {
                 ? inheritedConfig?.workingDirectory
                 : inheritedTerminalWorkingDirectory(fromPanelId: panelId))
         let splitWorkingDirectory = isRemoteStartupCommand
-            ? Self.normalizedTerminalWorkingDirectory(workingDirectory)
+            ? Self.normalizedTerminalWorkingDirectory(workingDirectory) ?? Self.safeLocalTerminalStartupWorkingDirectory()
             : resolvedTerminalStartupWorkingDirectory(
                 requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
                 inheritedWorkingDirectory: splitInheritedWorkingDirectory
@@ -7432,15 +7433,16 @@ final class Workspace: Identifiable, ObservableObject {
                 ? inheritedConfig?.workingDirectory
                 : inheritedTerminalWorkingDirectory(fromPanelId: fallbackSourcePanelId))
             : nil
+        let suppressInheritedStartupWorkingDirectory = isRemoteStartupCommand || (explicitInitialCommand != nil && inheritedConfigSourcePanelId.map { isRemoteTerminalSurface($0) } == true)
         if startupCommand != nil {
-            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: isRemoteStartupCommand)
+            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: suppressInheritedStartupWorkingDirectory)
         }
         let requestedWorkingDirectory = shouldInheritWorkingDirectoryFallback
             ? resolvedTerminalStartupWorkingDirectory(
                 requestedWorkingDirectory: workingDirectory, sourcePanelId: fallbackSourcePanelId,
                 inheritedWorkingDirectory: inheritedWorkingDirectory
             )
-            : workingDirectory
+            : (suppressInheritedStartupWorkingDirectory ? Self.normalizedTerminalWorkingDirectory(workingDirectory) ?? Self.safeLocalTerminalStartupWorkingDirectory() : workingDirectory)
         if shouldInheritWorkingDirectoryFallback {
             inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, clearWorkingDirectory: true)
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7447,9 +7447,7 @@ final class Workspace: Identifiable, ObservableObject {
                 inheritedWorkingDirectory: inheritedWorkingDirectory
             )
             : (suppressInheritedStartupWorkingDirectory ? Self.normalizedTerminalWorkingDirectory(workingDirectory) ?? Self.safeLocalTerminalStartupWorkingDirectory() : workingDirectory)
-        if shouldInheritWorkingDirectoryFallback {
-            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, clearWorkingDirectory: true)
-        }
+        inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, clearWorkingDirectory: true)
 
         let newPanel = TerminalPanel(
             id: newPanelID,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6763,7 +6763,7 @@ final class Workspace: Identifiable, ObservableObject {
             terminalStartupCandidateWorkingDirectory(inheritedWorkingDirectory, sourcePanelId: sourcePanelId),
             panelDirectoryForTerminalStartup(sourcePanelId: sourcePanelId),
             liveForegroundWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId),
-            sourcePanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
+            terminalRequestedWorkingDirectoryForLocalFallback(panelId: sourcePanelId),
             currentDirectoryForTerminalStartup(sourcePanelId: sourcePanelId),
         ].lazy.compactMap(Self.normalizedTerminalWorkingDirectory).first
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6737,7 +6737,7 @@ final class Workspace: Identifiable, ObservableObject {
         lastTerminalConfigInheritanceFontPoints
     }
 
-    nonisolated private static func normalizedTerminalWorkingDirectory(_ workingDirectory: String?) -> String? {
+    nonisolated static func normalizedTerminalWorkingDirectory(_ workingDirectory: String?) -> String? {
         let trimmed = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? nil : trimmed
     }
@@ -6745,8 +6745,7 @@ final class Workspace: Identifiable, ObservableObject {
     private func resolvedTerminalStartupWorkingDirectory(
         requestedWorkingDirectory: String?,
         sourcePanelId: UUID?,
-        inheritedWorkingDirectory: String? = nil,
-        inheritedWorkingDirectoryRequiresPromptIdle: Bool = false
+        inheritedWorkingDirectory: String? = nil
     ) -> String? {
         if let requested = Self.normalizedTerminalWorkingDirectory(requestedWorkingDirectory) {
             return requested
@@ -6756,7 +6755,7 @@ final class Workspace: Identifiable, ObservableObject {
             return rescued
         }
         return [
-            inheritedWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId, inheritedWorkingDirectory: inheritedWorkingDirectory, requiresPromptIdle: inheritedWorkingDirectoryRequiresPromptIdle),
+            inheritedWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId, inheritedWorkingDirectory: inheritedWorkingDirectory),
             sourcePanelId.flatMap { panelDirectories[$0] },
             sourcePanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
             currentDirectory,
@@ -6765,19 +6764,17 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func inheritedWorkingDirectoryForTerminalStartup(
         sourcePanelId: UUID?,
-        inheritedWorkingDirectory: String?,
-        requiresPromptIdle: Bool = false
+        inheritedWorkingDirectory: String?
     ) -> String? {
-        guard let inherited = Self.normalizedTerminalWorkingDirectory(inheritedWorkingDirectory),
-              let sourcePanelId,
-              restoredGuardedWorkingDirectoriesByPanelId[sourcePanelId] == nil,
-              restoredAgentResumeStatesByPanelId[sourcePanelId] != .awaitingAutoResumeCommand,
-              restoredAgentResumeStatesByPanelId[sourcePanelId] != .autoResumeCommandRunning,
-              !isRemoteTerminalSurface(sourcePanelId),
-              let terminalPanel = terminalPanel(for: sourcePanelId),
-              !((terminalPanel.surface.initialCommand != nil || terminalPanel.surface.tmuxStartCommand != nil || requiresPromptIdle) &&
-                  panelShellActivityStates[sourcePanelId] != .promptIdle) else { return nil }
-        return inherited
+        guard let sourcePanelId else { return nil }
+        return Self.terminalStartupInheritedWorkingDirectoryCandidate(
+            inheritedWorkingDirectory,
+            shellActivityState: panelShellActivityStates[sourcePanelId],
+            isRemoteTerminalSurface: isRemoteTerminalSurface(sourcePanelId),
+            isRestoreGuarded: restoredGuardedWorkingDirectoriesByPanelId[sourcePanelId] != nil,
+            isAgentResumePendingOrRunning: restoredAgentResumeStatesByPanelId[sourcePanelId] == .awaitingAutoResumeCommand ||
+                restoredAgentResumeStatesByPanelId[sourcePanelId] == .autoResumeCommandRunning
+        )
     }
 
     /// Foreground-process cwd provider; nil uses libproc on the live foreground pid.
@@ -7167,8 +7164,7 @@ final class Workspace: Identifiable, ObservableObject {
             ? Self.normalizedTerminalWorkingDirectory(workingDirectory)
             : resolvedTerminalStartupWorkingDirectory(
                 requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
-                inheritedWorkingDirectory: splitInheritedWorkingDirectory,
-                inheritedWorkingDirectoryRequiresPromptIdle: splitLiveWorkingDirectory != nil
+                inheritedWorkingDirectory: splitInheritedWorkingDirectory
             )
         inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, clearWorkingDirectory: true)
         let newPanel = TerminalPanel(
@@ -7454,8 +7450,7 @@ final class Workspace: Identifiable, ObservableObject {
         let requestedWorkingDirectory = shouldInheritWorkingDirectoryFallback
             ? resolvedTerminalStartupWorkingDirectory(
                 requestedWorkingDirectory: workingDirectory, sourcePanelId: fallbackSourcePanelId,
-                inheritedWorkingDirectory: inheritedWorkingDirectory,
-                inheritedWorkingDirectoryRequiresPromptIdle: fallbackLiveWorkingDirectory != nil
+                inheritedWorkingDirectory: inheritedWorkingDirectory
             )
             : workingDirectory
         if shouldInheritWorkingDirectoryFallback {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7134,6 +7134,7 @@ final class Workspace: Identifiable, ObservableObject {
         let remoteTerminalStartupCommand = suppressWorkspaceRemoteStartupCommand ? nil : remoteTerminalStartupCommand()
         let startupCommand = explicitInitialCommand ?? remoteTerminalStartupCommand
         let remoteStartupCommandForEnvironment = explicitInitialCommand == nil ? remoteTerminalStartupCommand : nil
+        let isRemoteStartupCommand = remoteStartupCommandForEnvironment != nil
         let newPanelID = UUID()
         let requestedRemotePTYSessionID = normalizedRemotePTYSessionID(remotePTYSessionID)
         let effectiveRemotePTYSessionID = requestedRemotePTYSessionID
@@ -7151,7 +7152,7 @@ final class Workspace: Identifiable, ObservableObject {
         // Hold remote-command panes open after exit so startup errors remain visible
         // instead of Ghostty respawning a local login shell.
         if startupCommand != nil {
-            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: true)
+            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: isRemoteStartupCommand)
         }
 #if DEBUG
         dlog(
@@ -7163,7 +7164,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         let splitWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
             requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
-            inheritedWorkingDirectory: startupCommand == nil && inheritedConfigSourcePanelId == panelId ? inheritedConfig?.workingDirectory : nil
+            inheritedWorkingDirectory: !isRemoteStartupCommand && inheritedConfigSourcePanelId == panelId ? inheritedConfig?.workingDirectory : nil
         )
         inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, clearWorkingDirectory: true)
 
@@ -7419,6 +7420,7 @@ final class Workspace: Identifiable, ObservableObject {
         let remoteTerminalStartupCommand = suppressWorkspaceRemoteStartupCommand ? nil : remoteTerminalStartupCommand()
         let startupCommand = explicitInitialCommand ?? remoteTerminalStartupCommand
         let remoteStartupCommandForEnvironment = explicitInitialCommand == nil ? remoteTerminalStartupCommand : nil
+        let isRemoteStartupCommand = remoteStartupCommandForEnvironment != nil
         let newPanelID = restoredSurfaceId ?? UUID()
         let requestedRemotePTYSessionID = normalizedRemotePTYSessionID(remotePTYSessionID)
         let effectiveRemotePTYSessionID = requestedRemotePTYSessionID
@@ -7435,7 +7437,7 @@ final class Workspace: Identifiable, ObservableObject {
         )
         let fallbackSourcePanelId = workingDirectoryFallbackSourcePanelId
             ?? bonsplitController.selectedTab(inPane: paneId).map(\.id).flatMap(panelIdFromSurfaceId)
-        let shouldInheritWorkingDirectoryFallback = inheritWorkingDirectoryFallback && startupCommand == nil
+        let shouldInheritWorkingDirectoryFallback = inheritWorkingDirectoryFallback && !isRemoteStartupCommand
         var inheritedConfigSourcePanelId: UUID?
         var inheritedConfig = inheritedTerminalConfig(inPane: paneId, sourcePanelId: { inheritedConfigSourcePanelId = $0 })
         let fallbackLiveWorkingDirectory = shouldInheritWorkingDirectoryFallback && inheritedConfigSourcePanelId != fallbackSourcePanelId
@@ -7445,7 +7447,7 @@ final class Workspace: Identifiable, ObservableObject {
             ? inheritedConfig?.workingDirectory
             : fallbackLiveWorkingDirectory
         if startupCommand != nil {
-            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: true)
+            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: isRemoteStartupCommand)
         }
         let requestedWorkingDirectory = shouldInheritWorkingDirectoryFallback
             ? resolvedTerminalStartupWorkingDirectory(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7162,10 +7162,12 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
 
-        let splitWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
-            requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
-            inheritedWorkingDirectory: !isRemoteStartupCommand && inheritedConfigSourcePanelId == panelId ? inheritedConfig?.workingDirectory : nil
-        )
+        let splitWorkingDirectory = isRemoteStartupCommand
+            ? Self.normalizedTerminalWorkingDirectory(workingDirectory)
+            : resolvedTerminalStartupWorkingDirectory(
+                requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
+                inheritedWorkingDirectory: inheritedConfigSourcePanelId == panelId ? inheritedConfig?.workingDirectory : nil
+            )
         inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, clearWorkingDirectory: true)
 
         let newPanel = TerminalPanel(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2350,6 +2350,7 @@ final class Workspace: Identifiable, ObservableObject {
     var restoredAgentSnapshotsByPanelId: [UUID: SessionRestorableAgentSnapshot] = [:]
     var surfaceResumeBindingsByPanelId: [UUID: SurfaceResumeBindingSnapshot] = [:]
     private var restoredGuardedWorkingDirectoriesByPanelId: [UUID: String] = [:]
+    func hasRestoredGuardedWorkingDirectory(panelId: UUID) -> Bool { restoredGuardedWorkingDirectoriesByPanelId[panelId] != nil }
     /// The session directory each restored auto-resume launcher targets, kept
     /// for the lifetime of the resumed run (unlike the one-shot report guard
     /// above, which the first spurious report consumes) so split/new-tab cwd
@@ -6755,40 +6756,12 @@ final class Workspace: Identifiable, ObservableObject {
             return rescued
         }
         return [
-            inheritedWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId, inheritedWorkingDirectory: inheritedWorkingDirectory),
-            sourcePanelId.flatMap { panelDirectories[$0] },
+            terminalStartupCandidateWorkingDirectory(inheritedWorkingDirectory, sourcePanelId: sourcePanelId),
+            panelDirectoryForTerminalStartup(sourcePanelId: sourcePanelId),
             liveForegroundWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId),
             sourcePanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
             currentDirectory,
         ].lazy.compactMap(Self.normalizedTerminalWorkingDirectory).first
-    }
-
-    private func inheritedWorkingDirectoryForTerminalStartup(
-        sourcePanelId: UUID?,
-        inheritedWorkingDirectory: String?
-    ) -> String? {
-        guard let sourcePanelId else { return nil }
-        return Self.terminalStartupInheritedWorkingDirectoryCandidate(
-            inheritedWorkingDirectory,
-            shellActivityState: panelShellActivityStates[sourcePanelId],
-            isRemoteTerminalSurface: isRemoteTerminalSurface(sourcePanelId),
-            isRestoreGuarded: restoredGuardedWorkingDirectoriesByPanelId[sourcePanelId] != nil,
-            isAgentResumePendingOrRunning: restoredAgentResumeStatesByPanelId[sourcePanelId] == .awaitingAutoResumeCommand ||
-                restoredAgentResumeStatesByPanelId[sourcePanelId] == .autoResumeCommandRunning
-        )
-    }
-
-    private func liveForegroundWorkingDirectoryForTerminalStartup(sourcePanelId: UUID?) -> String? {
-        guard let sourcePanelId else { return nil }
-        guard Self.normalizedTerminalWorkingDirectory(panelDirectories[sourcePanelId]) == nil else { return nil }
-        return Self.terminalStartupInheritedWorkingDirectoryCandidate(
-            liveForegroundProcessWorkingDirectory(panelId: sourcePanelId),
-            shellActivityState: panelShellActivityStates[sourcePanelId],
-            isRemoteTerminalSurface: isRemoteTerminalSurface(sourcePanelId),
-            isRestoreGuarded: restoredGuardedWorkingDirectoriesByPanelId[sourcePanelId] != nil,
-            isAgentResumePendingOrRunning: restoredAgentResumeStatesByPanelId[sourcePanelId] == .awaitingAutoResumeCommand ||
-                restoredAgentResumeStatesByPanelId[sourcePanelId] == .autoResumeCommandRunning
-        )
     }
 
     /// Foreground-process cwd provider; nil uses libproc on the live foreground pid.
@@ -6827,7 +6800,7 @@ final class Workspace: Identifiable, ObservableObject {
         return nil
     }
 
-    private func liveForegroundProcessWorkingDirectory(panelId: UUID) -> String? {
+    func liveForegroundProcessWorkingDirectory(panelId: UUID) -> String? {
         if let provider = foregroundProcessWorkingDirectoryProvider {
             return provider(panelId)
         }
@@ -7017,18 +6990,6 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         return nil
-    }
-
-    private func inheritedTerminalWorkingDirectory(fromPanelId panelId: UUID?) -> String? {
-        guard let panelId, let terminalPanel = terminalPanel(for: panelId) else { return nil }
-        let surface = terminalPanel.surface
-        guard let sourceSurface = surface.surface else { return nil }
-        let config = cmuxInheritedSurfaceConfig(
-            sourceSurface: sourceSurface,
-            context: GHOSTTY_SURFACE_CONTEXT_SPLIT
-        )
-        withExtendedLifetime((terminalPanel, surface)) {}
-        return config.workingDirectory
     }
 
     /// Create a new split with a terminal panel

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6745,7 +6745,8 @@ final class Workspace: Identifiable, ObservableObject {
     private func resolvedTerminalStartupWorkingDirectory(
         requestedWorkingDirectory: String?,
         sourcePanelId: UUID?,
-        inheritedWorkingDirectory: String? = nil
+        inheritedWorkingDirectory: String? = nil,
+        inheritedWorkingDirectoryRequiresPromptIdle: Bool = false
     ) -> String? {
         if let requested = Self.normalizedTerminalWorkingDirectory(requestedWorkingDirectory) {
             return requested
@@ -6755,14 +6756,18 @@ final class Workspace: Identifiable, ObservableObject {
             return rescued
         }
         return [
+            inheritedWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId, inheritedWorkingDirectory: inheritedWorkingDirectory, requiresPromptIdle: inheritedWorkingDirectoryRequiresPromptIdle),
             sourcePanelId.flatMap { panelDirectories[$0] },
-            inheritedWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId, inheritedWorkingDirectory: inheritedWorkingDirectory),
             sourcePanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
             currentDirectory,
         ].lazy.compactMap(Self.normalizedTerminalWorkingDirectory).first
     }
 
-    private func inheritedWorkingDirectoryForTerminalStartup(sourcePanelId: UUID?, inheritedWorkingDirectory: String?) -> String? {
+    private func inheritedWorkingDirectoryForTerminalStartup(
+        sourcePanelId: UUID?,
+        inheritedWorkingDirectory: String?,
+        requiresPromptIdle: Bool = false
+    ) -> String? {
         guard let inherited = Self.normalizedTerminalWorkingDirectory(inheritedWorkingDirectory),
               let sourcePanelId,
               restoredGuardedWorkingDirectoriesByPanelId[sourcePanelId] == nil,
@@ -6770,8 +6775,7 @@ final class Workspace: Identifiable, ObservableObject {
               restoredAgentResumeStatesByPanelId[sourcePanelId] != .autoResumeCommandRunning,
               !isRemoteTerminalSurface(sourcePanelId),
               let terminalPanel = terminalPanel(for: sourcePanelId),
-              terminalPanel.surface.surface != nil,
-              !((terminalPanel.surface.initialCommand != nil || terminalPanel.surface.tmuxStartCommand != nil) &&
+              !((terminalPanel.surface.initialCommand != nil || terminalPanel.surface.tmuxStartCommand != nil || requiresPromptIdle) &&
                   panelShellActivityStates[sourcePanelId] != .promptIdle) else { return nil }
         return inherited
     }
@@ -7147,9 +7151,7 @@ final class Workspace: Identifiable, ObservableObject {
         // Hold remote-command panes open after exit so startup errors remain visible
         // instead of Ghostty respawning a local login shell.
         if startupCommand != nil {
-            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
-            template.waitAfterCommand = true
-            inheritedConfig = template
+            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: true)
         }
 #if DEBUG
         dlog(
@@ -7161,10 +7163,10 @@ final class Workspace: Identifiable, ObservableObject {
 
         let splitWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
             requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
-            inheritedWorkingDirectory: inheritedConfigSourcePanelId == panelId ? inheritedConfig?.workingDirectory : nil
+            inheritedWorkingDirectory: startupCommand == nil && inheritedConfigSourcePanelId == panelId ? inheritedConfig?.workingDirectory : nil
         )
+        inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, clearWorkingDirectory: true)
 
-        // Create the new terminal panel.
         let newPanel = TerminalPanel(
             id: newPanelID,
             workspaceId: id,
@@ -7443,17 +7445,19 @@ final class Workspace: Identifiable, ObservableObject {
             ? inheritedConfig?.workingDirectory
             : fallbackLiveWorkingDirectory
         if startupCommand != nil {
-            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
-            template.waitAfterCommand = true
-            inheritedConfig = template
+            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: true)
         }
         let requestedWorkingDirectory = shouldInheritWorkingDirectoryFallback
             ? resolvedTerminalStartupWorkingDirectory(
                 requestedWorkingDirectory: workingDirectory,
                 sourcePanelId: fallbackSourcePanelId,
-                inheritedWorkingDirectory: inheritedWorkingDirectory
+                inheritedWorkingDirectory: inheritedWorkingDirectory,
+                inheritedWorkingDirectoryRequiresPromptIdle: inheritedConfigSourcePanelId != fallbackSourcePanelId
             )
             : workingDirectory
+        if shouldInheritWorkingDirectoryFallback {
+            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, clearWorkingDirectory: true)
+        }
 
         // Restored panels reuse their persisted Ghostty surface id so session
         // bindings survive relaunch; callers only pass ids verified as free.
@@ -11088,9 +11092,7 @@ final class Workspace: Identifiable, ObservableObject {
             remoteStartupCommand: startupCommand
         )
         if startupCommand != nil {
-            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
-            template.waitAfterCommand = true
-            inheritedConfig = template
+            inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: true)
         }
 
         let newPanel = TerminalPanel(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6757,6 +6757,7 @@ final class Workspace: Identifiable, ObservableObject {
         return [
             inheritedWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId, inheritedWorkingDirectory: inheritedWorkingDirectory),
             sourcePanelId.flatMap { panelDirectories[$0] },
+            liveForegroundWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId),
             sourcePanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
             currentDirectory,
         ].lazy.compactMap(Self.normalizedTerminalWorkingDirectory).first
@@ -6769,6 +6770,19 @@ final class Workspace: Identifiable, ObservableObject {
         guard let sourcePanelId else { return nil }
         return Self.terminalStartupInheritedWorkingDirectoryCandidate(
             inheritedWorkingDirectory,
+            shellActivityState: panelShellActivityStates[sourcePanelId],
+            isRemoteTerminalSurface: isRemoteTerminalSurface(sourcePanelId),
+            isRestoreGuarded: restoredGuardedWorkingDirectoriesByPanelId[sourcePanelId] != nil,
+            isAgentResumePendingOrRunning: restoredAgentResumeStatesByPanelId[sourcePanelId] == .awaitingAutoResumeCommand ||
+                restoredAgentResumeStatesByPanelId[sourcePanelId] == .autoResumeCommandRunning
+        )
+    }
+
+    private func liveForegroundWorkingDirectoryForTerminalStartup(sourcePanelId: UUID?) -> String? {
+        guard let sourcePanelId else { return nil }
+        guard Self.normalizedTerminalWorkingDirectory(panelDirectories[sourcePanelId]) == nil else { return nil }
+        return Self.terminalStartupInheritedWorkingDirectoryCandidate(
+            liveForegroundProcessWorkingDirectory(panelId: sourcePanelId),
             shellActivityState: panelShellActivityStates[sourcePanelId],
             isRemoteTerminalSurface: isRemoteTerminalSurface(sourcePanelId),
             isRestoreGuarded: restoredGuardedWorkingDirectoriesByPanelId[sourcePanelId] != nil,
@@ -7005,6 +7019,18 @@ final class Workspace: Identifiable, ObservableObject {
         return nil
     }
 
+    private func inheritedTerminalWorkingDirectory(fromPanelId panelId: UUID?) -> String? {
+        guard let panelId, let terminalPanel = terminalPanel(for: panelId) else { return nil }
+        let surface = terminalPanel.surface
+        guard let sourceSurface = surface.surface else { return nil }
+        let config = cmuxInheritedSurfaceConfig(
+            sourceSurface: sourceSurface,
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT
+        )
+        withExtendedLifetime((terminalPanel, surface)) {}
+        return config.workingDirectory
+    }
+
     /// Create a new split with a terminal panel
     @discardableResult
     func newTerminalSplit(
@@ -7156,10 +7182,11 @@ final class Workspace: Identifiable, ObservableObject {
             "remoteCommand=\(remoteTerminalStartupCommand == nil ? 0 : 1)"
         )
 #endif
-        let splitLiveWorkingDirectory = panelShellActivityStates[panelId] == .promptIdle
-            ? liveForegroundProcessWorkingDirectory(panelId: panelId)
-            : nil
-        let splitInheritedWorkingDirectory = splitLiveWorkingDirectory ?? (inheritedConfigSourcePanelId == panelId ? inheritedConfig?.workingDirectory : nil)
+        let splitInheritedWorkingDirectory = isRemoteStartupCommand
+            ? nil
+            : (inheritedConfigSourcePanelId == panelId
+                ? inheritedConfig?.workingDirectory
+                : inheritedTerminalWorkingDirectory(fromPanelId: panelId))
         let splitWorkingDirectory = isRemoteStartupCommand
             ? Self.normalizedTerminalWorkingDirectory(workingDirectory)
             : resolvedTerminalStartupWorkingDirectory(
@@ -7439,11 +7466,11 @@ final class Workspace: Identifiable, ObservableObject {
         let shouldInheritWorkingDirectoryFallback = inheritWorkingDirectoryFallback && !isRemoteStartupCommand
         var inheritedConfigSourcePanelId: UUID?
         var inheritedConfig = inheritedTerminalConfig(inPane: paneId, sourcePanelId: { inheritedConfigSourcePanelId = $0 })
-        let fallbackLiveWorkingDirectory = shouldInheritWorkingDirectoryFallback
-            && fallbackSourcePanelId.map({ panelShellActivityStates[$0] == .promptIdle }) == true
-            ? fallbackSourcePanelId.flatMap { liveForegroundProcessWorkingDirectory(panelId: $0) }
+        let inheritedWorkingDirectory = shouldInheritWorkingDirectoryFallback
+            ? (inheritedConfigSourcePanelId == fallbackSourcePanelId
+                ? inheritedConfig?.workingDirectory
+                : inheritedTerminalWorkingDirectory(fromPanelId: fallbackSourcePanelId))
             : nil
-        let inheritedWorkingDirectory = fallbackLiveWorkingDirectory ?? (inheritedConfigSourcePanelId == fallbackSourcePanelId ? inheritedConfig?.workingDirectory : nil)
         if startupCommand != nil {
             inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: isRemoteStartupCommand)
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6744,7 +6744,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func resolvedTerminalStartupWorkingDirectory(
         requestedWorkingDirectory: String?,
-        sourcePanelId: UUID?
+        sourcePanelId: UUID?, inheritedWorkingDirectory: String? = nil
     ) -> String? {
         if let requested = Self.normalizedTerminalWorkingDirectory(requestedWorkingDirectory) {
             return requested
@@ -6754,6 +6754,7 @@ final class Workspace: Identifiable, ObservableObject {
             return rescued
         }
         return [
+            inheritedWorkingDirectory,
             sourcePanelId.flatMap { panelDirectories[$0] },
             sourcePanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
             currentDirectory,
@@ -7161,15 +7162,14 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
 
-        // Explicit caller cwd is intent; Ghostty inherited cwd only outranks cached Workspace fallback.
-        let requestedWorkingDirectory = Self.normalizedTerminalWorkingDirectory(workingDirectory)
-        let ghosttyInheritedWorkingDirectory = Self.normalizedTerminalWorkingDirectory(inheritedConfig?.workingDirectory)
-        let splitWorkingDirectory = requestedWorkingDirectory
-            ?? ghosttyInheritedWorkingDirectory
-            ?? resolvedTerminalStartupWorkingDirectory(requestedWorkingDirectory: nil, sourcePanelId: panelId)
+        let ghosttyInheritedWorkingDirectory = terminalPanel(for: panelId)?.surface.surface == nil || restoredAgentResumeStatesByPanelId[panelId] == .autoResumeCommandRunning ? nil : Self.normalizedTerminalWorkingDirectory(inheritedConfig?.workingDirectory)
+        let splitWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
+            requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
+            inheritedWorkingDirectory: ghosttyInheritedWorkingDirectory
+        )
 #if DEBUG
         cmuxDebugLog(
-            "split.cwd panelId=\(panelId.uuidString.prefix(5)) panelDir=\(panelDirectories[panelId] ?? "nil") requestedDir=\(terminalPanel(for: panelId)?.requestedWorkingDirectory ?? "nil") currentDir=\(currentDirectory) requested=\(requestedWorkingDirectory ?? "nil") inherited=\(ghosttyInheritedWorkingDirectory ?? "nil") resolved=\(splitWorkingDirectory ?? "nil")"
+            "split.cwd panelId=\(panelId.uuidString.prefix(5)) panelDir=\(panelDirectories[panelId] ?? "nil") requestedDir=\(terminalPanel(for: panelId)?.requestedWorkingDirectory ?? "nil") currentDir=\(currentDirectory) requested=\(Self.normalizedTerminalWorkingDirectory(workingDirectory) ?? "nil") inherited=\(ghosttyInheritedWorkingDirectory ?? "nil") resolved=\(splitWorkingDirectory ?? "nil")"
         )
 #endif
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7177,7 +7177,7 @@ final class Workspace: Identifiable, ObservableObject {
         )
         panels[newPanel.id] = newPanel
         panelTitles[newPanel.id] = newPanel.displayTitle
-        let tracksRemoteTerminalSurface = remoteTerminalStartupCommand != nil || effectiveRemotePTYSessionID != nil
+        let tracksRemoteTerminalSurface = isRemoteStartupCommand || effectiveRemotePTYSessionID != nil
         if let effectiveRemotePTYSessionID {
             remotePTYSessionIDsByPanelId[newPanel.id] = effectiveRemotePTYSessionID
             registerRemoteRelayIDAliases(remotePTYSessionID: effectiveRemotePTYSessionID, restoredPanelId: newPanel.id)
@@ -7470,7 +7470,7 @@ final class Workspace: Identifiable, ObservableObject {
         )
         panels[newPanel.id] = newPanel
         panelTitles[newPanel.id] = newPanel.displayTitle
-        let tracksRemoteTerminalSurface = remoteTerminalStartupCommand != nil || effectiveRemotePTYSessionID != nil
+        let tracksRemoteTerminalSurface = isRemoteStartupCommand || effectiveRemotePTYSessionID != nil
         if let effectiveRemotePTYSessionID {
             remotePTYSessionIDsByPanelId[newPanel.id] = effectiveRemotePTYSessionID
             registerRemoteRelayIDAliases(remotePTYSessionID: effectiveRemotePTYSessionID, restoredPanelId: newPanel.id)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7162,7 +7162,7 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
 
-        let ghosttyInheritedWorkingDirectory = terminalPanel(for: panelId)?.surface.surface == nil || restoredAgentResumeStatesByPanelId[panelId] == .autoResumeCommandRunning ? nil : Self.normalizedTerminalWorkingDirectory(inheritedConfig?.workingDirectory)
+        let ghosttyInheritedWorkingDirectory = terminalPanel(for: panelId)?.surface.surface == nil || isRemoteTerminalSurface(panelId) || restoredAgentResumeStatesByPanelId[panelId] == .autoResumeCommandRunning ? nil : Self.normalizedTerminalWorkingDirectory(inheritedConfig?.workingDirectory)
         let splitWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
             requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
             inheritedWorkingDirectory: ghosttyInheritedWorkingDirectory

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6777,16 +6777,12 @@ final class Workspace: Identifiable, ObservableObject {
     /// pane's surface; injecting a substitute decouples callers from libproc.
     var foregroundProcessWorkingDirectoryProvider: ((UUID) -> String?)?
 
-    /// Rescues split/new-tab cwd inheritance from a pane whose restored
-    /// auto-resume command is still running (#7155).
+    /// Rescues cwd inheritance while a restored agent's auto-resume command owns the foreground.
     ///
-    /// While the resumed agent owns the foreground, the shell never reaches a
-    /// prompt, so tracked cwd can be stranded on a spurious default/home report.
-    /// Trust it only while it still equals the restored session directory;
-    /// otherwise prefer the live foreground process cwd, then the recorded
-    /// session directory.
-    /// Local panes only: a remote pane's tracked cwd is a remote path that no
-    /// local process inspection or existence check can validate.
+    /// Until the shell reaches a prompt, tracked cwd can be stranded on a
+    /// default/home report. Prefer the live foreground process cwd when that
+    /// happens, then the recorded session directory. Remote panes are excluded
+    /// because their cwd is not locally inspectable.
     private func resumedAgentPaneWorkingDirectoryRescue(panelId: UUID) -> String? {
         guard restoredAgentResumeStatesByPanelId[panelId] == .autoResumeCommandRunning else { return nil }
         guard !isRemoteTerminalSurface(panelId) else { return nil }
@@ -7007,6 +7003,17 @@ final class Workspace: Identifiable, ObservableObject {
         return nil
     }
 
+    private func inheritedTerminalWorkingDirectory(preferredPanelId: UUID?, inPane preferredPaneId: PaneID?) -> String? {
+        for terminalPanel in terminalPanelConfigInheritanceCandidates(preferredPanelId: preferredPanelId, inPane: preferredPaneId) {
+            let surface = terminalPanel.surface
+            guard let sourceSurface = surface.surface else { continue }
+            let inherited = ghostty_surface_inherited_config(sourceSurface, GHOSTTY_SURFACE_CONTEXT_SPLIT)
+            withExtendedLifetime((terminalPanel, surface)) {}
+            if let workingDirectory = inherited.working_directory.flatMap({ String(cString: $0, encoding: .utf8) }) { return workingDirectory }
+        }
+        return nil
+    }
+
     /// Create a new split with a terminal panel
     @discardableResult
     func newTerminalSplit(
@@ -7146,11 +7153,8 @@ final class Workspace: Identifiable, ObservableObject {
             base: startupEnvironmentWithRemoteSession,
             remoteStartupCommand: remoteStartupCommandForEnvironment
         )
-        // Hold the pane open after the remote session ends so the user can read the
-        // "ssh exited …" message the startup script prints. Otherwise Ghostty silently
-        // respawns a local login shell when the command exits (the PTY falls through
-        // to $SHELL), and a dead VM looks identical to a healthy workspace with a
-        // local prompt — which is what we saw during dogfood.
+        // Hold remote-command panes open after exit so startup errors remain visible
+        // instead of Ghostty respawning a local login shell.
         if startupCommand != nil {
             var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
             template.waitAfterCommand = true
@@ -7439,10 +7443,10 @@ final class Workspace: Identifiable, ObservableObject {
         let fallbackSourcePanelId = workingDirectoryFallbackSourcePanelId
             ?? bonsplitController.selectedTab(inPane: paneId).map(\.id).flatMap(panelIdFromSurfaceId)
         let shouldInheritWorkingDirectoryFallback = inheritWorkingDirectoryFallback && startupCommand == nil
-        var inheritedConfig = inheritedTerminalConfig(preferredPanelId: shouldInheritWorkingDirectoryFallback ? fallbackSourcePanelId : nil, inPane: paneId)
-        // See the comment at the other call site: hold the PTY open after the remote
-        // command exits so the user sees the error rather than a silently-respawned
-        // local login shell.
+        let inheritedWorkingDirectory = shouldInheritWorkingDirectoryFallback
+            ? inheritedTerminalWorkingDirectory(preferredPanelId: fallbackSourcePanelId, inPane: paneId)
+            : nil
+        var inheritedConfig = inheritedTerminalConfig(inPane: paneId)
         if startupCommand != nil {
             var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
             template.waitAfterCommand = true
@@ -7452,14 +7456,12 @@ final class Workspace: Identifiable, ObservableObject {
             ? resolvedTerminalStartupWorkingDirectory(
                 requestedWorkingDirectory: workingDirectory,
                 sourcePanelId: fallbackSourcePanelId,
-                inheritedWorkingDirectory: inheritedConfig?.workingDirectory
+                inheritedWorkingDirectory: inheritedWorkingDirectory
             )
             : workingDirectory
 
-        // Create new terminal panel. A restored panel reuses its persisted
-        // surface id (the panel/surface id IS the ghostty surface id, a
-        // Swift-side UUID), so a session's terminal binding survives relaunch
-        // and restore. The caller only passes an id it has verified is free.
+        // Restored panels reuse their persisted Ghostty surface id so session
+        // bindings survive relaunch; callers only pass ids verified as free.
         let newPanel = TerminalPanel(
             id: newPanelID,
             workspaceId: id,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7161,15 +7161,26 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
 
-        // Resolve cwd as explicit request, source reported cwd, source requested
-        // startup cwd, then workspace currentDirectory.
-        let splitWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
+        let ghosttyInheritedWd = inheritedConfig?
+            .workingDirectory?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let ghosttyInheritedNonEmpty: String? = {
+            guard let ghosttyInheritedWd, !ghosttyInheritedWd.isEmpty else { return nil }
+            return ghosttyInheritedWd
+        }()
+
+        // Prefer libghostty's inherited working directory (same source as standalone Ghostty
+        // when splitting). cmux's explicit TerminalSurface `workingDirectory` wins over
+        // configTemplate in TerminalSurface.createSurface; a stale sidebar cache or workspace
+        // `currentDirectory` must not clobber the live cwd Ghostty already tracks on the source
+        // surface when shell integration events lag or do not run.
+        let splitWorkingDirectory = ghosttyInheritedNonEmpty ?? resolvedTerminalStartupWorkingDirectory(
             requestedWorkingDirectory: workingDirectory,
             sourcePanelId: panelId
         )
 #if DEBUG
         cmuxDebugLog(
-            "split.cwd panelId=\(panelId.uuidString.prefix(5)) panelDir=\(panelDirectories[panelId] ?? "nil") requestedDir=\(terminalPanel(for: panelId)?.requestedWorkingDirectory ?? "nil") currentDir=\(currentDirectory) resolved=\(splitWorkingDirectory ?? "nil")"
+            "split.cwd panelId=\(panelId.uuidString.prefix(5)) panelDir=\(panelDirectories[panelId] ?? "nil") requestedDir=\(terminalPanel(for: panelId)?.requestedWorkingDirectory ?? "nil") currentDir=\(currentDirectory) inherited=\(ghosttyInheritedNonEmpty ?? "nil") resolved=\(splitWorkingDirectory ?? "nil")"
         )
 #endif
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -454,8 +454,8 @@ extension Workspace {
                !restorableDirectory.isEmpty {
                 return restorableDirectory
             }
-            if let terminalPanel = panel as? TerminalPanel,
-               let requestedDirectory = terminalPanel.requestedWorkingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+            if panel is TerminalPanel,
+               let requestedDirectory = terminalRequestedWorkingDirectoryForLocalFallback(panelId: panelId)?.trimmingCharacters(in: .whitespacesAndNewlines),
                !requestedDirectory.isEmpty {
                 return requestedDirectory
             }
@@ -3825,10 +3825,14 @@ final class Workspace: Identifiable, ObservableObject {
     /// three-tier order); the tiers are spelled out here so the public entry point is
     /// self-contained.
     func resolvedWorkingDirectory() -> String? {
-        let candidates = [
-            focusedPanelId.flatMap { panelDirectories[$0] },
-            focusedPanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
-            currentDirectory,
+        let candidates = focusedPanelId.map { panelId in
+            [
+                panelDirectories[panelId],
+                terminalRequestedWorkingDirectoryForLocalFallback(panelId: panelId),
+                usesRemoteDirectoryProvenance ? nil : currentDirectory,
+            ]
+        } ?? [
+            usesRemoteDirectoryProvenance ? nil : currentDirectory,
         ]
         for candidate in candidates {
             let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -4365,7 +4369,7 @@ final class Workspace: Identifiable, ObservableObject {
         // Remote workspace directories are remote-host paths; no local per-directory config can apply.
         if usesRemoteDirectoryProvenance { return nil }
         if let panelId {
-            for candidate in [panelDirectories[panelId], terminalPanel(for: panelId)?.requestedWorkingDirectory] {
+            for candidate in [panelDirectories[panelId], terminalRequestedWorkingDirectoryForLocalFallback(panelId: panelId)] {
                 let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                 if !trimmed.isEmpty { return trimmed }
             }
@@ -11221,7 +11225,7 @@ final class Workspace: Identifiable, ObservableObject {
         Self.firstNonEmptyPath([
             snapshot.workingDirectory,
             panelDirectories[panelId],
-            terminalPanel(for: panelId)?.requestedWorkingDirectory,
+            terminalRequestedWorkingDirectoryForLocalFallback(panelId: panelId),
             currentDirectory
         ])
     }
@@ -12701,7 +12705,7 @@ extension Workspace: BonsplitDelegate {
             }
 
             let paneDirectory = selectedTerminalPanel(inPane: pane).flatMap { terminal -> String? in
-                for candidate in [panelDirectories[terminal.id], terminal.requestedWorkingDirectory] {
+                for candidate in [panelDirectories[terminal.id], terminalRequestedWorkingDirectoryForLocalFallback(panelId: terminal.id)] {
                     let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines)
                     if let trimmed, !trimmed.isEmpty {
                         return trimmed

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6953,7 +6953,8 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func inheritedTerminalConfig(
         preferredPanelId: UUID? = nil,
-        inPane preferredPaneId: PaneID? = nil
+        inPane preferredPaneId: PaneID? = nil,
+        sourcePanelId: ((UUID) -> Void)? = nil
     ) -> CmuxSurfaceConfigTemplate? {
         // Walk candidates in priority order and use the first panel that still exposes
         // a runtime surface pointer.
@@ -6986,6 +6987,7 @@ final class Workspace: Identifiable, ObservableObject {
             if config.fontSize > 0 {
                 lastTerminalConfigInheritanceFontPoints = config.fontSize
             }
+            sourcePanelId?(terminalPanel.id)
             return config
         }
 
@@ -7000,17 +7002,6 @@ final class Workspace: Identifiable, ObservableObject {
             return config
         }
 
-        return nil
-    }
-
-    private func inheritedTerminalWorkingDirectory(preferredPanelId: UUID?, inPane preferredPaneId: PaneID?) -> String? {
-        for terminalPanel in terminalPanelConfigInheritanceCandidates(preferredPanelId: preferredPanelId, inPane: preferredPaneId) {
-            let surface = terminalPanel.surface
-            guard let sourceSurface = surface.surface else { continue }
-            let inherited = ghostty_surface_inherited_config(sourceSurface, GHOSTTY_SURFACE_CONTEXT_SPLIT)
-            withExtendedLifetime((terminalPanel, surface)) {}
-            if let workingDirectory = inherited.working_directory.flatMap({ String(cString: $0, encoding: .utf8) }) { return workingDirectory }
-        }
         return nil
     }
 
@@ -7133,7 +7124,12 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         guard let paneId = sourcePaneId else { return nil }
-        var inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId)
+        var inheritedConfigSourcePanelId: UUID?
+        var inheritedConfig = inheritedTerminalConfig(
+            preferredPanelId: panelId,
+            inPane: paneId,
+            sourcePanelId: { inheritedConfigSourcePanelId = $0 }
+        )
         let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
         let remoteTerminalStartupCommand = suppressWorkspaceRemoteStartupCommand ? nil : remoteTerminalStartupCommand()
@@ -7170,7 +7166,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         let splitWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
             requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
-            inheritedWorkingDirectory: inheritedConfig?.workingDirectory
+            inheritedWorkingDirectory: inheritedConfigSourcePanelId == panelId ? inheritedConfig?.workingDirectory : nil
         )
 
         // Create the new terminal panel.
@@ -7443,10 +7439,11 @@ final class Workspace: Identifiable, ObservableObject {
         let fallbackSourcePanelId = workingDirectoryFallbackSourcePanelId
             ?? bonsplitController.selectedTab(inPane: paneId).map(\.id).flatMap(panelIdFromSurfaceId)
         let shouldInheritWorkingDirectoryFallback = inheritWorkingDirectoryFallback && startupCommand == nil
-        let inheritedWorkingDirectory = shouldInheritWorkingDirectoryFallback
-            ? inheritedTerminalWorkingDirectory(preferredPanelId: fallbackSourcePanelId, inPane: paneId)
+        var inheritedConfigSourcePanelId: UUID?
+        var inheritedConfig = inheritedTerminalConfig(inPane: paneId, sourcePanelId: { inheritedConfigSourcePanelId = $0 })
+        let inheritedWorkingDirectory = shouldInheritWorkingDirectoryFallback && inheritedConfigSourcePanelId == fallbackSourcePanelId
+            ? inheritedConfig?.workingDirectory
             : nil
-        var inheritedConfig = inheritedTerminalConfig(inPane: paneId)
         if startupCommand != nil {
             var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
             template.waitAfterCommand = true

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6744,7 +6744,8 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func resolvedTerminalStartupWorkingDirectory(
         requestedWorkingDirectory: String?,
-        sourcePanelId: UUID?, inheritedWorkingDirectory: String? = nil
+        sourcePanelId: UUID?,
+        inheritedWorkingDirectory: String? = nil
     ) -> String? {
         if let requested = Self.normalizedTerminalWorkingDirectory(requestedWorkingDirectory) {
             return requested
@@ -6765,38 +6766,32 @@ final class Workspace: Identifiable, ObservableObject {
         guard let inherited = Self.normalizedTerminalWorkingDirectory(inheritedWorkingDirectory),
               let sourcePanelId,
               restoredGuardedWorkingDirectoriesByPanelId[sourcePanelId] == nil,
+              restoredAgentResumeStatesByPanelId[sourcePanelId] != .awaitingAutoResumeCommand,
               restoredAgentResumeStatesByPanelId[sourcePanelId] != .autoResumeCommandRunning,
               !isRemoteTerminalSurface(sourcePanelId),
               let terminalPanel = terminalPanel(for: sourcePanelId),
               terminalPanel.surface.surface != nil,
-              !(terminalPanel.surface.initialCommand != nil &&
-                  Self.normalizedTerminalWorkingDirectory(terminalPanel.requestedWorkingDirectory) == nil &&
+              !((terminalPanel.surface.initialCommand != nil || terminalPanel.surface.tmuxStartCommand != nil) &&
                   panelShellActivityStates[sourcePanelId] != .promptIdle) else { return nil }
         return inherited
     }
 
-    /// The foreground-process cwd read consulted by
-    /// ``resumedAgentPaneWorkingDirectoryRescue(panelId:)``. Nil selects the
-    /// libproc-backed default, which requires a live foreground process on the
-    /// pane's surface; injecting a substitute decouples callers from libproc.
+    /// Foreground-process cwd provider; nil uses libproc on the live foreground pid.
     var foregroundProcessWorkingDirectoryProvider: ((UUID) -> String?)?
 
-    /// Rescues cwd inheritance while a restored agent's auto-resume command owns the foreground.
-    ///
-    /// Until the shell reaches a prompt, tracked cwd can be stranded on a
-    /// default/home report. Prefer the live foreground process cwd when that
-    /// happens, then the recorded session directory. Remote panes are excluded
-    /// because their cwd is not locally inspectable.
     private func resumedAgentPaneWorkingDirectoryRescue(panelId: UUID) -> String? {
-        guard restoredAgentResumeStatesByPanelId[panelId] == .autoResumeCommandRunning else { return nil }
+        let resumeState = restoredAgentResumeStatesByPanelId[panelId]
+        guard resumeState == .awaitingAutoResumeCommand || resumeState == .autoResumeCommandRunning else { return nil }
         guard !isRemoteTerminalSurface(panelId) else { return nil }
-        // No recorded session directory means the resume launcher targets no directory of its own.
         guard let sessionDirectory = Self.normalizedTerminalWorkingDirectory(
             restoredResumeSessionWorkingDirectoriesByPanelId[panelId]
         ) else { return nil }
         let trackedDirectory = Self.normalizedTerminalWorkingDirectory(panelDirectories[panelId])
         if trackedDirectory == sessionDirectory { return nil }
-        for candidate in [liveForegroundProcessWorkingDirectory(panelId: panelId), sessionDirectory] {
+        let candidates = resumeState == .awaitingAutoResumeCommand
+            ? [sessionDirectory]
+            : [liveForegroundProcessWorkingDirectory(panelId: panelId), sessionDirectory]
+        for candidate in candidates {
             guard let candidate = Self.normalizedTerminalWorkingDirectory(candidate) else { continue }
             if candidate == trackedDirectory {
                 continue
@@ -7129,11 +7124,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         guard let paneId = sourcePaneId else { return nil }
         var inheritedConfigSourcePanelId: UUID?
-        var inheritedConfig = inheritedTerminalConfig(
-            preferredPanelId: panelId,
-            inPane: paneId,
-            sourcePanelId: { inheritedConfigSourcePanelId = $0 }
-        )
+        var inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId) { inheritedConfigSourcePanelId = $0 }
         let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
         let remoteTerminalStartupCommand = suppressWorkspaceRemoteStartupCommand ? nil : remoteTerminalStartupCommand()
@@ -7445,9 +7436,12 @@ final class Workspace: Identifiable, ObservableObject {
         let shouldInheritWorkingDirectoryFallback = inheritWorkingDirectoryFallback && startupCommand == nil
         var inheritedConfigSourcePanelId: UUID?
         var inheritedConfig = inheritedTerminalConfig(inPane: paneId, sourcePanelId: { inheritedConfigSourcePanelId = $0 })
-        let inheritedWorkingDirectory = shouldInheritWorkingDirectoryFallback && inheritedConfigSourcePanelId == fallbackSourcePanelId
-            ? inheritedConfig?.workingDirectory
+        let fallbackLiveWorkingDirectory = shouldInheritWorkingDirectoryFallback && inheritedConfigSourcePanelId != fallbackSourcePanelId
+            ? fallbackSourcePanelId.flatMap { liveForegroundProcessWorkingDirectory(panelId: $0) }
             : nil
+        let inheritedWorkingDirectory = inheritedConfigSourcePanelId == fallbackSourcePanelId
+            ? inheritedConfig?.workingDirectory
+            : fallbackLiveWorkingDirectory
         if startupCommand != nil {
             var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
             template.waitAfterCommand = true

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6767,7 +6767,11 @@ final class Workspace: Identifiable, ObservableObject {
               restoredGuardedWorkingDirectoriesByPanelId[sourcePanelId] == nil,
               restoredAgentResumeStatesByPanelId[sourcePanelId] != .autoResumeCommandRunning,
               !isRemoteTerminalSurface(sourcePanelId),
-              terminalPanel(for: sourcePanelId)?.surface.surface != nil else { return nil }
+              let terminalPanel = terminalPanel(for: sourcePanelId),
+              terminalPanel.surface.surface != nil,
+              !(terminalPanel.surface.initialCommand != nil &&
+                  Self.normalizedTerminalWorkingDirectory(terminalPanel.requestedWorkingDirectory) == nil &&
+                  panelShellActivityStates[sourcePanelId] != .promptIdle) else { return nil }
         return inherited
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6754,11 +6754,21 @@ final class Workspace: Identifiable, ObservableObject {
             return rescued
         }
         return [
-            inheritedWorkingDirectory,
             sourcePanelId.flatMap { panelDirectories[$0] },
+            inheritedWorkingDirectoryForTerminalStartup(sourcePanelId: sourcePanelId, inheritedWorkingDirectory: inheritedWorkingDirectory),
             sourcePanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
             currentDirectory,
         ].lazy.compactMap(Self.normalizedTerminalWorkingDirectory).first
+    }
+
+    private func inheritedWorkingDirectoryForTerminalStartup(sourcePanelId: UUID?, inheritedWorkingDirectory: String?) -> String? {
+        guard let inherited = Self.normalizedTerminalWorkingDirectory(inheritedWorkingDirectory),
+              let sourcePanelId,
+              restoredGuardedWorkingDirectoriesByPanelId[sourcePanelId] == nil,
+              restoredAgentResumeStatesByPanelId[sourcePanelId] != .autoResumeCommandRunning,
+              !isRemoteTerminalSurface(sourcePanelId),
+              terminalPanel(for: sourcePanelId)?.surface.surface != nil else { return nil }
+        return inherited
     }
 
     /// The foreground-process cwd read consulted by
@@ -6770,25 +6780,17 @@ final class Workspace: Identifiable, ObservableObject {
     /// Rescues split/new-tab cwd inheritance from a pane whose restored
     /// auto-resume command is still running (#7155).
     ///
-    /// While the resumed agent holds the pane's foreground the shell never
-    /// reaches a prompt, so the pane's tracked cwd cannot self-correct: the
-    /// one-shot restore guard (#6617) swallows only the first spurious
-    /// post-restore report, and any later stray report parks the tracked value
-    /// on the surface default (home) for the rest of the run. While that state
-    /// lasts, trust the tracked value only while it still equals the restored
-    /// session directory; otherwise prefer the live foreground process's
-    /// actual cwd (a resumed agent knows where it really is — e.g. Claude
-    /// restores its own cwd on resume), then the recorded session directory.
+    /// While the resumed agent owns the foreground, the shell never reaches a
+    /// prompt, so tracked cwd can be stranded on a spurious default/home report.
+    /// Trust it only while it still equals the restored session directory;
+    /// otherwise prefer the live foreground process cwd, then the recorded
+    /// session directory.
     /// Local panes only: a remote pane's tracked cwd is a remote path that no
     /// local process inspection or existence check can validate.
     private func resumedAgentPaneWorkingDirectoryRescue(panelId: UUID) -> String? {
         guard restoredAgentResumeStatesByPanelId[panelId] == .autoResumeCommandRunning else { return nil }
         guard !isRemoteTerminalSurface(panelId) else { return nil }
-        // No recorded session directory means the resume launcher targets no
-        // directory of its own (e.g. a registration with a `.ignore` cwd
-        // policy, whose resume command never cds) — the tracked cwd is
-        // genuine, so there is nothing to rescue and the live foreground
-        // process must not be consulted either.
+        // No recorded session directory means the resume launcher targets no directory of its own.
         guard let sessionDirectory = Self.normalizedTerminalWorkingDirectory(
             restoredResumeSessionWorkingDirectoriesByPanelId[panelId]
         ) else { return nil }
@@ -7162,16 +7164,10 @@ final class Workspace: Identifiable, ObservableObject {
         )
 #endif
 
-        let ghosttyInheritedWorkingDirectory = terminalPanel(for: panelId)?.surface.surface == nil || isRemoteTerminalSurface(panelId) || restoredAgentResumeStatesByPanelId[panelId] == .autoResumeCommandRunning ? nil : Self.normalizedTerminalWorkingDirectory(inheritedConfig?.workingDirectory)
         let splitWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
             requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
-            inheritedWorkingDirectory: ghosttyInheritedWorkingDirectory
+            inheritedWorkingDirectory: inheritedConfig?.workingDirectory
         )
-#if DEBUG
-        cmuxDebugLog(
-            "split.cwd panelId=\(panelId.uuidString.prefix(5)) panelDir=\(panelDirectories[panelId] ?? "nil") requestedDir=\(terminalPanel(for: panelId)?.requestedWorkingDirectory ?? "nil") currentDir=\(currentDirectory) requested=\(Self.normalizedTerminalWorkingDirectory(workingDirectory) ?? "nil") inherited=\(ghosttyInheritedWorkingDirectory ?? "nil") resolved=\(splitWorkingDirectory ?? "nil")"
-        )
-#endif
 
         // Create the new terminal panel.
         let newPanel = TerminalPanel(
@@ -7421,7 +7417,6 @@ final class Workspace: Identifiable, ObservableObject {
         let previousFocusedPanelId = focusedPanelId
         let previousHostedView = focusedTerminalPanel?.hostedView
 
-        var inheritedConfig = inheritedTerminalConfig(inPane: paneId)
         let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
         let remoteTerminalStartupCommand = suppressWorkspaceRemoteStartupCommand ? nil : remoteTerminalStartupCommand()
@@ -7441,6 +7436,10 @@ final class Workspace: Identifiable, ObservableObject {
             base: startupEnvironmentWithRemoteSession,
             remoteStartupCommand: remoteStartupCommandForEnvironment
         )
+        let fallbackSourcePanelId = workingDirectoryFallbackSourcePanelId
+            ?? bonsplitController.selectedTab(inPane: paneId).map(\.id).flatMap(panelIdFromSurfaceId)
+        let shouldInheritWorkingDirectoryFallback = inheritWorkingDirectoryFallback && startupCommand == nil
+        var inheritedConfig = inheritedTerminalConfig(preferredPanelId: shouldInheritWorkingDirectoryFallback ? fallbackSourcePanelId : nil, inPane: paneId)
         // See the comment at the other call site: hold the PTY open after the remote
         // command exits so the user sees the error rather than a silently-respawned
         // local login shell.
@@ -7449,12 +7448,11 @@ final class Workspace: Identifiable, ObservableObject {
             template.waitAfterCommand = true
             inheritedConfig = template
         }
-        let fallbackSourcePanelId = workingDirectoryFallbackSourcePanelId
-            ?? bonsplitController.selectedTab(inPane: paneId).map(\.id).flatMap(panelIdFromSurfaceId)
-        let requestedWorkingDirectory = inheritWorkingDirectoryFallback && startupCommand == nil
+        let requestedWorkingDirectory = shouldInheritWorkingDirectoryFallback
             ? resolvedTerminalStartupWorkingDirectory(
                 requestedWorkingDirectory: workingDirectory,
-                sourcePanelId: fallbackSourcePanelId
+                sourcePanelId: fallbackSourcePanelId,
+                inheritedWorkingDirectory: inheritedConfig?.workingDirectory
             )
             : workingDirectory
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7149,8 +7149,6 @@ final class Workspace: Identifiable, ObservableObject {
             base: startupEnvironmentWithRemoteSession,
             remoteStartupCommand: remoteStartupCommandForEnvironment
         )
-        // Hold remote-command panes open after exit so startup errors remain visible
-        // instead of Ghostty respawning a local login shell.
         if startupCommand != nil {
             inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: isRemoteStartupCommand)
         }
@@ -7161,15 +7159,18 @@ final class Workspace: Identifiable, ObservableObject {
             "remoteCommand=\(remoteTerminalStartupCommand == nil ? 0 : 1)"
         )
 #endif
-
+        let splitLiveWorkingDirectory = panelShellActivityStates[panelId] == .promptIdle
+            ? liveForegroundProcessWorkingDirectory(panelId: panelId)
+            : nil
+        let splitInheritedWorkingDirectory = splitLiveWorkingDirectory ?? (inheritedConfigSourcePanelId == panelId ? inheritedConfig?.workingDirectory : nil)
         let splitWorkingDirectory = isRemoteStartupCommand
             ? Self.normalizedTerminalWorkingDirectory(workingDirectory)
             : resolvedTerminalStartupWorkingDirectory(
                 requestedWorkingDirectory: workingDirectory, sourcePanelId: panelId,
-                inheritedWorkingDirectory: inheritedConfigSourcePanelId == panelId ? inheritedConfig?.workingDirectory : nil
+                inheritedWorkingDirectory: splitInheritedWorkingDirectory,
+                inheritedWorkingDirectoryRequiresPromptIdle: splitLiveWorkingDirectory != nil
             )
         inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, clearWorkingDirectory: true)
-
         let newPanel = TerminalPanel(
             id: newPanelID,
             workspaceId: id,
@@ -7442,29 +7443,25 @@ final class Workspace: Identifiable, ObservableObject {
         let shouldInheritWorkingDirectoryFallback = inheritWorkingDirectoryFallback && !isRemoteStartupCommand
         var inheritedConfigSourcePanelId: UUID?
         var inheritedConfig = inheritedTerminalConfig(inPane: paneId, sourcePanelId: { inheritedConfigSourcePanelId = $0 })
-        let fallbackLiveWorkingDirectory = shouldInheritWorkingDirectoryFallback && inheritedConfigSourcePanelId != fallbackSourcePanelId
+        let fallbackLiveWorkingDirectory = shouldInheritWorkingDirectoryFallback
+            && fallbackSourcePanelId.map({ panelShellActivityStates[$0] == .promptIdle }) == true
             ? fallbackSourcePanelId.flatMap { liveForegroundProcessWorkingDirectory(panelId: $0) }
             : nil
-        let inheritedWorkingDirectory = inheritedConfigSourcePanelId == fallbackSourcePanelId
-            ? inheritedConfig?.workingDirectory
-            : fallbackLiveWorkingDirectory
+        let inheritedWorkingDirectory = fallbackLiveWorkingDirectory ?? (inheritedConfigSourcePanelId == fallbackSourcePanelId ? inheritedConfig?.workingDirectory : nil)
         if startupCommand != nil {
             inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, waitAfterCommand: true, clearWorkingDirectory: isRemoteStartupCommand)
         }
         let requestedWorkingDirectory = shouldInheritWorkingDirectoryFallback
             ? resolvedTerminalStartupWorkingDirectory(
-                requestedWorkingDirectory: workingDirectory,
-                sourcePanelId: fallbackSourcePanelId,
+                requestedWorkingDirectory: workingDirectory, sourcePanelId: fallbackSourcePanelId,
                 inheritedWorkingDirectory: inheritedWorkingDirectory,
-                inheritedWorkingDirectoryRequiresPromptIdle: inheritedConfigSourcePanelId != fallbackSourcePanelId
+                inheritedWorkingDirectoryRequiresPromptIdle: fallbackLiveWorkingDirectory != nil
             )
             : workingDirectory
         if shouldInheritWorkingDirectoryFallback {
             inheritedConfig = Self.terminalStartupConfigTemplate(inheritedConfig, clearWorkingDirectory: true)
         }
 
-        // Restored panels reuse their persisted Ghostty surface id so session
-        // bindings survive relaunch; callers only pass ids verified as free.
         let newPanel = TerminalPanel(
             id: newPanelID,
             workspaceId: id,

--- a/Sources/WorkspaceSurfaceConfig.swift
+++ b/Sources/WorkspaceSurfaceConfig.swift
@@ -116,6 +116,17 @@ extension Workspace {
         return panelDirectories[sourcePanelId]
     }
 
+    func currentDirectoryForTerminalStartup(sourcePanelId: UUID?) -> String? {
+        guard sourcePanelId.map({ isRemoteTerminalSurface($0) }) != true else {
+            return Self.safeLocalTerminalStartupWorkingDirectory()
+        }
+        return currentDirectory
+    }
+
+    nonisolated static func safeLocalTerminalStartupWorkingDirectory() -> String {
+        normalizedTerminalWorkingDirectory(FileManager.default.homeDirectoryForCurrentUser.path) ?? NSHomeDirectory()
+    }
+
     func inheritedTerminalWorkingDirectory(fromPanelId panelId: UUID?) -> String? {
         guard let panelId, let terminalPanel = terminalPanel(for: panelId) else { return nil }
         let surface = terminalPanel.surface

--- a/Sources/WorkspaceSurfaceConfig.swift
+++ b/Sources/WorkspaceSurfaceConfig.swift
@@ -112,7 +112,8 @@ extension Workspace {
     }
 
     func panelDirectoryForTerminalStartup(sourcePanelId: UUID?) -> String? {
-        guard let sourcePanelId, !isRemoteTerminalSurface(sourcePanelId) else { return nil }
+        guard let sourcePanelId,
+              allowsLocalDirectoryFallback(panelId: sourcePanelId) else { return nil }
         return panelDirectories[sourcePanelId]
     }
 

--- a/Sources/WorkspaceSurfaceConfig.swift
+++ b/Sources/WorkspaceSurfaceConfig.swift
@@ -86,4 +86,45 @@ extension Workspace {
               !isAgentResumePendingOrRunning else { return nil }
         return normalizedTerminalWorkingDirectory(inheritedWorkingDirectory)
     }
+
+    func terminalStartupCandidateWorkingDirectory(
+        _ workingDirectory: String?,
+        sourcePanelId: UUID?
+    ) -> String? {
+        guard let sourcePanelId else { return nil }
+        return Self.terminalStartupInheritedWorkingDirectoryCandidate(
+            workingDirectory,
+            shellActivityState: panelShellActivityStates[sourcePanelId],
+            isRemoteTerminalSurface: isRemoteTerminalSurface(sourcePanelId),
+            isRestoreGuarded: hasRestoredGuardedWorkingDirectory(panelId: sourcePanelId),
+            isAgentResumePendingOrRunning: restoredAgentResumeStatesByPanelId[sourcePanelId] == .awaitingAutoResumeCommand ||
+                restoredAgentResumeStatesByPanelId[sourcePanelId] == .autoResumeCommandRunning
+        )
+    }
+
+    func liveForegroundWorkingDirectoryForTerminalStartup(sourcePanelId: UUID?) -> String? {
+        guard let sourcePanelId else { return nil }
+        guard Self.normalizedTerminalWorkingDirectory(panelDirectories[sourcePanelId]) == nil else { return nil }
+        return terminalStartupCandidateWorkingDirectory(
+            liveForegroundProcessWorkingDirectory(panelId: sourcePanelId),
+            sourcePanelId: sourcePanelId
+        )
+    }
+
+    func panelDirectoryForTerminalStartup(sourcePanelId: UUID?) -> String? {
+        guard let sourcePanelId, !isRemoteTerminalSurface(sourcePanelId) else { return nil }
+        return panelDirectories[sourcePanelId]
+    }
+
+    func inheritedTerminalWorkingDirectory(fromPanelId panelId: UUID?) -> String? {
+        guard let panelId, let terminalPanel = terminalPanel(for: panelId) else { return nil }
+        let surface = terminalPanel.surface
+        guard let sourceSurface = surface.surface else { return nil }
+        let config = cmuxInheritedSurfaceConfig(
+            sourceSurface: sourceSurface,
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT
+        )
+        withExtendedLifetime((terminalPanel, surface)) {}
+        return config.workingDirectory
+    }
 }

--- a/Sources/WorkspaceSurfaceConfig.swift
+++ b/Sources/WorkspaceSurfaceConfig.swift
@@ -54,3 +54,21 @@ func cmuxInheritedSurfaceConfig(
 
     return config
 }
+
+extension Workspace {
+    nonisolated static func terminalStartupConfigTemplate(
+        _ inheritedConfig: CmuxSurfaceConfigTemplate?,
+        waitAfterCommand: Bool = false,
+        clearWorkingDirectory: Bool = false
+    ) -> CmuxSurfaceConfigTemplate? {
+        guard waitAfterCommand || inheritedConfig != nil else { return nil }
+        var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
+        if waitAfterCommand {
+            template.waitAfterCommand = true
+        }
+        if clearWorkingDirectory {
+            template.workingDirectory = nil
+        }
+        return template
+    }
+}

--- a/Sources/WorkspaceSurfaceConfig.swift
+++ b/Sources/WorkspaceSurfaceConfig.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CmuxFoundation
 import CmuxTerminalCore
+import CmuxWorkspaces
 
 // CmuxSurfaceConfigTemplate and the surface runtime probes moved to
 // CmuxTerminalCore (SurfaceValues/CmuxSurfaceConfigTemplate.swift and

--- a/Sources/WorkspaceSurfaceConfig.swift
+++ b/Sources/WorkspaceSurfaceConfig.swift
@@ -71,4 +71,18 @@ extension Workspace {
         }
         return template
     }
+
+    nonisolated static func terminalStartupInheritedWorkingDirectoryCandidate(
+        _ inheritedWorkingDirectory: String?,
+        shellActivityState: PanelShellActivityState?,
+        isRemoteTerminalSurface: Bool,
+        isRestoreGuarded: Bool,
+        isAgentResumePendingOrRunning: Bool
+    ) -> String? {
+        guard shellActivityState == .promptIdle,
+              !isRemoteTerminalSurface,
+              !isRestoreGuarded,
+              !isAgentResumePendingOrRunning else { return nil }
+        return normalizedTerminalWorkingDirectory(inheritedWorkingDirectory)
+    }
 }

--- a/Sources/WorkspaceSurfaceConfig.swift
+++ b/Sources/WorkspaceSurfaceConfig.swift
@@ -117,6 +117,9 @@ extension Workspace {
     }
 
     func currentDirectoryForTerminalStartup(sourcePanelId: UUID?) -> String? {
+        guard !usesRemoteDirectoryProvenance else {
+            return Self.safeLocalTerminalStartupWorkingDirectory()
+        }
         guard sourcePanelId.map({ isRemoteTerminalSurface($0) }) != true else {
             return Self.safeLocalTerminalStartupWorkingDirectory()
         }

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CmuxCore
+import CmuxWorkspaces
 import Testing
 
 #if canImport(cmux_DEV)

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -350,6 +350,7 @@ import Testing
 
         #expect(panel.requestedWorkingDirectory == Workspace.safeLocalTerminalStartupWorkingDirectory())
         #expect(panel.surface.debugInitialCommand() == explicitCommand)
+        #expect(!workspace.isRemoteTerminalSurface(panel.id))
     }
 
     @Test func explicitSplitCommandDoesNotUseRemotePanelDirectoryAsLocalFallback() throws {
@@ -373,6 +374,7 @@ import Testing
 
         #expect(panel.requestedWorkingDirectory == Workspace.safeLocalTerminalStartupWorkingDirectory())
         #expect(panel.surface.debugInitialCommand() == explicitCommand)
+        #expect(!workspace.isRemoteTerminalSurface(panel.id))
     }
 
     @Test func explicitSplitCommandDoesNotUseRemoteRequestedWorkingDirectoryAsLocalFallback() throws {
@@ -400,6 +402,7 @@ import Testing
 
         #expect(panel.requestedWorkingDirectory == Workspace.safeLocalTerminalStartupWorkingDirectory())
         #expect(panel.surface.debugInitialCommand() == explicitCommand)
+        #expect(!workspace.isRemoteTerminalSurface(panel.id))
     }
 
     @Test func explicitWorkingDirectoryWinsOverRemoteStartupSplitFallback() throws {

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -302,6 +302,8 @@ import Testing
         )
         #expect(reportedSnapshot.directory == trustedRemoteDirectory)
         #expect(reportedSnapshot.terminal?.workingDirectory == trustedRemoteDirectory)
+        workspace.disconnectRemoteConnection()
+        #expect(workspace.panelDirectoryForTerminalStartup(sourcePanelId: panel.id) == nil)
     }
 
     @Test func remoteStartupSplitSafeLocalWorkingDirectoryIsNotCapturedAsSessionDirectory() throws {

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -268,6 +268,72 @@ import Testing
         #expect(sanitized.environmentVariables == inheritedConfig.environmentVariables)
     }
 
+    @Test func inheritedRuntimeWorkingDirectoryRequiresPromptIdleSource() {
+        let inheritedDirectory = "/tmp/cmux-inherited-runtime-\(UUID().uuidString)"
+
+        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
+            inheritedDirectory,
+            shellActivityState: .promptIdle,
+            isRemoteTerminalSurface: false,
+            isRestoreGuarded: false,
+            isAgentResumePendingOrRunning: false
+        ) == inheritedDirectory)
+        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
+            inheritedDirectory,
+            shellActivityState: .commandRunning,
+            isRemoteTerminalSurface: false,
+            isRestoreGuarded: false,
+            isAgentResumePendingOrRunning: false
+        ) == nil)
+        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
+            inheritedDirectory,
+            shellActivityState: .unknown,
+            isRemoteTerminalSurface: false,
+            isRestoreGuarded: false,
+            isAgentResumePendingOrRunning: false
+        ) == nil)
+        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
+            inheritedDirectory,
+            shellActivityState: nil,
+            isRemoteTerminalSurface: false,
+            isRestoreGuarded: false,
+            isAgentResumePendingOrRunning: false
+        ) == nil)
+    }
+
+    @Test func inheritedRuntimeWorkingDirectorySkipsRemoteRestoreAndAutoResumeSources() {
+        let inheritedDirectory = "/tmp/cmux-inherited-runtime-\(UUID().uuidString)"
+
+        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
+            inheritedDirectory,
+            shellActivityState: .promptIdle,
+            isRemoteTerminalSurface: true,
+            isRestoreGuarded: false,
+            isAgentResumePendingOrRunning: false
+        ) == nil)
+        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
+            inheritedDirectory,
+            shellActivityState: .promptIdle,
+            isRemoteTerminalSurface: false,
+            isRestoreGuarded: true,
+            isAgentResumePendingOrRunning: false
+        ) == nil)
+        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
+            inheritedDirectory,
+            shellActivityState: .promptIdle,
+            isRemoteTerminalSurface: false,
+            isRestoreGuarded: false,
+            isAgentResumePendingOrRunning: true
+        ) == nil)
+        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
+            " \n\t",
+            shellActivityState: .promptIdle,
+            isRemoteTerminalSurface: false,
+            isRestoreGuarded: false,
+            isAgentResumePendingOrRunning: false
+        ) == nil)
+    }
+
     private func sshRemoteConfiguration(command: String) -> WorkspaceRemoteConfiguration {
         WorkspaceRemoteConfiguration(
             destination: "seepine@192.168.5.20",

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -188,6 +188,47 @@ import Testing
         #expect(panel.surface.debugInitialCommand() != nil)
     }
 
+    @Test func remoteStartupCommandSuppressesSplitFallbackWorkingDirectoryInheritance() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let remoteDirectory = "/home/seepine/cmux-remote-\(UUID().uuidString)"
+        let remoteCommand = "ssh seepine@192.168.5.20"
+
+        workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
+        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: remoteDirectory))
+        workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
+
+        let panel = try #require(workspace.newTerminalSplit(
+            from: sourcePanelId,
+            orientation: .horizontal,
+            focus: false
+        ))
+
+        #expect(panel.requestedWorkingDirectory == nil)
+        #expect(panel.surface.debugInitialCommand() != nil)
+    }
+
+    @Test func explicitWorkingDirectoryWinsOverRemoteStartupSplitFallback() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let remoteDirectory = "/home/seepine/cmux-remote-\(UUID().uuidString)"
+        let explicitDirectory = "/tmp/cmux-explicit-split-\(UUID().uuidString)"
+        let remoteCommand = "ssh seepine@192.168.5.20"
+
+        workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
+        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: remoteDirectory))
+
+        let panel = try #require(workspace.newTerminalSplit(
+            from: sourcePanelId,
+            orientation: .horizontal,
+            focus: false,
+            workingDirectory: explicitDirectory
+        ))
+
+        #expect(panel.requestedWorkingDirectory == explicitDirectory)
+        #expect(panel.surface.debugInitialCommand() != nil)
+    }
+
     @Test func startupCommandConfigTemplateClearsInheritedWorkingDirectory() throws {
         var inheritedConfig = CmuxSurfaceConfigTemplate()
         inheritedConfig.fontSize = 17

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -49,14 +49,35 @@ import Testing
         )
     }
 
-    @Test func promptIdleFallbackLiveWorkingDirectoryBeatsTrackedDirectory() throws {
+    @Test func promptIdleFallbackTrackedDirectoryBeatsLiveWorkingDirectory() throws {
         let workspace = Workspace()
         let sourcePanelId = try #require(workspace.focusedPanelId)
         let paneId = try #require(workspace.bonsplitController.focusedPaneId)
-        let staleDirectory = "/tmp/cmux-stale-\(UUID().uuidString)"
+        let trackedDirectory = "/tmp/cmux-tracked-\(UUID().uuidString)"
         let liveDirectory = "/tmp/cmux-live-\(UUID().uuidString)"
 
-        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: staleDirectory))
+        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: trackedDirectory))
+        workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
+        workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
+            panelId == sourcePanelId ? liveDirectory : nil
+        }
+
+        let panel = try #require(workspace.newTerminalSurface(
+            inPane: paneId,
+            focus: false,
+            inheritWorkingDirectoryFallback: true,
+            workingDirectoryFallbackSourcePanelId: sourcePanelId
+        ))
+
+        #expect(panel.requestedWorkingDirectory == trackedDirectory)
+    }
+
+    @Test func promptIdleFallbackLiveWorkingDirectoryFillsMissingTrackedDirectory() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let liveDirectory = "/tmp/cmux-live-missing-tracked-\(UUID().uuidString)"
+
         workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
         workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
             panelId == sourcePanelId ? liveDirectory : nil
@@ -72,13 +93,32 @@ import Testing
         #expect(panel.requestedWorkingDirectory == liveDirectory)
     }
 
-    @Test func promptIdleSplitLiveWorkingDirectoryBeatsTrackedDirectory() throws {
+    @Test func promptIdleSplitTrackedDirectoryBeatsLiveWorkingDirectory() throws {
         let workspace = Workspace()
         let sourcePanelId = try #require(workspace.focusedPanelId)
-        let staleDirectory = "/tmp/cmux-stale-split-\(UUID().uuidString)"
+        let trackedDirectory = "/tmp/cmux-tracked-split-\(UUID().uuidString)"
         let liveDirectory = "/tmp/cmux-live-split-\(UUID().uuidString)"
 
-        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: staleDirectory))
+        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: trackedDirectory))
+        workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
+        workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
+            panelId == sourcePanelId ? liveDirectory : nil
+        }
+
+        let panel = try #require(workspace.newTerminalSplit(
+            from: sourcePanelId,
+            orientation: .horizontal,
+            focus: false
+        ))
+
+        #expect(panel.requestedWorkingDirectory == trackedDirectory)
+    }
+
+    @Test func promptIdleSplitLiveWorkingDirectoryFillsMissingTrackedDirectory() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let liveDirectory = "/tmp/cmux-live-split-missing-tracked-\(UUID().uuidString)"
+
         workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
         workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
             panelId == sourcePanelId ? liveDirectory : nil

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -72,6 +72,27 @@ import Testing
         #expect(panel.requestedWorkingDirectory == liveDirectory)
     }
 
+    @Test func promptIdleSplitLiveWorkingDirectoryBeatsTrackedDirectory() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let staleDirectory = "/tmp/cmux-stale-split-\(UUID().uuidString)"
+        let liveDirectory = "/tmp/cmux-live-split-\(UUID().uuidString)"
+
+        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: staleDirectory))
+        workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
+        workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
+            panelId == sourcePanelId ? liveDirectory : nil
+        }
+
+        let panel = try #require(workspace.newTerminalSplit(
+            from: sourcePanelId,
+            orientation: .horizontal,
+            focus: false
+        ))
+
+        #expect(panel.requestedWorkingDirectory == liveDirectory)
+    }
+
     @Test func commandRunningFallbackLiveWorkingDirectoryDoesNotBeatTrackedDirectory() throws {
         let workspace = Workspace()
         let sourcePanelId = try #require(workspace.focusedPanelId)

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CmuxCore
 import Testing
 
 #if canImport(cmux_DEV)
@@ -139,12 +140,12 @@ import Testing
         #expect(panel.requestedWorkingDirectory == explicitDirectory)
     }
 
-    @Test func startupCommandSuppressesFallbackWorkingDirectoryInheritance() throws {
+    @Test func explicitInitialCommandInheritsFallbackWorkingDirectory() throws {
         let workspace = Workspace()
         let sourcePanelId = try #require(workspace.focusedPanelId)
         let paneId = try #require(workspace.bonsplitController.focusedPaneId)
         let liveDirectory = "/tmp/cmux-live-\(UUID().uuidString)"
-        let startupCommand = "/tmp/cmux-command-\(UUID().uuidString).sh"
+        let initialCommand = "/tmp/cmux-command-\(UUID().uuidString).sh"
 
         workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
         workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
@@ -154,13 +155,37 @@ import Testing
         let panel = try #require(workspace.newTerminalSurface(
             inPane: paneId,
             focus: false,
-            initialCommand: startupCommand,
+            initialCommand: initialCommand,
+            inheritWorkingDirectoryFallback: true,
+            workingDirectoryFallbackSourcePanelId: sourcePanelId
+        ))
+
+        #expect(panel.requestedWorkingDirectory == liveDirectory)
+        #expect(panel.surface.debugInitialCommand() == initialCommand)
+    }
+
+    @Test func remoteStartupCommandSuppressesFallbackWorkingDirectoryInheritance() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let liveDirectory = "/tmp/cmux-live-\(UUID().uuidString)"
+        let remoteCommand = "ssh seepine@192.168.5.20"
+
+        workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
+        workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
+        workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
+            panelId == sourcePanelId ? liveDirectory : nil
+        }
+
+        let panel = try #require(workspace.newTerminalSurface(
+            inPane: paneId,
+            focus: false,
             inheritWorkingDirectoryFallback: true,
             workingDirectoryFallbackSourcePanelId: sourcePanelId
         ))
 
         #expect(panel.requestedWorkingDirectory == nil)
-        #expect(panel.surface.debugInitialCommand() == startupCommand)
+        #expect(panel.surface.debugInitialCommand() != nil)
     }
 
     @Test func startupCommandConfigTemplateClearsInheritedWorkingDirectory() throws {
@@ -179,5 +204,20 @@ import Testing
         #expect(sanitized.workingDirectory == nil)
         #expect(sanitized.fontSize == inheritedConfig.fontSize)
         #expect(sanitized.environmentVariables == inheritedConfig.environmentVariables)
+    }
+
+    private func sshRemoteConfiguration(command: String) -> WorkspaceRemoteConfiguration {
+        WorkspaceRemoteConfiguration(
+            destination: "seepine@192.168.5.20",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64007,
+            relayID: "relay-\(UUID().uuidString)",
+            relayToken: String(repeating: "a", count: 64),
+            localSocketPath: "/tmp/cmux-cwd-inheritance-\(UUID().uuidString).sock",
+            terminalStartupCommand: command
+        )
     }
 }

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -234,6 +234,7 @@ import Testing
         let remoteCommand = "ssh seepine@192.168.5.20"
 
         workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
+        #expect(workspace.currentDirectoryForTerminalStartup(sourcePanelId: nil) == Workspace.safeLocalTerminalStartupWorkingDirectory())
         workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
         workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
             panelId == sourcePanelId ? liveDirectory : nil

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -47,4 +47,137 @@ import Testing
             "Expected new terminal tab to inherit the selected source terminal's requested cwd when no reported cwd exists yet"
         )
     }
+
+    @Test func promptIdleFallbackLiveWorkingDirectoryBeatsTrackedDirectory() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let staleDirectory = "/tmp/cmux-stale-\(UUID().uuidString)"
+        let liveDirectory = "/tmp/cmux-live-\(UUID().uuidString)"
+
+        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: staleDirectory))
+        workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
+        workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
+            panelId == sourcePanelId ? liveDirectory : nil
+        }
+
+        let panel = try #require(workspace.newTerminalSurface(
+            inPane: paneId,
+            focus: false,
+            inheritWorkingDirectoryFallback: true,
+            workingDirectoryFallbackSourcePanelId: sourcePanelId
+        ))
+
+        #expect(panel.requestedWorkingDirectory == liveDirectory)
+    }
+
+    @Test func commandRunningFallbackLiveWorkingDirectoryDoesNotBeatTrackedDirectory() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let trackedDirectory = "/tmp/cmux-tracked-\(UUID().uuidString)"
+        let foregroundDirectory = "/tmp/cmux-child-process-\(UUID().uuidString)"
+
+        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: trackedDirectory))
+        workspace.panelShellActivityStates[sourcePanelId] = .commandRunning
+        workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
+            panelId == sourcePanelId ? foregroundDirectory : nil
+        }
+
+        let panel = try #require(workspace.newTerminalSurface(
+            inPane: paneId,
+            focus: false,
+            inheritWorkingDirectoryFallback: true,
+            workingDirectoryFallbackSourcePanelId: sourcePanelId
+        ))
+
+        #expect(panel.requestedWorkingDirectory == trackedDirectory)
+    }
+
+    @Test func unknownShellStateFallbackLiveWorkingDirectoryDoesNotBeatTrackedDirectory() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let trackedDirectory = "/tmp/cmux-tracked-\(UUID().uuidString)"
+        let foregroundDirectory = "/tmp/cmux-unknown-foreground-\(UUID().uuidString)"
+
+        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: trackedDirectory))
+        workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
+            panelId == sourcePanelId ? foregroundDirectory : nil
+        }
+
+        let panel = try #require(workspace.newTerminalSurface(
+            inPane: paneId,
+            focus: false,
+            inheritWorkingDirectoryFallback: true,
+            workingDirectoryFallbackSourcePanelId: sourcePanelId
+        ))
+
+        #expect(panel.requestedWorkingDirectory == trackedDirectory)
+    }
+
+    @Test func explicitWorkingDirectoryWinsOverFallbackLiveWorkingDirectory() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let explicitDirectory = "/tmp/cmux-explicit-\(UUID().uuidString)"
+        let liveDirectory = "/tmp/cmux-live-\(UUID().uuidString)"
+
+        workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
+        workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
+            panelId == sourcePanelId ? liveDirectory : nil
+        }
+
+        let panel = try #require(workspace.newTerminalSurface(
+            inPane: paneId,
+            focus: false,
+            workingDirectory: explicitDirectory,
+            inheritWorkingDirectoryFallback: true,
+            workingDirectoryFallbackSourcePanelId: sourcePanelId
+        ))
+
+        #expect(panel.requestedWorkingDirectory == explicitDirectory)
+    }
+
+    @Test func startupCommandSuppressesFallbackWorkingDirectoryInheritance() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let liveDirectory = "/tmp/cmux-live-\(UUID().uuidString)"
+        let startupCommand = "/tmp/cmux-command-\(UUID().uuidString).sh"
+
+        workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
+        workspace.foregroundProcessWorkingDirectoryProvider = { panelId in
+            panelId == sourcePanelId ? liveDirectory : nil
+        }
+
+        let panel = try #require(workspace.newTerminalSurface(
+            inPane: paneId,
+            focus: false,
+            initialCommand: startupCommand,
+            inheritWorkingDirectoryFallback: true,
+            workingDirectoryFallbackSourcePanelId: sourcePanelId
+        ))
+
+        #expect(panel.requestedWorkingDirectory == nil)
+        #expect(panel.surface.debugInitialCommand() == startupCommand)
+    }
+
+    @Test func startupCommandConfigTemplateClearsInheritedWorkingDirectory() throws {
+        var inheritedConfig = CmuxSurfaceConfigTemplate()
+        inheritedConfig.fontSize = 17
+        inheritedConfig.workingDirectory = "/tmp/cmux-inherited-\(UUID().uuidString)"
+        inheritedConfig.environmentVariables = ["CMUX_TEST_ENV": "1"]
+
+        let sanitized = try #require(Workspace.terminalStartupConfigTemplate(
+            inheritedConfig,
+            waitAfterCommand: true,
+            clearWorkingDirectory: true
+        ))
+
+        #expect(sanitized.waitAfterCommand)
+        #expect(sanitized.workingDirectory == nil)
+        #expect(sanitized.fontSize == inheritedConfig.fontSize)
+        #expect(sanitized.environmentVariables == inheritedConfig.environmentVariables)
+    }
 }

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -245,7 +245,7 @@ import Testing
             workingDirectoryFallbackSourcePanelId: sourcePanelId
         ))
 
-        #expect(panel.requestedWorkingDirectory == nil)
+        #expect(panel.requestedWorkingDirectory == Workspace.safeLocalTerminalStartupWorkingDirectory())
         #expect(panel.surface.debugInitialCommand() != nil)
     }
 
@@ -265,7 +265,7 @@ import Testing
             focus: false
         ))
 
-        #expect(panel.requestedWorkingDirectory == nil)
+        #expect(panel.requestedWorkingDirectory == Workspace.safeLocalTerminalStartupWorkingDirectory())
         #expect(panel.surface.debugInitialCommand() != nil)
     }
 
@@ -289,7 +289,7 @@ import Testing
             workingDirectoryFallbackSourcePanelId: remotePanel.id
         ))
 
-        #expect(panel.requestedWorkingDirectory != remoteDirectory)
+        #expect(panel.requestedWorkingDirectory == Workspace.safeLocalTerminalStartupWorkingDirectory())
         #expect(panel.surface.debugInitialCommand() == explicitCommand)
     }
 
@@ -312,7 +312,7 @@ import Testing
             initialCommand: explicitCommand
         ))
 
-        #expect(panel.requestedWorkingDirectory != remoteDirectory)
+        #expect(panel.requestedWorkingDirectory == Workspace.safeLocalTerminalStartupWorkingDirectory())
         #expect(panel.surface.debugInitialCommand() == explicitCommand)
     }
 

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -374,6 +374,33 @@ import Testing
         #expect(panel.surface.debugInitialCommand() == explicitCommand)
     }
 
+    @Test func explicitSplitCommandDoesNotUseRemoteRequestedWorkingDirectoryAsLocalFallback() throws {
+        let workspace = Workspace()
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let remoteDirectory = "/home/seepine/cmux-remote-requested-\(UUID().uuidString)"
+        let remoteCommand = "ssh seepine@192.168.5.20"
+        let explicitCommand = "/tmp/cmux-local-requested-split-\(UUID().uuidString).sh"
+
+        workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
+        let remotePanel = try #require(workspace.newTerminalSurface(
+            inPane: paneId,
+            focus: true,
+            workingDirectory: remoteDirectory
+        ))
+        #expect(workspace.isRemoteTerminalSurface(remotePanel.id))
+        #expect(remotePanel.requestedWorkingDirectory == remoteDirectory)
+
+        let panel = try #require(workspace.newTerminalSplit(
+            from: remotePanel.id,
+            orientation: .horizontal,
+            focus: false,
+            initialCommand: explicitCommand
+        ))
+
+        #expect(panel.requestedWorkingDirectory == Workspace.safeLocalTerminalStartupWorkingDirectory())
+        #expect(panel.surface.debugInitialCommand() == explicitCommand)
+    }
+
     @Test func explicitWorkingDirectoryWinsOverRemoteStartupSplitFallback() throws {
         let workspace = Workspace()
         let sourcePanelId = try #require(workspace.focusedPanelId)
@@ -416,67 +443,35 @@ import Testing
     @Test func inheritedRuntimeWorkingDirectoryRequiresPromptIdleSource() {
         let inheritedDirectory = "/tmp/cmux-inherited-runtime-\(UUID().uuidString)"
 
-        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
-            inheritedDirectory,
-            shellActivityState: .promptIdle,
-            isRemoteTerminalSurface: false,
-            isRestoreGuarded: false,
-            isAgentResumePendingOrRunning: false
-        ) == inheritedDirectory)
-        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
-            inheritedDirectory,
-            shellActivityState: .commandRunning,
-            isRemoteTerminalSurface: false,
-            isRestoreGuarded: false,
-            isAgentResumePendingOrRunning: false
-        ) == nil)
-        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
-            inheritedDirectory,
-            shellActivityState: .unknown,
-            isRemoteTerminalSurface: false,
-            isRestoreGuarded: false,
-            isAgentResumePendingOrRunning: false
-        ) == nil)
-        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
-            inheritedDirectory,
-            shellActivityState: nil,
-            isRemoteTerminalSurface: false,
-            isRestoreGuarded: false,
-            isAgentResumePendingOrRunning: false
-        ) == nil)
+        #expect(startupCandidate(inheritedDirectory, state: .promptIdle) == inheritedDirectory)
+        #expect(startupCandidate(inheritedDirectory, state: .commandRunning) == nil)
+        #expect(startupCandidate(inheritedDirectory, state: .unknown) == nil)
+        #expect(startupCandidate(inheritedDirectory, state: nil) == nil)
     }
 
     @Test func inheritedRuntimeWorkingDirectorySkipsRemoteRestoreAndAutoResumeSources() {
         let inheritedDirectory = "/tmp/cmux-inherited-runtime-\(UUID().uuidString)"
 
-        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
-            inheritedDirectory,
-            shellActivityState: .promptIdle,
-            isRemoteTerminalSurface: true,
-            isRestoreGuarded: false,
-            isAgentResumePendingOrRunning: false
-        ) == nil)
-        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
-            inheritedDirectory,
-            shellActivityState: .promptIdle,
-            isRemoteTerminalSurface: false,
-            isRestoreGuarded: true,
-            isAgentResumePendingOrRunning: false
-        ) == nil)
-        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
-            inheritedDirectory,
-            shellActivityState: .promptIdle,
-            isRemoteTerminalSurface: false,
-            isRestoreGuarded: false,
-            isAgentResumePendingOrRunning: true
-        ) == nil)
-        #expect(Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
-            " \n\t",
-            shellActivityState: .promptIdle,
-            isRemoteTerminalSurface: false,
-            isRestoreGuarded: false,
-            isAgentResumePendingOrRunning: false
-        ) == nil)
+        #expect(startupCandidate(inheritedDirectory, state: .promptIdle, remote: true) == nil)
+        #expect(startupCandidate(inheritedDirectory, state: .promptIdle, restore: true) == nil)
+        #expect(startupCandidate(inheritedDirectory, state: .promptIdle, resume: true) == nil)
+        #expect(startupCandidate(" \n\t", state: .promptIdle) == nil)
+    }
+
+    private func startupCandidate(
+        _ directory: String?,
+        state: PanelShellActivityState?,
+        remote: Bool = false,
+        restore: Bool = false,
+        resume: Bool = false
+    ) -> String? {
+        Workspace.terminalStartupInheritedWorkingDirectoryCandidate(
+            directory,
+            shellActivityState: state,
+            isRemoteTerminalSurface: remote,
+            isRestoreGuarded: restore,
+            isAgentResumePendingOrRunning: resume
+        )
     }
 
     private func sshRemoteConfiguration(command: String) -> WorkspaceRemoteConfiguration {

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -256,7 +256,7 @@ import Testing
         let remoteCommand = "ssh seepine@192.168.5.20"
 
         workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
-        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: remoteDirectory))
+        #expect(workspace.updateRemotePanelDirectory(panelId: sourcePanelId, directory: remoteDirectory))
         workspace.panelShellActivityStates[sourcePanelId] = .promptIdle
 
         let panel = try #require(workspace.newTerminalSplit(
@@ -337,7 +337,7 @@ import Testing
         workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
         let remotePanel = try #require(workspace.newTerminalSurface(inPane: paneId, focus: true))
         #expect(workspace.isRemoteTerminalSurface(remotePanel.id))
-        #expect(workspace.updatePanelDirectory(panelId: remotePanel.id, directory: remoteDirectory))
+        #expect(workspace.updateRemotePanelDirectory(panelId: remotePanel.id, directory: remoteDirectory))
 
         let panel = try #require(workspace.newTerminalSurface(
             inPane: paneId,
@@ -361,7 +361,7 @@ import Testing
         workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
         let remotePanel = try #require(workspace.newTerminalSurface(inPane: paneId, focus: true))
         #expect(workspace.isRemoteTerminalSurface(remotePanel.id))
-        #expect(workspace.updatePanelDirectory(panelId: remotePanel.id, directory: remoteDirectory))
+        #expect(workspace.updateRemotePanelDirectory(panelId: remotePanel.id, directory: remoteDirectory))
 
         let panel = try #require(workspace.newTerminalSplit(
             from: remotePanel.id,
@@ -382,7 +382,7 @@ import Testing
         let remoteCommand = "ssh seepine@192.168.5.20"
 
         workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
-        #expect(workspace.updatePanelDirectory(panelId: sourcePanelId, directory: remoteDirectory))
+        #expect(workspace.updateRemotePanelDirectory(panelId: sourcePanelId, directory: remoteDirectory))
 
         let panel = try #require(workspace.newTerminalSplit(
             from: sourcePanelId,

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -269,6 +269,53 @@ import Testing
         #expect(panel.surface.debugInitialCommand() != nil)
     }
 
+    @Test func explicitInitialCommandDoesNotUseRemotePanelDirectoryAsLocalFallback() throws {
+        let workspace = Workspace()
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let remoteDirectory = "/home/seepine/cmux-remote-explicit-\(UUID().uuidString)"
+        let remoteCommand = "ssh seepine@192.168.5.20"
+        let explicitCommand = "/tmp/cmux-local-command-\(UUID().uuidString).sh"
+
+        workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
+        let remotePanel = try #require(workspace.newTerminalSurface(inPane: paneId, focus: true))
+        #expect(workspace.isRemoteTerminalSurface(remotePanel.id))
+        #expect(workspace.updatePanelDirectory(panelId: remotePanel.id, directory: remoteDirectory))
+
+        let panel = try #require(workspace.newTerminalSurface(
+            inPane: paneId,
+            focus: false,
+            initialCommand: explicitCommand,
+            inheritWorkingDirectoryFallback: true,
+            workingDirectoryFallbackSourcePanelId: remotePanel.id
+        ))
+
+        #expect(panel.requestedWorkingDirectory != remoteDirectory)
+        #expect(panel.surface.debugInitialCommand() == explicitCommand)
+    }
+
+    @Test func explicitSplitCommandDoesNotUseRemotePanelDirectoryAsLocalFallback() throws {
+        let workspace = Workspace()
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let remoteDirectory = "/home/seepine/cmux-remote-split-explicit-\(UUID().uuidString)"
+        let remoteCommand = "ssh seepine@192.168.5.20"
+        let explicitCommand = "/tmp/cmux-local-split-command-\(UUID().uuidString).sh"
+
+        workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
+        let remotePanel = try #require(workspace.newTerminalSurface(inPane: paneId, focus: true))
+        #expect(workspace.isRemoteTerminalSurface(remotePanel.id))
+        #expect(workspace.updatePanelDirectory(panelId: remotePanel.id, directory: remoteDirectory))
+
+        let panel = try #require(workspace.newTerminalSplit(
+            from: remotePanel.id,
+            orientation: .horizontal,
+            focus: false,
+            initialCommand: explicitCommand
+        ))
+
+        #expect(panel.requestedWorkingDirectory != remoteDirectory)
+        #expect(panel.surface.debugInitialCommand() == explicitCommand)
+    }
+
     @Test func explicitWorkingDirectoryWinsOverRemoteStartupSplitFallback() throws {
         let workspace = Workspace()
         let sourcePanelId = try #require(workspace.focusedPanelId)

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -269,6 +269,64 @@ import Testing
         #expect(panel.surface.debugInitialCommand() != nil)
     }
 
+    @Test func remoteStartupSafeLocalWorkingDirectoryIsSpawnOnlyUntilRemoteReport() throws {
+        let workspace = Workspace()
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        let remoteCommand = "ssh seepine@192.168.5.20"
+        let trustedRemoteDirectory = "/home/seepine/cmux-trusted-\(UUID().uuidString)"
+
+        workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
+
+        let panel = try #require(workspace.newTerminalSurface(inPane: paneId, focus: true))
+
+        #expect(panel.requestedWorkingDirectory == Workspace.safeLocalTerminalStartupWorkingDirectory())
+        #expect(workspace.isRemoteTerminalSurface(panel.id))
+        #expect(workspace.terminalRequestedWorkingDirectoryForLocalFallback(panelId: panel.id) == nil)
+        #expect(workspace.effectivePanelDirectory(panelId: panel.id) == nil)
+        #expect(workspace.resolvedWorkingDirectory() == nil)
+
+        let pendingSnapshot = try #require(
+            workspace.sessionSnapshot(includeScrollback: false).panels.first { $0.id == panel.id }
+        )
+        #expect(pendingSnapshot.directory == nil)
+        #expect(pendingSnapshot.terminal?.workingDirectory == nil)
+
+        #expect(workspace.updateRemotePanelDirectory(panelId: panel.id, directory: trustedRemoteDirectory))
+        #expect(workspace.effectivePanelDirectory(panelId: panel.id) == trustedRemoteDirectory)
+        #expect(workspace.resolvedWorkingDirectory() == trustedRemoteDirectory)
+
+        let reportedSnapshot = try #require(
+            workspace.sessionSnapshot(includeScrollback: false).panels.first { $0.id == panel.id }
+        )
+        #expect(reportedSnapshot.directory == trustedRemoteDirectory)
+        #expect(reportedSnapshot.terminal?.workingDirectory == trustedRemoteDirectory)
+    }
+
+    @Test func remoteStartupSplitSafeLocalWorkingDirectoryIsNotCapturedAsSessionDirectory() throws {
+        let workspace = Workspace()
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+        let remoteCommand = "ssh seepine@192.168.5.20"
+
+        workspace.configureRemoteConnection(sshRemoteConfiguration(command: remoteCommand), autoConnect: false)
+
+        let panel = try #require(workspace.newTerminalSplit(
+            from: sourcePanelId,
+            orientation: .horizontal,
+            focus: true
+        ))
+
+        #expect(panel.requestedWorkingDirectory == Workspace.safeLocalTerminalStartupWorkingDirectory())
+        #expect(workspace.isRemoteTerminalSurface(panel.id))
+        #expect(workspace.terminalRequestedWorkingDirectoryForLocalFallback(panelId: panel.id) == nil)
+        #expect(workspace.effectivePanelDirectory(panelId: panel.id) == nil)
+
+        let snapshot = try #require(
+            workspace.sessionSnapshot(includeScrollback: false).panels.first { $0.id == panel.id }
+        )
+        #expect(snapshot.directory == nil)
+        #expect(snapshot.terminal?.workingDirectory == nil)
+    }
+
     @Test func explicitInitialCommandDoesNotUseRemotePanelDirectoryAsLocalFallback() throws {
         let workspace = Workspace()
         let paneId = try #require(workspace.bonsplitController.focusedPaneId)


### PR DESCRIPTION
Replacement for external PR #7292, which could not be updated because GitHub reports push=false for the current token on jleechanorg/cmux despite maintainerCanModify=true.\n\nSummary:\n- merge current origin/main into the PR work\n- share terminal startup cwd resolution across split and inherited new-tab paths\n- prefer Ghostty's live inherited cwd for local live terminal sources\n- preserve explicit cwd, restored auto-resume rescue, guarded restore cwd, and remote terminal cwd behavior\n\nVerification:\n- python3 scripts/swift_file_length_budget.py\n- git diff --check origin/main...HEAD\n- /Users/austinwang/manaflow/cmuxterm-hq/skills/review/autoreview/scripts/autoreview --mode branch --base origin/main\n\nNot run: local xcodebuild/app launch/XCUITests, per PR iteration constraints.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786090599&installation_id=133855650&pr_number=7614&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7614&signature=7dc7180f83f7359ce12ec0b8b432127f174507d7a3f85e13b3eafe43eb087ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Removing transcript snapshots and post-teardown restore monitoring materially increases risk of agent session data loss on hibernation, and CI/SwiftPM tolerance changes could let real failures slip through if diagnostics are misclassified.
> 
> **Overview**
> This diff is mostly **infrastructure and lifecycle refactors**, not the Ghostty cwd work described in the PR title (only a small **remote-directory guard** in command-click file open appears here).
> 
> **Agent hibernation** is greatly simplified: the whole **Claude transcript snapshot / restore-monitor** stack (`AgentHibernationTranscriptGuard` and related teardown types) is deleted. After the idle confirmation window, the controller now **SIGTERM-scoped processes and calls `enterAgentHibernation` directly**, with planner logic inlined and a **process-based fingerprint fallback** when scrollback is unavailable. Eligibility no longer excludes panes that only have a live process.
> 
> **macOS hosted browser sign-in** drops **default-browser handoff** (`openExternalURL`, `handedOffAttemptID`). A non-auth WebAuth completion **stops the sign-in UI** but keeps the attempt alive for a late `cmux://` callback; handoff-specific tests are removed and replaced.
> 
> **iOS mobile shell** skips **queued render-grid frames** older than the delivered high-water mark and ties **replay-barrier ack** to bypass deliveries, with new unit tests.
> 
> **CI / release**: App Store provisioning defaults and workflow copy move to **`com.cmuxterm.app`**; primary profile secret is **strict**; SwiftPM tests go through **`run_swift_package_tests`** with scoped cosmetic-failure tolerance; iOS `xcodebuild` may pass when tests succeeded **before simulator diagnostics time out**; the App Store lane identity check is removed. Swift file-length budgets are bumped for several large sources.
> 
> **Settings window** presentation is consolidated (no deminiaturize settle loop / verification unhide); navigation delivery uses the shared presenter again from `SettingsWindowHostRoot`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bb24b7064e2a519832ae8ef5e418f00b9c8dfc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer Ghostty’s inherited cwd for terminal splits and eligible new tabs, and tighten cwd fallback so remote paths never influence local startup or UI. Also discard stale mobile terminal render frames and carry replay‑barrier acks to keep streams unblocked.

- **Bug Fixes**
  - Inheritance: when the source is prompt‑idle, use Ghostty’s inherited workingDirectory from the exact config source; otherwise fall back to tracked cwd, then live foreground cwd; explicit `workingDirectory` still wins.
  - Startup commands: clear inherited cwd in the config template; for remote startup or explicit local commands from a remote pane, spawn in a safe local home that isn’t persisted, and adopt the remote cwd only after it’s reported.
  - Guarding: skip cwd inheritance for remote panes, restore‑guarded panes, and pending/running auto‑resume; rescue now covers the awaiting state and prefers live cwd once running.
  - Local fallbacks: route callers through `terminalRequestedWorkingDirectoryForLocalFallback` so remote‑sourced or trust‑guarded paths never feed local startup fallback, window title, file open, mobile payloads, tmux topology, or layout capture; avoid using a remote `currentDirectory` as a local startup cwd.
  - Mobile terminal output: drop queued render‑grid frames older than the delivered high‑water mark and attach replay‑barrier acks to bypassed frames; adds focused tests.

- **CI**
  - SwiftPM: centralize tests via `run_swift_package_tests` with scoped tolerance for GhosttyKit and `CMUXAuthCore` runner diagnostics when the all‑tests‑passed summary is present.
  - iOS: treat `xcodebuild` timeouts as pass only when tests finished before simulator diagnostics timed out, using a pre‑timeout log slice and/or the latest `.xcresult`; App Store/APNs paths use `com.cmuxterm.app`.

<sup>Written for commit bf7c1c5e178bef8426159d757c586181a4394ed3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved starting-folder selection for new terminal sessions by inheriting the working directory from an eligible existing terminal configuration.
  * Refined session-restore and directory reuse so inherited paths are applied only when they match the restored session context and pass trust checks (skipping guarded/resumed restore states and remote terminals).
  * Updated terminal split/surface startup behavior so inheritance derives from the correct source panel, and is avoided when a startup command or sensitive restore conditions are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->