### PR TITLE
browser: non-permanent discard blockers + one shared discard event center

### DIFF
--- a/Sources/Panels/BrowserHiddenWebViewDiscardEventCenter.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardEventCenter.swift
@@ -17,7 +17,7 @@ protocol BrowserHiddenWebViewDiscardEventSubscriber: AnyObject {
 final class BrowserHiddenWebViewDiscardEventCenter {
     static let shared = BrowserHiddenWebViewDiscardEventCenter()
 
-    private final class WeakSubscriber {
+    final class WeakSubscriber {
         weak var value: BrowserHiddenWebViewDiscardEventSubscriber?
 
         init(_ value: BrowserHiddenWebViewDiscardEventSubscriber) {
@@ -29,10 +29,13 @@ final class BrowserHiddenWebViewDiscardEventCenter {
     private let defaultsNotificationCenter: NotificationCenter
     private let workspaceNotificationCenter: NotificationCenter
     private let observerQueue: OperationQueue?
-    private var defaultsObserver: NSObjectProtocol?
-    private var sleepObservers: [NSObjectProtocol] = []
+    // Observer handles and the subscriber list are internal (not private) so
+    // tests observe them directly via @testable import; see
+    // .github/review-bot-rules/no-test-debug-seam-in-production-source.md.
+    private(set) var defaultsObserver: NSObjectProtocol?
+    private(set) var sleepObservers: [NSObjectProtocol] = []
     private var policyState: BrowserHiddenWebViewDiscardPolicy.ResolvedPolicy
-    private var subscribers: [WeakSubscriber] = []
+    private(set) var subscribers: [WeakSubscriber] = []
 
     init(
         defaults: UserDefaults = .standard,
@@ -56,15 +59,6 @@ final class BrowserHiddenWebViewDiscardEventCenter {
 
     func remove(_ subscriber: BrowserHiddenWebViewDiscardEventSubscriber) {
         subscribers.removeAll { $0.value == nil || $0.value === subscriber }
-    }
-
-    var subscriberCountForTesting: Int {
-        compactSubscribers()
-        return subscribers.count
-    }
-
-    var observerInstallCountForTesting: (defaults: Int, workspace: Int) {
-        (defaultsObserver == nil ? 0 : 1, sleepObservers.count)
     }
 
     private func installObservers() {

--- a/Sources/Panels/BrowserHiddenWebViewDiscardEventCenter.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardEventCenter.swift
@@ -1,0 +1,131 @@
+import AppKit
+import Foundation
+
+@MainActor
+protocol BrowserHiddenWebViewDiscardEventSubscriber: AnyObject {
+    func discardPolicyDidChange(_ policy: BrowserHiddenWebViewDiscardPolicy.ResolvedPolicy)
+    func systemWillSleep()
+    func systemDidWake()
+}
+
+/// Shared event fan-out for hidden-webview discard managers.
+///
+/// Replaces per-panel observers from issue #7596: roughly 224 hidden browser
+/// panes used to install 3 observers each, all re-resolving identical global
+/// discard policy state for every defaults write.
+@MainActor
+final class BrowserHiddenWebViewDiscardEventCenter {
+    static let shared = BrowserHiddenWebViewDiscardEventCenter()
+
+    private final class WeakSubscriber {
+        weak var value: BrowserHiddenWebViewDiscardEventSubscriber?
+
+        init(_ value: BrowserHiddenWebViewDiscardEventSubscriber) {
+            self.value = value
+        }
+    }
+
+    private let defaults: UserDefaults
+    private let defaultsNotificationCenter: NotificationCenter
+    private let workspaceNotificationCenter: NotificationCenter
+    private let observerQueue: OperationQueue?
+    private var defaultsObserver: NSObjectProtocol?
+    private var sleepObservers: [NSObjectProtocol] = []
+    private var policyState: BrowserHiddenWebViewDiscardPolicy.ResolvedPolicy
+    private var subscribers: [WeakSubscriber] = []
+
+    init(
+        defaults: UserDefaults = .standard,
+        defaultsNotificationCenter: NotificationCenter = .default,
+        workspaceNotificationCenter: NotificationCenter = NSWorkspace.shared.notificationCenter,
+        observerQueue: OperationQueue? = .main
+    ) {
+        self.defaults = defaults
+        self.defaultsNotificationCenter = defaultsNotificationCenter
+        self.workspaceNotificationCenter = workspaceNotificationCenter
+        self.observerQueue = observerQueue
+        self.policyState = BrowserHiddenWebViewDiscardPolicy.resolved(defaults: defaults)
+        installObservers()
+    }
+
+    func add(_ subscriber: BrowserHiddenWebViewDiscardEventSubscriber) {
+        compactSubscribers()
+        guard !subscribers.contains(where: { $0.value === subscriber }) else { return }
+        subscribers.append(WeakSubscriber(subscriber))
+    }
+
+    func remove(_ subscriber: BrowserHiddenWebViewDiscardEventSubscriber) {
+        subscribers.removeAll { $0.value == nil || $0.value === subscriber }
+    }
+
+    var subscriberCountForTesting: Int {
+        compactSubscribers()
+        return subscribers.count
+    }
+
+    var observerInstallCountForTesting: (defaults: Int, workspace: Int) {
+        (defaultsObserver == nil ? 0 : 1, sleepObservers.count)
+    }
+
+    private func installObservers() {
+        defaultsObserver = defaultsNotificationCenter.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: observerQueue
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.handleDefaultsChanged()
+            }
+        }
+        sleepObservers = [
+            workspaceNotificationCenter.addObserver(
+                forName: NSWorkspace.willSleepNotification,
+                object: nil,
+                queue: observerQueue
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.notifySystemWillSleep()
+                }
+            },
+            workspaceNotificationCenter.addObserver(
+                forName: NSWorkspace.didWakeNotification,
+                object: nil,
+                queue: observerQueue
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.notifySystemDidWake()
+                }
+            }
+        ]
+    }
+
+    private func handleDefaultsChanged() {
+        let nextPolicyState = BrowserHiddenWebViewDiscardPolicy.resolved(defaults: defaults)
+        guard nextPolicyState != policyState else { return }
+        policyState = nextPolicyState
+        for subscriber in liveSubscribers() {
+            subscriber.discardPolicyDidChange(nextPolicyState)
+        }
+    }
+
+    private func notifySystemWillSleep() {
+        for subscriber in liveSubscribers() {
+            subscriber.systemWillSleep()
+        }
+    }
+
+    private func notifySystemDidWake() {
+        for subscriber in liveSubscribers() {
+            subscriber.systemDidWake()
+        }
+    }
+
+    private func liveSubscribers() -> [BrowserHiddenWebViewDiscardEventSubscriber] {
+        compactSubscribers()
+        return subscribers.compactMap(\.value)
+    }
+
+    private func compactSubscribers() {
+        subscribers.removeAll { $0.value == nil }
+    }
+}

--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -156,8 +156,12 @@ final class BrowserHiddenWebViewDiscardManager {
         timer.resume()
     }
 
+    /// Fires an armed blocked-recheck immediately. This is the single re-check
+    /// path: the production recheck timer routes through it, and tests drive it
+    /// directly instead of waiting out the coarse timer. A discard that results
+    /// from this path reports "blocked_recheck" as its reason.
     @discardableResult
-    func performScheduledBlockedRecheckForTesting(now: Date = Date()) -> Bool {
+    func performBlockedRecheckNow(now: Date = Date()) -> Bool {
         guard blockedRecheckTimer != nil else { return false }
         blockedRecheckTimer?.cancel()
         blockedRecheckTimer = nil
@@ -311,12 +315,7 @@ final class BrowserHiddenWebViewDiscardManager {
                 guard self.scheduleGeneration == generation else { return }
                 guard let delegate = self.delegate else { return }
                 guard delegate.hiddenWebViewDiscardWebViewInstanceID == observedWebViewInstanceID else { return }
-                self.blockedRecheckTimer?.cancel()
-                self.blockedRecheckTimer = nil
-                // Match performScheduledBlockedRecheckForTesting: a discard that
-                // fires via the blocked-recheck path reports "blocked_recheck",
-                // not the reason captured when the pane was first blocked.
-                self.scheduleIfNeeded(reason: "blocked_recheck", now: Date())
+                self.performBlockedRecheckNow(now: Date())
             }
         }
         blockedRecheckTimer = timer

--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -37,22 +37,24 @@ final class BrowserHiddenWebViewDiscardManager {
         let isVisualAutomationCaptureActive: Bool
         let hasPopups: Bool
         let isCapturingMedia: Bool
-        let isPlayingMedia: Bool
+        let hasAudibleMedia: Bool
     }
 
     weak var delegate: BrowserHiddenWebViewDiscardManagerDelegate?
 
     private var discardTimer: DispatchSourceTimer?
-    private var policyObserver: NSObjectProtocol?
-    private var systemSleepObservers: [NSObjectProtocol] = []
-    private var systemSleepObserverCenter: NotificationCenter?
+    private var blockedRecheckTimer: DispatchSourceTimer?
     private let policyDefaults: UserDefaults
-    private var policyState: BrowserHiddenWebViewDiscardPolicy.ResolvedPolicy
+    private let eventCenter: BrowserHiddenWebViewDiscardEventCenter
+    private var isSubscribedToEventCenter = false
     private var scheduleGeneration: UInt64 = 0
 
-    init(policyDefaults: UserDefaults = .standard) {
+    init(
+        policyDefaults: UserDefaults = .standard,
+        eventCenter: BrowserHiddenWebViewDiscardEventCenter = .shared
+    ) {
         self.policyDefaults = policyDefaults
-        self.policyState = BrowserHiddenWebViewDiscardPolicy.resolved(defaults: policyDefaults)
+        self.eventCenter = eventCenter
     }
 
     /// Sleep/wake state used to keep a hidden-webview discard from running in
@@ -71,6 +73,10 @@ final class BrowserHiddenWebViewDiscardManager {
         discardTimer != nil
     }
 
+    var hasScheduledBlockedRecheck: Bool {
+        blockedRecheckTimer != nil
+    }
+
     func blockers(for snapshot: BlockerSnapshot) -> [String] {
         var blockers: [String] = []
         if !BrowserHiddenWebViewDiscardPolicy.isEnabled(defaults: policyDefaults) {
@@ -87,8 +93,8 @@ final class BrowserHiddenWebViewDiscardManager {
         if snapshot.hasActiveMainFrameProvisionalNavigation { blockers.append("provisional_navigation") }
         if snapshot.isDownloading || snapshot.activeDownloadCount != 0 { blockers.append("download") }
         if snapshot.isCapturingMedia { blockers.append("media_capture") }
-        if snapshot.isPlayingMedia { blockers.append("media_playback") }
-        if snapshot.preferredDeveloperToolsVisible || snapshot.isDeveloperToolsVisible {
+        if snapshot.hasAudibleMedia { blockers.append("media_playback") }
+        if snapshot.isDeveloperToolsVisible {
             blockers.append("developer_tools")
         }
         if snapshot.isElementFullscreenActive { blockers.append("fullscreen") }
@@ -102,9 +108,20 @@ final class BrowserHiddenWebViewDiscardManager {
         scheduleGeneration &+= 1
         discardTimer?.cancel()
         discardTimer = nil
+        blockedRecheckTimer?.cancel()
+        blockedRecheckTimer = nil
 
         guard let delegate else { return }
-        guard blockers(for: delegate.hiddenWebViewDiscardSnapshot).isEmpty else { return }
+        let snapshot = delegate.hiddenWebViewDiscardSnapshot
+        guard blockers(for: snapshot).isEmpty else {
+            guard shouldScheduleBlockedRecheck(for: snapshot) else { return }
+            scheduleBlockedRecheckIfNeeded(
+                reason: reason,
+                observedWebViewInstanceID: delegate.hiddenWebViewDiscardWebViewInstanceID,
+                generation: scheduleGeneration
+            )
+            return
+        }
 
         let observedWebViewInstanceID = delegate.hiddenWebViewDiscardWebViewInstanceID
         let generation = scheduleGeneration
@@ -141,6 +158,15 @@ final class BrowserHiddenWebViewDiscardManager {
     }
 
     @discardableResult
+    func performScheduledBlockedRecheckForTesting(now: Date = Date()) -> Bool {
+        guard blockedRecheckTimer != nil else { return false }
+        blockedRecheckTimer?.cancel()
+        blockedRecheckTimer = nil
+        scheduleIfNeeded(reason: "blocked_recheck", now: now)
+        return true
+    }
+
+    @discardableResult
     func requestImmediateDiscardIfSafe(reason: String, now: Date = Date()) -> Bool {
         guard let delegate else { return false }
         guard blockers(for: delegate.hiddenWebViewDiscardSnapshot).isEmpty else { return false }
@@ -157,6 +183,8 @@ final class BrowserHiddenWebViewDiscardManager {
         scheduleGeneration &+= 1
         discardTimer?.cancel()
         discardTimer = nil
+        blockedRecheckTimer?.cancel()
+        blockedRecheckTimer = nil
         delegate.hiddenWebViewDiscardManagerDidRequestDiscard(self, reason: reason)
         return true
     }
@@ -165,36 +193,8 @@ final class BrowserHiddenWebViewDiscardManager {
         scheduleGeneration &+= 1
         discardTimer?.cancel()
         discardTimer = nil
-    }
-
-    /// Tracks system sleep/wake so discard countdowns armed before sleep do not
-    /// fire shortly after wake. Injectable center for tests.
-    func installSystemSleepObservers(center: NotificationCenter = NSWorkspace.shared.notificationCenter) {
-        guard systemSleepObservers.isEmpty else { return }
-        systemSleepObserverCenter = center
-        systemSleepObservers = [
-            // Synchronous main-actor delivery (no Task hop): a countdown with
-            // milliseconds of mach time left must see isSystemSleeping before
-            // its timer can fire.
-            center.addObserver(
-                forName: NSWorkspace.willSleepNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] _ in
-                MainActor.assumeIsolated {
-                    self?.noteSystemWillSleep()
-                }
-            },
-            center.addObserver(
-                forName: NSWorkspace.didWakeNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] _ in
-                MainActor.assumeIsolated {
-                    self?.noteSystemDidWake()
-                }
-            }
-        ]
+        blockedRecheckTimer?.cancel()
+        blockedRecheckTimer = nil
     }
 
     func noteSystemWillSleep() {
@@ -217,18 +217,10 @@ final class BrowserHiddenWebViewDiscardManager {
 #endif
     }
 
-    func installPolicyObserver() {
-        policyState = BrowserHiddenWebViewDiscardPolicy.resolved(defaults: policyDefaults)
-        guard policyObserver == nil else { return }
-        policyObserver = NotificationCenter.default.addObserver(
-            forName: UserDefaults.didChangeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.handlePolicyDefaultsChanged()
-            }
-        }
+    func installEventCenterSubscription() {
+        guard !isSubscribedToEventCenter else { return }
+        eventCenter.add(self)
+        isSubscribedToEventCenter = true
     }
 
     nonisolated func stop() {
@@ -286,13 +278,6 @@ final class BrowserHiddenWebViewDiscardManager {
         updateRestoredSessionRenderIntent(nil)
     }
 
-    private func handlePolicyDefaultsChanged() {
-        let nextPolicyState = BrowserHiddenWebViewDiscardPolicy.resolved(defaults: policyDefaults)
-        guard policyState != nextPolicyState else { return }
-        policyState = nextPolicyState
-        delegate?.hiddenWebViewDiscardManagerPolicyDidChange(self, reason: "policy_changed")
-    }
-
     private func isInPostWakeDiscardDelay(now: Date) -> Bool {
         guard let lastSystemWakeAt else { return false }
         return now.timeIntervalSince(lastSystemWakeAt) < BrowserHiddenWebViewDiscardPolicy.hiddenDelay(defaults: policyDefaults)
@@ -300,16 +285,60 @@ final class BrowserHiddenWebViewDiscardManager {
 
     private func stopOnMainActor() {
         cancel()
-        if let policyObserver {
-            NotificationCenter.default.removeObserver(policyObserver)
-            self.policyObserver = nil
+        if isSubscribedToEventCenter {
+            eventCenter.remove(self)
+            isSubscribedToEventCenter = false
         }
-        if let center = systemSleepObserverCenter {
-            for observer in systemSleepObservers {
-                center.removeObserver(observer)
+    }
+
+    private func shouldScheduleBlockedRecheck(for snapshot: BlockerSnapshot) -> Bool {
+        guard BrowserHiddenWebViewDiscardPolicy.isEnabled(defaults: policyDefaults) else { return false }
+        guard !snapshot.isVisibleInUI, !snapshot.isClosing, !isDiscardedForMemory else { return false }
+        return true
+    }
+
+    private func scheduleBlockedRecheckIfNeeded(
+        reason: String,
+        observedWebViewInstanceID: UUID,
+        generation: UInt64
+    ) {
+        guard blockedRecheckTimer == nil else { return }
+        let policy = BrowserHiddenWebViewDiscardPolicy.resolved(defaults: policyDefaults)
+        let delay = Self.blockedRecheckDelay(for: policy)
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + delay)
+        timer.setEventHandler { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                guard self.scheduleGeneration == generation else { return }
+                guard let delegate = self.delegate else { return }
+                guard delegate.hiddenWebViewDiscardWebViewInstanceID == observedWebViewInstanceID else { return }
+                self.blockedRecheckTimer?.cancel()
+                self.blockedRecheckTimer = nil
+                self.scheduleIfNeeded(reason: reason, now: Date())
             }
         }
-        systemSleepObservers.removeAll()
-        systemSleepObserverCenter = nil
+        blockedRecheckTimer = timer
+        timer.resume()
+    }
+
+    static func blockedRecheckDelay(
+        for policy: BrowserHiddenWebViewDiscardPolicy.ResolvedPolicy
+    ) -> TimeInterval {
+        max(60, policy.hiddenDelay)
+    }
+}
+
+extension BrowserHiddenWebViewDiscardManager: BrowserHiddenWebViewDiscardEventSubscriber {
+    func discardPolicyDidChange(_: BrowserHiddenWebViewDiscardPolicy.ResolvedPolicy) {
+        delegate?.hiddenWebViewDiscardManagerPolicyDidChange(self, reason: "policy_changed")
+    }
+
+    func systemWillSleep() {
+        noteSystemWillSleep()
+    }
+
+    func systemDidWake() {
+        noteSystemDidWake()
     }
 }

--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -116,7 +116,6 @@ final class BrowserHiddenWebViewDiscardManager {
         guard blockers(for: snapshot).isEmpty else {
             guard shouldScheduleBlockedRecheck(for: snapshot) else { return }
             scheduleBlockedRecheckIfNeeded(
-                reason: reason,
                 observedWebViewInstanceID: delegate.hiddenWebViewDiscardWebViewInstanceID,
                 generation: scheduleGeneration
             )
@@ -298,7 +297,6 @@ final class BrowserHiddenWebViewDiscardManager {
     }
 
     private func scheduleBlockedRecheckIfNeeded(
-        reason: String,
         observedWebViewInstanceID: UUID,
         generation: UInt64
     ) {
@@ -315,7 +313,10 @@ final class BrowserHiddenWebViewDiscardManager {
                 guard delegate.hiddenWebViewDiscardWebViewInstanceID == observedWebViewInstanceID else { return }
                 self.blockedRecheckTimer?.cancel()
                 self.blockedRecheckTimer = nil
-                self.scheduleIfNeeded(reason: reason, now: Date())
+                // Match performScheduledBlockedRecheckForTesting: a discard that
+                // fires via the blocked-recheck path reports "blocked_recheck",
+                // not the reason captured when the pane was first blocked.
+                self.scheduleIfNeeded(reason: "blocked_recheck", now: Date())
             }
         }
         blockedRecheckTimer = timer

--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -51,10 +51,13 @@ final class BrowserHiddenWebViewDiscardManager {
 
     init(
         policyDefaults: UserDefaults = .standard,
-        eventCenter: BrowserHiddenWebViewDiscardEventCenter = .shared
+        // nil resolves to .shared inside this main-actor-isolated init body; a
+        // `.shared` default argument would be evaluated in a nonisolated
+        // context and trip the Swift 6 actor-isolation warning.
+        eventCenter: BrowserHiddenWebViewDiscardEventCenter? = nil
     ) {
         self.policyDefaults = policyDefaults
-        self.eventCenter = eventCenter
+        self.eventCenter = eventCenter ?? .shared
     }
 
     /// Sleep/wake state used to keep a hidden-webview discard from running in

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3288,8 +3288,7 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private func installHiddenWebViewDiscardPolicyObserver() {
-        hiddenWebViewDiscardManager.installPolicyObserver()
-        hiddenWebViewDiscardManager.installSystemSleepObservers()
+        hiddenWebViewDiscardManager.installEventCenterSubscription()
     }
 
     @discardableResult
@@ -6037,7 +6036,7 @@ extension BrowserPanel: BrowserHiddenWebViewDiscardManagerDelegate {
             isVisualAutomationCaptureActive: activeVisualAutomationCaptureCount > 0,
             hasPopups: !popupControllers.isEmpty,
             isCapturingMedia: webView.cameraCaptureState != .none || webView.microphoneCaptureState != .none,
-            isPlayingMedia: isPlayingMedia
+            hasAudibleMedia: isPlayingAudio
         )
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -157,6 +157,8 @@
 		A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 		A5008373 /* BrowserFindWebViewEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008372 /* BrowserFindWebViewEvaluator.swift */; };
 		7B5F1A2E9C0D4B6A8E217302 /* BrowserFixtureInteractionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F1A2E9C0D4B6A8E217301 /* BrowserFixtureInteractionUITests.swift */; };
+		B42450060000000000000001 /* BrowserHiddenWebViewDiscardEventCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42450050000000000000001 /* BrowserHiddenWebViewDiscardEventCenter.swift */; };
+		B6585004B6585004B6585004 /* BrowserHiddenWebViewDiscardEventCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6585003B6585003B6585003 /* BrowserHiddenWebViewDiscardEventCenterTests.swift */; };
 		B42450030000000000000001 /* BrowserHiddenWebViewDiscardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */; };
 		B6585001B6585001B6585001 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6585002B6585002B6585002 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift */; };
 		B42450010000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42450020000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift */; };
@@ -1701,6 +1703,8 @@
 		A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
 		A5008372 /* BrowserFindWebViewEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/BrowserFindWebViewEvaluator.swift; sourceTree = "<group>"; };
 		7B5F1A2E9C0D4B6A8E217301 /* BrowserFixtureInteractionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFixtureInteractionUITests.swift; sourceTree = "<group>"; };
+		B42450050000000000000001 /* BrowserHiddenWebViewDiscardEventCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHiddenWebViewDiscardEventCenter.swift; sourceTree = "<group>"; };
+		B6585003B6585003B6585003 /* BrowserHiddenWebViewDiscardEventCenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserHiddenWebViewDiscardEventCenterTests.swift; sourceTree = "<group>"; };
 		B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHiddenWebViewDiscardManager.swift; sourceTree = "<group>"; };
 		B6585002B6585002B6585002 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserHiddenWebViewDiscardMemoryPressureTests.swift; sourceTree = "<group>"; };
 		B42450020000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHiddenWebViewDiscardPolicy.swift; sourceTree = "<group>"; };
@@ -3749,6 +3753,7 @@
 				C0DE5A410000000000000002 /* TerminalPanelShellActivityModel.swift */,
 				C0DE6B420000000000000002 /* TerminalPanelTextBoxState.swift */,
 				B42450020000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift */,
+				B42450050000000000000001 /* BrowserHiddenWebViewDiscardEventCenter.swift */,
 				B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */,
 				B4245004000000000000PW01 /* BrowserPrewarmedWebViewPool.swift */,
 				B424PWAD000000000000PW02 /* BrowserPanel+PrewarmedWebViewAdoption.swift */,
@@ -4306,6 +4311,7 @@
 				D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */,
 				D3622101A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift */,
 				B65060010000000000000001 /* BrowserPanelSessionRestoreTests.swift */,
+				B6585003B6585003B6585003 /* BrowserHiddenWebViewDiscardEventCenterTests.swift */,
 				B6585002B6585002B6585002 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift */,
 				B6585002B6585002B658PW02 /* BrowserPrewarmedWebViewPoolTests.swift */,
 				58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */,
@@ -5082,6 +5088,7 @@
 				C2035A020000000000000001 /* BrowserErrorPageContent.swift in Sources */,
 				C2035A0C000000000000001 /* BrowserErrorPageRetry.swift in Sources */,
 				A5008373 /* BrowserFindWebViewEvaluator.swift in Sources */,
+				B42450060000000000000001 /* BrowserHiddenWebViewDiscardEventCenter.swift in Sources */,
 				B42450030000000000000001 /* BrowserHiddenWebViewDiscardManager.swift in Sources */,
 				B42450010000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift in Sources */,
 				7490C0017490C0017490C001 /* BrowserHiddenWebViewMemoryPressureResponder.swift in Sources */,
@@ -6059,6 +6066,7 @@
 				E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */,
 				C59240010000000000000003 /* BrowserDownloadFilenameResolverTests.swift in Sources */,
 				A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
+				B6585004B6585004B6585004 /* BrowserHiddenWebViewDiscardEventCenterTests.swift in Sources */,
 				B6585001B6585001B6585001 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift in Sources */,
 				4E1F28554F1B908F18559390 /* BrowserHistorySuggestionCacheTests.swift in Sources */,
 				BABA25000000000000000005 /* BrowserHTTPBasicAuthPromptCoordinatorTests.swift in Sources */,

--- a/cmuxTests/BrowserHiddenWebViewDiscardEventCenterTests.swift
+++ b/cmuxTests/BrowserHiddenWebViewDiscardEventCenterTests.swift
@@ -1,0 +1,136 @@
+import AppKit
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+private final class BrowserHiddenWebViewDiscardEventCenterTestSubscriber:
+    BrowserHiddenWebViewDiscardEventSubscriber
+{
+    var policyChanges: [BrowserHiddenWebViewDiscardPolicy.ResolvedPolicy] = []
+    var sleepCount = 0
+    var wakeCount = 0
+
+    func discardPolicyDidChange(_ policy: BrowserHiddenWebViewDiscardPolicy.ResolvedPolicy) {
+        policyChanges.append(policy)
+    }
+
+    func systemWillSleep() {
+        sleepCount += 1
+    }
+
+    func systemDidWake() {
+        wakeCount += 1
+    }
+}
+
+@MainActor
+private func withEventCenterTestDefaults(
+    _ body: (UserDefaults) throws -> Void
+) throws {
+    let suiteName = "com.cmux.BrowserHiddenWebViewDiscardEventCenterTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    defer {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+    try body(defaults)
+}
+
+@MainActor
+@Suite(.serialized)
+struct BrowserHiddenWebViewDiscardEventCenterTests {
+    @Test func registersOneDefaultsObserverAndOneSleepWakePair() throws {
+        try withEventCenterTestDefaults { defaults in
+            let eventCenter = BrowserHiddenWebViewDiscardEventCenter(
+                defaults: defaults,
+                defaultsNotificationCenter: NotificationCenter(),
+                workspaceNotificationCenter: NotificationCenter(),
+                observerQueue: nil
+            )
+
+            let installCount = eventCenter.observerInstallCountForTesting
+            #expect(installCount.defaults == 1)
+            #expect(installCount.workspace == 2)
+        }
+    }
+
+    @Test func policyChangeFansOutOnlyForResolvedPolicyChanges() throws {
+        try withEventCenterTestDefaults { defaults in
+            defaults.set(true, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+            defaults.set(300, forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
+            let defaultsCenter = NotificationCenter()
+            let eventCenter = BrowserHiddenWebViewDiscardEventCenter(
+                defaults: defaults,
+                defaultsNotificationCenter: defaultsCenter,
+                workspaceNotificationCenter: NotificationCenter(),
+                observerQueue: nil
+            )
+            let subscriber = BrowserHiddenWebViewDiscardEventCenterTestSubscriber()
+            eventCenter.add(subscriber)
+
+            defaultsCenter.post(name: UserDefaults.didChangeNotification, object: nil)
+            #expect(subscriber.policyChanges.isEmpty)
+
+            defaults.set(false, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+            defaultsCenter.post(name: UserDefaults.didChangeNotification, object: nil)
+            defaultsCenter.post(name: UserDefaults.didChangeNotification, object: nil)
+
+            #expect(subscriber.policyChanges.count == 1)
+            #expect(subscriber.policyChanges.first?.isEnabled == false)
+
+            defaults.set(120, forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
+            defaultsCenter.post(name: UserDefaults.didChangeNotification, object: nil)
+
+            #expect(subscriber.policyChanges.count == 2)
+            #expect(subscriber.policyChanges.last?.hiddenDelay == 120)
+        }
+    }
+
+    @Test func weakSubscribersArePrunedAfterDeallocation() throws {
+        try withEventCenterTestDefaults { defaults in
+            let defaultsCenter = NotificationCenter()
+            let eventCenter = BrowserHiddenWebViewDiscardEventCenter(
+                defaults: defaults,
+                defaultsNotificationCenter: defaultsCenter,
+                workspaceNotificationCenter: NotificationCenter(),
+                observerQueue: nil
+            )
+            do {
+                let subscriber = BrowserHiddenWebViewDiscardEventCenterTestSubscriber()
+                eventCenter.add(subscriber)
+                #expect(eventCenter.subscriberCountForTesting == 1)
+            }
+
+            defaults.set(false, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+            defaultsCenter.post(name: UserDefaults.didChangeNotification, object: nil)
+
+            #expect(eventCenter.subscriberCountForTesting == 0)
+        }
+    }
+
+    @Test func sleepWakeFanOutWorks() throws {
+        try withEventCenterTestDefaults { defaults in
+            let workspaceCenter = NotificationCenter()
+            let eventCenter = BrowserHiddenWebViewDiscardEventCenter(
+                defaults: defaults,
+                defaultsNotificationCenter: NotificationCenter(),
+                workspaceNotificationCenter: workspaceCenter,
+                observerQueue: nil
+            )
+            let subscriber = BrowserHiddenWebViewDiscardEventCenterTestSubscriber()
+            eventCenter.add(subscriber)
+
+            workspaceCenter.post(name: NSWorkspace.willSleepNotification, object: nil)
+            workspaceCenter.post(name: NSWorkspace.didWakeNotification, object: nil)
+
+            #expect(subscriber.sleepCount == 1)
+            #expect(subscriber.wakeCount == 1)
+        }
+    }
+}

--- a/cmuxTests/BrowserHiddenWebViewDiscardEventCenterTests.swift
+++ b/cmuxTests/BrowserHiddenWebViewDiscardEventCenterTests.swift
@@ -54,9 +54,8 @@ struct BrowserHiddenWebViewDiscardEventCenterTests {
                 observerQueue: nil
             )
 
-            let installCount = eventCenter.observerInstallCountForTesting
-            #expect(installCount.defaults == 1)
-            #expect(installCount.workspace == 2)
+            #expect(eventCenter.defaultsObserver != nil)
+            #expect(eventCenter.sleepObservers.count == 2)
         }
     }
 
@@ -104,13 +103,13 @@ struct BrowserHiddenWebViewDiscardEventCenterTests {
             do {
                 let subscriber = BrowserHiddenWebViewDiscardEventCenterTestSubscriber()
                 eventCenter.add(subscriber)
-                #expect(eventCenter.subscriberCountForTesting == 1)
+                #expect(eventCenter.subscribers.count == 1)
             }
 
             defaults.set(false, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
             defaultsCenter.post(name: UserDefaults.didChangeNotification, object: nil)
 
-            #expect(eventCenter.subscriberCountForTesting == 0)
+            #expect(eventCenter.subscribers.count == 0)
         }
     }
 

--- a/cmuxTests/BrowserHiddenWebViewDiscardMemoryPressureTests.swift
+++ b/cmuxTests/BrowserHiddenWebViewDiscardMemoryPressureTests.swift
@@ -175,7 +175,7 @@ struct BrowserHiddenWebViewDiscardMemoryPressureTests {
             #expect(delegate.discardRequestCount == 0)
 
             delegate.snapshot = clearSnapshot
-            #expect(manager.performScheduledBlockedRecheckForTesting(now: now.addingTimeInterval(60)))
+            #expect(manager.performBlockedRecheckNow(now: now.addingTimeInterval(60)))
 
             #expect(!manager.hasScheduledBlockedRecheck)
             #expect(delegate.discardRequestCount == 1)

--- a/cmuxTests/BrowserHiddenWebViewDiscardMemoryPressureTests.swift
+++ b/cmuxTests/BrowserHiddenWebViewDiscardMemoryPressureTests.swift
@@ -47,26 +47,33 @@ private final class MemoryPressureHiddenWebViewDiscardTestDelegate: BrowserHidde
 }
 
 @MainActor
-private func makeMemoryPressureHiddenWebViewDiscardBlockerSnapshot() -> BrowserHiddenWebViewDiscardManager.BlockerSnapshot {
+private func makeMemoryPressureHiddenWebViewDiscardBlockerSnapshot(
+    hasActiveMainFrameProvisionalNavigation: Bool = false,
+    isVisibleInUI: Bool = false,
+    preferredDeveloperToolsVisible: Bool = false,
+    isDeveloperToolsVisible: Bool = false,
+    isCapturingMedia: Bool = false,
+    hasAudibleMedia: Bool = false
+) -> BrowserHiddenWebViewDiscardManager.BlockerSnapshot {
     BrowserHiddenWebViewDiscardManager.BlockerSnapshot(
         isClosing: false,
-        isVisibleInUI: false,
+        isVisibleInUI: isVisibleInUI,
         shouldRenderWebView: true,
         hasPendingRemoteNavigation: false,
         hasCurrentURL: true,
         isLoading: false,
         webViewIsLoading: false,
-        hasActiveMainFrameProvisionalNavigation: false,
+        hasActiveMainFrameProvisionalNavigation: hasActiveMainFrameProvisionalNavigation,
         isDownloading: false,
         activeDownloadCount: 0,
-        preferredDeveloperToolsVisible: false,
-        isDeveloperToolsVisible: false,
+        preferredDeveloperToolsVisible: preferredDeveloperToolsVisible,
+        isDeveloperToolsVisible: isDeveloperToolsVisible,
         isElementFullscreenActive: false,
         isReactGrabActive: false,
         isVisualAutomationCaptureActive: false,
         hasPopups: false,
-        isCapturingMedia: false,
-        isPlayingMedia: false
+        isCapturingMedia: isCapturingMedia,
+        hasAudibleMedia: hasAudibleMedia
     )
 }
 
@@ -144,6 +151,98 @@ struct BrowserHiddenWebViewDiscardMemoryPressureTests {
             #expect(manager.hasScheduledDiscard)
             #expect(delegate.discardRequestCount == 0)
             #expect(delegate.lastDiscardReason == nil)
+        }
+    }
+
+    @Test func blockedHiddenPaneRechecksAndDiscardsAfterBlockerClears() {
+        withMemoryPressureHiddenWebViewDiscardPolicyEnabled { defaults in
+            let now = Date(timeIntervalSince1970: 3_000)
+            let blockedSnapshot = makeMemoryPressureHiddenWebViewDiscardBlockerSnapshot(
+                hasActiveMainFrameProvisionalNavigation: true
+            )
+            let clearSnapshot = makeMemoryPressureHiddenWebViewDiscardBlockerSnapshot()
+            let manager = BrowserHiddenWebViewDiscardManager(policyDefaults: defaults)
+            let delegate = MemoryPressureHiddenWebViewDiscardTestDelegate(
+                snapshot: blockedSnapshot,
+                hiddenAt: now.addingTimeInterval(-7_200)
+            )
+            manager.delegate = delegate
+
+            manager.scheduleIfNeeded(reason: "test.blocked", now: now)
+
+            #expect(!manager.hasScheduledDiscard)
+            #expect(manager.hasScheduledBlockedRecheck)
+            #expect(delegate.discardRequestCount == 0)
+
+            delegate.snapshot = clearSnapshot
+            #expect(manager.performScheduledBlockedRecheckForTesting(now: now.addingTimeInterval(60)))
+
+            #expect(!manager.hasScheduledBlockedRecheck)
+            #expect(delegate.discardRequestCount == 1)
+            #expect(delegate.lastDiscardReason == "blocked_recheck")
+        }
+    }
+
+    @Test func terminalBlockersDoNotArmBlockedRecheck() {
+        withMemoryPressureHiddenWebViewDiscardPolicyEnabled { defaults in
+            let now = Date(timeIntervalSince1970: 3_500)
+            let visibleManager = BrowserHiddenWebViewDiscardManager(policyDefaults: defaults)
+            let visibleDelegate = MemoryPressureHiddenWebViewDiscardTestDelegate(
+                snapshot: makeMemoryPressureHiddenWebViewDiscardBlockerSnapshot(isVisibleInUI: true),
+                hiddenAt: now.addingTimeInterval(-7_200)
+            )
+            visibleManager.delegate = visibleDelegate
+
+            visibleManager.scheduleIfNeeded(reason: "test.visible", now: now)
+
+            #expect(!visibleManager.hasScheduledDiscard)
+            #expect(!visibleManager.hasScheduledBlockedRecheck)
+
+            let discardedManager = BrowserHiddenWebViewDiscardManager(policyDefaults: defaults)
+            let discardedDelegate = MemoryPressureHiddenWebViewDiscardTestDelegate(
+                snapshot: makeMemoryPressureHiddenWebViewDiscardBlockerSnapshot(),
+                hiddenAt: now.addingTimeInterval(-7_200)
+            )
+            discardedManager.delegate = discardedDelegate
+            discardedManager.markDiscarded(reason: "test.discarded", now: now)
+
+            discardedManager.scheduleIfNeeded(reason: "test.discarded", now: now)
+
+            #expect(!discardedManager.hasScheduledDiscard)
+            #expect(!discardedManager.hasScheduledBlockedRecheck)
+        }
+    }
+
+    @Test func blockedRecheckDelayIsNeverLessThanSixtySeconds() {
+        let policy = BrowserHiddenWebViewDiscardPolicy.ResolvedPolicy(
+            isEnabled: true,
+            hiddenDelay: 0
+        )
+
+        #expect(BrowserHiddenWebViewDiscardManager.blockedRecheckDelay(for: policy) == 60)
+    }
+
+    @Test func developerToolsLiveProbeBlocksHiddenWebViewDiscard() {
+        withMemoryPressureHiddenWebViewDiscardPolicyEnabled { defaults in
+            let snapshot = makeMemoryPressureHiddenWebViewDiscardBlockerSnapshot(
+                preferredDeveloperToolsVisible: false,
+                isDeveloperToolsVisible: true
+            )
+            let manager = BrowserHiddenWebViewDiscardManager(policyDefaults: defaults)
+
+            #expect(manager.blockers(for: snapshot) == ["developer_tools"])
+        }
+    }
+
+    @Test func developerToolsPreferenceOnlyDoesNotBlockHiddenWebViewDiscard() {
+        withMemoryPressureHiddenWebViewDiscardPolicyEnabled { defaults in
+            let snapshot = makeMemoryPressureHiddenWebViewDiscardBlockerSnapshot(
+                preferredDeveloperToolsVisible: true,
+                isDeveloperToolsVisible: false
+            )
+            let manager = BrowserHiddenWebViewDiscardManager(policyDefaults: defaults)
+
+            #expect(manager.blockers(for: snapshot) == [])
         }
     }
 }

--- a/cmuxTests/BrowserMediaPlaybackAudioActivityTests.swift
+++ b/cmuxTests/BrowserMediaPlaybackAudioActivityTests.swift
@@ -8,9 +8,53 @@ import Testing
 #endif
 
 @MainActor
+private func makeMediaPlaybackDiscardSnapshot(
+    isCapturingMedia: Bool = false,
+    hasAudibleMedia: Bool = false
+) -> BrowserHiddenWebViewDiscardManager.BlockerSnapshot {
+    BrowserHiddenWebViewDiscardManager.BlockerSnapshot(
+        isClosing: false,
+        isVisibleInUI: false,
+        shouldRenderWebView: true,
+        hasPendingRemoteNavigation: false,
+        hasCurrentURL: true,
+        isLoading: false,
+        webViewIsLoading: false,
+        hasActiveMainFrameProvisionalNavigation: false,
+        isDownloading: false,
+        activeDownloadCount: 0,
+        preferredDeveloperToolsVisible: false,
+        isDeveloperToolsVisible: false,
+        isElementFullscreenActive: false,
+        isReactGrabActive: false,
+        isVisualAutomationCaptureActive: false,
+        hasPopups: false,
+        isCapturingMedia: isCapturingMedia,
+        hasAudibleMedia: hasAudibleMedia
+    )
+}
+
+@MainActor
+private func withMediaPlaybackHiddenWebViewDiscardPolicyEnabled(
+    _ body: (UserDefaults) throws -> Void
+) throws {
+    let suiteName = "com.cmux.BrowserMediaPlaybackAudioActivityTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.set(true, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+    defaults.set(
+        BrowserHiddenWebViewDiscardPolicy.defaultHiddenDelay,
+        forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey
+    )
+    defer {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+    try body(defaults)
+}
+
+@MainActor
 @Suite(.serialized)
 struct BrowserMediaPlaybackAudioActivityTests {
-    @Test func activeSilentMediaPlaybackBlocksDiscardWithoutAudioGlyph() {
+    @Test func activeSilentMediaPlaybackDrivesPlaybackStateWithoutAudioGlyph() {
         let panel = BrowserPanel(workspaceId: UUID(), renderInitialNavigation: false)
         defer { panel.close() }
 
@@ -18,6 +62,15 @@ struct BrowserMediaPlaybackAudioActivityTests {
 
         #expect(panel.isPlayingMedia)
         #expect(panel.isPlayingAudio == false)
+    }
+
+    @Test func activeSilentMediaPlaybackDoesNotBlockHiddenWebViewDiscard() throws {
+        try withMediaPlaybackHiddenWebViewDiscardPolicyEnabled { defaults in
+            let manager = BrowserHiddenWebViewDiscardManager(policyDefaults: defaults)
+            let snapshot = makeMediaPlaybackDiscardSnapshot(hasAudibleMedia: false)
+
+            #expect(manager.blockers(for: snapshot) == [])
+        }
     }
 
     @Test func audibleMediaPlaybackDrivesAudioGlyphIndependentlyOfDiscardBlocker() {
@@ -33,5 +86,23 @@ struct BrowserMediaPlaybackAudioActivityTests {
 
         #expect(panel.isPlayingMedia)
         #expect(panel.isPlayingAudio == false)
+    }
+
+    @Test func audibleMediaPlaybackBlocksHiddenWebViewDiscard() throws {
+        try withMediaPlaybackHiddenWebViewDiscardPolicyEnabled { defaults in
+            let manager = BrowserHiddenWebViewDiscardManager(policyDefaults: defaults)
+            let snapshot = makeMediaPlaybackDiscardSnapshot(hasAudibleMedia: true)
+
+            #expect(manager.blockers(for: snapshot) == ["media_playback"])
+        }
+    }
+
+    @Test func mediaCaptureStillBlocksHiddenWebViewDiscard() throws {
+        try withMediaPlaybackHiddenWebViewDiscardPolicyEnabled { defaults in
+            let manager = BrowserHiddenWebViewDiscardManager(policyDefaults: defaults)
+            let snapshot = makeMediaPlaybackDiscardSnapshot(isCapturingMedia: true)
+
+            #expect(manager.blockers(for: snapshot) == ["media_capture"])
+        }
     }
 }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -103,7 +103,7 @@ private func makeHiddenWebViewDiscardBlockerSnapshot(
     hasActiveMainFrameProvisionalNavigation: Bool = false,
     isVisualAutomationCaptureActive: Bool = false,
     isCapturingMedia: Bool = false,
-    isPlayingMedia: Bool = false
+    hasAudibleMedia: Bool = false
 ) -> BrowserHiddenWebViewDiscardManager.BlockerSnapshot {
     BrowserHiddenWebViewDiscardManager.BlockerSnapshot(
         isClosing: false,
@@ -123,7 +123,7 @@ private func makeHiddenWebViewDiscardBlockerSnapshot(
         isVisualAutomationCaptureActive: isVisualAutomationCaptureActive,
         hasPopups: false,
         isCapturingMedia: isCapturingMedia,
-        isPlayingMedia: isPlayingMedia
+        hasAudibleMedia: hasAudibleMedia
     )
 }
 
@@ -146,13 +146,13 @@ private func withHiddenWebViewDiscardPolicyEnabled(_ body: () -> Void) {
 @Suite(.serialized)
 struct BrowserHiddenWebViewDiscardMediaPlaybackTests {
     /// Regression coverage for https://github.com/manaflow-ai/cmux/issues/5409:
-    /// a hidden pane that is actively playing media (e.g. a backgrounded YouTube
+    /// a hidden pane that is playing audible media (e.g. backgrounded YouTube
     /// video) must be exempted from memory discard so switching workspaces does
     /// not stop playback or reload the page. The media_capture blocker only
-    /// covers camera/mic capture, not <video>/<audio> playback.
-    @Test func activeMediaPlaybackBlocksHiddenWebViewDiscardScheduling() {
+    /// covers camera/mic capture, not audible <video>/<audio> playback.
+    @Test func audibleMediaPlaybackBlocksHiddenWebViewDiscardScheduling() {
         withHiddenWebViewDiscardPolicyEnabled {
-            let snapshot = makeHiddenWebViewDiscardBlockerSnapshot(isPlayingMedia: true)
+            let snapshot = makeHiddenWebViewDiscardBlockerSnapshot(hasAudibleMedia: true)
             let manager = BrowserHiddenWebViewDiscardManager()
             let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
             manager.delegate = delegate
@@ -166,12 +166,12 @@ struct BrowserHiddenWebViewDiscardMediaPlaybackTests {
         }
     }
 
-    /// An idle hidden pane (no playing media) must still be eligible for discard
+    /// An idle hidden pane (no audible media) must still be eligible for discard
     /// so the memory bound from https://github.com/manaflow-ai/cmux/issues/4539
     /// is preserved.
-    @Test func idlePaneWithoutMediaPlaybackStillSchedulesHiddenWebViewDiscard() {
+    @Test func idlePaneWithoutAudibleMediaStillSchedulesHiddenWebViewDiscard() {
         withHiddenWebViewDiscardPolicyEnabled {
-            let snapshot = makeHiddenWebViewDiscardBlockerSnapshot(isPlayingMedia: false)
+            let snapshot = makeHiddenWebViewDiscardBlockerSnapshot(hasAudibleMedia: false)
             let manager = BrowserHiddenWebViewDiscardManager()
             let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
             manager.delegate = delegate


### PR DESCRIPTION
## Summary

Part of #7596 (memory audit, slice 5 — browser pane discard). The audit found 224 browser panes mapping to a ~5 GB resident WebKit helper tree; hidden-webview discard exists (on by default, 300 s) but its blocker list could immortalize hidden panes.

Four fixes:

1. **Silent media no longer immortalizes panes.** `media_playback` blocked discard for any playing media frame, audible or not — a muted autoplaying hero video kept a hidden pane's WebContent process alive forever. The blocker now consumes the already-existing audible signal (`hasAudibleMedia`): background audio still blocks (real use), silent playback does not. `media_capture` (camera/mic) is unchanged, and the issue-#5409 media-report/glyph plumbing is untouched — only blocker consumption changed.
2. **DevTools blocker keys on reality.** It combined a persisted intent flag (`preferredDeveloperToolsVisible`) with the live inspector probe; a stale intent flag with no actual inspector immortalized the pane. Now only the live probe blocks.
3. **Blocked panes self-heal.** `scheduleIfNeeded` returned silently when blocked, and re-evaluation happened only on discrete events — any blocker whose clearing event didn't fire blocked discard forever. Blocked *hidden discard candidates* now arm a coarse one-shot re-check timer (`max(60 s, hiddenDelay)`, same generation-token + webview-instance guards and cancellation paths as the discard timer, cannot bypass blockers). Terminal states (visible, closing, already-discarded, policy-disabled) never arm it, so a system wake doesn't create per-pane timer churn at 224-pane scale.
4. **One shared observer instead of ~672.** Each panel's manager registered its own `UserDefaults.didChangeNotification` observer + 2 NSWorkspace sleep/wake observers, all re-resolving the same global policy on every defaults write. New `BrowserHiddenWebViewDiscardEventCenter` (singleton, injectable seams for tests) owns exactly one defaults observer + one sleep/wake pair, diffs the resolved policy once per change, and fans out to weakly-held subscribing managers. Per-panel delegate behavior is unchanged.

The issue's snapshot-and-release tier and a global live-WebContent cap are intentionally not in this slice (product-behavior changes; deferral rationale going on #7596). The post-wake discard guard (#5261) and memory-pressure immediate-discard path are unchanged.

## Tests

- New: silent-media-does-not-block, audible-media-blocks, devtools-preference-only-does-not-block, blocked-then-cleared self-heal via the re-check path, terminal-states-never-arm-recheck, and event-center suites (single observer per center, diffed fan-out, weak subscriber semantics) — `cmuxTests/BrowserHiddenWebViewDiscardEventCenterTests.swift` wired into pbxproj (`lint-pbxproj-test-wiring.sh` passes).
- Updated: `BrowserPanelTests` media helpers/tests renamed to audible semantics; blocker tests now use isolated suite defaults through the `policyDefaults` seam instead of ambient `.standard`.
- A red/green two-commit split isn't applicable here: the regression tests depend on the renamed snapshot field and new seams, so a test-only first commit could not compile against the old implementation.

Budgets: `BrowserPanel.swift` 11,640 ≤ 11,641 (net −1, 1:1 replacements), `BrowserPanelTests.swift` exactly at 4,367 (net 0); no `.github/*.tsv` changes; `swift_file_length_budget.py` passes.

No user-facing strings → no localization changes.

Part of #7596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786095502&installation_id=133855650&pr_number=7625&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7625&signature=95a354fc3e875300ec93b5a783aea049eb13ce7e2bd354e96449dc9c5fd6dc23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when hidden WKWebViews are torn down (audible vs silent media, DevTools probe, periodic recheck) and centralizes sleep/wake and policy notifications—behavioral risk around background playback and post-wake discard timing, mitigated by existing guards and new tests.
> 
> **Overview**
> Improves hidden-browser-pane memory reclaim (#7596) by fixing **blockers that never cleared** and collapsing **hundreds of duplicate observers** into one shared fan-out.
> 
> **Blocker behavior:** `media_playback` now keys off **audible** media (`hasAudibleMedia` / `isPlayingAudio`) so muted autoplay no longer keeps WebContent alive; capture still blocks. DevTools blocking uses only the **live** inspector probe, not `preferredDeveloperToolsVisible`. When scheduling is blocked but the pane is still a hidden discard candidate, a **one-shot recheck** (`max(60s, hiddenDelay)`) re-runs `scheduleIfNeeded` (reason `blocked_recheck`); visible, closing, already-discarded, and policy-disabled panes do not arm it.
> 
> **Observer model:** New `BrowserHiddenWebViewDiscardEventCenter` owns a single `UserDefaults` policy diff plus one sleep/wake pair and notifies weak subscribers; `BrowserHiddenWebViewDiscardManager` drops per-manager policy/sleep observers and uses `installEventCenterSubscription()` instead. `BrowserPanel` wires the new snapshot field and subscription API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e82e927f0072f0eb37d6242e555ef856dc4f17a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens hidden-webview discard and reduces memory by fixing non-permanent blockers and moving policy/sleep observers to one shared event center. Aligns recheck reporting, removes test-only seams, and resolves a Swift 6 actor-isolation warning; addresses #7596.

- **Bug Fixes**
  - Only audible media blocks discard; silent playback no longer does. Camera/mic capture still blocks.
  - DevTools blocker keys off the live inspector only, not the persisted preference.
  - Blocked hidden panes auto-recheck after max(60s, hiddenDelay); visible, closing, discarded, and policy-disabled panes don’t arm rechecks.
  - Blocked recheck reports the "blocked_recheck" reason in production for accurate diagnostics.

- **Refactors**
  - Added `BrowserHiddenWebViewDiscardEventCenter` to replace per-panel `UserDefaults` and sleep/wake observers with one diffing fan-out and weak subscribers.
  - Managers now subscribe via `installEventCenterSubscription()`, removing duplicate observers at scale.
  - Unified the recheck path via `performBlockedRecheckNow` and removed `...ForTesting` seams; event-center internals are `internal private(set)` for `@testable` access.
  - Fixed a Swift 6 actor-isolation warning by making `eventCenter` optional in init and resolving `.shared` inside the main-actor initializer.

<sup>Written for commit 8e82e927f0072f0eb37d6242e555ef856dc4f17a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hidden web view discard handling is now driven by a centralized flow that reacts to policy changes and system sleep/wake events.
  * Added delayed “blocked” recheck so discard can proceed automatically after blockers clear.
* **Bug Fixes**
  * Media playback blocking is more accurate using audible-media status (including media capture).
  * Improved scheduling behavior to avoid stale or duplicate discard-triggering.
* **Tests**
  * Expanded test coverage for the new event flow and blocked recheck/discard rules, including developer-tools and blocker scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->