### PR TITLE
mux: dedupe and gate all grok agent-hook notifications

### DIFF
--- a/CLI/AgentHookNotificationPolicy.swift
+++ b/CLI/AgentHookNotificationPolicy.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+enum AgentHookNotificationStatus: String, Codable {
+    case idle
+    case needsInput
+    case error
+}
+
+/// Category tag the app uses to gate agent notifications by user config.
+/// Serialized into the `notify_target_async` payload's optional meta segment.
+enum AgentHookNotifyCategory: String {
+    case turnComplete = "turn-complete"
+    case needsPermission = "needs-permission"
+    case idleReminder = "idle-reminder"
+    case other
+
+    /// Delimiter-safe meta segment: `c=<category>;p=<0|1>`. `.other` is the
+    /// explicit ungated category and never rides the wire.
+    func metaSegment(pending: Bool) -> String? {
+        guard self != .other else { return nil }
+        return "c=\(rawValue);p=\(pending ? 1 : 0)"
+    }
+}
+
+struct AgentHookNotificationSummary {
+    let subtitle: String
+    let body: String
+    let status: AgentHookNotificationStatus?
+    let isFallback: Bool
+    /// Which user-facing notification setting gates this alert, decided by the
+    /// classifier alongside subtitle/status so "Permission" and "Waiting" cues
+    /// (both `.needsInput`) gate under their own settings. `.other` is the
+    /// deliberate ungated always-deliver category, reserved for errors.
+    var notifyCategory: AgentHookNotifyCategory
+}
+
+enum AgentHookNotificationClassifier {
+    static func classify(
+        displayName: String,
+        signal: String,
+        message: String,
+        isFallback: Bool
+    ) -> AgentHookNotificationSummary {
+        let lower = "\(signal) \(message)".lowercased()
+        if lower.contains("permission") || lower.contains("approve") || lower.contains("approval") || lower.contains("permission_prompt") {
+            let body = message.isEmpty
+                ? String(localized: "agent.generic.notification.body.approvalNeeded", defaultValue: "Approval needed")
+                : message
+            return AgentHookNotificationSummary(
+                subtitle: String(localized: "agent.generic.notification.subtitle.permission", defaultValue: "Permission"),
+                body: truncate(body, maxLength: 180),
+                status: .needsInput,
+                isFallback: isFallback,
+                notifyCategory: .needsPermission
+            )
+        }
+        if lower.contains("error") || lower.contains("failed") || lower.contains("failure") || lower.contains("exception") {
+            let body = message.isEmpty
+                ? String.localizedStringWithFormat(
+                    String(localized: "agent.generic.notification.body.reportedError", defaultValue: "%@ reported an error"),
+                    displayName
+                )
+                : message
+            return AgentHookNotificationSummary(
+                subtitle: String(localized: "agent.generic.notification.subtitle.error", defaultValue: "Error"),
+                body: truncate(body, maxLength: 180),
+                status: .error,
+                isFallback: isFallback,
+                notifyCategory: .other
+            )
+        }
+        if containsCompletionCue(lower) {
+            let body = message.isEmpty
+                ? String(localized: "agent.generic.notification.body.taskCompleted", defaultValue: "Task completed")
+                : message
+            return AgentHookNotificationSummary(
+                subtitle: String(localized: "agent.generic.notification.subtitle.completed", defaultValue: "Completed"),
+                body: truncate(body, maxLength: 180),
+                status: .idle,
+                isFallback: isFallback,
+                notifyCategory: .turnComplete
+            )
+        }
+        if containsWaitingCue(lower) {
+            let body = message.isEmpty
+                ? String(localized: "agent.generic.notification.body.waitingForInput", defaultValue: "Waiting for input")
+                : message
+            return AgentHookNotificationSummary(
+                subtitle: String(localized: "agent.generic.notification.subtitle.waiting", defaultValue: "Waiting"),
+                body: truncate(body, maxLength: 180),
+                status: .needsInput,
+                isFallback: isFallback,
+                notifyCategory: .idleReminder
+            )
+        }
+        if !message.isEmpty {
+            return AgentHookNotificationSummary(
+                subtitle: String(localized: "agent.generic.notification.subtitle.attention", defaultValue: "Attention"),
+                body: truncate(message, maxLength: 180),
+                status: nil,
+                isFallback: isFallback,
+                notifyCategory: .idleReminder
+            )
+        }
+        let body = String.localizedStringWithFormat(
+            String(localized: "agent.generic.notification.body.needsAttention", defaultValue: "%@ needs your attention"),
+            displayName
+        )
+        return AgentHookNotificationSummary(
+            subtitle: String(localized: "agent.generic.notification.subtitle.attention", defaultValue: "Attention"),
+            body: body,
+            status: .needsInput,
+            isFallback: true,
+            notifyCategory: .idleReminder
+        )
+    }
+
+    static func isGrokInternalSessionNotification(_ message: String) -> Bool {
+        let lowercasedMessage = message.lowercased()
+        return lowercasedMessage.hasPrefix("sessionnotification {")
+            || lowercasedMessage.contains("hookexecution {")
+            || lowercasedMessage.contains("event_name: user_prompt_submit")
+            || lowercasedMessage.contains(#""event_name":"user_prompt_submit""#)
+    }
+
+    static func isGrokGenericTurnCompletion(_ message: String) -> Bool {
+        message.range(
+            of: #"^turn complete(?:d)? in \d+(?:\.\d+)?s\.?$"#,
+            options: [.regularExpression, .caseInsensitive]
+        ) != nil
+    }
+
+    static func containsCompletionCue(_ lowercasedText: String) -> Bool {
+        notificationCueTokens(lowercasedText).contains { token in
+            token == "done"
+                || token == "succeed"
+                || token == "succeeded"
+                || token.hasPrefix("complet")
+                || token.hasPrefix("finish")
+                || token.hasPrefix("success")
+        }
+    }
+
+    static func containsWaitingCue(_ lowercasedText: String) -> Bool {
+        let tokens = notificationCueTokens(lowercasedText)
+        for (index, token) in tokens.enumerated() {
+            let previous = index > 0 ? tokens[index - 1] : nil
+            let next = index + 1 < tokens.count ? tokens[index + 1] : nil
+            if token == "idle" {
+                return true
+            }
+            if token == "wait" || token == "waiting" || token == "awaiting" {
+                return true
+            }
+            if token == "prompt", previous == "idle" || previous == "input" || previous == "user" {
+                return true
+            }
+            if token == "input" {
+                if previous == "need" || previous == "needs" || previous == "needed"
+                    || previous == "require" || previous == "requires" || previous == "required"
+                    || previous == "request" || previous == "requests" || previous == "requested"
+                    || previous == "wait" || previous == "waiting" || previous == "awaiting"
+                    || previous == "user" || previous == "your"
+                    || next == "needed" || next == "required" || next == "requested" {
+                    return true
+                }
+            }
+            if token == "question", lowercasedText.contains("?") || tokens.contains(where: {
+                $0 == "answer" || $0 == "respond" || $0 == "response" || $0 == "reply"
+                    || $0 == "choose" || $0 == "confirm" || $0 == "continue"
+            }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func notificationCueTokens(_ lowercasedText: String) -> [Substring] {
+        lowercasedText.split { !$0.isLetter && !$0.isNumber }
+    }
+
+    private static func truncate(_ value: String, maxLength: Int) -> String {
+        guard value.count > maxLength else { return value }
+        let index = value.index(value.startIndex, offsetBy: max(0, maxLength - 1))
+        return String(value[..<index]) + "…"
+    }
+}
+
+enum AgentHookNotificationPolicy {
+    static let dedupeEligibleAgents: Set<String> = ["grok", "antigravity"]
+
+    /// Stable per-session fingerprint. Grok 0.2.91 emits an identical generic
+    /// "Tool permission requested" Notification for every tool step, even in
+    /// auto-approve mode where nothing awaits the user; those repeats dedupe by
+    /// body/status. Novel permission text still delivers because the body hash
+    /// changes, and prompt-submit clears the store for a new turn.
+    static func dedupeFingerprint(
+        agentName: String,
+        sessionId: String,
+        status: AgentHookNotificationStatus?,
+        category: AgentHookNotifyCategory,
+        body: String
+    ) -> String? {
+        guard dedupeEligibleAgents.contains(agentName), !sessionId.isEmpty else {
+            return nil
+        }
+        if status == .idle {
+            return "idle-turn"
+        }
+        return "\(status?.rawValue ?? "attention"):\(stableHash(of: body))"
+    }
+
+    static func preservesDedupeAcrossSessionStart(agentName: String) -> Bool {
+        agentName == "grok"
+    }
+
+    static func stableHash(of value: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x100000001b3
+        }
+        return String(format: "%016llx", hash)
+    }
+}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -54,38 +54,11 @@ struct ClaudeHookParsedInput {
     let transcriptPath: String?
 }
 
-enum AgentHookNotificationStatus: String, Codable {
-    case idle
-    case needsInput
-    case error
-}
-
 enum AgentHookRuntimeStatus: String, Codable {
     case running
     case idle
     case needsInput
     case error
-}
-
-/// Category tag the app uses to gate agent notifications by user config.
-/// Serialized into the `notify_target_async` payload's optional meta segment.
-enum AgentHookNotifyCategory: String {
-    case turnComplete = "turn-complete"
-    case needsPermission = "needs-permission"
-    case idleReminder = "idle-reminder"
-    case other
-}
-
-private struct AgentHookNotificationSummary {
-    let subtitle: String
-    let body: String
-    let status: AgentHookNotificationStatus?
-    let isFallback: Bool
-    /// Which user-facing notification setting gates this alert, decided by the
-    /// classifier alongside subtitle/status so "Permission" and "Waiting" cues
-    /// (both `.needsInput`) gate under their own settings. `nil` = ungated,
-    /// always deliver (errors, unclassified attention alerts, fallbacks).
-    var notifyCategory: AgentHookNotifyCategory? = nil
 }
 
 #if DEBUG
@@ -165,6 +138,7 @@ struct ClaudeHookSessionRecord: Codable {
     var lastNotificationStatus: AgentHookNotificationStatus?
     var lastEmittedNotificationFingerprint: String?
     var lastEmittedNotificationAt: TimeInterval?
+    var recentEmittedNotificationFingerprints: [String: TimeInterval]?
     var runtimeStatus: AgentHookRuntimeStatus?
     var activePromptDepth: Int?
     var activePromptTurnId: String?
@@ -1173,6 +1147,7 @@ final class ClaudeHookSessionStore {
             let now = Date().timeIntervalSince1970
             record.lastEmittedNotificationFingerprint = nil
             record.lastEmittedNotificationAt = nil
+            record.recentEmittedNotificationFingerprints = nil
             record.updatedAt = now
             state.sessions[normalized] = record
         }
@@ -1188,12 +1163,17 @@ final class ClaudeHookSessionStore {
         let normalizedFingerprint = fingerprint.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedFingerprint.isEmpty else { return false }
         return try withLockedState { state in
-            guard let record = state.sessions[normalized],
-                  record.lastEmittedNotificationFingerprint == normalizedFingerprint,
+            guard let record = state.sessions[normalized] else { return false }
+            let now = Date().timeIntervalSince1970
+            if let emittedAt = record.recentEmittedNotificationFingerprints?[normalizedFingerprint],
+               now - emittedAt <= interval {
+                return true
+            }
+            guard record.lastEmittedNotificationFingerprint == normalizedFingerprint,
                   let emittedAt = record.lastEmittedNotificationAt else {
                 return false
             }
-            return Date().timeIntervalSince1970 - emittedAt <= interval
+            return now - emittedAt <= interval
         }
     }
 
@@ -1207,6 +1187,17 @@ final class ClaudeHookSessionStore {
             let now = Date().timeIntervalSince1970
             record.lastEmittedNotificationFingerprint = normalizedFingerprint
             record.lastEmittedNotificationAt = now
+            var recent = record.recentEmittedNotificationFingerprints ?? [:]
+            recent[normalizedFingerprint] = now
+            recent = recent.filter { now - $0.value <= 60 * 60 }
+            if recent.count > 16 {
+                let keep = recent.sorted { lhs, rhs in
+                    if lhs.value == rhs.value { return lhs.key < rhs.key }
+                    return lhs.value > rhs.value
+                }.prefix(16)
+                recent = Dictionary(uniqueKeysWithValues: keep.map { ($0.key, $0.value) })
+            }
+            record.recentEmittedNotificationFingerprints = recent.isEmpty ? nil : recent
             record.updatedAt = now
             state.sessions[normalized] = record
         }
@@ -24347,7 +24338,7 @@ struct CMUXCLI {
                         title: title,
                         subtitle: completion.subtitle,
                         body: completion.body,
-                        meta: notifyMeta(.turnComplete, pending: hasPendingBackgroundWork)
+                        meta: AgentHookNotifyCategory.turnComplete.metaSegment(pending: hasPendingBackgroundWork)
                     )
                     _ = try? sendV1Command("notify_target_async \(workspaceId) \(surfaceId) \(payload)", client: client)
                 }
@@ -24636,7 +24627,7 @@ struct CMUXCLI {
                 title: title,
                 subtitle: summary.subtitle,
                 body: summary.body,
-                meta: notifyCategory == .other ? nil : notifyMeta(notifyCategory, pending: notifyPending)
+                meta: notifyCategory.metaSegment(pending: notifyPending)
             )
 
             if let sessionId = parsedInput.sessionId, !suppressNeedsInputState {
@@ -24937,7 +24928,7 @@ struct CMUXCLI {
                         title: title,
                         subtitle: waitingSubtitle,
                         body: needsInputBody,
-                        meta: notifyMeta(.needsPermission, pending: false)
+                        meta: AgentHookNotifyCategory.needsPermission.metaSegment(pending: false)
                     )
                     _ = try? sendV1Command(
                         "notify_target_async \(workspaceId) \(existingSurfaceId) \(payload)",
@@ -27010,7 +27001,7 @@ struct CMUXCLI {
         let extra = (object["extra"] as? [String: Any]) ?? [:]
         let signalParts = [
             firstString(in: object, keys: ["event", "event_name", "hook_event_name", "hookEventName", "type", "kind"]),
-            firstString(in: object, keys: ["notification_type", "matcher", "reason"]),
+            firstString(in: object, keys: ["notification_type", "notificationType", "matcher", "reason"]),
             firstString(in: nested, keys: ["type", "kind", "reason"]),
         ]
         let messageCandidates = [
@@ -27128,18 +27119,11 @@ struct CMUXCLI {
     }
 
     private func isGrokInternalSessionNotification(_ message: String) -> Bool {
-        let lowercasedMessage = message.lowercased()
-        return lowercasedMessage.hasPrefix("sessionnotification {")
-            || lowercasedMessage.contains("hookexecution {")
-            || lowercasedMessage.contains("event_name: user_prompt_submit")
-            || lowercasedMessage.contains(#""event_name":"user_prompt_submit""#)
+        AgentHookNotificationClassifier.isGrokInternalSessionNotification(message)
     }
 
     private func isGrokGenericTurnCompletion(_ message: String) -> Bool {
-        message.range(
-            of: #"^turn complete(?:d)? in \d+(?:\.\d+)?s\.?$"#,
-            options: [.regularExpression, .caseInsensitive]
-        ) != nil
+        AgentHookNotificationClassifier.isGrokGenericTurnCompletion(message)
     }
 
     private func latestGrokAssistantMessage(
@@ -27284,74 +27268,11 @@ struct CMUXCLI {
         message: String,
         isFallback: Bool
     ) -> AgentHookNotificationSummary {
-        let lower = "\(signal) \(message)".lowercased()
-        if lower.contains("permission") || lower.contains("approve") || lower.contains("approval") || lower.contains("permission_prompt") {
-            let body = message.isEmpty
-                ? String(localized: "agent.generic.notification.body.approvalNeeded", defaultValue: "Approval needed")
-                : message
-            return AgentHookNotificationSummary(
-                subtitle: String(localized: "agent.generic.notification.subtitle.permission", defaultValue: "Permission"),
-                body: truncate(body, maxLength: 180),
-                status: .needsInput,
-                isFallback: isFallback,
-                notifyCategory: .needsPermission
-            )
-        }
-        if lower.contains("error") || lower.contains("failed") || lower.contains("failure") || lower.contains("exception") {
-            let body = message.isEmpty
-                ? String.localizedStringWithFormat(
-                    String(localized: "agent.generic.notification.body.reportedError", defaultValue: "%@ reported an error"),
-                    def.displayName
-                )
-                : message
-            return AgentHookNotificationSummary(
-                subtitle: String(localized: "agent.generic.notification.subtitle.error", defaultValue: "Error"),
-                body: truncate(body, maxLength: 180),
-                status: .error,
-                isFallback: isFallback
-            )
-        }
-        if containsCompletionCue(lower) {
-            let body = message.isEmpty
-                ? String(localized: "agent.generic.notification.body.taskCompleted", defaultValue: "Task completed")
-                : message
-            return AgentHookNotificationSummary(
-                subtitle: String(localized: "agent.generic.notification.subtitle.completed", defaultValue: "Completed"),
-                body: truncate(body, maxLength: 180),
-                status: .idle,
-                isFallback: isFallback,
-                notifyCategory: .turnComplete
-            )
-        }
-        if containsWaitingCue(lower) {
-            let body = message.isEmpty
-                ? String(localized: "agent.generic.notification.body.waitingForInput", defaultValue: "Waiting for input")
-                : message
-            return AgentHookNotificationSummary(
-                subtitle: String(localized: "agent.generic.notification.subtitle.waiting", defaultValue: "Waiting"),
-                body: truncate(body, maxLength: 180),
-                status: .needsInput,
-                isFallback: isFallback,
-                notifyCategory: .idleReminder
-            )
-        }
-        if !message.isEmpty {
-            return AgentHookNotificationSummary(
-                subtitle: String(localized: "agent.generic.notification.subtitle.attention", defaultValue: "Attention"),
-                body: truncate(message, maxLength: 180),
-                status: nil,
-                isFallback: isFallback
-            )
-        }
-        let body = String.localizedStringWithFormat(
-            String(localized: "agent.generic.notification.body.needsAttention", defaultValue: "%@ needs your attention"),
-            def.displayName
-        )
-        return AgentHookNotificationSummary(
-            subtitle: String(localized: "agent.generic.notification.subtitle.attention", defaultValue: "Attention"),
-            body: body,
-            status: .needsInput,
-            isFallback: true
+        AgentHookNotificationClassifier.classify(
+            displayName: def.displayName,
+            signal: signal,
+            message: message,
+            isFallback: isFallback
         )
     }
 
@@ -27365,11 +27286,11 @@ struct CMUXCLI {
             let body = message.isEmpty ? "Claude reported an error" : message
             return ("Error", body)
         }
-        if containsCompletionCue(lower) {
+        if AgentHookNotificationClassifier.containsCompletionCue(lower) {
             let body = message.isEmpty ? "Task completed" : message
             return ("Completed", body)
         }
-        if containsWaitingCue(lower) {
+        if AgentHookNotificationClassifier.containsWaitingCue(lower) {
             let body = message.isEmpty ? "Waiting for input" : message
             return ("Waiting", body)
         }
@@ -27378,55 +27299,6 @@ struct CMUXCLI {
             return ("Attention", message)
         }
         return ("Attention", "Claude needs your attention")
-    }
-
-    private func containsCompletionCue(_ lowercasedText: String) -> Bool {
-        notificationCueTokens(lowercasedText).contains { token in
-            token == "done"
-                || token == "succeed"
-                || token == "succeeded"
-                || token.hasPrefix("complet")
-                || token.hasPrefix("finish")
-                || token.hasPrefix("success")
-        }
-    }
-
-    private func containsWaitingCue(_ lowercasedText: String) -> Bool {
-        let tokens = notificationCueTokens(lowercasedText)
-        for (index, token) in tokens.enumerated() {
-            let previous = index > 0 ? tokens[index - 1] : nil
-            let next = index + 1 < tokens.count ? tokens[index + 1] : nil
-            if token == "idle" {
-                return true
-            }
-            if token == "wait" || token == "waiting" || token == "awaiting" {
-                return true
-            }
-            if token == "prompt", previous == "idle" || previous == "input" || previous == "user" {
-                return true
-            }
-            if token == "input" {
-                if previous == "need" || previous == "needs" || previous == "needed"
-                    || previous == "require" || previous == "requires" || previous == "required"
-                    || previous == "request" || previous == "requests" || previous == "requested"
-                    || previous == "wait" || previous == "waiting" || previous == "awaiting"
-                    || previous == "user" || previous == "your"
-                    || next == "needed" || next == "required" || next == "requested" {
-                    return true
-                }
-            }
-            if token == "question", lowercasedText.contains("?") || tokens.contains(where: {
-                $0 == "answer" || $0 == "respond" || $0 == "response" || $0 == "reply"
-                    || $0 == "choose" || $0 == "confirm" || $0 == "continue"
-            }) {
-                return true
-            }
-        }
-        return false
-    }
-
-    private func notificationCueTokens(_ lowercasedText: String) -> [Substring] {
-        lowercasedText.split { !$0.isLetter && !$0.isNumber }
     }
 
     private func sanitizeNotificationField(_ value: String) -> String {
@@ -27441,17 +27313,11 @@ struct CMUXCLI {
         meta: String? = nil
     ) -> String {
         let base = "\(sanitizeNotificationField(title))|\(sanitizeNotificationField(subtitle))|\(sanitizeNotificationField(body))"
-        // `meta` is a structured, delimiter-safe tag (see `notifyMeta`): it has no
+        // `meta` is a structured, delimiter-safe tag: it has no
         // "|" or spaces, so it is NOT sanitized and rides as a 4th pipe segment.
         // Omitting it reproduces the exact 3-field payload every legacy caller sends.
         guard let meta, !meta.isEmpty else { return base }
         return base + "|" + meta
-    }
-
-    /// Delimiter-safe meta segment: `c=<category>;p=<0|1>`. No "|" and no spaces,
-    /// so it survives the pipe-delimited payload and the app's strict `c=` guard.
-    private func notifyMeta(_ category: AgentHookNotifyCategory, pending: Bool) -> String {
-        "c=\(category.rawValue);p=\(pending ? 1 : 0)"
     }
 
     /// True when a Claude `Stop`/`Notification` payload reports unfinished
@@ -30607,11 +30473,18 @@ export default CMUXSessionRestore;
                 sendAgentFeedTelemetry(workspaceId: workspaceId, surfaceId: surfaceId)
             }
         }
-        func notificationDedupeFingerprint(status: AgentHookNotificationStatus?) -> String? {
-            guard (def.name == "grok" || def.name == "antigravity"), !sessionId.isEmpty, status == .idle else {
-                return nil
-            }
-            return "idle-turn"
+        func notificationDedupeFingerprint(
+            status: AgentHookNotificationStatus?,
+            category: AgentHookNotifyCategory,
+            body: String
+        ) -> String? {
+            AgentHookNotificationPolicy.dedupeFingerprint(
+                agentName: def.name,
+                sessionId: sessionId,
+                status: status,
+                category: category,
+                body: body
+            )
         }
         func hasActiveAntigravityBackgroundWork() -> Bool {
             def.name == "antigravity" && (input.rawObject?["fullyIdle"] as? Bool) == false
@@ -30838,7 +30711,9 @@ export default CMUXSessionRestore;
                         print("{}")
                         return
                     }
-                    try? store.clearNotificationEmission(sessionId: sessionId)
+                    if !AgentHookNotificationPolicy.preservesDedupeAcrossSessionStart(agentName: def.name) {
+                        try? store.clearNotificationEmission(sessionId: sessionId)
+                    }
                     publishAgentSurfaceResumeBinding(
                         client: client,
                         workspaceId: workspaceId,
@@ -31394,7 +31269,11 @@ export default CMUXSessionRestore;
                 )
             }
 
-            let notificationFingerprint = notificationDedupeFingerprint(status: stopNotificationStatus)
+            let notificationFingerprint = notificationDedupeFingerprint(
+                status: stopNotificationStatus,
+                category: stopNotificationStatus == .idle ? .turnComplete : .other,
+                body: body
+            )
             let stopNotificationAlreadyRouted = (input.rawObject?["cmux_notification_routed"] as? Bool) == true
                 || (input.object?["cmux_notification_routed"] as? Bool) == true
             // Antigravity's integration defines a stop with active background work
@@ -31425,7 +31304,7 @@ export default CMUXSessionRestore;
                 // setting covers every built-in agent, not just Claude. Error
                 // alerts stay untagged and always deliver.
                 let stopMeta: String? = stopNotificationStatus == .idle
-                    ? notifyMeta(.turnComplete, pending: antigravityHasActiveBackgroundWork)
+                    ? AgentHookNotifyCategory.turnComplete.metaSegment(pending: antigravityHasActiveBackgroundWork)
                     : nil
                 let payload = notificationPayload(title: def.displayName, subtitle: subtitle, body: body, meta: stopMeta)
                 let notifyCommand = "notify_target_async \(workspaceId) \(surfaceId) \(payload)"
@@ -31653,14 +31532,15 @@ export default CMUXSessionRestore;
             if summary.isFallback, let savedBody = mapped?.lastBody, !savedBody.isEmpty {
                 // Rebuilt from the stored session record: a stale .idle status is
                 // still a completion re-notification, so keep it under the
-                // "Agent Finished" gate. A stale .needsInput cannot distinguish
-                // permission from waiting, so it stays untagged (always deliver).
+                // "Agent Finished" gate. A stale non-idle status cannot
+                // distinguish permission from waiting; the fresh permission
+                // alert already delivered, so re-notifications gate as waiting.
                 summary = AgentHookNotificationSummary(
                     subtitle: mapped?.lastSubtitle ?? summary.subtitle,
                     body: savedBody,
                     status: mapped?.lastNotificationStatus,
                     isFallback: false,
-                    notifyCategory: mapped?.lastNotificationStatus == .idle ? .turnComplete : nil
+                    notifyCategory: mapped?.lastNotificationStatus == .idle ? .turnComplete : .idleReminder
                 )
             }
             let antigravitySuppressDuplicateIdleWhileBackgroundWork = def.name == "antigravity"
@@ -31798,7 +31678,11 @@ export default CMUXSessionRestore;
                 }
             }
 
-            let notificationFingerprint = notificationDedupeFingerprint(status: summary.status)
+            let notificationFingerprint = notificationDedupeFingerprint(
+                status: summary.status,
+                category: summary.notifyCategory,
+                body: summary.body
+            )
             if shouldSendNotification(fingerprint: notificationFingerprint) {
                 // Tag by the classifier's category so the app's agent notification
                 // settings cover every built-in agent: approval prompts gate under
@@ -31806,16 +31690,13 @@ export default CMUXSessionRestore;
                 // Waiting for Input", turn-boundary completions (grok and
                 // antigravity route them through this hook) under "Agent
                 // Finished". Errors and unclassified alerts stay untagged.
-                let notificationMeta: String? = summary.notifyCategory.map { category in
-                    // Completions AND waiting nags are both "pending" while
-                    // background work is live, so a fullyIdle=false Antigravity
-                    // waiting cue doesn't deliver a false "waiting for input".
-                    notifyMeta(
-                        category,
-                        pending: (category == .turnComplete || category == .idleReminder)
-                            && hasActiveAntigravityBackgroundWork()
-                    )
-                }
+                // Completions AND waiting nags are both "pending" while
+                // background work is live, so a fullyIdle=false Antigravity
+                // waiting cue doesn't deliver a false "waiting for input".
+                let notificationMeta = summary.notifyCategory.metaSegment(
+                    pending: (summary.notifyCategory == .turnComplete || summary.notifyCategory == .idleReminder)
+                        && hasActiveAntigravityBackgroundWork()
+                )
                 let payload = notificationPayload(title: def.displayName, subtitle: summary.subtitle, body: summary.body, meta: notificationMeta)
                 let notifyCommand = "notify_target_async \(workspaceId) \(surfaceId) \(payload)"
 #if DEBUG

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */; };
 		C46790000000000000000003 /* CLIForwardingLaunchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */; };
 		A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */; };
+		A76110030000000000000001 /* CLIGrokNotificationNoiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76110030000000000000002 /* CLIGrokNotificationNoiseTests.swift */; };
 		A5D41211A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41212A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift */; };
 		A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */; };
 		A5D41330A1B2C3D4E5F60718 /* CLIMockSocketServerSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41331A1B2C3D4E5F60718 /* CLIMockSocketServerSupport.swift */; };
@@ -1826,6 +1827,7 @@
 		C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIForwardingLaunchArgumentTests.swift; sourceTree = "<group>"; };
 		C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CLIForwardingLaunchRouter.swift; sourceTree = "<group>"; };
 		A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIGenericHookPersistenceTests.swift; sourceTree = "<group>"; };
