### PR TITLE
memory: scale footprint pressure thresholds to installed RAM

### DIFF
--- a/Sources/App/MemoryPressureFootprintThresholds.swift
+++ b/Sources/App/MemoryPressureFootprintThresholds.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 struct MemoryPressureFootprintThresholds: Equatable, Sendable {
-    static let `default` = MemoryPressureFootprintThresholds(
-        warningBytes: 8 * 1024 * 1024 * 1024,
-        criticalBytes: 16 * 1024 * 1024 * 1024
+    static let `default` = MemoryPressureFootprintThresholds.scaled(
+        forPhysicalMemoryBytes: ProcessInfo.processInfo.physicalMemory
     )
 
     let warningBytes: UInt64
@@ -12,6 +11,30 @@ struct MemoryPressureFootprintThresholds: Equatable, Sendable {
     init(warningBytes: UInt64, criticalBytes: UInt64) {
         self.warningBytes = warningBytes
         self.criticalBytes = max(criticalBytes, warningBytes)
+    }
+
+    /// Scales footprint pressure thresholds to installed RAM.
+    ///
+    /// Issue #7596 found that fixed 8/16 GiB thresholds never fired because a
+    /// bloated real session plateaued around 2 GiB. RAM-scaled thresholds engage
+    /// the renderer, browser, and notification responders on machines where
+    /// cmux's footprint is significant: 8/16 GiB RAM -> 2/4 GiB, 36 GiB ->
+    /// 3/6 GiB, 64 GiB -> about 5.3/10.7 GiB, and 128+ GiB caps at 6/12 GiB.
+    static func scaled(
+        forPhysicalMemoryBytes physicalMemoryBytes: UInt64
+    ) -> MemoryPressureFootprintThresholds {
+        MemoryPressureFootprintThresholds(
+            warningBytes: clamped(
+                physicalMemoryBytes / 12,
+                lowerBound: gib(2),
+                upperBound: gib(6)
+            ),
+            criticalBytes: clamped(
+                physicalMemoryBytes / 6,
+                lowerBound: gib(4),
+                upperBound: gib(12)
+            )
+        )
     }
 
     func severity(forPhysicalFootprintBytes bytes: UInt64?) -> MemoryPressureSeverity {
@@ -23,5 +46,17 @@ struct MemoryPressureFootprintThresholds: Equatable, Sendable {
             return .warning
         }
         return .normal
+    }
+
+    private static func gib(_ value: UInt64) -> UInt64 {
+        value * 1024 * 1024 * 1024
+    }
+
+    private static func clamped(
+        _ value: UInt64,
+        lowerBound: UInt64,
+        upperBound: UInt64
+    ) -> UInt64 {
+        min(max(value, lowerBound), upperBound)
     }
 }

--- a/cmuxTests/MemoryPressureMonitorTests.swift
+++ b/cmuxTests/MemoryPressureMonitorTests.swift
@@ -40,6 +40,67 @@ private struct FixedMemoryPressureFootprintSampler: MemoryPressureFootprintSampl
     }
 }
 
