### PR TITLE
Fix fork-fallback residuals: custom claude binaries, codex cwd, teams panes, registry fork markers

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -42,7 +42,7 @@
 2403	Sources/Mobile/MobileHostService.swift
 2328	cmuxTests/CJKIMEInputTests.swift
 2229	Sources/TerminalWindowPortal.swift
-2225	Sources/RestorableAgentSession.swift
+2203	Sources/RestorableAgentSession.swift
 2216	Sources/TerminalNotificationStore.swift
 2133	cmuxTests/ShortcutAndCommandPaletteTests.swift
 2126	cmuxTests/CmuxConfigTests.swift

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -30353,6 +30353,7 @@ export default CMUXSessionRestore;
         let hookCwd = input.cwd
             ?? normalizedHookValue(env["CMUX_AGENT_LAUNCH_CWD"])
             ?? normalizedHookValue(env["PWD"])
+            ?? (def.name == "codex" ? normalizedHookValue(FileManager.default.currentDirectoryPath) : nil)
         let sessionId = resolvedAgentHookSessionId(def: def, input: input, env: env, cwd: hookCwd)
         let action = Self.subcommandActions[subcommand] ?? .noop
 #if DEBUG

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -30352,8 +30352,7 @@ export default CMUXSessionRestore;
 
         let hookCwd = input.cwd
             ?? normalizedHookValue(env["CMUX_AGENT_LAUNCH_CWD"])
-            ?? normalizedHookValue(env["PWD"])
-            ?? (def.name == "codex" ? normalizedHookValue(FileManager.default.currentDirectoryPath) : nil)
+            ?? normalizedHookValue(env["PWD"]) ?? (def.name == "codex" ? normalizedHookValue(FileManager.default.currentDirectoryPath) : nil)
         let sessionId = resolvedAgentHookSessionId(def: def, input: input, env: env, cwd: hookCwd)
         let action = Self.subcommandActions[subcommand] ?? .noop
 #if DEBUG

