### PR TITLE
sdk: bump to 0.1.2 and finalize npm publish pipeline

### DIFF
--- a/.github/workflows/sdk-publish-npm.yml
+++ b/.github/workflows/sdk-publish-npm.yml
@@ -145,6 +145,13 @@ jobs:
           node-version: "22.14.0"
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm for OIDC trusted publishing
+        # Node 22 bundles npm 10, which signs provenance but cannot
+        # authenticate the publish via OIDC trusted publishing (the PUT is
+        # unauthenticated and 404s). npm >= 11.5.1 performs the OIDC token
+        # exchange for the publish itself.
+        run: npm install -g npm@^11.5.1
+
       - name: Build package
         working-directory: mux/bindings/typescript
         run: |

--- a/.github/workflows/sdk-publish-npm.yml
+++ b/.github/workflows/sdk-publish-npm.yml
@@ -124,7 +124,7 @@ jobs:
     # npm --provenance rejects self-hosted runners; the attestation is only
     # verifiable from a GitHub-hosted runner. This one publish job must stay on
     # ubuntu-latest (github-hosted), unlike the routed self-hosted jobs above.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # github-hosted-required: npm provenance needs a github-hosted runner
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/sdk-publish-npm.yml
+++ b/.github/workflows/sdk-publish-npm.yml
@@ -160,4 +160,7 @@ jobs:
 
       - name: Publish package to npm
         working-directory: mux/bindings/typescript
-        run: npm publish --provenance
+        # The npm `cmux` name still serves the cloud-VM CLI on the `latest`
+        # dist-tag (0.8.3). The SDK ships on its own `sdk` tag so installing
+        # bare `cmux` keeps resolving the CLI; use `npm i cmux@sdk` for the SDK.
+        run: npm publish --provenance --tag sdk

--- a/.github/workflows/sdk-publish-npm.yml
+++ b/.github/workflows/sdk-publish-npm.yml
@@ -121,7 +121,10 @@ jobs:
     # action, so tag pushes never publish to npm and manual runs must opt in.
     if: github.event_name == 'workflow_dispatch'
     needs: bindings-e2e-typescript
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    # npm --provenance rejects self-hosted runners; the attestation is only
+    # verifiable from a GitHub-hosted runner. This one publish job must stay on
+    # ubuntu-latest (github-hosted), unlike the routed self-hosted jobs above.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/mux/Cargo.lock
+++ b/mux/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "cmux-client"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/mux/bindings/python/pyproject.toml
+++ b/mux/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cmux"
-version = "0.1.0"
+version = "0.1.2"
 requires-python = ">=3.9"
 dependencies = []
 

--- a/mux/bindings/rust/Cargo.toml
+++ b/mux/bindings/rust/Cargo.toml
@@ -3,6 +3,9 @@ name = "cmux-client"
 version = "0.1.2"
 edition.workspace = true
 license.workspace = true
+description = "Rust client for the cmux-mux terminal multiplexer control protocol"
+repository = "https://github.com/manaflow-ai/cmux"
+homepage = "https://github.com/manaflow-ai/cmux/tree/main/mux/bindings/rust"
 publish = true
 
 [dependencies]

--- a/mux/bindings/rust/Cargo.toml
+++ b/mux/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmux-client"
-version = "0.1.0"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 publish = true

