### PR TITLE
Clear the persisted session when the server definitively rejects the refresh token

### DIFF
--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FallbackTokenStore.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FallbackTokenStore.swift
@@ -98,6 +98,14 @@ public actor FallbackTokenStore: StackAuthTokenStoreProtocol {
                 newRefreshToken: newRefreshToken,
                 newAccessToken: newAccessToken
             )
+            // Reads can fall back to the file store when Keychain returns nil;
+            // apply the same compare-guarded mutation so a matching stale
+            // file-fallback token cannot resurrect after the keychain path.
+            await file.compareAndSet(
+                compareRefreshToken: compareRefreshToken,
+                newRefreshToken: newRefreshToken,
+                newAccessToken: newAccessToken
+            )
             return
         }
         await file.compareAndSet(

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FallbackTokenStore.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FallbackTokenStore.swift
@@ -101,6 +101,12 @@ public actor FallbackTokenStore: StackAuthTokenStoreProtocol {
             // Reads can fall back to the file store when Keychain returns nil;
             // apply the same compare-guarded mutation so a matching stale
             // file-fallback token cannot resurrect after the keychain path.
+            // A NON-matching file token is intentionally preserved: it was
+            // written by a newer setTokens whose keychain write failed and was
+            // never rejected by the server, so clearing it here would destroy
+            // a possibly-valid session. If it is invalid, the next refresh
+            // definitively rejects it and this compareAndSet (routed to the
+            // file store once reads flip keychainWorks) clears it then.
             await file.compareAndSet(
                 compareRefreshToken: compareRefreshToken,
                 newRefreshToken: newRefreshToken,

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FallbackTokenStore.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FallbackTokenStore.swift
@@ -98,20 +98,27 @@ public actor FallbackTokenStore: StackAuthTokenStoreProtocol {
                 newRefreshToken: newRefreshToken,
                 newAccessToken: newAccessToken
             )
-            // Reads can fall back to the file store when Keychain returns nil;
-            // apply the same compare-guarded mutation so a matching stale
-            // file-fallback token cannot resurrect after the keychain path.
+            // Only the definitive-rejection clear (double-nil) propagates to
+            // the file store. Reads can fall back to the file store when
+            // Keychain returns nil, so a matching stale file-fallback token
+            // must not resurrect after the keychain clear. A successful
+            // refresh must NOT be mirrored here: writing the fresh pair would
+            // copy live keychain-backed credentials into the less-protected
+            // file store, violating the split-brain rule that keychain
+            // success clears the file store (see setTokens).
             // A NON-matching file token is intentionally preserved: it was
             // written by a newer setTokens whose keychain write failed and was
             // never rejected by the server, so clearing it here would destroy
             // a possibly-valid session. If it is invalid, the next refresh
             // definitively rejects it and this compareAndSet (routed to the
             // file store once reads flip keychainWorks) clears it then.
-            await file.compareAndSet(
-                compareRefreshToken: compareRefreshToken,
-                newRefreshToken: newRefreshToken,
-                newAccessToken: newAccessToken
-            )
+            if newRefreshToken == nil && newAccessToken == nil {
+                await file.compareAndSet(
+                    compareRefreshToken: compareRefreshToken,
+                    newRefreshToken: nil,
+                    newAccessToken: nil
+                )
+            }
             return
         }
         await file.compareAndSet(

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FileStackTokenStore.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/FileStackTokenStore.swift
@@ -69,6 +69,11 @@ public actor FileStackTokenStore: StackAuthTokenStoreProtocol {
         return true
     }
 
+    /// Replaces tokens only while the stored refresh token is still `compareRefreshToken`.
+    ///
+    /// The compare value is the staleness guard. A double-nil replacement is the
+    /// Stack SDK's `RefreshOutcome.definitivelyRejected` clear, and must delete
+    /// the persisted session once the current refresh token still matches.
     public func compareAndSet(
         compareRefreshToken: String,
         newRefreshToken: String?,
@@ -79,8 +84,7 @@ public actor FileStackTokenStore: StackAuthTokenStoreProtocol {
         log.log("file.compareAndSet: matches=\(matches) hasNewRefresh=\(newRefreshToken?.isEmpty == false) hasNewAccess=\(newAccessToken?.isEmpty == false)")
         guard matches else { return }
         if newRefreshToken == nil && newAccessToken == nil {
-            log.log("file.compareAndSet: blocked double-nil clear (preserving session)")
-            return
+            log.log("file.compareAndSet: cleared definitively-rejected session")
         }
         await setTokens(accessToken: newAccessToken, refreshToken: newRefreshToken)
     }

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/KeychainStackTokenStore.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/TokenStores/KeychainStackTokenStore.swift
@@ -100,6 +100,11 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
         return true
     }
 
+    /// Replaces tokens only while the stored refresh token is still `compareRefreshToken`.
+    ///
+    /// The compare value is the staleness guard. A double-nil replacement is the
+    /// Stack SDK's `RefreshOutcome.definitivelyRejected` clear, and must delete
+    /// the persisted session once the current refresh token still matches.
     public func compareAndSet(
         compareRefreshToken: String,
         newRefreshToken: String?,
@@ -109,12 +114,8 @@ public actor KeychainStackTokenStore: StackAuthTokenStoreProtocol {
         let matches = current == compareRefreshToken
         log.log("keychain.compareAndSet: matches=\(matches) hasNewRefresh=\(newRefreshToken?.isEmpty == false) hasNewAccess=\(newAccessToken?.isEmpty == false)")
         guard matches else { return }
-        // Don't let the StackClientApp's error cleanup path delete both tokens.
-        // If both new values are nil, it means the refresh failed and the SDK wants
-        // to clear the session. Preserve the refresh token so the user stays signed in.
         if newRefreshToken == nil && newAccessToken == nil {
-            log.log("keychain.compareAndSet: blocked double-nil clear (preserving session)")
-            return
+            log.log("keychain.compareAndSet: cleared definitively-rejected session")
         }
         await setTokens(accessToken: newAccessToken, refreshToken: newRefreshToken)
     }

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/TokenStoreCompareAndSetTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/TokenStoreCompareAndSetTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import CmuxAuthRuntime
+
+@Suite struct TokenStoreCompareAndSetTests {
+    @Test func fileStoreDoubleNilCompareAndSetClearsMatchingTokens() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = FileStackTokenStore(directory: directory)
+        await store.setTokens(accessToken: "access-1", refreshToken: "refresh-1")
+
+        await store.compareAndSet(
+            compareRefreshToken: "refresh-1",
+            newRefreshToken: nil,
+            newAccessToken: nil
+        )
+
+        #expect(await store.getStoredAccessToken() == nil)
+        #expect(await store.getStoredRefreshToken() == nil)
+
+        let freshStore = FileStackTokenStore(directory: directory)
+        #expect(await freshStore.getStoredAccessToken() == nil)
+        #expect(await freshStore.getStoredRefreshToken() == nil)
+    }
+
+    @Test func fileStoreDoubleNilCompareAndSetPreservesTokensWhenCompareIsStale() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = FileStackTokenStore(directory: directory)
+        await store.setTokens(accessToken: "access-1", refreshToken: "refresh-1")
+
+        await store.compareAndSet(
+            compareRefreshToken: "stale-refresh",
+            newRefreshToken: nil,
+            newAccessToken: nil
+        )
+
+        #expect(await store.getStoredAccessToken() == "access-1")
+        #expect(await store.getStoredRefreshToken() == "refresh-1")
+    }
+
+    @Test func fileStoreCompareAndSetUpdatesTokensWhenCompareMatches() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = FileStackTokenStore(directory: directory)
+        await store.setTokens(accessToken: "access-1", refreshToken: "refresh-1")
+
+        await store.compareAndSet(
+            compareRefreshToken: "refresh-1",
+            newRefreshToken: "refresh-2",
+            newAccessToken: "access-2"
+        )
+
+        #expect(await store.getStoredAccessToken() == "access-2")
+        #expect(await store.getStoredRefreshToken() == "refresh-2")
+    }
+
+    @Test func fallbackStoreDoubleNilCompareAndSetClearsFileSeededTokens() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let keychain = KeychainStackTokenStore(
+            service: "com.cmux.tests.TokenStoreCompareAndSetTests.\(UUID().uuidString)"
+        )
+        let file = FileStackTokenStore(directory: directory)
+        await file.setTokens(accessToken: "access-1", refreshToken: "refresh-1")
+        let store = FallbackTokenStore(primary: keychain, fallback: file)
+
+        await store.compareAndSet(
+            compareRefreshToken: "refresh-1",
+            newRefreshToken: nil,
+            newAccessToken: nil
+        )
+
+        #expect(await store.getStoredAccessToken() == nil)
+        #expect(await store.getStoredRefreshToken() == nil)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CmuxAuthRuntimeTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return directory
+    }
+}