--- a/Sources/CachedAgentProcessIdentityValidator.swift
+++ b/Sources/CachedAgentProcessIdentityValidator.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Foundation
 
 struct CachedAgentProcessIdentityValidator: Sendable {

--- a/Sources/CachedAgentProcessIdentityValidator.swift
+++ b/Sources/CachedAgentProcessIdentityValidator.swift
@@ -6,10 +6,10 @@ struct CachedAgentProcessIdentityValidator: Sendable {
         matches snapshot: SessionRestorableAgentSnapshot
     ) -> Bool {
         if let liveKind = normalizedProcessValue(process.environment["CMUX_AGENT_LAUNCH_KIND"]),
-           liveKind.compare(snapshot.kind.rawValue, options: [.caseInsensitive, .literal]) != .orderedSame {
+           !Self.launchKind(liveKind, matches: snapshot.kind, launcher: snapshot.launchCommand?.launcher) {
             return false
         }
-        guard currentProcessExecutable(process.arguments, matches: snapshot) else {
+        guard currentProcessExecutable(process.arguments, environment: process.environment, matches: snapshot) else {
             return false
         }
         return currentProcessSession(process.arguments, matches: snapshot)
@@ -17,15 +17,29 @@ struct CachedAgentProcessIdentityValidator: Sendable {
 
     private func currentProcessExecutable(
         _ arguments: [String],
+        environment: [String: String],
         matches snapshot: SessionRestorableAgentSnapshot
     ) -> Bool {
         guard let liveExecutable = arguments.first.map(executableBasename) else { return false }
+        if let liveKind = normalizedProcessValue(environment["CMUX_AGENT_LAUNCH_KIND"]),
+           Self.launchKind(liveKind, matches: snapshot.kind, launcher: snapshot.launchCommand?.launcher),
+           normalizedProcessValue(snapshot.launchCommand?.launcher)?.compare(liveKind, options: [.caseInsensitive, .literal]) == .orderedSame,
+           liveProcessExecutableMatchesRecordedAgent(
+               kind: snapshot.kind,
+               liveExecutable: liveExecutable,
+               recordedExecutable: snapshot.kind.rawValue,
+               arguments: arguments,
+               environment: [:]
+           ) {
+            return true
+        }
         if let recordedExecutable = recordedExecutableBasename(snapshot),
            liveProcessExecutableMatchesRecordedAgent(
                kind: snapshot.kind,
                liveExecutable: liveExecutable,
                recordedExecutable: recordedExecutable,
-               arguments: arguments
+               arguments: arguments,
+               environment: environment
            ) {
             return true
         }
@@ -34,7 +48,8 @@ struct CachedAgentProcessIdentityValidator: Sendable {
                 kind: snapshot.kind,
                 liveExecutable: liveExecutable,
                 recordedExecutable: snapshot.kind.rawValue,
-                arguments: arguments
+                arguments: arguments,
+                environment: environment
             )
         }
         return registrationDetectRule(registration.detect, matchesExecutable: liveExecutable, arguments: arguments)
@@ -60,9 +75,17 @@ struct CachedAgentProcessIdentityValidator: Sendable {
         kind: RestorableAgentKind,
         liveExecutable: String,
         recordedExecutable: String,
-        arguments: [String]
+        arguments: [String],
+        environment: [String: String]
     ) -> Bool {
         if liveExecutable.compare(recordedExecutable, options: [.caseInsensitive, .literal]) == .orderedSame {
+            return true
+        }
+        if Self.liveProcessMatchesLaunchExecutableEnvironment(
+            kind: kind,
+            executableCandidates: [liveExecutable],
+            environment: environment
+        ) {
             return true
         }
         if kind == .opencode, arguments.contains(where: argumentLooksLikeOpenCode) {
@@ -101,6 +124,34 @@ struct CachedAgentProcessIdentityValidator: Sendable {
             return executableBasename(argument).compare("codex", options: [.caseInsensitive, .literal]) == .orderedSame
                 || lowered.contains("@openai/codex")
                 || lowered.contains("oh-my-codex")
+        }
+    }
+
+    static func launchKind(_ liveKind: String, matches kind: RestorableAgentKind, launcher: String?) -> Bool {
+        if liveKind.compare(kind.rawValue, options: [.caseInsensitive, .literal]) == .orderedSame {
+            return true
+        }
+        guard let launcher = normalizedProcessValue(launcher),
+              launcher.compare(liveKind, options: [.caseInsensitive, .literal]) == .orderedSame else {
+            return false
+        }
+        return AgentLaunchCaptureTrust.launcherDescribesKind(liveKind, kind: kind.rawValue)
+    }
+
+    static func liveProcessMatchesLaunchExecutableEnvironment(
+        kind: RestorableAgentKind,
+        executableCandidates: [String],
+        environment: [String: String]
+    ) -> Bool {
+        guard let liveKind = normalizedProcessValue(environment["CMUX_AGENT_LAUNCH_KIND"]),
+              (liveKind.compare(kind.rawValue, options: [.caseInsensitive, .literal]) == .orderedSame
+                  || AgentLaunchCaptureTrust.launcherDescribesKind(liveKind, kind: kind.rawValue)),
+              let launchExecutable = normalizedProcessValue(environment["CMUX_AGENT_LAUNCH_EXECUTABLE"]) else {
+            return false
+        }
+        let launchBasename = executableBasename(launchExecutable)
+        return executableCandidates.contains { candidate in
+            executableBasename(candidate).compare(launchBasename, options: [.caseInsensitive, .literal]) == .orderedSame
         }
     }
 
@@ -171,11 +222,15 @@ struct CachedAgentProcessIdentityValidator: Sendable {
         Self.executableBasename(value)
     }
 
-    private func normalizedProcessValue(_ value: String?) -> String? {
+    private static func normalizedProcessValue(_ value: String?) -> String? {
         guard let rawValue = value?.trimmingCharacters(in: .whitespacesAndNewlines),
               !rawValue.isEmpty else {
             return nil
         }
         return rawValue
+    }
+
+    private func normalizedProcessValue(_ value: String?) -> String? {
+        Self.normalizedProcessValue(value)
     }
 }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -2157,28 +2157,6 @@ struct RestorableAgentSessionIndex: Sendable {
         return pid
     }
 
-    private static func liveProcessExecutableMatchesRecordedAgent(
-        kind: RestorableAgentKind,
-        liveExecutable: String,
-        recordedExecutable: String,
-        arguments: [String],
-        environment: [String: String]
-    ) -> Bool {
-        if liveExecutable.compare(recordedExecutable, options: [.caseInsensitive, .literal]) == .orderedSame {
-            return true
-        }
-        if CachedAgentProcessIdentityValidator.liveProcessMatchesLaunchExecutableEnvironment(
-            kind: kind,
-            executableCandidates: [liveExecutable],
-            environment: environment
-        ) {
-            return true
-        }
-
-        return CachedAgentProcessIdentityValidator.liveClaudeProcessExecutableMatches(kind: kind, liveExecutable: liveExecutable, arguments: arguments)
-            || CachedAgentProcessIdentityValidator.liveCodexProcessExecutableMatches(kind: kind, liveExecutable: liveExecutable, arguments: arguments)
-    }
-
     private static func recordedExecutableBasename(_ record: RestorableAgentHookSessionRecord) -> String? {
         let executable = normalizedProcessValue(record.launchCommand?.executablePath)
             ?? normalizedProcessValue(record.launchCommand?.arguments.first)

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1081,6 +1081,7 @@ struct RestorableAgentSessionIndex: Sendable {
             homeDirectory: homeDirectory,
             fileManager: fileManager
         )
+        let codexCwdLookup = CodexSessionCwdLookupCache(fileManager: fileManager)
         let builtInKindIDs = Set(RestorableAgentKind.allCases.map(\.rawValue))
         let hookKinds: [(kind: RestorableAgentKind, registration: CmuxVaultAgentRegistration?)] =
             RestorableAgentKind.allCases.map { (kind: $0, registration: nil) }
@@ -1136,7 +1137,8 @@ struct RestorableAgentSessionIndex: Sendable {
                         kind: kind,
                         registration: registration,
                         fileManager: fileManager,
-                        lookup: claudeTranscriptLookup
+                        lookup: claudeTranscriptLookup,
+                        codexCwdLookup: codexCwdLookup
                     ),
                     launchCommand: effectiveRecord.launchCommand,
                     registration: registration
@@ -1537,7 +1539,8 @@ struct RestorableAgentSessionIndex: Sendable {
         kind: RestorableAgentKind,
         registration: CmuxVaultAgentRegistration?,
         fileManager: FileManager,
-        lookup: ClaudeTranscriptLookupCache
+        lookup: ClaudeTranscriptLookupCache,
+        codexCwdLookup: CodexSessionCwdLookupCache
     ) -> String? {
         let recordedCwd = normalizedWorkingDirectory(record.cwd)
         let launchCwd = normalizedWorkingDirectory(record.launchCommand?.workingDirectory)
@@ -1555,7 +1558,7 @@ struct RestorableAgentSessionIndex: Sendable {
         case .cwdInFile:
             // Resume is addressed by id and the cwd lives inside the record, so the runtime cwd is
             // fine — keeping it preserves the directory the agent was working in.
-            return recordedCwd ?? launchCwd
+            return recordedCwd ?? launchCwd ?? codexCwdLookup.workingDirectory(kind: kind, sessionId: record.sessionId, launchCommand: record.launchCommand)
         case .byDirectory:
             if kind == .claude,
                let verified = claudeVerifiedRestorableWorkingDirectory(
@@ -2146,7 +2149,8 @@ struct RestorableAgentSessionIndex: Sendable {
             kind: kind,
             liveExecutable: liveExecutable,
             recordedExecutable: recordedExecutable,
-            arguments: process.arguments
+            arguments: process.arguments,
+            environment: process.environment
         ) else {
             return nil
         }
@@ -2157,9 +2161,17 @@ struct RestorableAgentSessionIndex: Sendable {
         kind: RestorableAgentKind,
         liveExecutable: String,
         recordedExecutable: String,
-        arguments: [String]
+        arguments: [String],
+        environment: [String: String]
     ) -> Bool {
         if liveExecutable.compare(recordedExecutable, options: [.caseInsensitive, .literal]) == .orderedSame {
+            return true
+        }
+        if CachedAgentProcessIdentityValidator.liveProcessMatchesLaunchExecutableEnvironment(
+            kind: kind,
+            executableCandidates: [liveExecutable],
+            environment: environment
+        ) {
             return true
         }
 

--- a/Sources/VaultAgentProcessScanner+CodexSessionCwd.swift
+++ b/Sources/VaultAgentProcessScanner+CodexSessionCwd.swift
@@ -1,0 +1,63 @@
+import Foundation
+import SQLite3
+
+final class CodexSessionCwdLookupCache {
+    private let fileManager: FileManager
+    private var cwdByDatabaseAndSession: [String: String?] = [:]
+
+    init(fileManager: FileManager) {
+        self.fileManager = fileManager
+    }
+
+    func workingDirectory(
+        kind: RestorableAgentKind,
+        sessionId: String,
+        launchCommand: AgentLaunchCommandSnapshot?
+    ) -> String? {
+        guard kind == .codex else { return nil }
+        guard let sessionId = normalizedCodexCwdValue(sessionId) else { return nil }
+        let codexHome = ((normalizedCodexCwdValue(launchCommand?.environment?["CODEX_HOME"]) ?? "~/.codex") as NSString)
+            .expandingTildeInPath
+        let dbPath = URL(fileURLWithPath: codexHome, isDirectory: true)
+            .appendingPathComponent("state_5.sqlite", isDirectory: false)
+            .path
+        guard fileManager.fileExists(atPath: dbPath) else { return nil }
+        let cacheKey = dbPath + "\u{0}" + sessionId
+        if let cached = cwdByDatabaseAndSession[cacheKey] {
+            return cached
+        }
+
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let db else {
+            sqlite3_close(db)
+            return nil
+        }
+        defer { sqlite3_close(db) }
+
+        let sql = "SELECT cwd FROM threads WHERE id = ? AND archived = 0 LIMIT 1"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else {
+            sqlite3_finalize(stmt)
+            return nil
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        let SQLITE_TRANSIENT_FN = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, sessionId, -1, SQLITE_TRANSIENT_FN)
+        guard sqlite3_step(stmt) == SQLITE_ROW,
+              let cwd = normalizedCodexCwdValue(SessionIndexStore.sqliteText(stmt, 0)) else {
+            cwdByDatabaseAndSession[cacheKey] = nil
+            return nil
+        }
+        cwdByDatabaseAndSession[cacheKey] = cwd
+        return cwd
+    }
+
+    private func normalizedCodexCwdValue(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Sources/VaultAgentProcessScanner+CodexSessionCwd.swift
+++ b/Sources/VaultAgentProcessScanner+CodexSessionCwd.swift
@@ -23,6 +23,7 @@ final class CodexSessionCwdLookupCache {
             .path
         guard fileManager.fileExists(atPath: dbPath) else { return nil }
         let cacheKey = dbPath + "\u{0}" + sessionId
+        // dict[key] is String?? here: .some(nil) is a memoized negative result.
         if let cached = cwdByDatabaseAndSession[cacheKey] {
             return cached
         }
@@ -46,7 +47,8 @@ final class CodexSessionCwdLookupCache {
         sqlite3_bind_text(stmt, 1, sessionId, -1, SQLITE_TRANSIENT_FN)
         guard sqlite3_step(stmt) == SQLITE_ROW,
               let cwd = normalizedCodexCwdValue(SessionIndexStore.sqliteText(stmt, 0)) else {
-            cwdByDatabaseAndSession[cacheKey] = nil
+            // updateValue stores .some(nil); subscript nil-assignment would remove the key.
+            cwdByDatabaseAndSession.updateValue(nil, forKey: cacheKey)
             return nil
         }
         cwdByDatabaseAndSession[cacheKey] = cwd

--- a/Sources/VaultAgentProcessScanner+ForkMarkers.swift
+++ b/Sources/VaultAgentProcessScanner+ForkMarkers.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+extension CmuxVaultAgentRegistration {
+    func processArgumentsCarryForkParentFlag(_ arguments: [String]) -> Bool {
+        let markers = forkParentMarkerTokens()
+        guard !markers.isEmpty else { return false }
+        return markers.allSatisfy { marker in
+            arguments.contains { argument in
+                argument.compare(marker, options: [.caseInsensitive, .literal]) == .orderedSame
+            }
+        }
+    }
+
+    private func forkParentMarkerTokens() -> [String] {
+        guard let forkCommand else { return [] }
+        let resumeConstants = Set(Self.constantTemplateTokens(in: resumeCommand))
+        let forkConstants = Self.constantTemplateTokens(in: forkCommand)
+        let markers = forkConstants.filter { !resumeConstants.contains($0) }
+        // If fork and resume differ only by placeholders, the live argv carries no
+        // constant marker that proves this process is a fork of its parent.
+        return markers
+    }
+
+    private static func constantTemplateTokens(in template: String) -> [String] {
+        splitShellWords(template).filter { !$0.contains("{{") && !$0.contains("}}") }
+    }
+
+    private static func splitShellWords(_ command: String) -> [String] {
+        enum Quote {
+            case single
+            case double
+        }
+
+        var words: [String] = []
+        var current = ""
+        var quote: Quote?
+        var escaping = false
+
+        func finishWord() {
+            guard !current.isEmpty else { return }
+            words.append(current)
+            current = ""
+        }
+
+        for character in command {
+            if escaping {
+                current.append(character)
+                escaping = false
+                continue
+            }
+            if character == "\\" {
+                escaping = true
+                continue
+            }
+            switch (quote, character) {
+            case (.single, "'"), (.double, "\""):
+                quote = nil
+            case (nil, "'"):
+                quote = .single
+            case (nil, "\""):
+                quote = .double
+            case (nil, " "), (nil, "\t"), (nil, "\n"):
+                finishWord()
+            default:
+                current.append(character)
+            }
+        }
+        if escaping {
+            current.append("\\")
+        }
+        finishWord()
+        return words
+    }
+}

--- a/Sources/VaultAgentProcessScanner+ForkParentFallback.swift
+++ b/Sources/VaultAgentProcessScanner+ForkParentFallback.swift
@@ -1,11 +1,5 @@
 import Foundation
 import CMUXAgentLaunch
-extension CmuxVaultAgentRegistration {
-    func processArgumentsCarryForkParentFlag(_ arguments: [String]) -> Bool {
-        forkCommand?.split(whereSeparator: \.isWhitespace).contains("--fork") == true && arguments.contains("--fork")
-    }
-}
-
 extension RestorableAgentSessionIndex {
     /// Fallback identity only: the caller merges these with `{ existing, _ in existing }`
     /// so a fork process never displaces an explicit same-pane detection
@@ -73,6 +67,14 @@ extension RestorableAgentSessionIndex {
         launcher: String,
         launchCommand: (executablePath: String, arguments: [String])
     )? {
+        if let wrapperFallback = forkParentFallbackWrapperLaunch(
+            processName: processName,
+            processPath: processPath,
+            arguments: arguments,
+            environment: environment
+        ) {
+            return wrapperFallback
+        }
         if processLooksLikeClaude(
             processName: processName,
             processPath: processPath,
@@ -80,13 +82,17 @@ extension RestorableAgentSessionIndex {
             environment: environment
         ),
            let parentSessionId = arguments.claudeForkFallbackParentSessionId,
-           let launchCommand = claudeForkFallbackLaunchCommand(
+           let launchCommand = claudeTeamsPersistentForkLaunchCommand(
+                liveArguments: arguments,
+                environment: environment
+           ) ?? claudeForkFallbackLaunchCommand(
                 processName: processName,
                 processPath: processPath,
                 arguments: arguments,
                 environment: environment
            ) {
-            return (.claude, parentSessionId, "claude", launchCommand)
+            let launcher = environmentLaunchKind(environment) == "claudeteams" ? "claudeTeams" : "claude"
+            return (.claude, parentSessionId, launcher, launchCommand)
         }
         if processLooksLikeCodex(
             processName: processName,
@@ -134,23 +140,12 @@ extension RestorableAgentSessionIndex {
             return true
         }
 
-        // `CMUX_AGENT_LAUNCH_KIND` is cmux's own launch token, but descendants of a
-        // claude launch inherit it, so ambient environment alone is not process
-        // identity. Trust it only when this process runs the executable the launcher
-        // recorded (covers custom claude binaries whose basename is not "claude"),
-        // never for a child that merely inherited the launch environment.
-        guard normalized(environment["CMUX_AGENT_LAUNCH_KIND"])?.compare(
-            "claude",
-            options: [.caseInsensitive, .literal]
-        ) == .orderedSame,
-              let launchExecutable = normalized(environment["CMUX_AGENT_LAUNCH_EXECUTABLE"]) else {
-            return false
-        }
-        let launchBasename = executableBasename(launchExecutable)
         let launchCandidates = executableCandidates + [arguments.dropFirst().first].compactMap(normalized)
-        return launchCandidates.contains { candidate in
-            executableBasename(candidate).compare(launchBasename, options: [.caseInsensitive, .literal]) == .orderedSame
-        }
+        return CachedAgentProcessIdentityValidator.liveProcessMatchesLaunchExecutableEnvironment(
+            kind: .claude,
+            executableCandidates: launchCandidates,
+            environment: environment
+        )
     }
 
     private static func claudeForkFallbackLaunchCommand(
@@ -272,15 +267,12 @@ extension RestorableAgentSessionIndex {
         }) {
             return true
         }
-        guard normalized(environment["CMUX_AGENT_LAUNCH_KIND"])?.compare("codex", options: [.caseInsensitive, .literal]) == .orderedSame,
-              let launchExecutable = normalized(environment["CMUX_AGENT_LAUNCH_EXECUTABLE"]) else {
-            return false
-        }
-        let launchBasename = executableBasename(launchExecutable)
         let launchCandidates = executableCandidates + [arguments.dropFirst().first].compactMap(normalized)
-        return launchCandidates.contains { candidate in
-            executableBasename(candidate).compare(launchBasename, options: [.caseInsensitive, .literal]) == .orderedSame
-        }
+        return CachedAgentProcessIdentityValidator.liveProcessMatchesLaunchExecutableEnvironment(
+            kind: .codex,
+            executableCandidates: launchCandidates,
+            environment: environment
+        )
     }
 
     private static func codexForkFallbackLaunchCommand(
@@ -390,6 +382,12 @@ extension RestorableAgentSessionIndex {
             return nil
         }
         return trimmed
+    }
+
+    static func environmentLaunchKind(_ environment: [String: String]) -> String? {
+        normalized(environment["CMUX_AGENT_LAUNCH_KIND"])?
+            .replacingOccurrences(of: "-", with: "")
+            .lowercased()
     }
 
     /// A pane's own hook record overrides the fork-parent fallback only when it was

--- a/Sources/VaultAgentProcessScanner+ForkParentFallbackWrappers.swift
+++ b/Sources/VaultAgentProcessScanner+ForkParentFallbackWrappers.swift
@@ -1,0 +1,153 @@
+import Foundation
+import CMUXAgentLaunch
+
+extension RestorableAgentSessionIndex {
+    static func forkParentFallbackWrapperLaunch(
+        processName: String,
+        processPath: String?,
+        arguments: [String],
+        environment: [String: String]
+    ) -> (
+        kind: RestorableAgentKind,
+        parentSessionId: String,
+        launcher: String,
+        launchCommand: (executablePath: String, arguments: [String])
+    )? {
+        guard wrapperProcessLooksLikeCmuxCLI(
+            processName: processName,
+            processPath: processPath,
+            arguments: arguments,
+            environment: environment
+        ) else {
+            return nil
+        }
+        if let codexTeams = wrapperCodexTeamsFallback(arguments: arguments) {
+            return codexTeams
+        }
+        return nil
+    }
+
+    private static func wrapperCodexTeamsFallback(
+        arguments: [String]
+    ) -> (
+        kind: RestorableAgentKind,
+        parentSessionId: String,
+        launcher: String,
+        launchCommand: (executablePath: String, arguments: [String])
+    )? {
+        guard let subcommandIndex = arguments.firstIndex(of: "codex-teams"),
+              arguments.index(subcommandIndex, offsetBy: 2, limitedBy: arguments.endIndex) != nil else {
+            return nil
+        }
+        let forkIndex = arguments.index(after: subcommandIndex)
+        let sessionIndex = arguments.index(after: forkIndex)
+        guard forkIndex < arguments.endIndex,
+              sessionIndex < arguments.endIndex,
+              arguments[forkIndex] == "fork",
+              let parentSessionId = normalizedWrapperUUID(arguments[sessionIndex]) else {
+            return nil
+        }
+        let tail = Array(arguments[arguments.index(after: subcommandIndex)...])
+        guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "codex-fork-replay", args: tail) else {
+            return nil
+        }
+        // codex-teams keeps the cmux wrapper process alive; its exec-time env does
+        // not carry CMUX_AGENT_LAUNCH_KIND, so cached validation has no teams/base
+        // kind mismatch to reject.
+        let executable = wrapperExecutable(arguments: arguments)
+        return (
+            .codex,
+            parentSessionId,
+            "codexTeams",
+            (executable, [executable, "codex-teams"] + preserved)
+        )
+    }
+
+    private static func wrapperProcessLooksLikeCmuxCLI(
+        processName: String,
+        processPath: String?,
+        arguments: [String],
+        environment: [String: String]
+    ) -> Bool {
+        let bundledCLIPath = normalizedWrapperValue(environment["CMUX_BUNDLED_CLI_PATH"])
+        let candidates = [arguments.first, processPath, processName].compactMap(normalizedWrapperValue)
+        return candidates.contains { candidate in
+            executableBasename(candidate).compare("cmux", options: [.caseInsensitive, .literal]) == .orderedSame
+                || bundledCLIPath.map { ($0 as NSString).standardizingPath == (candidate as NSString).standardizingPath } == true
+        }
+    }
+
+    private static func wrapperExecutable(arguments: [String]) -> String {
+        normalizedWrapperValue(arguments.first) ?? "cmux"
+    }
+
+    private static func normalizedWrapperUUID(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              !trimmed.hasPrefix("-"),
+              UUID(uuidString: trimmed) != nil else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func normalizedWrapperValue(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func executableBasename(_ value: String) -> String {
+        (value as NSString).lastPathComponent
+    }
+
+    static func claudeTeamsPersistentForkLaunchCommand(
+        liveArguments: [String],
+        environment: [String: String]
+    ) -> (executablePath: String, arguments: [String])? {
+        guard environmentLaunchKind(environment) == "claudeteams" else { return nil }
+        let launchArguments = decodedNULSeparatedBase64(environment["CMUX_AGENT_LAUNCH_ARGV_B64"])
+            ?? [normalizedWrapperValue(environment["CMUX_AGENT_LAUNCH_EXECUTABLE"]) ?? "cmux", "claude-teams"] + Array(liveArguments.dropFirst())
+        guard launchArguments.count >= 2,
+              launchArguments[1] == "claude-teams" else {
+            return nil
+        }
+        let executable = normalizedWrapperValue(environment["CMUX_AGENT_LAUNCH_EXECUTABLE"])
+            ?? normalizedWrapperValue(launchArguments.first)
+            ?? "cmux"
+        let tail = Array(launchArguments.dropFirst(2))
+        guard let preserved = AgentLaunchSanitizer.preservedClaudeTeamsLaunchArguments(args: tail) else {
+            return nil
+        }
+        return (executable, [executable, "claude-teams"] + preserved)
+    }
+
+    private static func decodedNULSeparatedBase64(_ rawValue: String?) -> [String]? {
+        guard let rawValue,
+              let data = Data(base64Encoded: rawValue) else {
+            return nil
+        }
+        var values: [String] = []
+        var start = data.startIndex
+        var index = start
+        while index < data.endIndex {
+            if data[index] == 0 {
+                if index > start,
+                   let value = String(data: data[start..<index], encoding: .utf8),
+                   !value.isEmpty {
+                    values.append(value)
+                }
+                start = data.index(after: index)
+            }
+            index = data.index(after: index)
+        }
+        if start < data.endIndex,
+           let value = String(data: data[start..<data.endIndex], encoding: .utf8),
+           !value.isEmpty {
+            values.append(value)
+        }
+        return values.isEmpty ? nil : values
+    }
+}

--- a/Sources/VaultAgentProcessScanner+LiveProcessIdentity.swift
+++ b/Sources/VaultAgentProcessScanner+LiveProcessIdentity.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension RestorableAgentSessionIndex {
+    /// Whether a live scoped process's executable is credibly the agent the hook
+    /// record captured: exact basename match, the launch-time executable recorded
+    /// in the process's own cmux launch environment, or a known agent entrypoint
+    /// shape in argv (versioned claude installs, node-launched codex, etc.).
+    static func liveProcessExecutableMatchesRecordedAgent(
+        kind: RestorableAgentKind,
+        liveExecutable: String,
+        recordedExecutable: String,
+        arguments: [String],
+        environment: [String: String]
+    ) -> Bool {
+        if liveExecutable.compare(recordedExecutable, options: [.caseInsensitive, .literal]) == .orderedSame {
+            return true
+        }
+        if CachedAgentProcessIdentityValidator.liveProcessMatchesLaunchExecutableEnvironment(
+            kind: kind,
+            executableCandidates: [liveExecutable],
+            environment: environment
+        ) {
+            return true
+        }
+
+        return CachedAgentProcessIdentityValidator.liveClaudeProcessExecutableMatches(kind: kind, liveExecutable: liveExecutable, arguments: arguments)
+            || CachedAgentProcessIdentityValidator.liveCodexProcessExecutableMatches(kind: kind, liveExecutable: liveExecutable, arguments: arguments)
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -677,6 +677,7 @@
 		AA5269A0C0DE0002FACE0002 /* ForeignFirstResponderPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5269A0C0DE0001FACE0001 /* ForeignFirstResponderPolicy.swift */; };
 		AA5269A0C0DE0004FACE0004 /* ForeignFirstResponderPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5269A0C0DE0003FACE0003 /* ForeignFirstResponderPolicyTests.swift */; };
 		F0F0CF0F0000000000000001 /* ForkParentFallbackGeneralizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0CF0F0000000000000002 /* ForkParentFallbackGeneralizationTests.swift */; };
+		F76550030000000000000001 /* ForkParentFallbackResidualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550030000000000000002 /* ForkParentFallbackResidualTests.swift */; };
 		F0F0CF0D0000000000000001 /* ForkParentFallbackSessionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0CF0D0000000000000002 /* ForkParentFallbackSessionIndexTests.swift */; };
 		F17F00000000000000000003 /* FullWidthTabCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17F00000000000000000004 /* FullWidthTabCommandTests.swift */; };
 		F17F00000000000000000001 /* FullWidthTabPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17F00000000000000000002 /* FullWidthTabPersistenceTests.swift */; };
@@ -2219,6 +2220,7 @@
 		AA5269A0C0DE0001FACE0001 /* ForeignFirstResponderPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ForeignFirstResponderPolicy.swift; sourceTree = "<group>"; };
 		AA5269A0C0DE0003FACE0003 /* ForeignFirstResponderPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForeignFirstResponderPolicyTests.swift; sourceTree = "<group>"; };
 		F0F0CF0F0000000000000002 /* ForkParentFallbackGeneralizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForkParentFallbackGeneralizationTests.swift; sourceTree = "<group>"; };
+		F76550030000000000000002 /* ForkParentFallbackResidualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForkParentFallbackResidualTests.swift; sourceTree = "<group>"; };
 		F0F0CF0D0000000000000002 /* ForkParentFallbackSessionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForkParentFallbackSessionIndexTests.swift; sourceTree = "<group>"; };
 		F17F00000000000000000004 /* FullWidthTabCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullWidthTabCommandTests.swift; sourceTree = "<group>"; };
 		F17F00000000000000000002 /* FullWidthTabPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullWidthTabPersistenceTests.swift; sourceTree = "<group>"; };
@@ -4382,6 +4384,7 @@
 				C6711B020000000000000001 /* RestorableAgentSessionIndexCodexWeakRecordTests.swift */,
 				F54100B1A1B2C3D4E5F60718 /* RestorableCodexForkTagTests.swift */,
 				F0F0CF0F0000000000000002 /* ForkParentFallbackGeneralizationTests.swift */,
+				F76550030000000000000002 /* ForkParentFallbackResidualTests.swift */,
 				F0F0CF0D0000000000000002 /* ForkParentFallbackSessionIndexTests.swift */,
 				F5410007A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift */,
 				F54100A1A1B2C3D4E5F60718 /* RestorableAgentSessionStalePIDTests.swift */,
@@ -6387,6 +6390,7 @@
 				C0DEFB300000000000000001 /* FocusSurfaceBroadcasterTests.swift in Sources */,
 				AA5269A0C0DE0004FACE0004 /* ForeignFirstResponderPolicyTests.swift in Sources */,
 				F0F0CF0F0000000000000001 /* ForkParentFallbackGeneralizationTests.swift in Sources */,
+				F76550030000000000000001 /* ForkParentFallbackResidualTests.swift in Sources */,
 				F0F0CF0D0000000000000001 /* ForkParentFallbackSessionIndexTests.swift in Sources */,
 				F17F00000000000000000003 /* FullWidthTabCommandTests.swift in Sources */,
 				F17F00000000000000000001 /* FullWidthTabPersistenceTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1414,7 +1414,10 @@
 		C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
 		A5001208 /* UpdateTitlebarAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001218 /* UpdateTitlebarAccessory.swift */; };
 		C2035A070000000000000001 /* URLRequest+BrowserFailedNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A070000000000000002 /* URLRequest+BrowserFailedNavigation.swift */; };
+		F76550040000000000000001 /* VaultAgentProcessScanner+CodexSessionCwd.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550040000000000000002 /* VaultAgentProcessScanner+CodexSessionCwd.swift */; };
+		F76550010000000000000001 /* VaultAgentProcessScanner+ForkMarkers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550010000000000000002 /* VaultAgentProcessScanner+ForkMarkers.swift */; };
 		F0F0CF0C0000000000000001 /* VaultAgentProcessScanner+ForkParentFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0CF0C0000000000000002 /* VaultAgentProcessScanner+ForkParentFallback.swift */; };
+		F76550020000000000000001 /* VaultAgentProcessScanner+ForkParentFallbackWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550020000000000000002 /* VaultAgentProcessScanner+ForkParentFallbackWrappers.swift */; };
 		B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000005 /* VaultAgentProcessScanner.swift */; };
 		B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000001 /* VaultAgentRegistry.swift */; };
 		C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */; };
@@ -2942,7 +2945,10 @@
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
 		A5001218 /* UpdateTitlebarAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateTitlebarAccessory.swift; sourceTree = "<group>"; };
 		C2035A070000000000000002 /* URLRequest+BrowserFailedNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/URLRequest+BrowserFailedNavigation.swift"; sourceTree = "<group>"; };
+		F76550040000000000000002 /* VaultAgentProcessScanner+CodexSessionCwd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+CodexSessionCwd.swift"; sourceTree = "<group>"; };
+		F76550010000000000000002 /* VaultAgentProcessScanner+ForkMarkers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+ForkMarkers.swift"; sourceTree = "<group>"; };
 		F0F0CF0C0000000000000002 /* VaultAgentProcessScanner+ForkParentFallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+ForkParentFallback.swift"; sourceTree = "<group>"; };
+		F76550020000000000000002 /* VaultAgentProcessScanner+ForkParentFallbackWrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+ForkParentFallbackWrappers.swift"; sourceTree = "<group>"; };
 		B35750000000000000000005 /* VaultAgentProcessScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentProcessScanner.swift; sourceTree = "<group>"; };
 		B35750000000000000000001 /* VaultAgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentRegistry.swift; sourceTree = "<group>"; };
 		C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalTabsSidebar+WorkspaceGroups.swift"; sourceTree = "<group>"; };
@@ -4167,7 +4173,10 @@
 				FE003001 /* SessionIndexStore.swift */,
 				B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */,
 				B35750000000000000000005 /* VaultAgentProcessScanner.swift */,
+				F76550040000000000000002 /* VaultAgentProcessScanner+CodexSessionCwd.swift */,
 				F0F0CF0C0000000000000002 /* VaultAgentProcessScanner+ForkParentFallback.swift */,
+				F76550010000000000000002 /* VaultAgentProcessScanner+ForkMarkers.swift */,
+				F76550020000000000000002 /* VaultAgentProcessScanner+ForkParentFallbackWrappers.swift */,
 				FE003004 /* SessionIndexStore+CodexSQL.swift */,
 				FE003005 /* RovoDevIndex.swift */,
 				F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */,
@@ -6001,7 +6010,10 @@
 				A500120D /* UpdateLogStore.swift in Sources */,
 				A5001208 /* UpdateTitlebarAccessory.swift in Sources */,
 				C2035A070000000000000001 /* URLRequest+BrowserFailedNavigation.swift in Sources */,
+				F76550040000000000000001 /* VaultAgentProcessScanner+CodexSessionCwd.swift in Sources */,
+				F76550010000000000000001 /* VaultAgentProcessScanner+ForkMarkers.swift in Sources */,
 				F0F0CF0C0000000000000001 /* VaultAgentProcessScanner+ForkParentFallback.swift in Sources */,
+				F76550020000000000000001 /* VaultAgentProcessScanner+ForkParentFallbackWrappers.swift in Sources */,
 				B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */,
 				B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */,
 				C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1418,6 +1418,7 @@
 		F76550010000000000000001 /* VaultAgentProcessScanner+ForkMarkers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550010000000000000002 /* VaultAgentProcessScanner+ForkMarkers.swift */; };
 		F0F0CF0C0000000000000001 /* VaultAgentProcessScanner+ForkParentFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0CF0C0000000000000002 /* VaultAgentProcessScanner+ForkParentFallback.swift */; };
 		F76550020000000000000001 /* VaultAgentProcessScanner+ForkParentFallbackWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550020000000000000002 /* VaultAgentProcessScanner+ForkParentFallbackWrappers.swift */; };
+		F76550050000000000000001 /* VaultAgentProcessScanner+LiveProcessIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550050000000000000002 /* VaultAgentProcessScanner+LiveProcessIdentity.swift */; };
 		B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000005 /* VaultAgentProcessScanner.swift */; };
 		B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000001 /* VaultAgentRegistry.swift */; };
 		C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */; };
