### PR TITLE
App browser SSO: share the desktop Stack session with the in-app browser

### DIFF
--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
@@ -13,17 +13,16 @@ public final class HostBrowserSignInFlow {
     /// Whether the in-flight popup has waited long enough for the UI to offer
     /// the default-browser fallback instead of an indefinite spinner.
     public private(set) var signInIsSlow = false
-
     /// Display-safe failure from the most recent hosted-browser sign-in
     /// attempt. `nil` for a fresh attempt and for deliberate cancellation.
     public private(set) var lastFailure: AuthError?
-
     private let coordinator: AuthCoordinator
     private let tokenStore: any StackAuthTokenStoreProtocol
     private let sessionFactory: any HostBrowserAuthSessionFactory
     private let callbackRouter: AuthCallbackRouter
     private let makeSignInURL: @MainActor (_ callbackState: String) -> URL
     private let callbackScheme: @MainActor () -> String
+    private let onSignedOut: @MainActor @Sendable () async -> Void
     private let clock: any Clock<Duration>
     private let browserAttemptTimeout: TimeInterval
     private let slowSignInThreshold: TimeInterval
@@ -40,7 +39,6 @@ public final class HostBrowserSignInFlow {
     @ObservationIgnored private var pendingManualCallbackState: String?
     @ObservationIgnored private var pendingFallbackCallbackState: String?
     @ObservationIgnored private var signOutGeneration: UInt64 = 0
-
     /// Creates the flow.
     public init(
         coordinator: AuthCoordinator,
@@ -49,6 +47,7 @@ public final class HostBrowserSignInFlow {
         callbackRouter: AuthCallbackRouter,
         makeSignInURL: @escaping @MainActor (_ callbackState: String) -> URL,
         callbackScheme: @escaping @MainActor () -> String,
+        onSignedOut: @escaping @MainActor @Sendable () async -> Void = {},
         clock: any Clock<Duration> = ContinuousClock(),
         browserAttemptTimeout: TimeInterval = 10 * 60,
         slowSignInThreshold: TimeInterval = 30
@@ -59,6 +58,7 @@ public final class HostBrowserSignInFlow {
         self.callbackRouter = callbackRouter
         self.makeSignInURL = makeSignInURL
         self.callbackScheme = callbackScheme
+        self.onSignedOut = onSignedOut
         self.clock = clock
         self.browserAttemptTimeout = browserAttemptTimeout
         self.slowSignInThreshold = slowSignInThreshold
@@ -145,13 +145,12 @@ public final class HostBrowserSignInFlow {
         signOutGeneration &+= 1
         lastFailure = nil
         cancelActiveAttempt()
+        await onSignedOut()
         await coordinator.signOut()
         log.log("auth.browser.signOut.end generation=\(signOutGeneration)")
     }
-
     /// Sign out with a socket deadline while sign-out continues in background.
     public func signOut(timeout: TimeInterval) async {
-        // Strong capture keeps user-requested sign-out alive past caller timeout.
         let attempt = Task { @MainActor in
             await self.signOut()
             return true
@@ -429,6 +428,7 @@ public final class HostBrowserSignInFlow {
             // Sign-out ran while the validation round trip was in flight. The
             // user's intent wins: tear the just-published session back down.
             log.log("auth.callback.coordinator.rollback attempt=\(attemptID.map(String.init) ?? "external") reason=signOutRaced generation=\(signOutGeneration)")
+            await onSignedOut()
             await coordinator.signOut()
             await tokenStore.clearTokensIfCurrent(
                 accessToken: payload.accessToken,

--- a/Sources/Auth/AuthEnvironment.swift
+++ b/Sources/Auth/AuthEnvironment.swift
@@ -99,7 +99,7 @@ enum AuthEnvironment {
     }
 
     static func resolvedPricingURL(environment: [String: String]) -> URL {
-        appWebOrigin(environment: environment).appendingPathComponent("pricing")
+        resolvedAppWebOrigin(environment: environment).appendingPathComponent("pricing")
     }
 
     static var appPricingURL: URL {
@@ -107,7 +107,35 @@ enum AuthEnvironment {
     }
 
     static func resolvedAppPricingURL(environment: [String: String]) -> URL {
-        appWebOrigin(environment: environment).appendingPathComponent("app-pricing")
+        resolvedAppWebOrigin(environment: environment).appendingPathComponent("app-pricing")
+    }
+
+    static var appWebOrigin: URL {
+        resolvedAppWebOrigin(environment: ProcessInfo.processInfo.environment)
+    }
+
+    static func resolvedAppWebOrigin(environment: [String: String]) -> URL {
+        if let explicitWebsite = environmentURL("CMUX_WWW_ORIGIN", environment: environment) {
+            return canonicalizedLoopbackURL(explicitWebsite)
+        }
+        if let authWebsite = environmentURL("CMUX_AUTH_WWW_ORIGIN", environment: environment) {
+            return canonicalizedLoopbackURL(authWebsite)
+        }
+        #if DEBUG
+        if environmentPort("CMUX_PORT", environment: environment) != nil ||
+            environmentPort("PORT", environment: environment) != nil {
+            return URL(string: resolvedDefaultWebOrigin(environment: environment))!
+        }
+        if let override = devOverride(key: "CMUX_WWW_ORIGIN"),
+           let url = URL(string: override) {
+            return canonicalizedLoopbackURL(url)
+        }
+        #endif
+        return resolvedURL(
+            environmentKey: "CMUX_WWW_ORIGIN",
+            fallback: resolvedDefaultWebOrigin(environment: environment),
+            environment: environment
+        )
     }
 
     /// Payment entrypoint used by native app UI. `CMUX_BILLING_WWW_ORIGIN`
@@ -206,31 +234,7 @@ enum AuthEnvironment {
         if let overridden = environmentURL("CMUX_BILLING_WWW_ORIGIN", environment: environment) {
             return overridden
         }
-        return appWebOrigin(environment: environment)
-    }
-
-    private static func appWebOrigin(environment: [String: String]) -> URL {
-        if let explicitWebsite = environmentURL("CMUX_WWW_ORIGIN", environment: environment) {
-            return canonicalizedLoopbackURL(explicitWebsite)
-        }
-        if let authWebsite = environmentURL("CMUX_AUTH_WWW_ORIGIN", environment: environment) {
-            return canonicalizedLoopbackURL(authWebsite)
-        }
-        #if DEBUG
-        if environmentPort("CMUX_PORT", environment: environment) != nil ||
-            environmentPort("PORT", environment: environment) != nil {
-            return URL(string: resolvedDefaultWebOrigin(environment: environment))!
-        }
-        if let override = devOverride(key: "CMUX_WWW_ORIGIN"),
-           let url = URL(string: override) {
-            return canonicalizedLoopbackURL(url)
-        }
-        #endif
-        return resolvedURL(
-            environmentKey: "CMUX_WWW_ORIGIN",
-            fallback: resolvedDefaultWebOrigin(environment: environment),
-            environment: environment
-        )
+        return resolvedAppWebOrigin(environment: environment)
     }
 
     private static func billingCheckoutURL(origin: URL, callbackScheme: String) -> URL {

--- a/Sources/Auth/MacAuthComposition.swift
+++ b/Sources/Auth/MacAuthComposition.swift
@@ -125,7 +125,10 @@ struct MacAuthComposition {
             sessionFactory: ASWebBrowserAuthSessionFactory(anchor: anchor),
             callbackRouter: callbackRouter,
             makeSignInURL: { AuthEnvironment.signInURL(callbackState: $0) },
-            callbackScheme: { AuthEnvironment.callbackScheme }
+            callbackScheme: { AuthEnvironment.callbackScheme },
+            onSignedOut: {
+                await BrowserAppSessionBridge.shared.clearCmuxWebSession()
+            }
         )
     }
 

--- a/Sources/Panels/BrowserAppSessionBridge.swift
+++ b/Sources/Panels/BrowserAppSessionBridge.swift
@@ -1,0 +1,147 @@
+import Foundation
+import WebKit
+
+@MainActor
+final class BrowserAppSessionBridge {
+    static let shared = BrowserAppSessionBridge()
+
+    private var generations: [UUID: UInt64] = [:]
+    private var handoffStores: [ObjectIdentifier: WKWebsiteDataStore] = [:]
+
+    func beginHandoffNavigationIfNeeded(
+        panelID: UUID,
+        destinationURL: URL,
+        request: URLRequest,
+        websiteDataStore: WKWebsiteDataStore,
+        navigate: @escaping @MainActor (URLRequest) -> Void
+    ) -> Bool {
+        generations[panelID, default: 0] &+= 1
+        let generation = generations[panelID, default: 0]
+        guard request.httpMethod?.uppercased() ?? "GET" == "GET",
+              BrowserAppSessionHandoff.shouldHandoff(
+                  destinationURL: destinationURL,
+                  webOrigin: AuthEnvironment.appWebOrigin
+              ) else {
+            return false
+        }
+
+        handoffStores[ObjectIdentifier(websiteDataStore)] = websiteDataStore
+        Task { @MainActor [weak self] in
+            guard let self,
+                  let tokens = await self.currentNativeTokens(),
+                  self.generations[panelID] == generation,
+                  let handoffRequest = BrowserAppSessionHandoff.handoffRequest(
+                      destinationURL: destinationURL,
+                      webOrigin: AuthEnvironment.appWebOrigin,
+                      tokens: tokens
+                  ) else {
+                return
+            }
+            navigate(handoffRequest)
+        }
+        return true
+    }
+
+    func clearCmuxWebSession() async {
+        let stores = trackedWebsiteDataStores()
+        for store in stores {
+            await clearCmuxWebSession(in: store)
+        }
+        handoffStores.removeAll()
+    }
+
+    private func currentNativeTokens() async -> BrowserAppSessionTokens? {
+        guard let coordinator = AppDelegate.shared?.auth?.coordinator else {
+            return nil
+        }
+        if let tokens = try? await coordinator.currentTokens() {
+            return BrowserAppSessionTokens(
+                accessToken: tokens.accessToken,
+                refreshToken: tokens.refreshToken
+            )
+        }
+        guard let refreshToken = await coordinator.refreshToken(), !refreshToken.isEmpty else {
+            return nil
+        }
+        let accessToken = await coordinator.storedAccessToken()
+        return BrowserAppSessionTokens(accessToken: accessToken, refreshToken: refreshToken)
+    }
+
+    private func trackedWebsiteDataStores() -> [WKWebsiteDataStore] {
+        var stores = handoffStores
+        let profileStore = BrowserProfileStore.shared
+        stores[ObjectIdentifier(WKWebsiteDataStore.default())] = WKWebsiteDataStore.default()
+        for profile in profileStore.profiles {
+            let store = profileStore.websiteDataStore(for: profile.id)
+            stores[ObjectIdentifier(store)] = store
+        }
+        return Array(stores.values)
+    }
+
+    private func clearCmuxWebSession(in store: WKWebsiteDataStore) async {
+        await clearCmuxCookies(in: store.httpCookieStore)
+        await clearWebsiteDataRecords(in: store)
+    }
+
+    private func clearCmuxCookies(in cookieStore: WKHTTPCookieStore) async {
+        let cookies = await allCookies(in: cookieStore)
+        let webOrigin = AuthEnvironment.appWebOrigin
+        let projectId = AuthEnvironment.stackProjectID
+        for cookie in cookies where BrowserAppSessionHandoff.shouldDeleteCookie(
+            name: cookie.name,
+            domain: cookie.domain,
+            webOrigin: webOrigin,
+            projectId: projectId
+        ) {
+            await delete(cookie, from: cookieStore)
+        }
+    }
+
+    private func clearWebsiteDataRecords(in store: WKWebsiteDataStore) async {
+        let records = await dataRecords(in: store)
+        guard let host = AuthEnvironment.appWebOrigin.host?.lowercased() else { return }
+        let matchingRecords = records.filter { $0.displayName.lowercased() == host }
+        guard !matchingRecords.isEmpty else { return }
+        await removeData(
+            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+            records: matchingRecords,
+            from: store
+        )
+    }
+
+    private func allCookies(in cookieStore: WKHTTPCookieStore) async -> [HTTPCookie] {
+        await withCheckedContinuation { continuation in
+            cookieStore.getAllCookies { cookies in
+                continuation.resume(returning: cookies)
+            }
+        }
+    }
+
+    private func delete(_ cookie: HTTPCookie, from cookieStore: WKHTTPCookieStore) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            cookieStore.delete(cookie) {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func dataRecords(in store: WKWebsiteDataStore) async -> [WKWebsiteDataRecord] {
+        await withCheckedContinuation { continuation in
+            store.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
+                continuation.resume(returning: records)
+            }
+        }
+    }
+
+    private func removeData(
+        ofTypes types: Set<String>,
+        records: [WKWebsiteDataRecord],
+        from store: WKWebsiteDataStore
+    ) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            store.removeData(ofTypes: types, for: records) {
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/Sources/Panels/BrowserAppSessionBridge.swift
+++ b/Sources/Panels/BrowserAppSessionBridge.swift
@@ -5,7 +5,19 @@ import WebKit
 final class BrowserAppSessionBridge {
     static let shared = BrowserAppSessionBridge()
 
-    private var generations: [UUID: UInt64] = [:]
+    // Per-panel navigation counter: a newer navigation in the same panel
+    // invalidates an in-flight handoff so it can't override the newer load.
+    private var navGenerations: [UUID: UInt64] = [:]
+    // Bumped whenever the cmux web session is cleared (sign-out / account
+    // switch); resets which data stores are considered primed.
+    private var signInGeneration: UInt64 = 0
+    // Data store -> the signInGeneration it was primed for. A store primed for
+    // the current generation navigates normally (its cookies are already set),
+    // so the handoff runs at most once per data store per sign-in.
+    private var handoffDoneStores: [ObjectIdentifier: UInt64] = [:]
+    // Stores with an in-flight handoff, so concurrent navigations don't mint
+    // duplicate server-side sessions.
+    private var handoffInFlight: Set<ObjectIdentifier> = []
     private var handoffStores: [ObjectIdentifier: WKWebsiteDataStore] = [:]
 
     func beginHandoffNavigationIfNeeded(
@@ -15,8 +27,8 @@ final class BrowserAppSessionBridge {
         websiteDataStore: WKWebsiteDataStore,
         navigate: @escaping @MainActor (URLRequest) -> Void
     ) -> Bool {
-        generations[panelID, default: 0] &+= 1
-        let generation = generations[panelID, default: 0]
+        navGenerations[panelID, default: 0] &+= 1
+        let navGeneration = navGenerations[panelID, default: 0]
         guard request.httpMethod?.uppercased() ?? "GET" == "GET",
               BrowserAppSessionHandoff.shouldHandoff(
                   destinationURL: destinationURL,
@@ -25,24 +37,50 @@ final class BrowserAppSessionBridge {
             return false
         }
 
-        handoffStores[ObjectIdentifier(websiteDataStore)] = websiteDataStore
+        let storeKey = ObjectIdentifier(websiteDataStore)
+        // Already primed for this sign-in, or a handoff is already running for
+        // this store: navigate normally (existing cookies authenticate).
+        if handoffDoneStores[storeKey] == signInGeneration { return false }
+        if handoffInFlight.contains(storeKey) { return false }
+
+        handoffInFlight.insert(storeKey)
+        handoffStores[storeKey] = websiteDataStore
+        let signInGen = signInGeneration
         Task { @MainActor [weak self] in
-            guard let self,
+            guard let self else { return }
+            defer { self.handoffInFlight.remove(storeKey) }
+            // Superseded by a newer navigation in this panel: drop silently
+            // (the newer navigation owns the webview now).
+            guard self.navGenerations[panelID] == navGeneration else { return }
+            guard self.signInGeneration == signInGen,
                   let tokens = await self.currentNativeTokens(),
-                  self.generations[panelID] == generation,
+                  self.navGenerations[panelID] == navGeneration,
+                  self.signInGeneration == signInGen,
                   let handoffRequest = BrowserAppSessionHandoff.handoffRequest(
                       destinationURL: destinationURL,
                       webOrigin: AuthEnvironment.appWebOrigin,
                       tokens: tokens
                   ) else {
+                // No session available (signed out) or a stale generation: load
+                // the original request so the page still renders instead of
+                // leaving the webview blank. Do not mark the store primed, so a
+                // later sign-in retries the handoff.
+                if self.navGenerations[panelID] == navGeneration {
+                    navigate(request)
+                }
                 return
             }
+            self.handoffDoneStores[storeKey] = signInGen
             navigate(handoffRequest)
         }
         return true
     }
 
     func clearCmuxWebSession() async {
+        // Invalidate every primed store so the next cmux-origin navigation
+        // re-runs the handoff with whatever session is current.
+        signInGeneration &+= 1
+        handoffDoneStores.removeAll()
         let stores = trackedWebsiteDataStores()
         for store in stores {
             await clearCmuxWebSession(in: store)

--- a/Sources/Panels/BrowserAppSessionHandoff.swift
+++ b/Sources/Panels/BrowserAppSessionHandoff.swift
@@ -35,7 +35,7 @@ struct BrowserAppSessionHandoff {
         // every value with a set that excludes "+", "&", "=", and "%".
         let pairs: [(String, String)] = [
             ("refresh_token", tokens.refreshToken),
-            ("access_token", tokens.accessToken),
+            ("access_token", tokens.accessToken ?? ""),
             ("after", relativePath(destinationURL)),
         ].filter { !$0.1.isEmpty }
         let body = pairs

--- a/Sources/Panels/BrowserAppSessionHandoff.swift
+++ b/Sources/Panels/BrowserAppSessionHandoff.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+struct BrowserAppSessionTokens: Equatable {
+    let accessToken: String?
+    let refreshToken: String
+}
+
+struct BrowserAppSessionHandoff {
+    static func shouldHandoff(destinationURL: URL, webOrigin: URL) -> Bool {
+        guard matchesOrigin(destinationURL, webOrigin) else { return false }
+        guard let scheme = destinationURL.scheme?.lowercased(),
+              scheme == "http" || scheme == "https" else {
+            return false
+        }
+        return destinationURL.path != "/handler/app-session-handoff"
+    }
+
+    static func handoffRequest(
+        destinationURL: URL,
+        webOrigin: URL,
+        tokens: BrowserAppSessionTokens
+    ) -> URLRequest? {
+        guard shouldHandoff(destinationURL: destinationURL, webOrigin: webOrigin) else {
+            return nil
+        }
+        guard let url = URLComponents(
+            url: webOrigin.appendingPathComponent("handler/app-session-handoff"),
+            resolvingAgainstBaseURL: false
+        )?.url else {
+            return nil
+        }
+        var bodyComponents = URLComponents()
+        bodyComponents.queryItems = [
+            URLQueryItem(name: "refresh_token", value: tokens.refreshToken),
+            URLQueryItem(name: "access_token", value: tokens.accessToken),
+            URLQueryItem(name: "after", value: relativePath(destinationURL)),
+        ].filter { $0.value?.isEmpty == false }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("no-referrer", forHTTPHeaderField: "Referrer-Policy")
+        request.httpBody = bodyComponents.percentEncodedQuery?.data(using: .utf8)
+        return request
+    }
+
+    static func isStackCookie(_ name: String, projectId: String) -> Bool {
+        let refreshName = "stack-refresh-\(projectId)"
+        return name == "stack-access" ||
+            name == "__Host-stack-access" ||
+            name == "__Secure-stack-access" ||
+            name == "stack-refresh" ||
+            name == "__Host-stack-refresh" ||
+            name == "__Secure-stack-refresh" ||
+            name == refreshName ||
+            name == "__Host-\(refreshName)" ||
+            name == "__Secure-\(refreshName)" ||
+            name.hasPrefix("\(refreshName)--") ||
+            name.hasPrefix("__Host-\(refreshName)--") ||
+            name.hasPrefix("__Secure-\(refreshName)--")
+    }
+
+    static func shouldDeleteCookie(
+        name: String,
+        domain: String,
+        webOrigin: URL,
+        projectId: String
+    ) -> Bool {
+        guard isStackCookie(name, projectId: projectId),
+              let host = webOrigin.host?.lowercased() else {
+            return false
+        }
+        let normalizedDomain = domain.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        return normalizedDomain == host
+    }
+
+    private static func matchesOrigin(_ lhs: URL, _ rhs: URL) -> Bool {
+        guard lhs.scheme?.lowercased() == rhs.scheme?.lowercased(),
+              lhs.host?.lowercased() == rhs.host?.lowercased() else {
+            return false
+        }
+        return effectivePort(lhs) == effectivePort(rhs)
+    }
+
+    private static func effectivePort(_ url: URL) -> Int? {
+        if let port = url.port { return port }
+        switch url.scheme?.lowercased() {
+        case "http": return 80
+        case "https": return 443
+        default: return nil
+        }
+    }
+
+    private static func relativePath(_ url: URL) -> String {
+        var result = url.path.isEmpty ? "/" : url.path
+        if let query = url.query, !query.isEmpty {
+            result += "?\(query)"
+        }
+        if let fragment = url.fragment, !fragment.isEmpty {
+            result += "#\(fragment)"
+        }
+        return result
+    }
+}

--- a/Sources/Panels/BrowserAppSessionHandoff.swift
+++ b/Sources/Panels/BrowserAppSessionHandoff.swift
@@ -29,18 +29,24 @@ struct BrowserAppSessionHandoff {
         )?.url else {
             return nil
         }
-        var bodyComponents = URLComponents()
-        bodyComponents.queryItems = [
-            URLQueryItem(name: "refresh_token", value: tokens.refreshToken),
-            URLQueryItem(name: "access_token", value: tokens.accessToken),
-            URLQueryItem(name: "after", value: relativePath(destinationURL)),
-        ].filter { $0.value?.isEmpty == false }
+        // Build the form body by hand: URLComponents.percentEncodedQuery leaves
+        // "+" literal, and application/x-www-form-urlencoded decodes "+" to a
+        // space, silently corrupting any token that contains "+". Percent-encode
+        // every value with a set that excludes "+", "&", "=", and "%".
+        let pairs: [(String, String)] = [
+            ("refresh_token", tokens.refreshToken),
+            ("access_token", tokens.accessToken),
+            ("after", relativePath(destinationURL)),
+        ].filter { !$0.1.isEmpty }
+        let body = pairs
+            .map { "\($0.0)=\(formURLEncode($0.1))" }
+            .joined(separator: "&")
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.setValue("no-referrer", forHTTPHeaderField: "Referrer-Policy")
-        request.httpBody = bodyComponents.percentEncodedQuery?.data(using: .utf8)
+        request.httpBody = body.data(using: .utf8)
         return request
     }
 
@@ -89,6 +95,16 @@ struct BrowserAppSessionHandoff {
         case "https": return 443
         default: return nil
         }
+    }
+
+    private static func formURLEncode(_ value: String) -> String {
+        // application/x-www-form-urlencoded value encoding: percent-encode
+        // everything except RFC 3986 unreserved characters, so "+", "&", "=",
+        // "%", and space are all escaped. A "+" left literal would decode back
+        // to a space and silently corrupt a token that contains "+".
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 
     private static func relativePath(_ url: URL) -> String {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5787,15 +5787,35 @@ final class BrowserPanel: Panel, ObservableObject {
             abandonRestoredSessionHistoryIfNeeded()
         }
         if BrowserAppSessionBridge.shared.beginHandoffNavigationIfNeeded(
-            panelID: id, destinationURL: originalURL, request: request,
-            websiteDataStore: webView.configuration.websiteDataStore
-        ) { [weak self] handoffRequest in
-            guard let self else { return }
-            self.navigationDelegate?.recordAttemptedRequest(URLRequest(url: originalURL), displayURL: originalURL)
-            self.refreshBackgroundAppearance()
-            self.shouldRenderWebView = true
-            browserLoadRequest(handoffRequest, in: self.webView)
-        } { return }
+            panelID: id,
+            destinationURL: originalURL,
+            request: request,
+            websiteDataStore: webView.configuration.websiteDataStore,
+            navigate: { [weak self] navigationRequest in
+                // Route the session-priming handoff (or the fallback original
+                // request when no session is available) through the same
+                // bookkeeping and remote-proxy rewrite as a normal navigation.
+                self?.finishNavigation(
+                    request: navigationRequest,
+                    originalURL: originalURL,
+                    recordTypedNavigation: recordTypedNavigation
+                )
+            }
+        ) {
+            return
+        }
+        finishNavigation(
+            request: request,
+            originalURL: originalURL,
+            recordTypedNavigation: recordTypedNavigation
+        )
+    }
+
+    private func finishNavigation(
+        request: URLRequest,
+        originalURL: URL,
+        recordTypedNavigation: Bool
+    ) {
         let effectiveRequest = remoteProxyPreparedRequest(from: request, logScope: "rewrite")
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
         hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5786,36 +5786,17 @@ final class BrowserPanel: Panel, ObservableObject {
         if !preserveRestoredSessionHistory {
             abandonRestoredSessionHistoryIfNeeded()
         }
+        // The handoff (when a session must be primed) and the fallback original
+        // request both go through finishNavigation, so they share bookkeeping.
         if BrowserAppSessionBridge.shared.beginHandoffNavigationIfNeeded(
-            panelID: id,
-            destinationURL: originalURL,
-            request: request,
+            panelID: id, destinationURL: originalURL, request: request,
             websiteDataStore: webView.configuration.websiteDataStore,
-            navigate: { [weak self] navigationRequest in
-                // Route the session-priming handoff (or the fallback original
-                // request when no session is available) through the same
-                // bookkeeping and remote-proxy rewrite as a normal navigation.
-                self?.finishNavigation(
-                    request: navigationRequest,
-                    originalURL: originalURL,
-                    recordTypedNavigation: recordTypedNavigation
-                )
-            }
-        ) {
-            return
-        }
-        finishNavigation(
-            request: request,
-            originalURL: originalURL,
-            recordTypedNavigation: recordTypedNavigation
-        )
+            navigate: { [weak self] in self?.finishNavigation(request: $0, originalURL: originalURL, recordTypedNavigation: recordTypedNavigation) }
+        ) { return }
+        finishNavigation(request: request, originalURL: originalURL, recordTypedNavigation: recordTypedNavigation)
     }
 
-    private func finishNavigation(
-        request: URLRequest,
-        originalURL: URL,
-        recordTypedNavigation: Bool
-    ) {
+    private func finishNavigation(request: URLRequest, originalURL: URL, recordTypedNavigation: Bool) {
         let effectiveRequest = remoteProxyPreparedRequest(from: request, logScope: "rewrite")
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
         hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
@@ -5826,9 +5807,7 @@ final class BrowserPanel: Panel, ObservableObject {
             shouldPreloadInitialNavigationInBackground = false
             ensureBackgroundPreloadHostIfNeeded(reason: "initial-navigation")
         }
-        if recordTypedNavigation {
-            historyStore.recordTypedNavigation(url: originalURL)
-        }
+        if recordTypedNavigation { historyStore.recordTypedNavigation(url: originalURL) }
         browserLoadRequest(effectiveRequest, in: webView)
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2731,18 +2731,12 @@ final class BrowserPanel: Panel, ObservableObject {
     let id: UUID
     let stableSurfaceIdentity = PanelStableSurfaceIdentity()
     let panelType: PanelType = .browser
-
-    /// The workspace ID this panel belongs to
     private(set) var workspaceId: UUID
-
     @Published private(set) var profileID: UUID
     @Published private(set) var historyStore: BrowserHistoryStore
-
-    /// The underlying web view
     private(set) var webView: WKWebView
     private var websiteDataStore: WKWebsiteDataStore
     var webViewDidRequestClose: (() -> Void)?
-
     /// Monotonic identity for the current WKWebView instance.
     /// Incremented whenever we replace the underlying WKWebView after a process crash.
     @Published private(set) var webViewInstanceID: UUID = UUID()
@@ -2754,7 +2748,6 @@ final class BrowserPanel: Panel, ObservableObject {
         }
     }
     private var pendingWebContentRecoveryURL: URL?
-
     /// Prevent the omnibar from auto-focusing for a short window after explicit programmatic focus.
     /// This avoids races where SwiftUI focus state steals first responder back from WebKit.
     private var suppressOmnibarAutofocusUntil: Date?
@@ -2776,14 +2769,12 @@ final class BrowserPanel: Panel, ObservableObject {
         logSink: Self.omnibarPageFocusLogSink
     )
 
-    /// Published URL being displayed
     @Published private(set) var currentURL: URL? {
         didSet {
             guard oldValue != currentURL else { return }
             applyConfiguredWebViewBackground()
         }
     }
-
     /// Whether the browser panel should render its WKWebView in the content area.
     /// New browser tabs stay in an empty "new tab" state until first navigation.
     @Published private(set) var shouldRenderWebView: Bool = false {
@@ -5795,8 +5786,17 @@ final class BrowserPanel: Panel, ObservableObject {
         if !preserveRestoredSessionHistory {
             abandonRestoredSessionHistoryIfNeeded()
         }
+        if BrowserAppSessionBridge.shared.beginHandoffNavigationIfNeeded(
+            panelID: id, destinationURL: originalURL, request: request,
+            websiteDataStore: webView.configuration.websiteDataStore
+        ) { [weak self] handoffRequest in
+            guard let self else { return }
+            self.navigationDelegate?.recordAttemptedRequest(URLRequest(url: originalURL), displayURL: originalURL)
+            self.refreshBackgroundAppearance()
+            self.shouldRenderWebView = true
+            browserLoadRequest(handoffRequest, in: self.webView)
+        } { return }
         let effectiveRequest = remoteProxyPreparedRequest(from: request, logScope: "rewrite")
-        // Some installs can end up with a legacy Chrome UA override; keep this pinned.
         webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
         hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
         navigationDelegate?.recordAttemptedRequest(effectiveRequest, displayURL: originalURL)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -138,6 +138,9 @@
 		D0B10010A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10011A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift */; };
 		D0B10002A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10003A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift */; };
 		AA1B2C3D4E5F60718 /* BonsplitTabDragUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */; };
+		B4550A010000000000000001 /* BrowserAppSessionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4550A010000000000000002 /* BrowserAppSessionBridge.swift */; };
+		B4550A020000000000000001 /* BrowserAppSessionHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4550A020000000000000002 /* BrowserAppSessionHandoff.swift */; };
+		B4550A030000000000000001 /* BrowserAppSessionHandoffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4550A030000000000000002 /* BrowserAppSessionHandoffTests.swift */; };
 		D3622000A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */; };
 		D7032A070000000000000001 /* BrowserAuthPromptTextFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7032A070000000000000002 /* BrowserAuthPromptTextFormatter.swift */; };
 		B3770BA00000000000000001 /* BrowserAutomation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3770BA00000000000000002 /* BrowserAutomation.swift */; };
@@ -1705,6 +1708,9 @@
 		D0B10011A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabBarDebug.swift; sourceTree = "<group>"; };
 		D0B10003A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabBarPassThrough.swift; sourceTree = "<group>"; };
 		AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabDragUITests.swift; sourceTree = "<group>"; };
+		B4550A010000000000000002 /* BrowserAppSessionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserAppSessionBridge.swift; sourceTree = "<group>"; };
+		B4550A020000000000000002 /* BrowserAppSessionHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserAppSessionHandoff.swift; sourceTree = "<group>"; };
+		B4550A030000000000000002 /* BrowserAppSessionHandoffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserAppSessionHandoffTests.swift; sourceTree = "<group>"; };
 		D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserArrowKeyForwardingTests.swift; sourceTree = "<group>"; };
 		D7032A070000000000000002 /* BrowserAuthPromptTextFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserAuthPromptTextFormatter.swift; sourceTree = "<group>"; };
 		B3770BA00000000000000002 /* BrowserAutomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserAutomation.swift; sourceTree = "<group>"; };
@@ -3806,6 +3812,8 @@
 				B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */,
 				B4245004000000000000PW01 /* BrowserPrewarmedWebViewPool.swift */,
 				B424PWAD000000000000PW02 /* BrowserPanel+PrewarmedWebViewAdoption.swift */,
+				B4550A010000000000000002 /* BrowserAppSessionBridge.swift */,
+				B4550A020000000000000002 /* BrowserAppSessionHandoff.swift */,
 				B424PWNP000000000000PW02 /* BrowserNavigationPolicy.swift */,
 				B424PWRS000000000000PW02 /* BrowserPortalWebViewRenderingState.swift */,
 				D7032A070000000000000002 /* BrowserAuthPromptTextFormatter.swift */,
@@ -4249,6 +4257,7 @@
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */,
 				B8E9500A0000000000000002 /* PostHogAnalyticsPropertiesTests.swift */,
 				604100010000000000000002 /* GhosttyDrawableSizeRetryTests.swift */,
+				B4550A030000000000000002 /* BrowserAppSessionHandoffTests.swift */,
 				BCBC0A0E0000000000000D02 /* BrowserChromeMetricsTests.swift */,
 				BCBC0A0E0000000000000E12 /* BrowserMediaActivityAggregationTests.swift */,
 				BCBC0A0E0000000000000E22 /* BrowserMediaPlaybackAudioActivityTests.swift */,
@@ -5139,6 +5148,8 @@
 					A50012F1 /* Backport.swift in Sources */,
 					D0B10010A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift in Sources */,
 				D0B10002A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift in Sources */,
+				B4550A010000000000000001 /* BrowserAppSessionBridge.swift in Sources */,
+				B4550A020000000000000001 /* BrowserAppSessionHandoff.swift in Sources */,
 				D7032A070000000000000001 /* BrowserAuthPromptTextFormatter.swift in Sources */,
 				B3770BA00000000000000001 /* BrowserAutomation.swift in Sources */,
 				BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */,
@@ -6137,6 +6148,7 @@
 				7C592156DCB3419BB95383E5 /* AutoNamingEngineTests.swift in Sources */,
 				A4ECF22C62724853A72D6BDE /* AutoNamingGrokAdapterTests.swift in Sources */,
 				74AB3F34FE3B4974A3A5D264 /* AutoNamingHookPayloadAdapterTests.swift in Sources */,
+				B4550A030000000000000001 /* BrowserAppSessionHandoffTests.swift in Sources */,
 				D3622000A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift in Sources */,
 				BCBC0A0E0000000000000D01 /* BrowserChromeMetricsTests.swift in Sources */,
 				D7032A030000000000000001 /* BrowserClientCertificateCredentialPickerTests.swift in Sources */,

--- a/cmuxTests/BrowserAppSessionHandoffTests.swift
+++ b/cmuxTests/BrowserAppSessionHandoffTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+@Suite
+struct BrowserAppSessionHandoffTests {
+    @Test
+    func buildsHandoffRequestOnlyForMatchingCmuxOrigin() throws {
+        let origin = try #require(URL(string: "https://cmux.test"))
+        let destination = try #require(URL(string: "https://cmux.test/dashboard/billing?tab=plan#current"))
+
+        let handoffRequest = try #require(BrowserAppSessionHandoff.handoffRequest(
+            destinationURL: destination,
+            webOrigin: origin,
+            tokens: BrowserAppSessionTokens(accessToken: "native-access", refreshToken: "native-refresh")
+        ))
+        let handoffURL = try #require(handoffRequest.url)
+        let body = String(data: try #require(handoffRequest.httpBody), encoding: .utf8)
+        let components = URLComponents(string: "https://cmux.invalid?\(body ?? "")")
+        let form = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).compactMap { item in
+            item.value.map { (item.name, $0) }
+        })
+
+        #expect(handoffURL.scheme == "https")
+        #expect(handoffURL.host == "cmux.test")
+        #expect(handoffURL.path == "/handler/app-session-handoff")
+        #expect(handoffRequest.httpMethod == "POST")
+        #expect(handoffURL.query == nil)
+        #expect(form["refresh_token"] == "native-refresh")
+        #expect(form["access_token"] == "native-access")
+        #expect(form["after"] == "/dashboard/billing?tab=plan#current")
+    }
+
+    @Test
+    func rejectsOffOriginAndNestedHandoffDestinations() throws {
+        let origin = try #require(URL(string: "https://cmux.test"))
+        let offOrigin = try #require(URL(string: "https://example.test/dashboard"))
+        let nested = try #require(URL(string: "https://cmux.test/handler/app-session-handoff?after=/dashboard"))
+
+        #expect(BrowserAppSessionHandoff.handoffRequest(
+            destinationURL: offOrigin,
+            webOrigin: origin,
+            tokens: BrowserAppSessionTokens(accessToken: "native-access", refreshToken: "native-refresh")
+        ) == nil)
+        #expect(BrowserAppSessionHandoff.handoffRequest(
+            destinationURL: nested,
+            webOrigin: origin,
+            tokens: BrowserAppSessionTokens(accessToken: "native-access", refreshToken: "native-refresh")
+        ) == nil)
+    }
+
+    @Test
+    func omitsAccessTokenWhenOnlyRefreshTokenIsAvailable() throws {
+        let origin = try #require(URL(string: "http://localhost:3777"))
+        let destination = try #require(URL(string: "http://localhost:3777/dashboard"))
+
+        let handoffRequest = try #require(BrowserAppSessionHandoff.handoffRequest(
+            destinationURL: destination,
+            webOrigin: origin,
+            tokens: BrowserAppSessionTokens(accessToken: nil, refreshToken: "native-refresh")
+        ))
+        let body = String(data: try #require(handoffRequest.httpBody), encoding: .utf8)
+        let components = URLComponents(string: "https://cmux.invalid?\(body ?? "")")
+        let formNames = Set((components?.queryItems ?? []).map(\.name))
+
+        #expect(formNames.contains("refresh_token"))
+        #expect(!formNames.contains("access_token"))
+    }
+
+    @Test
+    func stackCookieDeletionIsScopedToCmuxOrigin() throws {
+        let origin = try #require(URL(string: "https://cmux.test"))
+        let projectId = "project-123"
+
+        #expect(BrowserAppSessionHandoff.shouldDeleteCookie(
+            name: "stack-access",
+            domain: "cmux.test",
+            webOrigin: origin,
+            projectId: projectId
+        ))
+        #expect(BrowserAppSessionHandoff.shouldDeleteCookie(
+            name: "__Host-stack-refresh-project-123--default",
+            domain: ".cmux.test",
+            webOrigin: origin,
+            projectId: projectId
+        ))
+        #expect(!BrowserAppSessionHandoff.shouldDeleteCookie(
+            name: "stack-access",
+            domain: "example.test",
+            webOrigin: origin,
+            projectId: projectId
+        ))
+        #expect(!BrowserAppSessionHandoff.shouldDeleteCookie(
+            name: "unrelated",
+            domain: "cmux.test",
+            webOrigin: origin,
+            projectId: projectId
+        ))
+    }
+}

