### PR TITLE
Treat unreadable token storage as transient during iOS session restore

### DIFF
--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+SessionPriming.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+SessionPriming.swift
@@ -155,6 +155,14 @@ extension AuthCoordinator {
             return
         }
 
+        let tokenStorageAvailable = await isTokenStorageAvailable()
+        guard generation == sessionGeneration else { return }
+        if !tokenStorageAvailable {
+            authLog.info("Token storage unavailable during session restore; preserving cached session")
+            preserveCachedSessionAfterValidationFailure()
+            return
+        }
+
         if launch.includesDevAuth, let creds = debugCredentials {
             authLog.debug("Auto-login with persisted debug credentials")
             await performAutoLogin(creds, generation: generation, storeWriteHighWater: storeWriteHighWater)

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+SessionPriming.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+SessionPriming.swift
@@ -90,7 +90,7 @@ extension AuthCoordinator {
         ))
     }
 
-    func checkExistingSession() async {
+    func checkExistingSession(retryOnStorageAvailable: Bool = true) async {
         if launch.clearAuthRequested { return }
         // Coalesce overlapping runs (rapid foreground transitions): a second
         // call while one is in flight would race coordinator-state writes
@@ -102,6 +102,14 @@ extension AuthCoordinator {
         let storeWriteHighWater = tokenStoreWriteHighWater
 
         let cachedUser = loadCachedUser()
+        // The keychain token store (AfterFirstUnlock protection) becomes
+        // readable exactly once per boot, at the first unlock, and never
+        // regresses while this process lives; an unavailable report can only
+        // under-state readability. Snapshot before token reads so a first
+        // unlock that lands while the token probe is suspended cannot make a
+        // nil locked read look like a definitive empty store.
+        let tokenStorageWasAvailable = await isTokenStorageAvailable()
+        guard generation == sessionGeneration else { return }
         // accessToken() may refresh over the network; a sign-out can land
         // while these reads are parked, so bound the probe and re-check the
         // generation after. A timeout preserves the cached identity instead of
@@ -155,11 +163,22 @@ extension AuthCoordinator {
             return
         }
 
-        let tokenStorageAvailable = await isTokenStorageAvailable()
-        guard generation == sessionGeneration else { return }
-        if !tokenStorageAvailable {
+        if !tokenStorageWasAvailable {
             authLog.info("Token storage unavailable during session restore; preserving cached session")
             preserveCachedSessionAfterValidationFailure()
+            if retryOnStorageAvailable {
+                let tokenStorageIsAvailable = await isTokenStorageAvailable()
+                guard generation == sessionGeneration else { return }
+                if tokenStorageIsAvailable {
+                    // A protected-data notification can coalesce into this
+                    // in-flight restore. Retry exactly once when storage came
+                    // online mid-restore; tests may script oscillating
+                    // availability, while real protected data unlocks at most
+                    // once per process.
+                    isRevalidatingSession = false
+                    await checkExistingSession(retryOnStorageAvailable: false)
+                }
+            }
             return
         }
 

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
@@ -12,16 +12,19 @@ extension AuthCoordinator {
     /// Classifies a missing token the same way ``forceRefreshAccessToken()``
     /// does, so the connection layer can tell a recoverable session from a dead
     /// one: when the SDK could not hand back an access token but a refresh token
-    /// is still stored, the failure was transient (network/server) and this
-    /// throws ``AuthError/networkError`` so the caller retries without signing
-    /// out. When neither token survives, the session is genuinely gone, so this
-    /// calls ``clearAuthState()`` (flipping ``isAuthenticated`` to `false`, which
-    /// routes the root scene to the sign-in page) and throws
+    /// is still stored, or token storage was unavailable because the device was
+    /// locked, the failure was transient and this throws
+    /// ``AuthError/networkError`` so the caller retries without signing out.
+    /// When neither token survives from available storage, the session is
+    /// genuinely gone, so this calls ``clearAuthState()`` (flipping
+    /// ``isAuthenticated`` to `false`, which routes the root scene to the
+    /// sign-in page) and throws
     /// ``AuthError/unauthorized``.
     /// - Returns: A current access token.
     /// - Throws: ``AuthError/networkError`` on a transient failure with a
-    ///   surviving refresh token (retryable); ``AuthError/unauthorized`` once the
-    ///   session is definitively gone (also clears local auth state).
+    ///   surviving refresh token or unavailable token storage (retryable);
+    ///   ``AuthError/unauthorized`` once the session is definitively gone (also
+    ///   clears local auth state).
     public func accessToken() async throws -> String {
         do {
             return try await runTokenTouchingPhase(.accessToken, timeout: timeouts.network) {
@@ -42,6 +45,7 @@ extension AuthCoordinator {
     }
 
     private func accessTokenWithoutStateClear() async throws -> String {
+        let storageWasAvailable = await isTokenStorageAvailable()
         if let token = await client.accessToken() {
             return token
         }
@@ -58,10 +62,7 @@ extension AuthCoordinator {
         if await client.refreshToken() != nil {
             throw AuthError.networkError
         }
-        if await isTokenStorageAvailable() == false {
-            throw AuthError.networkError
-        }
-        throw AuthError.unauthorized
+        throw emptyTokenReadError(storageWasAvailable: storageWasAvailable)
     }
 
     private func devAuthAccessTokenFallback() async -> String? {
@@ -97,26 +98,22 @@ extension AuthCoordinator {
     /// session becomes available moments later.
     /// - Returns: The access and refresh tokens.
     /// - Throws: ``AuthError/networkError`` when the access token is missing
-    ///   but a refresh token survives, meaning the refresh failed transiently;
-    ///   ``AuthError/unauthorized`` when the session is missing either an access
-    ///   token with no refresh token to recover from, or the refresh token
-    ///   required by backend requests.
+    ///   but a refresh token survives, meaning the refresh failed transiently,
+    ///   or when token storage was unavailable because the device was locked;
+    ///   ``AuthError/unauthorized`` when available storage is missing either an
+    ///   access token with no refresh token to recover from, or the refresh
+    ///   token required by backend requests.
     public func currentTokens() async throws -> (accessToken: String, refreshToken: String) {
         await awaitBootstrapped()
+        let storageWasAvailable = await isTokenStorageAvailable()
         guard let access = await client.accessToken(), !access.isEmpty else {
             if let refresh = await client.refreshToken(), !refresh.isEmpty {
                 throw AuthError.networkError
             }
-            if await isTokenStorageAvailable() == false {
-                throw AuthError.networkError
-            }
-            throw AuthError.unauthorized
+            throw emptyTokenReadError(storageWasAvailable: storageWasAvailable)
         }
         guard let refresh = await client.refreshToken(), !refresh.isEmpty else {
-            if await isTokenStorageAvailable() == false {
-                throw AuthError.networkError
-            }
-            throw AuthError.unauthorized
+            throw emptyTokenReadError(storageWasAvailable: storageWasAvailable)
         }
         return (access, refresh)
     }
@@ -127,12 +124,14 @@ extension AuthCoordinator {
     ///
     /// - Returns: A freshly minted access token.
     /// - Throws: ``AuthError/networkError`` when the refresh failed transiently
-    ///   but the session is intact (a refresh token is still stored), so the
+    ///   but the session is intact (a refresh token is still stored), or when
+    ///   token storage was unavailable because the device was locked, so the
     ///   caller should retry rather than sign out; ``AuthError/unauthorized``
-    ///   only when the session is genuinely gone (the refresh token was
-    ///   definitively rejected and cleared). The definitive case also calls
-    ///   ``clearAuthState()`` so ``isAuthenticated`` flips to `false` and the
-    ///   root scene routes to the sign-in page instead of showing a stale shell.
+    ///   only when the session is genuinely gone from available storage (the
+    ///   refresh token was definitively rejected and cleared). The definitive
+    ///   case also calls ``clearAuthState()`` so ``isAuthenticated`` flips to
+    ///   `false` and the root scene routes to the sign-in page instead of
+    ///   showing a stale shell.
     public func forceRefreshAccessToken() async throws -> String {
         do {
             return try await runTokenTouchingPhase(.forceRefreshAccessToken, timeout: timeouts.network) {
@@ -145,6 +144,7 @@ extension AuthCoordinator {
     }
 
     private func forceRefreshAccessTokenWithoutStateClear() async throws -> String {
+        let storageWasAvailable = await isTokenStorageAvailable()
         if let token = await client.forceRefreshAccessToken() {
             return token
         }
@@ -154,9 +154,10 @@ extension AuthCoordinator {
         if await client.refreshToken() != nil {
             throw AuthError.networkError
         }
-        if await isTokenStorageAvailable() == false {
-            throw AuthError.networkError
-        }
-        throw AuthError.unauthorized
+        throw emptyTokenReadError(storageWasAvailable: storageWasAvailable)
+    }
+
+    private func emptyTokenReadError(storageWasAvailable: Bool) -> AuthError {
+        storageWasAvailable ? .unauthorized : .networkError
     }
 }

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
@@ -58,6 +58,9 @@ extension AuthCoordinator {
         if await client.refreshToken() != nil {
             throw AuthError.networkError
         }
+        if await isTokenStorageAvailable() == false {
+            throw AuthError.networkError
+        }
         throw AuthError.unauthorized
     }
 
@@ -104,9 +107,15 @@ extension AuthCoordinator {
             if let refresh = await client.refreshToken(), !refresh.isEmpty {
                 throw AuthError.networkError
             }
+            if await isTokenStorageAvailable() == false {
+                throw AuthError.networkError
+            }
             throw AuthError.unauthorized
         }
         guard let refresh = await client.refreshToken(), !refresh.isEmpty else {
+            if await isTokenStorageAvailable() == false {
+                throw AuthError.networkError
+            }
             throw AuthError.unauthorized
         }
         return (access, refresh)
@@ -143,6 +152,9 @@ extension AuthCoordinator {
         // (network/server), so stay retryable; a missing one means the SDK
         // definitively cleared the session.
         if await client.refreshToken() != nil {
+            throw AuthError.networkError
+        }
+        if await isTokenStorageAvailable() == false {
             throw AuthError.networkError
         }
         throw AuthError.unauthorized

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
@@ -66,6 +66,8 @@ public final class AuthCoordinator {
     let timeouts: AuthTimeouts
     let clock: any Clock<Duration>
     private let isOnline: @Sendable () async -> Bool
+    /// Reports whether the persisted token store is currently readable. On iOS the data-protection keychain is unreadable before the first unlock after boot (background push launch, prewarm); an empty token read while unavailable must be treated as transient, never as a signed-out verdict.
+    let isTokenStorageAvailable: @Sendable () async -> Bool
     private let onSignedIn: @Sendable () async -> Void
     let log = AuthDebugLog()
     let phaseTimeoutRegistry = AuthPhaseTimeoutRegistry()
@@ -146,6 +148,7 @@ public final class AuthCoordinator {
     ///     drive timeouts with virtual time. Defaults to `ContinuousClock`.
     ///   - isOnline: Connectivity probe; sign-in flows fail fast when offline.
     ///     Defaults to always-online so tests need not supply it.
+    ///   - isTokenStorageAvailable: Reports whether the persisted token store is currently readable. On iOS the data-protection keychain is unreadable before the first unlock after boot (background push launch, prewarm); an empty token read while unavailable must be treated as transient, never as a signed-out verdict.
     ///   - onSignedIn: Hook run after a successful sign-in / session restore, for
     ///     side effects above this package (e.g. push token re-upload). Defaults
     ///     to a no-op.
@@ -160,6 +163,7 @@ public final class AuthCoordinator {
         timeouts: AuthTimeouts = .default,
         clock: any Clock<Duration> = ContinuousClock(),
         isOnline: @escaping @Sendable () async -> Bool = { true },
+        isTokenStorageAvailable: @escaping @Sendable () async -> Bool = { true },
         onSignedIn: @escaping @Sendable () async -> Void = {}
     ) {
         self.client = client
@@ -172,6 +176,7 @@ public final class AuthCoordinator {
         self.timeouts = timeouts
         self.clock = clock
         self.isOnline = isOnline
+        self.isTokenStorageAvailable = isTokenStorageAvailable
         self.onSignedIn = onSignedIn
         self.selectedTeamID = teamSelection.selectedTeamID
         primeSessionState()

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorLockedStorageTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorLockedStorageTests.swift
@@ -8,34 +8,49 @@ actor LockedStorageAuthClient: AuthClient {
     private var refresh: String?
     private var user: CMUXAuthUser?
     private var locked: Bool
+    private var lockedTokenReadsRemaining: Int
     private(set) var clearLocalSessionCallCount = 0
 
     init(
         access: String? = nil,
         refresh: String? = nil,
         user: CMUXAuthUser? = nil,
-        locked: Bool
+        locked: Bool,
+        locksFirstReads: Int = 0
     ) {
         self.access = access
         self.refresh = refresh
         self.user = user
         self.locked = locked
+        self.lockedTokenReadsRemaining = locksFirstReads
     }
 
     func unlock() {
         locked = false
+        lockedTokenReadsRemaining = 0
+    }
+
+    private func tokenReadIsLocked() -> Bool {
+        if locked {
+            return true
+        }
+        if lockedTokenReadsRemaining > 0 {
+            lockedTokenReadsRemaining -= 1
+            return true
+        }
+        return false
     }
 
     func accessToken() async -> String? {
-        locked ? nil : access
+        tokenReadIsLocked() ? nil : access
     }
 
     func refreshToken() async -> String? {
-        locked ? nil : refresh
+        tokenReadIsLocked() ? nil : refresh
     }
 
     func forceRefreshAccessToken() async -> String? {
-        locked ? nil : access
+        tokenReadIsLocked() ? nil : access
     }
 
     func currentUser(throwOnMissing: Bool) async throws -> CMUXAuthUser? {
@@ -66,7 +81,7 @@ actor LockedStorageAuthClient: AuthClient {
     }
 
     func storedAccessToken() async -> String? {
-        locked ? nil : access
+        tokenReadIsLocked() ? nil : access
     }
 
     func clearLocalSession() async {
@@ -85,15 +100,17 @@ actor LockedStorageAuthClient: AuthClient {
     func revokeSession(accessToken: String?, refreshToken: String?) async throws {}
 
     func freshAccessToken(accessToken: String?, refreshToken: String) async -> String? {
-        locked ? nil : accessToken ?? access
+        tokenReadIsLocked() ? nil : accessToken ?? access
     }
 }
 
 actor TokenStorageAvailabilityProbe {
     private var available: Bool
+    private var unavailableReadsRemaining: Int
 
-    init(available: Bool) {
+    init(available: Bool, unavailableFirstReads: Int = 0) {
         self.available = available
+        self.unavailableReadsRemaining = unavailableFirstReads
     }
 
     func setAvailable(_ available: Bool) {
@@ -101,7 +118,11 @@ actor TokenStorageAvailabilityProbe {
     }
 
     func isAvailable() -> Bool {
-        available
+        if unavailableReadsRemaining > 0 {
+            unavailableReadsRemaining -= 1
+            return false
+        }
+        return available
     }
 }
 
@@ -160,6 +181,32 @@ actor TokenStorageAvailabilityProbe {
 
         #expect(coordinator.isAuthenticated == true)
         #expect(coordinator.currentUser == validatedUser)
+    }
+
+    @Test func unlockDuringLaunchTokenProbeRetriesAndRestoresSession() async throws {
+        let cachedUser = CMUXAuthUser(id: "cached", primaryEmail: "cached@example.com", displayName: "Cached")
+        let validatedUser = CMUXAuthUser(id: "validated", primaryEmail: "valid@example.com", displayName: "Validated")
+        let client = LockedStorageAuthClient(
+            access: "access",
+            refresh: "refresh",
+            user: validatedUser,
+            locked: false,
+            locksFirstReads: 2
+        )
+        let availability = TokenStorageAvailabilityProbe(available: true, unavailableFirstReads: 1)
+        let (coordinator, store) = try makeCoordinator(
+            client: client,
+            cachedUser: cachedUser,
+            availability: availability
+        )
+
+        coordinator.start()
+        await coordinator.awaitBootstrapped()
+
+        #expect(coordinator.isAuthenticated == true)
+        #expect(coordinator.currentUser == validatedUser)
+        #expect(store.bool(forKey: "has_tokens") == true)
+        #expect(await client.clearLocalSessionCallCount == 0)
     }
 
     @Test func availableEmptyStorageClearsSeededCache() async throws {

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorLockedStorageTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorLockedStorageTests.swift
@@ -1,0 +1,204 @@
+import CMUXAuthCore
+import Foundation
+import Testing
+@testable import CmuxAuthRuntime
+
+actor LockedStorageAuthClient: AuthClient {
+    private var access: String?
+    private var refresh: String?
+    private var user: CMUXAuthUser?
+    private var locked: Bool
+    private(set) var clearLocalSessionCallCount = 0
+
+    init(
+        access: String? = nil,
+        refresh: String? = nil,
+        user: CMUXAuthUser? = nil,
+        locked: Bool
+    ) {
+        self.access = access
+        self.refresh = refresh
+        self.user = user
+        self.locked = locked
+    }
+
+    func unlock() {
+        locked = false
+    }
+
+    func accessToken() async -> String? {
+        locked ? nil : access
+    }
+
+    func refreshToken() async -> String? {
+        locked ? nil : refresh
+    }
+
+    func forceRefreshAccessToken() async -> String? {
+        locked ? nil : access
+    }
+
+    func currentUser(throwOnMissing: Bool) async throws -> CMUXAuthUser? {
+        user
+    }
+
+    func listTeams() async throws -> [CMUXAuthTeam] {
+        []
+    }
+
+    func sendMagicLinkEmail(email: String, callbackURL: String) async throws -> String {
+        "nonce"
+    }
+
+    func signInWithMagicLink(code: String) async throws {
+        access = "access"
+        refresh = "refresh"
+    }
+
+    func signInWithCredential(email: String, password: String) async throws {
+        access = "access"
+        refresh = "refresh"
+    }
+
+    func signInWithOAuth(provider: String, anchor: any AuthPresentationAnchoring) async throws {
+        access = "access"
+        refresh = "refresh"
+    }
+
+    func storedAccessToken() async -> String? {
+        locked ? nil : access
+    }
+
+    func clearLocalSession() async {
+        clearLocalSessionCallCount += 1
+        access = nil
+        refresh = nil
+    }
+
+    func clearLocalSession(ifRefreshTokenMatches refreshToken: String) async {
+        clearLocalSessionCallCount += 1
+        guard refresh == refreshToken else { return }
+        access = nil
+        refresh = nil
+    }
+
+    func revokeSession(accessToken: String?, refreshToken: String?) async throws {}
+
+    func freshAccessToken(accessToken: String?, refreshToken: String) async -> String? {
+        locked ? nil : accessToken ?? access
+    }
+}
+
+actor TokenStorageAvailabilityProbe {
+    private var available: Bool
+
+    init(available: Bool) {
+        self.available = available
+    }
+
+    func setAvailable(_ available: Bool) {
+        self.available = available
+    }
+
+    func isAvailable() -> Bool {
+        available
+    }
+}
+
+@MainActor
+@Suite struct AuthCoordinatorLockedStorageTests {
+    private func makeCoordinator(
+        client: LockedStorageAuthClient,
+        cachedUser: CMUXAuthUser,
+        availability: TokenStorageAvailabilityProbe
+    ) throws -> (AuthCoordinator, FakeKeyValueStore) {
+        let store = FakeKeyValueStore()
+        let sessionCache = CMUXAuthSessionCache(keyValueStore: store, key: "has_tokens")
+        let userCache = CMUXAuthIdentityStore(keyValueStore: store, key: "cached_user")
+        sessionCache.setHasTokens(true)
+        try userCache.save(cachedUser)
+        let coordinator = AuthCoordinator(
+            client: client,
+            sessionCache: sessionCache,
+            userCache: userCache,
+            teamSelection: CMUXAuthTeamSelectionStore(keyValueStore: store, key: "selected_team"),
+            anchor: FakeAnchor(),
+            config: .test,
+            launch: .plain(),
+            isTokenStorageAvailable: { await availability.isAvailable() }
+        )
+        return (coordinator, store)
+    }
+
+    @Test func lockedLaunchPreservesCachedSessionAndRevalidatesAfterUnlock() async throws {
+        let cachedUser = CMUXAuthUser(id: "cached", primaryEmail: "cached@example.com", displayName: "Cached")
+        let validatedUser = CMUXAuthUser(id: "validated", primaryEmail: "valid@example.com", displayName: "Validated")
+        let client = LockedStorageAuthClient(
+            access: "access",
+            refresh: "refresh",
+            user: validatedUser,
+            locked: true
+        )
+        let availability = TokenStorageAvailabilityProbe(available: false)
+        let (coordinator, store) = try makeCoordinator(
+            client: client,
+            cachedUser: cachedUser,
+            availability: availability
+        )
+
+        coordinator.start()
+        await coordinator.awaitBootstrapped()
+
+        #expect(coordinator.isAuthenticated == true)
+        #expect(coordinator.currentUser == cachedUser)
+        #expect(store.bool(forKey: "has_tokens") == true)
+        #expect(await client.clearLocalSessionCallCount == 0)
+
+        await client.unlock()
+        await availability.setAvailable(true)
+        await coordinator.revalidateSession()
+
+        #expect(coordinator.isAuthenticated == true)
+        #expect(coordinator.currentUser == validatedUser)
+    }
+
+    @Test func availableEmptyStorageClearsSeededCache() async throws {
+        let cachedUser = CMUXAuthUser(id: "cached", primaryEmail: "cached@example.com", displayName: "Cached")
+        let client = LockedStorageAuthClient(access: nil, refresh: nil, user: nil, locked: false)
+        let availability = TokenStorageAvailabilityProbe(available: true)
+        let (coordinator, store) = try makeCoordinator(
+            client: client,
+            cachedUser: cachedUser,
+            availability: availability
+        )
+
+        coordinator.start()
+        await coordinator.awaitBootstrapped()
+
+        #expect(coordinator.isAuthenticated == false)
+        #expect(coordinator.currentUser == nil)
+        #expect(store.bool(forKey: "has_tokens") == false)
+    }
+
+    @Test func unavailableEmptyTokenReadIsRetryableButAvailableEmptyReadIsUnauthorized() async throws {
+        let cachedUser = CMUXAuthUser(id: "cached", primaryEmail: "cached@example.com", displayName: "Cached")
+        let client = LockedStorageAuthClient(access: nil, refresh: nil, user: nil, locked: false)
+        let availability = TokenStorageAvailabilityProbe(available: false)
+        let (coordinator, store) = try makeCoordinator(
+            client: client,
+            cachedUser: cachedUser,
+            availability: availability
+        )
+
+        await #expect(throws: AuthError.networkError) {
+            _ = try await coordinator.accessToken()
+        }
+        #expect(store.bool(forKey: "has_tokens") == true)
+        #expect(coordinator.isAuthenticated == true)
+
+        await availability.setAvailable(true)
+        await #expect(throws: AuthError.unauthorized) {
+            _ = try await coordinator.accessToken()
+        }
+    }
+}

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
@@ -33,6 +33,9 @@ public struct MobileAuthComposition {
     /// identity provider can label the channel its user ids belong to.
     public let authEnvironment: CMUXAuthEnvironment
 
+    /// UIKit protected-data availability bridge used by auth session restore.
+    private let protectedDataAvailability: ProtectedDataAvailability
+
     /// A reachability monitor used to fail sign-in flows fast when offline.
     private let reachability: any ReachabilityProviding
 
@@ -74,6 +77,7 @@ public struct MobileAuthComposition {
             config: resolvedConfig,
             tokenStore: Self.tokenStore
         )
+        let availability = ProtectedDataAvailability()
         let sessionCache = CMUXAuthSessionCache(
             keyValueStore: defaults,
             key: Self.sessionCacheDefaultsKey
@@ -127,6 +131,7 @@ public struct MobileAuthComposition {
             config: resolvedConfig,
             launch: launch,
             isOnline: { await monitor.isOnline },
+            isTokenStorageAvailable: { await MainActor.run { availability.isAvailable } },
             onSignedIn: { await deferredSignIn.run() }
         )
         let push = PushRegistrationService(
@@ -139,11 +144,15 @@ public struct MobileAuthComposition {
         deferredSignIn.set { await push.syncTokenIfPossible() }
         self.coordinator = coordinator
         self.pushRegistration = push
+        self.protectedDataAvailability = availability
     }
 
     /// Begin asynchronous session restore (call once after construction).
     public func start() {
         coordinator.start()
+        protectedDataAvailability.startObserving { [coordinator] in
+            Task { await coordinator.revalidateSession() }
+        }
     }
 
     private static var isDevelopmentBuild: Bool {

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
@@ -149,10 +149,10 @@ public struct MobileAuthComposition {
 
     /// Begin asynchronous session restore (call once after construction).
     public func start() {
-        coordinator.start()
         protectedDataAvailability.startObserving { [coordinator] in
             Task { await coordinator.revalidateSession() }
         }
+        coordinator.start()
     }
 
     private static var isDevelopmentBuild: Bool {

--- a/ios/cmuxPackage/Sources/cmuxFeature/ProtectedDataAvailability.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/ProtectedDataAvailability.swift
@@ -5,7 +5,7 @@ import UIKit
 final class ProtectedDataAvailability {
     private let notificationCenter: NotificationCenter
     private let availabilityRead: @MainActor () -> Bool
-    private var observer: NSObjectProtocol?
+    private var observer: ProtectedDataAvailabilityObserverToken?
 
     init(
         notificationCenter: NotificationCenter = .default,
@@ -23,7 +23,7 @@ final class ProtectedDataAvailability {
 
     func startObserving(onBecameAvailable: @escaping @MainActor () -> Void) {
         stopObserving()
-        observer = notificationCenter.addObserver(
+        let token = notificationCenter.addObserver(
             forName: UIApplication.protectedDataDidBecomeAvailableNotification,
             object: nil,
             queue: .main
@@ -32,18 +32,41 @@ final class ProtectedDataAvailability {
                 onBecameAvailable()
             }
         }
+        observer = ProtectedDataAvailabilityObserverToken(
+            token: token,
+            notificationCenter: notificationCenter
+        )
     }
 
     func stopObserving() {
         if let observer {
-            notificationCenter.removeObserver(observer)
+            observer.remove()
             self.observer = nil
         }
     }
 
     deinit {
         if let observer {
-            notificationCenter.removeObserver(observer)
+            observer.remove()
         }
+    }
+}
+
+/// NotificationCenter observer token owned and removed on the main actor.
+final class ProtectedDataAvailabilityObserverToken: @unchecked Sendable {
+    // Safety: the token is created, stored, and removed by
+    // ProtectedDataAvailability on the main actor. The wrapper is Sendable only
+    // so the @MainActor owner can touch it from deinit under Swift 6 checking;
+    // it does not permit cross-actor mutation of the token.
+    private let token: NSObjectProtocol
+    private let notificationCenter: NotificationCenter
+
+    init(token: NSObjectProtocol, notificationCenter: NotificationCenter) {
+        self.token = token
+        self.notificationCenter = notificationCenter
+    }
+
+    func remove() {
+        notificationCenter.removeObserver(token)
     }
 }

--- a/ios/cmuxPackage/Sources/cmuxFeature/ProtectedDataAvailability.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/ProtectedDataAvailability.swift
@@ -1,0 +1,49 @@
+import Foundation
+import UIKit
+
+@MainActor
+final class ProtectedDataAvailability {
+    private let notificationCenter: NotificationCenter
+    private let availabilityRead: @MainActor () -> Bool
+    private var observer: NSObjectProtocol?
+
+    init(
+        notificationCenter: NotificationCenter = .default,
+        availabilityRead: @escaping @MainActor () -> Bool = {
+            UIApplication.shared.isProtectedDataAvailable
+        }
+    ) {
+        self.notificationCenter = notificationCenter
+        self.availabilityRead = availabilityRead
+    }
+
+    var isAvailable: Bool {
+        availabilityRead()
+    }
+
+    func startObserving(onBecameAvailable: @escaping @MainActor () -> Void) {
+        stopObserving()
+        observer = notificationCenter.addObserver(
+            forName: UIApplication.protectedDataDidBecomeAvailableNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                onBecameAvailable()
+            }
+        }
+    }
+
+    func stopObserving() {
+        if let observer {
+            notificationCenter.removeObserver(observer)
+            self.observer = nil
+        }
+    }
+
+    deinit {
+        if let observer {
+            notificationCenter.removeObserver(observer)
+        }
+    }
+}


### PR DESCRIPTION
External beta users reported starting signed out after a TestFlight update. Root cause: the SDK keychain store collapses every SecItem error to nil, so a cold launch while the data-protection keychain is unreadable (background push launch or prewarm before first unlock after reboot; cmux has the remote-notification background mode and iOS prewarms freshly updated apps) reads both tokens as nil. `AuthCoordinator.checkExistingSession` took that as a definitive signed-out verdict: `clearAuthState` wiped the `auth_has_tokens`/`auth_cached_user` defaults, and `revalidateSession()`'s guard (`isAuthenticated || isRestoringSession || sessionCache.hasTokens`) then refused to re-probe when the user foregrounded the same process, stranding them on sign-in while a valid session sat in the keychain. A fresh cold launch would have restored it, which is why the bug reads as "the update signed me out" and is hard to reproduce on demand.

Fix: `AuthCoordinator` now takes an injected `isTokenStorageAvailable` probe (default always-available; macOS composition unchanged). Every path that concluded signed-out from an empty token read consults it first: launch restore preserves the cached session via the existing validation-failure path, and the token accessors (`accessToken()`, `currentTokens()`, `forceRefreshAccessToken()`) throw the retryable `AuthError.networkError` instead of `unauthorized`, so no caller clears state during a locked background launch. iOS wires the probe to `UIApplication.shared.isProtectedDataAvailable` and revalidates the session when `protectedDataDidBecomeAvailableNotification` fires. Available-storage behavior is unchanged: a genuinely empty store still routes to sign-in, pinned by a dedicated test.

Two-commit structure: the first commit adds the regression tests plus the unused seam (CI red), the second adds the fix (CI green). The regression test reproduces the exact field sequence: seeded signed-in caches, locked cold launch, unlock, foreground revalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786143439&installation_id=133855650&pr_number=7667&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7667&signature=47097bf13a5177d12bcfbc923669c2f113d750368c80ae8075663d0d45e92abc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes session-restore and token error classification on the auth critical path; incorrect handling could leave stale sessions or still sign users out incorrectly on edge launches.
> 
> **Overview**
> Fixes false sign-outs when a cold launch reads **nil** tokens from the data-protection keychain before first unlock (background push, prewarm after update), which previously triggered `clearAuthState` and stranded users on sign-in despite a valid keychain session.
> 
> **`AuthCoordinator`** gains an injected **`isTokenStorageAvailable`** probe (defaults to always available). Launch **`checkExistingSession`** snapshots availability before token reads; if storage was unavailable and probes look empty, it **preserves the cached session** instead of clearing, with a **single retry** when storage comes online mid-restore. Token paths (`accessToken`, `currentTokens`, `forceRefreshAccessToken`) use **`emptyTokenReadError`**: unavailable storage → retryable **`AuthError.networkError`**; available empty store → **`unauthorized`** (unchanged).
> 
> **iOS** wires the probe to **`UIApplication.isProtectedDataAvailable`** via **`ProtectedDataAvailability`**, observes **`protectedDataDidBecomeAvailableNotification`**, and calls **`revalidateSession()`** on unlock. **`AuthCoordinatorLockedStorageTests`** cover locked launch, mid-restore unlock, and error classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a36c8d30618ed3f17b1a8c4e89a795e561ca41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat unreadable token storage as transient during iOS cold launch and snapshot availability before token reads to prevent false sign-outs. Cached sessions are preserved and automatically revalidated after unlock, with a single retry when storage becomes available mid-restore.

- **Bug Fixes**
  - Added `isTokenStorageAvailable` to `AuthCoordinator` (default `true`); on iOS it uses `UIApplication.shared.isProtectedDataAvailable` via `ProtectedDataAvailability`, registers the observer before coordinator start, and uses a main-actor observer token wrapper to trigger `revalidateSession()`.
  - Session restore now snapshots storage availability before token reads; if unavailable, it preserves the cache and retries once if storage becomes available during the in-flight restore. When storage is available and empty, behavior is unchanged (routes to sign‑in).
  - Token accessors classify empty reads from unavailable storage as `AuthError.networkError` (retryable) and from available storage as `unauthorized` (clears state). Tests cover locked launch, mid-probe unlock retry, available empty store, and cache preservation.

<sup>Written for commit 7a36c8d30618ed3f17b1a8c4e89a795e561ca41c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented false sign-outs/unauthorized results during app launch when secure token storage is temporarily unreadable (e.g., before first device unlock).
  * Improved how empty access/refresh token reads are classified: treated as retryable while storage is unavailable, while still marking truly missing tokens as unauthorized once storage is available.
  * Added automatic session revalidation when protected data becomes available, reducing cases where users needed to manually refresh auth state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->