### PR TITLE
feat: add browser.preferredExternalBrowser config key

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BrowserCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BrowserCatalogSection.swift
@@ -116,5 +116,23 @@ public struct BrowserCatalogSection: SettingCatalogSection {
         userDefaultsKey: "browserImportHintDismissed"
     )
 
+    /// Application name or bundle ID to use when opening URLs externally
+    /// instead of routing to the macOS system default browser.
+    ///
+    /// Accepts either a display name (e.g. `"Microsoft Edge"`, `"Firefox"`)
+    /// or a bundle ID (e.g. `"com.microsoft.edgemac"`). Empty string (the
+    /// default) preserves existing behaviour — `NSWorkspace` routes to
+    /// whatever the user has set as their system default browser.
+    ///
+    /// Example `~/.config/cmux/cmux.json`:
+    /// ```json
+    /// { "browser": { "preferredExternalBrowser": "Microsoft Edge" } }
+    /// ```
+    public let preferredExternalBrowser = DefaultsKey<String>(
+        id: "browser.preferredExternalBrowser",
+        defaultValue: "",
+        userDefaultsKey: "browserPreferredExternalBrowser"
+    )
+
     public init() {}
 }

--- a/Sources/CmuxOpenURLExternally.swift
+++ b/Sources/CmuxOpenURLExternally.swift
@@ -1,14 +1,20 @@
 import AppKit
 import CmuxSettings
+import os
+
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.cmux", category: "browser")
 
 /// Opens `url` in the user's preferred external browser, as configured by
 /// `browser.preferredExternalBrowser` in `~/.config/cmux/cmux.json`.
 ///
 /// When the setting is empty (the default), behaviour is identical to calling
-/// `NSWorkspace.shared.open(url)` directly.  When set, cmux attempts to
-/// resolve the value as either a bundle ID or an application display name and
-/// opens the URL in that application, without touching the system default
-/// browser setting.
+/// `NSWorkspace.shared.open(url)` directly. When set, cmux resolves the value
+/// as a bundle ID or application display name and opens the URL in that app,
+/// without touching the macOS system default browser.
+///
+/// Uses `NSWorkspace.open(_:configuration:)` — the fire-and-forget overload —
+/// to avoid blocking the calling thread. This is safe to call from the main
+/// thread and from WKNavigationDelegate callbacks.
 @discardableResult
 func cmuxOpenURLExternally(_ url: URL) -> Bool {
     let preferred = CmuxSettingsCatalog.shared.browser.preferredExternalBrowser.value
@@ -18,45 +24,39 @@ func cmuxOpenURLExternally(_ url: URL) -> Bool {
         return NSWorkspace.shared.open(url)
     }
 
-    // 1. Try bundle ID (e.g. "com.microsoft.edgemac")
-    if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: preferred) {
+    if let appURL = resolvePreferredBrowserURL(preferred) {
         let cfg = NSWorkspace.OpenConfiguration()
         cfg.activates = true
-        var opened = false
-        let sem = DispatchSemaphore(value: 0)
-        NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: cfg) { _, _ in
-            opened = true
-            sem.signal()
-        }
-        sem.wait()
-        return opened
+        NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: cfg, completionHandler: nil)
+        return true
     }
 
-    // 2. Match by display name against all installed apps the workspace knows about.
-    //    Check running apps first (fast path), then fall back to a Spotlight lookup.
+    logger.warning("cmuxOpenURLExternally: could not resolve preferred browser; falling back to system default")
+    return NSWorkspace.shared.open(url)
+}
+
+/// Resolves a display name or bundle ID to an application file URL.
+///
+/// Lookup order:
+/// 1. Bundle ID exact match via `NSWorkspace.urlForApplication(withBundleIdentifier:)`
+/// 2. Running application by `localizedName` (fast path when the browser is already open)
+/// 3. `/Applications/<name>.app` and `~/Applications/<name>.app` by display name
+private func resolvePreferredBrowserURL(_ preferred: String) -> URL? {
+    // 1. Bundle ID (e.g. "com.microsoft.edgemac")
+    if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: preferred) {
+        return url
+    }
+
+    // 2. Running app by localised name
     let lowerPreferred = preferred.lowercased()