@@ -2949,6 +2950,7 @@
 		F76550010000000000000002 /* VaultAgentProcessScanner+ForkMarkers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+ForkMarkers.swift"; sourceTree = "<group>"; };
 		F0F0CF0C0000000000000002 /* VaultAgentProcessScanner+ForkParentFallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+ForkParentFallback.swift"; sourceTree = "<group>"; };
 		F76550020000000000000002 /* VaultAgentProcessScanner+ForkParentFallbackWrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+ForkParentFallbackWrappers.swift"; sourceTree = "<group>"; };
+		F76550050000000000000002 /* VaultAgentProcessScanner+LiveProcessIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+LiveProcessIdentity.swift"; sourceTree = "<group>"; };
 		B35750000000000000000005 /* VaultAgentProcessScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentProcessScanner.swift; sourceTree = "<group>"; };
 		B35750000000000000000001 /* VaultAgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentRegistry.swift; sourceTree = "<group>"; };
 		C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalTabsSidebar+WorkspaceGroups.swift"; sourceTree = "<group>"; };
@@ -4177,6 +4179,7 @@
 				F0F0CF0C0000000000000002 /* VaultAgentProcessScanner+ForkParentFallback.swift */,
 				F76550010000000000000002 /* VaultAgentProcessScanner+ForkMarkers.swift */,
 				F76550020000000000000002 /* VaultAgentProcessScanner+ForkParentFallbackWrappers.swift */,
