### PR TITLE
iOS: persist debug log to a file and capture crashes in it

### DIFF
--- a/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLog.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLog.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -19,7 +19,47 @@ public struct MobileDebugLog: Sendable {
     /// Process-wide instance used by the legacy anchormux call sites.
     // TRANSITIONAL (iOS refactor): call sites still reach for `.shared`; the
     // composition root should inject the sink once decomposition reaches them.
-    public static let shared = MobileDebugLog(sink: MobileDebugLogSink())
+    public static let shared: MobileDebugLog = {
+        let logFileURL = Self.logFileURL
+        let fileHeader = logFileURL == nil ? nil : Self.logFileHeader()
+        return MobileDebugLog(
+            sink: MobileDebugLogSink(
+                fileURL: logFileURL,
+                fileHeader: fileHeader,
+                installCrashCapture: true
+            )
+        )
+    }()
+
+    /// Default DEBUG-build file location for the durable iOS debug log.
+    ///
+    /// DEBUG builds write to `Application Support/cmux-debug.log` inside the app
+    /// container. Release builds always return `nil`, so callers cannot enable
+    /// durable debug logging by accident.
+    public static let logFileURL: URL? = {
+        #if DEBUG
+        let fileManager = FileManager.default
+        guard let applicationSupportURL = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return nil
+        }
+        do {
+            try fileManager.createDirectory(
+                at: applicationSupportURL,
+                withIntermediateDirectories: true
+            )
+            let fileURL = applicationSupportURL.appendingPathComponent("cmux-debug.log")
+            NSLog("cmux debug log file: %@", fileURL.path)
+            return fileURL
+        } catch {
+            return nil
+        }
+        #else
+        return nil
+        #endif
+    }()
 
     /// The actor that owns the ring buffer and broadcast stream.
     public let sink: MobileDebugLogSink
@@ -63,6 +103,11 @@ public struct MobileDebugLog: Sendable {
         return parts.isEmpty ? "build ?" : parts.joined(separator: " · ")
     }()
 
+    private static func logFileHeader(startedAt: Date = Date()) -> String {
+        let formatter = ISO8601DateFormatter()
+        return "cmux iOS debug log · \(buildStamp) · started \(formatter.string(from: startedAt))"
+    }
+
     #if canImport(UIKit)
     /// Copy the buffer to the system pasteboard, optionally prefixed with a
     /// section (e.g. the visible terminal text).
