### PR TITLE
terminal: cap macOS scrollback-limit default at 4 MB per surface

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig+ScrollbackLimitDefault.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig+ScrollbackLimitDefault.swift
@@ -7,10 +7,11 @@
 /// via `applyiOSDefaults`; macOS keeps a larger 4 MB default because local
 /// terminal users scroll locally. Runtime config loads this directive before
 /// user config files, so an explicit user `scrollback-limit` overrides it.
-public enum GhosttyScrollbackLimitDefault {
+extension GhosttyConfig {
     /// The cmux-managed macOS default `scrollback-limit`, in bytes.
-    public static let bytes: Int = 4_000_000
+    public static let defaultScrollbackLimitBytes: Int = 4_000_000
 
     /// The Ghostty config directive loaded before user config files.
-    public static let configDirective: String = "scrollback-limit = \(bytes)"
+    public static let defaultScrollbackLimitConfigDirective: String =
+        "scrollback-limit = \(defaultScrollbackLimitBytes)"
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -57,7 +57,7 @@ public struct GhosttyConfig {
     /// The configured `working-directory`, or `nil` when unset.
     public var workingDirectory: String?
     /// The scrollback limit in bytes, defaulting to cmux's macOS managed default.
-    public var scrollbackLimit: Int = GhosttyScrollbackLimitDefault.bytes
+    public var scrollbackLimit: Int = Self.defaultScrollbackLimitBytes
     /// The opacity (0...1) applied to unfocused split panes.
     public var unfocusedSplitOpacity: Double = 0.7
     /// The fill color for the unfocused-split overlay, or `nil` to use the

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -56,8 +56,8 @@ public struct GhosttyConfig {
     public var theme: String?
     /// The configured `working-directory`, or `nil` when unset.
     public var workingDirectory: String?
-    /// The scrollback limit. Ghostty measures this in bytes, not lines.
-    public var scrollbackLimit: Int = 10_000_000
+    /// The scrollback limit in bytes, defaulting to cmux's macOS managed default.
+    public var scrollbackLimit: Int = GhosttyScrollbackLimitDefault.bytes
     /// The opacity (0...1) applied to unfocused split panes.
     public var unfocusedSplitOpacity: Double = 0.7
     /// The fill color for the unfocused-split overlay, or `nil` to use the

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyScrollbackLimitDefault.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyScrollbackLimitDefault.swift
@@ -1,0 +1,16 @@
+/// The cmux-managed macOS `scrollback-limit` default.
+///
+/// Ghostty's stock default is 10,000,000 bytes per surface. The memory audit
+/// for issue #7596 measured about 799 MB in `MALLOC_SMALL` blocks from 177
+/// surfaces at that default. iOS already applies a 2 MB limit in
+/// `Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift`
+/// via `applyiOSDefaults`; macOS keeps a larger 4 MB default because local
+/// terminal users scroll locally. Runtime config loads this directive before
+/// user config files, so an explicit user `scrollback-limit` overrides it.
+public enum GhosttyScrollbackLimitDefault {
+    /// The cmux-managed macOS default `scrollback-limit`, in bytes.
+    public static let bytes: Int = 4_000_000
+
+    /// The Ghostty config directive loaded before user config files.
+    public static let configDirective: String = "scrollback-limit = \(bytes)"
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigScrollbackLimitTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigScrollbackLimitTests.swift
@@ -6,7 +6,7 @@ struct GhosttyConfigScrollbackLimitTests {
     @Test func defaultScrollbackLimitMatchesCmuxManagedDefault() {
         let config = GhosttyConfig()
 
-        #expect(config.scrollbackLimit == GhosttyScrollbackLimitDefault.bytes)
+        #expect(config.scrollbackLimit == GhosttyConfig.defaultScrollbackLimitBytes)
         #expect(config.scrollbackLimit == 4_000_000)
     }
 
@@ -29,17 +29,17 @@ struct GhosttyConfigScrollbackLimitTests {
     @Test func parseScrollbackLimitDefaultDirectiveRoundTrips() {
         var config = GhosttyConfig()
 
-        config.parse(GhosttyScrollbackLimitDefault.configDirective)
+        config.parse(GhosttyConfig.defaultScrollbackLimitConfigDirective)
 
-        #expect(config.scrollbackLimit == GhosttyScrollbackLimitDefault.bytes)
+        #expect(config.scrollbackLimit == GhosttyConfig.defaultScrollbackLimitBytes)
     }
 
     @Test func parseInvalidScrollbackLimitLeavesDefaultUntouched() {
         var config = GhosttyConfig()
 
         config.parse("scrollback-limit = abc")
-        #expect(config.scrollbackLimit == GhosttyScrollbackLimitDefault.bytes)
+        #expect(config.scrollbackLimit == GhosttyConfig.defaultScrollbackLimitBytes)
         config.parse("scrollback-limit = -1")
-        #expect(config.scrollbackLimit == GhosttyScrollbackLimitDefault.bytes)
+        #expect(config.scrollbackLimit == GhosttyConfig.defaultScrollbackLimitBytes)
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigScrollbackLimitTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigScrollbackLimitTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import CmuxTerminalCore
+
+@Suite
+struct GhosttyConfigScrollbackLimitTests {
+    @Test func defaultScrollbackLimitMatchesCmuxManagedDefault() {
+        let config = GhosttyConfig()
+
+        #expect(config.scrollbackLimit == GhosttyScrollbackLimitDefault.bytes)
+        #expect(config.scrollbackLimit == 4_000_000)
+    }
+
+    @Test func parseScrollbackLimitUserOverrideWins() {
+        var config = GhosttyConfig()
+
+        config.parse("scrollback-limit = 50000000")
+
+        #expect(config.scrollbackLimit == 50_000_000)
+    }
+
+    @Test func parseScrollbackLimitAllowsUnderscoreDigitSeparators() {
+        var config = GhosttyConfig()
+
+        config.parse("scrollback-limit = 10_000_000")
+
+        #expect(config.scrollbackLimit == 10_000_000)
+    }
+
+    @Test func parseScrollbackLimitDefaultDirectiveRoundTrips() {
+        var config = GhosttyConfig()
+
+        config.parse(GhosttyScrollbackLimitDefault.configDirective)
+
+        #expect(config.scrollbackLimit == GhosttyScrollbackLimitDefault.bytes)
+    }
+
+    @Test func parseInvalidScrollbackLimitLeavesDefaultUntouched() {
+        var config = GhosttyConfig()
+
+        config.parse("scrollback-limit = abc")
+        #expect(config.scrollbackLimit == GhosttyScrollbackLimitDefault.bytes)
+        config.parse("scrollback-limit = -1")
+        #expect(config.scrollbackLimit == GhosttyScrollbackLimitDefault.bytes)
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -975,6 +975,8 @@ class GhosttyApp {
                 return
             }
 
+            // Keep the fallback bounded even when user files fail to initialize.
+            loadInlineGhosttyConfig(GhosttyScrollbackLimitDefault.configDirective, into: fallbackConfig, prefix: "cmux-default-scrollback", logLabel: "default scrollback limit")
             loadInlineGhosttyConfig(
                 "macos-background-from-layer = true",
                 into: fallbackConfig,
@@ -1195,6 +1197,8 @@ class GhosttyApp {
         preferredColorScheme: GhosttyConfig.ColorSchemePreference = GhosttyConfig.currentColorSchemePreference(),
         conditionalThemeColorScheme: GhosttyConfig.ColorSchemePreference? = nil
     ) -> Bool {
+        // Load before user files so explicit user scrollback-limit overrides win.
+        loadInlineGhosttyConfig(GhosttyScrollbackLimitDefault.configDirective, into: config, prefix: "cmux-default-scrollback", logLabel: "default scrollback limit")
         // Surface-only reloads may use a terminal-derived scheme for background
         // handling, while Ghostty split-theme pairs follow app appearance.
         let themeColorScheme = conditionalThemeColorScheme ?? preferredColorScheme

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -976,7 +976,7 @@ class GhosttyApp {
             }
 
             // Keep the fallback bounded even when user files fail to initialize.
-            loadInlineGhosttyConfig(GhosttyScrollbackLimitDefault.configDirective, into: fallbackConfig, prefix: "cmux-default-scrollback", logLabel: "default scrollback limit")
+            loadInlineGhosttyConfig(GhosttyConfig.defaultScrollbackLimitConfigDirective, into: fallbackConfig, prefix: "cmux-default-scrollback", logLabel: "default scrollback limit")
             loadInlineGhosttyConfig(
                 "macos-background-from-layer = true",
                 into: fallbackConfig,
@@ -1198,7 +1198,7 @@ class GhosttyApp {
         conditionalThemeColorScheme: GhosttyConfig.ColorSchemePreference? = nil
     ) -> Bool {
         // Load before user files so explicit user scrollback-limit overrides win.
-        loadInlineGhosttyConfig(GhosttyScrollbackLimitDefault.configDirective, into: config, prefix: "cmux-default-scrollback", logLabel: "default scrollback limit")
+        loadInlineGhosttyConfig(GhosttyConfig.defaultScrollbackLimitConfigDirective, into: config, prefix: "cmux-default-scrollback", logLabel: "default scrollback limit")
         // Surface-only reloads may use a terminal-derived scheme for background
         // handling, while Ghostty split-theme pairs follow app appearance.
         let themeColorScheme = conditionalThemeColorScheme ?? preferredColorScheme


### PR DESCRIPTION
## Summary

Part of #7596 (memory audit, slice 1 — the top-priority fix).

Ghostty's stock `scrollback-limit` default is **10,000,000 bytes per surface** and cmux set no macOS override, so the #7596 audit measured **~799 MB of MALLOC_SMALL** (793 regions) from 177 surfaces 13 minutes after a fresh launch — the largest single block in the 2,084 MB footprint. iOS already overrides to 2 MB (`GhosttyRuntime.applyiOSDefaults`).

This PR introduces a cmux-managed macOS default of **4 MB per surface**, kept fully user-overridable:

- New `GhosttyScrollbackLimitDefault` constant in `CmuxTerminalCore` (`bytes` + derived `configDirective`), shared by runtime and the parsed model.
- `loadDefaultConfigFilesWithLegacyFallback` loads `scrollback-limit = 4000000` **before** `ghostty_config_load_default_files` / legacy / recursive user file loads, so an explicit user `scrollback-limit` in any ghostty config file still wins (ghostty scalar keys are last-wins — same ordering contract the managed default appearance already relies on). Covers primary initialize, DEBUG startup preview, full reload, and surface-only reload paths.
- The invalid-user-config fallback path loads the same bounded directive.
- `GhosttyConfig.scrollbackLimit`'s parsed-model default now uses the shared constant, so debug tooling (e.g. the debug scrollback tab) matches the runtime default.

No load that runs after user config files emits `scrollback-limit` (verified: managed terminal settings only emit `copy-on-select`; the other post-user loads emit font/keybind/vsync/shell-integration keys).

## Tests

New `GhosttyConfigScrollbackLimitTests` (Swift Testing, `CmuxTerminalCore` package, auto-discovered — no pbxproj wiring needed):
- default equals the shared constant (4,000,000)
- user override wins in the parsed model
- underscore digit separators parse
- the emitted directive round-trips through `GhosttyConfig.parse`
- invalid/negative values leave the default untouched

`swift test` in `Packages/macOS/CmuxTerminalCore`: 189 tests in 36 suites pass. `python3 scripts/swift_file_length_budget.py` passes with no TSV changes (GhosttyTerminalView.swift 12,505 ≤ 12,511; GhosttyConfig.swift stays exactly at 1,291).

The memory reduction itself is runtime/perf behavior and not unit-testable; verification is the footprint re-measurement described in #7596.

No user-facing strings added or changed → no localization updates required (localization audit: config/runtime/test code only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786091781&installation_id=133855650&pr_number=7616&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7616&signature=8ab4bbb0a84081111ad39e870c5fe2ea45f32ad85b1096de05ab682ceb59422d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral default for terminal scrollback memory only; users can override via ghostty config and no auth or data-path changes are involved.
> 
> **Overview**
> **Lowers the cmux-managed macOS `scrollback-limit` default from Ghostty’s 10 MB stock value to 4 MB per surface** (#7596 memory work), while keeping explicit user `scrollback-limit` settings authoritative.
> 
> Adds shared `GhosttyConfig` constants (`defaultScrollbackLimitBytes` and a `scrollback-limit = …` directive) and wires that directive into Ghostty runtime loading in `GhosttyTerminalView` **before** user config files (normal init/reload and invalid-config fallback), matching the existing last-wins override contract. The parsed `GhosttyConfig.scrollbackLimit` default now uses the same constant so tooling matches runtime.
> 
> New `GhosttyConfigScrollbackLimitTests` cover the default, user overrides, underscore separators, directive round-trip, and invalid values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba9b0fdaaedbfe72cf615085b12290f6a0e9c6a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap macOS `scrollback-limit` default at 4 MB per surface to reduce memory use while keeping it user‑overridable. Part of #7596 (memory audit).

- **New Features**
  - Load `scrollback-limit = 4000000` before user config files on all paths (init, DEBUG preview, reloads, invalid‑config fallback) so user overrides still win.
  - Use `GhosttyConfig.defaultScrollbackLimitBytes` as the parsed-model default and load via `defaultScrollbackLimitConfigDirective`; macOS only (iOS stays 2 MB).
  - Add `GhosttyConfigScrollbackLimitTests` covering defaults, overrides, underscore separators, round‑trip, and invalid values.

- **Refactors**
  - Move the scrollback default constants into a `GhosttyConfig` extension in `CmuxTerminalCore`; no behavior change.

<sup>Written for commit ba9b0fdaaedbfe72cf615085b12290f6a0e9c6a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the terminal’s default scrollback behavior to use a consistent built-in byte-based limit.
  * Default scrollback settings are now applied earlier so custom user settings can still override them.

* **Bug Fixes**
  * Improved handling of scrollback-limit values, including support for underscore-separated numbers and invalid input fallback behavior.
  * Added tests to confirm default, overridden, and invalid scrollback-limit cases work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->