### PR TITLE
taskmanager: honest memory labels, untruncated grouping, agent row folding

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -16144,7 +16144,7 @@ struct CMUXCLI {
 
             Output:
               CPU comes from macOS process accounting and can exceed 100% across cores.
-              Memory is summed from macOS physical footprint across the unique process IDs attributed to each tree node.
+              Memory is a summed physical footprint; shared pages can be counted once per attributed process.
               Browser webviews are attributed through their WebKit content process PID.
               TSV columns are: cpu_percent, memory_bytes, process_count, kind, ref, parent_ref, title.
 

--- a/Sources/CmuxTopMemoryDiagnostics.swift
+++ b/Sources/CmuxTopMemoryDiagnostics.swift
@@ -163,9 +163,11 @@ nonisolated extension CmuxTopProcessSnapshot {
                 ?? cmuxTopCanonicalProcessName(name: process.name, path: process.path)
                     .trimmingCharacters(in: .whitespacesAndNewlines)
             let groupName = displayName.isEmpty ? "pid-\(pid)" : displayName
-            let key = groupName
+            // Case-insensitive key so casing variants of one executable share a group;
+            // id/name keep the first-seen display casing.
+            let key = groupName.lowercased()
             if groups[key] == nil {
-                groups[key] = MemoryDiagnosticGroupAccumulator(id: key, name: groupName)
+                groups[key] = MemoryDiagnosticGroupAccumulator(id: groupName, name: groupName)
             }
             groups[key]?.append(
                 process: process,

--- a/Sources/CmuxTopMemoryDiagnostics.swift
+++ b/Sources/CmuxTopMemoryDiagnostics.swift
@@ -163,11 +163,12 @@ nonisolated extension CmuxTopProcessSnapshot {
                 ?? cmuxTopCanonicalProcessName(name: process.name, path: process.path)
                     .trimmingCharacters(in: .whitespacesAndNewlines)
             let groupName = displayName.isEmpty ? "pid-\(pid)" : displayName
-            // Case-insensitive key so casing variants of one executable share a group;
-            // id/name keep the first-seen display casing.
+            // Case-insensitive key so casing variants of one executable share a group.
+            // The key is also the stable group id (row identity across samples);
+            // only the display name keeps the first-seen casing.
             let key = groupName.lowercased()
             if groups[key] == nil {
-                groups[key] = MemoryDiagnosticGroupAccumulator(id: groupName, name: groupName)
+                groups[key] = MemoryDiagnosticGroupAccumulator(id: key, name: groupName)
             }
             groups[key]?.append(
                 process: process,

--- a/Sources/CmuxTopMemoryDiagnostics.swift
+++ b/Sources/CmuxTopMemoryDiagnostics.swift
@@ -156,13 +156,16 @@ nonisolated extension CmuxTopProcessSnapshot {
         attributionByPID: [Int: CmuxTopProcessAttribution]
     ) -> [[String: Any]] {
         var groups: [String: MemoryDiagnosticGroupAccumulator] = [:]
+        let agentDefinitions = codingAgentDefinitionsByPID(for: pids)
         for pid in pids.sorted() {
             guard let process = processesByPID[pid] else { continue }
-            let name = process.name.trimmingCharacters(in: .whitespacesAndNewlines)
-            let displayName = name.isEmpty ? "pid-\(pid)" : name
-            let key = displayName.lowercased()
+            let displayName = agentDefinitions[pid]?.displayName
+                ?? cmuxTopCanonicalProcessName(name: process.name, path: process.path)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            let groupName = displayName.isEmpty ? "pid-\(pid)" : displayName
+            let key = groupName
             if groups[key] == nil {
-                groups[key] = MemoryDiagnosticGroupAccumulator(id: key, name: displayName)
+                groups[key] = MemoryDiagnosticGroupAccumulator(id: key, name: groupName)
             }
             groups[key]?.append(
                 process: process,

--- a/Sources/CmuxTopProcessNaming.swift
+++ b/Sources/CmuxTopProcessNaming.swift
@@ -12,6 +12,9 @@ nonisolated func cmuxTopCanonicalProcessName(name: String, path: String?) -> Str
 /// Lock-guarded per-PID memo for coding-agent classification. The mutable cache is
 /// private so no caller can touch it without going through the guarded accessor,
 /// which preserves the snapshot's `@unchecked Sendable` safety argument.
+/// A lock (not an actor) is deliberate: every consumer is a synchronous
+/// `nonisolated` payload builder on the snapshot, so actor isolation would force
+/// `await` through the synchronous socket payload pipeline.
 nonisolated final class CmuxTopCodingAgentDefinitionMemo: @unchecked Sendable {
     private let lock = NSLock()
     private var cache: [Int: CmuxTaskManagerCodingAgentDefinition?] = [:]

--- a/Sources/CmuxTopProcessNaming.swift
+++ b/Sources/CmuxTopProcessNaming.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+nonisolated func cmuxTopCanonicalProcessName(name: String, path: String?) -> String {
+    guard name.count == 15 || name.count == 16 else { return name }
+    guard let path, !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return name }
+    let basename = (path as NSString).lastPathComponent
+    guard basename.count > name.count else { return name }
+    guard basename.lowercased().hasPrefix(name.lowercased()) else { return name }
+    return basename
+}
+
+nonisolated extension CmuxTopProcessSnapshot {
+    func codingAgentDefinitionsByPID(
+        for pids: some Sequence<Int>
+    ) -> [Int: CmuxTaskManagerCodingAgentDefinition] {
+        var definitions: [Int: CmuxTaskManagerCodingAgentDefinition] = [:]
+        for pid in pids {
+            guard let process = processesByPID[pid] else { continue }
+            let processArguments = Self.processArgumentsIfNeeded(for: process)
+            guard let definition = CmuxTaskManagerCodingAgentDefinition.matchingDefinition(
+                processName: process.name,
+                processPath: process.path,
+                arguments: processArguments?.arguments ?? [],
+                environment: processArguments?.environment ?? [:]
+            ) else { continue }
+            definitions[pid] = definition
+        }
+        return definitions
+    }
+}

--- a/Sources/CmuxTopProcessNaming.swift
+++ b/Sources/CmuxTopProcessNaming.swift
@@ -10,21 +10,49 @@ nonisolated func cmuxTopCanonicalProcessName(name: String, path: String?) -> Str
 }
 
 nonisolated extension CmuxTopProcessSnapshot {
+    static func processArgumentsIfNeeded(for process: CmuxTopProcessInfo) -> CmuxTopProcessArguments? {
+        guard CmuxTaskManagerCodingAgentDefinition.shouldReadArguments(
+            processName: process.name,
+            processPath: process.path
+        ) else { return nil }
+        return processArgumentsAndEnvironment(for: process.pid)
+    }
+
+    /// Memoized per snapshot: each PID is classified at most once, so program totals,
+    /// coding-agent totals, and memory diagnostics always agree even if a process
+    /// exits (or KERN_PROCARGS2 stops answering) between payload sections, and the
+    /// live argument read runs at most once per PID per snapshot.
     func codingAgentDefinitionsByPID(
         for pids: some Sequence<Int>
     ) -> [Int: CmuxTaskManagerCodingAgentDefinition] {
         var definitions: [Int: CmuxTaskManagerCodingAgentDefinition] = [:]
+        codingAgentDefinitionCacheLock.lock()
+        defer { codingAgentDefinitionCacheLock.unlock() }
         for pid in pids {
-            guard let process = processesByPID[pid] else { continue }
-            let processArguments = Self.processArgumentsIfNeeded(for: process)
-            guard let definition = CmuxTaskManagerCodingAgentDefinition.matchingDefinition(
-                processName: process.name,
-                processPath: process.path,
-                arguments: processArguments?.arguments ?? [],
-                environment: processArguments?.environment ?? [:]
-            ) else { continue }
-            definitions[pid] = definition
+            let definition: CmuxTaskManagerCodingAgentDefinition?
+            if let cached = codingAgentDefinitionCache[pid] {
+                definition = cached
+            } else {
+                definition = classifyCodingAgent(pid: pid)
+                // updateValue stores .some(nil) for unclassified PIDs; plain subscript
+                // assignment of a nil optional would remove the entry instead.
+                codingAgentDefinitionCache.updateValue(definition, forKey: pid)
+            }
+            if let definition {
+                definitions[pid] = definition
+            }
         }
         return definitions
+    }
+
+    private func classifyCodingAgent(pid: Int) -> CmuxTaskManagerCodingAgentDefinition? {
+        guard let process = processesByPID[pid] else { return nil }
+        let processArguments = Self.processArgumentsIfNeeded(for: process)
+        return CmuxTaskManagerCodingAgentDefinition.matchingDefinition(
+            processName: process.name,
+            processPath: process.path,
+            arguments: processArguments?.arguments ?? [],
+            environment: processArguments?.environment ?? [:]
+        )
     }
 }

--- a/Sources/CmuxTopProcessNaming.swift
+++ b/Sources/CmuxTopProcessNaming.swift
@@ -9,6 +9,38 @@ nonisolated func cmuxTopCanonicalProcessName(name: String, path: String?) -> Str
     return basename
 }
 
+/// Lock-guarded per-PID memo for coding-agent classification. The mutable cache is
+/// private so no caller can touch it without going through the guarded accessor,
+/// which preserves the snapshot's `@unchecked Sendable` safety argument.
+nonisolated final class CmuxTopCodingAgentDefinitionMemo: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cache: [Int: CmuxTaskManagerCodingAgentDefinition?] = [:]
+
+    func definitions(
+        for pids: some Sequence<Int>,
+        classify: (Int) -> CmuxTaskManagerCodingAgentDefinition?
+    ) -> [Int: CmuxTaskManagerCodingAgentDefinition] {
+        var definitions: [Int: CmuxTaskManagerCodingAgentDefinition] = [:]
+        lock.lock()
+        defer { lock.unlock() }
+        for pid in pids {
+            let definition: CmuxTaskManagerCodingAgentDefinition?
+            if let cached = cache[pid] {
+                definition = cached
+            } else {
+                definition = classify(pid)
+                // updateValue stores .some(nil) for unclassified PIDs; plain subscript
+                // assignment of a nil optional would remove the entry instead.
+                cache.updateValue(definition, forKey: pid)
+            }
+            if let definition {
+                definitions[pid] = definition
+            }
+        }
+        return definitions
+    }
+}
+
 nonisolated extension CmuxTopProcessSnapshot {
     static func processArgumentsIfNeeded(for process: CmuxTopProcessInfo) -> CmuxTopProcessArguments? {
         guard CmuxTaskManagerCodingAgentDefinition.shouldReadArguments(
@@ -25,34 +57,15 @@ nonisolated extension CmuxTopProcessSnapshot {
     func codingAgentDefinitionsByPID(
         for pids: some Sequence<Int>
     ) -> [Int: CmuxTaskManagerCodingAgentDefinition] {
-        var definitions: [Int: CmuxTaskManagerCodingAgentDefinition] = [:]
-        codingAgentDefinitionCacheLock.lock()
-        defer { codingAgentDefinitionCacheLock.unlock() }
-        for pid in pids {
-            let definition: CmuxTaskManagerCodingAgentDefinition?
-            if let cached = codingAgentDefinitionCache[pid] {
-                definition = cached
-            } else {
-                definition = classifyCodingAgent(pid: pid)
-                // updateValue stores .some(nil) for unclassified PIDs; plain subscript
-                // assignment of a nil optional would remove the entry instead.
-                codingAgentDefinitionCache.updateValue(definition, forKey: pid)
-            }
-            if let definition {
-                definitions[pid] = definition
-            }
+        codingAgentDefinitionMemo.definitions(for: pids) { pid in
+            guard let process = processesByPID[pid] else { return nil }
+            let processArguments = Self.processArgumentsIfNeeded(for: process)
+            return CmuxTaskManagerCodingAgentDefinition.matchingDefinition(
+                processName: process.name,
+                processPath: process.path,
+                arguments: processArguments?.arguments ?? [],
+                environment: processArguments?.environment ?? [:]
+            )
         }
-        return definitions
-    }
-
-    private func classifyCodingAgent(pid: Int) -> CmuxTaskManagerCodingAgentDefinition? {
-        guard let process = processesByPID[pid] else { return nil }
-        let processArguments = Self.processArgumentsIfNeeded(for: process)
-        return CmuxTaskManagerCodingAgentDefinition.matchingDefinition(
-            processName: process.name,
-            processPath: process.path,
-            arguments: processArguments?.arguments ?? [],
-            environment: processArguments?.environment ?? [:]
-        )
     }
 }

--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -354,11 +354,16 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
     }
 
     func programSummaryPayload(for pids: Set<Int>) -> [[String: Any]] {
+        let codingAgentDefinitions = codingAgentDefinitionsByPID(for: pids)
         var aggregates: [String: CmuxProgramProcessAggregate] = [:]
 
         for pid in pids.sorted() {
             guard let process = processesByPID[pid] else { continue }
-            let title = process.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard codingAgentDefinitions[pid] == nil else { continue }
+            let title = cmuxTopCanonicalProcessName(
+                name: process.name,
+                path: process.path
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
             guard !title.isEmpty else { continue }
             let key = title.lowercased()
             if aggregates[key] == nil {
@@ -426,16 +431,11 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
 
     func codingAgentSummaryPayload(for pids: Set<Int>) -> [[String: Any]] {
         var aggregates: [String: CmuxCodingAgentProcessAggregate] = [:]
+        let definitionsByPID = codingAgentDefinitionsByPID(for: pids)
 
         for pid in pids.sorted() {
-            guard let process = processesByPID[pid] else { continue }
-            let processArguments = Self.processArgumentsIfNeeded(for: process)
-            guard let definition = CmuxTaskManagerCodingAgentDefinition.matchingDefinition(
-                processName: process.name,
-                processPath: process.path,
-                arguments: processArguments?.arguments ?? [],
-                environment: processArguments?.environment ?? [:]
-            ) else { continue }
+            guard let process = processesByPID[pid],
+                  let definition = definitionsByPID[pid] else { continue }
 
             if aggregates[definition.id] == nil {
                 aggregates[definition.id] = CmuxCodingAgentProcessAggregate(definition: definition)
@@ -449,7 +449,7 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
         }
     }
 
-    private static func processArgumentsIfNeeded(for process: CmuxTopProcessInfo) -> CmuxTopProcessArguments? {
+    static func processArgumentsIfNeeded(for process: CmuxTopProcessInfo) -> CmuxTopProcessArguments? {
         guard CmuxTaskManagerCodingAgentDefinition.shouldReadArguments(
             processName: process.name,
             processPath: process.path

--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -138,8 +138,7 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
     private let pidsByTTYDevice: [Int64: [Int]]
     private let pidsByCMUXSurfaceID: [UUID: [Int]]
     private let residentMemorySources: [CmuxTopProcessMemorySource]
-    let codingAgentDefinitionCacheLock = NSLock()
-    var codingAgentDefinitionCache: [Int: CmuxTaskManagerCodingAgentDefinition?] = [:]
+    let codingAgentDefinitionMemo = CmuxTopCodingAgentDefinitionMemo()
 
     static func capture(
         includeProcessDetails: Bool = false,

--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -138,6 +138,8 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
     private let pidsByTTYDevice: [Int64: [Int]]
     private let pidsByCMUXSurfaceID: [UUID: [Int]]
     private let residentMemorySources: [CmuxTopProcessMemorySource]
+    let codingAgentDefinitionCacheLock = NSLock()
+    var codingAgentDefinitionCache: [Int: CmuxTaskManagerCodingAgentDefinition?] = [:]
 
     static func capture(
         includeProcessDetails: Bool = false,
@@ -447,14 +449,6 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
             guard let aggregate = aggregates[definition.id] else { return nil }
             return aggregate.payload()
         }
-    }
-
-    static func processArgumentsIfNeeded(for process: CmuxTopProcessInfo) -> CmuxTopProcessArguments? {
-        guard CmuxTaskManagerCodingAgentDefinition.shouldReadArguments(
-            processName: process.name,
-            processPath: process.path
-        ) else { return nil }
-        return processArgumentsAndEnvironment(for: process.pid)
     }
 
     private struct CmuxProgramProcessAggregate {

--- a/Sources/TaskManagerSnapshot.swift
+++ b/Sources/TaskManagerSnapshot.swift
@@ -87,10 +87,10 @@ struct CmuxTaskManagerSnapshot {
             assetNameByProcessID: Self.agentAssetNameByProcessID(from: agentRows)
         )
         self.agentRows = agentRows
-        let programTotalPayloads = payload["program_totals"] as? [[String: Any]] ?? []
-        self.aggregateRows = programTotalPayloads.isEmpty
-            ? Self.programAggregateRows(from: self.rows)
-            : Self.programAggregateRows(fromPayloads: programTotalPayloads)
+        // Present-but-empty program_totals is meaningful; only absent means legacy fallback.
+        self.aggregateRows = (payload["program_totals"] as? [[String: Any]])
+            .map(Self.programAggregateRows(fromPayloads:))
+            ?? Self.programAggregateRows(from: self.rows)
         let memoryDiagnostic = CmuxTaskManagerMemoryDiagnostic(payload["memory_diagnostic"] as? [String: Any])
         self.memoryDiagnostic = memoryDiagnostic
         self.childMemoryRows = Self.childMemoryRows(from: memoryDiagnostic)

--- a/Sources/TaskManagerView.swift
+++ b/Sources/TaskManagerView.swift
@@ -75,9 +75,10 @@ struct CmuxTaskManagerView: View {
                 value: CmuxTaskManagerFormat.cpu(model.snapshot.total.cpuPercent)
             )
             metric(
-                title: String(localized: "taskManager.summary.memory", defaultValue: "Memory"),
+                title: String(localized: "taskManager.summary.summedFootprint", defaultValue: "Summed Footprint"),
                 value: CmuxTaskManagerFormat.bytes(model.snapshot.total.memoryBytes)
             )
+            .help(String(localized: "taskManager.summary.summedFootprint.help", defaultValue: "Sum of each process's physical footprint. Shared memory (frameworks, dyld cache, IOSurfaces) is counted once per process, so this overstates real usage."))
             if let memoryDiagnostic = model.snapshot.memoryDiagnostic {
                 metric(
                     title: String(localized: "taskManager.summary.appFootprint", defaultValue: "App Footprint"),

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -470,6 +470,7 @@
 		C750500000000000000000A3 /* CmuxTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = C750500000000000000000A2 /* CmuxTerminal */; };
 		C750200000000000000000A3 /* CmuxTerminalCore in Frameworks */ = {isa = PBXBuildFile; productRef = C750200000000000000000A2 /* CmuxTerminalCore */; };
 		CFF12E0000000000000000A3 /* CmuxTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = CFF12E0000000000000000A2 /* CmuxTestSupport */; };
+		C7A514000000000000000002 /* CmuxTopAccountingGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A514000000000000000001 /* CmuxTopAccountingGroupingTests.swift */; };
 		C7A510000000000000000002 /* CmuxTopMemoryDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */; };
 		B35750000000000000000004 /* CmuxTopProcessArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000003 /* CmuxTopProcessArguments.swift */; };
 		C7A50C000000000000000003 /* CmuxTopProcessArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */; };
@@ -477,6 +478,7 @@
 		C7A50D000000000000000002 /* CmuxTopProcessCPUTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50D000000000000000001 /* CmuxTopProcessCPUTracker.swift */; };
 		C7A50E000000000000000002 /* CmuxTopProcessDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50E000000000000000001 /* CmuxTopProcessDetails.swift */; };
 		C7A511000000000000000002 /* CmuxTopProcessEnumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A511000000000000000001 /* CmuxTopProcessEnumeration.swift */; };
+		C7A513000000000000000002 /* CmuxTopProcessNaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A513000000000000000001 /* CmuxTopProcessNaming.swift */; };
 		C7A512000000000000000002 /* CmuxTopProcessSnapshotCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A512000000000000000001 /* CmuxTopProcessSnapshotCache.swift */; };
 		C7A501000000000000000002 /* CmuxTopSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A501000000000000000001 /* CmuxTopSnapshot.swift */; };
 		C7A508000000000000000002 /* CmuxTopSnapshotScopeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A508000000000000000001 /* CmuxTopSnapshotScopeCache.swift */; };
@@ -1966,6 +1968,7 @@
 		C3677001000000000000002 /* CmuxSSHURLRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxSSHURLRequestTests.swift; sourceTree = "<group>"; };
 		C10D00040000000000000004 /* CmuxSurfaceTabBarBuiltInAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxSurfaceTabBarBuiltInAction.swift; sourceTree = "<group>"; };
 		F1000002A1B2C3D4E5F60718 /* cmuxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7A514000000000000000001 /* CmuxTopAccountingGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopAccountingGroupingTests.swift; sourceTree = "<group>"; };
 		C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopMemoryDiagnostics.swift; sourceTree = "<group>"; };
 		B35750000000000000000003 /* CmuxTopProcessArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessArguments.swift; sourceTree = "<group>"; };
 		C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessArgumentsTests.swift; sourceTree = "<group>"; };
@@ -1973,6 +1976,7 @@
 		C7A50D000000000000000001 /* CmuxTopProcessCPUTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessCPUTracker.swift; sourceTree = "<group>"; };
 		C7A50E000000000000000001 /* CmuxTopProcessDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessDetails.swift; sourceTree = "<group>"; };
 		C7A511000000000000000001 /* CmuxTopProcessEnumeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessEnumeration.swift; sourceTree = "<group>"; };
+		C7A513000000000000000001 /* CmuxTopProcessNaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessNaming.swift; sourceTree = "<group>"; };
 		C7A512000000000000000001 /* CmuxTopProcessSnapshotCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessSnapshotCache.swift; sourceTree = "<group>"; };
 		C7A501000000000000000001 /* CmuxTopSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshot.swift; sourceTree = "<group>"; };
 		C7A508000000000000000001 /* CmuxTopSnapshotScopeCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeCache.swift; sourceTree = "<group>"; };
@@ -3622,6 +3626,7 @@
 				C7A501000000000000000001 /* CmuxTopSnapshot.swift */,
 				C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */,
 				C7A511000000000000000001 /* CmuxTopProcessEnumeration.swift */,
+				C7A513000000000000000001 /* CmuxTopProcessNaming.swift */,
 				C7A512000000000000000001 /* CmuxTopProcessSnapshotCache.swift */,
 				B35750000000000000000003 /* CmuxTopProcessArguments.swift */,
 				C7A508000000000000000001 /* CmuxTopSnapshotScopeCache.swift */,
@@ -4481,6 +4486,7 @@
 				C7A507000000000000000001 /* TaskManagerResourcesTests.swift */,
 				C7A507000000000000004530 /* TaskManagerViewSnapshotBoundaryTests.swift */,
 				C7A507000000000000005795 /* NotificationRowSnapshotBoundaryTests.swift */,
+				C7A514000000000000000001 /* CmuxTopAccountingGroupingTests.swift */,
 				C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */,
 				C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */,
 				C7A50C000000000000000001 /* CmuxTopProcessCPUTests.swift */,
@@ -5211,6 +5217,7 @@
 				C7A50D000000000000000002 /* CmuxTopProcessCPUTracker.swift in Sources */,
 				C7A50E000000000000000002 /* CmuxTopProcessDetails.swift in Sources */,
 				C7A511000000000000000002 /* CmuxTopProcessEnumeration.swift in Sources */,
+				C7A513000000000000000002 /* CmuxTopProcessNaming.swift in Sources */,
 				C7A512000000000000000002 /* CmuxTopProcessSnapshotCache.swift in Sources */,
 				C7A501000000000000000002 /* CmuxTopSnapshot.swift in Sources */,
 				C7A508000000000000000002 /* CmuxTopSnapshotScopeCache.swift in Sources */,
@@ -6134,6 +6141,7 @@
 				C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */,
 				C0DE31390000000000000111 /* CMUXOpenHTMLFocusTests.swift in Sources */,
 				C3677001000000000000001 /* CmuxSSHURLRequestTests.swift in Sources */,
+				C7A514000000000000000002 /* CmuxTopAccountingGroupingTests.swift in Sources */,
 				C7A50C000000000000000003 /* CmuxTopProcessArgumentsTests.swift in Sources */,
 				C7A50C000000000000000002 /* CmuxTopProcessCPUTests.swift in Sources */,
 				C7A5090000000000000005A2 /* CmuxTopSnapshotScopeCacheTests.swift in Sources */,

--- a/cmuxTests/CmuxTopAccountingGroupingTests.swift
+++ b/cmuxTests/CmuxTopAccountingGroupingTests.swift
@@ -1,0 +1,186 @@
+import Darwin
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct CmuxTopAccountingGroupingTests {
+    @Test func canonicalProcessNameUsesPathBasenameOnlyForTruncatedNames() {
+        #expect(cmuxTopCanonicalProcessName(
+            name: "com.apple.WebKi",
+            path: "/System/Library/com.apple.WebKit.WebContent"
+        ) == "com.apple.WebKit.WebContent")
+        #expect(cmuxTopCanonicalProcessName(name: "node", path: "/usr/local/bin/node") == "node")
+        #expect(cmuxTopCanonicalProcessName(name: "com.apple.WebKi", path: nil) == "com.apple.WebKi")
+        #expect(cmuxTopCanonicalProcessName(
+            name: "abcdefghijklmnop",
+            path: "/usr/bin/other-helper"
+        ) == "abcdefghijklmnop")
+        #expect(cmuxTopCanonicalProcessName(
+            name: "COM.APPLE.WEBKI",
+            path: "/System/Library/com.apple.WebKit.Networking"
+        ) == "com.apple.WebKit.Networking")
+    }
+
+    @Test func programRowsExcludeVersionedCodingAgentProcesses() throws {
+        let firstAgent = try SpawnedVersionedClaudeProcess.start()
+        let secondAgent = try SpawnedVersionedClaudeProcess.start()
+        defer {
+            firstAgent.terminate()
+            secondAgent.terminate()
+        }
+
+        let snapshot = snapshot([
+            process(pid: firstAgent.pid, name: "2.1.204", path: SpawnedVersionedClaudeProcess.executablePath),
+            process(pid: secondAgent.pid, name: "2.1.204", path: SpawnedVersionedClaudeProcess.executablePath),
+            process(pid: 9_001, name: "worker", path: "/usr/bin/worker"),
+            process(pid: 9_002, name: "worker", path: "/usr/bin/worker")
+        ])
+        let pids: Set<Int> = [firstAgent.pid, secondAgent.pid, 9_001, 9_002]
+
+        let programNames = snapshot.programSummaryPayload(for: pids).compactMap { $0["name"] as? String }
+        let codingAgentNames = snapshot.codingAgentSummaryPayload(for: pids).compactMap {
+            $0["display_name"] as? String
+        }
+
+        #expect(programNames.contains("worker"))
+        #expect(!programNames.contains("2.1.204"))
+        #expect(codingAgentNames == ["Claude Code"])
+    }
+
+    @Test func programRowsUseCanonicalUntruncatedDisplayName() {
+        let snapshot = snapshot([
+            process(pid: 101, name: "com.apple.WebKi", path: "/System/Library/com.apple.WebKit.WebContent"),
+            process(pid: 102, name: "com.apple.WebKi", path: "/System/Library/com.apple.WebKit.WebContent")
+        ])
+
+        let programs = snapshot.programSummaryPayload(for: [101, 102])
+        let names = programs.compactMap { $0["name"] as? String }
+
+        #expect(names == ["com.apple.WebKit.WebContent"])
+    }
+
+    @Test func memoryDiagnosticsFoldAgentsAndCanonicalizeChildGroups() throws {
+        let firstAgent = try SpawnedVersionedClaudeProcess.start()
+        let secondAgent = try SpawnedVersionedClaudeProcess.start()
+        defer {
+            firstAgent.terminate()
+            secondAgent.terminate()
+        }
+
+        let appPID = 42
+        let snapshot = snapshot([
+            process(pid: appPID, parentPID: 0, name: "cmux", path: "/Applications/cmux.app/cmux"),
+            process(pid: firstAgent.pid, parentPID: appPID, name: "2.1.204", path: SpawnedVersionedClaudeProcess.executablePath),
+            process(pid: secondAgent.pid, parentPID: appPID, name: "2.1.204", path: SpawnedVersionedClaudeProcess.executablePath),
+            process(pid: 201, parentPID: appPID, name: "com.apple.WebKi", path: "/System/Library/com.apple.WebKit.WebContent"),
+            process(pid: 202, parentPID: appPID, name: "com.apple.WebKi", path: "/System/Library/com.apple.WebKit.WebContent")
+        ])
+
+        let payload = snapshot.memoryDiagnosticPayload(appPID: appPID, topGroupLimit: 10)
+        let children = try #require(payload["children"] as? [String: Any])
+        let groups = try #require(children["groups"] as? [[String: Any]])
+        let groupNames = groups.compactMap { $0["name"] as? String }
+        let groupIds = groups.compactMap { $0["id"] as? String }
+
+        #expect(groupNames.contains("Claude Code"))
+        #expect(groupNames.contains("com.apple.WebKit.WebContent"))
+        #expect(groupIds.contains("Claude Code"))
+        #expect(groupIds.contains("com.apple.WebKit.WebContent"))
+        #expect(!groupNames.contains("2.1.204"))
+        #expect(!groupNames.contains("com.apple.WebKi"))
+    }
+
+    @Test func totalsMemoryBytesRemainClampedSum() {
+        let snapshot = snapshot([
+            process(pid: 301, name: "first", memoryBytes: Int64.max - 4, residentBytes: 1),
+            process(pid: 302, name: "second", memoryBytes: 10, residentBytes: 1)
+        ])
+
+        let payload = snapshot.summaryPayload(for: [301, 302])
+
+        #expect(payload["memory_bytes"] as? Int64 == Int64.max)
+    }
+
+    private func snapshot(_ processes: [CmuxTopProcessInfo]) -> CmuxTopProcessSnapshot {
+        CmuxTopProcessSnapshot(
+            processes: processes,
+            sampledAt: Date(timeIntervalSince1970: 0),
+            includesProcessDetails: true
+        )
+    }
+
+    private func process(
+        pid: Int,
+        parentPID: Int = 0,
+        name: String,
+        path: String? = nil,
+        memoryBytes: Int64 = 1024,
+        residentBytes: Int64 = 512
+    ) -> CmuxTopProcessInfo {
+        CmuxTopProcessInfo(
+            pid: pid,
+            parentPID: parentPID,
+            name: name,
+            path: path,
+            ttyDevice: nil,
+            cmuxWorkspaceID: nil,
+            cmuxSurfaceID: nil,
+            cmuxAttributionReason: nil,
+            processGroupID: nil,
+            terminalProcessGroupID: nil,
+            cpuPercent: 0,
+            memoryBytes: memoryBytes,
+            residentBytes: residentBytes,
+            virtualBytes: 0,
+            threadCount: 1
+        )
+    }
+}
+
+private final class SpawnedVersionedClaudeProcess {
+    static let executablePath = "/Users/example/.local/share/claude/versions/2.1.204"
+
+    let process: Process
+    let pid: Int
+
+    private init(process: Process) {
+        self.process = process
+        self.pid = Int(process.processIdentifier)
+    }
+
+    static func start() throws -> SpawnedVersionedClaudeProcess {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["-c", "exec -a '\(executablePath)' /bin/sleep 30"]
+        try process.run()
+        let fixture = SpawnedVersionedClaudeProcess(process: process)
+        try fixture.waitForReadableArguments()
+        return fixture
+    }
+
+    func terminate() {
+        guard process.isRunning else { return }
+        process.terminate()
+        process.waitUntilExit()
+    }
+
+    private func waitForReadableArguments() throws {
+        for _ in 0..<100 {
+            let arguments = CmuxTopProcessSnapshot.processArgumentsAndEnvironment(for: pid)?.arguments ?? []
+            if arguments.contains(where: { $0.contains("/.local/share/claude/versions/") }) {
+                return
+            }
+            usleep(20_000)
+        }
+        throw SpawnedVersionedClaudeProcessError.argumentsUnavailable
+    }
+}
+
+private enum SpawnedVersionedClaudeProcessError: Error {
+    case argumentsUnavailable
+}