+		A76110030000000000000002 /* CLIGrokNotificationNoiseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIGrokNotificationNoiseTests.swift; sourceTree = "<group>"; };
 		A5D41212A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIHookNoResponseTests.swift; sourceTree = "<group>"; };
 		A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLILegacyHookAliasTests.swift; sourceTree = "<group>"; };
 		A5D41331A1B2C3D4E5F60718 /* CLIMockSocketServerSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIMockSocketServerSupport.swift; sourceTree = "<group>"; };
@@ -4509,6 +4511,7 @@
 				A5D41233A1B2C3D4E5F60718 /* ClaudeBackgroundWorkNotifyTests.swift */,
 				C72280000000000000000003 /* CLINotifyClaudeHookWorkspaceRoutingTests.swift */,
 				A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */,
+				A76110030000000000000002 /* CLIGrokNotificationNoiseTests.swift */,
 				6379A0026379A0026379A002 /* CLISSHPTYResizeInputTests.swift */,
 				C0F16B000000000000000002 /* CLIRemoteShellStartupPerformanceTests.swift */,
 				A5D41331A1B2C3D4E5F60718 /* CLIMockSocketServerSupport.swift */,
@@ -6095,6 +6098,7 @@
 					E295EA3753206FE3FFCA6C0A /* CLIExplicitSurfaceRoutingTests.swift in Sources */,
 				C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */,
 				A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */,
