### PR TITLE
mux: publish cmux-mux release artifacts for linux and darwin

### DIFF
--- a/.github/workflows/mux-artifacts.yml
+++ b/.github/workflows/mux-artifacts.yml
@@ -1,0 +1,179 @@
+name: mux-artifacts
+
+# Builds release cmux-mux (the Rust TUI multiplexer) binaries for every
+# supported platform and publishes them to the cmux-binaries R2 bucket
+# (public at https://files.cmux.com/mux/...). Cloud VM snapshot builders and
+# install scripts download these instead of compiling from source.
+#
+# Layout in R2:
+#   mux/<commit-sha>/cmux-mux-<os>-<arch>   immutable, commit-addressed
+#   mux/<commit-sha>/manifest.json
+#   mux/latest/cmux-mux-<os>-<arch>         rolling, main pushes only
+#   mux/latest/manifest.json
+#
+# Asset names use uname-style os/arch (linux-x86_64, linux-aarch64,
+# darwin-arm64, darwin-x86_64) so install scripts can construct the URL from
+# `uname -s`/`uname -m` directly.
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - "mux/**"
+      - "ghostty"
+      - ".github/workflows/mux-artifacts.yml"
+      - "scripts/install-zig-ci.sh"
+  pull_request:
+    paths:
+      - ".github/workflows/mux-artifacts.yml"
+
+concurrency:
+  group: mux-artifacts-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-24.04
+            target: ""
+          - platform: linux-aarch64
+            runner: ubuntu-24.04-arm
+            target: ""
+          - platform: darwin-arm64
+            runner: macos-15
+            target: ""
+          - platform: darwin-x86_64
+            runner: macos-15
+            target: x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev pkg-config
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Install rust
+        run: |
+          rustc --version || true
+          if ! command -v cargo >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+          if [ -n "${{ matrix.target }}" ]; then
+            rustup target add "${{ matrix.target }}"
+          fi
+
+      - name: Build cmux-mux (release)
+        working-directory: mux
+        env:
+          CARGO_PROFILE_RELEASE_STRIP: symbols
+          CMUX_MUX_BUILD_COMMIT: ${{ github.sha }}
+        run: |
+          if [ -n "${{ matrix.target }}" ]; then
+            cargo build -p mux-tui --release --locked --target "${{ matrix.target }}"
+            BIN="target/${{ matrix.target }}/release/cmux-mux"
+          else
+            cargo build -p mux-tui --release --locked
+            BIN="target/release/cmux-mux"
+          fi
+          mkdir -p dist
+          cp "$BIN" "dist/cmux-mux-${{ matrix.platform }}"
+
+      - name: Smoke test
+        working-directory: mux
+        run: |
+          # Cross-built darwin-x86_64 runs on the arm64 runner via Rosetta.
+          ./dist/cmux-mux-${{ matrix.platform }} --version
+          ./dist/cmux-mux-${{ matrix.platform }} --help
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cmux-mux-${{ matrix.platform }}
+          path: mux/dist/cmux-mux-${{ matrix.platform }}
+          if-no-files-found: error
+
+  publish:
+    name: publish to R2
+    # PR runs of this workflow only validate the build matrix; publishing is
+    # main-push or manual dispatch.
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: assets
+          merge-multiple: true
+
+      - name: Build manifest and checksums
+        run: |
+          cd assets
+          chmod 0755 cmux-mux-*
+          sha256sum cmux-mux-* > cmux-mux-checksums.txt
+          python3 - "$GITHUB_SHA" <<'PY'
+          import hashlib, json, os, sys
+          from datetime import datetime, timezone
+          files = sorted(f for f in os.listdir(".") if f.startswith("cmux-mux-") and not f.endswith(".txt"))
+          manifest = {
+              "commit": sys.argv[1],
+              "builtAt": datetime.now(timezone.utc).isoformat(),
+              "binaries": {
+                  f: hashlib.sha256(open(f, "rb").read()).hexdigest() for f in files
+              },
+          }
+          with open("manifest.json", "w") as out:
+              json.dump(manifest, out, indent=2)
+          print(json.dumps(manifest, indent=2))
+          PY
+
+      - name: Upload to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+        run: |
+          set -euo pipefail
+          publish_prefix() {
+            local prefix="$1"
+            local cache="$2"
+            for file in assets/cmux-mux-* assets/manifest.json; do
+              python3 scripts/ci/upload-r2-object.py \
+                --file "$file" \
+                --endpoint-url "$R2_ENDPOINT" \
+                --bucket cmux-binaries \
+                --key "$prefix/$(basename "$file")" \
+                --cache-control "$cache"
+            done
+          }
+          publish_prefix "mux/$GITHUB_SHA" "public, max-age=31536000, immutable"
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            publish_prefix "mux/latest" "no-cache, no-store, must-revalidate"
+          fi
+          echo "Published: https://files.cmux.com/mux/$GITHUB_SHA/manifest.json"