--- a/cmuxTests/CmuxTopAccountingGroupingTests.swift
+++ b/cmuxTests/CmuxTopAccountingGroupingTests.swift
@@ -121,6 +121,38 @@ import Testing
         #expect(groupNames.filter { $0.lowercased() == "node" }.count == 1)
     }
 
+    @Test func snapshotParserHonorsExplicitlyEmptyProgramTotals() {
+        func windowPayload() -> [String: Any] {
+            [
+                "id": "window-1",
+                "ref": "window:1",
+                "processes": [
+                    ["pid": 101, "name": "2.1.204", "resources": ["cpu_percent": 1.0, "resident_bytes": 100]],
+                    ["pid": 202, "name": "2.1.204", "resources": ["cpu_percent": 2.0, "resident_bytes": 200]],
+                ],
+            ]
+        }
+
+        // Present-but-empty program_totals means the backend intentionally has no
+        // program aggregates (e.g. the only repeated processes are coding agents);
+        // the client must not recreate them from process rows.
+        let explicitlyEmpty = CmuxTaskManagerSnapshot(payload: [
+            "sample": ["sampled_at": "2026-05-13T12:00:00Z"],
+            "totals": [:],
+            "program_totals": [] as [[String: Any]],
+            "windows": [windowPayload()],
+        ])
+        #expect(explicitlyEmpty.aggregateRows.isEmpty)
+
+        // Absent program_totals is a legacy payload; client-side fallback applies.
+        let legacyAbsent = CmuxTaskManagerSnapshot(payload: [
+            "sample": ["sampled_at": "2026-05-13T12:00:00Z"],
+            "totals": [:],
+            "windows": [windowPayload()],
+        ])
+        #expect(legacyAbsent.aggregateRows.map(\.title) == ["2.1.204"])
+    }
+
     @Test func totalsMemoryBytesRemainClampedSum() {
         let snapshot = snapshot([
             process(pid: 301, name: "first", memoryBytes: Int64.max - 4, residentBytes: 1),

--- a/cmuxTests/CmuxTopAccountingGroupingTests.swift
+++ b/cmuxTests/CmuxTopAccountingGroupingTests.swift
@@ -100,7 +100,9 @@ import Testing
             process(pid: firstAgent.pid, parentPID: appPID, name: "2.1.204", path: SpawnedVersionedClaudeProcess.executablePath),
             process(pid: secondAgent.pid, parentPID: appPID, name: "2.1.204", path: SpawnedVersionedClaudeProcess.executablePath),
             process(pid: 201, parentPID: appPID, name: "com.apple.WebKi", path: "/System/Library/com.apple.WebKit.WebContent"),
-            process(pid: 202, parentPID: appPID, name: "com.apple.WebKi", path: "/System/Library/com.apple.WebKit.WebContent")
+            process(pid: 202, parentPID: appPID, name: "com.apple.WebKi", path: "/System/Library/com.apple.WebKit.WebContent"),
+            process(pid: 203, parentPID: appPID, name: "node", path: "/usr/local/bin/node"),
+            process(pid: 204, parentPID: appPID, name: "Node", path: "/usr/local/bin/Node")
         ])
 
         let payload = snapshot.memoryDiagnosticPayload(appPID: appPID, topGroupLimit: 10)
@@ -115,6 +117,8 @@ import Testing
         #expect(groupIds.contains("com.apple.WebKit.WebContent"))
         #expect(!groupNames.contains("2.1.204"))
         #expect(!groupNames.contains("com.apple.WebKi"))
+        // Casing variants of the same executable fold into one group.
+        #expect(groupNames.filter { $0.lowercased() == "node" }.count == 1)
     }
 
     @Test func totalsMemoryBytesRemainClampedSum() {

--- a/cmuxTests/CmuxTopAccountingGroupingTests.swift
+++ b/cmuxTests/CmuxTopAccountingGroupingTests.swift
@@ -113,8 +113,9 @@ import Testing
 
         #expect(groupNames.contains("Claude Code"))
         #expect(groupNames.contains("com.apple.WebKit.WebContent"))
-        #expect(groupIds.contains("Claude Code"))
-        #expect(groupIds.contains("com.apple.WebKit.WebContent"))
+        // Group ids stay lowercased (stable row identity); names keep display casing.
+        #expect(groupIds.contains("claude code"))
+        #expect(groupIds.contains("com.apple.webkit.webcontent"))
         #expect(!groupNames.contains("2.1.204"))
         #expect(!groupNames.contains("com.apple.WebKi"))
         // Casing variants of the same executable fold into one group.

--- a/cmuxTests/CmuxTopAccountingGroupingTests.swift
+++ b/cmuxTests/CmuxTopAccountingGroupingTests.swift
@@ -52,6 +52,28 @@ import Testing
         #expect(codingAgentNames == ["Claude Code"])
     }
 
