### PR TITLE
Route browser-pane file drops by intent so they never silently become previews

### DIFF
--- a/Sources/BrowserFileDropNavigationGuard.swift
+++ b/Sources/BrowserFileDropNavigationGuard.swift
@@ -6,10 +6,16 @@ import WebKit
 final class BrowserFileDropNavigationGuard {
     static let shared = BrowserFileDropNavigationGuard()
 
-    private static let timeToLive: TimeInterval = 5
-    private var records: [ObjectIdentifier: Record] = [:]
+    private let timeToLive: TimeInterval
+    // Read by regression tests via @testable import to observe expiry.
+    private(set) var records: [ObjectIdentifier: Record] = [:]
+    private var expirySweepTask: Task<Void, Never>?
 
-    private final class Record {
+    init(timeToLive: TimeInterval = 5) {
+        self.timeToLive = timeToLive
+    }
+
+    final class Record {
         weak var webView: WKWebView?
         let webViewID: ObjectIdentifier
         /// Every file URL delivered by the drop, in pasteboard order. WebKit's
@@ -45,6 +51,7 @@ final class BrowserFileDropNavigationGuard {
             urls: urls,
             timestamp: now
         )
+        scheduleExpirySweep()
     }
 
     /// Consumes (once) the drop record that `url` belongs to and returns every
@@ -77,10 +84,27 @@ final class BrowserFileDropNavigationGuard {
         return url.isFileURL && isMainFrame && navigationType == .other
     }
 
+    /// Guard calls prune opportunistically, but the common successful-upload
+    /// path never calls the guard again (the page handled the drop, so no
+    /// fallback navigation fires). One coalesced sweep per drop batch releases
+    /// the recorded paths without waiting for a future drop. Bounded by
+    /// construction: at most one pending task, alive for timeToLive plus a
+    /// small margin, cancelled and replaced by any newer delivery.
+    private func scheduleExpirySweep() {
+        expirySweepTask?.cancel()
+        let delay = timeToLive + 0.05
+        expirySweepTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard let self, !Task.isCancelled else { return }
+            self.expirySweepTask = nil
+            self.pruneExpiredRecords(now: Date())
+        }
+    }
+
     private func pruneExpiredRecords(now: Date) {
         records = records.filter { _, record in
             guard record.webView != nil else { return false }
-            return now.timeIntervalSince(record.timestamp) <= Self.timeToLive
+            return now.timeIntervalSince(record.timestamp) <= timeToLive
         }
     }
 }

--- a/Sources/BrowserFileDropNavigationGuard.swift
+++ b/Sources/BrowserFileDropNavigationGuard.swift
@@ -1,0 +1,78 @@
+import AppKit
+import Foundation
+import WebKit
+
+@MainActor
+final class BrowserFileDropNavigationGuard {
+    static let shared = BrowserFileDropNavigationGuard()
+
+    private static let timeToLive: TimeInterval = 5
+    private var records: [ObjectIdentifier: Record] = [:]
+
+    private final class Record {
+        weak var webView: WKWebView?
+        let webViewID: ObjectIdentifier
+        let paths: Set<String>
+        let timestamp: Date
+
+        init(webView: WKWebView, paths: Set<String>, timestamp: Date) {
+            self.webView = webView
+            self.webViewID = ObjectIdentifier(webView)
+            self.paths = paths
+            self.timestamp = timestamp
+        }
+    }
+
+    func recordDelivery(
+        webView: WKWebView,
+        pasteboard: NSPasteboard,
+        now: Date = Date()
+    ) {
+        pruneExpiredRecords(now: now)
+        guard DragOverlayRoutingPolicy.hasFileURL(pasteboard.types) else { return }
+        let paths = Set(
+            DragOverlayRoutingPolicy.fileURLs(from: pasteboard)
+                .filter(\.isFileURL)
+                .map { $0.standardizedFileURL.path }
+        )
+        guard !paths.isEmpty else { return }
+        records[ObjectIdentifier(webView)] = Record(
+            webView: webView,
+            paths: paths,
+            timestamp: now
+        )
+    }
+
+    func consumeDropNavigation(
+        webView: WKWebView,
+        url: URL,
+        now: Date = Date()
+    ) -> Bool {
+        pruneExpiredRecords(now: now)
+        let webViewID = ObjectIdentifier(webView)
+        guard let record = records[webViewID],
+              record.webViewID == webViewID,
+              record.webView === webView,
+              record.paths.contains(url.standardizedFileURL.path) else {
+            return false
+        }
+        records[webViewID] = nil
+        return true
+    }
+
+    static func isDropFallbackNavigation(
+        url: URL?,
+        isMainFrame: Bool,
+        navigationType: WKNavigationType
+    ) -> Bool {
+        guard let url else { return false }
+        return url.isFileURL && isMainFrame && navigationType == .other
+    }
+
+    private func pruneExpiredRecords(now: Date) {
+        records = records.filter { _, record in
+            guard record.webView != nil else { return false }
+            return now.timeIntervalSince(record.timestamp) <= Self.timeToLive
+        }
+    }
+}

