### PR TITLE
mux: fix sidebar clamp panic on terminals narrower than 50 columns

### DIFF
--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -2698,6 +2698,18 @@ mod tests {
     use crate::session::{Session, TreeView};
 
     #[test]
+    fn sidebar_width_hides_without_panicking_on_narrow_terminals() {
+        // SSH gateways (e.g. Freestyle's) can report width 0 until the first
+        // window-change arrives, and users can shrink real terminals below 50
+        // columns; the sidebar must hide, not panic in clamp().
+        let config = Config::default();
+        for width in [0u16, 1, 39, 49] {
+            assert_eq!(super::sidebar_width_for(&config, true, width, None), 0);
+        }
+        assert!(super::sidebar_width_for(&config, true, 120, None) >= 10);
+    }
+
+    #[test]
     fn browser_omnibar_reduces_content_rect_for_graphics_and_input() {
         let rect = Rect { x: 10, y: 4, width: 80, height: 24 };
         let (_bar, omnibar, content, track) =

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -445,7 +445,9 @@ fn clamp_sidebar_width(config: &Config, terminal_width: u16, desired: u16) -> Op
     let configured_max =
         if config.sidebar.max_width > 0 { config.sidebar.max_width } else { u16::MAX };
     let effective_max = terminal_max.min(configured_max);
-    (effective_max >= 10).then_some(desired.clamp(10, effective_max))
+    // then_some would evaluate clamp(10, effective_max) eagerly and panic when
+    // effective_max < 10 (terminal narrower than 50 columns).
+    (effective_max >= 10).then(|| desired.clamp(10, effective_max))
 }
 
 fn sidebar_drag_width(config: &Config, content: Rect, sidebar_width: u16, x: u16) -> Option<u16> {


### PR DESCRIPTION
cmux-mux panics at startup with `min > max. min = 10, max = 0` whenever the terminal width is under 50 columns. `clamp_sidebar_width` guards with `(effective_max >= 10).then_some(desired.clamp(10, effective_max))`, but `then_some` evaluates its argument eagerly, so `clamp(10, 0)` runs even when the guard is false. Hit in practice attaching over Freestyle's SSH gateway (`vm-ssh.freestyle.sh`), which reports width 0 until the first window-change; also reproducible by shrinking any terminal below 50 columns before attach.

Two commits: the first adds the failing regression test (CI red), the second switches to lazy `.then(|| ...)` (CI green).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786148125&installation_id=133855650&pr_number=7676&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7676&signature=ef875232a7491ec8fd4a1b50b2cb433164bcb68d7590956ff03734aef201f943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix in sidebar width calculation plus a unit test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **startup panic** when the TUI sees a terminal width under 50 columns (including width **0** from some SSH gateways before the first resize).
> 
> `clamp_sidebar_width` used `(effective_max >= 10).then_some(desired.clamp(10, effective_max))`, so `clamp` ran even when the guard was false and `effective_max` was 0. It now uses **lazy** `.then(|| desired.clamp(...))` so clamp only runs when the sidebar can be shown.
> 
> Adds a regression test: sidebar width is **0** for widths 0, 1, 39, and 49, and at least 10 at 120 columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e463696e5a4b11e1100a212e47affe38b999b906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup panic when the terminal is narrower than 50 columns or reports width 0. The sidebar now hides on small widths instead of crashing, including SSH gateways that start at width 0.

- **Bug Fixes**
  - Make `clamp_sidebar_width` lazy by switching to `.then(|| ...)` so `desired.clamp(10, effective_max)` isn’t evaluated when `effective_max < 10`.
  - Add a regression test: sidebar width is 0 for widths 0, 1, 39, 49; and >=10 at 120 columns.

<sup>Written for commit e463696e5a4b11e1100a212e47affe38b999b906. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test covering sidebar sizing on extremely narrow terminals, ensuring the sidebar hides correctly and the UI remains stable without panicking in small window sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->