+				A76110030000000000000001 /* CLIGrokNotificationNoiseTests.swift in Sources */,
 				A5D41211A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift in Sources */,
 				A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */,
 				A5D41330A1B2C3D4E5F60718 /* CLIMockSocketServerSupport.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		D36A00030000000000000003 /* AgentHibernationLifecycleState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00030000000000000002 /* AgentHibernationLifecycleState.swift */; };
 		D72260010000000000000001 /* AgentHibernationPortalVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72260010000000000000002 /* AgentHibernationPortalVisibilityTests.swift */; };
 		D36A00020000000000000001 /* AgentHibernationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00020000000000000002 /* AgentHibernationTests.swift */; };
+		A76110010000000000000001 /* AgentHookNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76110010000000000000002 /* AgentHookNotificationPolicy.swift */; };
+		A76110010000000000000003 /* AgentHookNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76110010000000000000002 /* AgentHookNotificationPolicy.swift */; };
+		A76110020000000000000001 /* AgentHookNotificationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76110020000000000000002 /* AgentHookNotificationPolicyTests.swift */; };
 		A5D41234A1B2C3D4E5F60718 /* AgentNotificationGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41235A1B2C3D4E5F60718 /* AgentNotificationGate.swift */; };
 		A5D41230A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */; };
 		C3744E030000000000000001 /* AgentPIDProcessIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E040000000000000001 /* AgentPIDProcessIdentity.swift */; };