+@Suite
+struct MemoryPressureFootprintThresholdsScalingTests {
+    @Test func floorClampsSmallRAM() {
+        let thresholds = MemoryPressureFootprintThresholds.scaled(
+            forPhysicalMemoryBytes: Self.gib(8)
+        )
+
+        #expect(thresholds.warningBytes == Self.gib(2))
+        #expect(thresholds.criticalBytes == Self.gib(4))
+    }
+
+    @Test func usesRatioInsideClampRange() {
+        let thresholds = MemoryPressureFootprintThresholds.scaled(
+            forPhysicalMemoryBytes: Self.gib(36)
+        )
+
+        #expect(thresholds.warningBytes == Self.gib(3))
+        #expect(thresholds.criticalBytes == Self.gib(6))
+    }
+
+    @Test(arguments: [UInt64(128), UInt64(256)])
+    func ceilingClampsLargeRAM(physicalMemoryGiB: UInt64) {
+        let thresholds = MemoryPressureFootprintThresholds.scaled(
+            forPhysicalMemoryBytes: Self.gib(physicalMemoryGiB)
+        )
+
+        #expect(thresholds.warningBytes == Self.gib(6))
+        #expect(thresholds.criticalBytes == Self.gib(12))
+    }
+
+    @Test func degenerateAndSweptRAMValuesKeepValidOrdering() {
+        let zero = MemoryPressureFootprintThresholds.scaled(forPhysicalMemoryBytes: 0)
+
+        #expect(zero.warningBytes == Self.gib(2))
+        #expect(zero.criticalBytes == Self.gib(4))
+
+        var physicalMemoryGiB: UInt64 = 4
+        while physicalMemoryGiB <= 256 {
+            let thresholds = MemoryPressureFootprintThresholds.scaled(
+                forPhysicalMemoryBytes: Self.gib(physicalMemoryGiB)
+            )
+
+            #expect(thresholds.criticalBytes >= thresholds.warningBytes)
+            #expect(thresholds.warningBytes > 0)
+
+            physicalMemoryGiB += 4
+        }
+    }
+
+    @Test func defaultUsesPhysicalMemoryScaledFactory() {
+        #expect(
+            MemoryPressureFootprintThresholds.default ==
+                .scaled(forPhysicalMemoryBytes: ProcessInfo.processInfo.physicalMemory)
+        )
+    }
+
+    private static func gib(_ value: UInt64) -> UInt64 {
+        value * 1024 * 1024 * 1024
+    }
+}
+
 struct MemoryPressureStateTrackerTests {
     @Test func footprintThresholdsMapToSeverity() {
         let thresholds = MemoryPressureFootprintThresholds(


### PR DESCRIPTION
## Summary

Part of #7596 (memory audit, slice 2).

`MemoryPressureFootprintThresholds.default` was a fixed **warning=8 GiB / critical=16 GiB** (`Sources/App/MemoryPressureFootprintThresholds.swift`). cmux's own phys_footprint in the audited bloated session was ~2 GB, so the already-built memory-pressure responders (renderer realization, browser hidden-webview discard, notification cache) never engaged from footprint sampling on any realistically provisioned machine.

This PR replaces the fixed default with a RAM-scaled pure factory:

- `warning = clamp(RAM/12, 2 GiB, 6 GiB)`
- `critical = clamp(RAM/6, 4 GiB, 12 GiB)`

Resulting thresholds: 8–16 GiB machines → 2/4 GiB; 36 GiB (the audit machine) → 3/6 GiB; 64 GiB → ~5.3/10.7 GiB; 128+ GiB → capped at 6/12 GiB. The `init` invariant (`critical ≥ warning`) is unchanged, and system dispatch-source pressure events continue to feed severity independently of these footprint thresholds.

## Tests

New `MemoryPressureFootprintThresholdsScalingTests` suite in the already-wired `cmuxTests/MemoryPressureMonitorTests.swift` (no pbxproj churn): floor clamps (8 GiB), pure ratio zone (36 GiB), ceiling clamps (128/256 GiB), zero-RAM degenerate case, a 4–256 GiB sweep asserting `critical ≥ warning > 0`, and `default == scaled(physicalMemory)`.

`python3 scripts/swift_file_length_budget.py` passes; no TSV changes. cmuxTests run on CI (local xcodebuild is intentionally not run per repo policy).

No user-facing strings added or changed → no localization updates required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786092181&installation_id=133855650&pr_number=7617&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7617&signature=062a21b7d42a0b33959b0c0554014de18ed1d575829e2cc2036feeaa1088aa44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when footprint-based warning/critical fire in production via `MemoryPressureMonitor`'s default thresholds, which can trigger renderer/browser/notification shedding earlier on many machines.
> 
> **Overview**
> Replaces **fixed 8/16 GiB** footprint warning/critical defaults with thresholds derived from **`ProcessInfo.processInfo.physicalMemory`**, so footprint sampling can actually trip memory-pressure responders on typical machines (issue #7596).
> 
> **`MemoryPressureFootprintThresholds.default`** now calls **`scaled(forPhysicalMemoryBytes:)`**: warning = `clamp(RAM/12, 2–6 GiB)`, critical = `clamp(RAM/6, 4–12 GiB)`. **`severity(forPhysicalFootprintBytes:)`** and the init invariant (`critical ≥ warning`) are unchanged; system dispatch-source pressure is still independent.
> 
> Adds **`MemoryPressureFootprintThresholdsScalingTests`** (floor, ratio, ceiling, zero-RAM, 4–256 GiB sweep, and `default == scaled(physicalMemory)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20c73294b94f864252a568df0e9e467de217369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory pressure warning and critical thresholds now automatically scale to the device’s installed RAM instead of using fixed limits.
  * Thresholds are clamped within sensible bounds to keep alerts consistent across small and large memory configurations.

* **Bug Fixes**
  * Improved behavior on extreme memory sizes so warning and critical thresholds remain correctly ordered and non-zero.

* **Tests**
  * Added automated coverage for RAM-based scaling, clamping boundaries, and default-threshold parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->