### PR TITLE
test-e2e: target-qualified test filters + fail on zero executed tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -480,9 +480,18 @@ jobs:
           with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
               text = handle.read()
 
-          matches = [int(value) for value in re.findall(r"Executed\s+(\d+)\s+tests?\b", text)]
-          if matches:
-              print(matches[-1])
+          # XCTest summaries ("Executed N tests") and Swift Testing run summaries
+          # ("Test run with N tests ...") are independent per-framework counts in
+          # one xcodebuild invocation; a filter can select a suite living in either.
+          xctest = [int(value) for value in re.findall(r"Executed\s+(\d+)\s+tests?\b", text)]
+          swift_testing = [int(value) for value in re.findall(r"Test run with\s+(\d+)\s+tests?\b", text)]
+          counts = []
+          if xctest:
+              counts.append(xctest[-1])
+          if swift_testing:
+              counts.append(swift_testing[-1])
+          if counts:
+              print(max(counts))
           PY
           )
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: ""
       test_filter:
-        description: "Test class or class/method (e.g. UpdatePillUITests or UpdatePillUITests/testSomething)"
+        description: "Test class or class/method; optionally target-qualified as cmuxUITests/Class or cmuxTests/Class"
         required: true
       test_timeout:
         description: "Per-test timeout in seconds"
@@ -20,7 +20,7 @@ on:
         required: false
         default: "20"
       record_video:
-        description: Record the virtual display during tests
+        description: Record the virtual display during UI tests
         required: false
         default: true
         type: boolean