@@ -1586,6 +1589,8 @@
 		D36A00030000000000000002 /* AgentHibernationLifecycleState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHibernation/AgentHibernationLifecycleState.swift; sourceTree = "<group>"; };
 		D72260010000000000000002 /* AgentHibernationPortalVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHibernationPortalVisibilityTests.swift; sourceTree = "<group>"; };
 		D36A00020000000000000002 /* AgentHibernationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHibernationTests.swift; sourceTree = "<group>"; };
+		A76110010000000000000002 /* AgentHookNotificationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookNotificationPolicy.swift; sourceTree = "<group>"; };
+		A76110020000000000000002 /* AgentHookNotificationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookNotificationPolicyTests.swift; sourceTree = "<group>"; };
 		A5D41235A1B2C3D4E5F60718 /* AgentNotificationGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationGate.swift; sourceTree = "<group>"; };
 		A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationGateTests.swift; sourceTree = "<group>"; };
 		C3744E040000000000000001 /* AgentPIDProcessIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPIDProcessIdentity.swift; sourceTree = "<group>"; };
@@ -4116,6 +4121,7 @@
 				E60610100000000000000001 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift */,
 				E60610300000000000000001 /* SSHPTYAttachReconnectInputFilterState.swift */,
 				C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */,
