### PR TITLE
terminal: propagate NSWindow occlusion to Ghostty surface occlusion

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/SurfaceOcclusionState.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/SurfaceOcclusionState.swift
@@ -1,0 +1,27 @@
+/// Two-axis occlusion state for a terminal surface.
+///
+/// Ghostty should render only when the surface is both visible in the UI
+/// (portal/canvas visibility) and its host window is visible according to
+/// `NSWindow.occlusionState`.
+public struct SurfaceOcclusionState: Equatable, Sendable {
+    /// Whether the portal or canvas currently considers the surface visible.
+    public var uiVisible: Bool
+
+    /// Whether the host window is currently visible to AppKit.
+    public var windowVisible: Bool
+
+    /// Creates occlusion state with both axes visible by default.
+    ///
+    /// - Parameters:
+    ///   - uiVisible: The current portal or canvas visibility.
+    ///   - windowVisible: The current host-window visibility.
+    public init(uiVisible: Bool = true, windowVisible: Bool = true) {
+        self.uiVisible = uiVisible
+        self.windowVisible = windowVisible
+    }
+
+    /// Whether Ghostty should treat the surface as visible.
+    public var effectiveVisible: Bool {
+        uiVisible && windowVisible
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
@@ -43,10 +43,28 @@ extension TerminalSurface {
         }
     }
 
-    /// Applies the occlusion state to the runtime surface.
+    /// Records the UI visibility axis and applies the effective occlusion.
     public func setOcclusion(_ visible: Bool) {
+        occlusionState.uiVisible = visible
+        applyOcclusionIfNeeded()
+    }
+
+    /// Records the host-window visibility axis and applies the effective occlusion.
+    ///
+    /// Detach and reparent transients intentionally leave this axis unchanged;
+    /// only an attached `NSWindow` occlusion observation should update it.
+    public func setWindowOcclusionVisible(_ visible: Bool) {
+        occlusionState.windowVisible = visible
+        applyOcclusionIfNeeded()
+    }
+
+    /// Applies the combined UI/window occlusion state to Ghostty, deduplicated.
+    private func applyOcclusionIfNeeded() {
         guard let surface = surface else { return }
-        ghostty_surface_set_occlusion(surface, visible)
+        let effectiveVisible = occlusionState.effectiveVisible
+        guard lastAppliedOcclusionVisible != effectiveVisible else { return }
+        ghostty_surface_set_occlusion(surface, effectiveVisible)
+        lastAppliedOcclusionVisible = effectiveVisible
     }
 
     /// Whether this surface currently holds realized GPU renderer resources.

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
@@ -315,6 +315,7 @@ extension TerminalSurface {
         pendingSocketInputQueue.removeAll(keepingCapacity: false)
         pendingSocketInputBytes = 0
         desiredFocusState = false
+        lastAppliedOcclusionVisible = nil
 
         guard let surfaceToFree else {
             callbackContext?.release()
@@ -597,9 +598,7 @@ extension TerminalSurface {
             lastYScale = scaleFactors.y
         }
 
-        // Flush remote-tmux output that arrived before the surface existed
-        // after sizing, so the seed paints into the final grid instead of
-        // wrapping at Ghostty's default grid.
+        // Flush remote-tmux output after sizing so the seed paints into the final grid.
         flushPendingRemoteOutput(to: createdSurface)
 
         // Some GhosttyKit builds can drop inherited font_size during post-create
@@ -619,10 +618,11 @@ extension TerminalSurface {
             }
         }
 
-        // Re-apply the desired focus state after creation so the live runtime
-        // surface converges with any focus changes that happened while the
-        // surface was being initialized.
+        // Re-apply states changed while the runtime surface was initializing.
         ghostty_surface_set_focus(createdSurface, desiredFocusState)
+        lastAppliedOcclusionVisible = nil
+        ghostty_surface_set_occlusion(createdSurface, occlusionState.effectiveVisible)
+        lastAppliedOcclusionVisible = occlusionState.effectiveVisible
 
         flushPendingSocketInputIfNeeded()
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -245,16 +245,14 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// surface. The Mac sync server reads the tee'd bytes to broadcast
     /// raw PTY output to paired iPhones (`MobileTerminalByteTee`).
     var mobileByteTeeLease: (any TerminalByteTeeLease)?
-    /// The desired focus state for the Ghostty C surface. May be set before the
-    /// C surface exists (e.g. during layout restoration); `createSurface`
-    /// reapplies this value once the runtime surface exists, then keeps using it
-    /// as a dedup guard to avoid redundant `ghostty_surface_set_focus` calls
-    /// (prevents prompt redraws with P10k).
-    ///
-    /// Start unfocused and only opt into focus when the workspace/AppKit focus
-    /// path explicitly requests it so background panes do not keep a focused
-    /// state unless the workspace focus path requests it.
+    /// Desired Ghostty focus, tracked before creation and replayed afterward.
+    /// Starts false: only the workspace/AppKit focus path opts a pane into
+    /// focus, so background panes never keep a focused state.
     var desiredFocusState: Bool = false
+    /// UI/window visibility axes applied to Ghostty occlusion when a surface exists.
+    var occlusionState = SurfaceOcclusionState()
+    /// Last effective occlusion value sent to the Ghostty C surface.
+    var lastAppliedOcclusionVisible: Bool?
 
     /// Bumped after every completed runtime clipboard read.
     public internal(set) var clipboardReadGeneration = 0

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/SurfaceOcclusionStateTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/SurfaceOcclusionStateTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import CmuxTerminal
+
+@Suite struct SurfaceOcclusionStateTests {
+    @Test func defaultsAreVisibleOnBothAxes() {
+        let state = SurfaceOcclusionState()
+
+        #expect(state.uiVisible)
+        #expect(state.windowVisible)
+        #expect(state.effectiveVisible)
+    }
+
+    @Test(arguments: [
+        (uiVisible: true, windowVisible: true, effectiveVisible: true),
+        (uiVisible: true, windowVisible: false, effectiveVisible: false),
+        (uiVisible: false, windowVisible: true, effectiveVisible: false),
+        (uiVisible: false, windowVisible: false, effectiveVisible: false)
+    ])
+    func effectiveVisibilityIsTheAndOfBothAxes(
+        uiVisible: Bool,
+        windowVisible: Bool,
+        effectiveVisible: Bool
+    ) {
+        let state = SurfaceOcclusionState(uiVisible: uiVisible, windowVisible: windowVisible)
+
+        #expect(state.effectiveVisible == effectiveVisible)
+    }
+
+    @Test func uiVisibilityMustReturnBeforeWindowVisibilityCanRenderAgain() {
+        var state = SurfaceOcclusionState()
+
+        state.uiVisible = false
+        #expect(!state.effectiveVisible)
+
+        state.windowVisible = false
+        #expect(!state.effectiveVisible)
+
+        state.windowVisible = true
+        #expect(!state.effectiveVisible)
+
+        state.uiVisible = true
+        #expect(state.effectiveVisible)
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3630,7 +3630,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #endif
     private var eventMonitor: Any?
     private var trackingArea: NSTrackingArea?
-    private var windowObserver: NSObjectProtocol?
+    private var windowObserver: NSObjectProtocol?, occlusionObserver: NSObjectProtocol?
     private var lastScrollEventTime: CFTimeInterval = 0
     private let scrollSpeedAccumulator = TerminalScrollSpeedAccumulator()
     private var visibleInUI: Bool = true
@@ -3878,10 +3878,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if let windowObserver {
-            NotificationCenter.default.removeObserver(windowObserver)
-            self.windowObserver = nil
+        for observer in [windowObserver, occlusionObserver].compactMap({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
         }
+        windowObserver = nil
+        occlusionObserver = nil
         // Balance the cursor stack if the view is removed while hover is active
         if wordPathHoverActive {
             wordPathHoverActive = false
@@ -3916,6 +3917,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         ) { [weak self] notification in
             self?.windowDidChangeScreen(notification)
         }
+        occlusionObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeOcclusionStateNotification, object: window, queue: .main
+        ) { [weak self, weak window] _ in
+            guard let self, let window, self.window === window else { return }
+            self.terminalSurface?.setWindowOcclusionVisible(window.occlusionState.contains(.visible))
+        }
+        terminalSurface?.setWindowOcclusionVisible(window.occlusionState.contains(.visible))
 
         if let surface = terminalSurface?.surface,
            let displayID = window.screen?.displayID,
@@ -3951,11 +3959,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             effectiveAppearance,
             source: "surface.viewDidChangeEffectiveAppearance"
         )
-    }
-
-    fileprivate func updateOcclusionState() {
-        // Intentionally no-op: we don't drive libghostty occlusion from AppKit occlusion state.
-        // This avoids transient clears during reparenting and keeps rendering logic minimal.
     }
 
     override func viewDidChangeBackingProperties() {
@@ -7505,9 +7508,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if let eventMonitor {
             NSEvent.removeMonitor(eventMonitor)
         }
-        if let windowObserver {
-            NotificationCenter.default.removeObserver(windowObserver)
+        for observer in [windowObserver, occlusionObserver].compactMap({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
         }
+        windowObserver = nil
+        occlusionObserver = nil
         if let trackingArea {
             removeTrackingArea(trackingArea)
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3869,6 +3869,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             surface.reconcileAttachedWindowIfNeeded(for: self)
         }
         surface.setKeyboardCopyModeActive(keyboardCopyModeActive)
+        // Seed the window-occlusion axis so a surface attached to a view already
+        // sitting in an occluded window does not keep rendering off-screen.
+        if let window {
+            surface.setWindowOcclusionVisible(window.occlusionState.contains(.visible))
+        }
         if !isAlreadyAttached {
             updateSurfaceSize()
         }


### PR DESCRIPTION
## Summary

Part of #7596 (memory audit, slice 4). Relates to #7186.

cmux drove `ghostty_surface_set_occlusion` from portal/UI visibility only (workspace/tab selection); window-level occlusion was a documented no-op (`updateOcclusionState()`, dead code). Result: with the cmux window fully covered by another app or miniaturized, the mounted workspace's surfaces kept rendering — the audit's 10s `sample` showed `renderer.updateFrame`/`drawFrame` hot stacks for surfaces that were not on screen.

### Design

- New `SurfaceOcclusionState` (CmuxTerminal package): two axes, `uiVisible` and `windowVisible`; Ghostty sees `uiVisible && windowVisible`.
- `TerminalSurface.setOcclusion(_:)` keeps its signature and becomes the UI-axis setter (existing callers — portal `setVisibleInUI`, canvas panes — unchanged in semantics since the window axis defaults to visible). New `setWindowOcclusionVisible(_:)` sets the window axis. Both funnel through one deduplicated apply.
- Each hosted terminal view observes `NSWindow.didChangeOcclusionStateNotification` for its current window (registered next to the existing screen-change observer, removed on detach/deinit), pushes the current state once on attach, and pushes nothing on detach — reparent transients keep the last window state, preserving the intent of the old no-op ("avoid transient clears during reparenting").
- Latent bug fixed: surface (re)creation now replays the current effective occlusion (previously only focus was replayed, so a surface created while hidden rendered as if visible).

## Tests

New `SurfaceOcclusionStateTests` (CmuxTerminal package, Swift Testing): defaults, full AND truth table, hide/show sequences. `swift test` in `Packages/macOS/CmuxTerminal`: 56 tests in 10 suites pass (the runner's XCTest arch preflight exits nonzero in this environment; Swift Testing reports all passing — same artifact as previous package runs). A live-render dedup test against the C seam isn't feasible without new stub instrumentation; the rendering-stops-when-covered behavior itself is runtime/perf work verified by the #7596 re-measurement procedure.

`python3 scripts/swift_file_length_budget.py` passes with no TSV changes (GhosttyTerminalView.swift 12,506 ≤ 12,511; TerminalSurface.swift 605 ≤ 607; RuntimeLifecycle stays exactly at 655).

No user-facing strings → no localization changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786092982&installation_id=133855650&pr_number=7621&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7621&signature=1fe3266592b1ec5e4a852293767c7a8b518246708938e0cd0dcd75703e94df55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Ghostty stops rendering (visibility/occlusion path) and touches main-thread window notifications; behavior is localized but affects renderer lifecycle and off-screen CPU/GPU use.
> 
> **Overview**
> **Stops Ghostty from rendering when the cmux window is covered or miniaturized**, not only when the portal hides the pane. Previously `ghostty_surface_set_occlusion` followed UI/portal visibility; window occlusion was intentionally ignored (including a no-op `updateOcclusionState()`), so off-screen windows could still drive `drawFrame` work.
> 
> Introduces **`SurfaceOcclusionState`** with `uiVisible` and `windowVisible`; Ghostty receives **`uiVisible && windowVisible`**. Existing **`setOcclusion(_:)`** updates the UI axis; new **`setWindowOcclusionVisible(_:)`** updates the window axis. Both paths dedupe via **`lastAppliedOcclusionVisible`** before calling **`ghostty_surface_set_occlusion`**.
> 
> **`GhosttyTerminalView`** observes **`NSWindow.didChangeOcclusionStateNotification`**, seeds window visibility on surface attach, and refreshes it when the view enters a window. Detach does not reset the window axis (same reparenting behavior as the old no-op). On **runtime surface (re)creation**, effective occlusion is replayed alongside focus so surfaces born while hidden do not render until both axes are visible. Occlusion tracking resets on agent-hibernation suspend.
> 
> Adds **`SurfaceOcclusionStateTests`** for defaults, AND logic, and hide/show ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00343eac74fe6a0fe59b4a24bbdb07e22f3cc59b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates `NSWindow` occlusion to Ghostty surface occlusion so a surface renders only when it’s visible in the UI and the window is visible. Also seeds window visibility when attaching a surface to a view already in a window, so hidden windows don’t keep rendering.

- **Bug Fixes**
  - Added `SurfaceOcclusionState` (`uiVisible` AND `windowVisible`) in `CmuxTerminal`; `setWindowOcclusionVisible(_:)` is new, `setOcclusion(_:)` remains the UI-axis setter. Calls to `ghostty_surface_set_occlusion` are deduplicated.
  - `GhosttyTerminalView` observes `NSWindow.didChangeOcclusionStateNotification`, seeds the window axis on window attach and when attaching a surface to an in-window view, and leaves it unchanged during detach/reparent.
  - Replays effective occlusion on surface (re)creation so hidden surfaces don’t render until visible. Added `SurfaceOcclusionStateTests` covering defaults, AND semantics, and hide/show sequences.

<sup>Written for commit 00343eac74fe6a0fe59b4a24bbdb07e22f3cc59b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two-axis occlusion visibility tracking (UI and window) with an automatically computed effective state.
  * The terminal view now synchronizes window occlusion changes into the active terminal surface.
* **Bug Fixes**
  * Ensures occlusion visibility is reapplied correctly after surface creation/resume and is cleared appropriately during hibernation.
  * Prevents redundant occlusion updates when the effective visibility hasn’t changed.
* **Tests**
  * Added tests covering default visibility, effective visibility logic, and visibility transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->