--- a/.github/workflows/mux-artifacts.yml
+++ b/.github/workflows/mux-artifacts.yml
@@ -119,7 +119,7 @@ jobs:
     # main-push or manual dispatch.
     if: github.event_name != 'pull_request'
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/mux/crates/ghostty-vt-sys/build.rs
+++ b/mux/crates/ghostty-vt-sys/build.rs
@@ -90,6 +90,10 @@ fn zig_target_for_rust_target(target: &str) -> Option<&'static str> {
         "x86_64-pc-windows-gnu" => Some("x86_64-windows-gnu"),
         "x86_64-pc-windows-msvc" => Some("x86_64-windows-msvc"),
         "aarch64-pc-windows-msvc" => Some("aarch64-windows-msvc"),
+        "x86_64-apple-darwin" => Some("x86_64-macos"),
+        "aarch64-apple-darwin" => Some("aarch64-macos"),
+        "x86_64-unknown-linux-gnu" => Some("x86_64-linux-gnu"),
+        "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
         _ => None,
     }
 }

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -54,6 +54,7 @@ OPTIONS:
   --headless         Run only the control socket, no TUI.
   --term <value>     TERM for child shells (default: xterm-256color).
   -h, --help         Show this help.
+  -V, --version      Print the cmux-mux version.
 
 KEYS (prefix: Ctrl-b)
   c  new tab in pane   B    new browser tab    n/p  next/prev tab
@@ -124,10 +125,23 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
                 print!("{USAGE}");
                 std::process::exit(0);
             }
+            "-V" | "--version" => {
+                println!("cmux-mux {}", version_string());
+                std::process::exit(0);
+            }
             other => usage_exit(&format!("unknown argument {other:?}")),
         }
     }
     out
+}
+
+fn version_string() -> String {
+    // CI artifact builds stamp the commit so binaries in cloud snapshots are
+    // traceable back to a cmux revision; local builds report the crate version.
+    match option_env!("CMUX_MUX_BUILD_COMMIT") {
+        Some(commit) => format!("{} ({commit})", env!("CARGO_PKG_VERSION")),
+        None => env!("CARGO_PKG_VERSION").to_string(),
+    }
 }
 
 fn main() {


### PR DESCRIPTION
Publishes raw `cmux-mux` binaries to the `cmux-binaries` R2 bucket so cloud VM snapshot builders and install scripts can curl a binary directly, without npm or PyPI. Binary building reuses the `tui-build-package.yml` reusable workflow from the npx/uvx distribution lane (https://github.com/manaflow-ai/cmux/pull/7651), so there is exactly one build path for cmux-mux binaries; this workflow only adds the raw-binary publish.

R2 layout: `mux/<commit-sha>/cmux-mux-<rust-target>` + `manifest.json` (immutable, commit-addressed) and `mux/latest/...` (rolling, main pushes only). Public URLs are `https://files.cmux.com/mux/...`, same bucket and upload helper as the appcast. Triggers: main pushes touching `mux/`/`ghostty` and manual dispatch; the `pull_request` trigger only validates the build.

Supporting changes: `cmux-mux` gets `-V`/`--version` printing the crate version plus a commit stamped via `CMUX_MUX_BUILD_COMMIT` in the shared build steps, so binaries in cloud snapshots and npm/PyPI packages are traceable to a cmux revision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces automated public binary publishing to R2 using existing upload secrets; runtime mux changes are limited to a new version flag and compile-time commit stamping.
> 
> **Overview**
> Adds a **`mux-artifacts`** GitHub Actions workflow that reuses **`tui-build-package.yml`** for release **`cmux-mux`** builds (npm/PyPI packaging disabled) and uploads binaries plus a **`manifest.json`** (per-file sha256) to the **`cmux-binaries`** R2 bucket at **`mux/<sha>/`** (immutable) and **`mux/latest/`** on main only. PR runs build-only; publish runs on main push or manual dispatch.
> 
> CI release builds now set **`CMUX_MUX_BUILD_COMMIT`** so **`cmux-mux`** can report **`crate version (commit)`** via new **`-V` / `--version`**, while local builds still show the crate version alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de4556e4f5c458ec3fd2d564bd526bf9e94a3cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->