--- a/mux/bindings/typescript/package-lock.json
+++ b/mux/bindings/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cmux",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cmux",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "devDependencies": {
         "@types/node": "20.19.25",
         "typescript": "5.9.3"

--- a/mux/bindings/typescript/package.json
+++ b/mux/bindings/typescript/package.json
@@ -2,6 +2,12 @@
   "name": "cmux",
   "version": "0.1.2",
   "description": "Node.js client for the cmux-mux JSON-lines protocol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/manaflow-ai/cmux.git",
+    "directory": "mux/bindings/typescript"
+  },
+  "homepage": "https://github.com/manaflow-ai/cmux/tree/main/mux/bindings/typescript",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/mux/bindings/typescript/package.json
+++ b/mux/bindings/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmux",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Node.js client for the cmux-mux JSON-lines protocol",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -785,7 +785,7 @@ check_no_bare_github_hosted_runners() {
   # deliberate single-runner pins such as the testmanagerd-wedged
   # `app-host-unit-tests` job.
   local hits
-  hits="$(grep -rnE "runs-on:[[:space:]]*(ubuntu-[a-z0-9.]+|macos-[a-z0-9]+)[[:space:]]*$" "$ROOT_DIR/.github/workflows" || true)"
+  hits="$(grep -rnE "runs-on:[[:space:]]*(ubuntu-[a-z0-9.]+|macos-[a-z0-9]+)([[:space:]]*$|[[:space:]]+#)" "$ROOT_DIR/.github/workflows" | grep -v "github-hosted-required" || true)"
   if [[ -n "$hits" ]]; then
     echo "FAIL: these jobs use a bare GitHub-hosted runner; route them through vars.LINUX_RUNNER / vars.MACOS_RUNNER_IOS so Blacksmith<->overflow stays a repo-variable flip:"
     echo "$hits"

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*.local


### PR DESCRIPTION
Lands the state that published cmux 0.1.2 to PyPI and npm.

- All SDK binding manifests + lockfiles bumped 0.1.0 -> 0.1.2 (0.1.2 is the smallest version free on both npm, where the CLI holds 0.1.0-0.8.3, and PyPI, where 0.1.0-0.1.1 are taken).
- npm publish workflow fixes (all needed for the live publish to succeed): upgrade to npm >=11.5.1 for OIDC trusted-publishing auth; publish under the `sdk` dist-tag so `npm i cmux` keeps resolving the CLI (`latest`=0.8.3) and `npm i cmux@sdk`=SDK; run the publish job on a github-hosted runner (npm --provenance rejects self-hosted); add `repository`/`homepage` to package.json (provenance validation).
- Self-hosted runner guard: documented `github-hosted-required` opt-out for jobs that must be github-hosted (npm provenance) and never enter the overflow rotation.

Already published live: PyPI cmux 0.1.2, npm cmux@sdk 0.1.2 (both via OIDC trusted publishing + provenance).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786130703&installation_id=133855650&pr_number=7642&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7642&signature=4cb1d9a4ccc5f4b11a7a454271182e42a520809f28be6a18ff21f11d7008e016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release versions, publish workflow, and CI guard rules—no application runtime or auth logic.
> 
> **Overview**
> Bumps **mux SDK bindings** from `0.1.0` to **`0.1.2`** across Python (`pyproject.toml`), Rust (`cmux-client` + lockfile), and TypeScript (`package.json` / lockfile). Rust and TypeScript manifests also gain **`repository` / `homepage`** metadata for registry provenance.
> 
> The **`sdk-publish-npm`** workflow is adjusted so live publishes succeed: the **publish** job runs on **`ubuntu-latest`** (required for `npm --provenance`), installs **npm ≥ 11.5.1** for OIDC trusted publishing, and publishes with **`--tag sdk`** so `npm i cmux` still resolves the CLI on `latest` while the SDK is **`cmux@sdk`**.
> 
> **`test_ci_self_hosted_guard.sh`** now allows documented **`github-hosted-required`** exceptions on `runs-on` lines so that publish job is not flagged. **`web/.gitignore`** adds **`.env*.local`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79af23ba23dc1a4e751a89d063aae031e7e3d39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the SDK bindings to 0.1.2 and finalizes the `npm` publish pipeline with provenance and OIDC trusted publishing. Adds crates.io metadata, keeps the `cmux` CLI on `latest`, and makes the SDK installable via `cmux@sdk`.

- **Dependencies**
  - Set `cmux`/`cmux-client` version to 0.1.2 in Python, Rust, and TypeScript bindings (manifests and lockfiles).

- **Bug Fixes**
  - Run the `npm` publish job on `ubuntu-latest` (GitHub‑hosted) for `npm --provenance`.
  - Upgrade `npm` to >= 11.5.1 to enable OIDC trusted publishing.
  - Publish the SDK with `--tag sdk` so `npm i cmux` keeps resolving the CLI; use `npm i cmux@sdk` for the SDK.
  - Add `repository`/`homepage` to the TS `package.json` and `description`/`repository`/`homepage` to the Rust crate for provenance/crates.io validation.
  - Exempt marked jobs from the self‑hosted runner guard using `github-hosted-required`; update the guard test accordingly.

<sup>Written for commit 79af23ba23dc1a4e751a89d063aae031e7e3d39d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SDK release publishing support with safer, provenance-backed publishing settings.
* **Bug Fixes**
  * Corrected CI self-hosted runner guard detection for `runs-on` lines with inline comments and exclusions.
* **Chores**
  * Bumped package version to **0.1.2** across Python, Rust, and TypeScript bindings.
  * Updated TypeScript package repository/homepage metadata.
  * Expanded the web app’s local environment file ignores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->