### PR TITLE
ci: stop skipped linux jobs from transitively skipping staged macOS jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,12 @@ jobs:
     needs:
       - changes
       - linux-preflight
-    if: ${{ needs.changes.outputs.macos == 'true' }}
+    # !cancelled() disables the implicit success() gate, which GitHub evaluates
+    # over the transitive needs chain: linux-preflight runs behind routed linux
+    # jobs that legitimately skip (web/go/agent-session paths), and that
+    # transitive skip otherwise marks every macOS job skipped even when
+    # linux-preflight itself succeeds. Require the direct needs explicitly.
+    if: ${{ !cancelled() && needs.changes.result == 'success' && needs.linux-preflight.result == 'success' && needs.changes.outputs.macos == 'true' }}
     name: app-host unit tests (${{ matrix.shard }}/4)
     # App-host XCTest needs a runner that can broker testmanagerd control
     # sessions. Validated head-to-head that warp-macos-15-arm64-6x runs the
@@ -772,7 +777,12 @@ jobs:
     needs:
       - changes
       - linux-preflight
-    if: ${{ needs.changes.outputs.macos == 'true' }}
+    # !cancelled() disables the implicit success() gate, which GitHub evaluates
+    # over the transitive needs chain: linux-preflight runs behind routed linux
+    # jobs that legitimately skip (web/go/agent-session paths), and that
+    # transitive skip otherwise marks every macOS job skipped even when
+    # linux-preflight itself succeeds. Require the direct needs explicitly.
+    if: ${{ !cancelled() && needs.changes.result == 'success' && needs.linux-preflight.result == 'success' && needs.changes.outputs.macos == 'true' }}
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 40
     env:
@@ -1076,7 +1086,12 @@ jobs:
     needs:
       - changes
       - linux-preflight
-    if: ${{ needs.changes.outputs.macos == 'true' }}
+    # !cancelled() disables the implicit success() gate, which GitHub evaluates
+    # over the transitive needs chain: linux-preflight runs behind routed linux
+    # jobs that legitimately skip (web/go/agent-session paths), and that
+    # transitive skip otherwise marks every macOS job skipped even when
+    # linux-preflight itself succeeds. Require the direct needs explicitly.
+    if: ${{ !cancelled() && needs.changes.result == 'success' && needs.linux-preflight.result == 'success' && needs.changes.outputs.macos == 'true' }}
     # Build the full cmux scheme once, then run the required display/runtime
     # regressions from the same DerivedData instead of queuing a second display
     # runner for UI-only checks.
@@ -1412,7 +1427,10 @@ jobs:
       - changes
       - linux-preflight
       - swift-package-tests
-    if: ${{ needs.changes.outputs.macos == 'true' }}
+    # See app-host-unit-tests: explicit direct-needs gate instead of the
+    # implicit success() so skipped routed linux jobs upstream of
+    # linux-preflight do not skip this job transitively.
+    if: ${{ !cancelled() && needs.changes.result == 'success' && needs.linux-preflight.result == 'success' && needs.swift-package-tests.result == 'success' && needs.changes.outputs.macos == 'true' }}
     # Compile the same unsigned universal Release app that nightly builds before
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -491,6 +491,11 @@ def test_required_tests_status_waits_for_app_host_matrix() -> None:
 
 
 def test_macos_jobs_wait_for_linux_preflight() -> None:
+    # The staged macOS jobs must gate on their direct needs explicitly.
+    # A bare `if: needs.changes.outputs.macos == 'true'` keeps the implicit
+    # success() gate, which GitHub evaluates over the transitive needs chain:
+    # routed linux jobs that legitimately skip (web/go/agent-session paths)
+    # then mark every macOS job skipped even though linux-preflight succeeded.
     for job_name in [
         "app-host-unit-tests",
         "swift-package-tests",
@@ -500,7 +505,16 @@ def test_macos_jobs_wait_for_linux_preflight() -> None:
         block = workflow_job_block(job_name)
         assert "      - changes" in block
         assert "      - linux-preflight" in block
-        assert "if: ${{ needs.changes.outputs.macos == 'true' }}" in block
+        assert "if: ${{ needs.changes.outputs.macos == 'true' }}" not in block
+        expected_needs = ["changes", "linux-preflight"]
+        if job_name == "release-build":
+            expected_needs.append("swift-package-tests")
+        expected_if = (
+            "if: ${{ !cancelled() && "
+            + " && ".join(f"needs.{need}.result == 'success'" for need in expected_needs)
+            + " && needs.changes.outputs.macos == 'true' }}"
+        )
+        assert expected_if in block, f"{job_name} must gate on direct needs explicitly"
 
 
 def test_linux_preflight_blocks_macos_on_cheap_layer_failure() -> None:


### PR DESCRIPTION
Since https://github.com/manaflow-ai/cmux/pull/7583 staged macOS CI behind `linux-preflight`, every PR that does not touch web/go/agent-session paths fails CI. The routed linux jobs (web-typecheck, react-apps-check, web-db-migrations, remote-daemon-tests, agent-session-web-resources) legitimately skip on such PRs; GitHub's implicit `success()` job gate evaluates the transitive needs chain, so `app-host-unit-tests`, `swift-package-tests`, `tests-build-and-lag`, and `release-build` all report skipped even though `linux-preflight` itself ran with `if: always()` and succeeded. The `tests` gate then fails with `app-host unit tests were required but did not pass: skipped`, and `ci-status` fails with it.

Evidence: every pull_request CI run created after b51ee74896 merged (08:24Z) shows the identical signature, e.g. https://github.com/manaflow-ai/cmux/actions/runs/28929597020 (feat-diff-viewer-fast-first-paint), https://github.com/manaflow-ai/cmux/actions/runs/28929672257, https://github.com/manaflow-ai/cmux/actions/runs/28929644066 — all with `changes.macos=true`, `linux-preflight=success`, macOS jobs skipped.

Fix: replace the implicit gate on the four staged macOS jobs with an explicit direct-needs condition: `!cancelled()` (which disables the implicit transitive `success()`) plus `result == 'success'` for each direct need (`changes`, `linux-preflight`, and for release-build also `swift-package-tests`), keeping the `changes.outputs.macos == 'true'` route filter. Staging semantics are preserved: macOS jobs still only start after linux-preflight passes.

Verification caveat: #7583's own PR run missed this because workflow-file changes set every path filter true, so no routed job skipped there. This PR's own run has the same property, so the skip path is only provable on a macOS-only PR after merge (e.g. re-run https://github.com/manaflow-ai/cmux/pull/7605 by updating its branch).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786092860&installation_id=133855650&pr_number=7620&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7620&signature=cf34ccab9d95005431b26476c1a909e3a1600346406352a3e8960c5b74429b09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions job `if` expressions and workflow guard tests; staging semantics (macOS only after preflight) are preserved.
> 
> **Overview**
> **Fixes false CI failures** on macOS-only PRs where required macOS jobs were **skipped** even though `linux-preflight` succeeded.
> 
> After staging macOS work behind `linux-preflight`, GitHub’s implicit `success()` on job `needs` still walks the **transitive** dependency graph. Routed Linux jobs (`web-typecheck`, `remote-daemon-tests`, etc.) legitimately **skip** when path filters don’t match; that skip propagated and skipped `app-host-unit-tests`, `swift-package-tests`, `tests-build-and-lag`, and `release-build`, which then broke the `tests` and `ci-status` gates.
> 
> The four jobs now use an explicit `if`: `!cancelled()` plus `needs.changes` / `needs.linux-preflight` (and `needs.swift-package-tests` for **release-build**) `result == 'success'`, still gated on `changes.outputs.macos == 'true'`. `tests/test_ci_change_areas.py` asserts those conditions so the old bare macOS-only `if` cannot regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a58d9f5ec5876029758db8beb3f29dc2576bfca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI so macOS jobs no longer get skipped when routed Linux jobs skip. Adds explicit direct-needs checks so macOS jobs run after `linux-preflight` succeeds and the macOS path filter matches, and adds a test to enforce this guard.

- **Bug Fixes**
  - Replace implicit gate with `!cancelled()` + explicit `needs.*.result == 'success'`.
  - Keep `needs.changes.outputs.macos == 'true'`.
  - Apply to: app-host unit tests, swift-package-tests, tests-build-and-lag, release-build.

<sup>Written for commit 2a58d9f5ec5876029758db8beb3f29dc2576bfca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