+    @Test func agentClassificationStaysConsistentWithinSnapshotAfterProcessExit() throws {
+        let agent = try SpawnedVersionedClaudeProcess.start()
+        defer { agent.terminate() }
+
+        let snapshot = snapshot([
+            process(pid: agent.pid, name: "2.1.204", path: SpawnedVersionedClaudeProcess.executablePath),
+            process(pid: 9_003, name: "worker", path: "/usr/bin/worker")
+        ])
+        let pids: Set<Int> = [agent.pid, 9_003]
+
+        // Classify while the process is alive, as the coding_agents section does.
+        #expect(snapshot.codingAgentSummaryPayload(for: pids).count == 1)
+
+        // Reap the process; live KERN_PROCARGS2 reads for this PID now fail.
+        agent.terminate()
+
+        // The same snapshot must keep the classification for every payload section.
+        let programNames = snapshot.programSummaryPayload(for: pids).compactMap { $0["name"] as? String }
+        #expect(!programNames.contains("2.1.204"))
+        #expect(snapshot.codingAgentSummaryPayload(for: pids).count == 1)
+    }
+
     @Test func programRowsUseCanonicalUntruncatedDisplayName() {
         let snapshot = snapshot([
             process(pid: 101, name: "com.apple.WebKi", path: "/System/Library/com.apple.WebKit.WebContent"),

--- a/cmuxTests/CmuxTopSnapshotScopeTests.swift
+++ b/cmuxTests/CmuxTopSnapshotScopeTests.swift
@@ -346,48 +346,40 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
     }
 
     func testUnavailableMemorySourcesAreExposedInAggregatePayloads() throws {
+        func makeProcess(pid: Int, name: String, unavailable: Bool) -> CmuxTopProcessInfo {
+            CmuxTopProcessInfo(
+                pid: pid,
+                parentPID: 0,
+                name: name,
+                path: nil,
+                ttyDevice: nil,
+                cmuxWorkspaceID: nil,
+                cmuxSurfaceID: nil,
+                cmuxAttributionReason: nil,
+                processGroupID: nil,
+                terminalProcessGroupID: nil,
+                cpuPercent: unavailable ? 1 : 2,
+                memoryBytes: unavailable ? 0 : 2048,
+                memorySource: unavailable ? .unavailable : .residentSize,
+                residentBytes: unavailable ? 0 : 1024,
+                residentMemorySource: unavailable ? .unavailable : .rusageResidentSize,
+                virtualBytes: unavailable ? 0 : 4096,
+                threadCount: 1
+            )
+        }
+
+        // Coding agents are folded out of program rows, so use a non-agent pair for
+        // the summary/program assertions and an agent pair for the coding-agent one.
         let unavailablePID = 1111
         let fallbackPID = 2222
+        let agentUnavailablePID = 3333
+        let agentFallbackPID = 4444
         let snapshot = CmuxTopProcessSnapshot(
             processes: [
-                CmuxTopProcessInfo(
-                    pid: unavailablePID,
-                    parentPID: 0,
-                    name: "codex",
-                    path: nil,
-                    ttyDevice: nil,
-                    cmuxWorkspaceID: nil,
-                    cmuxSurfaceID: nil,
-                    cmuxAttributionReason: nil,
-                    processGroupID: nil,
-                    terminalProcessGroupID: nil,
-                    cpuPercent: 1,
-                    memoryBytes: 0,
-                    memorySource: .unavailable,
-                    residentBytes: 0,
-                    residentMemorySource: .unavailable,
-                    virtualBytes: 0,
-                    threadCount: 1
-                ),
-                CmuxTopProcessInfo(
-                    pid: fallbackPID,
-                    parentPID: 0,
-                    name: "codex",
-                    path: nil,
-                    ttyDevice: nil,
-                    cmuxWorkspaceID: nil,
-                    cmuxSurfaceID: nil,
-                    cmuxAttributionReason: nil,
-                    processGroupID: nil,
-                    terminalProcessGroupID: nil,
-                    cpuPercent: 2,
-                    memoryBytes: 2048,
-                    memorySource: .residentSize,
-                    residentBytes: 1024,
-                    residentMemorySource: .rusageResidentSize,
-                    virtualBytes: 4096,
-                    threadCount: 1
-                )
+                makeProcess(pid: unavailablePID, name: "worker", unavailable: true),
+                makeProcess(pid: fallbackPID, name: "worker", unavailable: false),
+                makeProcess(pid: agentUnavailablePID, name: "codex", unavailable: true),
+                makeProcess(pid: agentFallbackPID, name: "codex", unavailable: false)
             ],
             sampledAt: Date(timeIntervalSince1970: 0),
             includesProcessDetails: false
@@ -396,16 +388,24 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
         let summary = snapshot.summaryPayload(for: [unavailablePID, fallbackPID])
         assertUnavailableMemoryPayload(summary, unavailablePID: unavailablePID, fallbackPID: fallbackPID)
 
-        let program = try XCTUnwrap(snapshot.programSummaryPayload(for: [unavailablePID, fallbackPID]).first)
+        let programs = snapshot.programSummaryPayload(
+            for: [unavailablePID, fallbackPID, agentUnavailablePID, agentFallbackPID]
+        )
+        XCTAssertEqual(programs.compactMap { $0["name"] as? String }, ["worker"])
+        let program = try XCTUnwrap(programs.first)
         let programResources = try XCTUnwrap(program["resources"] as? [String: Any])
         assertUnavailableMemoryPayload(programResources, unavailablePID: unavailablePID, fallbackPID: fallbackPID)
 
         let codingAgent = try XCTUnwrap(
-            snapshot.codingAgentSummaryPayload(for: [unavailablePID, fallbackPID])
+            snapshot.codingAgentSummaryPayload(for: [agentUnavailablePID, agentFallbackPID])
                 .first { $0["id"] as? String == "codex" }
         )
         let codingAgentResources = try XCTUnwrap(codingAgent["resources"] as? [String: Any])
-        assertUnavailableMemoryPayload(codingAgentResources, unavailablePID: unavailablePID, fallbackPID: fallbackPID)
+        assertUnavailableMemoryPayload(
+            codingAgentResources,
+            unavailablePID: agentUnavailablePID,
+            fallbackPID: agentFallbackPID
+        )
     }
 
     func testKernProcArgsWorkspaceID() {


### PR DESCRIPTION
## Summary

Part of #7596 (memory audit, slice 3 — Task Manager accounting).

Three fixes:

1. **Honest headline label.** The "Memory" tile (and `cmux top` totals help) is a naive sum of per-process `phys_footprint` across cmux + all descendants; shared pages (dyld cache, frameworks, shared IOSurfaces) are counted once per process, which is how the audit session showed 22.4 GB while whole-machine RSS across ALL processes was 28 GB. The tile is now **"Summed Footprint"** with a tooltip explaining the double-counting (localized en/ja), and the `cmux top` help text says the same. The value is deliberately unchanged — "App Footprint" (single-PID phys_footprint) remains the accurate number, per the issue's "fix or honestly label" guidance.
2. **Truncation class fixed.** Grouping keys used `proc_name` (p_comm, 16-char max), so the ~223 WebKit helpers grouped as "com.apple.WebKi". New `cmuxTopCanonicalProcessName` prefers the untruncated `proc_pidpath` basename when the comm looks truncated (15/16 chars and the basename extends it, case-insensitive) — no WebKit-specific hardcoding, fixes every truncated helper name. Applied to both program rows and child-memory diagnostic groups.
3. **Agent version-string rows folded.** Claude Code's native-installer node binary is named by its version dir (`~/.local/share/claude/versions/2.1.204`), so it appeared BOTH in the "Claude Code" coding-agents row and as a raw "2.1.204" program row. Program rows now exclude agent-classified PIDs, and child-memory groups fold agent processes under the agent's display name — one shared `codingAgentDefinitionsByPID` classifier mirrors the existing gating exactly (argv reads still gated by `shouldReadArguments`).

Per-pane WebContent PIDs were already attributed via `webview-root-pid`; attributing the *shared* WebKit GPU/Networking helpers to individual panes needs per-pane WebKit SPI that doesn't exist today — deferred, noted on the issue.

## Tests

New `CmuxTopAccountingGroupingTests` (wired into cmuxTests in pbxproj; `lint-pbxproj-test-wiring.sh` passes): canonical-name truncation matrix, agent-PID exclusion from program rows (agent still present in `coding_agents`), canonical program-row display names, child-group agent folding + truncated-helper renaming, and a guard that totals math (`clampedAdd` sum) is unchanged.

`python3 scripts/swift_file_length_budget.py` passes with no TSV changes — at-cap files stayed at cap (CmuxTopSnapshot.swift 664, CLI/cmux.swift exactly 35,600 via 1:1 replacement); new logic lives in new/untracked files.

## Localization audit

Added `taskManager.summary.summedFootprint` + `.help` with en and ja values (matching the locale coverage of the sibling `taskManager.summary.cpu`); removed the now-unreferenced `taskManager.summary.memory` key (verified zero references repo-wide); `taskManager.column.memory` untouched. The `cmux top` CLI help block was already a non-localized bare string; the 1:1 replacement preserves that pre-existing pattern.

Part of #7596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786094013&installation_id=133855650&pr_number=7624&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7624&signature=c78067ad9362853e5fa136c6e933b9ee084848b4a810f11fab5bbf049d0e6229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Task Manager / top labeling, grouping, and snapshot parsing; memory totals math is explicitly unchanged and covered by tests.
> 
> **Overview**
> Task Manager and **`cmux top`** now call the headline memory total **Summed Footprint** (with a tooltip / help text that shared pages are counted per process, so the number can overstate real usage). The underlying sum is unchanged.
> 
> Process accounting grouping is tightened: **`cmuxTopCanonicalProcessName`** expands truncated `proc_name` values using the executable path basename; program totals and child-memory diagnostic groups use that name and case-insensitive keys (stable lowercased group ids). Coding-agent PIDs are classified once per snapshot via a memoized helper and are **excluded** from program rows while appearing under agent display names in diagnostics and **`coding_agents`**.
> 
> The Task Manager client treats a present but **empty** **`program_totals`** payload as intentional (no Program Totals section) instead of rebuilding aggregates from hierarchy rows. New **`CmuxTopAccountingGroupingTests`** cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c42590c7d6489522dadd503474c32caab3f6d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Task Manager memory accounting and improves grouping by relabeling the memory tile, fixing truncated names, folding coding-agent processes under agent rows, and stabilizing memory-diagnostic group IDs. Also honors backend-provided empty `program_totals`. Part of #7596 Task Manager accounting.

- **Bug Fixes**
  - Renamed the Memory tile to "Summed Footprint" with an explanatory tooltip; updated `cmux top` help. Value unchanged.
  - Canonicalized process/group names using the untruncated path basename when `proc_name` is truncated; applied to program rows and memory diagnostics.
  - Kept memory-diagnostic grouping case-insensitive and derived group IDs from the lowercased key for stable row identity; display names keep first-seen casing.
  - Excluded agent-classified PIDs from program rows and folded them under the agent display name in child-memory groups via a shared classifier.
  - Memoized per-PID coding-agent classification per snapshot via a private, lock-guarded cache so all payload sections agree and to avoid duplicate reads.
  - Honored explicitly empty `program_totals` in the payload; legacy fallback only when the field is absent so filtered-out agent rows aren’t recomputed client-side.

<sup>Written for commit 6c42590c7d6489522dadd503474c32caab3f6d4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Summed Footprint” memory metric in the CPU/Memory/etc header, with a help tooltip explaining that shared memory can cause totals to appear higher than actual usage.
* **Bug Fixes**
  * Improved program/process naming and grouping by using canonicalized names for more consistent, case-insensitive aggregation.
  * Refined memory diagnostics so agent processes are folded into stable canonical groups.
  * Fixed snapshot aggregation to respect explicitly empty program totals (no legacy fallback).
* **Tests**
  * Added/expanded coverage for naming/canonicalization, grouping, and snapshot payload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->