@@ -73,8 +118,11 @@ public struct MobileDebugLog: Sendable {
     @discardableResult
     public func copyToPasteboard(prepending: String? = nil) async -> Int {
         let (count, body) = await sink.snapshotWithCount()
-        let header = "cmux iOS debug log — \(count) lines · \(Self.buildStamp)\n"
-            + String(repeating: "=", count: 40) + "\n"
+        var header = "cmux iOS debug log — \(count) lines · \(Self.buildStamp)\n"
+        if let logFileURL = Self.logFileURL {
+            header += "log file: \(logFileURL.path)\n"
+        }
+        header += String(repeating: "=", count: 40) + "\n"
         var out = ""
         if let prepending, !prepending.isEmpty {
             out += prepending + "\n\n"

--- a/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLogCrashCapture.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLogCrashCapture.swift
@@ -3,6 +3,10 @@ import Darwin
 import Foundation
 
 /// Crash-time writer for the DEBUG iOS durable debug log.
+///
+/// Signal crashes are written to the log, then the previously installed signal
+/// action is restored and the signal is re-raised so earlier crash reporters
+/// still observe the crash.
 final class MobileDebugLogCrashCapture {
     private init() {}
 
@@ -26,6 +30,8 @@ final class MobileDebugLogCrashCapture {
     nonisolated(unsafe) private static var signalEntryPointer: UnsafeMutablePointer<SignalEntry>?
     nonisolated(unsafe) private static var signalEntryCount: Int32 = 0
     nonisolated(unsafe) private static var signalBytePointer: UnsafeMutablePointer<UInt8>?
+    nonisolated(unsafe) private static var previousSignalActionPointer: UnsafeMutablePointer<sigaction>?
+    nonisolated(unsafe) private static var previousSignalActionCount: Int32 = 0
 
     static let signalRecordDefinitions: [(signo: Int32, name: String)] = [
         (SIGABRT, "SIGABRT"),
@@ -45,6 +51,7 @@ final class MobileDebugLogCrashCapture {
         let fd = MobileDebugLogCrashCapture.logFileDescriptor
         let entries = MobileDebugLogCrashCapture.signalEntryPointer
         let bytes = MobileDebugLogCrashCapture.signalBytePointer
+        let previousActions = MobileDebugLogCrashCapture.previousSignalActionPointer
         let count = MobileDebugLogCrashCapture.signalEntryCount
         if fd >= 0, let entries, let bytes {
             var index: Int32 = 0
@@ -56,7 +63,14 @@ final class MobileDebugLogCrashCapture {
                         bytes.advanced(by: Int(entry.offset)),
                         Int(entry.length)
                     )
-                    break
+                    if let previousActions {
+                        var previousAction = previousActions.advanced(by: Int(index)).pointee
+                        _ = sigaction(signo, &previousAction, nil)
+                    } else {
+                        _ = Darwin.signal(signo, SIG_DFL)
+                    }
+                    _ = Darwin.raise(signo)
+                    return
                 }
                 index += 1
             }
@@ -75,6 +89,7 @@ final class MobileDebugLogCrashCapture {
         }
 
         prepareSignalRecordStorage()
+        preparePreviousSignalActionStorage()
         Self.logFileDescriptor = duplicatedDescriptor
         previousExceptionHandler = NSGetUncaughtExceptionHandler()
         NSSetUncaughtExceptionHandler(exceptionHandler)
@@ -122,6 +137,11 @@ final class MobileDebugLogCrashCapture {
         return nil
     }
 
+    static func preparedPreviousSignalActionSlotCount() -> Int {
+        preparePreviousSignalActionStorage()
+        return Int(previousSignalActionCount)
+    }
+
     private static func handleUncaughtException(_ exception: NSException) {
         let record = exceptionRecord(
             name: exception.name.rawValue,
@@ -133,12 +153,26 @@ final class MobileDebugLogCrashCapture {
     }
 
     private static func installSignalHandlers() {
-        for record in signalRecordDefinitions {
+        preparePreviousSignalActionStorage()
+        guard let previousActions = previousSignalActionPointer else {
+            return
+        }
+
+        for index in signalRecordDefinitions.indices {
+            var previousAction = sigaction()
+            _ = sigaction(signalRecordDefinitions[index].signo, nil, &previousAction)
+            previousActions.advanced(by: index).pointee = previousAction
+        }
+
+        for index in signalRecordDefinitions.indices {
+            let record = signalRecordDefinitions[index]
             var action = sigaction()
             sigemptyset(&action.sa_mask)
             action.sa_flags = 0
             action.__sigaction_u.__sa_handler = signalHandler
-            _ = sigaction(record.signo, &action, nil)
+            var previousAction = previousActions.advanced(by: index).pointee
+            _ = sigaction(record.signo, &action, &previousAction)
+            previousActions.advanced(by: index).pointee = previousAction
         }
     }
 
@@ -185,6 +219,22 @@ final class MobileDebugLogCrashCapture {
         signalBytePointer = bytes
         signalEntryPointer = entries
         signalEntryCount = Int32(signalRecordDefinitions.count)
+    }
+
+    private static func preparePreviousSignalActionStorage() {
+        guard previousSignalActionPointer == nil else {
+            return
+        }
+
+        let actions = UnsafeMutablePointer<sigaction>.allocate(
+            capacity: signalRecordDefinitions.count
+        )
+        for index in signalRecordDefinitions.indices {
+            actions.advanced(by: index).initialize(to: sigaction())
+        }
+
+        previousSignalActionPointer = actions
+        previousSignalActionCount = Int32(signalRecordDefinitions.count)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLogCrashCapture.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLogCrashCapture.swift
@@ -6,6 +6,8 @@ import Foundation
 final class MobileDebugLogCrashCapture {
     private init() {}
 
+    typealias SignalEntry = (signo: Int32, offset: Int32, length: Int32)
+
     // Written once during install before handlers can run, then read by crash
     // handlers. The macOS 14 package floor rules out Synchronization.Atomic.
     nonisolated(unsafe) private static var logFileDescriptor: Int32 = -1
@@ -18,14 +20,21 @@ final class MobileDebugLogCrashCapture {
     // this logger writes its record so existing crash handling still runs.
     nonisolated(unsafe) private static var previousExceptionHandler: NSUncaughtExceptionHandler?
 
-    static let signalRecords: [(signo: Int32, name: String, bytes: ContiguousArray<UInt8>)] = [
-        signalRecord(signo: SIGABRT, name: "SIGABRT"),
-        signalRecord(signo: SIGBUS, name: "SIGBUS"),
-        signalRecord(signo: SIGFPE, name: "SIGFPE"),
-        signalRecord(signo: SIGILL, name: "SIGILL"),
-        signalRecord(signo: SIGSEGV, name: "SIGSEGV"),
-        signalRecord(signo: SIGTRAP, name: "SIGTRAP"),
-        signalRecord(signo: SIGSYS, name: "SIGSYS"),
+    // Prepared once outside signal context, then read directly by the signal
+    // handler via pointer arithmetic. The allocations intentionally live for
+    // the process lifetime so a crash never races deallocation.
+    nonisolated(unsafe) private static var signalEntryPointer: UnsafeMutablePointer<SignalEntry>?
+    nonisolated(unsafe) private static var signalEntryCount: Int32 = 0
+    nonisolated(unsafe) private static var signalBytePointer: UnsafeMutablePointer<UInt8>?
+
+    static let signalRecordDefinitions: [(signo: Int32, name: String)] = [
+        (SIGABRT, "SIGABRT"),
+        (SIGBUS, "SIGBUS"),
+        (SIGFPE, "SIGFPE"),
+        (SIGILL, "SIGILL"),
+        (SIGSEGV, "SIGSEGV"),
+        (SIGTRAP, "SIGTRAP"),
+        (SIGSYS, "SIGSYS"),
     ]
 
     private static let exceptionHandler: @convention(c) (NSException) -> Void = { exception in
@@ -34,14 +43,22 @@ final class MobileDebugLogCrashCapture {
 
     private static let signalHandler: @convention(c) (Int32) -> Void = { signo in
         let fd = MobileDebugLogCrashCapture.logFileDescriptor
-        if fd >= 0 {
-            for record in MobileDebugLogCrashCapture.signalRecords where record.signo == signo {
-                record.bytes.withUnsafeBufferPointer { buffer in
-                    if let baseAddress = buffer.baseAddress {
-                        _ = Darwin.write(fd, baseAddress, buffer.count)
-                    }
+        let entries = MobileDebugLogCrashCapture.signalEntryPointer
+        let bytes = MobileDebugLogCrashCapture.signalBytePointer
+        let count = MobileDebugLogCrashCapture.signalEntryCount
+        if fd >= 0, let entries, let bytes {
+            var index: Int32 = 0
+            while index < count {
+                let entry = entries.advanced(by: Int(index)).pointee
+                if entry.signo == signo {
+                    _ = Darwin.write(
+                        fd,
+                        bytes.advanced(by: Int(entry.offset)),
+                        Int(entry.length)
+                    )
+                    break
                 }
-                break
+                index += 1
             }
         }
         _ = Darwin.signal(signo, SIG_DFL)
@@ -57,7 +74,7 @@ final class MobileDebugLogCrashCapture {
             return
         }
 
-        _ = signalRecords.count
+        prepareSignalRecordStorage()
         Self.logFileDescriptor = duplicatedDescriptor
         previousExceptionHandler = NSGetUncaughtExceptionHandler()
         NSSetUncaughtExceptionHandler(exceptionHandler)
@@ -65,10 +82,44 @@ final class MobileDebugLogCrashCapture {
         installed = true
     }
 
+    static func updateLogFileDescriptor(_ fileDescriptor: Int32) {
+        let duplicatedDescriptor = Darwin.dup(fileDescriptor)
+        guard duplicatedDescriptor >= 0 else {
+            return
+        }
+        let previousDescriptor = logFileDescriptor
+        logFileDescriptor = duplicatedDescriptor
+        if previousDescriptor >= 0 {
+            _ = Darwin.close(previousDescriptor)
+        }
+    }
+
     static func exceptionRecord(name: String, reason: String, stack: [String]) -> String {
         var lines = ["CRASH uncaught-exception name=\(name) reason=\(reason)"]
         lines.append(contentsOf: stack.map { "  \($0)" })
         return lines.joined(separator: "\n") + "\n"
+    }
+
+    static func renderedSignalRecord(signo: Int32, name: String) -> String {
+        "CRASH signal=\(signo) name=\(name)\n"
+    }
+
+    static func installedSignalRecordBytes(for signo: Int32) -> [UInt8]? {
+        prepareSignalRecordStorage()
+        guard let entries = signalEntryPointer, let bytes = signalBytePointer else {
+            return nil
+        }
+        var index: Int32 = 0
+        while index < signalEntryCount {
+            let entry = entries.advanced(by: Int(index)).pointee
+            if entry.signo == signo {
+                let start = bytes.advanced(by: Int(entry.offset))
+                let buffer = UnsafeBufferPointer(start: start, count: Int(entry.length))
+                return Array(buffer)
+            }
+            index += 1
+        }
+        return nil
     }
 
     private static func handleUncaughtException(_ exception: NSException) {
@@ -82,7 +133,7 @@ final class MobileDebugLogCrashCapture {
     }
 
     private static func installSignalHandlers() {
-        for record in signalRecords {
+        for record in signalRecordDefinitions {
             var action = sigaction()
             sigemptyset(&action.sa_mask)
             action.sa_flags = 0
@@ -104,12 +155,36 @@ final class MobileDebugLogCrashCapture {
         }
     }
 
-    private static func signalRecord(
-        signo: Int32,
-        name: String
-    ) -> (signo: Int32, name: String, bytes: ContiguousArray<UInt8>) {
-        let line = "CRASH signal=\(signo) name=\(name)\n"
-        return (signo: signo, name: name, bytes: ContiguousArray(line.utf8))
+    private static func prepareSignalRecordStorage() {
+        guard signalEntryPointer == nil, signalBytePointer == nil else {
+            return
+        }
+
+        let renderedRecords = signalRecordDefinitions.map {
+            Array(renderedSignalRecord(signo: $0.signo, name: $0.name).utf8)
+        }
+        let byteCount = renderedRecords.reduce(0) { $0 + $1.count }
+        let entries = UnsafeMutablePointer<SignalEntry>.allocate(
+            capacity: signalRecordDefinitions.count
+        )
+        let bytes = UnsafeMutablePointer<UInt8>.allocate(capacity: byteCount)
+
+        var offset = 0
+        for index in signalRecordDefinitions.indices {
+            let recordBytes = renderedRecords[index]
+            let entry = signalRecordDefinitions[index]
+            bytes.advanced(by: offset).initialize(from: recordBytes, count: recordBytes.count)
+            entries.advanced(by: index).initialize(to: (
+                signo: entry.signo,
+                offset: Int32(offset),
+                length: Int32(recordBytes.count)
+            ))
+            offset += recordBytes.count
+        }
+
+        signalBytePointer = bytes
+        signalEntryPointer = entries
+        signalEntryCount = Int32(signalRecordDefinitions.count)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLogCrashCapture.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLogCrashCapture.swift
@@ -1,0 +1,115 @@
+#if DEBUG
+import Darwin
+import Foundation
+
+/// Crash-time writer for the DEBUG iOS durable debug log.
+final class MobileDebugLogCrashCapture {
+    private init() {}
+
+    // Written once during install before handlers can run, then read by crash
+    // handlers. The macOS 14 package floor rules out Synchronization.Atomic.
+    nonisolated(unsafe) private static var logFileDescriptor: Int32 = -1
+
+    // Install runs during debug-log setup and is not called concurrently.
+    // Keeping this nonisolated avoids locks in the crash-capture path.
+    nonisolated(unsafe) private static var installed = false
+
+    // Captured before replacing the uncaught-exception handler; invoked after
+    // this logger writes its record so existing crash handling still runs.
+    nonisolated(unsafe) private static var previousExceptionHandler: NSUncaughtExceptionHandler?
+
+    static let signalRecords: [(signo: Int32, name: String, bytes: ContiguousArray<UInt8>)] = [
+        signalRecord(signo: SIGABRT, name: "SIGABRT"),
+        signalRecord(signo: SIGBUS, name: "SIGBUS"),
+        signalRecord(signo: SIGFPE, name: "SIGFPE"),
+        signalRecord(signo: SIGILL, name: "SIGILL"),
+        signalRecord(signo: SIGSEGV, name: "SIGSEGV"),
+        signalRecord(signo: SIGTRAP, name: "SIGTRAP"),
+        signalRecord(signo: SIGSYS, name: "SIGSYS"),
+    ]
+
+    private static let exceptionHandler: @convention(c) (NSException) -> Void = { exception in
+        MobileDebugLogCrashCapture.handleUncaughtException(exception)
+    }
+
+    private static let signalHandler: @convention(c) (Int32) -> Void = { signo in
+        let fd = MobileDebugLogCrashCapture.logFileDescriptor
+        if fd >= 0 {
+            for record in MobileDebugLogCrashCapture.signalRecords where record.signo == signo {
+                record.bytes.withUnsafeBufferPointer { buffer in
+                    if let baseAddress = buffer.baseAddress {
+                        _ = Darwin.write(fd, baseAddress, buffer.count)
+                    }
+                }
+                break
+            }
+        }
+        _ = Darwin.signal(signo, SIG_DFL)
+        _ = Darwin.raise(signo)
+    }
+
+    static func install(logFileDescriptor: Int32) {
+        guard !installed else {
+            return
+        }
+        let duplicatedDescriptor = Darwin.dup(logFileDescriptor)
+        guard duplicatedDescriptor >= 0 else {
+            return
+        }
+
+        _ = signalRecords.count
+        Self.logFileDescriptor = duplicatedDescriptor
+        previousExceptionHandler = NSGetUncaughtExceptionHandler()
+        NSSetUncaughtExceptionHandler(exceptionHandler)
+        installSignalHandlers()
+        installed = true
+    }
+
+    static func exceptionRecord(name: String, reason: String, stack: [String]) -> String {
+        var lines = ["CRASH uncaught-exception name=\(name) reason=\(reason)"]
+        lines.append(contentsOf: stack.map { "  \($0)" })
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func handleUncaughtException(_ exception: NSException) {
+        let record = exceptionRecord(
+            name: exception.name.rawValue,
+            reason: exception.reason ?? "",
+            stack: exception.callStackSymbols
+        )
+        writeCrashRecord(record)
+        previousExceptionHandler?(exception)
+    }
+
+    private static func installSignalHandlers() {
+        for record in signalRecords {
+            var action = sigaction()
+            sigemptyset(&action.sa_mask)
+            action.sa_flags = 0
+            action.__sigaction_u.__sa_handler = signalHandler
+            _ = sigaction(record.signo, &action, nil)
+        }
+    }
+
+    private static func writeCrashRecord(_ record: String) {
+        let fd = logFileDescriptor
+        guard fd >= 0 else {
+            return
+        }
+        let bytes = Array(record.utf8)
+        bytes.withUnsafeBufferPointer { buffer in
+            if let baseAddress = buffer.baseAddress {
+                _ = Darwin.write(fd, baseAddress, buffer.count)
+            }
+        }
+    }
+
+    private static func signalRecord(
+        signo: Int32,
+        name: String
+    ) -> (signo: Int32, name: String, bytes: ContiguousArray<UInt8>) {
+        let line = "CRASH signal=\(signo) name=\(name)\n"
+        return (signo: signo, name: name, bytes: ContiguousArray(line.utf8))
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLogSink.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLogSink.swift
@@ -14,6 +14,8 @@ public actor MobileDebugLogSink {
     private let startedAt: Date
     private let now: @Sendable () -> Date
     private var continuations: [UUID: AsyncStream<String>.Continuation] = [:]
+    private var fileHandle: FileHandle?
+    private var fileLoggingEnabled: Bool
 
     /// Create a sink.
     ///
@@ -22,16 +24,50 @@ public actor MobileDebugLogSink {
     ///     once the buffer grows past this. Defaults to `4000`.
     ///   - now: Clock used to timestamp lines and anchor the elapsed offset.
     ///     Injected so tests can pin time; defaults to `Date.init`.
-    public init(capacity: Int = 4000, now: @escaping @Sendable () -> Date = { Date() }) {
+    ///   - fileURL: Optional on-disk log location. When non-`nil`, an existing
+    ///     file is rotated to `<path>.1`, a fresh file is opened, and each
+    ///     appended line is written immediately. File failures disable only file
+    ///     logging for this sink.
+    ///   - fileHeader: Optional first line written to a newly opened log file.
+    ///   - installCrashCapture: When `true`, DEBUG builds install crash handlers
+    ///     against the opened file descriptor. Defaults to `false` so tests and
+    ///     custom sinks do not mutate process-wide handler state.
+    public init(
+        capacity: Int = 4000,
+        now: @escaping @Sendable () -> Date = { Date() },
+        fileURL: URL? = nil,
+        fileHeader: String? = nil,
+        installCrashCapture: Bool = false
+    ) {
         self.capacity = capacity
         self.now = now
         self.startedAt = now()
+        if let fileURL, let fileHandle = Self.openLogFile(at: fileURL, header: fileHeader) {
+            self.fileHandle = fileHandle
+            self.fileLoggingEnabled = true
+            #if DEBUG
+            if installCrashCapture {
+                MobileDebugLogCrashCapture.install(logFileDescriptor: fileHandle.fileDescriptor)
+            }
+            #endif
+        } else {
+            self.fileHandle = nil
+            self.fileLoggingEnabled = false
+        }
+    }
+
+    deinit {
+        if let fileHandle {
+            try? fileHandle.close()
+        }
     }
 
     /// Append one timestamped line (seconds elapsed since the sink was created).
     ///
     /// The line is broadcast to every active ``lines()`` subscriber and stored
-    /// in the ring buffer, evicting the oldest entries past the capacity.
+    /// in the ring buffer, evicting the oldest entries past the capacity. When
+    /// file logging is configured, the same line is also appended to disk before
+    /// this method returns.
     public func append(_ message: String) {
         let elapsed = String(format: "%9.3f", now().timeIntervalSince(startedAt))
         let line = "[\(elapsed)] \(message)"
@@ -42,6 +78,7 @@ public actor MobileDebugLogSink {
         for continuation in continuations.values {
             continuation.yield(line)
         }
+        appendToFile(line)
     }
 
     /// The full buffer as newline-joined text, newest last.
@@ -58,6 +95,9 @@ public actor MobileDebugLogSink {
     }
 
     /// Remove every buffered line, keeping the allocated capacity.
+    ///
+    /// This clears only the in-memory buffer. A configured file log is the
+    /// durable record for crash diagnosis and is not truncated.
     public func clear() {
         buffer.removeAll(keepingCapacity: true)
     }
@@ -79,5 +119,52 @@ public actor MobileDebugLogSink {
 
     private func removeContinuation(_ id: UUID) {
         continuations[id] = nil
+    }
+
+    private static func openLogFile(at fileURL: URL, header: String?) -> FileHandle? {
+        let fileManager = FileManager.default
+        let rotatedURL = URL(fileURLWithPath: fileURL.path + ".1")
+        do {
+            if fileManager.fileExists(atPath: fileURL.path) {
+                if fileManager.fileExists(atPath: rotatedURL.path) {
+                    try fileManager.removeItem(at: rotatedURL)
+                }
+                try fileManager.moveItem(at: fileURL, to: rotatedURL)
+            }
+            guard fileManager.createFile(atPath: fileURL.path, contents: nil) else {
+                return nil
+            }
+            let fileHandle = try FileHandle(forWritingTo: fileURL)
+            if let header {
+                try fileHandle.write(contentsOf: Data("\(header)\n".utf8))
+            }
+            return fileHandle
+        } catch {
+            return nil
+        }
+    }
+
+    private func appendToFile(_ line: String) {
+        guard fileLoggingEnabled, let fileHandle else {
+            return
+        }
+        do {
+            try fileHandle.write(contentsOf: Data("\(line)\n".utf8))
+        } catch {
+            disableFileLogging()
+        }
+    }
+
+    private func disableFileLogging() {
+        fileLoggingEnabled = false
+        closeFileHandle()
+    }
+
+    private func closeFileHandle() {
+        guard let fileHandle else {
+            return
+        }
+        try? fileHandle.close()
+        self.fileHandle = nil
     }
 }

--- a/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLogSink.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLogSink.swift
@@ -14,8 +14,13 @@ public actor MobileDebugLogSink {
     private let startedAt: Date
     private let now: @Sendable () -> Date
     private var continuations: [UUID: AsyncStream<String>.Continuation] = [:]
+    private let fileURL: URL?
+    private let fileHeader: String?
+    private let maxFileBytes: Int
     private var fileHandle: FileHandle?
     private var fileLoggingEnabled: Bool
+    private var fileBytesWritten: Int
+    private var crashCaptureInstalled: Bool
 
     /// Create a sink.
     ///
@@ -29,6 +34,10 @@ public actor MobileDebugLogSink {
     ///     appended line is written immediately. File failures disable only file
     ///     logging for this sink.
     ///   - fileHeader: Optional first line written to a newly opened log file.
+    ///   - maxFileBytes: Maximum approximate size of the active log generation.
+    ///     When appending a line would exceed this limit, the current file is
+    ///     rotated to `<path>.1`, a fresh file is opened, and the line is written
+    ///     to the new generation. Defaults to `5_000_000`.
     ///   - installCrashCapture: When `true`, DEBUG builds install crash handlers
     ///     against the opened file descriptor. Defaults to `false` so tests and
     ///     custom sinks do not mutate process-wide handler state.
@@ -37,17 +46,27 @@ public actor MobileDebugLogSink {
         now: @escaping @Sendable () -> Date = { Date() },
         fileURL: URL? = nil,
         fileHeader: String? = nil,
+        maxFileBytes: Int = 5_000_000,
         installCrashCapture: Bool = false
     ) {
         self.capacity = capacity
         self.now = now
         self.startedAt = now()
-        if let fileURL, let fileHandle = Self.openLogFile(at: fileURL, header: fileHeader) {
-            self.fileHandle = fileHandle
+        self.fileURL = fileURL
+        self.fileHeader = fileHeader
+        self.maxFileBytes = maxFileBytes
+        self.fileBytesWritten = 0
+        self.crashCaptureInstalled = false
+        if let fileURL, let openedLogFile = Self.openLogFile(at: fileURL, header: fileHeader) {
+            self.fileHandle = openedLogFile.fileHandle
             self.fileLoggingEnabled = true
+            self.fileBytesWritten = openedLogFile.byteCount
             #if DEBUG
             if installCrashCapture {
-                MobileDebugLogCrashCapture.install(logFileDescriptor: fileHandle.fileDescriptor)
+                MobileDebugLogCrashCapture.install(
+                    logFileDescriptor: openedLogFile.fileHandle.fileDescriptor
+                )
+                self.crashCaptureInstalled = true
             }
             #endif
         } else {
@@ -121,38 +140,81 @@ public actor MobileDebugLogSink {
         continuations[id] = nil
     }
 
-    private static func openLogFile(at fileURL: URL, header: String?) -> FileHandle? {
+    private static func openLogFile(
+        at fileURL: URL,
+        header: String?
+    ) -> (fileHandle: FileHandle, byteCount: Int)? {
         let fileManager = FileManager.default
-        let rotatedURL = URL(fileURLWithPath: fileURL.path + ".1")
         do {
-            if fileManager.fileExists(atPath: fileURL.path) {
-                if fileManager.fileExists(atPath: rotatedURL.path) {
-                    try fileManager.removeItem(at: rotatedURL)
-                }
-                try fileManager.moveItem(at: fileURL, to: rotatedURL)
-            }
+            try rotateExistingLog(at: fileURL, fileManager: fileManager)
             guard fileManager.createFile(atPath: fileURL.path, contents: nil) else {
                 return nil
             }
             let fileHandle = try FileHandle(forWritingTo: fileURL)
+            var byteCount = 0
             if let header {
-                try fileHandle.write(contentsOf: Data("\(header)\n".utf8))
+                let headerData = Data("\(header)\n".utf8)
+                try fileHandle.write(contentsOf: headerData)
+                byteCount = headerData.count
             }
-            return fileHandle
+            return (fileHandle: fileHandle, byteCount: byteCount)
         } catch {
             return nil
         }
     }
 
+    private static func rotateExistingLog(at fileURL: URL, fileManager: FileManager) throws {
+        let rotatedURL = URL(fileURLWithPath: fileURL.path + ".1")
+        if fileManager.fileExists(atPath: fileURL.path) {
+            if fileManager.fileExists(atPath: rotatedURL.path) {
+                try fileManager.removeItem(at: rotatedURL)
+            }
+            try fileManager.moveItem(at: fileURL, to: rotatedURL)
+        }
+    }
+
     private func appendToFile(_ line: String) {
-        guard fileLoggingEnabled, let fileHandle else {
+        guard fileLoggingEnabled else {
+            return
+        }
+        let lineData = Data("\(line)\n".utf8)
+        if fileBytesWritten + lineData.count > maxFileBytes, !rotateLogFile() {
+            disableFileLogging()
+            return
+        }
+        guard let fileHandle else {
+            disableFileLogging()
             return
         }
         do {
-            try fileHandle.write(contentsOf: Data("\(line)\n".utf8))
+            try fileHandle.write(contentsOf: lineData)
+            fileBytesWritten += lineData.count
         } catch {
             disableFileLogging()
         }
+    }
+
+    private func rotateLogFile() -> Bool {
+        guard let fileURL else {
+            return false
+        }
+        closeFileHandle()
+        guard let openedLogFile = Self.openLogFile(at: fileURL, header: fileHeader) else {
+            return false
+        }
+        fileHandle = openedLogFile.fileHandle
+        fileBytesWritten = openedLogFile.byteCount
+        fileLoggingEnabled = true
+        #if DEBUG
+        if crashCaptureInstalled {
+            // A crash exactly during rotation may write into the just-rotated
+            // generation via the previous dup'd fd; that file still survives.
+            MobileDebugLogCrashCapture.updateLogFileDescriptor(
+                openedLogFile.fileHandle.fileDescriptor
+            )
+        }
+        #endif
+        return true
     }
 
     private func disableFileLogging() {

--- a/Packages/iOS/CmuxMobileDiagnostics/Tests/CmuxMobileDiagnosticsTests/MobileDebugLogCrashCaptureTests.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Tests/CmuxMobileDiagnosticsTests/MobileDebugLogCrashCaptureTests.swift
@@ -1,0 +1,50 @@
+#if DEBUG
+import Darwin
+import Foundation
+import Testing
+@testable import CmuxMobileDiagnostics
+
+@Suite struct MobileDebugLogCrashCaptureTests {
+    @Test func exceptionRecordFormatsCrashAndStackFrames() {
+        let record = MobileDebugLogCrashCapture.exceptionRecord(
+            name: "ExampleException",
+            reason: "example reason",
+            stack: [
+                "0   cmux  first",
+                "1   cmux  second",
+            ]
+        )
+
+        #expect(record == """
+        CRASH uncaught-exception name=ExampleException reason=example reason
+          0   cmux  first
+          1   cmux  second
+
+        """)
+    }
+
+    @Test func signalRecordsContainExpectedPreRenderedLines() throws {
+        let records = MobileDebugLogCrashCapture.signalRecords
+        let expected: [(signo: Int32, name: String)] = [
+            (SIGABRT, "SIGABRT"),
+            (SIGBUS, "SIGBUS"),
+            (SIGFPE, "SIGFPE"),
+            (SIGILL, "SIGILL"),
+            (SIGSEGV, "SIGSEGV"),
+            (SIGTRAP, "SIGTRAP"),
+            (SIGSYS, "SIGSYS"),
+        ]
+
+        #expect(records.count == expected.count)
+        #expect(Set(records.map(\.signo)).count == expected.count)
+
+        for expectedRecord in expected {
+            let record = try #require(records.first { $0.signo == expectedRecord.signo })
+            #expect(record.name == expectedRecord.name)
+            let line = String(decoding: record.bytes, as: UTF8.self)
+            #expect(line == "CRASH signal=\(expectedRecord.signo) name=\(expectedRecord.name)\n")
+            #expect(line.hasSuffix("\n"))
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileDiagnostics/Tests/CmuxMobileDiagnosticsTests/MobileDebugLogCrashCaptureTests.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Tests/CmuxMobileDiagnosticsTests/MobileDebugLogCrashCaptureTests.swift
@@ -55,5 +55,12 @@ import Testing
             #expect(line.hasSuffix("\n"))
         }
     }
+
+    @Test func previousSignalActionStorageHasOneSlotPerSignal() {
+        #expect(
+            MobileDebugLogCrashCapture.preparedPreviousSignalActionSlotCount()
+                == MobileDebugLogCrashCapture.signalRecordDefinitions.count
+        )
+    }
 }
 #endif

--- a/Packages/iOS/CmuxMobileDiagnostics/Tests/CmuxMobileDiagnosticsTests/MobileDebugLogCrashCaptureTests.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Tests/CmuxMobileDiagnosticsTests/MobileDebugLogCrashCaptureTests.swift
@@ -24,7 +24,7 @@ import Testing
     }
 
     @Test func signalRecordsContainExpectedPreRenderedLines() throws {
-        let records = MobileDebugLogCrashCapture.signalRecords
+        let records = MobileDebugLogCrashCapture.signalRecordDefinitions
         let expected: [(signo: Int32, name: String)] = [
             (SIGABRT, "SIGABRT"),
             (SIGBUS, "SIGBUS"),
@@ -41,8 +41,17 @@ import Testing
         for expectedRecord in expected {
             let record = try #require(records.first { $0.signo == expectedRecord.signo })
             #expect(record.name == expectedRecord.name)
-            let line = String(decoding: record.bytes, as: UTF8.self)
-            #expect(line == "CRASH signal=\(expectedRecord.signo) name=\(expectedRecord.name)\n")
+            let expectedLine = MobileDebugLogCrashCapture.renderedSignalRecord(
+                signo: expectedRecord.signo,
+                name: expectedRecord.name
+            )
+            let bytes = try #require(
+                MobileDebugLogCrashCapture.installedSignalRecordBytes(
+                    for: expectedRecord.signo
+                )
+            )
+            let line = String(decoding: bytes, as: UTF8.self)
+            #expect(line == expectedLine)
             #expect(line.hasSuffix("\n"))
         }
     }

--- a/Packages/iOS/CmuxMobileDiagnostics/Tests/CmuxMobileDiagnosticsTests/MobileDebugLogFileTests.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Tests/CmuxMobileDiagnosticsTests/MobileDebugLogFileTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Testing
+@testable import CmuxMobileDiagnostics
+
+@Suite struct MobileDebugLogFileTests {
+    @Test func writesHeaderAndAppendedLinesImmediately() async throws {
+        let logURL = makeLogURL()
+        defer { removeLogFiles(at: logURL) }
+        try FileManager.default.createDirectory(
+            at: logURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let clock = DateSequence([
+            Date(timeIntervalSince1970: 100),
+            Date(timeIntervalSince1970: 101.25),
+            Date(timeIntervalSince1970: 103.5),
+        ])
+        let sink = MobileDebugLogSink(
+            now: { clock.next() },
+            fileURL: logURL,
+            fileHeader: "h"
+        )
+
+        await sink.append("one")
+        await sink.append("two")
+
+        let contents = try String(contentsOf: logURL, encoding: .utf8)
+        #expect(contents == """
+        h
+        [    1.250] one
+        [    3.500] two
+
+        """)
+    }
+
+    @Test func rotatesExistingLogAndReplacesPreviousRotation() async throws {
+        let logURL = makeLogURL()
+        let rotatedURL = rotatedLogURL(for: logURL)
+        defer { removeLogFiles(at: logURL) }
+        try FileManager.default.createDirectory(
+            at: logURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "old\n".write(to: logURL, atomically: true, encoding: .utf8)
+        try "stale rotation\n".write(to: rotatedURL, atomically: true, encoding: .utf8)
+
+        let clock = DateSequence([
+            Date(timeIntervalSince1970: 10),
+            Date(timeIntervalSince1970: 11),
+        ])
+        let sink = MobileDebugLogSink(
+            now: { clock.next() },
+            fileURL: logURL,
+            fileHeader: "new"
+        )
+        await sink.append("fresh")
+
+        let current = try String(contentsOf: logURL, encoding: .utf8)
+        let rotated = try String(contentsOf: rotatedURL, encoding: .utf8)
+        #expect(current == """
+        new
+        [    1.000] fresh
+
+        """)
+        #expect(rotated == "old\n")
+    }
+
+    @Test func missingDirectoryDisablesFileWritesButKeepsBuffering() async {
+        let logURL = makeLogURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("missing")
+            .appendingPathComponent("cmux-debug.log")
+        defer { removeLogFiles(at: logURL.deletingLastPathComponent()) }
+
+        let sink = MobileDebugLogSink(fileURL: logURL, fileHeader: "h")
+        await sink.append("survives")
+
+        let result = await sink.snapshotWithCount()
+        #expect(result.count == 1)
+        #expect(result.body.hasSuffix("survives"))
+        #expect(!FileManager.default.fileExists(atPath: logURL.path))
+    }
+
+    @Test func clearLeavesFileContentsIntact() async throws {
+        let logURL = makeLogURL()
+        defer { removeLogFiles(at: logURL) }
+        try FileManager.default.createDirectory(
+            at: logURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let clock = DateSequence([
+            Date(timeIntervalSince1970: 50),
+            Date(timeIntervalSince1970: 52),
+        ])
+        let sink = MobileDebugLogSink(
+            now: { clock.next() },
+            fileURL: logURL,
+            fileHeader: "h"
+        )
+        await sink.append("kept on disk")
+        await sink.clear()
+
+        let result = await sink.snapshotWithCount()
+        let contents = try String(contentsOf: logURL, encoding: .utf8)
+        #expect(result.count == 0)
+        #expect(result.body.isEmpty)
+        #expect(contents == """
+        h
+        [    2.000] kept on disk
+
+        """)
+    }
+
+    private func makeLogURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-mobile-debug-log-tests-\(UUID().uuidString)")
+            .appendingPathComponent("cmux-debug.log")
+    }
+
+    private func rotatedLogURL(for logURL: URL) -> URL {
+        URL(fileURLWithPath: logURL.path + ".1")
+    }
+
+    private func removeLogFiles(at logURL: URL) {
+        try? FileManager.default.removeItem(at: logURL.deletingLastPathComponent())
+        try? FileManager.default.removeItem(at: rotatedLogURL(for: logURL))
+    }
+
+    /// A deterministic clock that returns the supplied dates in order.
+    ///
+    /// Mutation is serialized through an `NSLock` confined to this test fixture;
+    /// it never escapes the suite and is read serially by the sink under test.
+    private final class DateSequence: @unchecked Sendable {
+        private let dates: [Date]
+        private let lock = NSLock()
+        private var index = 0
+
+        init(_ dates: [Date]) {
+            self.dates = dates
+        }
+
+        func next() -> Date {
+            lock.lock()
+            defer { lock.unlock() }
+            defer { index += 1 }
+            return dates[min(index, dates.count - 1)]
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileDiagnostics/Tests/CmuxMobileDiagnosticsTests/MobileDebugLogFileTests.swift
+++ b/Packages/iOS/CmuxMobileDiagnostics/Tests/CmuxMobileDiagnosticsTests/MobileDebugLogFileTests.swift
@@ -113,6 +113,44 @@ import Testing
         """)
     }
 
+    @Test func rotatesWhenMaxFileBytesExceededMidRun() async throws {
+        let logURL = makeLogURL()
+        let rotatedURL = rotatedLogURL(for: logURL)
+        defer { removeLogFiles(at: logURL) }
+        try FileManager.default.createDirectory(
+            at: logURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let clock = DateSequence([
+            Date(timeIntervalSince1970: 10),
+            Date(timeIntervalSince1970: 11),
+            Date(timeIntervalSince1970: 12),
+        ])
+        let sink = MobileDebugLogSink(
+            now: { clock.next() },
+            fileURL: logURL,
+            fileHeader: "h",
+            maxFileBytes: 35
+        )
+
+        await sink.append("old-1")
+        await sink.append("new-2")
+
+        let current = try String(contentsOf: logURL, encoding: .utf8)
+        let rotated = try String(contentsOf: rotatedURL, encoding: .utf8)
+        #expect(rotated == """
+        h
+        [    1.000] old-1
+
+        """)
+        #expect(current == """
+        h
+        [    2.000] new-2
+
+        """)
+    }
+
     private func makeLogURL() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-mobile-debug-log-tests-\(UUID().uuidString)")

--- a/ios/cmux/AppCompositionRoot.swift
+++ b/ios/cmux/AppCompositionRoot.swift
@@ -49,6 +49,12 @@ final class AppCompositionRoot {
         auth: MobileAuthComposition,
         reachability: any ReachabilityProviding
     ) {
+        #if DEBUG
+        // Arm the durable debug log at launch: `.shared` is lazy, and without
+        // this a run that never logs would create no file or crash capture.
+        MobileDebugLog.shared.append("app launch · composition root initialized")
+        #endif
+
         self.runtime = runtime
         self.auth = auth
         self.reachability = reachability


### PR DESCRIPTION
macOS DEBUG builds append every debug line to `/tmp/cmux-debug-<tag>.log` via `CMUXDebugLog.DebugEventLog`, so the log is tailable and survives crashes. iOS kept only a 4000-line in-memory ring (`MobileDebugLogSink`) reachable through the debug menu's pasteboard copy, so a crash or app kill lost everything. This brings iOS to parity, plus crash capture.

Commit 1: `MobileDebugLogSink` gains optional file persistence. Each appended line is written immediately through a FileHandle owned by the actor; any I/O failure silently disables file writes for the sink's lifetime. `MobileDebugLog.shared` resolves the location DEBUG-only to `Application Support/cmux-debug.log` in the app container, rotates the previous run's log to `cmux-debug.log.1` at launch (bounded to two generations, and a crashed run's log survives relaunch), NSLogs the path at startup, and adds it to the Copy Debug Logs pasteboard header. Release builds resolve no URL at compile level, so log content can never reach disk there.

Commit 2: DEBUG-only `MobileDebugLogCrashCapture` writes the crash itself as the file's last record. Uncaught NSExceptions get `CRASH uncaught-exception name=... reason=...` plus `callStackSymbols`, chaining to any previous handler. Fatal signals (SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGSEGV, SIGTRAP, SIGSYS) get an async-signal-safe last gasp: the handler only `write(2)`s a pre-rendered `CRASH signal=N name=SIGX` byte record to a `dup`'d fd and re-raises with SIG_DFL so the OS crash report is preserved. Handlers are capture-free `@convention(c)` closures; install is idempotent and opt-in (`installCrashCapture:`), wired only for the file-backed `.shared` instance so tests and other sinks never touch process-global handler state. MetricKit was deliberately not used: it delivers nothing in the simulator, reports only on next launch, and would overlap the unmerged Sentry+MetricKit work on `feat-ios-crash-telemetry`.

No redaction port from macOS: the file lives inside the sandboxed DEBUG app container and carries exactly what the pasteboard copy already exposes (macOS redacts because `/tmp` is world-readable). No UI or localized surfaces changed; localization audit: no user-facing strings added.

Verification: `swift test` in `Packages/iOS/CmuxMobileDiagnostics` (12 tests, 3 suites, green; pre-existing sink tests unmodified), `swift build -c release`, and `./scripts/lint-ios-package-conventions.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786138086&installation_id=133855650&pr_number=7652&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7652&signature=dd03faa04f78997f4151ed931db2d26cb4d376767f8245262b3b9b721fd955ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Process-wide signal and uncaught-exception handlers are installed in DEBUG for the shared sink; handlers are designed to chain and re-raise, but any crash-path bug could affect other reporters or crash behavior during development only.
> 
> **Overview**
> **DEBUG iOS builds** now mirror macOS-style durable debug logging: `MobileDebugLog.shared` wires `MobileDebugLogSink` to `Application Support/cmux-debug.log`, rotates the prior run to `cmux-debug.log.1`, and enables crash capture. **Release** still has no file URL, so nothing new is written to disk in production.
> 
> `MobileDebugLogSink` optionally mirrors each appended line to disk immediately, rotates on open and when the active file exceeds **5 MB**, and leaves the on-disk file untouched when the in-memory buffer is cleared. I/O failures turn off file logging only; the ring buffer keeps working.
> 
> New **DEBUG-only** `MobileDebugLogCrashCapture` appends crash records to the dup’d log fd: uncaught `NSException` (name, reason, stack) and fatal signals via async-signal-safe pre-rendered `write(2)`, then chains/restores prior handlers and re-raises. Install is opt-in for the file-backed `.shared` sink; rotation updates the captured fd.
> 
> `AppCompositionRoot` touches `.shared` at launch so lazy init runs early. Copy Debug Logs pasteboard header includes the log file path when present. Tests cover file rotation, writes, clear behavior, and crash record formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2367239468cc5da0951572dc7c775b6c495aea84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist iOS debug logs to a file in DEBUG builds, capture crashes, and initialize at app launch so early crashes are recorded. Logs survive crashes and relaunches, are capped at 5 MB with mid-run rotation, and Release builds stay memory-only.

- New Features
  - DEBUG-only file log at Application Support/cmux-debug.log; previous run rotates to cmux-debug.log.1. Each line writes immediately; the active file is capped at 5 MB and rotates mid-session.
  - Crash capture: uncaught exceptions and fatal signals (SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGSEGV, SIGTRAP, SIGSYS). Signal handler is async-signal-safe with pre-rendered bytes, restores the prior sigaction then re-raises so OS and earlier handlers still run, and re-dups the fd on rotation so crashes land in the current file.
  - App launch arms logging and crash capture by touching `MobileDebugLog.shared` in `AppCompositionRoot` (DEBUG only) so early crashes are captured.
  - Log file path is NSLogged at startup and included in the Copy Debug Logs header; tests cover rotation (at launch and mid-run), immediate writes, clear behavior, crash record formatting, and chaining of previous signal handlers.

<sup>Written for commit 2367239468cc5da0951572dc7c775b6c495aea84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable in-app debug logging that persists to an on-disk file in debug builds (with size-limited rotation).
  * Added optional debug crash capture for uncaught exceptions and common fatal signals alongside debug logs.
  * Copy-to-pasteboard diagnostic output now includes the saved log file path when available.
* **Bug Fixes**
  * Rotated log files are replaced correctly (including mid-run rotation by size).
  * If disk logging can’t be enabled, logging continues in-memory without interruption.
  * Clearing only affects the buffered view and no longer truncates the saved file.
* **Tests**
  * Added coverage for file logging, rotation, crash record rendering, and signal handling.
* **Chores**
  * In debug builds, an app launch/composition-root message is appended to the shared debug log.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->