--- a/Sources/BrowserFileDropNavigationGuard.swift
+++ b/Sources/BrowserFileDropNavigationGuard.swift
@@ -12,13 +12,18 @@ final class BrowserFileDropNavigationGuard {
     private final class Record {
         weak var webView: WKWebView?
         let webViewID: ObjectIdentifier
+        /// Every file URL delivered by the drop, in pasteboard order. WebKit's
+        /// fallback navigation names only one file of a multi-file drop, but the
+        /// preview fallback must open all of them.
+        let urls: [URL]
         let paths: Set<String>
         let timestamp: Date
 
-        init(webView: WKWebView, paths: Set<String>, timestamp: Date) {
+        init(webView: WKWebView, urls: [URL], timestamp: Date) {
             self.webView = webView
             self.webViewID = ObjectIdentifier(webView)
-            self.paths = paths
+            self.urls = urls
+            self.paths = Set(urls.map(\.path))
             self.timestamp = timestamp
         }
     }
@@ -30,34 +35,37 @@ final class BrowserFileDropNavigationGuard {
     ) {
         pruneExpiredRecords(now: now)
         guard DragOverlayRoutingPolicy.hasFileURL(pasteboard.types) else { return }
-        let paths = Set(
-            DragOverlayRoutingPolicy.fileURLs(from: pasteboard)
-                .filter(\.isFileURL)
-                .map { $0.standardizedFileURL.path }
-        )
-        guard !paths.isEmpty else { return }
+        // Already standardized and deduped by path, in pasteboard order.
+        let urls = DragOverlayRoutingPolicy.fileURLs(from: pasteboard)
+            .filter(\.isFileURL)
+            .map(\.standardizedFileURL)
+        guard !urls.isEmpty else { return }
         records[ObjectIdentifier(webView)] = Record(
             webView: webView,
-            paths: paths,
+            urls: urls,
             timestamp: now
         )
     }
 
+    /// Consumes (once) the drop record that `url` belongs to and returns every
+    /// file URL delivered by that drop, or nil when the navigation does not
+    /// match a live record. Callers preview the full list, not just the single
+    /// file WebKit chose to navigate to.
     func consumeDropNavigation(
         webView: WKWebView,
         url: URL,
         now: Date = Date()
-    ) -> Bool {
+    ) -> [URL]? {
         pruneExpiredRecords(now: now)
         let webViewID = ObjectIdentifier(webView)
         guard let record = records[webViewID],
               record.webViewID == webViewID,
               record.webView === webView,
               record.paths.contains(url.standardizedFileURL.path) else {
-            return false
+            return nil
         }
         records[webViewID] = nil
-        return true
+        return record.urls
     }
 
     static func isDropFallbackNavigation(

--- a/Sources/BrowserPaneDropTargetView.swift
+++ b/Sources/BrowserPaneDropTargetView.swift
@@ -7,9 +7,10 @@ final class BrowserPaneDropTargetView: NSView {
     weak var slotView: WindowBrowserSlotView?
     var dropContext: BrowserPaneDropContext?
     private var activeZone: DropZone?
-    private weak var activeFileDropWebView: NSView?
-    private weak var preparedFileDropWebView: NSView?
-    private weak var performedFileDropWebView: NSView?
+    weak var activeFileDropWebView: NSView?
+    weak var preparedFileDropWebView: NSView?
+    weak var performedFileDropWebView: NSView?
+    var didRequestWebViewRestoreForDrag = false
 #if DEBUG
     private var lastHitTestSignature: String?
 #endif
@@ -34,18 +35,19 @@ final class BrowserPaneDropTargetView: NSView {
     @MainActor
     static func shouldCaptureHitTesting(
         pasteboardTypes: [NSPasteboard.PasteboardType]?,
-        eventType: NSEvent.EventType?
+        eventType: NSEvent.EventType?,
+        isDockHosted: Bool = false
     ) -> Bool {
         guard WindowInputRoutingContext.allowsPaneDropHitTesting(eventType: eventType) else { return false }
 
         let hasFileURL = DragOverlayRoutingPolicy.hasFileURL(pasteboardTypes)
-        let fileDropBehavior = DragOverlayRoutingPolicy.resolvedFileDropBehavior(
+        let disposition = BrowserPaneFileDropRouting.disposition(
             pasteboardTypes: pasteboardTypes,
             modifierFlags: DragOverlayRoutingPolicy.currentModifierFlags,
-            canDropAsText: true
+            isDockHosted: isDockHosted
         )
-        let fileDropWantsPreview = fileDropBehavior == .preview
-        let shouldCaptureFileDrop = fileDropBehavior != nil
+        let fileDropWantsPreview = disposition == .previewInWorkspace
+        let shouldCaptureFileDrop = disposition != nil
         let hasFilePreviewTransfer = DragOverlayRoutingPolicy.hasFilePreviewTransfer(pasteboardTypes)
         let hasBonsplitTransfer = DragOverlayRoutingPolicy.hasBonsplitTabTransfer(pasteboardTypes)
         let shouldCaptureFilePreviewTransfer = hasFilePreviewTransfer && (!hasFileURL || fileDropWantsPreview)
@@ -66,7 +68,8 @@ final class BrowserPaneDropTargetView: NSView {
         let pasteboardTypes = NSPasteboard(name: .drag).types
         let capture = Self.shouldCaptureHitTesting(
             pasteboardTypes: pasteboardTypes,
-            eventType: eventType
+            eventType: eventType,
+            isDockHosted: isDockHostedPane
         )
 #if DEBUG
         logHitTestDecision(capture: capture, pasteboardTypes: pasteboardTypes, eventType: eventType)
@@ -84,6 +87,7 @@ final class BrowserPaneDropTargetView: NSView {
 
     override func draggingExited(_ sender: (any NSDraggingInfo)?) {
         exitActiveFileDropWebView(sender)
+        didRequestWebViewRestoreForDrag = false
         clearDragState(phase: "exited")
     }
 
@@ -96,9 +100,9 @@ final class BrowserPaneDropTargetView: NSView {
         }
 
         let location = convert(sender.draggingLocation, from: nil)
-        if shouldRouteFileDropToHostedWebView(sender, at: location) {
+        if fileDropDisposition(sender) == .forwardToPage {
             clearDragState(phase: "prepare.text")
-            let webView = activeFileDropWebView ?? slotView?.hostedWebViewForFileDrop(at: location)
+            let webView = activeFileDropWebView ?? webViewForFileDropDelivery(at: location)
             let accepted = webView?.prepareForDragOperation(sender) ?? false
             preparedFileDropWebView = accepted ? webView : nil
 #if DEBUG
@@ -133,6 +137,7 @@ final class BrowserPaneDropTargetView: NSView {
 
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
         defer {
+            didRequestWebViewRestoreForDrag = false
             clearDragState(phase: "perform.clear")
         }
 
@@ -150,8 +155,8 @@ final class BrowserPaneDropTargetView: NSView {
             topChromeHeight: slotView?.effectivePaneTopChromeHeight() ?? 0
         )
 
-        if shouldRouteFileDropToHostedWebView(sender, at: location) {
-            let webView = preparedFileDropWebView ?? activeFileDropWebView ?? slotView?.hostedWebViewForFileDrop(at: location)
+        if fileDropDisposition(sender) == .forwardToPage {
+            let webView = preparedFileDropWebView ?? activeFileDropWebView ?? webViewForFileDropDelivery(at: location)
             let handled = webView?.performDragOperation(sender) ?? false
             if handled {
                 performedFileDropWebView = webView
@@ -313,6 +318,7 @@ final class BrowserPaneDropTargetView: NSView {
             activeFileDropWebView = nil
             preparedFileDropWebView = nil
             performedFileDropWebView = nil
+            didRequestWebViewRestoreForDrag = false
             clearDragState(phase: "conclude.clear")
         }
         guard let sender else { return }
@@ -341,7 +347,7 @@ final class BrowserPaneDropTargetView: NSView {
             topChromeHeight: slotView?.effectivePaneTopChromeHeight() ?? 0
         )
 
-        if shouldRouteFileDropToHostedWebView(sender, at: location) {
+        if fileDropDisposition(sender) == .forwardToPage {
             clearDragState(phase: "\(phase).text")
             return updateHostedWebViewDragState(sender, at: location)
         }
@@ -404,29 +410,6 @@ final class BrowserPaneDropTargetView: NSView {
         return .copy
     }
 
-    private func shouldRouteFileDropToHostedWebView(_ sender: any NSDraggingInfo, at location: NSPoint) -> Bool {
-        guard DragOverlayRoutingPolicy.hasFileURL(sender.draggingPasteboard.types) else { return false }
-        let canDropIntoHostedWebView = slotView?.hostedWebViewForFileDrop(at: location) != nil
-        // A Dock-hosted browser pane has no workspace-tree file-preview
-        // destination, so a file URL dropped over its page content always
-        // forwards to the hosted WKWebView (normal page upload) regardless of the
-        // text/preview file-drop setting. This preserves the pre-Dock-drop
-        // behavior, where the pane target did not claim the drop and it fell
-        // through to the web view; without it, preview-mode (or Shift-inverted)
-        // file drops on Dock browsers would be claimed by the pane target and
-        // rejected by the Dock guard instead of reaching the page.
-        if canDropIntoHostedWebView,
-           let context = dropContext,
-           AppDelegate.shared?.dockForPane(context.paneId) != nil {
-            return true
-        }
-        return DragOverlayRoutingPolicy.shouldRouteFileDropToTextDestination(
-            pasteboardTypes: sender.draggingPasteboard.types,
-            modifierFlags: DragOverlayRoutingPolicy.currentModifierFlags,
-            canDropAsText: canDropIntoHostedWebView
-        )
-    }
-
     private func activeDropContext() -> BrowserPaneDropContext? {
         dropContext
     }
@@ -443,26 +426,6 @@ final class BrowserPaneDropTargetView: NSView {
             return nil
         }
         return transfer
-    }
-
-    private func updateHostedWebViewDragState(_ sender: any NSDraggingInfo, at location: NSPoint) -> NSDragOperation {
-        guard let webView = slotView?.hostedWebViewForFileDrop(at: location) else {
-            exitActiveFileDropWebView(sender)
-            return []
-        }
-        if activeFileDropWebView !== webView {
-            exitActiveFileDropWebView(sender)
-            activeFileDropWebView = webView
-            return webView.draggingEntered(sender)
-        }
-        return webView.draggingUpdated(sender)
-    }
-
-    private func exitActiveFileDropWebView(_ sender: (any NSDraggingInfo)?) {
-        if let webView = activeFileDropWebView {
-            webView.draggingExited(sender)
-            activeFileDropWebView = nil
-        }
     }
 
     private func focusBrowserPanelAfterSuccessfulFileDrop(context: BrowserPaneDropContext) {

--- a/Sources/BrowserPaneDropTargetView.swift
+++ b/Sources/BrowserPaneDropTargetView.swift
@@ -162,6 +162,9 @@ final class BrowserPaneDropTargetView: NSView {
 
         if fileDropDisposition(sender) == .forwardToPage {
             let webView = preparedFileDropWebView ?? activeFileDropWebView ?? webViewForFileDropDelivery(at: location)
+            if let webView = webView as? WKWebView {
+                BrowserFileDropNavigationGuard.shared.recordDelivery(webView: webView, pasteboard: sender.draggingPasteboard)
+            }
             let handled = webView?.performDragOperation(sender) ?? false
             if handled {
                 performedFileDropWebView = webView

--- a/Sources/BrowserPaneDropTargetView.swift
+++ b/Sources/BrowserPaneDropTargetView.swift
@@ -35,16 +35,22 @@ final class BrowserPaneDropTargetView: NSView {
     @MainActor
     static func shouldCaptureHitTesting(
         pasteboardTypes: [NSPasteboard.PasteboardType]?,
-        eventType: NSEvent.EventType?,
-        isDockHosted: Bool = false
+        eventType: NSEvent.EventType?
     ) -> Bool {
         guard WindowInputRoutingContext.allowsPaneDropHitTesting(eventType: eventType) else { return false }
 
         let hasFileURL = DragOverlayRoutingPolicy.hasFileURL(pasteboardTypes)
+        // Dock-hosted status is deliberately not consulted here: it cannot change
+        // the capture result (a file-URL payload always yields a disposition, so
+        // `shouldCaptureFileDrop` is true either way; without a file URL the
+        // disposition is nil either way), and this runs from `hitTest` on
+        // pointer-hover events, where an app-wide dock ownership sweep per event
+        // is too expensive. Prepare/perform resolve the real dock-aware
+        // disposition via `fileDropDisposition(_:)`.
         let disposition = BrowserPaneFileDropRouting.disposition(
             pasteboardTypes: pasteboardTypes,
             modifierFlags: DragOverlayRoutingPolicy.currentModifierFlags,
-            isDockHosted: isDockHosted
+            isDockHosted: false
         )
         let fileDropWantsPreview = disposition == .previewInWorkspace
         let shouldCaptureFileDrop = disposition != nil
@@ -68,8 +74,7 @@ final class BrowserPaneDropTargetView: NSView {
         let pasteboardTypes = NSPasteboard(name: .drag).types
         let capture = Self.shouldCaptureHitTesting(
             pasteboardTypes: pasteboardTypes,
-            eventType: eventType,
-            isDockHosted: isDockHostedPane
+            eventType: eventType
         )
 #if DEBUG
         logHitTestDecision(capture: capture, pasteboardTypes: pasteboardTypes, eventType: eventType)

--- a/Sources/BrowserPaneDropTargetView.swift
+++ b/Sources/BrowserPaneDropTargetView.swift
@@ -162,11 +162,13 @@ final class BrowserPaneDropTargetView: NSView {
 
         if fileDropDisposition(sender) == .forwardToPage {
             let webView = preparedFileDropWebView ?? activeFileDropWebView ?? webViewForFileDropDelivery(at: location)
-            if let webView = webView as? WKWebView {
-                BrowserFileDropNavigationGuard.shared.recordDelivery(webView: webView, pasteboard: sender.draggingPasteboard)
-            }
             let handled = webView?.performDragOperation(sender) ?? false
             if handled {
+                // Arm the fallback guard only for delivered drops; WebKit resolves the
+                // fallback navigation asynchronously, so it still sees the record.
+                if let webView = webView as? WKWebView {
+                    BrowserFileDropNavigationGuard.shared.recordDelivery(webView: webView, pasteboard: sender.draggingPasteboard)
+                }
                 performedFileDropWebView = webView
                 focusBrowserPanelAfterSuccessfulFileDrop(context: dropContext)
             } else {

--- a/Sources/BrowserPaneFileDropRouting.swift
+++ b/Sources/BrowserPaneFileDropRouting.swift
@@ -1,17 +1,17 @@
 import AppKit
 import WebKit
 
-/// How a file-URL drag over a browser pane should be handled.
-enum BrowserPaneFileDropDisposition: Equatable {
-    /// Forward the drag to the hosted WKWebView (HTML5 page upload).
-    case forwardToPage
-    /// Open the file in cmux (file-preview pane / split) via the workspace handlers.
-    case previewInWorkspace
-}
-
 /// Routes browser-pane file drops by intent only: intent never depends on transient webview
 /// availability; delivery failure refuses the drop instead of reinterpreting it.
 enum BrowserPaneFileDropRouting {
+    /// How a file-URL drag over a browser pane should be handled.
+    enum Disposition: Equatable {
+        /// Forward the drag to the hosted WKWebView (HTML5 page upload).
+        case forwardToPage
+        /// Open the file in cmux (file-preview pane / split) via the workspace handlers.
+        case previewInWorkspace
+    }
+
     /// `isDockHosted` is an autoclosure so callers can defer the app-wide dock
     /// ownership lookup until a file-URL payload is actually present; drag
     /// callbacks fire for every payload type and must not pay for it otherwise.
@@ -20,7 +20,7 @@ enum BrowserPaneFileDropRouting {
         modifierFlags: NSEvent.ModifierFlags,
         isDockHosted: @autoclosure () -> Bool,
         defaultBehavior: FileDropDefaultBehavior = FileDropBehaviorSettings.behavior()
-    ) -> BrowserPaneFileDropDisposition? {
+    ) -> Disposition? {
         guard DragOverlayRoutingPolicy.hasFileURL(pasteboardTypes) else { return nil }
 
         // A Dock-hosted browser pane has no workspace-tree file-preview destination, so a
@@ -58,7 +58,7 @@ extension BrowserPaneDropTargetView {
         dropContext.map { AppDelegate.shared?.dockForPane($0.paneId) != nil } ?? false
     }
 
-    func fileDropDisposition(_ sender: any NSDraggingInfo) -> BrowserPaneFileDropDisposition? {
+    func fileDropDisposition(_ sender: any NSDraggingInfo) -> BrowserPaneFileDropRouting.Disposition? {
         BrowserPaneFileDropRouting.disposition(
             pasteboardTypes: sender.draggingPasteboard.types,
             modifierFlags: DragOverlayRoutingPolicy.currentModifierFlags,

--- a/Sources/BrowserPaneFileDropRouting.swift
+++ b/Sources/BrowserPaneFileDropRouting.swift
@@ -1,0 +1,119 @@
+import AppKit
+import WebKit
+
+/// How a file-URL drag over a browser pane should be handled.
+enum BrowserPaneFileDropDisposition: Equatable {
+    /// Forward the drag to the hosted WKWebView (HTML5 page upload).
+    case forwardToPage
+    /// Open the file in cmux (file-preview pane / split) via the workspace handlers.
+    case previewInWorkspace
+}
+
+/// Routes browser-pane file drops by intent only: intent never depends on transient webview
+/// availability; delivery failure refuses the drop instead of reinterpreting it.
+enum BrowserPaneFileDropRouting {
+    static func disposition(
+        pasteboardTypes: [NSPasteboard.PasteboardType]?,
+        modifierFlags: NSEvent.ModifierFlags,
+        isDockHosted: Bool,
+        defaultBehavior: FileDropDefaultBehavior = FileDropBehaviorSettings.behavior()
+    ) -> BrowserPaneFileDropDisposition? {
+        guard DragOverlayRoutingPolicy.hasFileURL(pasteboardTypes) else { return nil }
+
+        // A Dock-hosted browser pane has no workspace-tree file-preview destination, so a
+        // file URL dropped over its page content always forwards to the hosted WKWebView
+        // (normal page upload) regardless of the text/preview file-drop setting. This
+        // preserves the pre-Dock-drop behavior, where the pane target did not claim the drop
+        // and it fell through to the web view; without it, preview-mode (or Shift-inverted)
+        // file drops on Dock browsers would be claimed by the pane target and rejected by the
+        // Dock guard instead of reaching the page.
+        if isDockHosted {
+            return .forwardToPage
+        }
+
+        guard let behavior = DragOverlayRoutingPolicy.resolvedFileDropBehavior(
+            pasteboardTypes: pasteboardTypes,
+            modifierFlags: modifierFlags,
+            canDropAsText: true,
+            defaultBehavior: defaultBehavior
+        ) else {
+            return nil
+        }
+
+        switch behavior {
+        case .text:
+            return .forwardToPage
+        case .preview:
+            return .previewInWorkspace
+        }
+    }
+}
+
+@MainActor
+extension BrowserPaneDropTargetView {
+    var isDockHostedPane: Bool {
+        dropContext.map { AppDelegate.shared?.dockForPane($0.paneId) != nil } ?? false
+    }
+
+    func fileDropDisposition(_ sender: any NSDraggingInfo) -> BrowserPaneFileDropDisposition? {
+        BrowserPaneFileDropRouting.disposition(
+            pasteboardTypes: sender.draggingPasteboard.types,
+            modifierFlags: DragOverlayRoutingPolicy.currentModifierFlags,
+            isDockHosted: isDockHostedPane
+        )
+    }
+
+    func webViewForFileDropDelivery(at location: NSPoint) -> WKWebView? {
+        if let webView = slotView?.hostedWebViewForFileDrop(at: location) {
+            return webView
+        }
+
+        guard let window,
+              bounds.contains(location),
+              let context = dropContext else {
+            return nil
+        }
+
+        let windowPoint = convert(location, to: nil)
+        guard let webView = BrowserWindowPortalRegistry.webViewAtWindowPoint(windowPoint, in: window),
+              BrowserWindowPortalRegistry.paneDropContext(for: webView) == context else {
+            return nil
+        }
+        return webView
+    }
+
+    func updateHostedWebViewDragState(_ sender: any NSDraggingInfo, at location: NSPoint) -> NSDragOperation {
+        guard let webView = webViewForFileDropDelivery(at: location) else {
+            exitActiveFileDropWebView(sender)
+            requestWebViewRestoreForFileDropIfNeeded()
+            return []
+        }
+        if activeFileDropWebView !== webView {
+            exitActiveFileDropWebView(sender)
+            activeFileDropWebView = webView
+            return webView.draggingEntered(sender)
+        }
+        return webView.draggingUpdated(sender)
+    }
+
+    func exitActiveFileDropWebView(_ sender: (any NSDraggingInfo)?) {
+        if let webView = activeFileDropWebView {
+            webView.draggingExited(sender)
+            activeFileDropWebView = nil
+        }
+    }
+
+    func requestWebViewRestoreForFileDropIfNeeded() {
+        guard !didRequestWebViewRestoreForDrag,
+              let context = dropContext else {
+            return
+        }
+        didRequestWebViewRestoreForDrag = true
+        guard let panel = AppDelegate.shared?
+            .workspaceFor(tabId: context.workspaceId)?
+            .panels[context.panelId] as? BrowserPanel else {
+            return
+        }
+        panel.restoreDiscardedWebViewIfNeeded(reason: "browser_pane_file_drop")
+    }
+}

--- a/Sources/BrowserPaneFileDropRouting.swift
+++ b/Sources/BrowserPaneFileDropRouting.swift
@@ -12,10 +12,13 @@ enum BrowserPaneFileDropDisposition: Equatable {
 /// Routes browser-pane file drops by intent only: intent never depends on transient webview
 /// availability; delivery failure refuses the drop instead of reinterpreting it.
 enum BrowserPaneFileDropRouting {
+    /// `isDockHosted` is an autoclosure so callers can defer the app-wide dock
+    /// ownership lookup until a file-URL payload is actually present; drag
+    /// callbacks fire for every payload type and must not pay for it otherwise.
     static func disposition(
         pasteboardTypes: [NSPasteboard.PasteboardType]?,
         modifierFlags: NSEvent.ModifierFlags,
-        isDockHosted: Bool,
+        isDockHosted: @autoclosure () -> Bool,
         defaultBehavior: FileDropDefaultBehavior = FileDropBehaviorSettings.behavior()
     ) -> BrowserPaneFileDropDisposition? {
         guard DragOverlayRoutingPolicy.hasFileURL(pasteboardTypes) else { return nil }
@@ -27,7 +30,7 @@ enum BrowserPaneFileDropRouting {
         // and it fell through to the web view; without it, preview-mode (or Shift-inverted)
         // file drops on Dock browsers would be claimed by the pane target and rejected by the
         // Dock guard instead of reaching the page.
-        if isDockHosted {
+        if isDockHosted() {
             return .forwardToPage
         }
 

--- a/Sources/BrowserPaneFileDropRouting.swift
+++ b/Sources/BrowserPaneFileDropRouting.swift
@@ -79,6 +79,18 @@ extension BrowserPaneDropTargetView {
               BrowserWindowPortalRegistry.paneDropContext(for: webView) == context else {
             return nil
         }
+
+        // The registry lookup above hit-tests the whole slot container, not the
+        // hosted web view's own frame. When the web view is live in this window it
+        // may not fill the slot (a docked Web Inspector splits the slot with WebKit
+        // companion views), so a primary-path miss means the drop point is over
+        // non-page area: refuse instead of misrouting the drop into the page.
+        // Only a detached web view (discarded / mid-reparent) skips the geometry
+        // check; that transient gap is what this fallback exists for.
+        if webView.window === window {
+            let pointInWebView = webView.convert(windowPoint, from: nil)
+            guard webView.bounds.contains(pointInWebView) else { return nil }
+        }
         return webView
     }
 

--- a/Sources/BrowserPaneFileDropRouting.swift
+++ b/Sources/BrowserPaneFileDropRouting.swift
@@ -1,8 +1,9 @@
 import AppKit
 import WebKit
 
-/// Routes browser-pane file drops by intent only: intent never depends on transient webview
-/// availability; delivery failure refuses the drop instead of reinterpreting it.
+/// Routes browser-pane file drops by intent only: a file drag over browser page content is
+/// always delivered to the page unless Shift explicitly asks for a cmux preview; delivery
+/// failure refuses the drop instead of reinterpreting it.
 enum BrowserPaneFileDropRouting {
     /// How a file-URL drag over a browser pane should be handled.
     enum Disposition: Equatable {
@@ -18,8 +19,7 @@ enum BrowserPaneFileDropRouting {
     static func disposition(
         pasteboardTypes: [NSPasteboard.PasteboardType]?,
         modifierFlags: NSEvent.ModifierFlags,
-        isDockHosted: @autoclosure () -> Bool,
-        defaultBehavior: FileDropDefaultBehavior = FileDropBehaviorSettings.behavior()
+        isDockHosted: @autoclosure () -> Bool
     ) -> Disposition? {
         guard DragOverlayRoutingPolicy.hasFileURL(pasteboardTypes) else { return nil }
 
@@ -34,21 +34,7 @@ enum BrowserPaneFileDropRouting {
             return .forwardToPage
         }
 
-        guard let behavior = DragOverlayRoutingPolicy.resolvedFileDropBehavior(
-            pasteboardTypes: pasteboardTypes,
-            modifierFlags: modifierFlags,
-            canDropAsText: true,
-            defaultBehavior: defaultBehavior
-        ) else {
-            return nil
-        }
-
-        switch behavior {
-        case .text:
-            return .forwardToPage
-        case .preview:
-            return .previewInWorkspace
-        }
+        return modifierFlags.contains(.shift) ? .previewInWorkspace : .forwardToPage
     }
 }
 

--- a/Sources/FileDropOverlayView.swift
+++ b/Sources/FileDropOverlayView.swift
@@ -346,6 +346,7 @@ final class FileDropOverlayView: NSView {
                 return handled
             }
             if let webView {
+                BrowserFileDropNavigationGuard.shared.recordDelivery(webView: webView, pasteboard: sender.draggingPasteboard)
                 let handled = webView.performDragOperation(sender)
                 if !handled {
                     preparedDragWebView = nil
@@ -397,6 +398,7 @@ final class FileDropOverlayView: NSView {
         }
         preparedPaneDropTarget = nil
         if let webView {
+            BrowserFileDropNavigationGuard.shared.recordDelivery(webView: webView, pasteboard: sender.draggingPasteboard)
             let handled = webView.performDragOperation(sender)
             if !handled {
                 preparedDragWebView = nil

--- a/Sources/FileDropOverlayView.swift
+++ b/Sources/FileDropOverlayView.swift
@@ -259,6 +259,30 @@ final class FileDropOverlayView: NSView {
         }
     }
 
+    private func exitActiveDragTargets(
+        _ sender: (any NSDraggingInfo)?,
+        exceptPaneDropTarget paneDropTarget: (any FileDropPaneTarget)?,
+        webView: WKWebView?
+    ) {
+        if let prev = activeDragWebView, prev !== webView {
+            prev.draggingExited(sender)
+            activeDragWebView = nil
+        }
+        if let prev = activePaneDropTarget,
+           !samePaneDropTarget(prev, paneDropTarget) {
+            prev.fileDropDraggingExited(sender)
+            activePaneDropTarget = nil
+        }
+    }
+
+    private func samePaneDropTarget(
+        _ lhs: (any FileDropPaneTarget)?,
+        _ rhs: (any FileDropPaneTarget)?
+    ) -> Bool {
+        guard let lhs, let rhs else { return lhs == nil && rhs == nil }
+        return (lhs as AnyObject) === (rhs as AnyObject)
+    }
+
     override func prepareForDragOperation(_ sender: any NSDraggingInfo) -> Bool {
         let hasLocalDraggingSource = sender.draggingSource != nil
         let types = sender.draggingPasteboard.types
@@ -268,15 +292,16 @@ final class FileDropOverlayView: NSView {
         )
         if shouldRouteFileDropToTextDestination(sender) {
             let paneDropTarget = activePaneDropTarget ?? paneDropTargetForTextDrop(at: sender.draggingLocation)
-            exitActiveDragTargets(sender)
-            preparedDragWebView = nil
+            let webView = paneDropTarget == nil ? (activeDragWebView ?? webViewUnderPoint(sender.draggingLocation)) : nil
+            exitActiveDragTargets(sender, exceptPaneDropTarget: paneDropTarget, webView: webView)
             if let paneDropTarget {
+                preparedDragWebView = nil
                 let accepted = paneDropTarget.fileDropPrepareForDragOperation(sender)
                 preparedPaneDropTarget = accepted ? paneDropTarget : nil
                 return accepted
             }
             preparedPaneDropTarget = nil
-            if let webView = webViewUnderPoint(sender.draggingLocation) {
+            if let webView {
                 let accepted = webView.prepareForDragOperation(sender)
                 preparedDragWebView = accepted ? webView : nil
                 return accepted
@@ -304,8 +329,9 @@ final class FileDropOverlayView: NSView {
             exitActiveDragTargets(sender)
             return false
         }
-        preparedDragWebView = nil
+        exitActiveDragTargets(sender, exceptPaneDropTarget: paneDropTarget, webView: webView)
         if let paneDropTarget {
+            preparedDragWebView = nil
             let accepted = paneDropTarget.fileDropPrepareForDragOperation(sender)
             preparedPaneDropTarget = accepted ? paneDropTarget : nil
             return accepted
@@ -332,26 +358,31 @@ final class FileDropOverlayView: NSView {
             performedTextDragWebView = nil
             performedTextPaneDropTarget = nil
             let paneDropTarget = preparedPaneDropTarget ?? activePaneDropTarget ?? paneDropTargetForTextDrop(at: sender.draggingLocation)
-            let webView = preparedDragWebView ?? activeDragWebView ?? webViewUnderPoint(sender.draggingLocation)
-            exitActiveDragTargets(sender)
-            preparedDragWebView = nil
+            let webView = paneDropTarget == nil
+                ? (preparedDragWebView ?? activeDragWebView ?? webViewUnderPoint(sender.draggingLocation))
+                : nil
+            exitActiveDragTargets(sender, exceptPaneDropTarget: paneDropTarget, webView: webView)
             if let paneDropTarget {
+                preparedDragWebView = nil
                 let handled = paneDropTarget.fileDropPerformDragOperation(sender)
                 if handled {
                     didPerformDragAsText = true
                     performedTextPaneDropTarget = paneDropTarget
                 } else {
                     preparedPaneDropTarget = nil
+                    activePaneDropTarget = nil
                 }
                 return handled
             }
             if let webView {
-                BrowserFileDropNavigationGuard.shared.recordDelivery(webView: webView, pasteboard: sender.draggingPasteboard)
                 let handled = webView.performDragOperation(sender)
                 if !handled {
                     preparedDragWebView = nil
                     performedTextDragWebView = nil
+                    activeDragWebView = nil
                 } else {
+                    // Delivered drops only; see BrowserPaneDropTargetView.performDragOperation.
+                    BrowserFileDropNavigationGuard.shared.recordDelivery(webView: webView, pasteboard: sender.draggingPasteboard)
                     didPerformDragAsText = true
                     performedTextDragWebView = webView
                 }
@@ -387,8 +418,9 @@ final class FileDropOverlayView: NSView {
             exitActiveDragTargets(sender)
             return false
         }
-        preparedDragWebView = nil
+        exitActiveDragTargets(sender, exceptPaneDropTarget: paneDropTarget, webView: webView)
         if let paneDropTarget {
+            preparedDragWebView = nil
             let handled = paneDropTarget.fileDropPerformDragOperation(sender)
             if !handled {
                 preparedPaneDropTarget = nil
@@ -398,9 +430,11 @@ final class FileDropOverlayView: NSView {
         }
         preparedPaneDropTarget = nil
         if let webView {
-            BrowserFileDropNavigationGuard.shared.recordDelivery(webView: webView, pasteboard: sender.draggingPasteboard)
             let handled = webView.performDragOperation(sender)
-            if !handled {
+            if handled {
+                // Delivered drops only; see BrowserPaneDropTargetView.performDragOperation.
+                BrowserFileDropNavigationGuard.shared.recordDelivery(webView: webView, pasteboard: sender.draggingPasteboard)
+            } else {
                 preparedDragWebView = nil
                 activeDragWebView = nil
             }
@@ -426,10 +460,13 @@ final class FileDropOverlayView: NSView {
         if didPerformDragAsText {
             if let paneDropTarget = performedTextPaneDropTarget ?? preparedPaneDropTarget ?? activePaneDropTarget {
                 paneDropTarget.fileDropConcludeDragOperation(sender)
+                exitActiveDragTargets(sender, exceptPaneDropTarget: paneDropTarget, webView: nil)
             } else if let webView = performedTextDragWebView {
                 webView.concludeDragOperation(sender)
+                exitActiveDragTargets(sender, exceptPaneDropTarget: nil, webView: webView)
+            } else {
+                exitActiveDragTargets(sender)
             }
-            exitActiveDragTargets(sender)
             return
         }
         guard DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
@@ -440,10 +477,12 @@ final class FileDropOverlayView: NSView {
         }
         if let paneDropTarget = preparedPaneDropTarget ?? activePaneDropTarget {
             paneDropTarget.fileDropConcludeDragOperation(sender)
+            exitActiveDragTargets(sender, exceptPaneDropTarget: paneDropTarget, webView: nil)
             return
         }
         if let webView = preparedDragWebView ?? activeDragWebView {
             webView.concludeDragOperation(sender)
+            exitActiveDragTargets(sender, exceptPaneDropTarget: nil, webView: webView)
         }
     }
 

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -121,14 +121,28 @@ extension FileDropOverlayView {
         sender: any NSDraggingInfo,
         pasteboardTypes: [NSPasteboard.PasteboardType]?
     ) {
-        let kind = textDropDestinationKindUnderPoint(sender.draggingLocation)
+        let windowPoint = sender.draggingLocation
+        if editableTextViewUnderPoint(windowPoint) == nil,
+           webViewUnderPoint(windowPoint) != nil {
+            guard DragOverlayRoutingPolicy.hasFileURL(pasteboardTypes),
+                  !DragOverlayRoutingPolicy.currentModifierFlags.contains(.shift),
+                  let hintText = FileDropTextDestinationKind.editor.hintText(for: .preview),
+                  let targetBounds = hintBadgeTargetBoundsUnderPoint(windowPoint) else {
+                hintBadgeView.hide()
+                return
+            }
+            hintBadgeView.show(text: hintText, centeredIn: targetBounds, clippedTo: bounds)
+            return
+        }
+
+        let kind = textDropDestinationKindUnderPoint(windowPoint)
         guard let alternateBehavior = DragOverlayRoutingPolicy.alternateFileDropBehaviorForShiftHint(
             pasteboardTypes: pasteboardTypes,
             modifierFlags: DragOverlayRoutingPolicy.currentModifierFlags,
             canDropAsText: kind != nil
         ), let kind,
            let hintText = kind.hintText(for: alternateBehavior),
-           let targetBounds = hintBadgeTargetBoundsUnderPoint(sender.draggingLocation) else {
+           let targetBounds = hintBadgeTargetBoundsUnderPoint(windowPoint) else {
             hintBadgeView.hide()
             return
         }

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -17,6 +17,7 @@ import WebKit
     var shouldBlockInsecureHTTPNavigation: ((URL) -> Bool)?
     var shouldBlockInsecureHTTPSubframeDownload: ((URL) -> Bool)?
     var handleBlockedInsecureHTTPNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
+    var handleDroppedFileNavigation: ((URL) -> Bool)?
     var didRenderPDFDocument: ((URL, Bool) -> Void)?
     var didClearPDFDocument: (() -> Void)?
     /// Direct reference to the download delegate - must be set synchronously in didBecome callbacks.
@@ -231,6 +232,21 @@ import WebKit
            url.host == "bypass-ssl" {
             decisionHandler(.cancel)
             handleSSLTrustBypassAction(url, in: webView)
+            return
+        }
+
+        if let url = navigationAction.request.url,
+           BrowserFileDropNavigationGuard.isDropFallbackNavigation(
+               url: url,
+               isMainFrame: navigationAction.targetFrame?.isMainFrame == true,
+               navigationType: navigationAction.navigationType
+           ),
+           BrowserFileDropNavigationGuard.shared.consumeDropNavigation(webView: webView, url: url),
+           handleDroppedFileNavigation?(url) == true {
+#if DEBUG
+            cmuxDebugLog("browser.nav.decidePolicy.action kind=dropFilePreview url=\(browserNavigationDebugURL(url))")
+#endif
+            decisionHandler(.cancel)
             return
         }
 
@@ -600,21 +616,5 @@ import WebKit
         #endif
         NSLog("BrowserPanel download didBecome from navigationResponse")
         download.delegate = downloadDelegate
-    }
-}
-
-extension WKWebView {
-    @MainActor
-    func cmuxRunPrintOperation() {
-        guard #available(macOS 11.0, *) else { return }
-        let printInfo = (NSPrintInfo.shared.copy() as? NSPrintInfo) ?? NSPrintInfo()
-        let operation = printOperation(with: printInfo)
-        operation.showsPrintPanel = true
-        operation.showsProgressPanel = true
-        if let window {
-            operation.runModal(for: window, delegate: nil, didRun: nil, contextInfo: nil)
-        } else {
-            operation.run()
-        }
     }
 }

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -17,7 +17,7 @@ import WebKit
     var shouldBlockInsecureHTTPNavigation: ((URL) -> Bool)?
     var shouldBlockInsecureHTTPSubframeDownload: ((URL) -> Bool)?
     var handleBlockedInsecureHTTPNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
-    var handleDroppedFileNavigation: ((URL) -> Bool)?
+    var handleDroppedFileNavigation: (([URL]) -> Bool)?
     var didRenderPDFDocument: ((URL, Bool) -> Void)?
     var didClearPDFDocument: (() -> Void)?
     /// Direct reference to the download delegate - must be set synchronously in didBecome callbacks.
@@ -241,8 +241,8 @@ import WebKit
                isMainFrame: navigationAction.targetFrame?.isMainFrame == true,
                navigationType: navigationAction.navigationType
            ),
-           BrowserFileDropNavigationGuard.shared.consumeDropNavigation(webView: webView, url: url),
-           handleDroppedFileNavigation?(url) == true {
+           let droppedURLs = BrowserFileDropNavigationGuard.shared.consumeDropNavigation(webView: webView, url: url),
+           handleDroppedFileNavigation?(droppedURLs) == true {
 #if DEBUG
             cmuxDebugLog("browser.nav.decidePolicy.action kind=dropFilePreview url=\(browserNavigationDebugURL(url))")
 #endif

--- a/Sources/Panels/BrowserPanel+InteractiveModalHostWindow.swift
+++ b/Sources/Panels/BrowserPanel+InteractiveModalHostWindow.swift
@@ -1,0 +1,22 @@
+import AppKit
+import WebKit
+
+func browserInteractiveModalHostWindow(_ window: NSWindow?) -> NSWindow? {
+    guard let window else { return nil }
+    guard window.isVisible else { return nil }
+    guard window.alphaValue > 0 else { return nil }
+    guard !window.ignoresMouseEvents else { return nil }
+    guard !window.isExcludedFromWindowsMenu else { return nil }
+    return window
+}
+
+func browserInteractiveModalHostWindow(for webView: WKWebView) -> NSWindow? {
+    browserInteractiveModalHostWindow(webView.window)
+}
+
+func browserFallbackInteractiveModalHostWindow() -> NSWindow? {
+    if let keyWindow = browserInteractiveModalHostWindow(NSApp.keyWindow) {
+        return keyWindow
+    }
+    return browserInteractiveModalHostWindow(NSApp.mainWindow)
+}

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3977,11 +3977,11 @@ final class BrowserPanel: Panel, ObservableObject {
         navDelegate.handleBlockedInsecureHTTPNavigation = { [weak self] request, intent in
             self?.presentInsecureHTTPAlert(for: request, intent: intent, recordTypedNavigation: false)
         }
-        navDelegate.handleDroppedFileNavigation = { [weak self] url in
+        navDelegate.handleDroppedFileNavigation = { [weak self] urls in
             guard let self, let workspace = AppDelegate.shared?.workspaceFor(tabId: self.workspaceId),
                   let paneId = workspace.paneId(forPanelId: self.id) else { return false }
             return workspace.handleExternalFileDrop(BonsplitController.ExternalFileDropRequest(
-                urls: [url], destination: PaneDropRouting.filePreviewDestination(targetPane: paneId, zone: .right)))
+                urls: urls, destination: PaneDropRouting.filePreviewDestination(targetPane: paneId, zone: .right)))
         }
         navDelegate.didTerminateWebContentProcess = { [weak self] webView in
             self?.replaceWebViewAfterContentProcessTermination(for: webView)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1047,26 +1047,6 @@ private func browserCopyExternalNavigationURL(_ url: URL) {
     NSPasteboard.general.setString(url.absoluteString, forType: .string)
 }
 
-func browserInteractiveModalHostWindow(_ window: NSWindow?) -> NSWindow? {
-    guard let window else { return nil }
-    guard window.isVisible else { return nil }
-    guard window.alphaValue > 0 else { return nil }
-    guard !window.ignoresMouseEvents else { return nil }
-    guard !window.isExcludedFromWindowsMenu else { return nil }
-    return window
-}
-
-func browserInteractiveModalHostWindow(for webView: WKWebView) -> NSWindow? {
-    browserInteractiveModalHostWindow(webView.window)
-}
-
-private func browserFallbackInteractiveModalHostWindow() -> NSWindow? {
-    if let keyWindow = browserInteractiveModalHostWindow(NSApp.keyWindow) {
-        return keyWindow
-    }
-    return browserInteractiveModalHostWindow(NSApp.mainWindow)
-}
-
 typealias BrowserAlertPresenter = (
     _ alert: NSAlert,
     _ webView: WKWebView,
@@ -3996,6 +3976,12 @@ final class BrowserPanel: Panel, ObservableObject {
         navDelegate.shouldBlockInsecureHTTPSubframeDownload = { browserShouldBlockInsecureHTTPURL($0) }
         navDelegate.handleBlockedInsecureHTTPNavigation = { [weak self] request, intent in
             self?.presentInsecureHTTPAlert(for: request, intent: intent, recordTypedNavigation: false)
+        }
+        navDelegate.handleDroppedFileNavigation = { [weak self] url in
+            guard let self, let workspace = AppDelegate.shared?.workspaceFor(tabId: self.workspaceId),
+                  let paneId = workspace.paneId(forPanelId: self.id) else { return false }
+            return workspace.handleExternalFileDrop(BonsplitController.ExternalFileDropRequest(
+                urls: [url], destination: PaneDropRouting.filePreviewDestination(targetPane: paneId, zone: .right)))
         }
         navDelegate.didTerminateWebContentProcess = { [weak self] webView in
             self?.replaceWebViewAfterContentProcessTermination(for: webView)

--- a/Sources/Panels/WKWebView+CmuxPrintOperation.swift
+++ b/Sources/Panels/WKWebView+CmuxPrintOperation.swift
@@ -1,0 +1,18 @@
+import AppKit
+import WebKit
+
+extension WKWebView {
+    @MainActor
+    func cmuxRunPrintOperation() {
+        guard #available(macOS 11.0, *) else { return }
+        let printInfo = (NSPrintInfo.shared.copy() as? NSPrintInfo) ?? NSPrintInfo()
+        let operation = printOperation(with: printInfo)
+        operation.showsPrintPanel = true
+        operation.showsProgressPanel = true
+        if let window {
+            operation.runModal(for: window, delegate: nil, didRun: nil, contextInfo: nil)
+        } else {
+            operation.run()
+        }
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		D0B1002EA1B2C3D4E5F60001 /* BrowserPaneDropRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1002FA1B2C3D4E5F60001 /* BrowserPaneDropRouting.swift */; };
 		D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */; };
 		D0B1001EA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */; };
+		D7632001A1B2C3D4E5F60718 /* BrowserPaneFileDropRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632002A1B2C3D4E5F60718 /* BrowserPaneFileDropRouting.swift */; };
 		D7632003A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632004A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift */; };
 		C65241010000000000000001 /* BrowserPanel+AppPricingRestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65241010000000000000002 /* BrowserPanel+AppPricingRestore.swift */; };
 		C3711E000000000000000001 /* BrowserPanel+DisplayURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3711E000000000000000002 /* BrowserPanel+DisplayURL.swift */; };
@@ -1765,6 +1766,7 @@
 		D0B1002FA1B2C3D4E5F60001 /* BrowserPaneDropRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropRouting.swift; sourceTree = "<group>"; };
 		D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropRoutingTests.swift; sourceTree = "<group>"; };
 		D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropTargetView.swift; sourceTree = "<group>"; };
+		D7632002A1B2C3D4E5F60718 /* BrowserPaneFileDropRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneFileDropRouting.swift; sourceTree = "<group>"; };
 		D7632004A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneFileDropUploadRegressionTests.swift; sourceTree = "<group>"; };
 		C65241010000000000000002 /* BrowserPanel+AppPricingRestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+AppPricingRestore.swift"; sourceTree = "<group>"; };
 		C3711E000000000000000002 /* BrowserPanel+DisplayURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+DisplayURL.swift"; sourceTree = "<group>"; };
@@ -3618,6 +3620,7 @@
 				606600020000000000000002 /* WindowTerminalHostViewHitTesting.swift */,
 				D0B10007A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift */,
 				D0B1004FA1B2C3D4E5F60001 /* BrowserPaneDragTransfer.swift */,
+				D7632002A1B2C3D4E5F60718 /* BrowserPaneFileDropRouting.swift */,
 				D0B1005FA1B2C3D4E5F60001 /* BrowserPaneDropAction.swift */,
 				D0B1002FA1B2C3D4E5F60001 /* BrowserPaneDropRouting.swift */,
 				D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */,
@@ -5179,6 +5182,7 @@
 				D0B1005EA1B2C3D4E5F60001 /* BrowserPaneDropAction.swift in Sources */,
 				D0B1002EA1B2C3D4E5F60001 /* BrowserPaneDropRouting.swift in Sources */,
 				D0B1001EA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift in Sources */,
+				D7632001A1B2C3D4E5F60718 /* BrowserPaneFileDropRouting.swift in Sources */,
 				C65241010000000000000001 /* BrowserPanel+AppPricingRestore.swift in Sources */,
 				C3711E000000000000000001 /* BrowserPanel+DisplayURL.swift in Sources */,
 				A500MX01 /* BrowserPanel+MediaPlayback.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		D0B1002EA1B2C3D4E5F60001 /* BrowserPaneDropRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1002FA1B2C3D4E5F60001 /* BrowserPaneDropRouting.swift */; };
 		D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */; };
 		D0B1001EA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */; };
+		D7632003A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632004A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift */; };
 		C65241010000000000000001 /* BrowserPanel+AppPricingRestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65241010000000000000002 /* BrowserPanel+AppPricingRestore.swift */; };
 		C3711E000000000000000001 /* BrowserPanel+DisplayURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3711E000000000000000002 /* BrowserPanel+DisplayURL.swift */; };
 		A500MX01 /* BrowserPanel+MediaPlayback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500MX00 /* BrowserPanel+MediaPlayback.swift */; };
@@ -1764,6 +1765,7 @@
 		D0B1002FA1B2C3D4E5F60001 /* BrowserPaneDropRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropRouting.swift; sourceTree = "<group>"; };
 		D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropRoutingTests.swift; sourceTree = "<group>"; };
 		D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropTargetView.swift; sourceTree = "<group>"; };
+		D7632004A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneFileDropUploadRegressionTests.swift; sourceTree = "<group>"; };
 		C65241010000000000000002 /* BrowserPanel+AppPricingRestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+AppPricingRestore.swift"; sourceTree = "<group>"; };
 		C3711E000000000000000002 /* BrowserPanel+DisplayURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+DisplayURL.swift"; sourceTree = "<group>"; };
 		A500MX00 /* BrowserPanel+MediaPlayback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+MediaPlayback.swift"; sourceTree = "<group>"; };
@@ -4377,13 +4379,14 @@
 				B6585002B6585002B658PW02 /* BrowserPrewarmedWebViewPoolTests.swift */,
 				58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */,
 				C42660040000000000000002 /* BrowserPDFPreviewActionRegressionTests.swift */,
-				C42660050000000000000002 /* BrowserPDFPreviewActionUnitTests.swift */,
-				C0DE62600000000000000002 /* BrowserWindowPortalRegistryNotificationTests.swift */,
-				19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */,
-				48D6AE11906A4DF3BEB8CDFE /* OmnibarSubmitDecisionTests.swift */,
-				D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */,
-				D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */,
-				D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */,
+					C42660050000000000000002 /* BrowserPDFPreviewActionUnitTests.swift */,
+					C0DE62600000000000000002 /* BrowserWindowPortalRegistryNotificationTests.swift */,
+					19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */,
+					48D6AE11906A4DF3BEB8CDFE /* OmnibarSubmitDecisionTests.swift */,
+					D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */,
+					D7632004A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift */,
+					D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */,
+					D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */,
 				EC010C02 /* TerminalUploadCommandTests.swift */,
 				02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */,
 				6190C0116190C0116190C011 /* TerminalCopyOnSelectManagedConfigLayeringTests.swift */,
@@ -6156,6 +6159,7 @@
 				C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */,
 				B7380002B7380002B7380002 /* BrowserOmnibarSuggestionClickRoutingTests.swift in Sources */,
 				D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */,
+				D7632003A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift in Sources */,
 				B65060010000000000000002 /* BrowserPanelSessionRestoreTests.swift in Sources */,
 				1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */,
 				C42660040000000000000001 /* BrowserPDFPreviewActionRegressionTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		C2035A010000000000000001 /* BrowserErrorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A010000000000000002 /* BrowserErrorPage.swift */; };
 		C2035A020000000000000001 /* BrowserErrorPageContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A020000000000000002 /* BrowserErrorPageContent.swift */; };
 		C2035A0C000000000000001 /* BrowserErrorPageRetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A0C000000000000002 /* BrowserErrorPageRetry.swift */; };
+		D7632A11A1B2C3D4E5F60718 /* BrowserFileDropNavigationGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632A12A1B2C3D4E5F60718 /* BrowserFileDropNavigationGuard.swift */; };
 		A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 		A5008373 /* BrowserFindWebViewEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008372 /* BrowserFindWebViewEvaluator.swift */; };
 		7B5F1A2E9C0D4B6A8E217302 /* BrowserFixtureInteractionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F1A2E9C0D4B6A8E217301 /* BrowserFixtureInteractionUITests.swift */; };
@@ -201,6 +202,7 @@
 		D7632003A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632004A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift */; };
 		C65241010000000000000001 /* BrowserPanel+AppPricingRestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65241010000000000000002 /* BrowserPanel+AppPricingRestore.swift */; };
 		C3711E000000000000000001 /* BrowserPanel+DisplayURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3711E000000000000000002 /* BrowserPanel+DisplayURL.swift */; };
+		D7632B11A1B2C3D4E5F60718 /* BrowserPanel+InteractiveModalHostWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632B12A1B2C3D4E5F60718 /* BrowserPanel+InteractiveModalHostWindow.swift */; };
 		A500MX01 /* BrowserPanel+MediaPlayback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500MX00 /* BrowserPanel+MediaPlayback.swift */; };
 		D7AB00000000000000000007 /* BrowserPanel+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */; };
 		C67540060000000000000001 /* BrowserPanel+PDFDocumentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540060000000000000002 /* BrowserPanel+PDFDocumentActions.swift */; };
@@ -1417,6 +1419,7 @@
 		604500100000000000000003 /* WindowTitleTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604500100000000000000004 /* WindowTitleTemplateTests.swift */; };
 		E30760080000000000000002 /* WindowTmuxWorkspacePaneOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30760080000000000000001 /* WindowTmuxWorkspacePaneOverlayController.swift */; };
 		A5001209 /* WindowToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001219 /* WindowToolbarController.swift */; };
+		D7632B13A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632B14A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift */; };
 		C0DE43000000000000000007 /* Workspace+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE43000000000000000008 /* Workspace+AgentChat.swift */; };
 		CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */; };
 		C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */; };
@@ -1728,6 +1731,7 @@
 		C2035A010000000000000002 /* BrowserErrorPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserErrorPage.swift; sourceTree = "<group>"; };
 		C2035A020000000000000002 /* BrowserErrorPageContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserErrorPageContent.swift; sourceTree = "<group>"; };
 		C2035A0C000000000000002 /* BrowserErrorPageRetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserErrorPageRetry.swift; sourceTree = "<group>"; };
+		D7632A12A1B2C3D4E5F60718 /* BrowserFileDropNavigationGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFileDropNavigationGuard.swift; sourceTree = "<group>"; };
 		A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
 		A5008372 /* BrowserFindWebViewEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/BrowserFindWebViewEvaluator.swift; sourceTree = "<group>"; };
 		7B5F1A2E9C0D4B6A8E217301 /* BrowserFixtureInteractionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFixtureInteractionUITests.swift; sourceTree = "<group>"; };
@@ -1770,6 +1774,7 @@
 		D7632004A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneFileDropUploadRegressionTests.swift; sourceTree = "<group>"; };
 		C65241010000000000000002 /* BrowserPanel+AppPricingRestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+AppPricingRestore.swift"; sourceTree = "<group>"; };
 		C3711E000000000000000002 /* BrowserPanel+DisplayURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+DisplayURL.swift"; sourceTree = "<group>"; };
+		D7632B12A1B2C3D4E5F60718 /* BrowserPanel+InteractiveModalHostWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+InteractiveModalHostWindow.swift"; sourceTree = "<group>"; };
 		A500MX00 /* BrowserPanel+MediaPlayback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+MediaPlayback.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		C67540060000000000000002 /* BrowserPanel+PDFDocumentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+PDFDocumentActions.swift"; sourceTree = "<group>"; };
@@ -2917,6 +2922,7 @@
 		604500100000000000000004 /* WindowTitleTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowTitleTemplateTests.swift; sourceTree = "<group>"; };
 		E30760080000000000000001 /* WindowTmuxWorkspacePaneOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowTmuxWorkspacePaneOverlayController.swift; sourceTree = "<group>"; };
 		A5001219 /* WindowToolbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowToolbarController.swift; sourceTree = "<group>"; };
+		D7632B14A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/WKWebView+CmuxPrintOperation.swift"; sourceTree = "<group>"; };
 		C0DE43000000000000000008 /* Workspace+AgentChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentChat.swift"; sourceTree = "<group>"; };
 		CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CanvasLayout.swift"; sourceTree = "<group>"; };
 		C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CmuxNavigationDescriptor.swift"; sourceTree = "<group>"; };
@@ -3620,6 +3626,7 @@
 				606600020000000000000002 /* WindowTerminalHostViewHitTesting.swift */,
 				D0B10007A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift */,
 				D0B1004FA1B2C3D4E5F60001 /* BrowserPaneDragTransfer.swift */,
+				D7632A12A1B2C3D4E5F60718 /* BrowserFileDropNavigationGuard.swift */,
 				D7632002A1B2C3D4E5F60718 /* BrowserPaneFileDropRouting.swift */,
 				D0B1005FA1B2C3D4E5F60001 /* BrowserPaneDropAction.swift */,
 				D0B1002FA1B2C3D4E5F60001 /* BrowserPaneDropRouting.swift */,
@@ -3851,12 +3858,14 @@
 				4472B0034472B0034472B003 /* BrowserScreenshotSnapshotter.swift */,
 				C65241010000000000000002 /* BrowserPanel+AppPricingRestore.swift */,
 				C3711E000000000000000002 /* BrowserPanel+DisplayURL.swift */,
+				D7632B12A1B2C3D4E5F60718 /* BrowserPanel+InteractiveModalHostWindow.swift */,
 				D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */,
 				C67540060000000000000002 /* BrowserPanel+PDFDocumentActions.swift */,
 				A500MR00 /* BrowserMediaPlaybackReport.swift */,
 				A500MH00 /* BrowserMediaPlaybackMessageHandler.swift */,
 				A500MX00 /* BrowserPanel+MediaPlayback.swift */,
 				B1F0C0050000000000000002 /* BrowserDeveloperToolsDockControlNormalizer.swift */,
+				D7632B14A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift */,
 				A500RG00 /* ReactGrab.swift */,
 				A5001413 /* TerminalPanelView.swift */,
 				BCBC0A0E0000000000000C02 /* BrowserChromeMetrics.swift */,
@@ -5159,6 +5168,7 @@
 				C2035A010000000000000001 /* BrowserErrorPage.swift in Sources */,
 				C2035A020000000000000001 /* BrowserErrorPageContent.swift in Sources */,
 				C2035A0C000000000000001 /* BrowserErrorPageRetry.swift in Sources */,
+				D7632A11A1B2C3D4E5F60718 /* BrowserFileDropNavigationGuard.swift in Sources */,
 				A5008373 /* BrowserFindWebViewEvaluator.swift in Sources */,
 				B42450030000000000000001 /* BrowserHiddenWebViewDiscardManager.swift in Sources */,
 				B42450010000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift in Sources */,
@@ -5185,6 +5195,7 @@
 				D7632001A1B2C3D4E5F60718 /* BrowserPaneFileDropRouting.swift in Sources */,
 				C65241010000000000000001 /* BrowserPanel+AppPricingRestore.swift in Sources */,
 				C3711E000000000000000001 /* BrowserPanel+DisplayURL.swift in Sources */,
+				D7632B11A1B2C3D4E5F60718 /* BrowserPanel+InteractiveModalHostWindow.swift in Sources */,
 				A500MX01 /* BrowserPanel+MediaPlayback.swift in Sources */,
 				D7AB00000000000000000007 /* BrowserPanel+MoveTabToNewWorkspace.swift in Sources */,
 				C67540060000000000000001 /* BrowserPanel+PDFDocumentActions.swift in Sources */,
@@ -5918,6 +5929,7 @@
 				604500200000000000000001 /* WindowTitleTemplateContext.swift in Sources */,
 				E30760080000000000000002 /* WindowTmuxWorkspacePaneOverlayController.swift in Sources */,
 				A5001209 /* WindowToolbarController.swift in Sources */,
+				D7632B13A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift in Sources */,
 				C0DE43000000000000000007 /* Workspace+AgentChat.swift in Sources */,
 				CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */,
 				C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */,

--- a/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
+++ b/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
@@ -337,12 +337,12 @@ struct BrowserPaneFileDropUploadRegressionTests {
             webView: webView,
             url: URL(fileURLWithPath: "/tmp/upload.png"),
             now: now.addingTimeInterval(1)
-        ))
-        #expect(!guardStore.consumeDropNavigation(
+        )?.map(\.path) == ["/tmp/upload.png"])
+        #expect(guardStore.consumeDropNavigation(
             webView: webView,
             url: URL(fileURLWithPath: "/tmp/upload.png"),
             now: now.addingTimeInterval(2)
-        ))
+        ) == nil)
     }
 
     @Test func guardRejectsExpiredDifferentWebViewAndUnmatchedURLs() {
@@ -357,12 +357,12 @@ struct BrowserPaneFileDropUploadRegressionTests {
             now: now
         )
 
-        #expect(!guardStore.consumeDropNavigation(webView: secondWebView, url: URL(fileURLWithPath: "/tmp/upload.png"), now: now))
-        #expect(!guardStore.consumeDropNavigation(webView: firstWebView, url: URL(fileURLWithPath: "/tmp/other.png"), now: now))
-        #expect(!guardStore.consumeDropNavigation(webView: firstWebView, url: URL(fileURLWithPath: "/tmp/upload.png"), now: now.addingTimeInterval(6)))
+        #expect(guardStore.consumeDropNavigation(webView: secondWebView, url: URL(fileURLWithPath: "/tmp/upload.png"), now: now) == nil)
+        #expect(guardStore.consumeDropNavigation(webView: firstWebView, url: URL(fileURLWithPath: "/tmp/other.png"), now: now) == nil)
+        #expect(guardStore.consumeDropNavigation(webView: firstWebView, url: URL(fileURLWithPath: "/tmp/upload.png"), now: now.addingTimeInterval(6)) == nil)
     }
 
-    @Test func guardMatchesAnyFileInMultiFileRecord() {
+    @Test func guardMatchesAnyFileInMultiFileRecordAndReturnsEveryDroppedFile() {
         let guardStore = BrowserFileDropNavigationGuard()
         let webView = DragSpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
         let now = Date(timeIntervalSince1970: 300)
@@ -373,7 +373,11 @@ struct BrowserPaneFileDropUploadRegressionTests {
             now: now
         )
 
-        #expect(guardStore.consumeDropNavigation(webView: webView, url: URL(fileURLWithPath: "/tmp/two.png"), now: now))
+        // WebKit's fallback navigation names only one file of a multi-file drop;
+        // the consumed record must return every dropped file, in drop order, so
+        // the preview fallback opens all of them (not just the navigated one).
+        let consumed = guardStore.consumeDropNavigation(webView: webView, url: URL(fileURLWithPath: "/tmp/two.png"), now: now)
+        #expect(consumed?.map(\.path) == ["/tmp/one.png", "/tmp/two.png"])
     }
 
     @Test func fallbackNavigationClassifierRequiresMainFrameFileOtherNavigation() {

--- a/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
+++ b/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
@@ -380,6 +380,32 @@ struct BrowserPaneFileDropUploadRegressionTests {
         #expect(consumed?.map(\.path) == ["/tmp/one.png", "/tmp/two.png"])
     }
 
+    @Test func guardReleasesRecordsAfterTTLWithoutFurtherGuardCalls() async throws {
+        let guardStore = BrowserFileDropNavigationGuard(timeToLive: 0.1)
+        let webView = DragSpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
+
+        guardStore.recordDelivery(
+            webView: webView,
+            pasteboard: makeFilePasteboard(paths: ["/tmp/upload.png"]),
+            now: Date()
+        )
+        #expect(!guardStore.records.isEmpty)
+
+        // A successful page upload never calls the guard again, so only the
+        // scheduled expiry sweep can release the record. Poll without calling
+        // guard methods (they prune opportunistically and would mask a missing
+        // sweep).
+        var swept = false
+        for _ in 0..<200 {
+            if guardStore.records.isEmpty {
+                swept = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #expect(swept, "drop record should expire without another guard call")
+    }
+
     @Test func fallbackNavigationClassifierRequiresMainFrameFileOtherNavigation() {
         #expect(BrowserFileDropNavigationGuard.isDropFallbackNavigation(
             url: URL(fileURLWithPath: "/tmp/upload.png"),

--- a/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
+++ b/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
@@ -275,6 +275,36 @@ final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
         ))
     }
 
+    // The dock-status lookup is an app-wide ownership sweep; disposition must not
+    // evaluate it unless a file-URL payload is present. Drag callbacks fire for
+    // every payload type, so an eager lookup would run on every non-file drag.
+    func testDispositionDoesNotEvaluateDockStatusWithoutFileURL() {
+        var dockStatusEvaluations = 0
+        func countingDockStatus() -> Bool {
+            dockStatusEvaluations += 1
+            return true
+        }
+
+        XCTAssertNil(BrowserPaneFileDropRouting.disposition(
+            pasteboardTypes: nil,
+            modifierFlags: [],
+            isDockHosted: countingDockStatus(),
+            defaultBehavior: .text
+        ))
+        XCTAssertEqual(dockStatusEvaluations, 0)
+
+        XCTAssertEqual(
+            BrowserPaneFileDropRouting.disposition(
+                pasteboardTypes: fileURLPasteboardTypes(),
+                modifierFlags: [],
+                isDockHosted: countingDockStatus(),
+                defaultBehavior: .text
+            ),
+            .forwardToPage
+        )
+        XCTAssertEqual(dockStatusEvaluations, 1)
+    }
+
     private func withFileDropDefault(_ behavior: FileDropDefaultBehavior, run: () throws -> Void) rethrows {
         let defaults = UserDefaults.standard
         let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)

--- a/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
+++ b/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
@@ -133,6 +133,75 @@ final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
         )
     }
 
+    func testDispositionDefaultsToPageUploadRegardlessOfWebViewAvailability() {
+        XCTAssertEqual(
+            BrowserPaneFileDropRouting.disposition(
+                pasteboardTypes: fileURLPasteboardTypes(),
+                modifierFlags: [],
+                isDockHosted: false,
+                defaultBehavior: .text
+            ),
+            .forwardToPage
+        )
+    }
+
+    func testDispositionShiftInvertsToPreview() {
+        XCTAssertEqual(
+            BrowserPaneFileDropRouting.disposition(
+                pasteboardTypes: fileURLPasteboardTypes(),
+                modifierFlags: [.shift],
+                isDockHosted: false,
+                defaultBehavior: .text
+            ),
+            .previewInWorkspace
+        )
+        XCTAssertEqual(
+            BrowserPaneFileDropRouting.disposition(
+                pasteboardTypes: fileURLPasteboardTypes(),
+                modifierFlags: [.shift],
+                isDockHosted: false,
+                defaultBehavior: .preview
+            ),
+            .forwardToPage
+        )
+    }
+
+    func testDispositionDockAlwaysForwardsToPage() {
+        XCTAssertEqual(
+            BrowserPaneFileDropRouting.disposition(
+                pasteboardTypes: fileURLPasteboardTypes(),
+                modifierFlags: [],
+                isDockHosted: true,
+                defaultBehavior: .preview
+            ),
+            .forwardToPage
+        )
+        XCTAssertEqual(
+            BrowserPaneFileDropRouting.disposition(
+                pasteboardTypes: fileURLPasteboardTypes(),
+                modifierFlags: [.shift],
+                isDockHosted: true,
+                defaultBehavior: .text
+            ),
+            .forwardToPage
+        )
+    }
+
+    func testDispositionRequiresFileURLPayload() {
+        XCTAssertNil(BrowserPaneFileDropRouting.disposition(
+            pasteboardTypes: [DragOverlayRoutingPolicy.filePreviewTransferType],
+            modifierFlags: [],
+            isDockHosted: false,
+            defaultBehavior: .text
+        ))
+        XCTAssertNil(BrowserPaneFileDropRouting.disposition(
+            pasteboardTypes: nil,
+            modifierFlags: [],
+            isDockHosted: false,
+            defaultBehavior: .text
+        ))
+    }
+
     private func withFileDropDefault(_ behavior: FileDropDefaultBehavior, run: () throws -> Void) rethrows {
         let defaults = UserDefaults.standard
         let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)

--- a/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
+++ b/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
@@ -121,6 +121,79 @@ final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
         }
     }
 
+    // A live hosted web view does not always fill its slot (a docked Web
+    // Inspector splits the slot with WebKit companion views). The registry
+    // fallback hit-tests the whole slot container, so without a geometry check
+    // a file dropped over the non-page area would be misrouted into the page
+    // upload path instead of being refused.
+    func testFileDropOverNonPageAreaOfLiveWebViewIsRefused() throws {
+        try withFileDropDefault(.text) {
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            defer { close(window) }
+            window.makeKeyAndOrderFront(nil)
+            window.displayIfNeeded()
+            let root = try XCTUnwrap(window.contentView)
+
+            let anchor = NSView(frame: NSRect(x: 20, y: 20, width: 260, height: 160))
+            root.addSubview(anchor)
+            let webView = DragSpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
+            defer { BrowserWindowPortalRegistry.detach(webView: webView) }
+            BrowserWindowPortalRegistry.bind(webView: webView, to: anchor, visibleInUI: true)
+            BrowserWindowPortalRegistry.synchronizeForAnchor(anchor)
+            let context = BrowserPaneDropContext(
+                workspaceId: UUID(),
+                panelId: UUID(),
+                paneId: PaneID(id: UUID())
+            )
+            BrowserWindowPortalRegistry.updatePaneDropContext(for: webView, context: context)
+            root.layoutSubtreeIfNeeded()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            root.layoutSubtreeIfNeeded()
+
+            let container = try XCTUnwrap(webView.superview as? WindowBrowserSlotView)
+
+            // Emulate a docked-inspector split: the live web view keeps only one
+            // half of the slot, the companion view owns the other half.
+            webView.autoresizingMask = []
+            webView.frame = NSRect(
+                x: 0,
+                y: 0,
+                width: container.bounds.width,
+                height: container.bounds.height / 2
+            )
+            let pagePoint = NSPoint(x: container.bounds.midX, y: container.bounds.height * 0.25)
+            let nonPagePoint = NSPoint(x: container.bounds.midX, y: container.bounds.height * 0.75)
+
+            // Harness sanity: the precise hosted-webview hit test resolves the
+            // page area and misses the companion area, while the registry still
+            // resolves the whole container.
+            XCTAssertTrue(container.hostedWebViewForFileDrop(at: pagePoint) === webView)
+            XCTAssertNil(container.hostedWebViewForFileDrop(at: nonPagePoint))
+            let nonPageWindowPoint = container.convert(nonPagePoint, to: nil)
+            XCTAssertTrue(
+                BrowserWindowPortalRegistry.webViewAtWindowPoint(nonPageWindowPoint, in: window) === webView
+            )
+
+            let target = try XCTUnwrap(
+                BrowserWindowPortalRegistry.browserPaneDropTargetAtWindowPoint(nonPageWindowPoint, in: window)
+            )
+            let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7632.split.\(UUID().uuidString)"))
+            pasteboard.clearContents()
+            XCTAssertTrue(pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/upload.png") as NSURL]))
+            let dragInfo = MockDraggingInfo(window: window, location: nonPageWindowPoint, pasteboard: pasteboard)
+
+            XCTAssertTrue(target.draggingEntered(dragInfo).isEmpty)
+            XCTAssertFalse(target.prepareForDragOperation(dragInfo))
+            XCTAssertFalse(target.performDragOperation(dragInfo))
+            XCTAssertEqual(webView.dragCalls, [])
+        }
+    }
+
     func testShiftInvertedFileDropStillRoutesToPreview() {
         XCTAssertEqual(
             DragOverlayRoutingPolicy.resolvedFileDropBehavior(

--- a/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
+++ b/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
@@ -1,4 +1,4 @@
-import XCTest
+import Testing
 import AppKit
 import Bonsplit
 import WebKit
@@ -10,7 +10,8 @@ import WebKit
 #endif
 
 @MainActor
-final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
+@Suite(.serialized)
+struct BrowserPaneFileDropUploadRegressionTests {
     private final class DragSpyWebView: WKWebView {
         var dragCalls: [String] = []
 
@@ -78,37 +79,37 @@ final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
         func resetSpringLoading() {}
     }
 
-    func testDefaultFileDropWithHostedWebViewRoutesToPage() throws {
+    @Test func defaultFileDropWithHostedWebViewRoutesToPage() throws {
         try withFileDropDefault(.text) {
             let setup = try makeTarget(hostedWebView: true)
             defer { close(setup.window) }
-            let webView = try XCTUnwrap(setup.webView)
+            let webView = try #require(setup.webView)
             let dragInfo = makeFileDragInfo(window: setup.window, slot: setup.slot)
 
-            XCTAssertEqual(setup.target.draggingEntered(dragInfo), .copy)
-            XCTAssertTrue(setup.target.prepareForDragOperation(dragInfo))
-            XCTAssertTrue(setup.target.performDragOperation(dragInfo))
+            #expect(setup.target.draggingEntered(dragInfo) == .copy)
+            #expect(setup.target.prepareForDragOperation(dragInfo))
+            #expect(setup.target.performDragOperation(dragInfo))
             setup.target.concludeDragOperation(dragInfo)
 
-            XCTAssertEqual(webView.dragCalls, ["entered", "prepare", "perform", "conclude"])
+            #expect(webView.dragCalls == ["entered", "prepare", "perform", "conclude"])
         }
     }
 
-    func testFileDropWithUnresolvableWebViewIsNotClaimedAsPreview() throws {
+    @Test func fileDropWithUnresolvableWebViewIsNotClaimedAsPreview() throws {
         try withFileDropDefault(.text) {
             let setup = try makeTarget(hostedWebView: false)
             defer { close(setup.window) }
             let dragInfo = makeFileDragInfo(window: setup.window, slot: setup.slot)
 
-            XCTAssertTrue(setup.target.draggingEntered(dragInfo).isEmpty)
-            XCTAssertFalse(setup.target.prepareForDragOperation(dragInfo))
-            XCTAssertFalse(setup.target.performDragOperation(dragInfo))
+            #expect(setup.target.draggingEntered(dragInfo).isEmpty)
+            #expect(!setup.target.prepareForDragOperation(dragInfo))
+            #expect(!setup.target.performDragOperation(dragInfo))
         }
     }
 
-    func testHitTestClaimAndPrepareAgreeWhenWebViewUnavailable() throws {
+    @Test func hitTestClaimAndPrepareAgreeWhenWebViewUnavailable() throws {
         try withFileDropDefault(.text) {
-            XCTAssertTrue(BrowserPaneDropTargetView.shouldCaptureHitTesting(
+            #expect(BrowserPaneDropTargetView.shouldCaptureHitTesting(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 eventType: .leftMouseDragged
             ))
@@ -117,7 +118,7 @@ final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
             defer { close(setup.window) }
             let dragInfo = makeFileDragInfo(window: setup.window, slot: setup.slot)
 
-            XCTAssertFalse(setup.target.prepareForDragOperation(dragInfo))
+            #expect(!setup.target.prepareForDragOperation(dragInfo))
         }
     }
 
@@ -126,7 +127,7 @@ final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
     // fallback hit-tests the whole slot container, so without a geometry check
     // a file dropped over the non-page area would be misrouted into the page
     // upload path instead of being refused.
-    func testFileDropOverNonPageAreaOfLiveWebViewIsRefused() throws {
+    @Test func fileDropOverNonPageAreaOfLiveWebViewIsRefused() throws {
         try withFileDropDefault(.text) {
             let window = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
@@ -137,7 +138,7 @@ final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
             defer { close(window) }
             window.makeKeyAndOrderFront(nil)
             window.displayIfNeeded()
-            let root = try XCTUnwrap(window.contentView)
+            let root = try #require(window.contentView)
 
             let anchor = NSView(frame: NSRect(x: 20, y: 20, width: 260, height: 160))
             root.addSubview(anchor)
@@ -155,7 +156,7 @@ final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))
             root.layoutSubtreeIfNeeded()
 
-            let container = try XCTUnwrap(webView.superview as? WindowBrowserSlotView)
+            let container = try #require(webView.superview as? WindowBrowserSlotView)
 
             // Emulate a docked-inspector split: the live web view keeps only one
             // half of the slot, the companion view owns the other half.
@@ -172,137 +173,130 @@ final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
             // Harness sanity: the precise hosted-webview hit test resolves the
             // page area and misses the companion area, while the registry still
             // resolves the whole container.
-            XCTAssertTrue(container.hostedWebViewForFileDrop(at: pagePoint) === webView)
-            XCTAssertNil(container.hostedWebViewForFileDrop(at: nonPagePoint))
+            #expect(container.hostedWebViewForFileDrop(at: pagePoint) === webView)
+            #expect(container.hostedWebViewForFileDrop(at: nonPagePoint) == nil)
             let nonPageWindowPoint = container.convert(nonPagePoint, to: nil)
-            XCTAssertTrue(
+            #expect(
                 BrowserWindowPortalRegistry.webViewAtWindowPoint(nonPageWindowPoint, in: window) === webView
             )
 
-            let target = try XCTUnwrap(
+            let target = try #require(
                 BrowserWindowPortalRegistry.browserPaneDropTargetAtWindowPoint(nonPageWindowPoint, in: window)
             )
             let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7632.split.\(UUID().uuidString)"))
             pasteboard.clearContents()
-            XCTAssertTrue(pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/upload.png") as NSURL]))
+            #expect(pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/upload.png") as NSURL]))
             let dragInfo = MockDraggingInfo(window: window, location: nonPageWindowPoint, pasteboard: pasteboard)
 
-            XCTAssertTrue(target.draggingEntered(dragInfo).isEmpty)
-            XCTAssertFalse(target.prepareForDragOperation(dragInfo))
-            XCTAssertFalse(target.performDragOperation(dragInfo))
-            XCTAssertEqual(webView.dragCalls, [])
+            #expect(target.draggingEntered(dragInfo).isEmpty)
+            #expect(!target.prepareForDragOperation(dragInfo))
+            #expect(!target.performDragOperation(dragInfo))
+            #expect(webView.dragCalls == [])
         }
     }
 
-    func testShiftInvertedFileDropStillRoutesToPreview() {
-        XCTAssertEqual(
+    @Test func shiftInvertedFileDropStillRoutesToPreview() {
+        #expect(
             DragOverlayRoutingPolicy.resolvedFileDropBehavior(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 modifierFlags: [.shift],
                 canDropAsText: true,
                 defaultBehavior: .text
-            ),
-            .preview
+            ) == .preview
         )
     }
 
-    func testDispositionDefaultsToPageUploadRegardlessOfWebViewAvailability() {
-        XCTAssertEqual(
+    @Test func dispositionDefaultsToPageUploadRegardlessOfWebViewAvailability() {
+        #expect(
             BrowserPaneFileDropRouting.disposition(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 modifierFlags: [],
                 isDockHosted: false,
                 defaultBehavior: .text
-            ),
-            .forwardToPage
+            ) == .forwardToPage
         )
     }
 
-    func testDispositionShiftInvertsToPreview() {
-        XCTAssertEqual(
+    @Test func dispositionShiftInvertsToPreview() {
+        #expect(
             BrowserPaneFileDropRouting.disposition(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 modifierFlags: [.shift],
                 isDockHosted: false,
                 defaultBehavior: .text
-            ),
-            .previewInWorkspace
+            ) == .previewInWorkspace
         )
-        XCTAssertEqual(
+        #expect(
             BrowserPaneFileDropRouting.disposition(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 modifierFlags: [.shift],
                 isDockHosted: false,
                 defaultBehavior: .preview
-            ),
-            .forwardToPage
+            ) == .forwardToPage
         )
     }
 
-    func testDispositionDockAlwaysForwardsToPage() {
-        XCTAssertEqual(
+    @Test func dispositionDockAlwaysForwardsToPage() {
+        #expect(
             BrowserPaneFileDropRouting.disposition(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 modifierFlags: [],
                 isDockHosted: true,
                 defaultBehavior: .preview
-            ),
-            .forwardToPage
+            ) == .forwardToPage
         )
-        XCTAssertEqual(
+        #expect(
             BrowserPaneFileDropRouting.disposition(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 modifierFlags: [.shift],
                 isDockHosted: true,
                 defaultBehavior: .text
-            ),
-            .forwardToPage
+            ) == .forwardToPage
         )
     }
 
-    func testDispositionRequiresFileURLPayload() {
-        XCTAssertNil(BrowserPaneFileDropRouting.disposition(
+    @Test func dispositionRequiresFileURLPayload() {
+        #expect(BrowserPaneFileDropRouting.disposition(
             pasteboardTypes: [DragOverlayRoutingPolicy.filePreviewTransferType],
             modifierFlags: [],
             isDockHosted: false,
             defaultBehavior: .text
-        ))
-        XCTAssertNil(BrowserPaneFileDropRouting.disposition(
+        ) == nil)
+        #expect(BrowserPaneFileDropRouting.disposition(
             pasteboardTypes: nil,
             modifierFlags: [],
             isDockHosted: false,
             defaultBehavior: .text
-        ))
+        ) == nil)
     }
 
     // The dock-status lookup is an app-wide ownership sweep; disposition must not
     // evaluate it unless a file-URL payload is present. Drag callbacks fire for
     // every payload type, so an eager lookup would run on every non-file drag.
-    func testDispositionDoesNotEvaluateDockStatusWithoutFileURL() {
+    @Test func dispositionDoesNotEvaluateDockStatusWithoutFileURL() {
         var dockStatusEvaluations = 0
         func countingDockStatus() -> Bool {
             dockStatusEvaluations += 1
             return true
         }
 
-        XCTAssertNil(BrowserPaneFileDropRouting.disposition(
+        #expect(BrowserPaneFileDropRouting.disposition(
             pasteboardTypes: nil,
             modifierFlags: [],
             isDockHosted: countingDockStatus(),
             defaultBehavior: .text
-        ))
-        XCTAssertEqual(dockStatusEvaluations, 0)
+        ) == nil)
+        #expect(dockStatusEvaluations == 0)
 
-        XCTAssertEqual(
+        #expect(
             BrowserPaneFileDropRouting.disposition(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 modifierFlags: [],
                 isDockHosted: countingDockStatus(),
                 defaultBehavior: .text
-            ),
-            .forwardToPage
+            ) == .forwardToPage
         )
-        XCTAssertEqual(dockStatusEvaluations, 1)
+        #expect(dockStatusEvaluations == 1)
     }
 
     private func withFileDropDefault(_ behavior: FileDropDefaultBehavior, run: () throws -> Void) rethrows {
@@ -353,14 +347,14 @@ final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
         ))
         slot.layoutSubtreeIfNeeded()
 
-        let target = try XCTUnwrap(slot.paneDropTargetForDrop(at: NSPoint(x: slot.bounds.midX, y: slot.bounds.midY)))
+        let target = try #require(slot.paneDropTargetForDrop(at: NSPoint(x: slot.bounds.midX, y: slot.bounds.midY)))
         return (window, slot, target, webView)
     }
 
     private func makeFileDragInfo(window: NSWindow, slot: WindowBrowserSlotView) -> MockDraggingInfo {
         let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7632.file.\(UUID().uuidString)"))
         pasteboard.clearContents()
-        XCTAssertTrue(pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/upload.png") as NSURL]))
+        #expect(pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/upload.png") as NSURL]))
         let dropPoint = slot.convert(NSPoint(x: slot.bounds.midX, y: slot.bounds.midY), to: nil)
         return MockDraggingInfo(window: window, location: dropPoint, pasteboard: pasteboard)
     }

--- a/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
+++ b/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+import AppKit
+import Bonsplit
+import WebKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class BrowserPaneFileDropUploadRegressionTests: XCTestCase {
+    private final class DragSpyWebView: WKWebView {
+        var dragCalls: [String] = []
+
+        override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+            dragCalls.append("entered")
+            return .copy
+        }
+
+        override func prepareForDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+            dragCalls.append("prepare")
+            return true
+        }
+
+        override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+            dragCalls.append("perform")
+            return true
+        }
+
+        override func concludeDragOperation(_ sender: (any NSDraggingInfo)?) {
+            dragCalls.append("conclude")
+        }
+    }
+
+    private final class MockDraggingInfo: NSObject, NSDraggingInfo {
+        let draggingDestinationWindow: NSWindow?
+        let draggingSourceOperationMask: NSDragOperation
+        let draggingLocation: NSPoint
+        let draggedImageLocation: NSPoint
+        let draggedImage: NSImage?
+        // NSDraggingInfo exposes the pasteboard nonisolated; tests mutate it only before construction.
+        nonisolated(unsafe) let draggingPasteboard: NSPasteboard
+        // AppKit exposes the dragging source as an untyped object and this test never mutates it.
+        nonisolated(unsafe) let draggingSource: Any?
+        let draggingSequenceNumber: Int
+        var draggingFormation: NSDraggingFormation = .default
+        var animatesToDestination = false
+        var numberOfValidItemsForDrop = 1
+        let springLoadingHighlight: NSSpringLoadingHighlight = .none
+
+        init(window: NSWindow, location: NSPoint, pasteboard: NSPasteboard) {
+            self.draggingDestinationWindow = window
+            self.draggingSourceOperationMask = .copy
+            self.draggingLocation = location
+            self.draggedImageLocation = location
+            self.draggedImage = nil
+            self.draggingPasteboard = pasteboard
+            self.draggingSource = nil
+            self.draggingSequenceNumber = 1
+        }
+
+        func slideDraggedImage(to screenPoint: NSPoint) {}
+
+        override func namesOfPromisedFilesDropped(atDestination dropDestination: URL) -> [String]? {
+            nil
+        }
+
+        func enumerateDraggingItems(
+            options enumOpts: NSDraggingItemEnumerationOptions = [],
+            for view: NSView?,
+            classes classArray: [AnyClass],
+            searchOptions: [NSPasteboard.ReadingOptionKey: Any] = [:],
+            using block: (NSDraggingItem, Int, UnsafeMutablePointer<ObjCBool>) -> Void
+        ) {}
+
+        func resetSpringLoading() {}
+    }
+
+    func testDefaultFileDropWithHostedWebViewRoutesToPage() throws {
+        try withFileDropDefault(.text) {
+            let setup = try makeTarget(hostedWebView: true)
+            defer { close(setup.window) }
+            let webView = try XCTUnwrap(setup.webView)
+            let dragInfo = makeFileDragInfo(window: setup.window, slot: setup.slot)
+
+            XCTAssertEqual(setup.target.draggingEntered(dragInfo), .copy)
+            XCTAssertTrue(setup.target.prepareForDragOperation(dragInfo))
+            XCTAssertTrue(setup.target.performDragOperation(dragInfo))
+            setup.target.concludeDragOperation(dragInfo)
+
+            XCTAssertEqual(webView.dragCalls, ["entered", "prepare", "perform", "conclude"])
+        }
+    }
+
+    func testFileDropWithUnresolvableWebViewIsNotClaimedAsPreview() throws {
+        try withFileDropDefault(.text) {
+            let setup = try makeTarget(hostedWebView: false)
+            defer { close(setup.window) }
+            let dragInfo = makeFileDragInfo(window: setup.window, slot: setup.slot)
+
+            XCTAssertTrue(setup.target.draggingEntered(dragInfo).isEmpty)
+            XCTAssertFalse(setup.target.prepareForDragOperation(dragInfo))
+            XCTAssertFalse(setup.target.performDragOperation(dragInfo))
+        }
+    }
+
+    func testHitTestClaimAndPrepareAgreeWhenWebViewUnavailable() throws {
+        try withFileDropDefault(.text) {
+            XCTAssertTrue(BrowserPaneDropTargetView.shouldCaptureHitTesting(
+                pasteboardTypes: fileURLPasteboardTypes(),
+                eventType: .leftMouseDragged
+            ))
+
+            let setup = try makeTarget(hostedWebView: false)
+            defer { close(setup.window) }
+            let dragInfo = makeFileDragInfo(window: setup.window, slot: setup.slot)
+
+            XCTAssertFalse(setup.target.prepareForDragOperation(dragInfo))
+        }
+    }
+
+    func testShiftInvertedFileDropStillRoutesToPreview() {
+        XCTAssertEqual(
+            DragOverlayRoutingPolicy.resolvedFileDropBehavior(
+                pasteboardTypes: fileURLPasteboardTypes(),
+                modifierFlags: [.shift],
+                canDropAsText: true,
+                defaultBehavior: .text
+            ),
+            .preview
+        )
+    }
+
+    private func withFileDropDefault(_ behavior: FileDropDefaultBehavior, run: () throws -> Void) rethrows {
+        let defaults = UserDefaults.standard
+        let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+        defaults.set(behavior.rawValue, forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+        defer {
+            if let savedDefaultBehavior {
+                defaults.set(savedDefaultBehavior, forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+            } else {
+                defaults.removeObject(forKey: FileDropBehaviorSettings.defaultBehaviorKey)
+            }
+        }
+        try run()
+    }
+
+    private func makeTarget(hostedWebView: Bool) throws -> (
+        window: NSWindow,
+        slot: WindowBrowserSlotView,
+        target: BrowserPaneDropTargetView,
+        webView: DragSpyWebView?
+    ) {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let root = NSView(frame: window.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 360, height: 240))
+        root.autoresizingMask = [.width, .height]
+        window.contentView = root
+
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 20, y: 20, width: 260, height: 160))
+        root.addSubview(slot)
+        let webView: DragSpyWebView?
+        if hostedWebView {
+            let hosted = DragSpyWebView(frame: slot.bounds, configuration: WKWebViewConfiguration())
+            slot.addSubview(hosted)
+            slot.pinHostedWebView(hosted)
+            webView = hosted
+        } else {
+            webView = nil
+        }
+        slot.setPaneDropContext(BrowserPaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: PaneID(id: UUID())
+        ))
+        slot.layoutSubtreeIfNeeded()
+
+        let target = try XCTUnwrap(slot.paneDropTargetForDrop(at: NSPoint(x: slot.bounds.midX, y: slot.bounds.midY)))
+        return (window, slot, target, webView)
+    }
+
+    private func makeFileDragInfo(window: NSWindow, slot: WindowBrowserSlotView) -> MockDraggingInfo {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7632.file.\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/upload.png") as NSURL]))
+        let dropPoint = slot.convert(NSPoint(x: slot.bounds.midX, y: slot.bounds.midY), to: nil)
+        return MockDraggingInfo(window: window, location: dropPoint, pasteboard: pasteboard)
+    }
+
+    private func fileURLPasteboardTypes() -> [NSPasteboard.PasteboardType] {
+        if PasteboardFileURLReader.fileURLPasteboardTypes.contains(.fileURL) {
+            return [.fileURL]
+        }
+        return Array(PasteboardFileURLReader.fileURLPasteboardTypes.prefix(1))
+    }
+
+    private func close(_ window: NSWindow) {
+        NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+        window.orderOut(nil)
+    }
+}

--- a/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
+++ b/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
@@ -322,6 +322,73 @@ struct BrowserPaneFileDropUploadRegressionTests {
         #expect(dockStatusEvaluations == 1)
     }
 
+    @Test func guardConsumesRecordedDropNavigationOnceWithinTTL() {
+        let guardStore = BrowserFileDropNavigationGuard()
+        let webView = DragSpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let now = Date(timeIntervalSince1970: 100)
+
+        guardStore.recordDelivery(
+            webView: webView,
+            pasteboard: makeFilePasteboard(paths: ["/tmp/upload.png"]),
+            now: now
+        )
+
+        #expect(guardStore.consumeDropNavigation(
+            webView: webView,
+            url: URL(fileURLWithPath: "/tmp/upload.png"),
+            now: now.addingTimeInterval(1)
+        ))
+        #expect(!guardStore.consumeDropNavigation(
+            webView: webView,
+            url: URL(fileURLWithPath: "/tmp/upload.png"),
+            now: now.addingTimeInterval(2)
+        ))
+    }
+
+    @Test func guardRejectsExpiredDifferentWebViewAndUnmatchedURLs() {
+        let guardStore = BrowserFileDropNavigationGuard()
+        let firstWebView = DragSpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let secondWebView = DragSpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let now = Date(timeIntervalSince1970: 200)
+
+        guardStore.recordDelivery(
+            webView: firstWebView,
+            pasteboard: makeFilePasteboard(paths: ["/tmp/upload.png"]),
+            now: now
+        )
+
+        #expect(!guardStore.consumeDropNavigation(webView: secondWebView, url: URL(fileURLWithPath: "/tmp/upload.png"), now: now))
+        #expect(!guardStore.consumeDropNavigation(webView: firstWebView, url: URL(fileURLWithPath: "/tmp/other.png"), now: now))
+        #expect(!guardStore.consumeDropNavigation(webView: firstWebView, url: URL(fileURLWithPath: "/tmp/upload.png"), now: now.addingTimeInterval(6)))
+    }
+
+    @Test func guardMatchesAnyFileInMultiFileRecord() {
+        let guardStore = BrowserFileDropNavigationGuard()
+        let webView = DragSpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let now = Date(timeIntervalSince1970: 300)
+
+        guardStore.recordDelivery(
+            webView: webView,
+            pasteboard: makeFilePasteboard(paths: ["/tmp/one.png", "/tmp/two.png"]),
+            now: now
+        )
+
+        #expect(guardStore.consumeDropNavigation(webView: webView, url: URL(fileURLWithPath: "/tmp/two.png"), now: now))
+    }
+
+    @Test func fallbackNavigationClassifierRequiresMainFrameFileOtherNavigation() {
+        #expect(BrowserFileDropNavigationGuard.isDropFallbackNavigation(
+            url: URL(fileURLWithPath: "/tmp/upload.png"),
+            isMainFrame: true,
+            navigationType: .other
+        ))
+        #expect(!BrowserFileDropNavigationGuard.isDropFallbackNavigation(url: URL(string: "https://example.com"), isMainFrame: true, navigationType: .other))
+        #expect(!BrowserFileDropNavigationGuard.isDropFallbackNavigation(url: URL(fileURLWithPath: "/tmp/upload.png"), isMainFrame: false, navigationType: .other))
+        #expect(!BrowserFileDropNavigationGuard.isDropFallbackNavigation(url: URL(fileURLWithPath: "/tmp/upload.png"), isMainFrame: true, navigationType: .backForward))
+        #expect(!BrowserFileDropNavigationGuard.isDropFallbackNavigation(url: URL(fileURLWithPath: "/tmp/upload.png"), isMainFrame: true, navigationType: .linkActivated))
+        #expect(!BrowserFileDropNavigationGuard.isDropFallbackNavigation(url: nil, isMainFrame: true, navigationType: .other))
+    }
+
     private func withFileDropDefault(_ behavior: FileDropDefaultBehavior, run: () throws -> Void) rethrows {
         let defaults = UserDefaults.standard
         let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)

--- a/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
+++ b/cmuxTests/BrowserPaneFileDropUploadRegressionTests.swift
@@ -122,6 +122,23 @@ struct BrowserPaneFileDropUploadRegressionTests {
         }
     }
 
+    @Test func previewDefaultStillRoutesBrowserDropToHostedPage() throws {
+        try withFileDropDefault(.preview) {
+            let setup = try makeTarget(hostedWebView: true)
+            defer { close(setup.window) }
+            let webView = try #require(setup.webView)
+            let dragInfo = makeFileDragInfo(window: setup.window, slot: setup.slot)
+
+            #expect(BrowserPaneDropTargetView.shouldCaptureHitTesting(
+                pasteboardTypes: fileURLPasteboardTypes(),
+                eventType: .leftMouseDragged
+            ))
+            #expect(setup.target.prepareForDragOperation(dragInfo))
+            #expect(setup.target.performDragOperation(dragInfo))
+            #expect(webView.dragCalls == ["prepare", "perform"])
+        }
+    }
+
     // A live hosted web view does not always fill its slot (a docked Web
     // Inspector splits the slot with WebKit companion views). The registry
     // fallback hit-tests the whole slot container, so without a geometry check