+				A76110010000000000000002 /* AgentHookNotificationPolicy.swift */,
 				FEEDC1A50000000000000002 /* FeedEventClassifier.swift */,
 				B900004BA1B2C3D4E5F60719 /* CLISocketPathResolver.swift */,
 				C510C1E00000000000000001 /* SocketOperationTelemetry.swift */,
@@ -4508,6 +4514,7 @@
 				C7A534000000000000000001 /* ClaudeHookFeedTelemetrySwiftTests.swift */,
 				A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */,
 				A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */,
+				A76110020000000000000002 /* AgentHookNotificationPolicyTests.swift */,
 				A5D41233A1B2C3D4E5F60718 /* ClaudeBackgroundWorkNotifyTests.swift */,
 				C72280000000000000000003 /* CLINotifyClaudeHookWorkspaceRoutingTests.swift */,
 				A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */,
@@ -5895,6 +5902,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D36A00030000000000000003 /* AgentHibernationLifecycleState.swift in Sources */,
+				A76110010000000000000001 /* AgentHookNotificationPolicy.swift in Sources */,
 				B900004AA1B2C3D4E5F60719 /* CLISocketPathResolver.swift in Sources */,
 				C12985000000000000000002 /* CLISocketSentryTelemetry.swift in Sources */,
 				B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */,
@@ -6031,6 +6039,8 @@
 				A9E020000000000000000005 /* AgentExecutableResolverTests.swift in Sources */,
 				D72260010000000000000001 /* AgentHibernationPortalVisibilityTests.swift in Sources */,
 				D36A00020000000000000001 /* AgentHibernationTests.swift in Sources */,
+				A76110010000000000000003 /* AgentHookNotificationPolicy.swift in Sources */,
+				A76110020000000000000001 /* AgentHookNotificationPolicyTests.swift in Sources */,
 				A5D41230A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift in Sources */,
 				D3610B010000000000000001 /* AgentSessionAutoResumeSettingsTests.swift in Sources */,
 				D3610B020000000000000001 /* AgentSessionAutoResumeSwiftTests.swift in Sources */,

