### PR TITLE
cmux TUI distribution: npx cmux / uvx cmux via prebuilt binaries

### DIFF
--- a/.github/workflows/mux-tui-release.yml
+++ b/.github/workflows/mux-tui-release.yml
@@ -20,6 +20,9 @@ jobs:
     name: build ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    # Windows is experimental (bindgen clang include-path issue with the nested
+    # ghostty vt headers); its failure must not block the unix release.
+    continue-on-error: ${{ matrix.experimental || false }}
     permissions:
       contents: read
     strategy:
@@ -45,6 +48,7 @@ jobs:
           - target: x86_64-pc-windows-gnu
             runner: windows-latest
             cross: true
+            experimental: true
             ext: ".exe"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/mux-tui-release.yml
+++ b/.github/workflows/mux-tui-release.yml
@@ -21,143 +21,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: build ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    # Windows is experimental (bindgen clang include-path issue with the nested
-    # ghostty vt headers); its failure must not block the unix release.
-    continue-on-error: ${{ matrix.experimental || false }}
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-            cross: false
-            ext: ""
-          - target: x86_64-apple-darwin
-            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-            cross: true
-            ext: ""
-          - target: x86_64-unknown-linux-gnu
-            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-            cross: false
-            ext: ""
-          - target: aarch64-unknown-linux-gnu
-            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-            cross: true
-            ext: ""
-          - target: x86_64-pc-windows-gnu
-            runner: windows-latest
-            cross: true
-            experimental: true
-            ext: ".exe"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Init ghostty submodule
-        run: git submodule update --init --depth 1 ghostty
-
-      - name: Install Linux build dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang libclang-dev pkg-config
-
-      - name: Install zig
-        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
-        with:
-          version: 0.15.2
-
-      - name: Install Rust target
-        shell: bash
-        run: |
-          rustup target add ${{ matrix.target }}
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            printf '%s\n' 'C:\msys64\mingw64\bin' >> "$GITHUB_PATH"
-          fi
-
-      - name: Install cargo-zigbuild
-        if: matrix.cross == true && runner.os != 'Windows'
-        shell: bash
-        run: cargo install --locked cargo-zigbuild@0.20.0
-
-      - name: Build cmux-mux (native)
-        if: matrix.cross == false
-        working-directory: mux
-        shell: bash
-        run: cargo build -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
-
-      - name: Build cmux-mux (cross, non-Windows)
-        if: matrix.cross == true && runner.os != 'Windows'
-        working-directory: mux
-        shell: bash
-        run: cargo zigbuild -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
-
-      - name: Build libghostty-vt + cmux-mux (Windows GNU)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          cd ghostty
-          zig build -Demit-lib-vt=true -Demit-xcframework=false -Doptimize=ReleaseFast -Dtarget=x86_64-windows-gnu --prefix "$RUNNER_TEMP/ghostty-vt-win-gnu"
-          cd ../mux
-          cargo build -p mux-tui --bin cmux-mux --release --locked --target x86_64-pc-windows-gnu
-
-      - name: Stage binary
-        shell: bash
-        run: |
-          mkdir -p dist
-          cp "mux/target/${{ matrix.target }}/release/cmux-mux${{ matrix.ext }}" "dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}"
-          ls -la dist
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: cmux-mux-${{ matrix.target }}
-          path: dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}
-          if-no-files-found: error
-
-  package:
-    name: package npm and PyPI distributions
-    needs: build
+  version:
+    name: derive package version
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Download darwin arm64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-aarch64-apple-darwin
-          path: dist/binaries
-
-      - name: Download darwin x64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-x86_64-apple-darwin
-          path: dist/binaries
-
-      - name: Download linux x64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-x86_64-unknown-linux-gnu
-          path: dist/binaries
-
-      - name: Download linux arm64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-aarch64-unknown-linux-gnu
-          path: dist/binaries
-
       - name: Derive package version
         id: version
         env:
@@ -179,88 +50,13 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Build package directories and wheels
-        run: |
-          set -euo pipefail
-          python3 mux/dist/scripts/package_npm.py \
-            --binaries-dir dist/binaries \
-            --version "${{ steps.version.outputs.version }}" \
-            --out dist/npm-packages
-          python3 mux/dist/scripts/package_pypi.py \
-            --binaries-dir dist/binaries \
-            --version "${{ steps.version.outputs.version }}" \
-            --out dist/pypi-wheels
-
-      - name: Smoke verify distributions
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import pathlib
-          import stat
-          import sys
-          import zipfile
-
-          version = "${{ steps.version.outputs.version }}"
-          root = pathlib.Path("dist/npm-packages")
-          platforms = {
-              "cmux-tui-darwin-arm64": ("darwin", "arm64"),
-              "cmux-tui-darwin-x64": ("darwin", "x64"),
-              "cmux-tui-linux-x64": ("linux", "x64"),
-              "cmux-tui-linux-arm64": ("linux", "arm64"),
-          }
-          launcher = json.loads((root / "cmux" / "package.json").read_text())
-          deps = launcher.get("optionalDependencies", {})
-          if deps != {name: version for name in platforms}:
-              print(f"optionalDependencies mismatch: {deps}", file=sys.stderr)
-              raise SystemExit(1)
-          for name, (os_name, cpu) in platforms.items():
-              package_json = json.loads((root / name / "package.json").read_text())
-              if package_json["version"] != version:
-                  raise SystemExit(f"{name}: version mismatch")
-              if package_json["os"] != [os_name] or package_json["cpu"] != [cpu]:
-                  raise SystemExit(f"{name}: os/cpu mismatch")
-              binary = root / name / "bin" / "cmux-mux"
-              mode = binary.stat().st_mode
-              if not mode & stat.S_IXUSR:
-                  raise SystemExit(f"{binary} is not executable")
-          for wheel_path in sorted(pathlib.Path("dist/pypi-wheels").glob("*.whl")):
-              with zipfile.ZipFile(wheel_path) as wheel:
-                  names = set(wheel.namelist())
-                  required = {
-                      "cmux_tui/__init__.py",
-                      "cmux_tui/_main.py",
-                      "cmux_tui/bin/cmux-mux",
-                      f"cmux-{version}.dist-info/WHEEL",
-                      f"cmux-{version}.dist-info/METADATA",
-                      f"cmux-{version}.dist-info/entry_points.txt",
-                      f"cmux-{version}.dist-info/RECORD",
-                  }
-                  missing = required - names
-                  if missing:
-                      raise SystemExit(f"{wheel_path}: missing {sorted(missing)}")
-          PY
-          chmod +x dist/binaries/cmux-mux-x86_64-unknown-linux-gnu
-          dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --version >/tmp/cmux-mux-version.txt 2>&1 || \
-            dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --help >/tmp/cmux-mux-version.txt 2>&1
-          for wheel in dist/pypi-wheels/*.whl; do
-            python3 -m zipfile -l "$wheel" >>/tmp/cmux-wheel-list.txt
-          done
-          python3 -m venv /tmp/cmux-tui-wheel-smoke
-          /tmp/cmux-tui-wheel-smoke/bin/python -m pip install --no-index --find-links dist/pypi-wheels cmux=="${{ steps.version.outputs.version }}"
-          /tmp/cmux-tui-wheel-smoke/bin/cmux --help >/tmp/cmux-help.txt
-          grep -i usage /tmp/cmux-help.txt
-
-      - name: Upload npm package directories
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: npm-packages
-          path: dist/npm-packages
-          if-no-files-found: error
-
-      - name: Upload PyPI wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: pypi-wheels
-          path: dist/pypi-wheels/*.whl
-          if-no-files-found: error
+  build-package:
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/tui-build-package.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      package_npm: true
+      package_pypi: true
+      include_windows: true

--- a/.github/workflows/mux-tui-release.yml
+++ b/.github/workflows/mux-tui-release.yml
@@ -1,0 +1,114 @@
+name: mux tui release binaries
+
+# Builds the cmux-mux TUI binary for every distribution target (npm/PyPI `cmux`).
+# Dispatch-only until wired to a tag; uploads one artifact per target so the
+# npm/PyPI wrapper-packaging jobs can bundle them.
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "cmux-tui-v*"
+
+permissions: {}
+
+concurrency:
+  group: mux-tui-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+            cross: false
+            ext: ""
+          - target: x86_64-apple-darwin
+            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+            cross: true
+            ext: ""
+          - target: x86_64-unknown-linux-gnu
+            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+            cross: false
+            ext: ""
+          - target: aarch64-unknown-linux-gnu
+            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+            cross: true
+            ext: ""
+          - target: x86_64-pc-windows-gnu
+            runner: windows-latest
+            cross: true
+            ext: ".exe"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev pkg-config
+
+      - name: Install zig
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: 0.15.2
+
+      - name: Install Rust target
+        shell: bash
+        run: |
+          rustup target add ${{ matrix.target }}
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "C:\\msys64\\mingw64\\bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Install cargo-zigbuild
+        if: matrix.cross == true && runner.os != 'Windows'
+        shell: bash
+        run: cargo install --locked cargo-zigbuild@0.20.0
+
+      - name: Build cmux-mux (native)
+        if: matrix.cross == false
+        working-directory: mux
+        shell: bash
+        run: cargo build -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
+
+      - name: Build cmux-mux (cross, non-Windows)
+        if: matrix.cross == true && runner.os != 'Windows'
+        working-directory: mux
+        shell: bash
+        run: cargo zigbuild -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
+
+      - name: Build libghostty-vt + cmux-mux (Windows GNU)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cd ghostty
+          zig build -Demit-lib-vt=true -Demit-xcframework=false -Doptimize=ReleaseFast -Dtarget=x86_64-windows-gnu --prefix "$RUNNER_TEMP/ghostty-vt-win-gnu"
+          cd ../mux
+          cargo build -p mux-tui --bin cmux-mux --release --locked --target x86_64-pc-windows-gnu
+
+      - name: Stage binary
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "mux/target/${{ matrix.target }}/release/cmux-mux${{ matrix.ext }}" "dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}"
+          ls -la dist
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cmux-mux-${{ matrix.target }}
+          path: dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}
+          if-no-files-found: error

--- a/.github/workflows/tui-build-package.yml
+++ b/.github/workflows/tui-build-package.yml
@@ -1,0 +1,318 @@
+name: tui build package
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "npm package version, or the shared stable X.Y.Z version"
+        required: true
+        type: string
+      pypi_version:
+        description: "PyPI package version; defaults to version"
+        required: false
+        default: ""
+        type: string
+      package_npm:
+        description: "Build and upload npm package directory artifacts"
+        required: false
+        default: true
+        type: boolean
+      package_pypi:
+        description: "Build and upload PyPI wheel artifacts"
+        required: false
+        default: true
+        type: boolean
+      include_windows:
+        description: "Also build and upload the experimental Windows artifact"
+        required: false
+        default: false
+        type: boolean
+      checkout_ref:
+        description: "Optional git ref to build instead of the caller ref"
+        required: false
+        default: ""
+        type: string
+
+permissions: {}
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+            cross: false
+            ext: ""
+          - target: x86_64-apple-darwin
+            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+            cross: true
+            ext: ""
+          - target: x86_64-unknown-linux-gnu
+            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+            cross: false
+            ext: ""
+          - target: aarch64-unknown-linux-gnu
+            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+            cross: true
+            ext: ""
+    steps:
+      - name: Checkout caller ref
+        if: inputs.checkout_ref == ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout requested ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev pkg-config
+
+      - name: Install zig
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: 0.15.2
+
+      - name: Install Rust target
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install cargo-zigbuild
+        if: matrix.cross == true
+        shell: bash
+        run: cargo install --locked cargo-zigbuild@0.20.0
+
+      - name: Build cmux-mux (native)
+        if: matrix.cross == false
+        working-directory: mux
+        shell: bash
+        run: cargo build -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
+
+      - name: Build cmux-mux (cross)
+        if: matrix.cross == true
+        working-directory: mux
+        shell: bash
+        run: cargo zigbuild -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
+
+      - name: Stage binary
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "mux/target/${{ matrix.target }}/release/cmux-mux${{ matrix.ext }}" "dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}"
+          ls -la dist
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cmux-mux-${{ matrix.target }}
+          path: dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}
+          if-no-files-found: error
+
+  build-windows:
+    name: build x86_64-pc-windows-gnu
+    if: inputs.include_windows
+    runs-on: ${{ vars.WINDOWS_RUNNER || 'windows-latest' }}
+    timeout-minutes: 60
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout caller ref
+        if: inputs.checkout_ref == ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout requested ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install zig
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: 0.15.2
+
+      - name: Install Rust target
+        shell: bash
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+          printf '%s\n' 'C:\msys64\mingw64\bin' >> "$GITHUB_PATH"
+
+      - name: Build libghostty-vt + cmux-mux (Windows GNU)
+        shell: bash
+        run: |
+          cd ghostty
+          zig build -Demit-lib-vt=true -Demit-xcframework=false -Doptimize=ReleaseFast -Dtarget=x86_64-windows-gnu --prefix "$RUNNER_TEMP/ghostty-vt-win-gnu"
+          cd ../mux
+          cargo build -p mux-tui --bin cmux-mux --release --locked --target x86_64-pc-windows-gnu
+
+      - name: Stage binary
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "mux/target/x86_64-pc-windows-gnu/release/cmux-mux.exe" "dist/cmux-mux-x86_64-pc-windows-gnu.exe"
+          ls -la dist
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cmux-mux-x86_64-pc-windows-gnu
+          path: dist/cmux-mux-x86_64-pc-windows-gnu.exe
+          if-no-files-found: error
+
+  package:
+    name: package distributions
+    needs: build
+    if: inputs.package_npm || inputs.package_pypi
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      NPM_VERSION: ${{ inputs.version }}
+      PYPI_VERSION: ${{ inputs.pypi_version != '' && inputs.pypi_version || inputs.version }}
+    steps:
+      - name: Checkout caller ref
+        if: inputs.checkout_ref == ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout requested ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Download darwin arm64 binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: cmux-mux-aarch64-apple-darwin
+          path: dist/binaries
+
+      - name: Download darwin x64 binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: cmux-mux-x86_64-apple-darwin
+          path: dist/binaries
+
+      - name: Download linux x64 binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: cmux-mux-x86_64-unknown-linux-gnu
+          path: dist/binaries
+
+      - name: Download linux arm64 binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: cmux-mux-aarch64-unknown-linux-gnu
+          path: dist/binaries
+
+      - name: Build npm package directories
+        if: inputs.package_npm
+        run: |
+          python3 mux/dist/scripts/package_npm.py \
+            --binaries-dir dist/binaries \
+            --version "$NPM_VERSION" \
+            --out dist/npm-packages
+
+      - name: Build PyPI wheels
+        if: inputs.package_pypi
+        run: |
+          python3 mux/dist/scripts/package_pypi.py \
+            --binaries-dir dist/binaries \
+            --version "$PYPI_VERSION" \
+            --out dist/pypi-wheels
+
+      - name: Smoke verify npm packages
+        if: inputs.package_npm
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import stat
+          import sys
+
+          version = os.environ["NPM_VERSION"]
+          root = pathlib.Path("dist/npm-packages")
+          platforms = {
+              "cmux-tui-darwin-arm64": ("darwin", "arm64"),
+              "cmux-tui-darwin-x64": ("darwin", "x64"),
+              "cmux-tui-linux-x64": ("linux", "x64"),
+              "cmux-tui-linux-arm64": ("linux", "arm64"),
+          }
+          launcher = json.loads((root / "cmux" / "package.json").read_text())
+          deps = launcher.get("optionalDependencies", {})
+          if deps != {name: version for name in platforms}:
+              print(f"optionalDependencies mismatch: {deps}", file=sys.stderr)
+              raise SystemExit(1)
+          for name, (os_name, cpu) in platforms.items():
+              package_json = json.loads((root / name / "package.json").read_text())
+              if package_json["version"] != version:
+                  raise SystemExit(f"{name}: version mismatch")
+              if package_json["os"] != [os_name] or package_json["cpu"] != [cpu]:
+                  raise SystemExit(f"{name}: os/cpu mismatch")
+              binary = root / name / "bin" / "cmux-mux"
+              if not binary.stat().st_mode & stat.S_IXUSR:
+                  raise SystemExit(f"{binary} is not executable")
+          PY
+          chmod +x dist/binaries/cmux-mux-x86_64-unknown-linux-gnu
+          dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --version >/tmp/cmux-mux-version.txt 2>&1 || \
+            dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --help >/tmp/cmux-mux-version.txt 2>&1
+
+      - name: Smoke verify PyPI wheels
+        if: inputs.package_pypi
+        run: |
+          set -euo pipefail
+          for wheel in dist/pypi-wheels/*.whl; do
+            python3 -m zipfile -l "$wheel" >"/tmp/$(basename "$wheel").list"
+          done
+          chmod +x dist/binaries/cmux-mux-x86_64-unknown-linux-gnu
+          dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --version >/tmp/cmux-mux-version.txt 2>&1 || \
+            dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --help >/tmp/cmux-mux-version.txt 2>&1
+          python3 -m venv /tmp/cmux-tui-wheel-smoke
+          /tmp/cmux-tui-wheel-smoke/bin/python -m pip install --no-index --find-links dist/pypi-wheels cmux=="$PYPI_VERSION"
+          /tmp/cmux-tui-wheel-smoke/bin/cmux --help >/tmp/cmux-help.txt
+          grep -i usage /tmp/cmux-help.txt
+
+      - name: Upload npm package directories
+        if: inputs.package_npm
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: npm-packages
+          path: dist/npm-packages
+          if-no-files-found: error
+
+      - name: Upload PyPI wheels
+        if: inputs.package_pypi
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pypi-wheels
+          path: dist/pypi-wheels/*.whl
+          if-no-files-found: error

--- a/.github/workflows/tui-nightly.yml
+++ b/.github/workflows/tui-nightly.yml
@@ -1,0 +1,146 @@
+name: tui nightly
+
+on:
+  schedule:
+    - cron: "23 9 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: tui-nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    name: derive nightly versions
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      contents: read
+    outputs:
+      npm_version: ${{ steps.version.outputs.npm_version }}
+      pypi_version: ${{ steps.version.outputs.pypi_version }}
+      head_sha: ${{ steps.version.outputs.head_sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: main
+          fetch-depth: 0
+
+      - name: Derive nightly versions
+        id: version
+        run: |
+          set -euo pipefail
+          git fetch --force --tags
+          latest_tag="$(
+            git tag --merged HEAD --list 'cmux-tui-v*' --sort=-v:refname |
+              grep -E '^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$' |
+              head -n 1 || true
+          )"
+          if [[ -z "$latest_tag" ]]; then
+            next_stable="0.9.0"
+          else
+            latest="${latest_tag#cmux-tui-v}"
+            IFS=. read -r major minor patch <<<"$latest"
+            next_stable="$major.$minor.$((patch + 1))"
+          fi
+          stamp="$(date -u +%Y%m%d)"
+          npm_version="$next_stable-nightly.$stamp.$GITHUB_RUN_NUMBER"
+          pypi_version="$next_stable.dev${stamp}${GITHUB_RUN_NUMBER}"
+          head_sha="$(git rev-parse HEAD)"
+          {
+            echo "npm_version=$npm_version"
+            echo "pypi_version=$pypi_version"
+            echo "head_sha=$head_sha"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "### TUI nightly"
+            echo
+            echo "- HEAD: $head_sha"
+            echo "- npm: $npm_version"
+            echo "- PyPI: $pypi_version"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  build-package:
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/tui-build-package.yml
+    with:
+      version: ${{ needs.version.outputs.npm_version }}
+      pypi_version: ${{ needs.version.outputs.pypi_version }}
+      package_npm: true
+      package_pypi: true
+      include_windows: true
+      # Pin the exact sha the version job resolved so every matrix leg builds
+      # the same commit even if main advances mid-run.
+      checkout_ref: ${{ needs.version.outputs.head_sha }}
+
+  publish-npm:
+    needs:
+      - version
+      - build-package
+    runs-on: ubuntu-latest # github-hosted-required: npm provenance needs a github-hosted runner
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: npm-tui
+      url: https://www.npmjs.com/package/cmux
+    steps:
+      - name: Download npm package directories
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: npm-packages
+          path: dist/npm-packages
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22.14.0"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install npm with OIDC support
+        run: npm install -g npm@^11.5.1
+
+      - name: Publish platform packages with nightly dist-tag
+        run: |
+          set -euo pipefail
+          packages=(
+            cmux-tui-darwin-arm64
+            cmux-tui-darwin-x64
+            cmux-tui-linux-x64
+            cmux-tui-linux-arm64
+          )
+          for package in "${packages[@]}"; do
+            echo "Publishing $package"
+            npm publish --provenance --tag nightly "dist/npm-packages/$package"
+          done
+
+      - name: Publish launcher package with nightly dist-tag
+        run: npm publish --provenance --tag nightly dist/npm-packages/cmux
+
+  publish-pypi:
+    needs:
+      - version
+      - build-package
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi-tui
+      url: https://pypi.org/p/cmux
+    steps:
+      - name: Download PyPI wheels
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: pypi-wheels
+          path: dist
+
+      - name: Publish nightly package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist
+          attestations: true

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -20,184 +20,38 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: build ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-            cross: false
-            ext: ""
-          - target: x86_64-apple-darwin
-            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-            cross: true
-            ext: ""
-          - target: x86_64-unknown-linux-gnu
-            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-            cross: false
-            ext: ""
-          - target: aarch64-unknown-linux-gnu
-            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-            cross: true
-            ext: ""
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Init ghostty submodule
-        run: git submodule update --init --depth 1 ghostty
-
-      - name: Install Linux build dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang libclang-dev pkg-config
-
-      - name: Install zig
-        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
-        with:
-          version: 0.15.2
-
-      - name: Install Rust target
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Install cargo-zigbuild
-        if: matrix.cross == true
-        run: cargo install --locked cargo-zigbuild@0.20.0
-
-      - name: Build cmux-mux (native)
-        if: matrix.cross == false
-        working-directory: mux
-        run: cargo build -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
-
-      - name: Build cmux-mux (cross)
-        if: matrix.cross == true
-        working-directory: mux
-        run: cargo zigbuild -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
-
-      - name: Stage binary
-        run: |
-          mkdir -p dist
-          cp "mux/target/${{ matrix.target }}/release/cmux-mux${{ matrix.ext }}" "dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}"
-          ls -la dist
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: cmux-mux-${{ matrix.target }}
-          path: dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}
-          if-no-files-found: error
-
-  package:
-    name: package npm distributions
-    needs: build
+  validate-version:
+    # This workflow's launcher publish deliberately omits --tag so the version
+    # becomes npm `latest`. Only strict stable X.Y.Z may go through here; a
+    # nightly-form version on latest would put a nightly in front of every
+    # `npx cmux` user (nightlies publish via tui-nightly.yml with --tag nightly).
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 30
-    permissions:
-      contents: read
+    timeout-minutes: 5
+    permissions: {}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Download darwin arm64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-aarch64-apple-darwin
-          path: dist/binaries
-
-      - name: Download darwin x64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-x86_64-apple-darwin
-          path: dist/binaries
-
-      - name: Download linux x64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-x86_64-unknown-linux-gnu
-          path: dist/binaries
-
-      - name: Download linux arm64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-aarch64-unknown-linux-gnu
-          path: dist/binaries
-
-      - name: Validate version
+      - name: Require strict stable version
         env:
           DISPATCH_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           [[ "$DISPATCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-            echo "workflow_dispatch version must match X.Y.Z" >&2
+            echo "workflow_dispatch version must match stable X.Y.Z (no prerelease); nightlies go through tui-nightly.yml" >&2
             exit 1
           }
 
-      - name: Build npm package directories
-        env:
-          DISPATCH_VERSION: ${{ inputs.version }}
-        run: |
-          python3 mux/dist/scripts/package_npm.py \
-            --binaries-dir dist/binaries \
-            --version "$DISPATCH_VERSION" \
-            --out dist/npm-packages
-
-      - name: Smoke verify npm packages
-        env:
-          DISPATCH_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import os
-          import pathlib
-          import stat
-          import sys
-
-          version = os.environ["DISPATCH_VERSION"]
-          root = pathlib.Path("dist/npm-packages")
-          platforms = {
-              "cmux-tui-darwin-arm64": ("darwin", "arm64"),
-              "cmux-tui-darwin-x64": ("darwin", "x64"),
-              "cmux-tui-linux-x64": ("linux", "x64"),
-              "cmux-tui-linux-arm64": ("linux", "arm64"),
-          }
-          launcher = json.loads((root / "cmux" / "package.json").read_text())
-          deps = launcher.get("optionalDependencies", {})
-          if deps != {name: version for name in platforms}:
-              print(f"optionalDependencies mismatch: {deps}", file=sys.stderr)
-              raise SystemExit(1)
-          for name, (os_name, cpu) in platforms.items():
-              package_json = json.loads((root / name / "package.json").read_text())
-              if package_json["version"] != version:
-                  raise SystemExit(f"{name}: version mismatch")
-              if package_json["os"] != [os_name] or package_json["cpu"] != [cpu]:
-                  raise SystemExit(f"{name}: os/cpu mismatch")
-              binary = root / name / "bin" / "cmux-mux"
-              if not binary.stat().st_mode & stat.S_IXUSR:
-                  raise SystemExit(f"{binary} is not executable")
-          PY
-          chmod +x dist/binaries/cmux-mux-x86_64-unknown-linux-gnu
-          dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --version >/tmp/cmux-mux-version.txt 2>&1 || \
-            dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --help >/tmp/cmux-mux-version.txt 2>&1
-
-      - name: Upload npm package directories
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: npm-packages
-          path: dist/npm-packages
-          if-no-files-found: error
+  build-package:
+    needs: validate-version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/tui-build-package.yml
+    with:
+      version: ${{ inputs.version }}
+      package_npm: true
+      package_pypi: false
+      include_windows: false
 
   publish:
-    needs: package
+    needs: build-package
     runs-on: ubuntu-latest # github-hosted-required: npm provenance needs a github-hosted runner
     permissions:
       contents: read

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -1,33 +1,29 @@
-name: mux tui release binaries
+name: tui publish npm
 
-# Builds the cmux-mux TUI binary for every distribution target (npm/PyPI `cmux`).
-# Manual dispatch or cmux-tui tag builds upload one artifact per target so the
-# npm/PyPI wrapper-packaging jobs can bundle them.
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "TUI package version to build, for example 0.1.0"
+        description: "TUI package version to publish, for example 0.1.0"
         required: true
         type: string
-  push:
-    tags:
-      - "cmux-tui-v*"
+      confirm_tui_cmux:
+        description: "Set true only for the coordinated npm cmux TUI publish"
+        required: true
+        default: false
+        type: boolean
 
 permissions: {}
 
 concurrency:
-  group: mux-tui-release-${{ github.ref }}
-  cancel-in-progress: true
+  group: tui-publish-npm-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
     name: build ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
-    # Windows is experimental (bindgen clang include-path issue with the nested
-    # ghostty vt headers); its failure must not block the unix release.
-    continue-on-error: ${{ matrix.experimental || false }}
     permissions:
       contents: read
     strategy:
@@ -50,11 +46,6 @@ jobs:
             runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
             cross: true
             ext: ""
-          - target: x86_64-pc-windows-gnu
-            runner: windows-latest
-            cross: true
-            experimental: true
-            ext: ".exe"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -75,41 +66,23 @@ jobs:
           version: 0.15.2
 
       - name: Install Rust target
-        shell: bash
-        run: |
-          rustup target add ${{ matrix.target }}
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            printf '%s\n' 'C:\msys64\mingw64\bin' >> "$GITHUB_PATH"
-          fi
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install cargo-zigbuild
-        if: matrix.cross == true && runner.os != 'Windows'
-        shell: bash
+        if: matrix.cross == true
         run: cargo install --locked cargo-zigbuild@0.20.0
 
       - name: Build cmux-mux (native)
         if: matrix.cross == false
         working-directory: mux
-        shell: bash
         run: cargo build -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
 
-      - name: Build cmux-mux (cross, non-Windows)
-        if: matrix.cross == true && runner.os != 'Windows'
+      - name: Build cmux-mux (cross)
+        if: matrix.cross == true
         working-directory: mux
-        shell: bash
         run: cargo zigbuild -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
 
-      - name: Build libghostty-vt + cmux-mux (Windows GNU)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          cd ghostty
-          zig build -Demit-lib-vt=true -Demit-xcframework=false -Doptimize=ReleaseFast -Dtarget=x86_64-windows-gnu --prefix "$RUNNER_TEMP/ghostty-vt-win-gnu"
-          cd ../mux
-          cargo build -p mux-tui --bin cmux-mux --release --locked --target x86_64-pc-windows-gnu
-
       - name: Stage binary
-        shell: bash
         run: |
           mkdir -p dist
           cp "mux/target/${{ matrix.target }}/release/cmux-mux${{ matrix.ext }}" "dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}"
@@ -123,7 +96,7 @@ jobs:
           if-no-files-found: error
 
   package:
-    name: package npm and PyPI distributions
+    name: package npm distributions
     needs: build
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 30
@@ -158,50 +131,38 @@ jobs:
           name: cmux-mux-aarch64-unknown-linux-gnu
           path: dist/binaries
 
-      - name: Derive package version
-        id: version
+      - name: Validate version
         env:
           DISPATCH_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
-            [[ "$GITHUB_REF_NAME" =~ ^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-              echo "tag must match cmux-tui-vX.Y.Z" >&2
-              exit 1
-            }
-            version="${GITHUB_REF_NAME#cmux-tui-v}"
-          else
-            version="$DISPATCH_VERSION"
-            [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-              echo "workflow_dispatch version must match X.Y.Z" >&2
-              exit 1
-            }
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          [[ "$DISPATCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "workflow_dispatch version must match X.Y.Z" >&2
+            exit 1
+          }
 
-      - name: Build package directories and wheels
+      - name: Build npm package directories
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
         run: |
-          set -euo pipefail
           python3 mux/dist/scripts/package_npm.py \
             --binaries-dir dist/binaries \
-            --version "${{ steps.version.outputs.version }}" \
+            --version "$DISPATCH_VERSION" \
             --out dist/npm-packages
-          python3 mux/dist/scripts/package_pypi.py \
-            --binaries-dir dist/binaries \
-            --version "${{ steps.version.outputs.version }}" \
-            --out dist/pypi-wheels
 
-      - name: Smoke verify distributions
+      - name: Smoke verify npm packages
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
           import json
+          import os
           import pathlib
           import stat
           import sys
-          import zipfile
 
-          version = "${{ steps.version.outputs.version }}"
+          version = os.environ["DISPATCH_VERSION"]
           root = pathlib.Path("dist/npm-packages")
           platforms = {
               "cmux-tui-darwin-arm64": ("darwin", "arm64"),
@@ -221,35 +182,12 @@ jobs:
               if package_json["os"] != [os_name] or package_json["cpu"] != [cpu]:
                   raise SystemExit(f"{name}: os/cpu mismatch")
               binary = root / name / "bin" / "cmux-mux"
-              mode = binary.stat().st_mode
-              if not mode & stat.S_IXUSR:
+              if not binary.stat().st_mode & stat.S_IXUSR:
                   raise SystemExit(f"{binary} is not executable")
-          for wheel_path in sorted(pathlib.Path("dist/pypi-wheels").glob("*.whl")):
-              with zipfile.ZipFile(wheel_path) as wheel:
-                  names = set(wheel.namelist())
-                  required = {
-                      "cmux_tui/__init__.py",
-                      "cmux_tui/_main.py",
-                      "cmux_tui/bin/cmux-mux",
-                      f"cmux-{version}.dist-info/WHEEL",
-                      f"cmux-{version}.dist-info/METADATA",
-                      f"cmux-{version}.dist-info/entry_points.txt",
-                      f"cmux-{version}.dist-info/RECORD",
-                  }
-                  missing = required - names
-                  if missing:
-                      raise SystemExit(f"{wheel_path}: missing {sorted(missing)}")
           PY
           chmod +x dist/binaries/cmux-mux-x86_64-unknown-linux-gnu
           dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --version >/tmp/cmux-mux-version.txt 2>&1 || \
             dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --help >/tmp/cmux-mux-version.txt 2>&1
-          for wheel in dist/pypi-wheels/*.whl; do
-            python3 -m zipfile -l "$wheel" >>/tmp/cmux-wheel-list.txt
-          done
-          python3 -m venv /tmp/cmux-tui-wheel-smoke
-          /tmp/cmux-tui-wheel-smoke/bin/python -m pip install --no-index --find-links dist/pypi-wheels cmux=="${{ steps.version.outputs.version }}"
-          /tmp/cmux-tui-wheel-smoke/bin/cmux --help >/tmp/cmux-help.txt
-          grep -i usage /tmp/cmux-help.txt
 
       - name: Upload npm package directories
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -258,9 +196,74 @@ jobs:
           path: dist/npm-packages
           if-no-files-found: error
 
-      - name: Upload PyPI wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+  publish:
+    needs: package
+    runs-on: ubuntu-latest # github-hosted-required: npm provenance needs a github-hosted runner
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: npm-tui
+      url: https://www.npmjs.com/package/cmux
+    steps:
+      - name: Require npm cmux confirmation
+        if: inputs.confirm_tui_cmux != true
+        run: |
+          echo "Refusing to publish npm package cmux for the TUI without confirm_tui_cmux=true." >&2
+          exit 1
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          name: pypi-wheels
-          path: dist/pypi-wheels/*.whl
-          if-no-files-found: error
+          persist-credentials: false
+
+      - name: Download npm package directories
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: npm-packages
+          path: dist/npm-packages
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22.14.0"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install npm with OIDC support
+        run: npm install -g npm@^11.5.1
+
+      - name: Publish platform packages
+        run: |
+          set -euo pipefail
+          packages=(
+            cmux-tui-darwin-arm64
+            cmux-tui-darwin-x64
+            cmux-tui-linux-x64
+            cmux-tui-linux-arm64
+          )
+          for package in "${packages[@]}"; do
+            echo "Publishing $package"
+            if ! npm publish --provenance "dist/npm-packages/$package"; then
+              cat >&2 <<'EOF'
+          npm publish failed.
+
+          For the first publish of the new TUI platform package names, add npm Trusted Publishers for:
+          - cmux-tui-darwin-arm64
+          - cmux-tui-darwin-x64
+          - cmux-tui-linux-x64
+          - cmux-tui-linux-arm64
+
+          Trusted publisher settings for each package:
+          - Repository: manaflow-ai/cmux
+          - Workflow: tui-publish-npm.yml
+          - Environment: npm-tui
+          EOF
+              exit 1
+            fi
+          done
+
+      - name: Publish launcher package
+        run: |
+          set -euo pipefail
+          # Deliberately do not pass --tag: this coordinated TUI publish takes
+          # over the cmux latest dist-tag from the old 0.8.3 CLI when version > 0.8.3.
+          npm publish --provenance dist/npm-packages/cmux

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -18,117 +18,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: build ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-            cross: false
-            ext: ""
-          - target: x86_64-apple-darwin
-            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-            cross: true
-            ext: ""
-          - target: x86_64-unknown-linux-gnu
-            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-            cross: false
-            ext: ""
-          - target: aarch64-unknown-linux-gnu
-            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-            cross: true
-            ext: ""
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Init ghostty submodule
-        run: git submodule update --init --depth 1 ghostty
-
-      - name: Install Linux build dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang libclang-dev pkg-config
-
-      - name: Install zig
-        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
-        with:
-          version: 0.15.2
-
-      - name: Install Rust target
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Install cargo-zigbuild
-        if: matrix.cross == true
-        run: cargo install --locked cargo-zigbuild@0.20.0
-
-      - name: Build cmux-mux (native)
-        if: matrix.cross == false
-        working-directory: mux
-        run: cargo build -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
-
-      - name: Build cmux-mux (cross)
-        if: matrix.cross == true
-        working-directory: mux
-        run: cargo zigbuild -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
-
-      - name: Stage binary
-        run: |
-          mkdir -p dist
-          cp "mux/target/${{ matrix.target }}/release/cmux-mux${{ matrix.ext }}" "dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}"
-          ls -la dist
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: cmux-mux-${{ matrix.target }}
-          path: dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}
-          if-no-files-found: error
-
-  package:
-    name: package PyPI wheels
-    needs: build
+  version:
+    name: derive package version
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Download darwin arm64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-aarch64-apple-darwin
-          path: dist/binaries
-
-      - name: Download darwin x64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-x86_64-apple-darwin
-          path: dist/binaries
-
-      - name: Download linux x64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-x86_64-unknown-linux-gnu
-          path: dist/binaries
-
-      - name: Download linux arm64 binary
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: cmux-mux-aarch64-unknown-linux-gnu
-          path: dist/binaries
-
       - name: Derive package version
         id: version
         env:
@@ -150,36 +47,19 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Build PyPI wheels
-        run: |
-          python3 mux/dist/scripts/package_pypi.py \
-            --binaries-dir dist/binaries \
-            --version "${{ steps.version.outputs.version }}" \
-            --out dist/pypi-wheels
-
-      - name: Smoke verify wheels
-        run: |
-          set -euo pipefail
-          for wheel in dist/pypi-wheels/*.whl; do
-            python3 -m zipfile -l "$wheel" >"/tmp/$(basename "$wheel").list"
-          done
-          chmod +x dist/binaries/cmux-mux-x86_64-unknown-linux-gnu
-          dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --version >/tmp/cmux-mux-version.txt 2>&1 || \
-            dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --help >/tmp/cmux-mux-version.txt 2>&1
-          python3 -m venv /tmp/cmux-tui-wheel-smoke
-          /tmp/cmux-tui-wheel-smoke/bin/python -m pip install --no-index --find-links dist/pypi-wheels cmux=="${{ steps.version.outputs.version }}"
-          /tmp/cmux-tui-wheel-smoke/bin/cmux --help >/tmp/cmux-help.txt
-          grep -i usage /tmp/cmux-help.txt
-
-      - name: Upload PyPI wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: pypi-wheels
-          path: dist/pypi-wheels/*.whl
-          if-no-files-found: error
+  build-package:
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/tui-build-package.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      package_npm: false
+      package_pypi: true
+      include_windows: false
 
   publish:
-    needs: package
+    needs: build-package
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -1,33 +1,27 @@
-name: mux tui release binaries
+name: tui publish pypi
 
-# Builds the cmux-mux TUI binary for every distribution target (npm/PyPI `cmux`).
-# Manual dispatch or cmux-tui tag builds upload one artifact per target so the
-# npm/PyPI wrapper-packaging jobs can bundle them.
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "TUI package version to build, for example 0.1.0"
-        required: true
-        type: string
   push:
     tags:
       - "cmux-tui-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "TUI package version to publish, for example 0.1.0"
+        required: true
+        type: string
 
 permissions: {}
 
 concurrency:
-  group: mux-tui-release-${{ github.ref }}
-  cancel-in-progress: true
+  group: tui-publish-pypi-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
     name: build ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
-    # Windows is experimental (bindgen clang include-path issue with the nested
-    # ghostty vt headers); its failure must not block the unix release.
-    continue-on-error: ${{ matrix.experimental || false }}
     permissions:
       contents: read
     strategy:
@@ -50,11 +44,6 @@ jobs:
             runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
             cross: true
             ext: ""
-          - target: x86_64-pc-windows-gnu
-            runner: windows-latest
-            cross: true
-            experimental: true
-            ext: ".exe"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -75,41 +64,23 @@ jobs:
           version: 0.15.2
 
       - name: Install Rust target
-        shell: bash
-        run: |
-          rustup target add ${{ matrix.target }}
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            printf '%s\n' 'C:\msys64\mingw64\bin' >> "$GITHUB_PATH"
-          fi
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install cargo-zigbuild
-        if: matrix.cross == true && runner.os != 'Windows'
-        shell: bash
+        if: matrix.cross == true
         run: cargo install --locked cargo-zigbuild@0.20.0
 
       - name: Build cmux-mux (native)
         if: matrix.cross == false
         working-directory: mux
-        shell: bash
         run: cargo build -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
 
-      - name: Build cmux-mux (cross, non-Windows)
-        if: matrix.cross == true && runner.os != 'Windows'
+      - name: Build cmux-mux (cross)
+        if: matrix.cross == true
         working-directory: mux
-        shell: bash
         run: cargo zigbuild -p mux-tui --bin cmux-mux --release --locked --target ${{ matrix.target }}
 
-      - name: Build libghostty-vt + cmux-mux (Windows GNU)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          cd ghostty
-          zig build -Demit-lib-vt=true -Demit-xcframework=false -Doptimize=ReleaseFast -Dtarget=x86_64-windows-gnu --prefix "$RUNNER_TEMP/ghostty-vt-win-gnu"
-          cd ../mux
-          cargo build -p mux-tui --bin cmux-mux --release --locked --target x86_64-pc-windows-gnu
-
       - name: Stage binary
-        shell: bash
         run: |
           mkdir -p dist
           cp "mux/target/${{ matrix.target }}/release/cmux-mux${{ matrix.ext }}" "dist/cmux-mux-${{ matrix.target }}${{ matrix.ext }}"
@@ -123,7 +94,7 @@ jobs:
           if-no-files-found: error
 
   package:
-    name: package npm and PyPI distributions
+    name: package PyPI wheels
     needs: build
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 30
@@ -179,84 +150,26 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Build package directories and wheels
+      - name: Build PyPI wheels
         run: |
-          set -euo pipefail
-          python3 mux/dist/scripts/package_npm.py \
-            --binaries-dir dist/binaries \
-            --version "${{ steps.version.outputs.version }}" \
-            --out dist/npm-packages
           python3 mux/dist/scripts/package_pypi.py \
             --binaries-dir dist/binaries \
             --version "${{ steps.version.outputs.version }}" \
             --out dist/pypi-wheels
 
-      - name: Smoke verify distributions
+      - name: Smoke verify wheels
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import pathlib
-          import stat
-          import sys
-          import zipfile
-
-          version = "${{ steps.version.outputs.version }}"
-          root = pathlib.Path("dist/npm-packages")
-          platforms = {
-              "cmux-tui-darwin-arm64": ("darwin", "arm64"),
-              "cmux-tui-darwin-x64": ("darwin", "x64"),
-              "cmux-tui-linux-x64": ("linux", "x64"),
-              "cmux-tui-linux-arm64": ("linux", "arm64"),
-          }
-          launcher = json.loads((root / "cmux" / "package.json").read_text())
-          deps = launcher.get("optionalDependencies", {})
-          if deps != {name: version for name in platforms}:
-              print(f"optionalDependencies mismatch: {deps}", file=sys.stderr)
-              raise SystemExit(1)
-          for name, (os_name, cpu) in platforms.items():
-              package_json = json.loads((root / name / "package.json").read_text())
-              if package_json["version"] != version:
-                  raise SystemExit(f"{name}: version mismatch")
-              if package_json["os"] != [os_name] or package_json["cpu"] != [cpu]:
-                  raise SystemExit(f"{name}: os/cpu mismatch")
-              binary = root / name / "bin" / "cmux-mux"
-              mode = binary.stat().st_mode
-              if not mode & stat.S_IXUSR:
-                  raise SystemExit(f"{binary} is not executable")
-          for wheel_path in sorted(pathlib.Path("dist/pypi-wheels").glob("*.whl")):
-              with zipfile.ZipFile(wheel_path) as wheel:
-                  names = set(wheel.namelist())
-                  required = {
-                      "cmux_tui/__init__.py",
-                      "cmux_tui/_main.py",
-                      "cmux_tui/bin/cmux-mux",
-                      f"cmux-{version}.dist-info/WHEEL",
-                      f"cmux-{version}.dist-info/METADATA",
-                      f"cmux-{version}.dist-info/entry_points.txt",
-                      f"cmux-{version}.dist-info/RECORD",
-                  }
-                  missing = required - names
-                  if missing:
-                      raise SystemExit(f"{wheel_path}: missing {sorted(missing)}")
-          PY
+          for wheel in dist/pypi-wheels/*.whl; do
+            python3 -m zipfile -l "$wheel" >"/tmp/$(basename "$wheel").list"
+          done
           chmod +x dist/binaries/cmux-mux-x86_64-unknown-linux-gnu
           dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --version >/tmp/cmux-mux-version.txt 2>&1 || \
             dist/binaries/cmux-mux-x86_64-unknown-linux-gnu --help >/tmp/cmux-mux-version.txt 2>&1
-          for wheel in dist/pypi-wheels/*.whl; do
-            python3 -m zipfile -l "$wheel" >>/tmp/cmux-wheel-list.txt
-          done
           python3 -m venv /tmp/cmux-tui-wheel-smoke
           /tmp/cmux-tui-wheel-smoke/bin/python -m pip install --no-index --find-links dist/pypi-wheels cmux=="${{ steps.version.outputs.version }}"
           /tmp/cmux-tui-wheel-smoke/bin/cmux --help >/tmp/cmux-help.txt
           grep -i usage /tmp/cmux-help.txt
-
-      - name: Upload npm package directories
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: npm-packages
-          path: dist/npm-packages
-          if-no-files-found: error
 
       - name: Upload PyPI wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -264,3 +177,35 @@ jobs:
           name: pypi-wheels
           path: dist/pypi-wheels/*.whl
           if-no-files-found: error
+
+  publish:
+    needs: package
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi-tui
+      url: https://pypi.org/p/cmux
+    steps:
+      - name: Download PyPI wheels
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: pypi-wheels
+          path: dist
+
+      - name: Trusted publisher setup note
+        run: |
+          cat <<'EOF'
+          PyPI Trusted Publisher required:
+          - Project: cmux
+          - Repository: manaflow-ai/cmux
+          - Workflow: tui-publish-pypi.yml
+          - Environment: pypi-tui
+          EOF
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist
+          attestations: true

--- a/.github/workflows/tui-release-cut.yml
+++ b/.github/workflows/tui-release-cut.yml
@@ -1,0 +1,167 @@
+name: tui release cut
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version component to bump when version is not set"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      version:
+        description: "Explicit X.Y.Z version override"
+        required: false
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: tui-release-cut-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: create release tag
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      contents: write
+      # actions: write lets this job dispatch the downstream build/publish
+      # workflows: a tag pushed with the default GITHUB_TOKEN does NOT fire
+      # other workflows' push triggers (GitHub suppresses token-created events),
+      # so the release cut must dispatch them explicitly.
+      actions: write
+    steps:
+      - name: Require main branch dispatch
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Refusing to cut a TUI release from $GITHUB_REF; dispatch this workflow on main." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Compute next TUI version
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+          EXPLICIT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --force --tags
+          latest_tag="$(
+            git tag --merged HEAD --list 'cmux-tui-v*' --sort=-v:refname |
+              grep -E '^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$' |
+              head -n 1 || true
+          )"
+          if [[ -z "$latest_tag" ]]; then
+            latest_version="0.0.0"
+          else
+            latest_version="${latest_tag#cmux-tui-v}"
+          fi
+
+          version_gt() {
+            local lhs="$1"
+            local rhs="$2"
+            IFS=. read -r lhs_major lhs_minor lhs_patch <<<"$lhs"
+            IFS=. read -r rhs_major rhs_minor rhs_patch <<<"$rhs"
+            if (( lhs_major != rhs_major )); then
+              (( lhs_major > rhs_major ))
+              return
+            fi
+            if (( lhs_minor != rhs_minor )); then
+              (( lhs_minor > rhs_minor ))
+              return
+            fi
+            (( lhs_patch > rhs_patch ))
+          }
+
+          if [[ -n "$EXPLICIT_VERSION" ]]; then
+            [[ "$EXPLICIT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "version must match X.Y.Z" >&2
+              exit 1
+            }
+            next_version="$EXPLICIT_VERSION"
+          else
+            IFS=. read -r major minor patch <<<"$latest_version"
+            case "$BUMP" in
+              patch)
+                patch=$((patch + 1))
+                ;;
+              minor)
+                minor=$((minor + 1))
+                patch=0
+                ;;
+              major)
+                major=$((major + 1))
+                minor=0
+                patch=0
+                ;;
+              *)
+                echo "unsupported bump: $BUMP" >&2
+                exit 1
+                ;;
+            esac
+            next_version="$major.$minor.$patch"
+          fi
+
+          if ! version_gt "$next_version" "$latest_version"; then
+            echo "next version $next_version must be greater than latest $latest_version" >&2
+            exit 1
+          fi
+
+          tag="cmux-tui-v$next_version"
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "tag already exists: $tag" >&2
+            exit 1
+          fi
+          {
+            echo "version=$next_version"
+            echo "tag=$tag"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "### TUI release cut"
+            echo
+            echo "- Latest: $latest_version"
+            echo "- New tag: $tag"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create annotated tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "cmux TUI $VERSION"
+
+      - name: Push tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: git push origin "refs/tags/$TAG"
+
+      - name: Dispatch downstream build and PyPI publish
+        # The tag push above was made with the default GITHUB_TOKEN, which
+        # never triggers other workflows' tag-push events. Dispatch them
+        # explicitly against the new tag so the release actually builds and
+        # publishes. npm stays a deliberate manual dispatch (confirm gate).
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh workflow run mux-tui-release.yml --repo "$GITHUB_REPOSITORY" --ref "refs/tags/$TAG" -f version="$VERSION"
+          gh workflow run tui-publish-pypi.yml --repo "$GITHUB_REPOSITORY" --ref "refs/tags/$TAG" -f version="$VERSION"
+          {
+            echo "- Dispatched mux-tui-release.yml and tui-publish-pypi.yml on $TAG"
+            echo "- npm publish: dispatch tui-publish-npm.yml with version=$VERSION and confirm_tui_cmux=true"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/mux/crates/ghostty-vt-sys/build.rs
+++ b/mux/crates/ghostty-vt-sys/build.rs
@@ -20,6 +20,7 @@ fn main() {
             e
         )
     });
+    let ghostty_dir = strip_windows_verbatim(ghostty_dir);
 
     println!("cargo:rerun-if-env-changed=CMUX_GHOSTTY_SRC");
     println!("cargo:rerun-if-env-changed=ZIG");
@@ -83,6 +84,24 @@ fn main() {
         .generate()
         .expect("bindgen failed for ghostty/vt.h");
     bindings.write_to_file(out_dir.join("bindings.rs")).expect("failed to write bindings.rs");
+}
+
+// std::fs::canonicalize on Windows returns \\?\-prefixed extended-length
+// paths. clang accepts such a path for the root header but cannot resolve
+// nested relative includes from it (ghostty/vt.h -> "ghostty/vt/types.h"
+// fails with file-not-found), which broke the windows-gnu bindgen step.
+// Strip the verbatim prefix so bindgen/clang see plain paths.
+fn strip_windows_verbatim(path: PathBuf) -> PathBuf {
+    if cfg!(windows) {
+        let s = path.to_string_lossy();
+        if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+            return PathBuf::from(format!(r"\\{rest}"));
+        }
+        if let Some(rest) = s.strip_prefix(r"\\?\") {
+            return PathBuf::from(rest);
+        }
+    }
+    path
 }
 
 fn zig_target_for_rust_target(target: &str) -> Option<&'static str> {

--- a/mux/crates/ghostty-vt-sys/build.rs
+++ b/mux/crates/ghostty-vt-sys/build.rs
@@ -90,6 +90,13 @@ fn zig_target_for_rust_target(target: &str) -> Option<&'static str> {
         "x86_64-pc-windows-gnu" => Some("x86_64-windows-gnu"),
         "x86_64-pc-windows-msvc" => Some("x86_64-windows-msvc"),
         "aarch64-pc-windows-msvc" => Some("aarch64-windows-msvc"),
+        // Cross-compiling libghostty-vt for the release distribution targets
+        // (npm/PyPI `cmux` binaries). zig cross-compiles these cleanly and
+        // pairs with cargo-zigbuild for the Rust link step.
+        "x86_64-apple-darwin" => Some("x86_64-macos"),
+        "aarch64-apple-darwin" => Some("aarch64-macos"),
+        "x86_64-unknown-linux-gnu" => Some("x86_64-linux-gnu"),
+        "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
         _ => None,
     }
 }

--- a/mux/dist/RELEASING-TUI.md
+++ b/mux/dist/RELEASING-TUI.md
@@ -1,0 +1,52 @@
+# cmux TUI Distribution Release
+
+The cmux TUI distribution uses `cmux-tui-vX.Y.Z` tags. The npm launcher
+package, npm platform packages, and PyPI wheels all share the same `X.Y.Z`
+version for a release.
+
+TUI distribution versions are independent of the SDK version. The SDK package
+relocation to `cmux-sdk` is tracked separately and is not part of this release
+path.
+
+## Packages
+
+- npm `cmux`: launcher package for `npx cmux`.
+- npm `cmux-tui-darwin-arm64`: macOS arm64 binary package.
+- npm `cmux-tui-darwin-x64`: macOS x64 binary package.
+- npm `cmux-tui-linux-x64`: Linux x64 binary package.
+- npm `cmux-tui-linux-arm64`: Linux arm64 binary package.
+- PyPI `cmux`: platform wheels for `uvx cmux` / `pipx run cmux`.
+
+## One-time registry setup
+
+Add npm Trusted Publishers for all five npm package names:
+
+- `cmux`
+- `cmux-tui-darwin-arm64`
+- `cmux-tui-darwin-x64`
+- `cmux-tui-linux-x64`
+- `cmux-tui-linux-arm64`
+
+Use these npm trusted-publisher settings for each package:
+
+- Repository: `manaflow-ai/cmux`
+- Workflow: `tui-publish-npm.yml`
+- Environment: `npm-tui`
+
+Add a PyPI Trusted Publisher for:
+
+- Project: `cmux`
+- Repository: `manaflow-ai/cmux`
+- Workflow: `tui-publish-pypi.yml`
+- Environment: `pypi-tui`
+
+## Publishing
+
+PyPI publishing can run from `cmux-tui-vX.Y.Z` tags or manual dispatch.
+
+npm publishing is manual dispatch only and requires `confirm_tui_cmux=true`.
+The platform packages are published first, then the `cmux` launcher.
+
+The npm launcher publish deliberately does not pass `--tag`: when the TUI
+version is greater than `0.8.3`, this coordinated release takes over the npm
+`latest` dist-tag for `cmux` from the old CLI package.

--- a/mux/dist/RELEASING-TUI.md
+++ b/mux/dist/RELEASING-TUI.md
@@ -8,6 +8,10 @@ TUI distribution versions are independent of the SDK version. The SDK package
 relocation to `cmux-sdk` is tracked separately and is not part of this release
 path.
 
+The TUI does not store its version in a checked-in manifest. The packaging
+scripts receive `--version`, so cutting a stable TUI release is just creating a
+`cmux-tui-vX.Y.Z` tag on `main`.
+
 ## Packages
 
 - npm `cmux`: launcher package for `npx cmux`.
@@ -39,6 +43,59 @@ Add a PyPI Trusted Publisher for:
 - Repository: `manaflow-ai/cmux`
 - Workflow: `tui-publish-pypi.yml`
 - Environment: `pypi-tui`
+
+Nightly publishing uses the same environments. Add trusted publishers for:
+
+- npm packages:
+  - Repository: `manaflow-ai/cmux`
+  - Workflow: `tui-nightly.yml`
+  - Environment: `npm-tui`
+- PyPI project `cmux`:
+  - Repository: `manaflow-ai/cmux`
+  - Workflow: `tui-nightly.yml`
+  - Environment: `pypi-tui`
+
+## Nightly channel
+
+`.github/workflows/tui-nightly.yml` runs on a daily schedule and by manual
+dispatch. It always checks out `main`, derives the next stable version from the
+latest reachable `cmux-tui-vX.Y.Z` tag by bumping patch, and falls back to
+`0.9.0` when no stable TUI tag exists.
+
+Nightly versions use registry-specific prerelease forms:
+
+- npm: `<next-stable>-nightly.<YYYYMMDD>.<run-number>`, for example
+  `0.9.1-nightly.20260708.1`.
+- PyPI: `<next-stable>.dev<YYYYMMDD><run-number>`, for example
+  `0.9.1.dev202607081`.
+
+npm nightlies are published with `npm publish --provenance --tag nightly`, so
+`npx cmux@nightly` opts into the latest nightly and `npx cmux` remains on the
+stable `latest` dist-tag. PyPI nightlies are dev releases, so normal
+`uvx cmux` resolution ignores them; `uvx --prerelease allow cmux` opts in.
+
+The nightly workflow intentionally always builds and publishes a fresh run
+instead of trying to skip when `main` has not changed. The build is cheap, and a
+GitHub API lookup for the last successful nightly is more fragile than the
+extra build.
+
+## Cutting a Stable Release
+
+Use `.github/workflows/tui-release-cut.yml` from `main`.
+
+- Select `patch`, `minor`, or `major`, or provide an explicit `X.Y.Z` version.
+- The workflow reads the latest reachable `cmux-tui-vX.Y.Z` tag, validates the
+  new version is strictly greater, creates annotated tag `cmux-tui-vX.Y.Z` on
+  `main` HEAD, and pushes that tag.
+- The tag is pushed with the default `GITHUB_TOKEN`, and GitHub suppresses
+  workflow triggers for token-created events, so the release-cut workflow then
+  explicitly dispatches `mux-tui-release.yml` (build + package) and
+  `tui-publish-pypi.yml` (PyPI wheels) against the new tag. A manual
+  `git push origin cmux-tui-vX.Y.Z` from a developer machine still fires both
+  tag triggers directly.
+- npm remains dispatch-gated. After the tag cut, manually dispatch
+  `tui-publish-npm.yml` with the same `X.Y.Z` version and
+  `confirm_tui_cmux=true`.
 
 ## Publishing
 

--- a/mux/dist/npm/cmux/bin/cmux.js
+++ b/mux/dist/npm/cmux/bin/cmux.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+"use strict";
+
+// Launcher for `npx cmux` / a global `cmux` install. The actual TUI is a
+// prebuilt Rust binary shipped in a per-platform optional dependency
+// (cmux-tui-<platform>); npm installs only the one matching os+cpu. This shim
+// resolves that binary and execs it, forwarding argv, stdio, exit code, and
+// signals so cmux behaves exactly like the native binary.
+
+const { spawnSync } = require("child_process");
+
+const PACKAGE_BY_PLATFORM = {
+  "darwin-arm64": "cmux-tui-darwin-arm64",
+  "darwin-x64": "cmux-tui-darwin-x64",
+  "linux-x64": "cmux-tui-linux-x64",
+  "linux-arm64": "cmux-tui-linux-arm64",
+  "win32-x64": "cmux-tui-win32-x64",
+};
+
+const key = `${process.platform}-${process.arch}`;
+const pkg = PACKAGE_BY_PLATFORM[key];
+
+if (!pkg) {
+  console.error(
+    `cmux: no prebuilt binary for ${key}. Supported: ${Object.keys(PACKAGE_BY_PLATFORM).join(", ")}.`
+  );
+  process.exit(1);
+}
+
+const binName = process.platform === "win32" ? "cmux-mux.exe" : "cmux-mux";
+
+let binPath;
+try {
+  binPath = require.resolve(`${pkg}/bin/${binName}`);
+} catch {
+  console.error(
+    `cmux: platform package ${pkg} is not installed. Reinstall cmux, ` +
+      `or set npm to install optional dependencies (--include=optional).`
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(binPath, process.argv.slice(2), { stdio: "inherit" });
+
+if (result.error) {
+  console.error(`cmux: failed to launch ${binPath}: ${result.error.message}`);
+  process.exit(1);
+}
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+  return;
+}
+process.exit(result.status === null ? 1 : result.status);

--- a/mux/dist/npm/cmux/bin/cmux.js
+++ b/mux/dist/npm/cmux/bin/cmux.js
@@ -14,7 +14,7 @@ const PACKAGE_BY_PLATFORM = {
   "darwin-x64": "cmux-tui-darwin-x64",
   "linux-x64": "cmux-tui-linux-x64",
   "linux-arm64": "cmux-tui-linux-arm64",
-  "win32-x64": "cmux-tui-win32-x64",
+  // win32-x64 pending: ghostty vt headers fail bindgen under mingw clang.
 };
 
 const key = `${process.platform}-${process.arch}`;

--- a/mux/dist/npm/cmux/package.json
+++ b/mux/dist/npm/cmux/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "cmux",
+  "version": "0.0.0-managed",
+  "description": "cmux — a tmux-like terminal multiplexer TUI backed by libghostty-vt. Run with `npx cmux`.",
+  "bin": {
+    "cmux": "bin/cmux.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/manaflow-ai/cmux.git",
+    "directory": "mux/dist/npm/cmux"
+  },
+  "homepage": "https://github.com/manaflow-ai/cmux/tree/main/mux",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "bin/cmux.js"
+  ],
+  "optionalDependencies": {
+    "cmux-tui-darwin-arm64": "0.0.0-managed",
+    "cmux-tui-darwin-x64": "0.0.0-managed",
+    "cmux-tui-linux-x64": "0.0.0-managed",
+    "cmux-tui-linux-arm64": "0.0.0-managed",
+    "cmux-tui-win32-x64": "0.0.0-managed"
+  }
+}

--- a/mux/dist/npm/cmux/package.json
+++ b/mux/dist/npm/cmux/package.json
@@ -22,7 +22,6 @@
     "cmux-tui-darwin-arm64": "0.0.0-managed",
     "cmux-tui-darwin-x64": "0.0.0-managed",
     "cmux-tui-linux-x64": "0.0.0-managed",
-    "cmux-tui-linux-arm64": "0.0.0-managed",
-    "cmux-tui-win32-x64": "0.0.0-managed"
+    "cmux-tui-linux-arm64": "0.0.0-managed"
   }
 }

--- a/mux/dist/scripts/package_npm.py
+++ b/mux/dist/scripts/package_npm.py
@@ -38,7 +38,9 @@ TARGETS = [
     },
 ]
 
-VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+VERSION_RE = re.compile(
+    r"^(?:[0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{8}\.[0-9]+)$"
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -54,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--version",
         required=True,
-        help="Package version in X.Y.Z form.",
+        help="Package version in X.Y.Z or X.Y.Z-nightly.YYYYMMDD.N form.",
     )
     parser.add_argument(
         "--out",
@@ -146,7 +148,7 @@ def package_launcher(version: str, out_dir: Path) -> None:
 def main() -> None:
     args = parse_args()
     if not VERSION_RE.fullmatch(args.version):
-        raise SystemExit("--version must match X.Y.Z")
+        raise SystemExit("--version must match X.Y.Z or X.Y.Z-nightly.YYYYMMDD.N")
 
     binaries_dir = args.binaries_dir.resolve()
     out_dir = args.out.resolve()

--- a/mux/dist/scripts/package_npm.py
+++ b/mux/dist/scripts/package_npm.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Build npm packages for the cmux TUI launcher and platform binaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import stat
+from pathlib import Path
+
+
+TARGETS = [
+    {
+        "rust_target": "aarch64-apple-darwin",
+        "package": "cmux-tui-darwin-arm64",
+        "os": "darwin",
+        "cpu": "arm64",
+    },
+    {
+        "rust_target": "x86_64-apple-darwin",
+        "package": "cmux-tui-darwin-x64",
+        "os": "darwin",
+        "cpu": "x64",
+    },
+    {
+        "rust_target": "x86_64-unknown-linux-gnu",
+        "package": "cmux-tui-linux-x64",
+        "os": "linux",
+        "cpu": "x64",
+    },
+    {
+        "rust_target": "aarch64-unknown-linux-gnu",
+        "package": "cmux-tui-linux-arm64",
+        "os": "linux",
+        "cpu": "arm64",
+    },
+]
+
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate cmux TUI npm launcher and platform packages."
+    )
+    parser.add_argument(
+        "--binaries-dir",
+        required=True,
+        type=Path,
+        help="Directory containing cmux-mux-<rust-target> binaries.",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Package version in X.Y.Z form.",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output directory for generated npm package directories.",
+    )
+    return parser.parse_args()
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+def copy_executable(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+    mode = dst.stat().st_mode
+    dst.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def recreate_dir(path: Path) -> None:
+    if path.exists():
+        if not path.is_dir():
+            raise SystemExit(f"{path} exists and is not a directory")
+        shutil.rmtree(path)
+    path.mkdir(parents=True)
+
+
+def package_platforms(binaries_dir: Path, version: str, out_dir: Path) -> None:
+    for target in TARGETS:
+        src = binaries_dir / f"cmux-mux-{target['rust_target']}"
+        if not src.is_file():
+            raise SystemExit(f"missing binary: {src}")
+
+        package_dir = out_dir / target["package"]
+        recreate_dir(package_dir)
+        copy_executable(src, package_dir / "bin" / "cmux-mux")
+
+        write_json(
+            package_dir / "package.json",
+            {
+                "name": target["package"],
+                "version": version,
+                "description": (
+                    "Prebuilt cmux-mux TUI binary for "
+                    f"{target['os']}-{target['cpu']}."
+                ),
+                "repository": {
+                    "type": "git",
+                    "url": "git+https://github.com/manaflow-ai/cmux.git",
+                    "directory": "mux/dist",
+                },
+                "license": "MIT",
+                "os": [target["os"]],
+                "cpu": [target["cpu"]],
+                "files": ["bin/cmux-mux"],
+            },
+        )
+
+
+def package_launcher(version: str, out_dir: Path) -> None:
+    source_dir = Path(__file__).resolve().parents[1] / "npm" / "cmux"
+    if not source_dir.is_dir():
+        raise SystemExit(f"missing launcher template: {source_dir}")
+
+    launcher_dir = out_dir / "cmux"
+    recreate_dir(launcher_dir)
+    shutil.copytree(source_dir, launcher_dir, dirs_exist_ok=True)
+
+    package_json_path = launcher_dir / "package.json"
+    package_json = json.loads(package_json_path.read_text())
+    package_json["version"] = version
+    package_json["optionalDependencies"] = {
+        target["package"]: version for target in TARGETS
+    }
+    write_json(package_json_path, package_json)
+
+    launcher_bin = launcher_dir / "bin" / "cmux.js"
+    if launcher_bin.exists():
+        launcher_bin.chmod(
+            launcher_bin.stat().st_mode
+            | stat.S_IXUSR
+            | stat.S_IXGRP
+            | stat.S_IXOTH
+        )
+
+
+def main() -> None:
+    args = parse_args()
+    if not VERSION_RE.fullmatch(args.version):
+        raise SystemExit("--version must match X.Y.Z")
+
+    binaries_dir = args.binaries_dir.resolve()
+    out_dir = args.out.resolve()
+    if not binaries_dir.is_dir():
+        raise SystemExit(f"--binaries-dir is not a directory: {binaries_dir}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    package_platforms(binaries_dir, args.version, out_dir)
+    package_launcher(args.version, out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/mux/dist/scripts/package_pypi.py
+++ b/mux/dist/scripts/package_pypi.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Build PyPI wheels for the cmux TUI with bundled platform binaries."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import hashlib
+import io
+import re
+import stat
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+DIST_NAME = "cmux"
+PACKAGE_NAME = "cmux_tui"
+ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+
+
+@dataclass(frozen=True)
+class Target:
+    rust_target: str
+    platform_tag: str
+
+
+TARGETS = [
+    Target("aarch64-apple-darwin", "macosx_11_0_arm64"),
+    Target("x86_64-apple-darwin", "macosx_10_12_x86_64"),
+    Target("x86_64-unknown-linux-gnu", "manylinux_2_17_x86_64.manylinux2014_x86_64"),
+    Target("aarch64-unknown-linux-gnu", "manylinux_2_17_aarch64.manylinux2014_aarch64"),
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate cmux TUI PyPI wheels with bundled binaries."
+    )
+    parser.add_argument(
+        "--binaries-dir",
+        required=True,
+        type=Path,
+        help="Directory containing cmux-mux-<rust-target> binaries.",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Package version in X.Y.Z form.",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output directory for generated wheels.",
+    )
+    return parser.parse_args()
+
+
+def text_bytes(text: str) -> bytes:
+    return text.encode("utf-8")
+
+
+def sha256_record_digest(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    return "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def wheel_info(name: str, data: bytes, mode: int) -> tuple[zipfile.ZipInfo, bytes, int]:
+    info = zipfile.ZipInfo(name, ZIP_TIMESTAMP)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.create_system = 3
+    info.external_attr = ((stat.S_IFREG | mode) & 0xFFFF) << 16
+    return info, data, mode
+
+
+def wheel_bytes(version: str, tag: str, binary: bytes) -> list[tuple[str, bytes, int]]:
+    dist_info = f"{DIST_NAME}-{version}.dist-info"
+    return [
+        (
+            f"{PACKAGE_NAME}/__init__.py",
+            text_bytes(f'"""cmux TUI wheel package."""\n\n__version__ = "{version}"\n'),
+            0o644,
+        ),
+        (
+            f"{PACKAGE_NAME}/_main.py",
+            text_bytes(
+                """from __future__ import annotations
+
+import os
+import pathlib
+import sys
+
+
+def main() -> None:
+    binary = pathlib.Path(__file__).resolve().parent / "bin" / "cmux-mux"
+    os.execv(str(binary), ["cmux", *sys.argv[1:]])
+"""
+            ),
+            0o644,
+        ),
+        (f"{PACKAGE_NAME}/bin/cmux-mux", binary, 0o755),
+        (
+            f"{dist_info}/WHEEL",
+            text_bytes(
+                f"""Wheel-Version: 1.0
+Generator: cmux-dist
+Root-Is-Purelib: false
+Tag: py3-none-{tag}
+"""
+            ),
+            0o644,
+        ),
+        (
+            f"{dist_info}/METADATA",
+            text_bytes(
+                f"""Metadata-Version: 2.1
+Name: {DIST_NAME}
+Version: {version}
+Summary: cmux \u2014 a tmux-like terminal multiplexer TUI backed by libghostty-vt
+License: MIT
+Project-URL: Source, https://github.com/manaflow-ai/cmux
+"""
+            ),
+            0o644,
+        ),
+        (
+            f"{dist_info}/entry_points.txt",
+            text_bytes(
+                """[console_scripts]
+cmux = cmux_tui._main:main
+"""
+            ),
+            0o644,
+        ),
+    ]
+
+
+def write_wheel(path: Path, files: list[tuple[str, bytes, int]], version: str) -> None:
+    dist_info = f"{DIST_NAME}-{version}.dist-info"
+    record_name = f"{dist_info}/RECORD"
+    rows: list[list[str]] = []
+
+    with zipfile.ZipFile(path, "w") as wheel:
+        for name, data, mode in files:
+            info, content, _ = wheel_info(name, data, mode)
+            wheel.writestr(info, content)
+            rows.append([name, sha256_record_digest(content), str(len(content))])
+
+        rows.append([record_name, "", ""])
+        record_buffer = io.StringIO(newline="")
+        writer = csv.writer(record_buffer, lineterminator="\n")
+        writer.writerows(rows)
+        record_data = record_buffer.getvalue().encode("utf-8")
+        record_info, _, _ = wheel_info(record_name, record_data, 0o644)
+        wheel.writestr(record_info, record_data)
+
+
+def main() -> None:
+    args = parse_args()
+    if not VERSION_RE.fullmatch(args.version):
+        raise SystemExit("--version must match X.Y.Z")
+
+    binaries_dir = args.binaries_dir.resolve()
+    out_dir = args.out.resolve()
+    if not binaries_dir.is_dir():
+        raise SystemExit(f"--binaries-dir is not a directory: {binaries_dir}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for target in TARGETS:
+        binary_path = binaries_dir / f"cmux-mux-{target.rust_target}"
+        if not binary_path.is_file():
+            raise SystemExit(f"missing binary: {binary_path}")
+        wheel_name = f"{DIST_NAME}-{args.version}-py3-none-{target.platform_tag}.whl"
+        wheel_path = out_dir / wheel_name
+        if wheel_path.exists():
+            wheel_path.unlink()
+        write_wheel(
+            wheel_path,
+            wheel_bytes(args.version, target.platform_tag, binary_path.read_bytes()),
+            args.version,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/mux/dist/scripts/package_pypi.py
+++ b/mux/dist/scripts/package_pypi.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+VERSION_RE = re.compile(r"^(?:[0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]{9,})$")
 DIST_NAME = "cmux"
 PACKAGE_NAME = "cmux_tui"
 ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
@@ -48,7 +48,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--version",
         required=True,
-        help="Package version in X.Y.Z form.",
+        help="Package version in X.Y.Z or X.Y.Z.devYYYYMMDDN form.",
     )
     parser.add_argument(
         "--out",
@@ -161,7 +161,7 @@ def write_wheel(path: Path, files: list[tuple[str, bytes, int]], version: str) -
 def main() -> None:
     args = parse_args()
     if not VERSION_RE.fullmatch(args.version):
-        raise SystemExit("--version must match X.Y.Z")
+        raise SystemExit("--version must match X.Y.Z or X.Y.Z.devYYYYMMDDN")
 
     binaries_dir = args.binaries_dir.resolve()
     out_dir = args.out.resolve()


### PR DESCRIPTION
Makes the cmux-mux TUI installable as `npx cmux` and `uvx cmux`.

- Cross-platform release binaries (darwin arm64/x64, linux x64/arm64 green; windows experimental) via cargo-zigbuild + a zig cross-target map in ghostty-vt-sys build.rs, plus a fix for the windows bindgen failure that has been red on main since 2026-07-06 (canonicalize returns \\?\ verbatim paths clang can't resolve nested includes from).
- npm: `cmux` launcher (esbuild-style) + 4 platform packages via optionalDependencies; publishing at 0.9.0 with no --tag deliberately takes over `latest` from the 0.8.3 cloud-VM CLI (confirm_tui_cmux dispatch gate).
- PyPI: per-platform wheels with a `cmux` console entry point exec'ing the bundled binary; 0.9.0 outranks the 0.1.x SDK so uvx resolves the TUI.
- Nightly channel: tui-nightly.yml publishes prerelease versions to npm `nightly` dist-tag and PEP 440 .dev wheels; default resolution never sees them.
- Release cuts: tui-release-cut.yml computes the next version from cmux-tui-v* tags, tags, and explicitly dispatches build + PyPI publish (GITHUB_TOKEN tag pushes don't trigger workflows). npm publish stays a manual confirm-gated dispatch.
- All publish workflows are inert until dispatched/tagged; OIDC trusted publishing + provenance; SHA-pinned actions; fable-judged over two rounds (real npm pack/install and pip install/run verified).

Verified in CI: full build+package pipeline green on tag cmux-tui-v0.0.2 (real binaries, linux binary executed, wheel pip-installed and `cmux --help` run). SDK relocation to cmux-sdk is a separate follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786136478&installation_id=133855650&pr_number=7651&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7651&signature=f4dd0631b99f41d2a86457dcefea1878920c12393ddbe5c0c8168aab0f69bba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Publishing workflows can change npm `latest` and PyPI `cmux` resolution for all users once dispatched; gates and dist-tags mitigate mistakes but registry impact is real.
> 
> **Overview**
> Adds end-to-end distribution for the `cmux-mux` TUI as **`npx cmux`** and **`uvx cmux`**, with GitHub Actions to build per-platform binaries, wrap them for npm/PyPI, and publish stable, nightly, and tag-driven releases.
> 
> A reusable **`tui-build-package.yml`** matrix-builds `cmux-mux` for macOS (arm64/x64) and Linux (x64/arm64) via native/cross `cargo-zigbuild`, optionally an experimental Windows GNU binary, then runs **`package_npm.py`** / **`package_pypi.py`** to produce a launcher plus four platform npm packages and per-platform wheels, with CI smoke checks. **`mux-tui-release.yml`**, **`tui-nightly.yml`**, **`tui-publish-npm.yml`**, **`tui-publish-pypi.yml`**, and **`tui-release-cut.yml`** wire version derivation, OIDC publishing (npm `nightly` vs un-tagged stable `latest` with **`confirm_tui_cmux`**), PyPI attestations, and explicit workflow dispatches after token-pushed tags.
> 
> Packaging adds an npm **`cmux.js`** shim that execs optional **`cmux-tui-*`** binaries, plus **`mux/dist/RELEASING-TUI.md`**. **`ghostty-vt-sys/build.rs`** strips Windows `\\?\` paths for bindgen and extends zig cross-target mappings for release builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa8c8f6b3fd0052de630549f0ee19acf17f0bf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship the cmux TUI as prebuilt binaries so it runs with `npx cmux` and `uvx cmux`. Adds cross‑platform builds, packaging, nightly channel, and release workflows.

- **New Features**
  - Cross‑platform binaries (macOS arm64/x64, Linux x64/arm64; Windows experimental) via `cargo-zigbuild` + zig target map in `ghostty-vt-sys`.
  - npm: `cmux` launcher that execs a per‑platform optional dependency (`cmux-tui-darwin-*`, `cmux-tui-linux-*`). Use `npx cmux`.
  - PyPI: per‑platform `cmux` wheels with a `cmux` console entry point. Use `uvx cmux`.
  - Workflows: reusable `tui-build-package.yml`; release builder `mux-tui-release.yml`; nightly `tui-nightly.yml` (npm `nightly` tag and PEP 440 `.dev` wheels); `tui-publish-npm.yml` (manual, confirm‑gated); `tui-publish-pypi.yml`; `tui-release-cut.yml` to tag `cmux-tui-vX.Y.Z` and dispatch builds. Docs in `mux/dist/RELEASING-TUI.md`.

- **Bug Fixes**
  - Windows bindgen: strip `\\?\` verbatim prefixes so clang can resolve nested includes (fixes build failure); adds zig cross‑target mappings for release builds.

<sup>Written for commit 8aa8c8f6b3fd0052de630549f0ee19acf17f0bf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release and publishing workflows for TUI binaries and packages, including manual, tagged, nightly, npm, and PyPI release paths.
  * Added support for packaging multiple platforms, with Windows builds included where needed.
  * Added a release-cut flow that creates version tags and triggers downstream publishing automatically.

* **Bug Fixes**
  * Improved Windows path handling during builds.
  * Expanded cross-compilation target support for release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->