@@ -90,6 +90,64 @@ jobs:
         id: sha
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Normalize test filter
+        id: filter
+        env:
+          TEST_FILTER_INPUT: ${{ inputs.test_filter }}
+          RECORD_VIDEO_INPUT: ${{ inputs.record_video }}
+        run: |
+          set -euo pipefail
+          raw_filter="$TEST_FILTER_INPUT"
+          if [ -z "$raw_filter" ]; then
+            echo "::error::test_filter must not be empty"
+            exit 1
+          fi
+
+          case "$raw_filter" in
+            cmuxTests/*)
+              test_target="cmuxTests"
+              normalized_filter="${raw_filter#cmuxTests/}"
+              ;;
+            cmuxUITests/*)
+              test_target="cmuxUITests"
+              normalized_filter="${raw_filter#cmuxUITests/}"
+              ;;
+            *)
+              # Back-compat: bare Class or Class/method continues to target UI tests.
+              test_target="cmuxUITests"
+              normalized_filter="$raw_filter"
+              ;;
+          esac
+
+          if [ -z "$normalized_filter" ]; then
+            echo "::error::test_filter '$raw_filter' is missing a class or class/method after '$test_target/'"
+            exit 1
+          fi
+
+          case "$normalized_filter" in
+            /*|*//*)
+              echo "::error::test_filter '$raw_filter' is not a valid class or class/method selector"
+              exit 1
+              ;;
+          esac
+
+          test_selector="$test_target/$normalized_filter"
+          record_video_effective="false"
+          if [ "$test_target" = "cmuxUITests" ] && [ "$RECORD_VIDEO_INPUT" = "true" ]; then
+            record_video_effective="true"
+          fi
+
+          {
+            echo "target=$test_target"
+            echo "filter=$normalized_filter"
+            echo "selector=$test_selector"
+            echo "record_video=$record_video_effective"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Requested filter: $raw_filter"
+          echo "Resolved target: $test_target"
+          echo "Resolved selector: $test_selector"
+
       - name: Select Xcode
         run: |
           set -euo pipefail
@@ -132,13 +190,13 @@ jobs:
           ./scripts/install-rust-ci.sh
 
       - name: Install Bun for Feed sidebar tests
-        if: ${{ inputs.test_filter == 'FeedSidebarUITests' || startsWith(inputs.test_filter, 'FeedSidebarUITests/') }}
+        if: ${{ steps.filter.outputs.target == 'cmuxUITests' && (steps.filter.outputs.filter == 'FeedSidebarUITests' || startsWith(steps.filter.outputs.filter, 'FeedSidebarUITests/')) }}
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Create virtual display
-        if: ${{ inputs.test_filter != 'DisplayResolutionRegressionUITests' }}
+        if: ${{ steps.filter.outputs.target == 'cmuxUITests' && steps.filter.outputs.filter != 'DisplayResolutionRegressionUITests' }}
         run: |
           set -euo pipefail
           echo "=== Display before ==="
@@ -180,7 +238,7 @@ jobs:
           system_profiler SPDisplaysDataType 2>/dev/null || echo "(none)"
 
       - name: Install ffmpeg
-        if: ${{ inputs.record_video }}
+        if: ${{ steps.filter.outputs.record_video == 'true' }}
         run: |
           brew install --quiet ffmpeg
           FFMPEG_PATH=$(which ffmpeg)
@@ -189,7 +247,7 @@ jobs:
           echo "FFMPEG_PATH=$FFMPEG_PATH" >> "$GITHUB_ENV"
 
       - name: Grant TCC screen recording permission
-        if: ${{ inputs.record_video }}
+        if: ${{ steps.filter.outputs.record_video == 'true' }}
         run: |
           FFMPEG_BIN="${FFMPEG_PATH:-/opt/homebrew/bin/ffmpeg}"
 
@@ -224,6 +282,14 @@ jobs:
       - name: Clean DerivedData
         run: rm -rf ~/Library/Developer/Xcode/DerivedData/cmux-*
 
+      - name: Prepare isolated DerivedData
+        run: |
+          set -euo pipefail
+          DERIVED_DATA_PATH="${RUNNER_TEMP}/cmux-derived-data-e2e-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf "$DERIVED_DATA_PATH"
+          mkdir -p "$DERIVED_DATA_PATH"
+          echo "CMUX_DERIVED_DATA_PATH=$DERIVED_DATA_PATH" >> "$GITHUB_ENV"
+
       - name: Cache Swift packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -241,9 +307,16 @@ jobs:
           mkdir -p "$SOURCE_PACKAGES_DIR"
           for attempt in 1 2 3; do
             if xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
+              -derivedDataPath "$CMUX_DERIVED_DATA_PATH" \
               -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
               -resolvePackageDependencies; then
-              exit 0
+              # Guard against a stale/poisoned Swift-package cache: resolve can
+              # report success without binary artifacts materialized.
+              if [ -d "$SOURCE_PACKAGES_DIR/artifacts/sparkle/Sparkle/Sparkle.xcframework" ] && [ -d "$SOURCE_PACKAGES_DIR/artifacts/sentry-cocoa/Sentry/Sentry.xcframework" ]; then
+                exit 0
+              fi
+              echo "Resolve succeeded but binary artifacts are missing (stale cache); clearing and retrying" >&2
+              rm -rf "$SOURCE_PACKAGES_DIR"
             fi
             if [ "$attempt" -eq 3 ]; then
               echo "Failed to resolve Swift packages after 3 attempts" >&2
@@ -253,19 +326,26 @@ jobs:
             sleep $((attempt * 5))
           done
 
-      - name: Run UI tests
+      - name: Run selected tests
         id: tests
         env:
           TEST_FILTER: ${{ inputs.test_filter }}
+          TEST_TARGET: ${{ steps.filter.outputs.target }}
+          TEST_SELECTOR: ${{ steps.filter.outputs.selector }}
+          NORMALIZED_FILTER: ${{ steps.filter.outputs.filter }}
           TEST_TIMEOUT: ${{ inputs.test_timeout || '120' }}
-          RECORD_VIDEO: ${{ inputs.record_video }}
+          RECORD_VIDEO: ${{ steps.filter.outputs.record_video }}
+          # App-host crash recovery must not stall on interactive backtraces
+          # (mirrors ci.yml's tests job hardening).
+          SWIFT_BACKTRACE: "interactive=no,timeout=0s,symbolicate=off,color=no"
+          CMUX_XCODEBUILD_NONINTERACTIVE_POST_TEST_TIMEOUT_SECONDS: "45"
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
-          ONLY_TESTING="-only-testing:cmuxUITests/$TEST_FILTER"
+          ONLY_TESTING="-only-testing:$TEST_SELECTOR"
           DISPLAY_ENV_PREFIX=()
 
-          if [ "$TEST_FILTER" = "DisplayResolutionRegressionUITests" ]; then
+          if [ "$TEST_TARGET" = "cmuxUITests" ] && [ "$NORMALIZED_FILTER" = "DisplayResolutionRegressionUITests" ]; then
             HELPER_PATH="/tmp/create-virtual-display"
             MANIFEST_PATH="/tmp/cmux-ui-test-display-harness.json"
 
@@ -315,6 +395,7 @@ jobs:
             "LOGNAME=${LOGNAME:-$USER}"
             "CI=${CI:-true}"
             "GITHUB_ACTIONS=${GITHUB_ACTIONS:-true}"
+            "GITHUB_WORKSPACE=${GITHUB_WORKSPACE:-$PWD}"
             "RUNNER_TEMP=${RUNNER_TEMP:-}"
             "TMPDIR=${TMPDIR:-/tmp}"
           )
@@ -323,37 +404,56 @@ jobs:
           fi
 
           RUN_XCODEBUILD=(env "${XCODEBUILD_ENV[@]}")
-          CURRENT_USER="$(id -un)"
-          GUI_USER="$(stat -f %Su /dev/console 2>/dev/null || true)"
-          if [ -n "$GUI_USER" ] && [ "$GUI_USER" != "root" ] && GUI_UID="$(id -u "$GUI_USER" 2>/dev/null)"; then
-            echo "Console GUI user: $GUI_USER ($GUI_UID); current user: $CURRENT_USER"
-            if command -v automationmodetool >/dev/null 2>&1; then
-              sudo -n automationmodetool enable-automationmode-without-authentication \
-                || echo "::warning::Could not enable Automation Mode"
-            fi
+          if [ "$TEST_TARGET" = "cmuxUITests" ]; then
+            CURRENT_USER="$(id -un)"
+            GUI_USER="$(stat -f %Su /dev/console 2>/dev/null || true)"
+            if [ -n "$GUI_USER" ] && [ "$GUI_USER" != "root" ] && GUI_UID="$(id -u "$GUI_USER" 2>/dev/null)"; then
+              echo "Console GUI user: $GUI_USER ($GUI_UID); current user: $CURRENT_USER"
+              if command -v automationmodetool >/dev/null 2>&1; then
+                sudo -n automationmodetool enable-automationmode-without-authentication \
+                  || echo "::warning::Could not enable Automation Mode"
+              fi
 
-            if sudo -n true 2>/dev/null; then
-              RUN_XCODEBUILD=(
-                sudo -n launchctl asuser "$GUI_UID"
-                sudo -n -H -u "$GUI_USER" /usr/bin/env "${XCODEBUILD_ENV[@]}"
-              )
-              echo "Running xcodebuild in console user's GUI bootstrap"
+              if sudo -n true 2>/dev/null; then
+                RUN_XCODEBUILD=(
+                  sudo -n launchctl asuser "$GUI_UID"
+                  sudo -n -H -u "$GUI_USER" /usr/bin/env "${XCODEBUILD_ENV[@]}"
+                )
+                echo "Running xcodebuild in console user's GUI bootstrap"
+              else
+                echo "::warning::Passwordless sudo unavailable; running xcodebuild in current bootstrap"
+              fi
             else
-              echo "::warning::Passwordless sudo unavailable; running xcodebuild in current bootstrap"
+              echo "::warning::No non-root console GUI user found; running xcodebuild in current bootstrap"
             fi
-          else
-            echo "::warning::No non-root console GUI user found; running xcodebuild in current bootstrap"
           fi
 
-          XCODEBUILD_CMD=(
-            xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug
-            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR"
-            -disableAutomaticPackageResolution
-            -destination "platform=macOS"
-            -maximum-test-execution-time-allowance "$TEST_TIMEOUT"
-            "$ONLY_TESTING"
-            test
-          )
+          if [ "$TEST_TARGET" = "cmuxTests" ]; then
+            XCODEBUILD_CMD=(
+              scripts/ci/run-in-console-session.sh
+              scripts/ci/run-app-host-xcodebuild.sh
+              -project cmux.xcodeproj -scheme cmux-unit -configuration Debug
+              -derivedDataPath "$CMUX_DERIVED_DATA_PATH"
+              -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR"
+              -disableAutomaticPackageResolution
+              -destination "platform=macOS"
+              -maximum-test-execution-time-allowance "$TEST_TIMEOUT"
+              "$ONLY_TESTING"
+              CMUX_SKIP_ZIG_BUILD=1
+              test
+            )
+          else
+            XCODEBUILD_CMD=(
+              xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug
+              -derivedDataPath "$CMUX_DERIVED_DATA_PATH"
+              -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR"
+              -disableAutomaticPackageResolution
+              -destination "platform=macOS"
+              -maximum-test-execution-time-allowance "$TEST_TIMEOUT"
+              "$ONLY_TESTING"
+              test
+            )
+          fi
 
           set +e
           # Stream xcodebuild output into the live job log (and a file for the
@@ -372,6 +472,43 @@ jobs:
             echo "EOFSUM"
           } >> "$GITHUB_OUTPUT"
 
+          EXECUTED_TESTS=$(python3 - /tmp/xcodebuild-e2e.log <<'PY'
+          import re
+          import sys
+
+          log_path = sys.argv[1]
+          with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+              text = handle.read()
+
+          matches = [int(value) for value in re.findall(r"Executed\s+(\d+)\s+tests?\b", text)]
+          if matches:
+              print(matches[-1])
+          PY
+          )
+
+          if [ -z "$EXECUTED_TESTS" ]; then
+            echo "::error::Could not determine executed test count for $TEST_SELECTOR from xcodebuild output"
+            echo "test_result=failed" >> "$GITHUB_OUTPUT"
+            {
+              echo "test_output<<EOFOUT"
+              echo "$OUTPUT" | tail -200
+              echo "EOFOUT"
+            } >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          echo "Executed tests for $TEST_SELECTOR: $EXECUTED_TESTS"
+          if [ "$EXECUTED_TESTS" -eq 0 ]; then
+            echo "::error::test_filter '$TEST_FILTER' resolved to target '$TEST_TARGET' selector '$TEST_SELECTOR' but xcodebuild executed 0 tests"
+            echo "test_result=failed" >> "$GITHUB_OUTPUT"
+            {
+              echo "test_output<<EOFOUT"
+              echo "$OUTPUT" | tail -200
+              echo "EOFOUT"
+            } >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
           if [ "$EXIT_CODE" -eq 0 ]; then
             echo "test_result=passed" >> "$GITHUB_OUTPUT"
           else
@@ -386,7 +523,7 @@ jobs:
           fi
 
       - name: Stop recording and trim
-        if: ${{ always() && inputs.record_video && env.RECORD_PID != '' }}
+        if: ${{ always() && steps.filter.outputs.record_video == 'true' && env.RECORD_PID != '' }}
         run: |
           # Stop ffmpeg cleanly
           kill -INT "$RECORD_PID" 2>/dev/null || true
@@ -427,7 +564,7 @@ jobs:
             | xargs -I{} echo "Duration: {}s"
 
       - name: Upload recording artifact
-        if: ${{ always() && inputs.record_video }}
+        if: ${{ always() && steps.filter.outputs.record_video == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-recording
@@ -444,7 +581,7 @@ jobs:
           TEST_FILTER: ${{ inputs.test_filter }}
           COMMIT_SHA: ${{ steps.sha.outputs.sha }}
           RUN_ID: ${{ github.run_id }}
-          RECORD_VIDEO: ${{ inputs.record_video }}
+          RECORD_VIDEO: ${{ steps.filter.outputs.record_video }}
         run: |
           set -euo pipefail
 

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -5,6 +5,7 @@
 #   ./scripts/run-e2e.sh UpdatePillUITests
 #   ./scripts/run-e2e.sh UpdatePillUITests --wait
 #   ./scripts/run-e2e.sh UpdatePillUITests/testFoo --ref my-branch
+#   ./scripts/run-e2e.sh cmuxTests/ForkParentFallbackGeneralizationTests
 #   ./scripts/run-e2e.sh UpdatePillUITests --no-video --timeout 300
 set -euo pipefail
 
@@ -22,7 +23,8 @@ usage() {
 Usage: $(basename "$0") <test_filter> [options]
 
 Arguments:
-  test_filter    Test class or class/method (e.g. UpdatePillUITests)
+  test_filter    Test class or class/method. Bare filters target cmuxUITests;
+                 use cmuxUITests/Class or cmuxTests/Class for explicit targets.
 
 Options:
   --ref <ref>      Branch or SHA to test (default: current branch)


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/7654.

`test_filter` accepts `cmuxTests/Class[/method]` and `cmuxUITests/Class[/method]`; bare `Class[/method]` defaults to `cmuxUITests` unchanged. Unit filters run the `cmux-unit` scheme via the same console-session/app-host wrappers as ci.yml's tests job (with its backtrace/post-test-timeout hardening); UI-only harness steps are gated to UI runs. After xcodebuild the job parses the final `Executed N tests` summary and goes red with a named error when the filter executed zero tests — the vacuous-pass mode that let dispatches 'pass' while running nothing.

Verification: live dispatches from this branch (links to follow in comments) — a `cmuxTests/ForkParentFallbackGeneralizationTests` run that executes the suite, and a `BogusClassName` run that fails on the zero-test guard. Note: `.github/workflows/test-depot.yml` has the same hardcoded-target bug, left for a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI dispatch semantics and adds a strict post-run test-count gate that could fail edge-case log formats; unit e2e now shares app-host/console-session paths used in production CI.
> 
> **Overview**
> The **test-e2e** workflow no longer assumes every dispatch is a UI test. A **Normalize test filter** step parses `cmuxTests/Class[/method]` vs `cmuxUITests/Class[/method]` (bare names still map to `cmuxUITests`) and drives `-only-testing` from the resolved selector. **Unit** runs use the `cmux-unit` scheme through `run-in-console-session.sh` / `run-app-host-xcodebuild.sh` with the same non-interactive backtrace hardening as main CI; **UI-only** setup (virtual display, ffmpeg/TCC, Feed Sidebar Bun) and effective video recording are gated to `cmuxUITests`.
> 
> After `xcodebuild`, the job parses XCTest/Swift Testing summaries and **fails** if no executed count is found or **zero** tests ran, closing vacuous passes from bad filters (#7654). It also uses per-run **isolated DerivedData**, passes `-derivedDataPath` through resolve/test, and retries SPM resolve when binary artifacts are missing from a stale cache. **`scripts/run-e2e.sh`** documents target-qualified filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65181c5eb4cdd6b825cfa9d3c99c21308eec4ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786140799&installation_id=133855650&pr_number=7658&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7658&signature=6779c6243eff43534108561cd163cabb80fe4e6e5fa37e4bd9cb33e7e9d1a930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds target-qualified e2e test filters and enforces a fail when no tests run, counting both XCTest and Swift Testing summaries. Enables running `cmuxTests` through the e2e workflow with CI hardening while keeping UI-only setup scoped to `cmuxUITests`.

- **New Features**
  - `test_filter` now accepts `cmuxUITests/Class[/method]` or `cmuxTests/Class[/method]`; bare `Class[/method]` still targets `cmuxUITests`.
  - `cmuxTests` filters run the `cmux-unit` scheme via the same console-session/app-host wrappers and non-interactive backtrace/timeout hardening used in CI; UI-only steps (virtual display, recording, TCC, Bun for Feed Sidebar tests) run only for `cmuxUITests`. Isolated DerivedData and Swift package artifact checks reduce cache flakiness. `scripts/run-e2e.sh` help documents target-qualified filters.

- **Bug Fixes**
  - After tests, the workflow parses both XCTest (“Executed N tests”) and Swift Testing (“Test run with N tests …”) summaries and fails with a clear error if the max count is zero or missing, preventing vacuous passes from bad filters or target mismatches (fixes #7654).

<sup>Written for commit 65181c5eb4cdd6b825cfa9d3c99c21308eec4ce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved end-to-end test run options so test selection and video recording now behave more predictably from the workflow inputs.
  * Added better handling for UI test runs to make execution more reliable in CI.

* **Bug Fixes**
  * Reduced flaky test runs by improving environment setup, retrying missing test artifacts, and validating that executed tests are detected correctly.

* **Documentation**
  * Clarified the available test filter examples and how to target different test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->