### PR TITLE
ci: classify mux/ as macOS-neutral so mux-only PRs pass the routing guard

### DIFF
--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -105,7 +105,9 @@ def is_agent_session_web_change(path: str) -> bool:
 
 
 def is_macos_neutral(path: str) -> bool:
-    if path.startswith(("docs/", "design/", "plans/", "ios/", "web/", "webviews/", "daemon/remote/")):
+    # `mux/` is the standalone cmux-mux Rust project, gated by its own `mux`
+    # workflow; it never affects the macOS app build or app-host tests.
+    if path.startswith(("docs/", "design/", "plans/", "ios/", "web/", "webviews/", "daemon/remote/", "mux/")):
         return True
     return path == "README.md" or (path.startswith("README.") and path.endswith(".md"))
 

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -55,6 +55,17 @@ def test_web_only_runs_web_without_macos() -> None:
     assert_areas(["web/app/page.tsx", "webviews/src/diff/App.tsx"], macos=False, web=True, go=False)
 
 
+def test_mux_only_skips_macos() -> None:
+    # cmux-mux is a standalone Rust project with its own `mux` workflow; its
+    # changes must not require the macOS app-host tests.
+    assert_areas(
+        ["mux/crates/mux-core/src/browser.rs", "mux/README.md", "mux/docs/protocol.md"],
+        macos=False,
+        web=False,
+        go=False,
+    )
+
+
 def test_website_only_does_not_run_agent_session_resource_check() -> None:
     assert_areas(["web/app/page.tsx"], macos=False, web=True, go=False, agent_session_web=False)
 


### PR DESCRIPTION
## Problem

Every mux-only PR fails the `tests` and `ci-status` routing checks (e.g. https://github.com/manaflow-ai/cmux/pull/7609), while the `mux` workflow itself passes. The guard reports `app-host unit tests were required but did not pass: skipped`.

Root cause: `scripts/ci/detect_ci_change_areas.py`'s `is_macos_change` is a catch-all — any path not explicitly in `is_macos_neutral` counts as a macOS change. `mux/` isn't listed, so mux-only PRs resolve `macos=true`. After #7583 staged the macOS app-host shards behind the linux preflight, those shards report `skipped` while `changes.macos=true`, and the aggregator guard (`if macos == "true" and tests["result"] != "success"`) fails.

## Fix

`cmux-mux` is a standalone Rust project gated by its own `mux` workflow; it never affects the macOS app build or app-host tests. Add `mux/` to `is_macos_neutral` so mux-only PRs resolve `macos=false`, the app-host job skips legitimately, and the guard's `macos != "true"` branch accepts the skip.

Verified: `Resolved areas: macos=false` for a mux-only file set; all 36 detector tests pass including the new `test_mux_only_skips_macos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786093192&installation_id=133855650&pr_number=7622&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7622&signature=eb0738480475331c5b96803eaae739adaa878323a820dd9d94d47d002b49870d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI routing-only change with a focused unit test; no runtime app or mux build behavior changes.
> 
> **Overview**
> **Fixes mux-only PRs failing `tests` / `ci-status`** when macOS app-host shards are legitimately skipped. Paths under `mux/` were treated as macOS changes because they were not in the neutral prefix list, so `changes.macos=true` conflicted with skipped app-host jobs after the linux preflight gate.
> 
> `is_macos_neutral` in `detect_ci_change_areas.py` now includes **`mux/`**, matching the standalone **cmux-mux** Rust tree covered by the separate **`mux`** workflow. Mux-only diffs resolve **`macos=false`** (and not web/go) so guards accept skipped macOS jobs.
> 
> Adds **`test_mux_only_skips_macos`** to lock in classification for typical mux paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce33f774f62007cd2a6fe5601dad029ed15cb8a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classify `mux/` as macOS-neutral in the CI change detector so mux-only PRs correctly skip macOS app-host tests and pass the routing guard.

- **Bug Fixes**
  - Include `mux/` in `is_macos_neutral()` to avoid false `macos=true`.
  - Add `test_mux_only_skips_macos` to lock the behavior.
  - Result: mux-only changes run only the `mux` workflow; `tests`/`ci-status` no longer fail due to skipped app-host shards.

<sup>Written for commit ce33f774f62007cd2a6fe5601dad029ed15cb8a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