-
-    let runningMatch = NSWorkspace.shared.runningApplications.first {
+    if let match = NSWorkspace.shared.runningApplications.first(where: {
         ($0.localizedName ?? "").lowercased() == lowerPreferred
-    }
-    if let bundleID = runningMatch?.bundleIdentifier,
-       let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
-        let cfg = NSWorkspace.OpenConfiguration()
-        cfg.activates = true
-        var opened = false
-        let sem = DispatchSemaphore(value: 0)
-        NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: cfg) { _, _ in
-            opened = true
-            sem.signal()
-        }
-        sem.wait()
-        return opened
+    }), let bundleID = match.bundleIdentifier,
+       let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+        return url
     }
 
-    // 3. Ask NSWorkspace to find an app by display name via file URL heuristic.
-    //    NSWorkspace.urlForApplication(toOpen:) matches by UTI, not name, so we
-    //    use LSCopyApplicationURLsForBundleIdentifier-style lookup via the app
-    //    directories instead.
+    // 3. Display name in standard app directories
     let appDirs = [
         URL(fileURLWithPath: "/Applications"),
         URL(fileURLWithPath: "\(NSHomeDirectory())/Applications"),
@@ -64,20 +64,9 @@ func cmuxOpenURLExternally(_ url: URL) -> Bool {
     for dir in appDirs {
         let candidate = dir.appendingPathComponent("\(preferred).app")
         if FileManager.default.fileExists(atPath: candidate.path) {
-            let cfg = NSWorkspace.OpenConfiguration()
-            cfg.activates = true
-            var opened = false
-            let sem = DispatchSemaphore(value: 0)
-            NSWorkspace.shared.open([url], withApplicationAt: candidate, configuration: cfg) { _, _ in
-                opened = true
-                sem.signal()
-            }
-            sem.wait()
-            return opened
+            return candidate
         }
     }
 
-    // 4. System default browser fallback — preferred app was not found.
-    NSLog("cmuxOpenURLExternally: could not resolve preferred browser \"%@\"; falling back to system default", preferred)
-    return NSWorkspace.shared.open(url)
+    return nil
 }

--- a/Sources/CmuxOpenURLExternally.swift
+++ b/Sources/CmuxOpenURLExternally.swift
@@ -1,0 +1,83 @@
+import AppKit
+import CmuxSettings
+
+/// Opens `url` in the user's preferred external browser, as configured by
+/// `browser.preferredExternalBrowser` in `~/.config/cmux/cmux.json`.
+///
+/// When the setting is empty (the default), behaviour is identical to calling
+/// `NSWorkspace.shared.open(url)` directly.  When set, cmux attempts to
+/// resolve the value as either a bundle ID or an application display name and
+/// opens the URL in that application, without touching the system default
+/// browser setting.
+@discardableResult
+func cmuxOpenURLExternally(_ url: URL) -> Bool {
+    let preferred = CmuxSettingsCatalog.shared.browser.preferredExternalBrowser.value
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard !preferred.isEmpty else {
+        return NSWorkspace.shared.open(url)
+    }
+
+    // 1. Try bundle ID (e.g. "com.microsoft.edgemac")
+    if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: preferred) {
+        let cfg = NSWorkspace.OpenConfiguration()
+        cfg.activates = true
+        var opened = false
+        let sem = DispatchSemaphore(value: 0)
+        NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: cfg) { _, _ in
+            opened = true
+            sem.signal()
+        }
+        sem.wait()
+        return opened
+    }
+
+    // 2. Match by display name against all installed apps the workspace knows about.
+    //    Check running apps first (fast path), then fall back to a Spotlight lookup.
+    let lowerPreferred = preferred.lowercased()
+
+    let runningMatch = NSWorkspace.shared.runningApplications.first {
+        ($0.localizedName ?? "").lowercased() == lowerPreferred
+    }
+    if let bundleID = runningMatch?.bundleIdentifier,
+       let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+        let cfg = NSWorkspace.OpenConfiguration()
+        cfg.activates = true
+        var opened = false
+        let sem = DispatchSemaphore(value: 0)
+        NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: cfg) { _, _ in
+            opened = true
+            sem.signal()
+        }
+        sem.wait()
+        return opened
+    }
+
+    // 3. Ask NSWorkspace to find an app by display name via file URL heuristic.
+    //    NSWorkspace.urlForApplication(toOpen:) matches by UTI, not name, so we
+    //    use LSCopyApplicationURLsForBundleIdentifier-style lookup via the app
+    //    directories instead.
+    let appDirs = [
+        URL(fileURLWithPath: "/Applications"),
+        URL(fileURLWithPath: "\(NSHomeDirectory())/Applications"),
+    ]
+    for dir in appDirs {
+        let candidate = dir.appendingPathComponent("\(preferred).app")
+        if FileManager.default.fileExists(atPath: candidate.path) {
+            let cfg = NSWorkspace.OpenConfiguration()
+            cfg.activates = true
+            var opened = false
+            let sem = DispatchSemaphore(value: 0)
+            NSWorkspace.shared.open([url], withApplicationAt: candidate, configuration: cfg) { _, _ in
+                opened = true
+                sem.signal()
+            }
+            sem.wait()
+            return opened
+        }
+    }
+
+    // 4. System default browser fallback — preferred app was not found.
+    NSLog("cmuxOpenURLExternally: could not resolve preferred browser \"%@\"; falling back to system default", preferred)
+    return NSWorkspace.shared.open(url)
+}

