### PR TITLE
sdk: bump binding versions to 0.1.1 for first publish

### DIFF
--- a/mux/Cargo.lock
+++ b/mux/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "cmux-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/mux/bindings/python/pyproject.toml
+++ b/mux/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cmux"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.9"
 dependencies = []
 

--- a/mux/bindings/rust/Cargo.toml
+++ b/mux/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmux-client"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 publish = true

--- a/mux/bindings/typescript/package-lock.json
+++ b/mux/bindings/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cmux",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cmux",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/node": "20.19.25",
         "typescript": "5.9.3"

--- a/mux/bindings/typescript/package.json
+++ b/mux/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmux",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node.js client for the cmux-mux JSON-lines protocol",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Bumps the SDK binding manifests (TypeScript, Python, Rust) and lockfiles from 0.1.0 to 0.1.1. PyPI's `cmux` 0.1.0 is the existing placeholder, so 0.1.1 is the first real SDK release; the publish workflows validate that the `mux-sdk-v0.1.1` tag matches every manifest. No code/behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786091507&installation_id=133855650&pr_number=7615&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7615&signature=46a9669677c1632eff7b7bc54ab152db77b6418b6ed3eada060bef67c3295fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest and lockfile version updates only; no application or protocol code changes.
> 
> **Overview**
> Bumps all SDK binding package versions from **0.1.0** to **0.1.1** so the first real client release can ship (PyPI already has a **0.1.0** placeholder for `cmux`).
> 
> Updated manifests and lockfiles: Python `pyproject.toml`, Rust `cmux-client` in `bindings/rust/Cargo.toml` and workspace `Cargo.lock`, and TypeScript `package.json` / `package-lock.json`. No library or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578625f45c19ea593b44cca04ce38d3725dd5e29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates SDK binding versions to 0.1.1 for the first real publish. Aligns TypeScript (`cmux`), Python (`cmux`), and Rust (`cmux-client`) manifests and lockfiles with the `mux-sdk-v0.1.1` tag; no code or behavior changes.

<sup>Written for commit 578625f45c19ea593b44cca04ce38d3725dd5e29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