+				F76550050000000000000002 /* VaultAgentProcessScanner+LiveProcessIdentity.swift */,
 				FE003004 /* SessionIndexStore+CodexSQL.swift */,
 				FE003005 /* RovoDevIndex.swift */,
 				F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */,
@@ -6014,6 +6017,7 @@
 				F76550010000000000000001 /* VaultAgentProcessScanner+ForkMarkers.swift in Sources */,
 				F0F0CF0C0000000000000001 /* VaultAgentProcessScanner+ForkParentFallback.swift in Sources */,
 				F76550020000000000000001 /* VaultAgentProcessScanner+ForkParentFallbackWrappers.swift in Sources */,
+				F76550050000000000000001 /* VaultAgentProcessScanner+LiveProcessIdentity.swift in Sources */,
 				B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */,
 				B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */,
 				C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */,

--- a/cmuxTests/ForkParentFallbackGeneralizationTests.swift
+++ b/cmuxTests/ForkParentFallbackGeneralizationTests.swift
@@ -144,6 +144,49 @@ struct ForkParentFallbackGeneralizationTests {
         #expect(entry.sessionIDSource == .forkParentFallback)
     }
 
+    @Test func customRegistryForkTemplateWithNonForkMarkerDemotesParent() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+        let registration = customBranchFromRegistration()
+        let registry = CmuxVaultAgentRegistry(registrations: [registration])
+
+        let detected = detectedSnapshots(
+            fixture: fixture,
+            registry: registry,
+            argv: ["/usr/local/bin/brancher", "--thread", fixture.parentCodexId, "--branch-from"],
+            launchKind: "brancher",
+            processName: "brancher",
+            processPath: "/usr/local/bin/brancher"
+        )
+
+        #expect(detected[fixture.forkKey]?.sessionIDSource == .forkParentFallback)
+    }
+
+    @Test func customRegistryForkTemplateWithoutConstantMarkerStaysExplicit() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+        let registration = CmuxVaultAgentRegistration(
+            id: "brancher",
+            name: "Brancher",
+            detect: CmuxVaultAgentDetectRule(processName: "brancher"),
+            sessionIdSource: .argvOption("--thread"),
+            resumeCommand: "{{executable}} --thread {{sessionId}}",
+            forkCommand: "{{executable}} --thread {{sessionId}}"
+        )
+        let registry = CmuxVaultAgentRegistry(registrations: [registration])
+
+        let detected = detectedSnapshots(
+            fixture: fixture,
+            registry: registry,
+            argv: ["/usr/local/bin/brancher", "--thread", fixture.parentCodexId],
+            launchKind: "brancher",
+            processName: "brancher",
+            processPath: "/usr/local/bin/brancher"
+        )
+
+        #expect(detected[fixture.forkKey]?.sessionIDSource == .explicit)
+    }
+
     @Test func customRegistryPaneHookIdentityWinsAfterForkMintsOwnSession() throws {
         let fixture = try Fixture.make()
         defer { fixture.cleanup() }
@@ -360,6 +403,17 @@ struct ForkParentFallbackGeneralizationTests {
             sessionIdSource: .argvOption("--thread"),
             resumeCommand: "{{executable}} --thread {{sessionId}}",
             forkCommand: "{{executable}} --thread {{sessionId}} --fork"
+        )
+    }
+
+    private func customBranchFromRegistration() -> CmuxVaultAgentRegistration {
+        CmuxVaultAgentRegistration(
+            id: "brancher",
+            name: "Brancher",
+            detect: CmuxVaultAgentDetectRule(processName: "brancher"),
+            sessionIdSource: .argvOption("--thread"),
+            resumeCommand: "{{executable}} --thread {{sessionId}}",
+            forkCommand: "{{executable}} --thread {{sessionId}} --branch-from"
         )
     }
 