--- a/Sources/CmuxOpenURLExternally.swift
+++ b/Sources/CmuxOpenURLExternally.swift
@@ -2,7 +2,7 @@ import AppKit
 import CmuxSettings
 import os
 
-private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.cmux", category: "browser")
+nonisolated private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.cmux", category: "browser")
 
 /// Opens `url` in the user's preferred external browser, as configured by
 /// `browser.preferredExternalBrowser` in `~/.config/cmux/cmux.json`.
@@ -27,7 +27,11 @@ func cmuxOpenURLExternally(_ url: URL) -> Bool {
     if let appURL = resolvePreferredBrowserURL(preferred) {
         let cfg = NSWorkspace.OpenConfiguration()
         cfg.activates = true
-        NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: cfg, completionHandler: nil)
+        NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: cfg) { _, error in
+            if let error {
+                logger.error("Failed to open URL in preferred browser: \(error.localizedDescription, privacy: .public)")
+            }
+        }
         return true
     }
 

--- a/Sources/CmuxOpenURLExternally.swift
+++ b/Sources/CmuxOpenURLExternally.swift
@@ -17,7 +17,7 @@ nonisolated private let logger = Logger(subsystem: Bundle.main.bundleIdentifier 
 /// thread and from WKNavigationDelegate callbacks.
 @discardableResult
 func cmuxOpenURLExternally(_ url: URL) -> Bool {
-    let preferred = CmuxSettingsCatalog.shared.browser.preferredExternalBrowser.value
+    let preferred = SettingCatalog().browser.preferredExternalBrowser.value(in: .standard)
         .trimmingCharacters(in: .whitespacesAndNewlines)
 
     guard !preferred.isEmpty else {

--- a/Sources/CmuxOpenURLExternally.swift
+++ b/Sources/CmuxOpenURLExternally.swift
@@ -4,73 +4,75 @@ import os
 
 nonisolated private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.cmux", category: "browser")
 
-/// Opens `url` in the user's preferred external browser, as configured by
+/// Opens external URLs in the user's preferred browser, as configured by
 /// `browser.preferredExternalBrowser` in `~/.config/cmux/cmux.json`.
 ///
-/// When the setting is empty (the default), behaviour is identical to calling
-/// `NSWorkspace.shared.open(url)` directly. When set, cmux resolves the value
-/// as a bundle ID or application display name and opens the URL in that app,
-/// without touching the macOS system default browser.
-///
-/// Uses `NSWorkspace.open(_:configuration:)` — the fire-and-forget overload —
-/// to avoid blocking the calling thread. This is safe to call from the main
-/// thread and from WKNavigationDelegate callbacks.
-@discardableResult
-func cmuxOpenURLExternally(_ url: URL) -> Bool {
-    let preferred = SettingCatalog().browser.preferredExternalBrowser.value(in: .standard)
-        .trimmingCharacters(in: .whitespacesAndNewlines)
+/// Construct an instance and call `open(_:)`. The preferred-browser lookup is
+/// intentionally re-read at call time (not cached) so config changes take effect
+/// without restarting the app.
+struct ExternalBrowserOpener {
 
-    guard !preferred.isEmpty else {
+    /// Opens `url` in the configured preferred browser, falling back to the
+    /// system default when the setting is empty or the app cannot be resolved.
+    ///
+    /// Uses `NSWorkspace.open(_:withApplicationAt:configuration:completionHandler:)`
+    /// — the fire-and-forget overload — so this is safe to call from any thread,
+    /// including the main thread and WKNavigationDelegate callbacks.
+    @discardableResult
+    func open(_ url: URL) -> Bool {
+        let preferred = SettingCatalog().browser.preferredExternalBrowser.value(in: .standard)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !preferred.isEmpty else {
+            return NSWorkspace.shared.open(url)
+        }
+
+        if let appURL = resolvePreferredBrowserURL(preferred) {
+            let cfg = NSWorkspace.OpenConfiguration()
+            cfg.activates = true
+            NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: cfg) { _, error in
+                if let error {
+                    logger.error("Failed to open URL in preferred browser: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+            return true
+        }
+
+        logger.warning("ExternalBrowserOpener: could not resolve preferred browser; falling back to system default")
         return NSWorkspace.shared.open(url)
     }
 
-    if let appURL = resolvePreferredBrowserURL(preferred) {
-        let cfg = NSWorkspace.OpenConfiguration()
-        cfg.activates = true
-        NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: cfg) { _, error in
-            if let error {
-                logger.error("Failed to open URL in preferred browser: \(error.localizedDescription, privacy: .public)")
+    /// Resolves a display name or bundle ID to an application file URL.
+    ///
+    /// Lookup order:
+    /// 1. Bundle ID exact match via `NSWorkspace.urlForApplication(withBundleIdentifier:)`
+    /// 2. Running application by `localizedName` (fast path when the browser is already open)
+    /// 3. `/Applications/<name>.app` and `~/Applications/<name>.app` by display name
+    private func resolvePreferredBrowserURL(_ preferred: String) -> URL? {
+        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: preferred) {
+            return url
+        }
+
+        let lowerPreferred = preferred.lowercased()
+        if let match = NSWorkspace.shared.runningApplications.first(where: {
+            ($0.localizedName ?? "").lowercased() == lowerPreferred
+        }), let bundleID = match.bundleIdentifier,
+           let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+            return url
+        }
+
+        let appDirs = [
+            URL(fileURLWithPath: "/Applications"),
+            URL(fileURLWithPath: "\(NSHomeDirectory())/Applications"),
+        ]
+        for dir in appDirs {
+            let candidate = dir.appendingPathComponent("\(preferred).app")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
             }
         }
-        return true
-    }
 
-    logger.warning("cmuxOpenURLExternally: could not resolve preferred browser; falling back to system default")
-    return NSWorkspace.shared.open(url)
+        return nil
+    }
 }
 
-/// Resolves a display name or bundle ID to an application file URL.
-///
-/// Lookup order:
-/// 1. Bundle ID exact match via `NSWorkspace.urlForApplication(withBundleIdentifier:)`
-/// 2. Running application by `localizedName` (fast path when the browser is already open)
-/// 3. `/Applications/<name>.app` and `~/Applications/<name>.app` by display name
-private func resolvePreferredBrowserURL(_ preferred: String) -> URL? {
-    // 1. Bundle ID (e.g. "com.microsoft.edgemac")
-    if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: preferred) {
-        return url
-    }
-
-    // 2. Running app by localised name
-    let lowerPreferred = preferred.lowercased()
-    if let match = NSWorkspace.shared.runningApplications.first(where: {
-        ($0.localizedName ?? "").lowercased() == lowerPreferred
-    }), let bundleID = match.bundleIdentifier,
-       let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
-        return url
-    }
-
-    // 3. Display name in standard app directories
-    let appDirs = [
-        URL(fileURLWithPath: "/Applications"),
-        URL(fileURLWithPath: "\(NSHomeDirectory())/Applications"),
-    ]
-    for dir in appDirs {
-        let candidate = dir.appendingPathComponent("\(preferred).app")
-        if FileManager.default.fileExists(atPath: candidate.path) {
-            return candidate
-        }
-    }
-
-    return nil
-}

--- a/Sources/CmuxSidebarActionDispatch.swift
+++ b/Sources/CmuxSidebarActionDispatch.swift
@@ -53,10 +53,12 @@ func makeCmuxSidebarActionDispatch() -> SidebarActionDispatch {
                           let line = String(data: data, encoding: .utf8) else { continue }
                     _ = controller.handleSocketLine(line)
                 case let .openURL(urlString):
-                    // NSWorkspace.open is main-only; run it synchronously to keep the
-                    // command's position in the sequence.
+                    // Route through cmuxOpenURLExternally so the user's
+                    // browser.preferredExternalBrowser setting is respected.
+                    // NSWorkspace.open is main-only; run it synchronously to
+                    // keep the command's position in the sequence.
                     if let url = URL(string: urlString) {
-                        DispatchQueue.main.sync { _ = NSWorkspace.shared.open(url) }
+                        DispatchQueue.main.sync { cmuxOpenURLExternally(url) }
                     }
                 case .log:
                     break

--- a/Sources/CmuxSidebarActionDispatch.swift
+++ b/Sources/CmuxSidebarActionDispatch.swift
@@ -26,7 +26,8 @@ private let cmuxSidebarWorkerQueue = DispatchQueue(label: "com.cmux.sidebar-acti
 /// socket CLI uses); `log` is a debug-only no-op for now.
 @MainActor
 func makeCmuxSidebarActionDispatch() -> SidebarActionDispatch {
-    SidebarActionDispatch { action in
+    let browserOpener = ExternalBrowserOpener()
+    return SidebarActionDispatch { action in
         // Capture the controller on the main actor, then run the whole command
         // sequence on the serial worker queue so the commands keep their authored
         // order. handleSocketLine runs worker-lane methods (browser JS, waits) on
@@ -53,12 +54,10 @@ func makeCmuxSidebarActionDispatch() -> SidebarActionDispatch {
                           let line = String(data: data, encoding: .utf8) else { continue }
                     _ = controller.handleSocketLine(line)
                 case let .openURL(urlString):
-                    // Route through cmuxOpenURLExternally so the user's
-                    // browser.preferredExternalBrowser setting is respected.
-                    // NSWorkspace.open is main-only; run it synchronously to
-                    // keep the command's position in the sequence.
+                    // ExternalBrowserOpener.open uses the async NSWorkspace overload —
+                    // fire-and-forget, no main-thread requirement, safe on the worker queue.
                     if let url = URL(string: urlString) {
-                        DispatchQueue.main.sync { cmuxOpenURLExternally(url) }
+                        browserOpener.open(url)
                     }
                 case .log:
                     break
@@ -67,3 +66,4 @@ func makeCmuxSidebarActionDispatch() -> SidebarActionDispatch {
         }
     }
 }
+

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -831,9 +831,9 @@ struct MarkdownWebRenderer: NSViewRepresentable {
 
         /// Route a clicked link to a brand-new cmux browser tab in the same
         /// pane as this markdown panel — mirroring how Browser panels open
-        /// child links via `openLinkInNewTab`. Falls back to the system
-        /// browser only when the in-app browser is disabled or the panel
-        /// can't be located in any workspace.
+        /// child links via `openLinkInNewTab`. Falls back to the preferred
+        /// external browser (or system default) when the in-app browser is
+        /// disabled or the panel can't be located in any workspace.
         private func handleExternalLink(_ url: URL) {
 #if DEBUG
             NSLog("MarkdownPanel.handleExternalLink url=\(url.absoluteString)")
@@ -856,7 +856,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             }
 
             guard BrowserAvailabilitySettings.isEnabled() else {
-                NSWorkspace.shared.open(url)
+                cmuxOpenURLExternally(url)
                 return
             }
 
@@ -867,7 +867,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
                   ),
                   let paneId = location.workspace.paneId(forPanelId: panelId) else {
                 // No workspace context — last-resort fallback.
-                NSWorkspace.shared.open(url)
+                cmuxOpenURLExternally(url)
                 return
             }
 

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -856,7 +856,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             }
 
             guard BrowserAvailabilitySettings.isEnabled() else {
-                cmuxOpenURLExternally(url)
+                ExternalBrowserOpener().open(url)
                 return
             }
 
@@ -867,7 +867,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
                   ),
                   let paneId = location.workspace.paneId(forPanelId: panelId) else {
                 // No workspace context — last-resort fallback.
-                cmuxOpenURLExternally(url)
+                ExternalBrowserOpener().open(url)
                 return
             }
 


### PR DESCRIPTION
## Summary

Adds a `browser.preferredExternalBrowser` setting to `~/.config/cmux/cmux.json` so users can route external URL opens to a specific browser without changing the macOS system default browser.

**Motivation:** macOS has no per-app browser override API — system default is global. Users who want cmux to open links in (e.g.) Edge or Firefox while keeping Safari as system default have no current option. This closes that gap without touching the system setting.

**Usage:**
```json
{ "browser": { "preferredExternalBrowser": "Microsoft Edge" } }
```
Accepts a display name (`"Microsoft Edge"`, `"Firefox"`) or bundle ID (`"com.microsoft.edgemac"`). Empty string (default) preserves existing behaviour — `NSWorkspace` routes to the system default.

## Changes

- **`BrowserCatalogSection.swift`** — new `DefaultsKey<String>` for `browser.preferredExternalBrowser` (UserDefaults key: `browserPreferredExternalBrowser`, default: `""`)
- **`Sources/CmuxOpenURLExternally.swift`** — new `struct ExternalBrowserOpener` with an `open(_:)` method. Lookup order: bundle ID → running app name → `/Applications/.app` → system default fallback. Uses fire-and-forget `NSWorkspace.open(_:withApplicationAt:configuration:completionHandler:)` with an error-logging completion handler — no semaphore, no blocking, safe to call from any thread.
- **`CmuxSidebarActionDispatch.swift`** — `ExternalBrowserOpener` is constructed in `makeCmuxSidebarActionDispatch` and captured in the action closure (no singleton). Sidebar `.openURL` actions call `browserOpener.open(url)` directly on the worker queue — no `DispatchQueue.main.sync`.
- **`Sources/Panels/MarkdownWebRenderer.swift`** — http/https fallback paths in `handleExternalLink` now call `ExternalBrowserOpener().open(url)`; non-http schemes (mailto:, slack://, etc.) still go directly to `NSWorkspace` unchanged.

## Notes for reviewers

- The remaining `NSWorkspace.shared.open` call sites (billing checkout, auth sign-in, help links, "Report issue") are intentionally left unchanged — those are internal/system flows where the preferred browser setting does not apply.
- `ExternalBrowserOpener` is a zero-storage struct; constructing per call in `MarkdownWebRenderer` is free.
- `ExternalBrowserOpener.open` uses the async `NSWorkspace.open(_:withApplicationAt:configuration:completionHandler:)` overload — the completion handler logs errors via `os.Logger` but does not block the caller. This is safe to call from any thread, including `WKNavigationDelegate` callbacks.
- The `browser.preferredExternalBrowser` `id` field follows the same `DefaultsKey` pattern as all other `BrowserCatalogSection` keys — the settings framework reads `cmux.json` and maps the dotted key path to UserDefaults automatically.
- Fixes #455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new browser preference for choosing the app used to open external links.
  * External links can now open in a preferred browser app or bundle ID instead of always using the default browser.

* **Bug Fixes**
  * Improved fallback handling when a preferred browser can’t be found.
  * Kept existing behavior unchanged when no preference is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->