### PR TITLE
Extend Cmd-P surface search by workspace name

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4687,7 +4687,7 @@ struct ContentView: View {
     ) -> Bool {
         let scope = commandPaletteListScope(for: query)
         guard scope == .switcher else { return false }
-        return searchAllSurfaces && !commandPaletteQueryForMatching(query: query, scope: scope).isEmpty
+        return searchAllSurfaces
     }
 
     private func refreshCommandPaletteSearchCorpus(
@@ -5136,12 +5136,16 @@ struct ContentView: View {
                         surfaces: includeSurfaces
                             ? commandPaletteOrderedSwitcherPanels(for: workspace).compactMap { panelId in
                                 guard let panel = workspace.panels[panelId] else { return nil }
+                                let surfaceName = panelDisplayName(
+                                    workspace: workspace,
+                                    panelId: panelId,
+                                    fallback: panel.displayTitle
+                                )
                                 return CommandPaletteSwitcherFingerprintSurface(
                                     id: panelId,
-                                    displayName: panelDisplayName(
-                                        workspace: workspace,
-                                        panelId: panelId,
-                                        fallback: panel.displayTitle
+                                    displayName: Self.commandPaletteSwitcherSurfaceTitle(
+                                        workspaceName: workspaceDisplayName(workspace),
+                                        surfaceName: surfaceName
                                     ),
                                     kindLabel: commandPaletteSurfaceKindLabel(for: panel.panelType),
                                     metadata: commandPaletteSurfaceSearchMetadata(
@@ -5294,6 +5298,10 @@ struct ContentView: View {
                         panelId: panelId,
                         fallback: panel.displayTitle
                     )
+                    let surfaceTitle = Self.commandPaletteSwitcherSurfaceTitle(
+                        workspaceName: workspaceName,
+                        surfaceName: surfaceName
+                    )
                     let surfaceKindLabel = commandPaletteSurfaceKindLabel(for: panel.panelType)
                     let surfaceCommandId = "switcher.surface.\(panelId.uuidString.lowercased())"
                     let surfaceKeywords = CommandPaletteSwitcherSearchIndexer(
@@ -5303,6 +5311,7 @@ struct ContentView: View {
                             "switch",
                             "go",
                             "open",
+                            surfaceTitle,
                             surfaceName,
                             workspaceName
                         ] + commandPaletteSurfaceKeywords(for: panel.panelType) + windowKeywords,
@@ -5313,7 +5322,7 @@ struct ContentView: View {
                         CommandPaletteCommand(
                             id: surfaceCommandId,
                             rank: nextRank,
-                            title: surfaceName,
+                            title: surfaceTitle,
                             subtitle: Self.commandPaletteSwitcherSubtitle(base: workspaceName, windowLabel: context.windowLabel),
                             shortcutHint: nil,
                             kindLabel: surfaceKindLabel,
@@ -5485,6 +5494,18 @@ struct ContentView: View {
             ports: ports
         )
     }
+
+    private static func commandPaletteSwitcherSurfaceTitle(
+        workspaceName: String,
+        surfaceName: String
+    ) -> String {
+        let trimmedWorkspace = workspaceName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedSurface = surfaceName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedWorkspace.isEmpty else { return trimmedSurface }
+        guard !trimmedSurface.isEmpty else { return trimmedWorkspace }
+        return "\(trimmedWorkspace):\(trimmedSurface)"
+    }
+
     private func commandPaletteSurfaceKindLabel(for panelType: PanelType) -> String {
         switch panelType {
         case .terminal:

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -2042,10 +2042,10 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
 
         XCTAssertEqual(inputs.scope, "switcher")
         XCTAssertEqual(inputs.matchingQuery, "")
-        XCTAssertFalse(inputs.includesSurfaces)
+        XCTAssertTrue(inputs.includesSurfaces)
     }
 
-    func testRefreshInputsIncludeSurfacesOnlyForNonEmptySwitcherQuery() {
+    func testRefreshInputsIncludeSurfacesForSwitcherWhenEnabled() {
         let switcherInputs = ContentView.commandPaletteRefreshInputsForTests(
             stateQuery: "",
             observedQuery: "  feature/search  ",
@@ -2072,6 +2072,23 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         XCTAssertEqual(workspaceOnlyInputs.scope, "switcher")
         XCTAssertEqual(workspaceOnlyInputs.matchingQuery, "feature/search")
         XCTAssertFalse(workspaceOnlyInputs.includesSurfaces)
+    }
+
+    func testSwitcherSurfaceTitlePrefixesWorkspaceName() {
+        XCTAssertEqual(
+            ContentView.commandPaletteSwitcherSurfaceTitle(
+                workspaceName: "personal",
+                surfaceName: "fleet"
+            ),
+            "personal:fleet"
+        )
+        XCTAssertEqual(
+            ContentView.commandPaletteSwitcherSurfaceTitle(
+                workspaceName: "personal",
+                surfaceName: "prayerly"
+            ),
+            "personal:prayerly"
+        )
     }
 
     func testCommandContextFingerprintTracksExactContextValues() {


### PR DESCRIPTION
## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786126401&installation_id=133855650&pr_number=7638&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7638&signature=e9204679aac524e677ba8d3f6facbfff88638c22da3d6ae82a828ed61c59ff2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized command palette switcher UI and search indexing; behavior change is gated by existing search-all-surfaces preference.
> 
> **Overview**
> **Cmd-P switcher** now keeps **surface/tab entries** in the search corpus whenever **search all surfaces** is on, including an **empty query**—previously surfaces were omitted until the user typed something.
> 
> Surface rows use a new **`workspace:surface`** display title (e.g. `personal:fleet`), applied to list labels, switcher fingerprints, and extra search keywords so queries can match the combined name.
> 
> Tests were updated for the new **includesSurfaces** rules and for **`commandPaletteSwitcherSurfaceTitle`** formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b99e12d88e9df6e9086a7969015bc95fd718199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend Cmd‑P switcher search to include workspace names and show surfaces as "workspace:surface" (e.g., personal:fleet). Surface results now appear even with an empty query when the "search all surfaces" option is on.

- **New Features**
  - Surface titles in the switcher now use "workspace:surface".
  - Search matches workspace names, surface names, or the combined "workspace:surface".
  - Include surface results in switcher when "search all surfaces" is enabled, even for blank queries.

<sup>Written for commit 2b99e12d88e9df6e9086a7969015bc95fd718199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command palette switcher results now include workspace names in item titles, making similar surfaces easier to distinguish.
  * Search results can now appear more broadly in the command palette when switcher search is enabled.

* **Bug Fixes**
  * Improved matching behavior for command palette switcher entries so relevant surfaces are shown more consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->