--- a/cmuxTests/AgentHookNotificationPolicyTests.swift
+++ b/cmuxTests/AgentHookNotificationPolicyTests.swift
@@ -1,0 +1,129 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Agent hook notification policy")
+struct AgentHookNotificationPolicyTests {
+    @Test func classificationTable() {
+        let waiting = classify("waiting for input")
+        #expect(waiting.status == .needsInput)
+        #expect(waiting.notifyCategory == .idleReminder)
+
+        let permission = classify("Grok needs permission to run rm")
+        #expect(permission.status == .needsInput)
+        #expect(permission.notifyCategory == .needsPermission)
+
+        let error = classify("Build failed: exit 1")
+        #expect(error.status == .error)
+        #expect(error.notifyCategory == .other)
+
+        let completion = classify("Turn complete in 1.2s.")
+        #expect(completion.status == .idle)
+        #expect(completion.notifyCategory == .turnComplete)
+
+        let arbitrary = classify("Reviewing project files")
+        #expect(arbitrary.status == nil)
+        #expect(arbitrary.notifyCategory == .idleReminder)
+
+        let emptyFallback = AgentHookNotificationClassifier.classify(
+            displayName: "Grok",
+            signal: "",
+            message: "",
+            isFallback: true
+        )
+        #expect(emptyFallback.status == .needsInput)
+        #expect(emptyFallback.notifyCategory == .idleReminder)
+        #expect(emptyFallback.isFallback == true)
+    }
+
+    @Test func dedupeFingerprintTable() {
+        let first = fingerprint(status: .needsInput, body: "waiting for input")
+        let same = fingerprint(status: .needsInput, body: "waiting for input")
+        let different = fingerprint(status: .needsInput, body: "waiting for input again")
+
+        #expect(first == same)
+        #expect(first != different)
+        #expect(fingerprint(status: .idle, body: "a") == "idle-turn")
+        #expect(fingerprint(status: .idle, body: "b") == "idle-turn")
+        let permissionFingerprint = AgentHookNotificationPolicy.dedupeFingerprint(
+            agentName: "grok",
+            sessionId: "session-1",
+            status: .needsInput,
+            category: .needsPermission,
+            body: "permission"
+        )
+        #expect(permissionFingerprint == fingerprint(status: .needsInput, body: "permission"))
+        #expect(permissionFingerprint?.hasPrefix("needsInput:") == true)
+        #expect(AgentHookNotificationPolicy.dedupeFingerprint(
+            agentName: "codex",
+            sessionId: "session-1",
+            status: .needsInput,
+            category: .idleReminder,
+            body: "waiting"
+        ) == nil)
+        #expect(AgentHookNotificationPolicy.dedupeFingerprint(
+            agentName: "grok",
+            sessionId: "",
+            status: .needsInput,
+            category: .idleReminder,
+            body: "waiting"
+        ) == nil)
+        #expect(first == "needsInput:5ed8d1309a36515b")
+    }
+
+    @Test func metaRoundTripsWithAppGate() throws {
+        let taggedCategories: [AgentHookNotifyCategory] = [.turnComplete, .needsPermission, .idleReminder]
+        for category in taggedCategories {
+            let metaSegment = try #require(category.metaSegment(pending: false))
+            let parsed = try #require(AgentNotificationMeta(meta: metaSegment))
+            #expect(parsed.category.rawValue == category.rawValue)
+            #expect(parsed.pending == false)
+        }
+        #expect(AgentHookNotifyCategory.other.metaSegment(pending: false) == nil)
+
+        #expect(agentNotificationShouldDeliver(
+            category: .idleReminder,
+            pending: false,
+            permissionEnabled: true,
+            turnMode: .always,
+            idleEnabled: false
+        ) == false)
+        #expect(agentNotificationShouldDeliver(
+            category: .needsPermission,
+            pending: false,
+            permissionEnabled: false,
+            turnMode: .always,
+            idleEnabled: true
+        ) == false)
+        #expect(agentNotificationShouldDeliver(
+            category: .turnComplete,
+            pending: false,
+            permissionEnabled: true,
+            turnMode: .never,
+            idleEnabled: true
+        ) == false)
+    }
+
+    private func classify(_ message: String) -> AgentHookNotificationSummary {
+        AgentHookNotificationClassifier.classify(
+            displayName: "Grok",
+            signal: "",
+            message: message,
+            isFallback: false
+        )
+    }
+
+    private func fingerprint(status: AgentHookNotificationStatus?, body: String) -> String? {
+        AgentHookNotificationPolicy.dedupeFingerprint(
+            agentName: "grok",
+            sessionId: "session-1",
+            status: status,
+            category: .idleReminder,
+            body: body
+        )
+    }
+}