--- a/web/app/handler/app-session-handoff/route.ts
+++ b/web/app/handler/app-session-handoff/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "../../env";
+import { stackServerApp } from "../../lib/stack";
+
+export const dynamic = "force-dynamic";
+
+const SESSION_EXPIRES_IN_MS = 30 * 24 * 60 * 60 * 1000;
+const STACK_ACCESS_COOKIE = "stack-access";
+const STACK_REFRESH_COOKIE_PREFIX = "stack-refresh";
+
+type StackAuthSessionLike = {
+  getTokens: () => Promise<{
+    refreshToken?: string | null;
+    accessToken?: string | null;
+  }>;
+};
+
+type StackAuthUserLike = {
+  createSession: (options: { expiresInMillis: number }) => Promise<StackAuthSessionLike>;
+};
+
+type StackServerAppLike = {
+  getUser: (options: {
+    tokenStore: {
+      accessToken?: string;
+      refreshToken: string;
+    };
+  }) => Promise<StackAuthUserLike | null>;
+} | null;
+
+type AppSessionHandoffDependencies = {
+  projectId: string | undefined;
+  stackServerApp: StackServerAppLike | null;
+};
+
+type HandoffRateLimitEntry = {
+  count: number;
+  resetAt: number;
+};
+
+const handoffRateLimits = new Map<string, HandoffRateLimitEntry>();
+
+function sanitizedAfterPath(value: string | null): string | null {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) return null;
+  try {
+    const parsed = new URL(value, "https://cmux.invalid");
+    if (parsed.origin !== "https://cmux.invalid") return null;
+    if (parsed.pathname === "/handler/app-session-handoff") return null;
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return null;
+  }
+}
+
+function signInRedirect(request: NextRequest, afterPath: string): NextResponse {
+  const target = new URL("/handler/sign-in", request.nextUrl.origin);
+  target.searchParams.set("after_auth_return_to", afterPath);
+  return NextResponse.redirect(target, 302);
+}
+
+function requestRateLimitKey(request: NextRequest): string {
+  const forwarded = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const address = forwarded || request.headers.get("x-real-ip") || "unknown";
+  return `${address}:${request.headers.get("user-agent") ?? ""}`;
+}
+
+function isRateLimited(request: NextRequest, now = Date.now()): boolean {
+  const key = requestRateLimitKey(request);
+  const resetAt = now + 60_000;
+  const entry = handoffRateLimits.get(key);
+  if (!entry || entry.resetAt <= now) {
+    handoffRateLimits.set(key, { count: 1, resetAt });
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > 60;
+}
+
+function secureCookiesFor(request: NextRequest): boolean {
+  return request.nextUrl.protocol === "https:";
+}
+
+function stackRefreshCookieName(projectId: string): string {
+  return `${STACK_REFRESH_COOKIE_PREFIX}-${projectId}`;
+}
+
+function setCookie(
+  response: NextResponse,
+  name: string,
+  value: string,
+  request: NextRequest
+) {
+  response.cookies.set(name, value, {
+    httpOnly: true,
+    maxAge: SESSION_EXPIRES_IN_MS / 1000,
+    path: "/",
+    sameSite: "lax",
+    secure: name.startsWith("__") || secureCookiesFor(request),
+  });
+}
+
+function setStackSessionCookies(
+  response: NextResponse,
+  request: NextRequest,
+  projectId: string,
+  tokens: { refreshToken: string; accessToken: string }
+) {
+  const accessCookieValue = JSON.stringify([tokens.refreshToken, tokens.accessToken]);
+  const refreshName = stackRefreshCookieName(projectId);
+  const refreshNames = [refreshName, `${refreshName}--default`];
+
+  setCookie(response, STACK_ACCESS_COOKIE, accessCookieValue, request);
+  for (const name of refreshNames) {
+    setCookie(response, name, tokens.refreshToken, request);
+  }
+
+  if (!secureCookiesFor(request)) return;
+  setCookie(response, `__Host-${STACK_ACCESS_COOKIE}`, accessCookieValue, request);
+  for (const name of refreshNames) {
+    setCookie(response, `__Host-${name}`, tokens.refreshToken, request);
+    setCookie(response, `__Secure-${name}`, tokens.refreshToken, request);
+  }
+}
+
+export function makeAppSessionHandoffHandler(dependencies: AppSessionHandoffDependencies) {
+  return async function POST(request: NextRequest) {
+    const projectId = dependencies.projectId;
+    const app = dependencies.stackServerApp;
+    const formData = await request.formData();
+    const afterPath = sanitizedAfterPath(formData.get("after")?.toString() ?? null);
+    if (!afterPath) return NextResponse.redirect(new URL("/", request.url), 302);
+    if (!projectId || !app) return signInRedirect(request, afterPath);
+    if (isRateLimited(request)) return signInRedirect(request, afterPath);
+
+    const refreshToken = formData.get("refresh_token")?.toString().trim();
+    const accessToken = formData.get("access_token")?.toString().trim();
+    if (!refreshToken) return signInRedirect(request, afterPath);
+
+    try {
+      const user = await app.getUser({
+        tokenStore: {
+          ...(accessToken ? { accessToken } : {}),
+          refreshToken,
+        },
+      });
+      if (!user) return signInRedirect(request, afterPath);
+
+      const session = await user.createSession({ expiresInMillis: SESSION_EXPIRES_IN_MS });
+      const tokens = await session.getTokens();
+      if (!tokens.refreshToken || !tokens.accessToken) return signInRedirect(request, afterPath);
+
+      const response = NextResponse.redirect(new URL(afterPath, request.nextUrl.origin), 302);
+      setStackSessionCookies(response, request, projectId, {
+        refreshToken: tokens.refreshToken,
+        accessToken: tokens.accessToken,
+      });
+      response.headers.set("Referrer-Policy", "no-referrer");
+      response.headers.set("Cache-Control", "no-store");
+      return response;
+    } catch {
+      return signInRedirect(request, afterPath);
+    }
+  };
+}
+
+export const POST = makeAppSessionHandoffHandler({
+  projectId: env.NEXT_PUBLIC_STACK_PROJECT_ID,
+  // The handler only calls the narrow getUser({ tokenStore }) subset; the real
+  // StackServerApp getUser has broader overloads that don't structurally match
+  // StackServerAppLike, so cast at this boundary.
+  stackServerApp: stackServerApp as unknown as StackServerAppLike,
+});

--- a/web/app/handler/app-session-handoff/route.ts
+++ b/web/app/handler/app-session-handoff/route.ts
@@ -46,7 +46,13 @@ function sanitizedAfterPath(value: string | null): string | null {
     const parsed = new URL(value, "https://cmux.invalid");
     if (parsed.origin !== "https://cmux.invalid") return null;
     if (parsed.pathname === "/handler/app-session-handoff") return null;
-    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    const result = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    // Dot-segment normalization can turn "/..//evil.com" into pathname
+    // "//evil.com", which is protocol-relative when later resolved and would
+    // 302 off-origin. Reject anything that is not a plain same-origin path.
+    if (result.startsWith("//") || result.startsWith("/\\")) return null;
+    if (new URL(result, "https://cmux.invalid").origin !== "https://cmux.invalid") return null;
+    return result;
   } catch {
     return null;
   }

--- a/web/app/handler/app-session-handoff/route.ts
+++ b/web/app/handler/app-session-handoff/route.ts
@@ -132,7 +132,15 @@ export function makeAppSessionHandoffHandler(dependencies: AppSessionHandoffDepe
   return async function POST(request: NextRequest) {
     const projectId = dependencies.projectId;
     const app = dependencies.stackServerApp;
-    const formData = await request.formData();
+    // A malformed POST (wrong/absent Content-Type) makes formData() throw; the
+    // app always sends application/x-www-form-urlencoded, so treat anything
+    // else as an unauthenticated request rather than a 500.
+    let formData: FormData;
+    try {
+      formData = await request.formData();
+    } catch {
+      return NextResponse.redirect(new URL("/", request.url), 302);
+    }
     const afterPath = sanitizedAfterPath(formData.get("after")?.toString() ?? null);
     if (!afterPath) return NextResponse.redirect(new URL("/", request.url), 302);
     if (!projectId || !app) return signInRedirect(request, afterPath);

--- a/web/tests/app-session-handoff-route.test.ts
+++ b/web/tests/app-session-handoff-route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.NEXT_PUBLIC_STACK_PROJECT_ID = "12345678-1234-4123-8123-123456789abc";
+process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY = "test-publishable-key";
+process.env.STACK_SECRET_SERVER_KEY = "test-secret-key";
+
+const getTokens = mock(async () => ({
+  refreshToken: "fresh-refresh",
+  accessToken: "fresh-access",
+}));
+const createSession = mock(async () => ({ getTokens }));
+const getUser = mock(async () => ({ createSession }));
+
+const { makeAppSessionHandoffHandler } = await import("../app/handler/app-session-handoff/route");
+
+const POST = makeAppSessionHandoffHandler({
+  projectId: "12345678-1234-4123-8123-123456789abc",
+  stackServerApp: { getUser },
+});
+
+function handoffRequest(body: Record<string, string>): NextRequest {
+  return new NextRequest("https://cmux.test/handler/app-session-handoff", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "user-agent": "bun-test",
+      "x-forwarded-for": "203.0.113.10",
+    },
+    body: new URLSearchParams(body),
+  });
+}
+
+describe("app session handoff", () => {
+  beforeEach(() => {
+    getUser.mockClear();
+    createSession.mockClear();
+    getTokens.mockClear();
+    getUser.mockResolvedValue({ createSession });
+    getTokens.mockResolvedValue({
+      refreshToken: "fresh-refresh",
+      accessToken: "fresh-access",
+    });
+  });
+
+  test("validates native tokens, sets Stack cookies, and redirects to the sanitized app path", async () => {
+    const response = await POST(handoffRequest({
+      refresh_token: "native-refresh",
+      access_token: "native-access",
+      after: "/dashboard?tab=billing#plan",
+    }));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://cmux.test/dashboard?tab=billing#plan");
+    expect(response.headers.get("location")).not.toContain("native-refresh");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+
+    expect(getUser).toHaveBeenCalledWith({
+      tokenStore: {
+        accessToken: "native-access",
+        refreshToken: "native-refresh",
+      },
+    });
+    expect(createSession).toHaveBeenCalledWith({ expiresInMillis: 30 * 24 * 60 * 60 * 1000 });
+
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("stack-access=");
+    expect(setCookie).toContain(encodeURIComponent(JSON.stringify(["fresh-refresh", "fresh-access"])));
+    expect(setCookie).toContain("stack-refresh-12345678-1234-4123-8123-123456789abc=fresh-refresh");
+    expect(setCookie).toContain("stack-refresh-12345678-1234-4123-8123-123456789abc--default=fresh-refresh");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=lax");
+    expect(setCookie).not.toContain("native-refresh");
+    expect(setCookie).not.toContain("native-access");
+  });
+
+  test("accepts refresh-only handoff so access-token expiry can be recovered server-side", async () => {
+    const response = await POST(handoffRequest({
+      refresh_token: "native-refresh",
+      after: "/dashboard",
+    }));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://cmux.test/dashboard");
+    expect(getUser).toHaveBeenCalledWith({
+      tokenStore: {
+        refreshToken: "native-refresh",
+      },
+    });
+    expect(response.headers.get("set-cookie")).toContain("stack-access=");
+  });
+
+  test("does not set cookies when Stack rejects the refresh token", async () => {
+    getUser.mockResolvedValue(null);
+
+    const response = await POST(handoffRequest({
+      refresh_token: "bad-refresh",
+      after: "/dashboard",
+    }));
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.pathname).toBe("/handler/sign-in");
+    expect(location.searchParams.get("after_auth_return_to")).toBe("/dashboard");
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+
+  test("rejects off-origin or nested handoff targets before reading tokens", async () => {
+    const offOrigin = await POST(handoffRequest({
+      refresh_token: "native-refresh",
+      after: "https://evil.test/dashboard",
+    }));
+    const nested = await POST(handoffRequest({
+      refresh_token: "native-refresh",
+      after: "/handler/app-session-handoff?after=%2Fdashboard",
+    }));
+
+    expect(offOrigin.status).toBe(302);
+    expect(offOrigin.headers.get("location")).toBe("https://cmux.test/");
+    expect(nested.status).toBe(302);
+    expect(nested.headers.get("location")).toBe("https://cmux.test/");
+    expect(getUser).not.toHaveBeenCalled();
+  });
+});

--- a/web/tests/app-session-handoff-route.test.ts
+++ b/web/tests/app-session-handoff-route.test.ts
@@ -123,4 +123,27 @@ describe("app session handoff", () => {
     expect(nested.headers.get("location")).toBe("https://cmux.test/");
     expect(getUser).not.toHaveBeenCalled();
   });
+
+  test("never redirects off-origin for dot-segment / protocol-relative vectors", async () => {
+    // "/..//evil.com" normalizes to pathname "//evil.com", which is
+    // protocol-relative and would 302 to https://evil.com/ if returned as-is.
+    // Sanitization must reject it so the redirect stays on the app origin.
+    for (const after of [
+      "/..//evil.com",
+      "/a/..//evil.com",
+      "/%2f%2fevil.com",
+      "/\\evil.com",
+      "/\\\\evil.com",
+    ]) {
+      const response = await POST(handoffRequest({
+        refresh_token: "native-refresh",
+        after,
+      }));
+      expect(response.status).toBe(302);
+      // The only security-critical property: the redirect never leaves the
+      // app origin (a same-origin literal path like /%2f%2fevil.com is fine).
+      expect(new URL(response.headers.get("location")!).origin).toBe("https://cmux.test");
+    }
+    expect(getUser).not.toHaveBeenCalled();
+  });
 });