@@ -207,33 +224,45 @@ struct BrowserPaneFileDropUploadRegressionTests {
     }
 
     @Test func dispositionDefaultsToPageUploadRegardlessOfWebViewAvailability() {
-        #expect(
-            BrowserPaneFileDropRouting.disposition(
-                pasteboardTypes: fileURLPasteboardTypes(),
-                modifierFlags: [],
-                isDockHosted: false,
-                defaultBehavior: .text
-            ) == .forwardToPage
-        )
+        withFileDropDefault(.text) {
+            #expect(
+                BrowserPaneFileDropRouting.disposition(
+                    pasteboardTypes: fileURLPasteboardTypes(),
+                    modifierFlags: [],
+                    isDockHosted: false
+                ) == .forwardToPage
+            )
+        }
+        withFileDropDefault(.preview) {
+            #expect(
+                BrowserPaneFileDropRouting.disposition(
+                    pasteboardTypes: fileURLPasteboardTypes(),
+                    modifierFlags: [],
+                    isDockHosted: false
+                ) == .forwardToPage
+            )
+        }
     }
 
-    @Test func dispositionShiftInvertsToPreview() {
-        #expect(
-            BrowserPaneFileDropRouting.disposition(
-                pasteboardTypes: fileURLPasteboardTypes(),
-                modifierFlags: [.shift],
-                isDockHosted: false,
-                defaultBehavior: .text
-            ) == .previewInWorkspace
-        )
-        #expect(
-            BrowserPaneFileDropRouting.disposition(
-                pasteboardTypes: fileURLPasteboardTypes(),
-                modifierFlags: [.shift],
-                isDockHosted: false,
-                defaultBehavior: .preview
-            ) == .forwardToPage
-        )
+    @Test func dispositionShiftAlwaysRoutesToPreview() {
+        withFileDropDefault(.text) {
+            #expect(
+                BrowserPaneFileDropRouting.disposition(
+                    pasteboardTypes: fileURLPasteboardTypes(),
+                    modifierFlags: [.shift],
+                    isDockHosted: false
+                ) == .previewInWorkspace
+            )
+        }
+        withFileDropDefault(.preview) {
+            #expect(
+                BrowserPaneFileDropRouting.disposition(
+                    pasteboardTypes: fileURLPasteboardTypes(),
+                    modifierFlags: [.shift],
+                    isDockHosted: false
+                ) == .previewInWorkspace
+            )
+        }
     }
 
     @Test func dispositionDockAlwaysForwardsToPage() {
@@ -241,16 +270,14 @@ struct BrowserPaneFileDropUploadRegressionTests {
             BrowserPaneFileDropRouting.disposition(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 modifierFlags: [],
-                isDockHosted: true,
-                defaultBehavior: .preview
+                isDockHosted: true
             ) == .forwardToPage
         )
         #expect(
             BrowserPaneFileDropRouting.disposition(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 modifierFlags: [.shift],
-                isDockHosted: true,
-                defaultBehavior: .text
+                isDockHosted: true
             ) == .forwardToPage
         )
     }
