### PR TITLE
Use approved iOS version 1.0.1 for TestFlight beta CI

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -36,9 +36,9 @@ on:
     # successful run (SHA compare, not a wall-clock window), so an iOS-affecting
     # change reaches the TestFlight beta lane within ~2h of landing on main, and
     # a failed or missed run retries the not-yet-uploaded commit instead of
-    # permanently stranding it. These uploads are external-eligible too, and the
-    # post-upload external-distribution job auto-submits the first build of a new
-    # MARKETING_VERSION for Apple Beta App Review.
+    # permanently stranding it. These uploads are external-eligible too, and reuse
+    # the checked-in iOS MARKETING_VERSION so external testers receive new builds
+    # under the already-approved version until that version is intentionally bumped.
     #
     # Why ~2h and not a push trigger / per-commit: a per-push lane needs either a
     # shared concurrency group (which cancels superseded pending runs into red
@@ -99,9 +99,9 @@ jobs:
             //
             // Manual marketing-version-override uploads are deliberately excluded
             // from this canonical lane. They ship the current main SHA under an
-            // older approved MARKETING_VERSION as a one-off escape hatch, but they
-            // must NOT suppress the next scheduled auto-versioned beta for the same
-            // commit. Override runs upload a dedicated
+            // operator-selected MARKETING_VERSION as a one-off escape hatch, but
+            // they must NOT suppress the next scheduled canonical beta for the
+            // same commit. Override runs upload a dedicated
             // ios-testflight-build-metadata-override artifact instead of the
             // canonical ios-testflight-build-metadata artifact, and we skip only
             // those runs here.
@@ -275,8 +275,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-          # Full history + tags so generate-testflight-notes.sh can walk the
-          # commit range since the last beta and --auto-version can read ios-v*.
+          # Full history so generate-testflight-notes.sh can walk the commit
+          # range since the last beta.
           fetch-depth: 0
           fetch-tags: true
 
@@ -437,15 +437,24 @@ jobs:
               --marketing-version "$INPUT_MARKETING_VERSION_OVERRIDE" \
               --skip-notes
           else
-            # --auto-version: every beta stamps the next-release marketing version.
+            # Reuse the checked-in iOS MARKETING_VERSION for scheduled betas.
+            # External TestFlight only requires Beta App Review once per marketing
+            # version, so staying on the approved version lets CI keep publishing
+            # main-tracking builds automatically while the next version remains
+            # pending.
+            # This unblocks external testers, who cannot install an unapproved
+            # higher-marketing-version build. Internal testers who already installed
+            # that pending higher version need a one-time TestFlight reinstall, or
+            # an intentional higher-version internal cut, because TestFlight does
+            # not offer lower marketing versions as updates.
             # --external: publish the same main-tracking build to the external lane.
-            # The post-upload job assigns the build to the external group and, when
-            # Apple reports READY_FOR_BETA_SUBMISSION for a new MARKETING_VERSION,
+            # The post-upload job assigns the build to the external group and, if a
+            # future intentional version bump is READY_FOR_BETA_SUBMISSION,
             # auto-submits it for Beta App Review.
             # --notes-from-range: auto-generate audience-appropriate "What to
             # Test" notes from the commits since the previous beta (skipped if we
             # have no base SHA yet).
-            ARGS=(--lane beta --signing manual --auto-version --external)
+            ARGS=(--lane beta --signing manual --external)
             if [ -n "${LAST_UPLOADED_SHA:-}" ]; then
               ARGS+=(--notes-from-range "$LAST_UPLOADED_SHA")
             fi