--- a/web/tests/app-session-handoff-route.test.ts
+++ b/web/tests/app-session-handoff-route.test.ts
@@ -141,9 +141,11 @@ describe("app session handoff", () => {
       }));
       expect(response.status).toBe(302);
       // The only security-critical property: the redirect never leaves the
-      // app origin (a same-origin literal path like /%2f%2fevil.com is fine).
+      // app origin. Some of these (e.g. "/%2f%2fevil.com") are literal
+      // same-origin paths that the handler legitimately accepts, so we assert
+      // the origin invariant per vector rather than that auth was skipped
+      // (whether getUser runs depends on platform URL parsing of "%2f").
       expect(new URL(response.headers.get("location")!).origin).toBe("https://cmux.test");
     }
-    expect(getUser).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

The desktop app signs in via the system browser and stores Stack tokens natively (keychain, used as Bearer for /api/*). The in-app WKWebView has its own cookie store and does not carry the Stack session, so cmux web pages opened in-app (dashboard, pricing, the Pro welcome page) are unauthenticated server-side (getUser() returns null).

This adds a server-side session handoff so the in-app browser authenticates for the cmux web origin: opening cmux.com/dashboard in-app is signed in, no second login.

## How

- **Web** `/handler/app-session-handoff` (POST): the app posts its native refresh token; the route validates it via Stack, sets the Stack session cookies (same names/flags as the native-sign-in handler: httpOnly, sameSite=lax, conditional secure, plus __Host-/__Secure- variants), and 302-redirects to a sanitized same-origin `after` path. Invalid/expired token redirects to sign-in without setting cookies.
- **Swift** `BrowserAppSessionBridge` + `BrowserAppSessionHandoff`: on an app-initiated load to the cmux origin, run the handoff (POST token, then follow the redirect) so the webview lands authenticated; clear the cmux web session from the webview data store on sign-out.

## Security

- Origin scoped by **exact** scheme+host+port match (not suffix), so the token never goes to another site.
- Refresh token travels only in the POST body, never a URL/query; `Referrer-Policy: no-referrer` on the handoff request; no token logging anywhere.
- `after` sanitized to same-origin relative paths only (rejects absolute, protocol-relative `//`, and re-entrancy to the handoff itself), so no open redirect.
- Sign-out clears the injected cookies (exact-host match). Additive: native auth, system-browser sign-in, and /api/* Bearer flows are unchanged.

## Verified

- Live against the dev stack: POST a fresh refresh token to the handoff → 302 to the after-path → stack-access + stack-refresh cookies set → /api/billing/plan returns `authenticated: true`. (The core "webview now authenticates getUser()" proof.)
- typecheck clean; full sorted web suite 564 tests pass; new handoff route test (valid→cookies+redirect, invalid→no cookies, off-origin after rejected) and Swift origin-scoping test.
- Tagged macOS build compiles clean.

## Follow-up

Once this lands, the Pro welcome page (#7608) can restore a real web `getUser()` + Pro gate, since the webview will be authenticated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786133602&installation_id=133855650&pr_number=7647&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7647&signature=a15da31d61492cd3e9eb63d3b132b0c7a7a151f198c2a7bc0d1ce5b373211e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication end-to-end: native refresh tokens are posted into the webview, session cookies are minted server-side, and sign-out must clear web state—bugs could leak sessions, mis-redirect, or leave stale cookies.
> 
> **Overview**
> **Adds SSO between the desktop Stack session and in-app WKWebView** so cmux web pages (dashboard, pricing, etc.) load authenticated without a second login.
> 
> The **web** side adds `POST /handler/app-session-handoff`: validates native refresh (and optional access) tokens via Stack, sets Stack session cookies, and redirects to a sanitized same-origin `after` path—with rate limiting, `no-referrer`, and strict redirect sanitization (no open redirects).
> 
> The **macOS app** intercepts app-initiated navigations to `AuthEnvironment.appWebOrigin` via `BrowserAppSessionBridge` / `BrowserAppSessionHandoff`, POSTing tokens once per `WKWebsiteDataStore` per sign-in before continuing to the intended URL. **`HostBrowserSignInFlow`** gains an `onSignedOut` hook wired from `MacAuthComposition` to **`clearCmuxWebSession`** (Stack cookies + site data across profile stores). **`AuthEnvironment`** exposes **`appWebOrigin`** for shared origin resolution.
> 
> Tests cover handoff request building, cookie scoping, route behavior, and redirect hardening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9c7d7b59bea6bb1dc44c6c9b101bed711d731ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share the desktop Stack session with the in‑app browser so cmux pages (dashboard, pricing, welcome) open signed in without a second login. Adds a server handoff and a Swift bridge with lazy one‑time priming, stricter redirect checks, safe form encoding, sign‑out cleanup, and graceful handling of malformed POSTs.

- **New Features**
  - Web: POST `/handler/app-session-handoff` validates refresh (and optional access) tokens, sets `stack-access` and project‑scoped `stack-refresh*` cookies, and 302s to a sanitized same‑origin `after`; rejects absolute/nested/protocol‑relative and dot‑segment–normalized paths; rate‑limited; `Referrer-Policy: no-referrer`; `Cache-Control: no-store`; hand‑encodes the form so `+` is preserved and omits `access_token` when absent; malformed POSTs redirect to `/` instead of 500.
  - App: `BrowserAppSessionBridge`/`BrowserAppSessionHandoff` run the handoff only once per `WKWebsiteDataStore` per sign‑in (generation + in‑flight guards); if no session, load the original request; clear cmux web cookies and site data across all stores on sign‑out via `HostBrowserSignInFlow.onSignedOut`; `BrowserPanel` funnels handoff and fallback through a shared finish path.
  - Config/Tests: Expose `AuthEnvironment.appWebOrigin` and route pricing via it; add Bun route tests (happy path, refresh‑only, cookie setting, token omission, open‑redirect vectors incl. dot‑segment/protocol‑relative, rate limit) and Swift tests for origin matching, form encoding, and cookie scoping; fix a flaky off‑origin test to assert the same‑origin redirect invariant.

<sup>Written for commit e9c7d7b59bea6bb1dc44c6c9b101bed711d731ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an app-session handoff flow that securely transfers sign-in state from browser navigation to the web app and continues to the intended destination, including a new server endpoint and handoff request/cookie handling.
* **Bug Fixes**
  * Improved sign-out handling to reliably clear browser web sessions and related tokens on sign-out and account switches.
  * Strengthened handoff redirect/origin validation and scoping of cookies to the correct site.
  * Refined pricing URL web-origin resolution for more consistent URL generation.
* **Tests**
  * Added automated tests covering handoff request creation, redirect sanitization, cookie/session behavior, and sign-out cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->