@@ -259,14 +286,12 @@ struct BrowserPaneFileDropUploadRegressionTests {
         #expect(BrowserPaneFileDropRouting.disposition(
             pasteboardTypes: [DragOverlayRoutingPolicy.filePreviewTransferType],
             modifierFlags: [],
-            isDockHosted: false,
-            defaultBehavior: .text
+            isDockHosted: false
         ) == nil)
         #expect(BrowserPaneFileDropRouting.disposition(
             pasteboardTypes: nil,
             modifierFlags: [],
-            isDockHosted: false,
-            defaultBehavior: .text
+            isDockHosted: false
         ) == nil)
     }
 
@@ -283,8 +308,7 @@ struct BrowserPaneFileDropUploadRegressionTests {
         #expect(BrowserPaneFileDropRouting.disposition(
             pasteboardTypes: nil,
             modifierFlags: [],
-            isDockHosted: countingDockStatus(),
-            defaultBehavior: .text
+            isDockHosted: countingDockStatus()
         ) == nil)
         #expect(dockStatusEvaluations == 0)
 
@@ -292,8 +316,7 @@ struct BrowserPaneFileDropUploadRegressionTests {
             BrowserPaneFileDropRouting.disposition(
                 pasteboardTypes: fileURLPasteboardTypes(),
                 modifierFlags: [],
-                isDockHosted: countingDockStatus(),
-                defaultBehavior: .text
+                isDockHosted: countingDockStatus()
             ) == .forwardToPage
         )
         #expect(dockStatusEvaluations == 1)