### PR DESCRIPTION
## Bug

Nightly 0.64.17 showed a permanent Cloud VM failure: "You are signed in, but cmux could not refresh your session (network or server issue)", surviving every retry, with `cmux auth status` still claiming signed in and the sign-in page never appearing.

Live diagnosis against the running nightly (CFNetwork capture while pressing Retry): `POST https://api.stack-auth.com/api/v1/auth/oauth/token` returns **HTTP 401** — the refresh token was revoked/expired server-side (the endpoint itself is healthy). Per the vendored Stack SDK's `RefreshOutcome` classification that is `definitivelyRejected`, and the SDK issues a compare-guarded double-nil `compareAndSet` to clear the dead session so the user re-authenticates.

Both cmux token stores blocked exactly that clear ("blocked double-nil clear (preserving session)"). The guard predates https://github.com/manaflow-ai/cmux/commit/5a97438344a579607217cce95deb95f7ce481854, which moved transient-vs-definitive classification into the SDK; since then transient failures never reach `compareAndSet` at all, so the guard only ever blocked correct clears. Result: the dead refresh token was immortal, every token fetch saw access=nil/refresh=present and threw `AuthError.networkError`, and the UI reported an eternal fake network error. The same guard also silently broke the coordinator's `clearLocalSession(ifRefreshTokenMatches:)` route-to-login clear.