--- a/cmuxTests/ForkParentFallbackResidualTests.swift
+++ b/cmuxTests/ForkParentFallbackResidualTests.swift
@@ -1,0 +1,460 @@
+import Darwin
+import Foundation
+import SQLite3
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite
+struct ForkParentFallbackResidualTests {
+    @Test func customClaudeBinaryForkFallbackPassesCachedForkValidation() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        let sessionId = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
+        let processArguments = fixture.processArguments(
+            argv: ["/opt/cmux-tools/claude-custom", "--resume", sessionId, "--fork-session"],
+            launchKind: "claude",
+            extraEnvironment: ["CMUX_AGENT_LAUNCH_EXECUTABLE": "/opt/cmux-tools/claude-custom"]
+        )
+        let identity = AgentPIDProcessIdentity(
+            pid: pid_t(fixture.processID),
+            startSeconds: 100,
+            startMicroseconds: 0
+        )
+        let loader = SharedLiveAgentIndexLoader(
+            homeDirectory: fixture.root.path,
+            fileManager: fixture.fileManager,
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            processSnapshotProvider: {
+                fixture.processSnapshot(processName: "claude-custom", processPath: "/opt/cmux-tools/claude-custom")
+            },
+            capturedAtProvider: { 42 },
+            processArgumentsProvider: { $0 == fixture.processID ? processArguments : nil },
+            processIdentityProvider: { $0 == fixture.processID ? identity : nil }
+        )
+
+        let result = loader.loadResultSynchronously()
+        #expect(result.forkValidatedPanels.contains(fixture.panelKey))
+    }
+
+    @Test func customClaudeValidatorRejectsDifferentLiveExecutableThanLaunchExecutable() {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "claude",
+                arguments: ["claude"],
+                workingDirectory: nil,
+                environment: nil,
+                capturedAt: nil,
+                source: "process"
+            ),
+            registration: nil
+        )
+        let process = CmuxTopProcessArguments(
+            arguments: ["/opt/cmux-tools/not-claude", "--resume", snapshot.sessionId, "--fork-session"],
+            environment: [
+                "CMUX_AGENT_LAUNCH_KIND": "claude",
+                "CMUX_AGENT_LAUNCH_EXECUTABLE": "/opt/cmux-tools/claude-custom",
+            ]
+        )
+
+        #expect(CachedAgentProcessIdentityValidator().currentProcess(process, matches: snapshot) == false)
+    }
+
+    @Test func validatorAcceptsTeamsLaunchKindOnlyForMatchingBaseKind() {
+        let claudeTeamsSnapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claudeTeams",
+                executablePath: "/usr/local/bin/cmux",
+                arguments: ["/usr/local/bin/cmux", "claude-teams"],
+                workingDirectory: nil,
+                environment: nil,
+                capturedAt: nil,
+                source: "process"
+            ),
+            registration: nil
+        )
+        let claudeTeamsProcess = CmuxTopProcessArguments(
+            arguments: ["/usr/local/bin/claude", "--resume", claudeTeamsSnapshot.sessionId, "--fork-session"],
+            environment: [
+                "CMUX_AGENT_LAUNCH_KIND": "claudeTeams",
+                "CMUX_AGENT_LAUNCH_EXECUTABLE": "/usr/local/bin/cmux",
+            ]
+        )
+        #expect(CachedAgentProcessIdentityValidator().currentProcess(claudeTeamsProcess, matches: claudeTeamsSnapshot))
+
+        let codexTeamsSnapshot = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "019f436f-1111-4222-8333-aaaaaaaaaaaa",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codexTeams",
+                executablePath: "/usr/local/bin/cmux",
+                arguments: ["/usr/local/bin/cmux", "codex-teams"],
+                workingDirectory: nil,
+                environment: nil,
+                capturedAt: nil,
+                source: "process"
+            ),
+            registration: nil
+        )
+        #expect(CachedAgentProcessIdentityValidator().currentProcess(
+            CmuxTopProcessArguments(
+                arguments: ["/usr/local/bin/cmux", "codex-teams", "fork", codexTeamsSnapshot.sessionId],
+                environment: ["CMUX_AGENT_LAUNCH_KIND": "codexTeams"]
+            ),
+            matches: codexTeamsSnapshot
+        ))
+        #expect(CachedAgentProcessIdentityValidator().currentProcess(
+            CmuxTopProcessArguments(
+                arguments: ["/usr/local/bin/cmux", "codex-teams", "fork", claudeTeamsSnapshot.sessionId],
+                environment: ["CMUX_AGENT_LAUNCH_KIND": "codexTeams"]
+            ),
+            matches: claudeTeamsSnapshot
+        ) == false)
+    }
+
+    @Test func codexRecordWithoutHookCwdUsesCodexThreadCwdForResumeAndFork() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        let sessionId = "019f436f-1111-4222-8333-aaaaaaaaaaaa"
+        let codexHome = fixture.root.appendingPathComponent("codex-home", isDirectory: true)
+        try fixture.fileManager.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try writeCodexStateDB(codexHome: codexHome, sessionId: sessionId, cwd: fixture.cwd.path)
+        try writeStore(root: fixture.root, filename: "codex-hook-sessions.json", sessions: [
+            sessionId: [
+                "sessionId": sessionId,
+                "workspaceId": fixture.workspaceId.uuidString,
+                "surfaceId": fixture.panelId.uuidString,
+                "pid": NSNull(),
+                "updatedAt": 10,
+                "isRestorable": true,
+                "launchCommand": [
+                    "launcher": "codex",
+                    "executablePath": "/usr/local/bin/codex",
+                    "arguments": ["/usr/local/bin/codex"],
+                    "environment": ["CODEX_HOME": codexHome.path],
+                    "capturedAt": 10,
+                    "source": "environment",
+                ],
+            ],
+        ])
+
+        let snapshot = try #require(
+            RestorableAgentSessionIndex.load(homeDirectory: fixture.root.path, fileManager: fixture.fileManager)
+                .snapshot(workspaceId: fixture.workspaceId, panelId: fixture.panelId)
+        )
+        #expect(snapshot.workingDirectory == fixture.cwd.path)
+        #expect(snapshot.resumeStartupInput()?.contains("cd -- '\(fixture.cwd.path)'") == true)
+        #expect(snapshot.forkStartupInput()?.contains("cd -- '\(fixture.cwd.path)'") == true)
+
+        let cwdless = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: sessionId,
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "/usr/local/bin/codex",
+                arguments: ["/usr/local/bin/codex"],
+                workingDirectory: nil,
+                environment: nil,
+                capturedAt: nil,
+                source: "process"
+            ),
+            registration: nil
+        )
+        #expect(cwdless.forkStartupInput() != nil)
+        #expect(cwdless.forkStartupInput()?.contains("cd --") == false)
+    }
+
+    @Test func codexTeamsWrapperForkFallbackRoundTripsAndParentHookSurvives() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        let parentSessionId = "019f436f-1111-4222-8333-aaaaaaaaaaaa"
+        try writeStore(root: fixture.root, filename: "codex-hook-sessions.json", sessions: [
+            parentSessionId: fixture.hookRecord(kind: "codex", sessionId: parentSessionId, panelId: fixture.parentPanelId),
+        ])
+        let detected = RestorableAgentSessionIndex.processDetectedSnapshots(
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            fileManager: fixture.fileManager,
+            processSnapshot: fixture.processSnapshot(processName: "cmux", processPath: "/usr/local/bin/cmux"),
+            capturedAt: 42,
+            processArgumentsProvider: { pid in
+                pid == fixture.processID
+                    ? fixture.processArguments(
+                        argv: ["/usr/local/bin/cmux", "codex-teams", "fork", parentSessionId, "--model", "gpt-5"],
+                        launchKind: nil
+                    )
+                    : nil
+            }
+        )
+        let index = RestorableAgentSessionIndex.load(
+            homeDirectory: fixture.root.path,
+            fileManager: fixture.fileManager,
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            detectedSnapshots: detected,
+            processArgumentsProvider: { _ in nil },
+            processIdentityProvider: { _ in nil }
+        )
+
+        let forkSnapshot = try #require(index.snapshot(workspaceId: fixture.workspaceId, panelId: fixture.panelId))
+        #expect(forkSnapshot.kind == .codex)
+        #expect(forkSnapshot.sessionId == parentSessionId)
+        #expect(forkSnapshot.forkCommand?.contains("'codex-teams' 'fork' '\(parentSessionId)' '--model' 'gpt-5'") == true)
+        #expect(index.snapshot(workspaceId: fixture.workspaceId, panelId: fixture.parentPanelId)?.sessionId == parentSessionId)
+    }
+
+    @Test func codexTeamsWrapperSameKindHookRecordWinsAfterForkMintsSession() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        let parentSessionId = "019f436f-1111-4222-8333-aaaaaaaaaaaa"
+        let childSessionId = "019f436f-2222-4222-8333-bbbbbbbbbbbb"
+        try writeStore(root: fixture.root, filename: "codex-hook-sessions.json", sessions: [
+            parentSessionId: fixture.hookRecord(kind: "codex", sessionId: parentSessionId, panelId: fixture.parentPanelId, updatedAt: 10),
+            childSessionId: fixture.hookRecord(kind: "codex", sessionId: childSessionId, panelId: fixture.panelId, updatedAt: 20),
+        ])
+        let detected = RestorableAgentSessionIndex.processDetectedSnapshots(
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            fileManager: fixture.fileManager,
+            processSnapshot: fixture.processSnapshot(processName: "cmux", processPath: "/usr/local/bin/cmux"),
+            capturedAt: 42,
+            processArgumentsProvider: { pid in
+                pid == fixture.processID
+                    ? fixture.processArguments(
+                        argv: ["/usr/local/bin/cmux", "codex-teams", "fork", parentSessionId],
+                        launchKind: nil
+                    )
+                    : nil
+            }
+        )
+        let index = RestorableAgentSessionIndex.load(
+            homeDirectory: fixture.root.path,
+            fileManager: fixture.fileManager,
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            detectedSnapshots: detected,
+            processArgumentsProvider: { _ in nil },
+            processIdentityProvider: { _ in nil }
+        )
+
+        #expect(index.snapshot(workspaceId: fixture.workspaceId, panelId: fixture.panelId)?.sessionId == childSessionId)
+    }
+
+    @Test func claudeTeamsPersistentClaudeProcessForkFallbackRoundTripsAndValidates() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        let parentSessionId = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
+        let liveArguments = [
+            "/usr/local/bin/claude",
+            "--teammate-mode",
+            "auto",
+            "--resume",
+            parentSessionId,
+            "--fork-session",
+            "--model",
+            "sonnet",
+        ]
+        let launchArguments = [
+            "/usr/local/bin/cmux",
+            "claude-teams",
+            "--resume",
+            parentSessionId,
+            "--fork-session",
+            "--model",
+            "sonnet",
+        ]
+        let processArguments = fixture.processArguments(
+            argv: liveArguments,
+            launchKind: "claudeTeams",
+            extraEnvironment: [
+                "CMUX_AGENT_LAUNCH_EXECUTABLE": "/usr/local/bin/cmux",
+                "CMUX_AGENT_LAUNCH_ARGV_B64": base64NULSeparated(launchArguments),
+            ]
+        )
+        let identity = AgentPIDProcessIdentity(
+            pid: pid_t(fixture.processID),
+            startSeconds: 100,
+            startMicroseconds: 0
+        )
+        let loader = SharedLiveAgentIndexLoader(
+            homeDirectory: fixture.root.path,
+            fileManager: fixture.fileManager,
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            processSnapshotProvider: {
+                fixture.processSnapshot(processName: "claude", processPath: "/usr/local/bin/claude")
+            },
+            capturedAtProvider: { 42 },
+            processArgumentsProvider: { pid in
+                pid == fixture.processID ? processArguments : nil
+            },
+            processIdentityProvider: { pid in
+                pid == fixture.processID ? identity : nil
+            }
+        )
+        let result = loader.loadResultSynchronously()
+        let snapshot = try #require(result.index.snapshot(workspaceId: fixture.workspaceId, panelId: fixture.panelId))
+        #expect(snapshot.kind == .claude)
+        #expect(result.forkValidatedPanels.contains(fixture.panelKey))
+        #expect(snapshot.forkCommand?.contains("'claude-teams' '--resume' '\(parentSessionId)' '--fork-session' '--model' 'sonnet'") == true)
+    }
+
+    private struct Fixture {
+        let fileManager: FileManager
+        let root: URL
+        let cwd: URL
+        let workspaceId: UUID
+        let panelId: UUID
+        let parentPanelId: UUID
+        let processID = 7_655
+
+        var panelKey: RestorableAgentSessionIndex.PanelKey {
+            RestorableAgentSessionIndex.PanelKey(workspaceId: workspaceId, panelId: panelId)
+        }
+
+        static func make() throws -> Fixture {
+            let fileManager = FileManager.default
+            let root = fileManager.temporaryDirectory.appendingPathComponent("cmux-fork-residual-\(UUID().uuidString)", isDirectory: true)
+            let cwd = root.appendingPathComponent("repo", isDirectory: true)
+            try fileManager.createDirectory(at: cwd, withIntermediateDirectories: true)
+            return Fixture(
+                fileManager: fileManager,
+                root: root,
+                cwd: cwd,
+                workspaceId: UUID(),
+                panelId: UUID(),
+                parentPanelId: UUID()
+            )
+        }
+
+        func cleanup() {
+            try? fileManager.removeItem(at: root)
+        }
+
+        func processSnapshot(processName: String, processPath: String?) -> CmuxTopProcessSnapshot {
+            CmuxTopProcessSnapshot(
+                processes: [
+                    CmuxTopProcessInfo(
+                        pid: processID,
+                        parentPID: 1,
+                        name: processName,
+                        path: processPath,
+                        ttyDevice: nil,
+                        cmuxWorkspaceID: workspaceId,
+                        cmuxSurfaceID: panelId,
+                        cmuxAttributionReason: "cmux-test",
+                        processGroupID: nil,
+                        terminalProcessGroupID: nil,
+                        cpuPercent: 0,
+                        residentBytes: 0,
+                        virtualBytes: 0,
+                        threadCount: 1
+                    ),
+                ],
+                sampledAt: Date(timeIntervalSince1970: 0),
+                includesProcessDetails: true
+            )
+        }
+
+        func processArguments(
+            argv: [String],
+            launchKind: String?,
+            extraEnvironment: [String: String] = [:]
+        ) -> CmuxTopProcessArguments {
+            var environment = [
+                "CMUX_AGENT_LAUNCH_CWD": cwd.path,
+                "CMUX_BUNDLED_CLI_PATH": "/usr/local/bin/cmux",
+                "CMUX_WORKSPACE_ID": workspaceId.uuidString,
+                "CMUX_SURFACE_ID": panelId.uuidString,
+                "PWD": cwd.path,
+            ]
+            if let launchKind {
+                environment["CMUX_AGENT_LAUNCH_KIND"] = launchKind
+            }
+            environment.merge(extraEnvironment) { _, new in new }
+            return CmuxTopProcessArguments(arguments: argv, environment: environment)
+        }
+
+        func hookRecord(
+            kind: String,
+            sessionId: String,
+            panelId: UUID,
+            updatedAt: TimeInterval = 10
+        ) -> [String: Any] {
+            [
+                "sessionId": sessionId,
+                "workspaceId": workspaceId.uuidString,
+                "surfaceId": panelId.uuidString,
+                "cwd": cwd.path,
+                "pid": NSNull(),
+                "updatedAt": updatedAt,
+                "isRestorable": true,
+                "launchCommand": [
+                    "launcher": kind,
+                    "executablePath": "/usr/local/bin/\(kind)",
+                    "arguments": ["/usr/local/bin/\(kind)"],
+                    "workingDirectory": cwd.path,
+                    "capturedAt": updatedAt,
+                    "source": "test",
+                ],
+            ]
+        }
+    }
+
+    private func writeStore(root: URL, filename: String, sessions: [String: [String: Any]]) throws {
+        let stateDir = root.appendingPathComponent(".cmuxterm", isDirectory: true)
+        try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: ["version": 1, "sessions": sessions], options: [.prettyPrinted])
+        try data.write(to: stateDir.appendingPathComponent(filename), options: .atomic)
+    }
+
+    private func writeCodexStateDB(codexHome: URL, sessionId: String, cwd: String) throws {
+        let dbPath = codexHome.appendingPathComponent("state_5.sqlite", isDirectory: false).path
+        var db: OpaquePointer?
+        guard sqlite3_open(dbPath, &db) == SQLITE_OK, let db else {
+            throw testFailure()
+        }
+        defer { sqlite3_close(db) }
+        guard sqlite3_exec(db, "CREATE TABLE threads (id TEXT PRIMARY KEY, cwd TEXT, archived INTEGER)", nil, nil, nil) == SQLITE_OK else {
+            throw testFailure()
+        }
+        let sql = "INSERT INTO threads (id, cwd, archived) VALUES (?, ?, 0)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else {
+            throw testFailure()
+        }
+        defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT_FN = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, sessionId, -1, SQLITE_TRANSIENT_FN)
+        sqlite3_bind_text(stmt, 2, cwd, -1, SQLITE_TRANSIENT_FN)
+        guard sqlite3_step(stmt) == SQLITE_DONE else {
+            throw testFailure()
+        }
+    }
+
+    private func base64NULSeparated(_ values: [String]) -> String {
+        var data = Data()
+        for value in values {
+            data.append(contentsOf: value.utf8)
+            data.append(0)
+        }
+        return data.base64EncodedString()
+    }
+
+    private func testFailure() -> NSError {
+        NSError(domain: "ForkParentFallbackResidualTests", code: 1)
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/7655 — the four residuals deferred from https://github.com/manaflow-ai/cmux/pull/7580.

1. **Custom claude binaries** pass fork-availability revalidation: a shared launch-kind + launch-executable trust helper accepts a live process running exactly the binary recorded in `CMUX_AGENT_LAUNCH_EXECUTABLE` with a matching launch kind; env inheritance alone still never validates (pid + start-time pinning unchanged).
2. **Codex cwd**: codex hooks record the hook process cwd when the payload gives none, and legacy cwd-less records recover their cwd read-only from `CODEX_HOME/state_5.sqlite` at index load (memoized per load, fail-safe). Forking a codex pane now opens directly in the session cwd instead of codex's interactive directory chooser.
3. **Teams panes** get the fork-parent fallback: `cmux codex-teams fork <uuid>` wrapper processes (observable because `startCodexTeamsProcess` keeps the wrapper alive), and claude-teams's REAL persistent shape — `runClaudeTeams` `execv`s the claude binary, so the observable process is claude argv + `CMUX_AGENT_LAUNCH_KIND=claudeTeams` — synthesize snapshots whose launcher round-trips the wrapper fork command; the validator accepts a teams launch kind only against its base kind and recorded launcher.
4. **Registry fork markers** derive from the fork-vs-resume template diff, so custom registrations with markers like `--branch-from` demote to `.forkParentFallback` (no parent-pane eviction/pinning); marker-less templates stay explicit.

Two-commit red/green: 6e74ac668b (tests only — teams/codex-cwd/custom-binary/marker tests fail on main; guard tests pass) then f4b1c63127 (fix). Judge notes accepted as-is: launcher label derivation could be returned from the builder for structural safety (practically unreachable mispairing), and `liveScopedProcessID` still uses the strict env-kind compare for teams hook records (harmless today).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786142723&installation_id=133855650&pr_number=7664&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7664&signature=c75a19bd45736d7927c20f34dc5875e38cfc9995a2dacc1938103b9178143ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches restorable session index load, live PID validation, and fork-parent heuristics—wrong identity or cwd would mis-attribute panes or break resume/fork, but changes are guarded by tests and fail-safe SQLite lookups.
> 
> **Overview**
> Closes four fork-fallback gaps so restorable agent panes match live processes and fork/resume commands land in the right directory.
> 
> **Process identity** — `CachedAgentProcessIdentityValidator` now treats teams launch kinds (`claudeTeams` / `codexTeams`) as matching their base agent when the recorded launcher agrees, and trusts a live process only when `CMUX_AGENT_LAUNCH_KIND` and `CMUX_AGENT_LAUNCH_EXECUTABLE` line up (not inherited env alone). Live executable checks are centralized and shared with scoped-PID validation.
> 
> **Codex working directory** — Legacy cwd-less hook records can recover `cwd` read-only from `CODEX_HOME/state_5.sqlite` (`CodexSessionCwdLookupCache`), so resume/fork startup includes `cd` into the session directory instead of Codex’s interactive picker. Codex hooks also fall back to the process current directory when env cwd is missing.
> 
> **Teams fork panes** — Fork-parent fallback recognizes `cmux codex-teams fork <uuid>` wrapper processes and persistent `claude-teams` shapes (live `claude` argv + teams launch env), synthesizing snapshots whose launcher round-trips the wrapper fork command.
> 
> **Vault registry forks** — Fork vs resume template diff drives fork-parent markers (not a hardcoded `--fork`), so registrations with markers like `--branch-from` demote to `.forkParentFallback` while marker-less templates stay explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c724606105545e3971db320fac6ef5d89b5d5a86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four fork-fallback gaps: custom Claude binaries now validate, Codex forks use the right cwd, Teams fork panes restore reliably, and registry fork markers demote correctly. Also memoizes missing Codex cwd lookups to avoid repeated SQLite reads; forks open in the expected directory and validation is robust against inherited env.

- **Bug Fixes**
  - Custom Claude binaries: accept a live process only when the launch kind matches and the executable equals `CMUX_AGENT_LAUNCH_EXECUTABLE`; inherited env alone is not trusted.
  - Codex cwd: record cwd from the hook when missing; legacy records recover cwd from `CODEX_HOME/state_5.sqlite` and memoize negative lookups; resume/fork commands include a cd into the session cwd.
  - Teams panes: support `codex-teams` wrapper forks and `claude-teams` (execv to `claude`) by synthesizing snapshots that round-trip the wrapper fork command; validator ties a teams launch kind to its base kind and recorded launcher (via `CMUXAgentLaunch`).
  - Registry markers: compute constant markers from fork vs resume templates; if markers (e.g., `--branch-from`) are present, demote to fork‑parent fallback; marker‑less templates stay explicit.

- **Refactors**
  - Moved live process identity matching to `VaultAgentProcessScanner+LiveProcessIdentity.swift` and imported `CMUXAgentLaunch` in the validator to centralize kind mapping and keep within file-length budgets.

<sup>Written for commit c724606105545e3971db320fac6ef5d89b5d5a86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved session recovery with Codex working-directory lookup backed by a local SQLite-based cache.
  * Enhanced process identity matching using live launch-kind/executable environment signals, including wrapper and team-based fork scenarios.
  * Added improved Codex working-directory resolution fallback behavior.

* **Bug Fixes**
  * More reliable fork-parent detection and residual fork fallback resolution, especially when recorded launch details (like cwd) are missing.
  * Expanded executable matching to consider environment-provided launch executable data.

* **Tests**
  * Added new coverage for fork-template variants and residual fork fallback behavior, plus additional scenarios around identity validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->