@@ -476,7 +485,7 @@ jobs:
             if [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
               echo "- marketing version override: \`${INPUT_MARKETING_VERSION_OVERRIDE}\`"
             else
-              echo "- marketing version: auto-versioned from the beta lane"
+              echo "- marketing version: checked-in iOS MARKETING_VERSION"
             fi
             echo "- build number (CFBundleVersion): \`${BUILD_NUMBER}\`"
             echo "- audience: internal testers immediately, external testers automatically after external-group assignment; new MARKETING_VERSIONs are auto-submitted for Apple Beta App Review"
@@ -492,7 +501,7 @@ jobs:
           if [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
             UPLOAD_MODE="marketing_version_override"
           else
-            UPLOAD_MODE="auto_version"
+            UPLOAD_MODE="checked_in_version"
           fi
           cat > "$RUNNER_TEMP/ios-testflight-build.json" <<EOF
           {"head_sha":"${GITHUB_SHA}","build_number":"${FINAL_BUILD_NUMBER}","upload_mode":"${UPLOAD_MODE}"}

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -13,7 +13,7 @@ PRODUCT_BUNDLE_IDENTIFIER = dev.cmux.ios
 // release with ios/scripts/bump-ios-version.sh. Keep this human-meaningful and
 // tellable; CFBundleVersion (CURRENT_PROJECT_VERSION) is the monotonic build id
 // (a UTC timestamp stamped by ios/scripts/upload-testflight.sh on TestFlight).
-MARKETING_VERSION = 1.0.3
+MARKETING_VERSION = 1.0.1
 CURRENT_PROJECT_VERSION = 1
 
 // Dev-build identity, surfaced in-app (Settings > About) so a DEBUG dogfood

--- a/ios/README.md
+++ b/ios/README.md
@@ -99,13 +99,21 @@ no review. An `--external` build is different: the FIRST external build of a new
 external tester can install it. Subsequent external builds of the same version
 ship without re-review. The scheduled `main` sync lane now uploads
 external-eligible builds too, so founders track `main` once the current version
-has cleared that review gate. The upload path assigns the processed build to the
+has cleared that review gate. That lane reuses the checked-in
+`ios/Config/Shared.xcconfig` `MARKETING_VERSION`; bump it only when you want a
+fresh Beta App Review cycle. The upload path assigns the processed build to the
 app's external beta group automatically, auto-selecting the single external
 group or using `IOS_TESTFLIGHT_EXTERNAL_GROUP_ID` / `IOS_TESTFLIGHT_EXTERNAL_GROUP_NAME`
 repo variables when the app has multiple external groups. When Apple reports the
 build as `READY_FOR_BETA_SUBMISSION`, the same lane also creates the beta app
 review submission automatically so a new `MARKETING_VERSION` is not left stuck
 at "Ready to Submit".
+
+If CI is moved back from a pending higher version to the last approved version,
+external testers are unblocked because they could not install the pending build.
+Internal testers who already installed that higher internal-only build will not
+see lower-version builds as updates in TestFlight. They need a one-time app
+reinstall, or operators need to cut an internal-only build on the higher version.
 
 ## TestFlight GitHub Actions signing
 
@@ -115,9 +123,10 @@ omit `aps-environment=production`. That upload is intentionally blocked because
 TestFlight push would silently fail. The workflow tracks `main` on a schedule and
 uploads beta builds as external-eligible. Internal testers get the build
 immediately, and the post-upload external distribution step both assigns the
-build to the founders group and auto-submits a new `MARKETING_VERSION` for Beta
-App Review so external testers get the same `main` build as soon as Apple
-approves it.
+build to the founders group and keeps using the checked-in approved
+`MARKETING_VERSION`. When that version is intentionally bumped, the same
+distribution step auto-submits the first build of the new version for Beta App
+Review.
 
 Required GitHub secrets:
 


### PR DESCRIPTION
## Summary
- stop the scheduled iOS TestFlight lane from passing `--auto-version`
- set checked-in iOS `MARKETING_VERSION` to the approved `1.0.1`
- keep scheduled external betas on the checked-in iOS `MARKETING_VERSION` so CI can publish builds under the already-approved version
- document the TestFlight downgrade caveat for internal testers who installed a pending higher-version build

## Caveat
External testers could not install the unapproved pending version, so this unblocks the external beta path. Internal testers who already installed a higher internal-only TestFlight build will not see lower-version builds as updates. They need a one-time reinstall, or an operator needs to cut an internal-only build on the higher version.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-testflight.yml"); puts "workflow yaml ok"'`\n- `bash -n ios/scripts/upload-testflight.sh`\n\nNo tagged reload: workflow/version metadata change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release versioning and TestFlight distribution behavior for all scheduled main betas; wrong MARKETING_VERSION in xcconfig could ship misleading user-visible versions or delay external access until review.
> 
> **Overview**
> Scheduled **iOS TestFlight** uploads on `main` no longer pass **`--auto-version`**, so each beta uses the **`MARKETING_VERSION` in `ios/Config/Shared.xcconfig`** instead of stamping the next patch above the last `ios-v*` tag. That keeps **external** builds on an **already Beta App Review–approved** marketing version so CI can keep shipping `main` without waiting on a pending higher version.
> 
> The checked-in version is set to **`1.0.1`** (down from `1.0.3`). Workflow comments, step summaries, and build metadata now label this path as **`checked_in_version`** rather than **`auto_version`**. **`ios/README.md`** explains that external testers are unblocked by the rollback, while **internal** testers who already installed a higher pending build must **reinstall** or take a one-off higher-version internal cut—TestFlight does not treat lower marketing versions as updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9895d501cf8fb168cbb5a773688e8f137e987c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified TestFlight external eligibility, Beta App Review timing, and how unblocking works after version rollbacks.
  * Updated guidance that scheduled sync uses the checked-in iOS marketing version, and that a new Beta App Review submission occurs only when the marketing version is intentionally bumped.

* **Bug Fixes**
  * Updated scheduled TestFlight uploads to stop auto-versioning and consistently use the checked-in marketing version.
  * Improved override behavior so it doesn’t affect the next scheduled canonical beta, with corrected build metadata and notes generation context.

* **Chores**
  * Updated the iOS `MARKETING_VERSION` value from `1.0.3` to `1.0.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->