## Fix

- Remove the double-nil block from `KeychainStackTokenStore.compareAndSet` and `FileStackTokenStore.compareAndSet`. The `compareRefreshToken` match remains the staleness guard, so stale flows still cannot clobber a newer session.
- `FallbackTokenStore.compareAndSet` keychain path now also applies the compare-guarded mutation to the file store, so a stale file-fallback copy cannot resurrect the dead session (reads fall back to the file store when the keychain returns nil).

## Commits (red/green)

1. Failing regression tests only — `TokenStoreCompareAndSetTests` (6 failures without the fix).
2. The fix — full `CmuxAuthRuntime` package: 142 tests green.

Transient-failure behavior is unchanged: on `.transientFailure` the SDK preserves tokens and never calls `compareAndSet` (verified at every SDK call site).

User remedy on already-stuck builds: sign out and back in (sign-out uses the unconditional clear, which was never blocked).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786130259&installation_id=133855650&pr_number=7640&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7640&signature=72224bb89e84ade8dca5188a70bca9df9c5774b322ea69ce8d0c1f3e0a67eeeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth session persistence and when local credentials are deleted; behavior is narrowly scoped to compare-matched definitive rejection, but incorrect edge cases could sign users out or leave split-brain tokens.
> 
> **Overview**
> Fixes **stuck “signed in”** sessions when the server returns **401** on refresh by honoring the Stack SDK’s compare-guarded **double-nil** `compareAndSet` instead of blocking it.
> 
> **Keychain** and **file** token stores no longer refuse a matching double-nil update; they clear persisted tokens when the compare refresh token still matches. The **`compareRefreshToken`** check is unchanged, so stale flows still cannot wipe a newer session.
> 
> **`FallbackTokenStore`** on the keychain path now mirrors **only** definitive-rejection clears to the file fallback (not successful refreshes), so a leftover file copy cannot resurrect a session after keychain is cleared. Comments document why non-matching file tokens are left alone.
> 
> Adds **`TokenStoreCompareAndSetTests`** for file store clear/update behavior and fallback double-nil clearing when tokens live only on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42363607c5baa5b5b4e7e4f72d5ed9158f3861b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears revoked/expired sessions when the server rejects the refresh token, fixing the “stuck signed-in with network error” loop and sending users back to sign-in.

- **Bug Fixes**
  - Removed the double-nil clear guard in `KeychainStackTokenStore` and `FileStackTokenStore` so the SDK’s `definitivelyRejected` outcome clears the persisted session when the refresh token matches.
  - Updated `FallbackTokenStore` so the keychain path propagates only the compare-guarded double‑nil clear to the file store; successful refreshes are not mirrored. Non‑matching file tokens are preserved to avoid deleting a possibly valid session. Added tests. Transient failures unchanged.

<sup>Written for commit c42363607c5baa5b5b4e7e4f72d5ed9158f3861b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token “compare-and-set” handling so definitively rejected refreshes now clear persisted session tokens instead of being preserved.
  * Ensured double-`nil` clear semantics propagate consistently across token storage layers, including fallback storage behavior.
  * Improved staleness-guard behavior so only matching refresh tokens allow replacements, while stale comparisons preserve existing tokens.

* **Tests**
  * Added new test suite covering correct token clearing/preservation for file-backed, keychain-backed, and fallback scenarios, including stale comparison cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->