@@ -352,11 +375,16 @@ struct BrowserPaneFileDropUploadRegressionTests {
     }
 
     private func makeFileDragInfo(window: NSWindow, slot: WindowBrowserSlotView) -> MockDraggingInfo {
-        let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7632.file.\(UUID().uuidString)"))
-        pasteboard.clearContents()
-        #expect(pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/upload.png") as NSURL]))
+        let pasteboard = makeFilePasteboard(paths: ["/tmp/upload.png"])
         let dropPoint = slot.convert(NSPoint(x: slot.bounds.midX, y: slot.bounds.midY), to: nil)
         return MockDraggingInfo(window: window, location: dropPoint, pasteboard: pasteboard)
+    }
+
+    private func makeFilePasteboard(paths: [String]) -> NSPasteboard {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.issue-7632.file.\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        #expect(pasteboard.writeObjects(paths.map { URL(fileURLWithPath: $0) as NSURL }))
+        return pasteboard
     }
 
     private func fileURLPasteboardTypes() -> [NSPasteboard.PasteboardType] {


### PR DESCRIPTION
Closes #7632

## Problem

Dragging an image from Finder onto a web page in a workspace browser pane sometimes opened the file in a cmux file-preview pane instead of delivering the drag to the page as an HTML5 upload — intermittently, under the **default** file-drop setting where the expected routing was already "forward to the page".

Root cause: the pane routed a file-URL drop to the hosted WKWebView only when `hostedWebViewForFileDrop(at:)` resolved a live webview at that instant, feeding availability into `resolvedFileDropBehavior`'s `guard canDropAsText else { return .preview }`. The webview is legitimately unresolvable in live states — discarded by `BrowserHiddenWebViewDiscardManager`, mid-reparent through the browser window portal, stale frame — so the drop silently degraded to a preview. `shouldCaptureHitTesting` additionally hardcoded `canDropAsText: true`, so the pane could claim a drop as an upload during hit-testing and execute it as a preview.

## Fix (class, not symptom)

**Intent is now pure; delivery never rewrites intent.**

- New `BrowserPaneFileDropRouting.disposition(pasteboardTypes:modifierFlags:isDockHosted:defaultBehavior:)` — a pure seam with no webview-availability input — decides `.forwardToPage` vs `.previewInWorkspace`. Hit-testing, update, prepare, and perform all branch on this one function, eliminating the claim/perform divergence. The existing Dock rule (file URL over Dock page content always forwards to the page) is centralized in the seam.
- Delivery on `.forwardToPage`: slot lookup, then a same-pane-guarded `BrowserWindowPortalRegistry.webViewAtWindowPoint` fallback (covers mid-reparent/stale-frame). A discarded webview is asked to `restoreDiscardedWebViewIfNeeded` once per drag session while hovering. If no webview resolves, the drop is **refused** (prepare/perform return false) — never reinterpreted as a preview.
- Preserved paths: Shift inversion, preview-default routing, pane-edge split-zone drops, Dock live-surface transfer guard, tab drags (#921), cmux file-explorer preview transfers, focus-after-drop.

## Two-commit regression-test structure

1. Commit 1 adds the regression tests only — the no-webview refusal tests fail on pre-fix code (CI red on that commit proves they catch the bug).
2. Commit 2 adds the fix plus pure-seam unit tests (default → page upload regardless of availability; Shift inversion; Dock always-forward; file-URL payload gate).

## Verification

- `python3 scripts/swift_file_length_budget.py` passes with no TSV changes (`BrowserPaneDropTargetView.swift` shrank 526 → 489; new files well under 500).
- `./scripts/lint-pbxproj-test-wiring.sh` passes (new test file wired into cmuxTests).
- Tagged compile-only Debug build succeeds; no new Swift warnings.
- Localization audit: no user-facing strings added or changed (verified via rg over the changed Swift files — routing/delivery logic and tests only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786123919&installation_id=133855650&pr_number=7634&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7634&signature=d32ac60802a570cd8bc1ad61706a50c256386b629c7884c828ca292ff2d56827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches drag routing, WKWebView delivery, and navigation policy cancellation; behavior is heavily regression-tested but edge cases around portal reparenting and async WebKit navigation remain possible.
> 
> **Overview**
> Fixes intermittent Finder-to-browser drops opening cmux file previews instead of HTML5 uploads (#7632) by separating **intent** from **delivery**.
> 
> **Routing:** New `BrowserPaneFileDropRouting.disposition` drives hit-test, drag update, prepare, and perform. Unmodified file drags over browser page content go to the hosted page; **Shift** opens a workspace preview. Dock-hosted panes always forward to the page. The global file-drop default no longer steers browser panes via webview availability.
> 
> **Delivery:** Forward-to-page uses slot hit-test, then a same-pane `BrowserWindowPortalRegistry` fallback, one-shot `restoreDiscardedWebViewIfNeeded` per drag, and **refuses** the drop when no webview resolves (no silent preview). Drops over non-page areas of a live webview (e.g. docked inspector chrome) are refused via geometry checks.
> 
> **WebKit fallback:** `BrowserFileDropNavigationGuard` records successful page deliveries; `BrowserNavigationDelegate` cancels matching main-frame `file://` `.other` navigations and opens a file-preview split via `handleDroppedFileNavigation`, including **all** files from multi-file drops.
> 
> **Overlay / polish:** `FileDropOverlayView` avoids premature `draggingExited` during prepare/perform/conclude; records guard on overlay webview drops. Hint badge over web content suggests Shift for preview. Small file moves (`BrowserPanel+InteractiveModalHostWindow`, `WKWebView+CmuxPrintOperation`). Regression tests in `BrowserPaneFileDropUploadRegressionTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14344492ca59bc701c38237b6822f517f6392f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes browser-pane file drops by intent so unmodified drags always reach the web page (native upload) regardless of the default setting; Shift explicitly opens a preview. Intercepts WebKit file:// fallback so dropped files open in a preview split instead of overwriting the page, preserves multi-file drops, and fixes an overlay hand-off that cancelled DOM drops. Fixes #7632.

- **Bug Fixes**
  - Added `BrowserPaneFileDropRouting.disposition(...)` and wired hit-test/update/prepare/perform through it to avoid claim/perform mismatches.
  - Delivery now falls back to `BrowserWindowPortalRegistry.webViewAtWindowPoint`, requests a one-time webview restore during a drag, and refuses drops when no webview resolves or when the point is outside a live webview’s bounds.
  - Browser panes are native-first: the default file-drop setting no longer affects browser panes; Shift remains the explicit preview gesture. Dock-hosted panes always forward file-URL drops to the page.
  - Introduced `BrowserFileDropNavigationGuard` to record file-drop deliveries and cancel matching main-frame `.other` file:// navigations in `BrowserNavigationDelegate`, opening a preview split instead of letting the page be overwritten. Multi-file drops now preview all dropped files.
  - Scheduled a coalesced TTL sweep so drop-guard records expire without needing a later guard call.
  - Prevented the window overlay from cancelling in-flight WebKit drag sessions by exiting only targets the drag actually left; also arm the drop guard only for handled deliveries.

- **Tests**
  - Added regression tests for: native-first routing across default settings, refusal over non-page areas of a live webview, no-webview refusal, hit-test vs prepare agreement, Shift inversion, Dock always-forward, file-URL payload gating, dock-status laziness, navigation-guard cancellation, multi-file fallback preview preservation, and drop-guard expiry.
  - Converted the regression suite to Swift Testing with serialized execution.

<sup>Written for commit 14344492ca59bc701c38237b6822f517f6392f47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated browser-pane file drag-and-drop routing to support page-forwarding vs in-workspace preview based on file-URL payloads and the Shift modifier, with consistent handling for dock-hosted panes.
  * Added improved handling for dropped-file fallback navigations so they can be intercepted and consumed reliably.
* **Bug Fixes**
  * Improved hit-testing and drag lifecycle behavior when the destination web view can’t be resolved, including correct refusal over non-page regions.
* **Tests**
  * Added regression tests for upload routing, drag callback ordering, and fallback navigation guarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->