--- a/cmuxTests/CLIGrokNotificationNoiseTests.swift
+++ b/cmuxTests/CLIGrokNotificationNoiseTests.swift
@@ -1,0 +1,244 @@
+import XCTest
+import Darwin
+
+extension CLINotifyProcessIntegrationRegressionTests {
+    func testGrokRepeatedWaitingNotificationsDedupe() throws {
+        let context = try makeGrokNoiseContext(name: "grok-wait-dedupe")
+        defer { context.cleanup() }
+
+        try runGrokNoiseHook(context, "session-start", payload: grokNoisePayload(context, event: "SessionStart"))
+        let firstStart = context.state.snapshot().count
+        try runGrokNoiseHook(context, "notification", payload: grokNoisePayload(context, event: "Notification", message: "waiting for input"))
+        try runGrokNoiseHook(context, "notification", payload: grokNoisePayload(context, event: "Notification", message: "waiting for input"))
+
+        let commands = Array(context.state.snapshot().dropFirst(firstStart))
+        XCTAssertEqual(notifyCommands(in: commands).count, 1, "Repeated waiting events should dedupe, saw \(commands)")
+    }
+
+    func testGrokUnclassifiedFallbackRebuildIsGateableAndDedupeable() throws {
+        let context = try makeGrokNoiseContext(name: "grok-fallback-gate", sessionId: nil)
+        defer { context.cleanup() }
+
+        try runGrokNoiseHook(context, "session-start", payload: grokNoisePayload(context, event: "SessionStart"))
+        try runGrokNoiseHook(context, "notification", payload: grokNoisePayload(context, event: "Notification", message: "Grok needs permission to run rm"))
+        try runGrokNoiseHook(context, "prompt-submit", payload: grokNoisePayload(context, event: "UserPromptSubmit"))
+
+        let fallbackStart = context.state.snapshot().count
+        let unclassified = grokUnclassifiedPayload(context)
+        try runGrokNoiseHook(context, "notification", payload: unclassified)
+        try runGrokNoiseHook(context, "notification", payload: unclassified)
+
+        let notifications = notifyCommands(in: Array(context.state.snapshot().dropFirst(fallbackStart)))
+        XCTAssertEqual(notifications.count, 1, "Unclassified fallback re-notification should dedupe, saw \(notifications)")
+        XCTAssertTrue(
+            notifications.first?.hasSuffix("|c=idle-reminder;p=0") == true,
+            "Fallback re-notification should be gateable as idle-reminder, saw \(notifications)"
+        )
+    }
+
+    func testGrokIncidentalCompletionCueAfterInterleavedNotificationDoesNotReding() throws {
+        let context = try makeGrokNoiseContext(name: "grok-incidental")
+        defer { context.cleanup() }
+
+        try runGrokNoiseHook(context, "session-start", payload: grokNoisePayload(context, event: "SessionStart"))
+        let start = context.state.snapshot().count
+        try runGrokNoiseHook(context, "notification", payload: grokNoisePayload(context, event: "Notification", message: "Turn complete in 1.2s."))
+        try runGrokNoiseHook(context, "notification", payload: grokNoisePayload(context, event: "Notification", message: "waiting for input"))
+        try runGrokNoiseHook(context, "notification", payload: grokNoisePayload(context, event: "Notification", message: "All done reviewing the files you asked about"))
+
+        // This is already green pre-fix because old waiting events do not
+        // overwrite the single legacy fingerprint slot. Keep it as a guard that
+        // the new multi-fingerprint store does not regress the eviction case.
+        let notifications = notifyCommands(in: Array(context.state.snapshot().dropFirst(start)))
+        XCTAssertEqual(notifications.count, 2, "Incidental completion cue should not send after a real completion, saw \(notifications)")
+        XCTAssertEqual(notifications.filter { $0.contains("Grok|Completed|") }.count, 1, notifications.joined(separator: "\n"))
+    }
+
+    func testGrokSessionStartRefireDoesNotRearmCompletionDedupe() throws {
+        let context = try makeGrokNoiseContext(name: "grok-start-refire")
+        defer { context.cleanup() }
+
+        let startPayload = grokNoisePayload(context, event: "SessionStart")
+        let completionPayload = grokNoisePayload(context, event: "Notification", message: "Turn complete in 1.2s.")
+        try runGrokNoiseHook(context, "session-start", payload: startPayload)
+        let start = context.state.snapshot().count
+        try runGrokNoiseHook(context, "notification", payload: completionPayload)
+        try runGrokNoiseHook(context, "session-start", payload: startPayload)
+        try runGrokNoiseHook(context, "notification", payload: completionPayload)
+
+        let notifications = notifyCommands(in: Array(context.state.snapshot().dropFirst(start)))
+        XCTAssertEqual(notifications.count, 1, "SessionStart refire should not re-arm the same completion notification, saw \(notifications)")
+    }
+
+    func testGrokRepeatedIdenticalPermissionPromptsDedupePerTurn() throws {
+        let context = try makeGrokNoiseContext(name: "grok-permission")
+        defer { context.cleanup() }
+
+        try runGrokNoiseHook(context, "session-start", payload: grokNoisePayload(context, event: "SessionStart"))
+        let start = context.state.snapshot().count
+        let permissionPrompt = grokPermissionPromptPayload(context)
+        try runGrokNoiseHook(context, "notification", payload: permissionPrompt)
+        try runGrokNoiseHook(context, "notification", payload: permissionPrompt)
+
+        let firstTurnNotifications = notifyCommands(in: Array(context.state.snapshot().dropFirst(start)))
+        XCTAssertEqual(firstTurnNotifications.count, 1, "Repeated identical permission prompts should dedupe per turn, saw \(firstTurnNotifications)")
+        XCTAssertTrue(
+            firstTurnNotifications.first?.hasSuffix("|c=needs-permission;p=0") == true,
+            firstTurnNotifications.joined(separator: "\n")
+        )
+
+        try runGrokNoiseHook(context, "prompt-submit", payload: grokNoisePayload(context, event: "UserPromptSubmit"))
+        try runGrokNoiseHook(context, "notification", payload: permissionPrompt)
+
+        let notifications = notifyCommands(in: Array(context.state.snapshot().dropFirst(start)))
+        XCTAssertEqual(notifications.count, 2, "Prompt submit should re-arm permission prompt delivery for the next turn, saw \(notifications)")
+        XCTAssertTrue(notifications.allSatisfy { $0.hasSuffix("|c=needs-permission;p=0") }, notifications.joined(separator: "\n"))
+    }
+
+    func testGrokDistinctPermissionPromptsAlwaysDeliver() throws {
+        let context = try makeGrokNoiseContext(name: "grok-distinct-permission")
+        defer { context.cleanup() }
+
+        try runGrokNoiseHook(context, "session-start", payload: grokNoisePayload(context, event: "SessionStart"))
+        let start = context.state.snapshot().count
+        try runGrokNoiseHook(context, "notification", payload: grokPermissionPromptPayload(context, message: "Grok needs permission to run rm"))
+        try runGrokNoiseHook(context, "notification", payload: grokPermissionPromptPayload(context, message: "Grok needs permission to edit config.yaml"))
+
+        let notifications = notifyCommands(in: Array(context.state.snapshot().dropFirst(start)))
+        XCTAssertEqual(notifications.count, 2, "Distinct permission prompts should each deliver, saw \(notifications)")
+        XCTAssertTrue(notifications.allSatisfy { $0.hasSuffix("|c=needs-permission;p=0") }, notifications.joined(separator: "\n"))
+    }
+
+    func testAntigravityErrorNotificationRemainsUntagged() throws {
+        let context = try makeGrokNoiseContext(name: "antigravity-error", agent: "antigravity")
+        defer { context.cleanup() }
+
+        try runGrokNoiseHook(context, "session-start", payload: antigravityNoisePayload(context, event: "SessionStart"))
+        let start = context.state.snapshot().count
+        try runGrokNoiseHook(context, "notification", payload: antigravityNoisePayload(context, event: "Notification", message: "Build failed: exit 1"))
+
+        let notifications = notifyCommands(in: Array(context.state.snapshot().dropFirst(start)))
+        XCTAssertEqual(notifications.count, 1, "Expected one Antigravity error notification, saw \(notifications)")
+        XCTAssertFalse(
+            notifications.first?.contains("|c=") == true,
+            "Error notifications should remain untagged, saw \(notifications)"
+        )
+    }
+
+    private struct GrokNoiseContext {
+        let cliPath: String
+        let socketPath: String
+        let listenerFD: Int32
+        let state: MockSocketServerState
+        let root: URL
+        let workspaceId: String
+        let surfaceId: String
+        let sessionId: String
+        let agent: String
+        let environment: [String: String]
+
+        func cleanup() {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+
+    private func makeGrokNoiseContext(
+        name: String,
+        agent: String = "grok",
+        sessionId requestedSessionId: String? = "grok-noise-session"
+    ) throws -> GrokNoiseContext {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath(name)
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-\(name)-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+        let sessionId = requestedSessionId ?? surfaceId
+        let grokHome = root.appendingPathComponent("grok-home", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let environment: [String: String] = [
+            "HOME": root.path,
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "PWD": root.path,
+            "CMUX_SOCKET_PATH": socketPath,
+            "CMUX_WORKSPACE_ID": workspaceId,
+            "CMUX_SURFACE_ID": surfaceId,
+            "CMUX_AGENT_HOOK_STATE_DIR": root.path,
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+            "GROK_HOME": grokHome.path,
+        ]
+
+        startDetachedAgentHookMockServer(listenerFD: listenerFD, state: state, surfaceId: surfaceId, connectionCount: 128)
+        return GrokNoiseContext(
+            cliPath: cliPath,
+            socketPath: socketPath,
+            listenerFD: listenerFD,
+            state: state,
+            root: root,
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            sessionId: sessionId,
+            agent: agent,
+            environment: environment
+        )
+    }
+
+    private func runGrokNoiseHook(_ context: GrokNoiseContext, _ subcommand: String, payload: String) throws {
+        let result = runProcess(
+            executablePath: context.cliPath,
+            arguments: ["hooks", context.agent, subcommand],
+            environment: context.environment,
+            standardInput: payload,
+            timeout: 5
+        )
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout, "{}\n")
+    }
+
+    private func grokNoisePayload(_ context: GrokNoiseContext, event: String, message: String? = nil) -> String {
+        notificationNoisePayload(sessionKey: "sessionId", context: context, eventKey: "hookEventName", event: event, message: message)
+    }
+
+    private func grokPermissionPromptPayload(
+        _ context: GrokNoiseContext,
+        message: String = "Tool permission requested"
+    ) -> String {
+        #"{"hookEventName":"notification","sessionId":"\#(context.sessionId)","cwd":"\#(context.root.path)","notificationType":"permission_prompt","message":"\#(message)","level":"info"}"#
+    }
+
+    private func antigravityNoisePayload(_ context: GrokNoiseContext, event: String, message: String? = nil) -> String {
+        notificationNoisePayload(sessionKey: "session_id", context: context, eventKey: "hook_event_name", event: event, message: message)
+    }
+
+    private func grokUnclassifiedPayload(_ context: GrokNoiseContext) -> String {
+        #"{"sessionId":"\#(context.sessionId)","cwd":"\#(context.root.path)","unparseable":true}"#
+    }
+
+    private func notificationNoisePayload(
+        sessionKey: String,
+        context: GrokNoiseContext,
+        eventKey: String,
+        event: String,
+        message: String?
+    ) -> String {
+        var fields = [
+            #""\#(sessionKey)":"\#(context.sessionId)""#,
+            #""cwd":"\#(context.root.path)""#,
+            #""\#(eventKey)":"\#(event)""#,
+        ]
+        if let message {
+            fields.append(#""message":"\#(message)""#)
+        }
+        return "{\(fields.joined(separator: ","))}"
+    }
+
+    private func notifyCommands(in commands: [String]) -> [String] {
+        commands.filter { $0.hasPrefix("notify_target_async ") }
+    }
+}


### PR DESCRIPTION
Closes #7611

## Problem

Grok Build sessions spam notification sounds. Two report waves, both root-caused:

1. Only `.idle` hook notifications were deduped — every repeated Waiting/Error/Attention event delivered a fresh banner + sound; unclassified fallback payloads carried no `c=<category>;p=<0|1>` meta so the per-category settings from #7129 could not silence them; mid-session `SessionStart` re-fires re-armed the completion ding.
2. Dogfood follow-up: "long tasks ring on every step." Captured live Grok Build 0.2.91 hook traffic (tee on hook stdin, isolated `GROK_HOME`): grok emits an **identical** `{"notificationType":"permission_prompt","message":"Tool permission requested"}` Notification for **every tool step — even in `--permission-mode auto`** where nothing awaits the user. A 6-step task = 6 banners + 6 sounds. Grok has no cmux Feed approval lane (PreToolUse is non-actionable telemetry), so these were classified needsPermission and deliberately exempt from dedupe.

## Fix (class-level)

- **Dedupe all statuses**: fingerprints are `status + FNV-1a(body)` (stable across CLI processes — `String.hashValue` is per-process-randomized and the fingerprint persists in the session store). `.idle` keeps the whole-turn `"idle-turn"` fingerprint so incidental completion keywords ("All done…") can't re-ding after the real turn-complete.
- **Permission prompts dedupe per turn**: identical permission bodies within a session/window dedupe to one banner; `prompt-submit` (a real turn boundary) re-arms delivery; permission prompts with **novel content always deliver**. First prompt of a turn still alerts an away user; the per-step spam dies.
- **Everything gateable**: every summary carries a non-optional `notifyCategory`. The "needs your attention" fallback, arbitrary-text attention alerts, and the stale-record rebuild path tag `c=idle-reminder`, so "Agent Waiting for Input" silences them. Errors keep the explicit `.other` always-deliver exemption (wire output unchanged).
- **No re-arm on SessionStart re-fire** (grok auto-continue/restarts); other agents unchanged.
- **Multi-fingerprint store**: the single-slot emitted-fingerprint record becomes a small per-session map (60 min window, 16-entry cap, legacy back-compat) so an interleaved notification can't evict `"idle-turn"`.
- Classifier signal now also reads grok's camelCase `notificationType` key (captured from real traffic).

The classification/dedupe policy moves to a pure new file `CLI/AgentHookNotificationPolicy.swift`, compiled into both `cmux-cli` and `cmuxTests` (same pattern as `FeedEventClassifier`). `CLI/cmux.swift` shrinks by 119 lines; no budget TSV changes. Claude-lane wire output and antigravity fullyIdle gating are byte-identical.

## Two-commit red/green structure

Commit 1 adds only the integration regression tests (spawn-the-CLI harness, isolated temp HOME/GROK_HOME/state, payload shapes from live capture): repeated-waiting dedupe, per-turn permission dedupe + prompt-submit re-arm, distinct-permission always-deliver guard, gateable fallback rebuild, SessionStart re-fire, antigravity error guard, incidental-keyword guard. Commit 2 turns it green and adds pure policy unit tests. Note: the `tests` gate treats assertion-only failures as "expected" (`(0 unexpected)` tolerance), so the commit-1 redness is visible in the shard logs (failing `Test Case` lines) rather than in the check status.

## Verification

- Dogfooded on a tagged Debug build against the live app socket with isolated `GROK_HOME`/state (no real hook configs touched), including **real Grok Build 0.2.91 sessions**: pre-v2, a 6-tool-step auto-mode task delivered 6 permission banners; post-v2 expectation is 1 (re-verified after the rebuild). Synthetic repro matrix: repeated `waiting for input` → 1 banner + `skipDuplicate`; `{"unparseable":true}` after a permission seed → 1 tagged banner + dedupe; with "Agent Waiting for Input" disabled the app logs `socket.notifyTargetAsync.gated category=idle-reminder` and shows nothing; incidental "All done…" after a real completion → `skipDuplicate idle-turn`; SessionStart re-fire + same completion → `skipDuplicate`.
- `python3 scripts/swift_file_length_budget.py`, `./scripts/lint-pbxproj-test-wiring.sh`, `python3 scripts/normalize-pbxproj.py --check` all pass; tagged `xcodebuild build-for-testing` compiles app + test bundles (no local test execution per repo policy).
- Localization audit: no new user-facing strings; existing `Localizable.xcstrings` keys move verbatim into the policy file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced agent hook notification classification to produce consistent status and categories for emitted notifications.
  * Improved deduplication across a session, including correct handling of repeated turn/session-start events.
* **Bug Fixes**
  * Refined notification emission metadata and parsing (including notification type recognition) to prevent incorrect re-sends and ensure proper tagging.
* **Tests**
  * Added automated coverage for notification classification and deduplication, including end-to-end “Grok noise” scenarios and permission/idle/completion edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes notification delivery and dedupe for Grok/Antigravity hooks; misclassification or fingerprint bugs could suppress real alerts or reintroduce spam, though behavior is heavily regression-tested.
> 
> **Overview**
> Cuts **Grok** (and shared **Antigravity**) agent-hook notification spam by moving classification, dedupe, and notify meta into **`AgentHookNotificationPolicy.swift`** and tightening hook behavior in **`cmux.swift`**.
> 
> **Dedupe** now applies to all notification statuses for eligible agents, not only idle completions: fingerprints use **`idle-turn`** for completions and **`status + FNV-1a(body)`** for everything else. The session store keeps a **multi-fingerprint map** (with legacy single-slot fallback) so interleaved events do not drop the completion fingerprint. **Grok** skips clearing dedupe on mid-session **`SessionStart`** re-fires; **`prompt-submit`** still clears for a new turn.
> 
> **User settings** can gate more alerts: summaries always carry a **`notifyCategory`**; attention/fallback and stale-record rebuilds tag **`c=idle-reminder`**, while errors stay untagged via **`.other`**. Wire meta is built through **`metaSegment(pending:)`** instead of ad-hoc helpers.
> 
> Adds **unit** (`AgentHookNotificationPolicyTests`) and **CLI integration** (`CLIGrokNotificationNoiseTests`) coverage for repeated waiting, permission dedupe per turn, SessionStart re-fire, gateable fallbacks, and incidental completion cues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57cf56293437d09019ba9d2ac002f1718a76b42c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->