### PR TITLE
ci: unskip macOS jobs behind linux-preflight on macOS-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
     needs:
       - changes
       - linux-preflight
-    if: ${{ needs.changes.outputs.macos == 'true' }}
+    if: ${{ !cancelled() && needs.changes.outputs.macos == 'true' && needs.linux-preflight.result == 'success' }}
     name: app-host unit tests (${{ matrix.shard }}/4)
     # App-host XCTest needs a runner that can broker testmanagerd control
     # sessions. Validated head-to-head that warp-macos-15-arm64-6x runs the
@@ -772,7 +772,7 @@ jobs:
     needs:
       - changes
       - linux-preflight
-    if: ${{ needs.changes.outputs.macos == 'true' }}
+    if: ${{ !cancelled() && needs.changes.outputs.macos == 'true' && needs.linux-preflight.result == 'success' }}
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 40
     env:
@@ -1076,7 +1076,7 @@ jobs:
     needs:
       - changes
       - linux-preflight
-    if: ${{ needs.changes.outputs.macos == 'true' }}
+    if: ${{ !cancelled() && needs.changes.outputs.macos == 'true' && needs.linux-preflight.result == 'success' }}
     # Build the full cmux scheme once, then run the required display/runtime
     # regressions from the same DerivedData instead of queuing a second display
     # runner for UI-only checks.
@@ -1412,7 +1412,7 @@ jobs:
       - changes
       - linux-preflight
       - swift-package-tests
-    if: ${{ needs.changes.outputs.macos == 'true' }}
+    if: ${{ !cancelled() && needs.changes.outputs.macos == 'true' && needs.linux-preflight.result == 'success' && needs.swift-package-tests.result == 'success' }}
     # Compile the same unsigned universal Release app that nightly builds before
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -491,16 +491,24 @@ def test_required_tests_status_waits_for_app_host_matrix() -> None:
 
 
 def test_macos_jobs_wait_for_linux_preflight() -> None:
+    macos_preflight_if = "if: ${{ !cancelled() && needs.changes.outputs.macos == 'true' && needs.linux-preflight.result == 'success' }}"
     for job_name in [
         "app-host-unit-tests",
         "swift-package-tests",
         "tests-build-and-lag",
-        "release-build",
     ]:
         block = workflow_job_block(job_name)
         assert "      - changes" in block
         assert "      - linux-preflight" in block
-        assert "if: ${{ needs.changes.outputs.macos == 'true' }}" in block
+        assert "!cancelled()" in block
+        assert macos_preflight_if in block
+
+    block = workflow_job_block("release-build")
+    assert "      - changes" in block
+    assert "      - linux-preflight" in block
+    assert "      - swift-package-tests" in block
+    assert "!cancelled()" in block
+    assert "if: ${{ !cancelled() && needs.changes.outputs.macos == 'true' && needs.linux-preflight.result == 'success' && needs.swift-package-tests.result == 'success' }}" in block
 
 
 def test_linux_preflight_blocks_macos_on_cheap_layer_failure() -> None:


### PR DESCRIPTION
Every macOS-only PR has failed the required `tests` gate since https://github.com/manaflow-ai/cmux/pull/7583. The web jobs skip on those PRs, and GitHub evaluates a job's implicit `success()` over transitive needs, so the skip propagates through `linux-preflight` (which itself runs and succeeds via `always()`) into every downstream macOS job: the `app-host unit tests` shards conclude `skipped` with the matrix unexpanded and the gate fails with `required but did not pass: skipped`. Evidence: run 28929574674 (changes success, linux-preflight success, shards skipped); same signature on issue-6565/issue-7306/issue-7596/feat-diff-viewer PRs.

Fix: `app-host-unit-tests`, `swift-package-tests`, `tests-build-and-lag`, and `release-build` get `if: ${{ !cancelled() && needs.changes.outputs.macos == 'true' && needs.linux-preflight.result == 'success' }}`. `!cancelled()` suppresses the implicit `success()` while still cancelling on cancellation; the explicit preflight-result check preserves the staging intent (macOS runners only start when the cheap layer passed). `release-build` additionally requires `needs.swift-package-tests.result == 'success'` because it downloads that job's Ghostty CLI helper artifact; without it a failed swift-package-tests would burn a ~60-minute release runner before failing on the missing artifact. The `tests`/`ci-status` aggregates already use `always()` with explicit result reads and are untouched. Web-inclusive PRs are unchanged: a failed web job still fails `linux-preflight`'s verdict script, which now explicitly (rather than implicitly) skips the macOS layer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786093616&installation_id=133855650&pr_number=7623&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7623&signature=5344b0c43e7e4885b534a46e2311abe519afb718dcfc70055e768cf3a600d1ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow `if` conditions only; no app runtime or security paths. Mis-guarding could skip macOS tests or run them too early, but behavior is locked by unit tests on the YAML.
> 
> **Overview**
> **Fixes required `tests` failing on macOS-only PRs** where downstream macOS jobs were **skipped** (matrix never expanded) even though `linux-preflight` succeeded.
> 
> Replaces the simple `macos == 'true'` guard on **`app-host-unit-tests`**, **`swift-package-tests`**, and **`tests-build-and-lag`** with `!cancelled() && macos == 'true' && needs.linux-preflight.result == 'success'`. **`!cancelled()`** avoids GitHub’s implicit `success()` on transitive needs when routed web jobs skip; the explicit preflight check keeps macOS runners off until the cheap Linux layer passes.
> 
> **`release-build`** uses the same preflight guard plus **`needs.swift-package-tests.result == 'success'`** so a failed package-test job does not start a long release build without the Ghostty CLI artifact.
> 
> **`tests/test_ci_change_areas.py`** now asserts these exact `if` strings (including a separate assertion for `release-build`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf1e4210a81bf1207ca8787cc7bab076dac4520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI so macOS‑only PRs stop failing the required tests gate. macOS jobs now wait for `linux-preflight` and no longer inherit skipped states; web‑inclusive PRs are unchanged.

- **Bug Fixes**
  - Guard `app-host-unit-tests`, `swift-package-tests`, and `tests-build-and-lag` with `if: ${{ !cancelled() && needs.changes.outputs.macos == 'true' && needs.linux-preflight.result == 'success' }}`.
  - Guard `release-build` with the same plus `needs.swift-package-tests.result == 'success'` to avoid starting without required artifacts.
  - Update `tests/test_ci_change_areas.py` to assert these exact guards for all four jobs; reverting any clause fails the test.

<sup>Written for commit fcf1e4210a81bf1207ca8787cc7bab076dac4520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI job gating so macOS jobs only run when earlier checks pass and the workflow is still active.
  * Added stricter ordering for release builds to wait for required test results before creating artifacts.
* **Tests**
  * Updated CI validation coverage to reflect the new job conditions and dependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->