### PR TITLE
Team invites: invite people to your team

### DIFF
--- a/web/app/[locale]/dashboard/dashboard-shell.tsx
+++ b/web/app/[locale]/dashboard/dashboard-shell.tsx
@@ -48,6 +48,11 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
           active: pathname.startsWith("/dashboard/billing"),
         },
         {
+          href: "/dashboard/team",
+          label: t("team"),
+          active: pathname.startsWith("/dashboard/team"),
+        },
+        {
           href: "/dashboard/testflight",
           label: t("testflight"),
           active: pathname.startsWith("/dashboard/testflight"),

--- a/web/app/[locale]/dashboard/team/accept/page.tsx
+++ b/web/app/[locale]/dashboard/team/accept/page.tsx
@@ -1,0 +1,84 @@
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
+import { Link } from "@/i18n/navigation";
+
+export const dynamic = "force-dynamic";
+
+type StackAcceptUser = {
+  acceptTeamInvitation?: (code: string) => Promise<unknown>;
+  listTeamInvitations?: () => Promise<readonly {
+    id: string;
+    accept?: () => Promise<void>;
+  }[]>;
+};
+
+export default async function TeamInviteAcceptPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>;
+  searchParams?: Promise<{ code?: string | string[]; invitation?: string | string[] }>;
+}) {
+  const [{ locale }, query] = await Promise.all([
+    params,
+    searchParams ?? Promise.resolve({} as { code?: string | string[]; invitation?: string | string[] }),
+  ]);
+  const code = Array.isArray(query.code) ? query.code[0] : query.code;
+  const invitationId = Array.isArray(query.invitation) ? query.invitation[0] : query.invitation;
+  const acceptQuery = code
+    ? `code=${encodeURIComponent(code)}`
+    : `invitation=${encodeURIComponent(invitationId ?? "")}`;
+  const acceptPath = localizedVaultPath(locale, `/dashboard/team/accept?${acceptQuery}`);
+  const t = await getTranslations({ locale, namespace: "dashboard.team.accept" });
+  if (!isStackConfigured()) redirect("/");
+  if (!code && !invitationId) {
+    return <AcceptError title={t("badCodeTitle")} body={t("badCodeBody")} switchAccount={t("switchAccount")} />;
+  }
+  const user = await getStackServerApp().getUser({ or: "return-null" }) as StackAcceptUser | null;
+  if (!user) redirect(vaultSignInHref(acceptPath));
+  try {
+    if (code) {
+      if (!user.acceptTeamInvitation) throw new Error("acceptTeamInvitation unavailable");
+      const result = await user.acceptTeamInvitation(code);
+      if (isStackResultError(result)) throw result.error;
+    } else {
+      if (!user.listTeamInvitations) throw new Error("listTeamInvitations unavailable");
+      const invitation = (await user.listTeamInvitations()).find((candidate) => candidate.id === invitationId);
+      if (!invitation?.accept) throw new Error("VerificationCodeError");
+      await invitation.accept();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/mismatch|email/i.test(message)) {
+      return <AcceptError title={t("emailMismatchTitle")} body={t("emailMismatchBody")} switchAccount={t("switchAccount")} />;
+    }
+    return <AcceptError title={t("badCodeTitle")} body={t("badCodeBody")} switchAccount={t("switchAccount")} />;
+  }
+  redirect(localizedVaultPath(locale, "/dashboard/team?joined=1"));
+}
+
+function AcceptError({ title, body, switchAccount }: { title: string; body: string; switchAccount: string }) {
+  return (
+    <div className="mx-auto w-full max-w-2xl px-3 py-8">
+      <section className="border border-border p-3">
+        <h1 className="text-sm font-medium">{title}</h1>
+        <p className="mt-2 text-sm text-muted">{body}</p>
+        <Link
+          href="/handler/sign-out-and-sign-in"
+          className="mt-3 inline-block border border-border px-3 py-1.5 text-sm"
+        >
+          {switchAccount}
+        </Link>
+      </section>
+    </div>
+  );
+}
+
+function isStackResultError(value: unknown): value is { status: "error"; error: unknown } {
+  return !!value &&
+    typeof value === "object" &&
+    (value as { status?: unknown }).status === "error";
+}

--- a/web/app/[locale]/dashboard/team/accept/page.tsx
+++ b/web/app/[locale]/dashboard/team/accept/page.tsx
@@ -42,7 +42,6 @@ export default async function TeamInviteAcceptPage({
   const user = await getStackServerApp().getUser({ or: "return-null" }) as StackAcceptUser | null;
   if (!user) redirect(vaultSignInHref(acceptPath));
   let acceptedInvitationId: string | null = null;
-  let acceptedTeamId: string | null = null;
   try {
     if (code) {
       if (!user.acceptTeamInvitation) throw new Error("acceptTeamInvitation unavailable");
@@ -56,7 +55,6 @@ export default async function TeamInviteAcceptPage({
       if (isStackResultError(result)) throw result.error;
       if (pending.length === 1) {
         acceptedInvitationId = pending[0].id;
-        acceptedTeamId = pending[0].teamId ?? null;
       }
     } else {
       if (!user.listTeamInvitations) throw new Error("listTeamInvitations unavailable");
@@ -64,7 +62,6 @@ export default async function TeamInviteAcceptPage({
       if (!invitation?.accept) throw new Error("VerificationCodeError");
       await invitation.accept();
       acceptedInvitationId = invitation.id;
-      acceptedTeamId = invitation.teamId ?? null;
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -74,7 +71,7 @@ export default async function TeamInviteAcceptPage({
     return <AcceptError title={t("badCodeTitle")} body={t("badCodeBody")} switchAccount={t("switchAccount")} />;
   }
   if (acceptedInvitationId) {
-    await applyAcceptedInvitationRole({ user, invitationId: acceptedInvitationId, teamId: acceptedTeamId });
+    await applyAcceptedInvitationRole({ user, invitationId: acceptedInvitationId });
   }
   redirect(localizedVaultPath(locale, "/dashboard/team?joined=1"));
 }

--- a/web/app/[locale]/dashboard/team/accept/page.tsx
+++ b/web/app/[locale]/dashboard/team/accept/page.tsx
@@ -4,13 +4,15 @@ import { redirect } from "next/navigation";
 import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { Link } from "@/i18n/navigation";
+import { applyAcceptedInvitationRole, type StackTeamUserLike } from "@/services/team/invites";
 
 export const dynamic = "force-dynamic";
 
-type StackAcceptUser = {
+type StackAcceptUser = StackTeamUserLike & {
   acceptTeamInvitation?: (code: string) => Promise<unknown>;
   listTeamInvitations?: () => Promise<readonly {
     id: string;
+    teamId?: string;
     accept?: () => Promise<void>;
   }[]>;
 };
@@ -39,6 +41,8 @@ export default async function TeamInviteAcceptPage({
   }
   const user = await getStackServerApp().getUser({ or: "return-null" }) as StackAcceptUser | null;
   if (!user) redirect(vaultSignInHref(acceptPath));
+  let acceptedInvitationId: string | null = null;
+  let acceptedTeamId: string | null = null;
   try {
     if (code) {
       if (!user.acceptTeamInvitation) throw new Error("acceptTeamInvitation unavailable");
@@ -49,6 +53,8 @@ export default async function TeamInviteAcceptPage({
       const invitation = (await user.listTeamInvitations()).find((candidate) => candidate.id === invitationId);
       if (!invitation?.accept) throw new Error("VerificationCodeError");
       await invitation.accept();
+      acceptedInvitationId = invitation.id;
+      acceptedTeamId = invitation.teamId ?? null;
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -56,6 +62,9 @@ export default async function TeamInviteAcceptPage({
       return <AcceptError title={t("emailMismatchTitle")} body={t("emailMismatchBody")} switchAccount={t("switchAccount")} />;
     }
     return <AcceptError title={t("badCodeTitle")} body={t("badCodeBody")} switchAccount={t("switchAccount")} />;
+  }
+  if (acceptedInvitationId) {
+    await applyAcceptedInvitationRole({ user, invitationId: acceptedInvitationId, teamId: acceptedTeamId });
   }
   redirect(localizedVaultPath(locale, "/dashboard/team?joined=1"));
 }

--- a/web/app/[locale]/dashboard/team/accept/page.tsx
+++ b/web/app/[locale]/dashboard/team/accept/page.tsx
@@ -46,8 +46,18 @@ export default async function TeamInviteAcceptPage({
   try {
     if (code) {
       if (!user.acceptTeamInvitation) throw new Error("acceptTeamInvitation unavailable");
+      // The Stack code is opaque, so capture the pending received invitations
+      // first (their ids match the stored role). Accepting the code consumes
+      // one of them; if exactly one was pending we know which invitation it was
+      // and can apply the invited role. Ambiguous multi-invite cases fall
+      // through to member (safe: a missing grant is a downgrade, not escalation).
+      const pending = user.listTeamInvitations ? await user.listTeamInvitations() : [];
       const result = await user.acceptTeamInvitation(code);
       if (isStackResultError(result)) throw result.error;
+      if (pending.length === 1) {
+        acceptedInvitationId = pending[0].id;
+        acceptedTeamId = pending[0].teamId ?? null;
+      }
     } else {
       if (!user.listTeamInvitations) throw new Error("listTeamInvitations unavailable");
       const invitation = (await user.listTeamInvitations()).find((candidate) => candidate.id === invitationId);

--- a/web/app/[locale]/dashboard/team/create-team-form.tsx
+++ b/web/app/[locale]/dashboard/team/create-team-form.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
+
+export function CreateTeamForm() {
+  const t = useTranslations("dashboard.team");
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <form
+      className="border border-border p-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        setError(null);
+        startTransition(async () => {
+          const response = await fetch("/api/team", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ action: "create", displayName: name }),
+          });
+          if (response.ok) {
+            window.location.reload();
+            return;
+          }
+          setError(t("errors.createFailed"));
+        });
+      }}
+    >
+      <h2 className="text-sm font-medium">{t("create.title")}</h2>
+      <p className="mt-1 text-xs text-muted">{t("create.body")}</p>
+      <div className="mt-3 flex flex-col gap-2 md:flex-row">
+        <input
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder={t("create.placeholder")}
+          className="min-w-0 flex-1 border border-border bg-background px-3 py-2 text-sm"
+        />
+        <button
+          type="submit"
+          disabled={isPending || !name.trim()}
+          className="border border-border px-3 py-2 text-sm hover:bg-foreground hover:text-background disabled:opacity-50"
+        >
+          {t("create.submit")}
+        </button>
+      </div>
+      {error ? <p className="mt-2 text-xs text-muted">{error}</p> : null}
+    </form>
+  );
+}

--- a/web/app/[locale]/dashboard/team/optimistic.ts
+++ b/web/app/[locale]/dashboard/team/optimistic.ts
@@ -1,0 +1,22 @@
+import type { TeamSummaryDto } from "@/services/team/invites";
+
+type OptimisticMutation<T> = {
+  readonly requestId: string;
+  readonly previous: T;
+  readonly next: T;
+};
+
+export function applyOptimisticRevoke(
+  state: TeamSummaryDto,
+  invitationId: string,
+  requestId: string,
+): OptimisticMutation<TeamSummaryDto> {
+  return {
+    requestId,
+    previous: state,
+    next: {
+      ...state,
+      invitations: state.invitations.filter((invitation) => invitation.id !== invitationId),
+    },
+  };
+}

--- a/web/app/[locale]/dashboard/team/page.tsx
+++ b/web/app/[locale]/dashboard/team/page.tsx
@@ -1,0 +1,54 @@
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
+import { loadTeamSummary, type StackTeamUserLike } from "@/services/team/invites";
+import { CreateTeamForm } from "./create-team-form";
+import { TeamManagerClient } from "./team-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardTeamPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>;
+  searchParams?: Promise<{ joined?: string | string[] }>;
+}) {
+  const [{ locale }, query] = await Promise.all([
+    params,
+    searchParams ?? Promise.resolve({} as { joined?: string | string[] }),
+  ]);
+  if (!isStackConfigured()) redirect("/");
+  const user = await getStackServerApp().getUser({ or: "return-null" }) as StackTeamUserLike | null;
+  if (!user) redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard/team")));
+  const t = await getTranslations({ locale, namespace: "dashboard.team" });
+  let summary = null;
+  try {
+    summary = await loadTeamSummary(user);
+  } catch {
+    summary = null;
+  }
+  const joined = (Array.isArray(query.joined) ? query.joined[0] : query.joined) === "1";
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-3 py-4">
+      <div className="mb-4 border-b border-border pb-3">
+        <p className="text-xs font-medium text-muted">{t("eyebrow")}</p>
+        <h1 className="mt-1 text-sm font-medium">{t("title")}</h1>
+        <p className="mt-1 max-w-2xl text-muted">{t("description")}</p>
+      </div>
+      {summary ? (
+        <TeamManagerClient
+          initialSummary={summary}
+          currentUserId={user.id}
+          locale={locale}
+          joined={joined}
+        />
+      ) : (
+        <CreateTeamForm />
+      )}
+    </div>
+  );
+}

--- a/web/app/[locale]/dashboard/team/team-client.tsx
+++ b/web/app/[locale]/dashboard/team/team-client.tsx
@@ -6,6 +6,8 @@ import { useTranslations } from "next-intl";
 import type { TeamInvitationDto, TeamMemberDto, TeamSummaryDto } from "@/services/team/invites";
 import { applyOptimisticRevoke } from "./optimistic";
 
+type TeamRole = "admin" | "member";
+
 type InviteStatus = {
   readonly email: string;
   readonly state: "pending" | "sent" | "failed";
@@ -28,10 +30,13 @@ export function TeamManagerClient({
   const [chips, setChips] = useState<string[]>([]);
   const [input, setInput] = useState("");
   const [statuses, setStatuses] = useState<InviteStatus[]>([]);
+  const [inviteRole, setInviteRole] = useState<TeamRole>("member");
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [isPending, startTransition] = useTransition();
   const overSeats = summary.seats > 0 && summary.members.length > summary.seats;
+  const canManageTeam = summary.canManageTeam;
+  const adminCount = summary.members.filter((member) => member.role === "admin").length;
 
   const shareUrl = useMemo(() => {
     const first = summary.invitations.find((invite) => invite.acceptUrl)?.acceptUrl;
@@ -58,7 +63,7 @@ export function TeamManagerClient({
         const response = await fetch("/api/team/invite", {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ email, locale }),
+          body: JSON.stringify({ email, locale, role: inviteRole }),
         });
         const body = await response.json() as { invitation?: TeamInvitationDto; error?: string };
         if (!response.ok || !body.invitation) throw new Error(body.error ?? "failed");
@@ -115,7 +120,7 @@ export function TeamManagerClient({
   }
 
   function removeMember(memberId: string) {
-    if (!confirm(t("members.removeConfirm"))) return;
+    if (!confirm(memberId === currentUserId ? t("members.leaveConfirm") : t("members.removeConfirm"))) return;
     startTransition(async () => {
       try {
         const response = await fetch("/api/team/members/remove", {
@@ -129,6 +134,24 @@ export function TeamManagerClient({
         setError(null);
       } catch {
         setError(t("errors.removeFailed"));
+      }
+    });
+  }
+
+  function updateRole(memberId: string, role: TeamRole) {
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/team/members/role", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ memberId, role }),
+        });
+        const body = await response.json() as TeamSummaryDto | { error?: string };
+        if (!response.ok || !("teamId" in body)) throw new Error("failed");
+        setSummary(body);
+        setError(null);
+      } catch {
+        setError(t("errors.roleFailed"));
       }
     });
   }
@@ -165,12 +188,13 @@ export function TeamManagerClient({
               </a>
             ) : null}
           </div>
-          <RenameForm currentName={summary.teamName} onRenamed={setSummary} />
+          {canManageTeam ? <RenameForm currentName={summary.teamName} onRenamed={setSummary} /> : null}
         </div>
       </section>
 
-      <section className="border border-border p-3">
-        <h2 className="text-sm font-medium">{t("invite.title")}</h2>
+      {canManageTeam ? (
+        <section className="border border-border p-3">
+          <h2 className="text-sm font-medium">{t("invite.title")}</h2>
         <div className="mt-3 flex flex-wrap gap-2">
           {chips.map((email) => (
             <button
@@ -197,6 +221,15 @@ export function TeamManagerClient({
             placeholder={t("invite.placeholder")}
             className="min-w-0 flex-1 border border-border bg-background px-3 py-2 text-sm focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground"
           />
+          <select
+            value={inviteRole}
+            onChange={(event) => setInviteRole(event.target.value as TeamRole)}
+            aria-label={t("invite.roleLabel")}
+            className="border border-border bg-background px-3 py-2 text-sm"
+          >
+            <option value="member">{t("roles.member")}</option>
+            <option value="admin">{t("roles.admin")}</option>
+          </select>
           <button
             type="button"
             disabled={isPending}
@@ -222,7 +255,8 @@ export function TeamManagerClient({
             ))}
           </div>
         ) : null}
-      </section>
+        </section>
+      ) : null}
 
       <section className="border border-border">
         <div className="border-b border-border px-3 py-2 text-sm font-medium">{t("pending.title")}</div>
@@ -232,6 +266,7 @@ export function TeamManagerClient({
           <InviteRow
             key={invitation.id}
             invitation={invitation}
+            canManageTeam={canManageTeam}
             onResend={() => resend(invitation.id)}
             onRevoke={() => revoke(invitation.id)}
           />
@@ -246,7 +281,10 @@ export function TeamManagerClient({
             member={member}
             currentUserId={currentUserId}
             memberCount={summary.members.length}
+            adminCount={adminCount}
+            canManageTeam={canManageTeam}
             onRemove={() => removeMember(member.id)}
+            onRoleChange={(role) => updateRole(member.id, role)}
           />
         ))}
       </section>
@@ -295,10 +333,12 @@ function RenameForm({
 
 function InviteRow({
   invitation,
+  canManageTeam,
   onResend,
   onRevoke,
 }: {
   invitation: TeamInvitationDto;
+  canManageTeam: boolean;
   onResend: () => void;
   onRevoke: () => void;
 }) {
@@ -307,16 +347,18 @@ function InviteRow({
     <div className="grid gap-2 border-b border-border px-3 py-2 last:border-b-0 md:grid-cols-[1fr_auto] md:items-center">
       <div>
         <div className="text-sm">{invitation.email}</div>
-        <div className="text-xs text-muted">{invitation.createdAt ?? t("pending.unknownDate")}</div>
+        <div className="text-xs text-muted">
+          {invitation.createdAt ?? t("pending.unknownDate")} · {t(`roles.${invitation.role}`)}
+        </div>
       </div>
-      <div className="flex gap-2">
+      {canManageTeam ? <div className="flex gap-2">
         <button type="button" onClick={onResend} className="border border-border px-2 py-1 text-xs">
           {t("pending.resend")}
         </button>
         <button type="button" onClick={onRevoke} className="border border-border px-2 py-1 text-xs">
           {t("pending.revoke")}
         </button>
-      </div>
+      </div> : null}
     </div>
   );
 }
@@ -325,19 +367,27 @@ function MemberRow({
   member,
   currentUserId,
   memberCount,
+  adminCount,
+  canManageTeam,
   onRemove,
+  onRoleChange,
 }: {
   member: TeamMemberDto;
   currentUserId: string;
   memberCount: number;
+  adminCount: number;
+  canManageTeam: boolean;
   onRemove: () => void;
+  onRoleChange: (role: TeamRole) => void;
 }) {
   const t = useTranslations("dashboard.team");
   const isSelf = member.id === currentUserId;
-  const disabled = isSelf || memberCount <= 1;
+  const isLastAdmin = member.role === "admin" && adminCount <= 1;
+  const canLeave = isSelf && memberCount > 1 && !isLastAdmin;
+  const canRemove = canManageTeam && !isSelf && memberCount > 1 && !isLastAdmin;
   const label = member.displayName ?? member.email ?? member.id;
   return (
-    <div className="grid gap-2 border-b border-border px-3 py-2 last:border-b-0 md:grid-cols-[auto_1fr_auto] md:items-center">
+    <div className="grid gap-2 border-b border-border px-3 py-2 last:border-b-0 md:grid-cols-[auto_1fr_auto_auto] md:items-center">
       <div className="flex h-8 w-8 items-center justify-center border border-border text-xs">
         {label.slice(0, 1).toUpperCase()}
       </div>
@@ -345,16 +395,31 @@ function MemberRow({
         <div className="truncate text-sm">
           {label} {isSelf ? <span className="text-xs text-muted">{t("members.you")}</span> : null}
         </div>
-        <div className="truncate text-xs text-muted">{member.email ?? t("members.noEmail")}</div>
+        <div className="truncate text-xs text-muted">
+          {member.email ?? t("members.noEmail")} · {t(`roles.${member.role}`)}
+        </div>
       </div>
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={onRemove}
-        className="border border-border px-2 py-1 text-xs disabled:opacity-50"
-      >
-        {t("members.remove")}
-      </button>
+      {canManageTeam ? (
+        <select
+          value={member.role}
+          disabled={isLastAdmin}
+          onChange={(event) => onRoleChange(event.target.value as TeamRole)}
+          aria-label={t("members.roleLabel")}
+          className="border border-border bg-background px-2 py-1 text-xs disabled:opacity-50"
+        >
+          <option value="member">{t("roles.member")}</option>
+          <option value="admin">{t("roles.admin")}</option>
+        </select>
+      ) : null}
+      {canRemove || canLeave ? (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="border border-border px-2 py-1 text-xs"
+        >
+          {isSelf ? t("members.leave") : t("members.remove")}
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/web/app/[locale]/dashboard/team/team-client.tsx
+++ b/web/app/[locale]/dashboard/team/team-client.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
+
+import type { TeamInvitationDto, TeamMemberDto, TeamSummaryDto } from "@/services/team/invites";
+import { applyOptimisticRevoke } from "./optimistic";
+
+type InviteStatus = {
+  readonly email: string;
+  readonly state: "pending" | "sent" | "failed";
+  readonly message: string | null;
+};
+
+export function TeamManagerClient({
+  initialSummary,
+  currentUserId,
+  locale,
+  joined,
+}: {
+  initialSummary: TeamSummaryDto;
+  currentUserId: string;
+  locale: string;
+  joined: boolean;
+}) {
+  const t = useTranslations("dashboard.team");
+  const [summary, setSummary] = useState(initialSummary);
+  const [chips, setChips] = useState<string[]>([]);
+  const [input, setInput] = useState("");
+  const [statuses, setStatuses] = useState<InviteStatus[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const overSeats = summary.seats > 0 && summary.members.length > summary.seats;
+
+  const shareUrl = useMemo(() => {
+    const first = summary.invitations.find((invite) => invite.acceptUrl)?.acceptUrl;
+    return first ?? null;
+  }, [summary.invitations]);
+
+  function addInputEmails(raw: string) {
+    const parts = raw.split(/[,\s]+/).map((part) => part.trim()).filter(Boolean);
+    if (parts.length === 0) return;
+    setChips((current) => Array.from(new Set([...current, ...parts.map((part) => part.toLowerCase())])));
+    setInput("");
+  }
+
+  async function sendInvites() {
+    const emails = [...chips];
+    if (input.trim()) {
+      emails.push(...input.split(/[,\s]+/).map((part) => part.trim()).filter(Boolean));
+    }
+    const unique = Array.from(new Set(emails.map((email) => email.toLowerCase())));
+    setChips(unique);
+    setStatuses(unique.map((email) => ({ email, state: "pending", message: null })));
+    for (const email of unique) {
+      try {
+        const response = await fetch("/api/team/invite", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ email, locale }),
+        });
+        const body = await response.json() as { invitation?: TeamInvitationDto; error?: string };
+        if (!response.ok || !body.invitation) throw new Error(body.error ?? "failed");
+        setSummary((current) => ({
+          ...current,
+          invitations: [
+            body.invitation!,
+            ...current.invitations.filter((invite) => invite.id !== body.invitation!.id),
+          ],
+        }));
+        setStatuses((current) => updateStatus(current, email, "sent", t("invite.sent")));
+      } catch {
+        setStatuses((current) => updateStatus(current, email, "failed", t("errors.inviteFailed")));
+      }
+    }
+    setChips([]);
+    setInput("");
+  }
+
+  function revoke(invitationId: string) {
+    const mutation = applyOptimisticRevoke(summary, invitationId, crypto.randomUUID());
+    setSummary(mutation.next);
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/team/invite/revoke", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ invitationId }),
+        });
+        const body = await response.json() as TeamSummaryDto | { error?: string };
+        if (!response.ok || !("teamId" in body)) throw new Error("failed");
+        setSummary(body);
+      } catch {
+        setSummary(mutation.previous);
+        setError(t("errors.revokeFailed"));
+      }
+    });
+  }
+
+  function resend(invitationId: string) {
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/team/invite/resend", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ invitationId, locale }),
+        });
+        if (!response.ok) throw new Error("failed");
+        setError(null);
+      } catch {
+        setError(t("errors.resendFailed"));
+      }
+    });
+  }
+
+  function removeMember(memberId: string) {
+    if (!confirm(t("members.removeConfirm"))) return;
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/team/members/remove", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ memberId }),
+        });
+        const body = await response.json() as TeamSummaryDto | { error?: string };
+        if (!response.ok || !("teamId" in body)) throw new Error("failed");
+        setSummary(body);
+        setError(null);
+      } catch {
+        setError(t("errors.removeFailed"));
+      }
+    });
+  }
+
+  async function copyInviteLink() {
+    const url = shareUrl;
+    if (!url) {
+      setError(t("invite.copyUnavailable"));
+      return;
+    }
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+  }
+
+  return (
+    <div className="space-y-4">
+      {joined ? (
+        <div className="border border-border p-3 text-sm">{t("joinedBanner")}</div>
+      ) : null}
+      {error ? <div className="border border-border p-3 text-sm">{error}</div> : null}
+      <section className="border border-border p-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h2 className="text-sm font-medium">{summary.teamName}</h2>
+            <p className="mt-1 text-xs text-muted">
+              {t("seatSummary", { members: summary.members.length, seats: summary.seats })}
+            </p>
+            {overSeats ? (
+              <a
+                href="/api/billing/portal?scope=team"
+                className="mt-2 inline-block text-xs text-muted underline hover:text-foreground"
+              >
+                {t("seatNudge")}
+              </a>
+            ) : null}
+          </div>
+          <RenameForm currentName={summary.teamName} onRenamed={setSummary} />
+        </div>
+      </section>
+
+      <section className="border border-border p-3">
+        <h2 className="text-sm font-medium">{t("invite.title")}</h2>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {chips.map((email) => (
+            <button
+              key={email}
+              type="button"
+              onClick={() => setChips((current) => current.filter((item) => item !== email))}
+              className="border border-border px-2 py-1 text-xs"
+            >
+              {email}
+            </button>
+          ))}
+        </div>
+        <div className="mt-3 flex flex-col gap-2 md:flex-row">
+          <input
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            onBlur={() => addInputEmails(input)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === ",") {
+                event.preventDefault();
+                addInputEmails(input);
+              }
+            }}
+            placeholder={t("invite.placeholder")}
+            className="min-w-0 flex-1 border border-border bg-background px-3 py-2 text-sm focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground"
+          />
+          <button
+            type="button"
+            disabled={isPending}
+            onClick={sendInvites}
+            className="border border-border px-3 py-2 text-sm hover:bg-foreground hover:text-background disabled:opacity-50"
+          >
+            {t("invite.send")}
+          </button>
+          <button
+            type="button"
+            onClick={copyInviteLink}
+            className="border border-border px-3 py-2 text-sm hover:bg-foreground hover:text-background"
+          >
+            {copied ? t("invite.copied") : t("invite.copyLink")}
+          </button>
+        </div>
+        {statuses.length > 0 ? (
+          <div className="mt-3 space-y-1 text-xs">
+            {statuses.map((status) => (
+              <p key={status.email}>
+                {status.email}: {status.message ?? t(`invite.${status.state}`)}
+              </p>
+            ))}
+          </div>
+        ) : null}
+      </section>
+
+      <section className="border border-border">
+        <div className="border-b border-border px-3 py-2 text-sm font-medium">{t("pending.title")}</div>
+        {summary.invitations.length === 0 ? (
+          <p className="p-3 text-xs text-muted">{t("pending.empty")}</p>
+        ) : summary.invitations.map((invitation) => (
+          <InviteRow
+            key={invitation.id}
+            invitation={invitation}
+            onResend={() => resend(invitation.id)}
+            onRevoke={() => revoke(invitation.id)}
+          />
+        ))}
+      </section>
+
+      <section className="border border-border">
+        <div className="border-b border-border px-3 py-2 text-sm font-medium">{t("members.title")}</div>
+        {summary.members.map((member) => (
+          <MemberRow
+            key={member.id}
+            member={member}
+            currentUserId={currentUserId}
+            memberCount={summary.members.length}
+            onRemove={() => removeMember(member.id)}
+          />
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function RenameForm({
+  currentName,
+  onRenamed,
+}: {
+  currentName: string;
+  onRenamed: (summary: TeamSummaryDto) => void;
+}) {
+  const t = useTranslations("dashboard.team");
+  const [name, setName] = useState(currentName);
+  const [isPending, startTransition] = useTransition();
+  return (
+    <form
+      className="flex gap-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        startTransition(async () => {
+          const response = await fetch("/api/team", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ action: "rename", displayName: name }),
+          });
+          const body = await response.json() as TeamSummaryDto;
+          if (response.ok) onRenamed(body);
+        });
+      }}
+    >
+      <input
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+        aria-label={t("rename.label")}
+        className="w-44 border border-border bg-background px-2 py-1 text-sm"
+      />
+      <button type="submit" disabled={isPending} className="border border-border px-2 py-1 text-sm disabled:opacity-50">
+        {t("rename.save")}
+      </button>
+    </form>
+  );
+}
+
+function InviteRow({
+  invitation,
+  onResend,
+  onRevoke,
+}: {
+  invitation: TeamInvitationDto;
+  onResend: () => void;
+  onRevoke: () => void;
+}) {
+  const t = useTranslations("dashboard.team");
+  return (
+    <div className="grid gap-2 border-b border-border px-3 py-2 last:border-b-0 md:grid-cols-[1fr_auto] md:items-center">
+      <div>
+        <div className="text-sm">{invitation.email}</div>
+        <div className="text-xs text-muted">{invitation.createdAt ?? t("pending.unknownDate")}</div>
+      </div>
+      <div className="flex gap-2">
+        <button type="button" onClick={onResend} className="border border-border px-2 py-1 text-xs">
+          {t("pending.resend")}
+        </button>
+        <button type="button" onClick={onRevoke} className="border border-border px-2 py-1 text-xs">
+          {t("pending.revoke")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function MemberRow({
+  member,
+  currentUserId,
+  memberCount,
+  onRemove,
+}: {
+  member: TeamMemberDto;
+  currentUserId: string;
+  memberCount: number;
+  onRemove: () => void;
+}) {
+  const t = useTranslations("dashboard.team");
+  const isSelf = member.id === currentUserId;
+  const disabled = isSelf || memberCount <= 1;
+  const label = member.displayName ?? member.email ?? member.id;
+  return (
+    <div className="grid gap-2 border-b border-border px-3 py-2 last:border-b-0 md:grid-cols-[auto_1fr_auto] md:items-center">
+      <div className="flex h-8 w-8 items-center justify-center border border-border text-xs">
+        {label.slice(0, 1).toUpperCase()}
+      </div>
+      <div className="min-w-0">
+        <div className="truncate text-sm">
+          {label} {isSelf ? <span className="text-xs text-muted">{t("members.you")}</span> : null}
+        </div>
+        <div className="truncate text-xs text-muted">{member.email ?? t("members.noEmail")}</div>
+      </div>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onRemove}
+        className="border border-border px-2 py-1 text-xs disabled:opacity-50"
+      >
+        {t("members.remove")}
+      </button>
+    </div>
+  );
+}
+
+function updateStatus(
+  statuses: readonly InviteStatus[],
+  email: string,
+  state: InviteStatus["state"],
+  message: string,
+): InviteStatus[] {
+  return statuses.map((status) => status.email === email ? { ...status, state, message } : status);
+}

--- a/web/app/api/billing/checkout/route.ts
+++ b/web/app/api/billing/checkout/route.ts
@@ -21,6 +21,7 @@ import {
   stripe,
   type ProBillingInterval,
 } from "../../../../services/billing/stripe";
+import { TEAM_ADMIN_PERMISSION_ID } from "../../../../services/team/invites";
 
 export const dynamic = "force-dynamic";
 
@@ -248,6 +249,7 @@ type CheckoutTeamUser = {
   readonly selectedTeam?: CheckoutTeamCustomer | null;
   listTeams?(): Promise<CheckoutTeamCustomer[]>;
   createTeam?(data: { displayName: string }): Promise<CheckoutTeamCustomer>;
+  grantPermission?(scope: CheckoutTeamCustomer, permissionId: string): Promise<void>;
 };
 
 async function checkoutTeamCustomer(user: CheckoutTeamUser): Promise<CheckoutTeamCustomer> {
@@ -262,6 +264,7 @@ async function checkoutTeamCustomer(user: CheckoutTeamUser): Promise<CheckoutTea
   }
 
   const team = await user.createTeam({ displayName: "cmux Team" });
+  await user.grantPermission?.(team, TEAM_ADMIN_PERMISSION_ID);
   return team;
 }
 

--- a/web/app/api/team/invite/resend/route.ts
+++ b/web/app/api/team/invite/resend/route.ts
@@ -1,0 +1,30 @@
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import {
+  readBoundedJson,
+  resendTeamInvite,
+  teamInviteErrorResponse,
+  teamInviteJson,
+  type StackTeamUserLike,
+} from "@/services/team/invites";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  if (!isStackConfigured()) return teamInviteJson({ error: "service_unavailable" }, 503);
+  try {
+    const user = await getStackServerApp().getUser({ or: "return-null" }) as StackTeamUserLike | null;
+    if (!user) return teamInviteJson({ error: "unauthorized" }, 401);
+    const body = await readBoundedJson(request);
+    const record = body && typeof body === "object" ? body as Record<string, unknown> : {};
+    const locale = typeof record.locale === "string" && record.locale.trim() ? record.locale.trim() : "en";
+    return teamInviteJson(await resendTeamInvite({
+      user,
+      request,
+      invitationId: record.invitationId,
+      locale,
+    }));
+  } catch (error) {
+    return teamInviteErrorResponse(error);
+  }
+}

--- a/web/app/api/team/invite/revoke/route.ts
+++ b/web/app/api/team/invite/revoke/route.ts
@@ -1,0 +1,24 @@
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import {
+  readBoundedJson,
+  revokeTeamInvite,
+  teamInviteErrorResponse,
+  teamInviteJson,
+  type StackTeamUserLike,
+} from "@/services/team/invites";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  if (!isStackConfigured()) return teamInviteJson({ error: "service_unavailable" }, 503);
+  try {
+    const user = await getStackServerApp().getUser({ or: "return-null" }) as StackTeamUserLike | null;
+    if (!user) return teamInviteJson({ error: "unauthorized" }, 401);
+    const body = await readBoundedJson(request);
+    const record = body && typeof body === "object" ? body as Record<string, unknown> : {};
+    return teamInviteJson(await revokeTeamInvite(user, record.invitationId));
+  } catch (error) {
+    return teamInviteErrorResponse(error);
+  }
+}

--- a/web/app/api/team/invite/route.ts
+++ b/web/app/api/team/invite/route.ts
@@ -1,0 +1,31 @@
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import {
+  readBoundedJson,
+  sendTeamInvite,
+  teamInviteErrorResponse,
+  teamInviteJson,
+  type StackTeamUserLike,
+} from "@/services/team/invites";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  if (!isStackConfigured()) return teamInviteJson({ error: "service_unavailable" }, 503);
+  try {
+    const user = await getStackServerApp().getUser({ or: "return-null" }) as StackTeamUserLike | null;
+    if (!user) return teamInviteJson({ error: "unauthorized" }, 401);
+    const body = await readBoundedJson(request);
+    const record = body && typeof body === "object" ? body as Record<string, unknown> : {};
+    const locale = typeof record.locale === "string" && record.locale.trim() ? record.locale.trim() : "en";
+    const result = await sendTeamInvite({
+      user,
+      request,
+      email: record.email,
+      locale,
+    });
+    return teamInviteJson(result);
+  } catch (error) {
+    return teamInviteErrorResponse(error);
+  }
+}

--- a/web/app/api/team/invite/team-invite-email.ts
+++ b/web/app/api/team/invite/team-invite-email.ts
@@ -1,0 +1,80 @@
+export const DEFAULT_TEAM_INVITE_FROM_EMAIL = "austin@manaflow.ai";
+export const TEAM_INVITE_REPLY_TO = "austin@manaflow.ai";
+export const TEAM_INVITE_SUBJECT = "Join {team} on cmux";
+
+export type TeamInviteEmail = {
+  from: string;
+  to: string[];
+  replyTo: string;
+  subject: string;
+  text: string;
+  html: string;
+  headers: Record<string, string>;
+};
+
+function firstName(fullName: string | null | undefined): string {
+  const trimmed = (fullName ?? "").trim();
+  if (!trimmed) return "there";
+  return trimmed.split(/\s+/)[0] ?? "there";
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function subjectForTeam(teamName: string): string {
+  return TEAM_INVITE_SUBJECT.replace("{team}", teamName);
+}
+
+export function teamInviteThreadRef(invitationId: string): string {
+  return `team-invite/${invitationId}`;
+}
+
+export function buildTeamInviteEmail(params: {
+  from: string;
+  to: string;
+  teamName: string;
+  inviterName: string | null | undefined;
+  acceptUrl: string;
+  invitationId: string;
+}): TeamInviteEmail {
+  const inviter = firstName(params.inviterName);
+  const teamName = params.teamName.trim() || "cmux Team";
+  const text = [
+    `Hi there!`,
+    "",
+    `${inviter} invited you to join ${teamName} on cmux.`,
+    "",
+    `Accept the invite: ${params.acceptUrl}`,
+    "",
+    "If you were not expecting this invite, you can ignore this email.",
+    "",
+    "Best,",
+    "The cmux team",
+  ].join("\n");
+  const escapedTeam = escapeHtml(teamName);
+  const escapedInviter = escapeHtml(inviter);
+  const escapedUrl = escapeHtml(params.acceptUrl);
+  return {
+    from: params.from,
+    to: [params.to],
+    replyTo: TEAM_INVITE_REPLY_TO,
+    subject: subjectForTeam(teamName),
+    text,
+    html: [
+      "<!doctype html>",
+      '<html><body style="font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;line-height:1.5;color:#111">',
+      `<p>Hi there!</p>`,
+      `<p>${escapedInviter} invited you to join <strong>${escapedTeam}</strong> on cmux.</p>`,
+      `<p><a href="${escapedUrl}" style="display:inline-block;border:1px solid #111;padding:8px 12px;color:#111;text-decoration:none">Accept invite</a></p>`,
+      `<p>If you were not expecting this invite, you can ignore this email.</p>`,
+      `<p>Best,<br>The cmux team</p>`,
+      "</body></html>",
+    ].join(""),
+    headers: { "X-Entity-Ref-ID": teamInviteThreadRef(params.invitationId) },
+  };
+}

--- a/web/app/api/team/members/remove/route.ts
+++ b/web/app/api/team/members/remove/route.ts
@@ -1,0 +1,24 @@
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import {
+  readBoundedJson,
+  removeTeamMember,
+  teamInviteErrorResponse,
+  teamInviteJson,
+  type StackTeamUserLike,
+} from "@/services/team/invites";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  if (!isStackConfigured()) return teamInviteJson({ error: "service_unavailable" }, 503);
+  try {
+    const user = await getStackServerApp().getUser({ or: "return-null" }) as StackTeamUserLike | null;
+    if (!user) return teamInviteJson({ error: "unauthorized" }, 401);
+    const body = await readBoundedJson(request);
+    const record = body && typeof body === "object" ? body as Record<string, unknown> : {};
+    return teamInviteJson(await removeTeamMember(user, record.memberId));
+  } catch (error) {
+    return teamInviteErrorResponse(error);
+  }
+}

--- a/web/app/api/team/members/role/route.ts
+++ b/web/app/api/team/members/role/route.ts
@@ -1,9 +1,9 @@
 import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
 import {
   readBoundedJson,
-  sendTeamInvite,
   teamInviteErrorResponse,
   teamInviteJson,
+  updateTeamMemberRole,
   type StackTeamUserLike,
 } from "@/services/team/invites";
 
@@ -17,15 +17,7 @@ export async function POST(request: Request): Promise<Response> {
     if (!user) return teamInviteJson({ error: "unauthorized" }, 401);
     const body = await readBoundedJson(request);
     const record = body && typeof body === "object" ? body as Record<string, unknown> : {};
-    const locale = typeof record.locale === "string" && record.locale.trim() ? record.locale.trim() : "en";
-    const result = await sendTeamInvite({
-      user,
-      request,
-      email: record.email,
-      locale,
-      role: record.role,
-    });
-    return teamInviteJson(result);
+    return teamInviteJson(await updateTeamMemberRole(user, record.memberId, record.role));
   } catch (error) {
     return teamInviteErrorResponse(error);
   }

--- a/web/app/api/team/route.ts
+++ b/web/app/api/team/route.ts
@@ -1,0 +1,33 @@
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import {
+  createTeamForUser,
+  loadTeamSummary,
+  readBoundedJson,
+  teamInviteErrorResponse,
+  teamInviteJson,
+  updateTeamName,
+  type StackTeamUserLike,
+} from "@/services/team/invites";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  if (!isStackConfigured()) return teamInviteJson({ error: "service_unavailable" }, 503);
+  try {
+    const user = await getStackServerApp().getUser({ or: "return-null" }) as StackTeamUserLike | null;
+    if (!user) return teamInviteJson({ error: "unauthorized" }, 401);
+    const body = await readBoundedJson(request);
+    const record = body && typeof body === "object" ? body as Record<string, unknown> : {};
+    if (record.action === "create") {
+      await createTeamForUser(user, record.displayName);
+      return teamInviteJson({ ok: true });
+    }
+    if (record.action === "rename") {
+      return teamInviteJson(await updateTeamName(user, record.displayName));
+    }
+    return teamInviteJson(await loadTeamSummary(user));
+  } catch (error) {
+    return teamInviteErrorResponse(error);
+  }
+}

--- a/web/db/migrations/20260709000000_team_invite_roles/migration.sql
+++ b/web/db/migrations/20260709000000_team_invite_roles/migration.sql
@@ -1,0 +1,13 @@
+CREATE TYPE "team_invite_role" AS ENUM ('admin', 'member');
+--> statement-breakpoint
+CREATE TABLE "team_invite_roles" (
+  "invitation_id" text PRIMARY KEY NOT NULL,
+  "stack_team_id" text NOT NULL,
+  "role" "team_invite_role" DEFAULT 'member' NOT NULL,
+  "created_by_user_id" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "accepted_at" timestamp with time zone,
+  "revoked_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE INDEX "team_invite_roles_stack_team_idx" ON "team_invite_roles" ("stack_team_id");

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -47,6 +47,24 @@ export const cloudVmNotificationDeliveryStatus = pgEnum("cloud_vm_notification_d
   "dismissed",
 ]);
 
+export const teamInviteRole = pgEnum("team_invite_role", ["admin", "member"]);
+
+export const teamInviteRoles = pgTable(
+  "team_invite_roles",
+  {
+    invitationId: text("invitation_id").primaryKey(),
+    stackTeamId: text("stack_team_id").notNull(),
+    role: teamInviteRole("role").notNull().default("member"),
+    createdByUserId: text("created_by_user_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    acceptedAt: timestamp("accepted_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+  },
+  (table) => [
+    index("team_invite_roles_stack_team_idx").on(table.stackTeamId),
+  ],
+);
+
 export const cloudVms = pgTable(
   "cloud_vms",
   {

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/bs.json
+++ b/web/messages/bs.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/bs.json
+++ b/web/messages/bs.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -54,7 +54,8 @@
       "subrouterOverview": "overview",
       "accountGroup": "account",
       "billing": "billing",
-      "testflight": "iOS TestFlight"
+      "testflight": "iOS TestFlight",
+      "team": "team"
     },
     "home": {
       "title": "dashboard",
@@ -219,6 +220,63 @@
       "cancelAction": "Cancel",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "vault": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -247,7 +247,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -261,7 +262,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -275,7 +279,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -247,7 +247,8 @@
         "copyUnavailable": "共有リンクを作成するには、まず招待を送信してください。",
         "pending": "送信中",
         "sent": "送信済み",
-        "failed": "失敗"
+        "failed": "失敗",
+        "roleLabel": "招待する役割"
       },
       "pending": {
         "title": "保留中の招待",
@@ -261,7 +262,10 @@
         "you": "あなた",
         "noEmail": "メールなし",
         "remove": "削除",
-        "removeConfirm": "このチームメンバーを削除しますか？"
+        "removeConfirm": "このチームメンバーを削除しますか？",
+        "roleLabel": "メンバーの役割",
+        "leave": "退出",
+        "leaveConfirm": "このチームから退出しますか？"
       },
       "accept": {
         "badCodeTitle": "招待リンクが無効です",
@@ -275,7 +279,12 @@
         "inviteFailed": "招待を送信できませんでした。",
         "revokeFailed": "招待を取り消せませんでした。",
         "resendFailed": "招待を再送信できませんでした。",
-        "removeFailed": "メンバーを削除できませんでした。"
+        "removeFailed": "メンバーを削除できませんでした。",
+        "roleFailed": "メンバーの役割を更新できませんでした。"
+      },
+      "roles": {
+        "admin": "管理者",
+        "member": "メンバー"
       }
     }
   },

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -54,7 +54,8 @@
       "subrouterOverview": "概要",
       "accountGroup": "アカウント",
       "billing": "請求",
-      "testflight": "iOS TestFlight"
+      "testflight": "iOS TestFlight",
+      "team": "チーム"
     },
     "home": {
       "title": "ダッシュボード",
@@ -219,6 +220,63 @@
       "cancelAction": "キャンセル",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "team": {
+      "eyebrow": "チーム",
+      "title": "チーム",
+      "description": "メンバーを招待し、チームのメンバーシップを管理します。",
+      "joinedBanner": "チームに参加しました。",
+      "seatSummary": "{members}人のメンバー · {seats}シート",
+      "seatNudge": "有料シート数よりメンバーが多くなっています。シートを追加してください。",
+      "create": {
+        "title": "チームを作成",
+        "body": "メンバーを招待する前に共有チームを作成します。",
+        "placeholder": "チーム名",
+        "submit": "チームを作成"
+      },
+      "rename": {
+        "label": "チーム名",
+        "save": "保存"
+      },
+      "invite": {
+        "title": "メンバーを招待",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "招待を送信",
+        "copyLink": "招待リンクをコピー",
+        "copied": "コピーしました",
+        "copyUnavailable": "共有リンクを作成するには、まず招待を送信してください。",
+        "pending": "送信中",
+        "sent": "送信済み",
+        "failed": "失敗"
+      },
+      "pending": {
+        "title": "保留中の招待",
+        "empty": "保留中の招待はありません。",
+        "unknownDate": "最近送信",
+        "resend": "再送信",
+        "revoke": "取り消し"
+      },
+      "members": {
+        "title": "メンバー",
+        "you": "あなた",
+        "noEmail": "メールなし",
+        "remove": "削除",
+        "removeConfirm": "このチームメンバーを削除しますか？"
+      },
+      "accept": {
+        "badCodeTitle": "招待リンクが無効です",
+        "badCodeBody": "チームメンバーに新しい招待を送ってもらってください。",
+        "emailMismatchTitle": "招待されたメールアドレスを使用してください",
+        "emailMismatchBody": "この招待は別のメールアドレスに紐づいています。アカウントを切り替えるか、新しい招待を依頼してください。",
+        "switchAccount": "アカウントを切り替え"
+      },
+      "errors": {
+        "createFailed": "チームを作成できませんでした。",
+        "inviteFailed": "招待を送信できませんでした。",
+        "revokeFailed": "招待を取り消せませんでした。",
+        "resendFailed": "招待を再送信できませんでした。",
+        "removeFailed": "メンバーを削除できませんでした。"
+      }
     }
   },
   "vault": {

--- a/web/messages/km.json
+++ b/web/messages/km.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/km.json
+++ b/web/messages/km.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/no.json
+++ b/web/messages/no.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/no.json
+++ b/web/messages/no.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {
@@ -556,7 +616,7 @@
         "summary": "Kod tabanınızın gerçekten ihtiyaç duyduğu worktree iş akışını oluşturmak için Claude Code, Codex, komut dosyalarını ve cmux temel öğelerini kullanın.",
         "date": "3 Temmuz 2026",
         "p1": "Yerleşik worktree yöneticilerinin sınırlı olması garanti edilir. Genellikle bir repo, Git, bereketli bir dal akışı ve bir ürün ekibinin kurulumun ne anlama gelmesi gerektiğine dair fikrini varsayarlar. Gerçek kod tabanları bu satırların içinde kalmaz.",
-      "p2": "cmux'in <zen>Zen'i</zen>, geliştiricilerin kendi araçlarını oluşturmaları ve kodla çalışma yollarının arama alanını keşfetmeleri gerektiğidir. Çalışma ağaçları kullanışlı bir ilkeldir, ancak aynı şekilde çoklu ödemeler, farklı klasörlerdeki backend/frontend depoları, uzak makineler, no-git projeler, yerel komut dosyaları ve bazen de sadece ana kodlama çünkü bu görev için en hızlı şeydir.",
+        "p2": "cmux'in <zen>Zen'i</zen>, geliştiricilerin kendi araçlarını oluşturmaları ve kodla çalışma yollarının arama alanını keşfetmeleri gerektiğidir. Çalışma ağaçları kullanışlı bir ilkeldir, ancak aynı şekilde çoklu ödemeler, farklı klasörlerdeki backend/frontend depoları, uzak makineler, no-git projeler, yerel komut dosyaları ve bazen de sadece ana kodlama çünkü bu görev için en hızlı şeydir.",
         "superRepoTitle": "Süper repo modeli",
         "superRepoP1": "Süper depo, tüm gerçek depoların nerede yaşadığını, worktrees'nin nasıl oluşturulduğunu, ilgili depoların nasıl eşleştirildiğini, her çalışma alanını hangi komut dosyalarının hazırladığını ve PRs'nın nasıl incelenip birleştirildiğini bilen bir kontrol ödemesidir. cmuxterm-hq bir süper depodur: birincil cmux ödemesini, görev başına cmux worktrees, Zed kontrollerini, hq komut dosyalarını, yeniden kullanılabilir becerileri ve aracıların birbirlerine basmamak için takip ettiği kuralları içerir.",
         "superRepoP2": "Mesele herkesin bu dizin ağacını tam olarak kopyalaması değil. Mesele şu ki, bir yerel kontrol deposu tüm mühendislik işletim sisteminizi tanımlayabilir. Arka uç repo ve ön uç repo birlikte açılabilir. Bir mobil uygulama ve web API birlikte yeniden yüklenebilir. Bir repoda bir şube, diğerinde eşleşen bir şube oluşturulabilir. Bu şekil ekibinize aittir, genel bir worktree düğmesine değil.",

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -163,6 +163,66 @@
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
       "openAiKeyPlaceholder": "sk-..."
+    },
+    "nav": {
+      "team": "team"
+    },
+    "team": {
+      "eyebrow": "team",
+      "title": "team",
+      "description": "invite people and manage team membership.",
+      "joinedBanner": "You've joined the team.",
+      "seatSummary": "{members} members · {seats} seats",
+      "seatNudge": "You have more members than paid seats. Add seats.",
+      "create": {
+        "title": "Create a team",
+        "body": "Create a shared team before inviting members.",
+        "placeholder": "Team name",
+        "submit": "Create team"
+      },
+      "rename": {
+        "label": "Team name",
+        "save": "Save"
+      },
+      "invite": {
+        "title": "Invite people",
+        "placeholder": "name@example.com, teammate@example.com",
+        "send": "Send invites",
+        "copyLink": "Copy invite link",
+        "copied": "Copied",
+        "copyUnavailable": "Send an invite first to create a shareable link.",
+        "pending": "Sending",
+        "sent": "Sent",
+        "failed": "Failed"
+      },
+      "pending": {
+        "title": "Pending invites",
+        "empty": "No pending invites.",
+        "unknownDate": "Sent recently",
+        "resend": "Resend",
+        "revoke": "Revoke"
+      },
+      "members": {
+        "title": "Members",
+        "you": "You",
+        "noEmail": "No email",
+        "remove": "Remove",
+        "removeConfirm": "Remove this team member?"
+      },
+      "accept": {
+        "badCodeTitle": "Invite link is invalid",
+        "badCodeBody": "Ask a team member to send a new invite.",
+        "emailMismatchTitle": "Use the invited email address",
+        "emailMismatchBody": "This invite belongs to a different email. Switch accounts or ask for a new invite.",
+        "switchAccount": "Switch account"
+      },
+      "errors": {
+        "createFailed": "Team could not be created.",
+        "inviteFailed": "Invite could not be sent.",
+        "revokeFailed": "Invite could not be revoked.",
+        "resendFailed": "Invite could not be resent.",
+        "removeFailed": "Member could not be removed."
+      }
     }
   },
   "community": {

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -193,7 +193,8 @@
         "copyUnavailable": "Send an invite first to create a shareable link.",
         "pending": "Sending",
         "sent": "Sent",
-        "failed": "Failed"
+        "failed": "Failed",
+        "roleLabel": "Invite role"
       },
       "pending": {
         "title": "Pending invites",
@@ -207,7 +208,10 @@
         "you": "You",
         "noEmail": "No email",
         "remove": "Remove",
-        "removeConfirm": "Remove this team member?"
+        "removeConfirm": "Remove this team member?",
+        "roleLabel": "Member role",
+        "leave": "Leave",
+        "leaveConfirm": "Leave this team?"
       },
       "accept": {
         "badCodeTitle": "Invite link is invalid",
@@ -221,7 +225,12 @@
         "inviteFailed": "Invite could not be sent.",
         "revokeFailed": "Invite could not be revoked.",
         "resendFailed": "Invite could not be resent.",
-        "removeFailed": "Member could not be removed."
+        "removeFailed": "Member could not be removed.",
+        "roleFailed": "Member role could not be updated."
+      },
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
       }
     }
   },

--- a/web/services/team/invites.ts
+++ b/web/services/team/invites.ts
@@ -565,10 +565,14 @@ async function canManageTeam(user: StackTeamUserLike, team: StackTeam): Promise<
   if (await hasTeamAdminPermission(user, team)) return true;
   const members = await requireTeamUsers(team);
   if (!members.some((member) => member.id === user.id)) return false;
-  const roles = await roleMapForMembers(team, members);
-  const hasAnyAdmin = Array.from(roles.values()).includes("admin");
-  if (!hasAnyAdmin) {
-    console.warn("team has no admins; applying legacy member-as-admin fallback", { teamId: team.id });
+  // Fail CLOSED: never treat a member of a multi-member team as admin just
+  // because the admin lookup came back empty (an API error, propagation lag, or
+  // a legacy team with no grant would otherwise escalate every member to admin).
+  // Only self-bootstrap admin for a SOLE member, who is unambiguously the owner
+  // of their own team; that covers legacy personal teams without opening a
+  // privilege-escalation hole on shared teams.
+  if (members.length === 1 && members[0]?.id === user.id) {
+    await grantTeamAdmin(user, team);
     return true;
   }
   return false;

--- a/web/services/team/invites.ts
+++ b/web/services/team/invites.ts
@@ -1,0 +1,396 @@
+import { checkRateLimit } from "@vercel/firewall";
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { Resend } from "resend";
+import { z } from "zod";
+
+import { env } from "@/app/env";
+import {
+  DEFAULT_TEAM_INVITE_FROM_EMAIL,
+  buildTeamInviteEmail,
+} from "@/app/api/team/invite/team-invite-email";
+import { cloudDb } from "@/db/client";
+import { stripeSubscriptions } from "@/db/schema";
+import { ACTIVE_STRIPE_PRO_STATUSES, TEAM_PLAN_ID } from "@/services/billing/pro";
+import { resolveBillingTeam } from "@/services/billing/teamResolution";
+import { captureBillingError } from "@/services/errors";
+
+const emailSchema = z.string().trim().toLowerCase().email().max(320);
+const teamNameSchema = z.string().trim().min(1).max(80);
+const MAX_TEAM_INVITE_BODY_BYTES = 16 * 1024;
+
+export type StackTeamUser = {
+  readonly id: string;
+  readonly displayName?: string | null;
+  readonly primaryEmail?: string | null;
+  readonly profileImageUrl?: string | null;
+};
+
+export type StackTeamInvitation = {
+  readonly id: string;
+  readonly recipientEmail?: string | null;
+  readonly expiresAt?: Date | string | null;
+  readonly revoke?: () => Promise<void>;
+  readonly send?: () => Promise<void>;
+  readonly resend?: () => Promise<void>;
+};
+
+export type StackTeam = {
+  readonly id: string;
+  readonly displayName?: string | null;
+  readonly name?: string | null;
+  update?: (options: { displayName: string }) => Promise<void>;
+  listUsers?: () => Promise<readonly StackTeamUser[]>;
+  removeUser?: (userId: string) => Promise<void>;
+  inviteUser?: (options: { email: string; callbackUrl?: string }) => Promise<StackTeamInvitation | void>;
+  sendTeamInvitation?: (options: { email: string; callbackUrl: string }) => Promise<StackTeamInvitation | void>;
+  listInvitations?: () => Promise<readonly StackTeamInvitation[]>;
+};
+
+export type StackTeamUserLike = {
+  readonly id: string;
+  readonly displayName?: string | null;
+  readonly primaryEmail?: string | null;
+  readonly selectedTeam?: unknown;
+  readonly listTeams?: () => Promise<readonly unknown[]>;
+  readonly createTeam?: (options: { displayName: string }) => Promise<StackTeam>;
+};
+
+export type TeamMemberDto = {
+  readonly id: string;
+  readonly displayName: string | null;
+  readonly email: string | null;
+  readonly profileImageUrl: string | null;
+};
+
+export type TeamInvitationDto = {
+  readonly id: string;
+  readonly email: string;
+  readonly createdAt: string | null;
+  readonly acceptUrl: string | null;
+};
+
+export type TeamSummaryDto = {
+  readonly teamId: string;
+  readonly teamName: string;
+  readonly members: readonly TeamMemberDto[];
+  readonly invitations: readonly TeamInvitationDto[];
+  readonly seats: number;
+};
+
+export function normalizeInviteEmail(email: unknown): string | null {
+  const parsed = emailSchema.safeParse(email);
+  return parsed.success ? parsed.data : null;
+}
+
+export async function readBoundedJson(request: Request): Promise<unknown> {
+  const text = await request.text();
+  if (new TextEncoder().encode(text).byteLength > MAX_TEAM_INVITE_BODY_BYTES) {
+    throw new TeamInviteHttpError("invalid_request", 413);
+  }
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    throw new TeamInviteHttpError("invalid_request", 400);
+  }
+}
+
+export class TeamInviteHttpError extends Error {
+  constructor(
+    readonly code: string,
+    readonly status: number,
+  ) {
+    super(code);
+    this.name = "TeamInviteHttpError";
+  }
+}
+
+export async function enforceTeamInviteRateLimit(request: Request): Promise<void> {
+  if (process.env.VERCEL !== "1") return;
+  const rateLimitId = env.CMUX_FEEDBACK_RATE_LIMIT_ID;
+  if (!rateLimitId) return;
+  const { error, rateLimited } = await checkRateLimit(rateLimitId, { request });
+  if (rateLimited || error === "blocked") {
+    throw new TeamInviteHttpError("rate_limited", 429);
+  }
+  if (error) {
+    throw new TeamInviteHttpError("service_unavailable", 503);
+  }
+}
+
+export async function currentTeamForMember(user: StackTeamUserLike): Promise<StackTeam> {
+  const team = await resolveBillingTeam(user);
+  if (!team) throw new TeamInviteHttpError("team_not_found", 404);
+  const stackTeam = await stackTeamById(user, team.id);
+  if (!stackTeam) throw new TeamInviteHttpError("team_not_found", 404);
+  await requireTeamMember(stackTeam, user.id);
+  return stackTeam;
+}
+
+export async function createTeamForUser(user: StackTeamUserLike, displayName: unknown): Promise<StackTeam> {
+  const parsed = teamNameSchema.safeParse(displayName);
+  if (!parsed.success) throw new TeamInviteHttpError("invalid_request", 400);
+  if (!user.createTeam) throw new TeamInviteHttpError("service_unavailable", 503);
+  return user.createTeam({ displayName: parsed.data });
+}
+
+export async function updateTeamName(user: StackTeamUserLike, displayName: unknown): Promise<TeamSummaryDto> {
+  const parsed = teamNameSchema.safeParse(displayName);
+  if (!parsed.success) throw new TeamInviteHttpError("invalid_request", 400);
+  const team = await currentTeamForMember(user);
+  if (!team.update) throw new TeamInviteHttpError("service_unavailable", 503);
+  await team.update({ displayName: parsed.data });
+  return loadTeamSummary(user);
+}
+
+export async function loadTeamSummary(user: StackTeamUserLike): Promise<TeamSummaryDto> {
+  const team = await currentTeamForMember(user);
+  const [members, invitations, seats] = await Promise.all([
+    team.listUsers?.() ?? Promise.resolve([]),
+    team.listInvitations?.() ?? Promise.resolve([]),
+    latestActiveTeamSeatCount(team.id),
+  ]);
+  return {
+    teamId: team.id,
+    teamName: teamDisplayName(team),
+    members: members.map(memberDto),
+    invitations: invitations.map((invitation) => invitationDto(invitation, null)),
+    seats,
+  };
+}
+
+export async function sendTeamInvite(params: {
+  user: StackTeamUserLike;
+  request: Request;
+  email: unknown;
+  locale: string;
+}): Promise<{ invitation: TeamInvitationDto; acceptUrl: string }> {
+  await enforceTeamInviteRateLimit(params.request);
+  const email = normalizeInviteEmail(params.email);
+  if (!email) throw new TeamInviteHttpError("invalid_email", 400);
+  const team = await currentTeamForMember(params.user);
+  const callbackUrl = acceptBaseUrl(params.request, params.locale);
+  const invitation = await createStackInvitation(team, email, callbackUrl);
+  const acceptUrl = acceptUrlForInvitation(params.request, params.locale, invitation);
+  await sendBrandedInviteEmail({
+    to: email,
+    teamName: teamDisplayName(team),
+    inviterName: params.user.displayName ?? params.user.primaryEmail ?? null,
+    acceptUrl,
+    invitationId: invitation.id,
+  });
+  return { invitation: invitationDto(invitation, acceptUrl), acceptUrl };
+}
+
+export async function resendTeamInvite(params: {
+  user: StackTeamUserLike;
+  request: Request;
+  invitationId: unknown;
+  locale: string;
+}): Promise<{ invitation: TeamInvitationDto; acceptUrl: string | null }> {
+  await enforceTeamInviteRateLimit(params.request);
+  const invitationId = stringId(params.invitationId);
+  const team = await currentTeamForMember(params.user);
+  const invitation = await findInvitation(team, invitationId);
+  const email = invitationEmail(invitation);
+  let resentInvitation = invitation;
+  if (invitation.resend) {
+    await invitation.resend();
+  } else if (invitation.send) {
+    await invitation.send();
+  } else if (email && invitation.revoke) {
+    await invitation.revoke();
+    resentInvitation = await createStackInvitation(
+      team,
+      email,
+      acceptBaseUrl(params.request, params.locale),
+    );
+  }
+  const acceptUrl = acceptUrlForInvitation(params.request, params.locale, resentInvitation);
+  if (email) {
+    await sendBrandedInviteEmail({
+      to: email,
+      teamName: teamDisplayName(team),
+      inviterName: params.user.displayName ?? params.user.primaryEmail ?? null,
+      acceptUrl,
+      invitationId: resentInvitation.id,
+    });
+  }
+  return { invitation: invitationDto(resentInvitation, acceptUrl), acceptUrl };
+}
+
+export async function revokeTeamInvite(user: StackTeamUserLike, invitationId: unknown): Promise<TeamSummaryDto> {
+  const team = await currentTeamForMember(user);
+  const invitation = await findInvitation(team, stringId(invitationId));
+  if (!invitation.revoke) throw new TeamInviteHttpError("service_unavailable", 503);
+  await invitation.revoke();
+  return loadTeamSummary(user);
+}
+
+export async function removeTeamMember(user: StackTeamUserLike, memberId: unknown): Promise<TeamSummaryDto> {
+  const targetId = stringId(memberId);
+  if (targetId === user.id) throw new TeamInviteHttpError("cannot_remove_self", 400);
+  const team = await currentTeamForMember(user);
+  const members = await requireTeamUsers(team);
+  if (members.length <= 1) throw new TeamInviteHttpError("cannot_remove_last_member", 400);
+  if (!members.some((member) => member.id === targetId)) {
+    throw new TeamInviteHttpError("member_not_found", 404);
+  }
+  if (!team.removeUser) throw new TeamInviteHttpError("service_unavailable", 503);
+  await team.removeUser(targetId);
+  return loadTeamSummary(user);
+}
+
+export function teamInviteJson(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+export function teamInviteErrorResponse(error: unknown): Response {
+  if (error instanceof TeamInviteHttpError) {
+    return teamInviteJson({ error: error.code }, error.status);
+  }
+  captureBillingError(error, { route: "/api/team" });
+  return teamInviteJson({ error: "service_unavailable" }, 503);
+}
+
+async function createStackInvitation(
+  team: StackTeam,
+  email: string,
+  callbackUrl: string,
+): Promise<StackTeamInvitation> {
+  const invite = team.sendTeamInvitation ?? team.inviteUser;
+  if (!invite) throw new TeamInviteHttpError("service_unavailable", 503);
+  const invitation = await invite.call(team, { email, callbackUrl });
+  if (isInvitation(invitation)) return invitation;
+  const found = (await (team.listInvitations?.() ?? Promise.resolve([])))
+    .find((candidate) => invitationEmail(candidate) === email);
+  if (found) return found;
+  throw new TeamInviteHttpError("service_unavailable", 503);
+}
+
+async function sendBrandedInviteEmail(params: {
+  to: string;
+  teamName: string;
+  inviterName: string | null;
+  acceptUrl: string;
+  invitationId: string;
+}): Promise<void> {
+  if (!env.RESEND_API_KEY) return;
+  const fromEmail = env.CMUX_FEEDBACK_FROM_EMAIL || DEFAULT_TEAM_INVITE_FROM_EMAIL;
+  const resend = new Resend(env.RESEND_API_KEY);
+  const { error } = await resend.emails.send(
+    buildTeamInviteEmail({
+      from: `cmux <${fromEmail}>`,
+      ...params,
+    }),
+    { idempotencyKey: `team-invite/${params.invitationId}` },
+  );
+  if (error) throw new TeamInviteHttpError("email_unavailable", 502);
+}
+
+async function stackTeamById(user: StackTeamUserLike, teamId: string): Promise<StackTeam | null> {
+  const selected = stackTeamFromUnknown(user.selectedTeam);
+  if (selected?.id === teamId) return selected;
+  const teams = typeof user.listTeams === "function" ? await user.listTeams() : [];
+  return teams.map(stackTeamFromUnknown).find((team): team is StackTeam => !!team && team.id === teamId) ?? null;
+}
+
+function stackTeamFromUnknown(value: unknown): StackTeam | null {
+  if (!value || typeof value !== "object") return null;
+  const id = (value as { id?: unknown }).id;
+  if (typeof id !== "string" || !id) return null;
+  return value as StackTeam;
+}
+
+async function requireTeamMember(team: StackTeam, userId: string): Promise<void> {
+  const members = await requireTeamUsers(team);
+  if (!members.some((member) => member.id === userId)) {
+    throw new TeamInviteHttpError("team_not_found", 403);
+  }
+}
+
+async function requireTeamUsers(team: StackTeam): Promise<readonly StackTeamUser[]> {
+  if (!team.listUsers) throw new TeamInviteHttpError("service_unavailable", 503);
+  return team.listUsers();
+}
+
+async function findInvitation(team: StackTeam, invitationId: string): Promise<StackTeamInvitation> {
+  const invitation = (await (team.listInvitations?.() ?? Promise.resolve([])))
+    .find((candidate) => candidate.id === invitationId);
+  if (!invitation) throw new TeamInviteHttpError("invitation_not_found", 404);
+  return invitation;
+}
+
+function stringId(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TeamInviteHttpError("invalid_request", 400);
+  }
+  return value.trim();
+}
+
+function isInvitation(value: unknown): value is StackTeamInvitation {
+  return !!value && typeof value === "object" && typeof (value as { id?: unknown }).id === "string";
+}
+
+function invitationEmail(invitation: StackTeamInvitation): string | null {
+  const email = invitation.recipientEmail;
+  return typeof email === "string" && email.trim() ? email.trim().toLowerCase() : null;
+}
+
+function invitationDto(invitation: StackTeamInvitation, acceptUrl: string | null): TeamInvitationDto {
+  return {
+    id: invitation.id,
+    email: invitationEmail(invitation) ?? "",
+    createdAt: dateString(invitation.expiresAt),
+    acceptUrl,
+  };
+}
+
+function memberDto(member: StackTeamUser): TeamMemberDto {
+  return {
+    id: member.id,
+    displayName: member.displayName ?? null,
+    email: member.primaryEmail ?? null,
+    profileImageUrl: member.profileImageUrl ?? null,
+  };
+}
+
+function dateString(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
+function teamDisplayName(team: StackTeam): string {
+  return team.displayName ?? team.name ?? "cmux Team";
+}
+
+function acceptBaseUrl(request: Request, locale: string): string {
+  const url = new URL(`/${locale}/dashboard/team/accept`, request.url);
+  return url.toString();
+}
+
+function acceptUrlForInvitation(request: Request, locale: string, invitation: StackTeamInvitation): string {
+  const url = new URL(acceptBaseUrl(request, locale));
+  url.searchParams.set("invitation", invitation.id);
+  return url.toString();
+}
+
+async function latestActiveTeamSeatCount(stackTeamId: string): Promise<number> {
+  const rows = await cloudDb()
+    .select({ seats: stripeSubscriptions.seats })
+    .from(stripeSubscriptions)
+    .where(
+      and(
+        eq(stripeSubscriptions.stackTeamId, stackTeamId),
+        eq(stripeSubscriptions.scope, "team"),
+        eq(stripeSubscriptions.plan, TEAM_PLAN_ID),
+        inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES),
+      ),
+    )
+    .orderBy(desc(stripeSubscriptions.currentPeriodEnd), desc(stripeSubscriptions.updatedAt))
+    .limit(1);
+  return Math.max(0, Number(rows[0]?.seats ?? 0));
+}

--- a/web/services/team/invites.ts
+++ b/web/services/team/invites.ts
@@ -12,6 +12,7 @@ import { cloudDb } from "@/db/client";
 import { stripeSubscriptions } from "@/db/schema";
 import { ACTIVE_STRIPE_PRO_STATUSES, TEAM_PLAN_ID } from "@/services/billing/pro";
 import { resolveBillingTeam } from "@/services/billing/teamResolution";
+import { locales } from "@/i18n/routing";
 import { captureBillingError } from "@/services/errors";
 
 const emailSchema = z.string().trim().toLowerCase().email().max(320);
@@ -367,8 +368,16 @@ function teamDisplayName(team: StackTeam): string {
   return team.displayName ?? team.name ?? "cmux Team";
 }
 
+function safeLocale(locale: string): string {
+  // The locale comes from untrusted request JSON and is interpolated into the
+  // invite/callback URL path. Without validation a value like "//evil.com" or
+  // "..%2f" would resolve to an off-origin host, letting a member send
+  // cmux-branded invite emails pointing anywhere. Only allow supported locales.
+  return (locales as readonly string[]).includes(locale) ? locale : "en";
+}
+
 function acceptBaseUrl(request: Request, locale: string): string {
-  const url = new URL(`/${locale}/dashboard/team/accept`, request.url);
+  const url = new URL(`/${safeLocale(locale)}/dashboard/team/accept`, request.url);
   return url.toString();
 }
 

--- a/web/services/team/invites.ts
+++ b/web/services/team/invites.ts
@@ -336,16 +336,26 @@ export async function updateTeamMemberRole(
 export async function applyAcceptedInvitationRole(params: {
   user: StackTeamUserLike;
   invitationId: string;
-  teamId?: string | null;
 }): Promise<void> {
-  const role = await storedInviteRole(params.invitationId);
-  if (role !== "admin") {
+  const invite = await storedInvite(params.invitationId);
+  if (!invite || invite.role !== "admin") {
     await markInviteAccepted(params.invitationId);
     return;
   }
-  const team = await acceptedTeam(params.user, params.teamId);
-  await grantTeamAdmin(params.user, team);
+  // Grant admin on the team the invite was created FOR (the authoritative
+  // stackTeamId stored at invite time), never a passed-in/received teamId that
+  // could be missing and resolve to the wrong team. Only grant if the accepting
+  // user is actually a member of that team.
+  const team = await memberTeamById(params.user, invite.stackTeamId);
+  if (team) await grantTeamAdmin(params.user, team);
   await markInviteAccepted(params.invitationId);
+}
+
+async function memberTeamById(user: StackTeamUserLike, teamId: string): Promise<StackTeam | null> {
+  const teams = typeof user.listTeams === "function" ? await user.listTeams() : [];
+  return teams
+    .map(stackTeamFromUnknown)
+    .find((candidate): candidate is StackTeam => !!candidate && candidate.id === teamId) ?? null;
 }
 
 export function teamInviteJson(data: unknown, status = 200): Response {
@@ -634,15 +644,6 @@ async function guardTargetIsNotLastAdmin(
   if (adminCount <= 1) throw new TeamInviteHttpError(code, 400);
 }
 
-async function acceptedTeam(user: StackTeamUserLike, teamId: string | null | undefined): Promise<StackTeam> {
-  const teams = typeof user.listTeams === "function" ? await user.listTeams() : [];
-  const team = teams.map(stackTeamFromUnknown).find((candidate): candidate is StackTeam =>
-    !!candidate && (!teamId || candidate.id === teamId)
-  );
-  if (!team) throw new TeamInviteHttpError("team_not_found", 404);
-  return team;
-}
-
 async function recordInviteRole(params: {
   invitationId: string;
   stackTeamId: string;
@@ -671,6 +672,18 @@ async function storedInviteRole(invitationId: string): Promise<TeamRole> {
     .where(eq(teamInviteRoles.invitationId, invitationId))
     .limit(1);
   return row?.role === "admin" ? "admin" : "member";
+}
+
+async function storedInvite(
+  invitationId: string,
+): Promise<{ role: TeamRole; stackTeamId: string } | null> {
+  const [row] = await cloudDb()
+    .select({ role: teamInviteRoles.role, stackTeamId: teamInviteRoles.stackTeamId })
+    .from(teamInviteRoles)
+    .where(eq(teamInviteRoles.invitationId, invitationId))
+    .limit(1);
+  if (!row) return null;
+  return { role: row.role === "admin" ? "admin" : "member", stackTeamId: row.stackTeamId };
 }
 
 async function markInviteAccepted(invitationId: string): Promise<void> {

--- a/web/services/team/invites.ts
+++ b/web/services/team/invites.ts
@@ -8,8 +8,9 @@ import {
   DEFAULT_TEAM_INVITE_FROM_EMAIL,
   buildTeamInviteEmail,
 } from "@/app/api/team/invite/team-invite-email";
+import { getStackServerApp } from "@/app/lib/stack";
 import { cloudDb } from "@/db/client";
-import { stripeSubscriptions } from "@/db/schema";
+import { stripeSubscriptions, teamInviteRoles } from "@/db/schema";
 import { ACTIVE_STRIPE_PRO_STATUSES, TEAM_PLAN_ID } from "@/services/billing/pro";
 import { resolveBillingTeam } from "@/services/billing/teamResolution";
 import { locales } from "@/i18n/routing";
@@ -17,13 +18,20 @@ import { captureBillingError } from "@/services/errors";
 
 const emailSchema = z.string().trim().toLowerCase().email().max(320);
 const teamNameSchema = z.string().trim().min(1).max(80);
+const teamRoleSchema = z.enum(["admin", "member"]).catch("member");
 const MAX_TEAM_INVITE_BODY_BYTES = 16 * 1024;
+export const TEAM_ADMIN_PERMISSION_ID = "team_admin";
+const DEFAULT_TEAM_INVITE_ORIGIN = "https://cmux.com";
 
 export type StackTeamUser = {
   readonly id: string;
   readonly displayName?: string | null;
   readonly primaryEmail?: string | null;
   readonly profileImageUrl?: string | null;
+  hasPermission?: (scope: StackTeam, permissionId: string) => Promise<boolean>;
+  grantPermission?: (scope: StackTeam, permissionId: string) => Promise<void>;
+  revokePermission?: (scope: StackTeam, permissionId: string) => Promise<void>;
+  listPermissions?: (scope: StackTeam, options?: { recursive?: boolean }) => Promise<readonly { id: string }[]>;
 };
 
 export type StackTeamInvitation = {
@@ -54,6 +62,11 @@ export type StackTeamUserLike = {
   readonly selectedTeam?: unknown;
   readonly listTeams?: () => Promise<readonly unknown[]>;
   readonly createTeam?: (options: { displayName: string }) => Promise<StackTeam>;
+  readonly listTeamInvitations?: () => Promise<readonly StackReceivedTeamInvitation[]>;
+  hasPermission?: (scope: StackTeam, permissionId: string) => Promise<boolean>;
+  grantPermission?: (scope: StackTeam, permissionId: string) => Promise<void>;
+  revokePermission?: (scope: StackTeam, permissionId: string) => Promise<void>;
+  listPermissions?: (scope: StackTeam, options?: { recursive?: boolean }) => Promise<readonly { id: string }[]>;
 };
 
 export type TeamMemberDto = {
@@ -61,6 +74,7 @@ export type TeamMemberDto = {
   readonly displayName: string | null;
   readonly email: string | null;
   readonly profileImageUrl: string | null;
+  readonly role: TeamRole;
 };
 
 export type TeamInvitationDto = {
@@ -68,6 +82,7 @@ export type TeamInvitationDto = {
   readonly email: string;
   readonly createdAt: string | null;
   readonly acceptUrl: string | null;
+  readonly role: TeamRole;
 };
 
 export type TeamSummaryDto = {
@@ -76,6 +91,16 @@ export type TeamSummaryDto = {
   readonly members: readonly TeamMemberDto[];
   readonly invitations: readonly TeamInvitationDto[];
   readonly seats: number;
+  readonly currentUserRole: TeamRole;
+  readonly canManageTeam: boolean;
+};
+
+export type TeamRole = "admin" | "member";
+
+export type StackReceivedTeamInvitation = {
+  readonly id: string;
+  readonly teamId: string;
+  accept?: () => Promise<void>;
 };
 
 export function normalizeInviteEmail(email: unknown): string | null {
@@ -131,13 +156,16 @@ export async function createTeamForUser(user: StackTeamUserLike, displayName: un
   const parsed = teamNameSchema.safeParse(displayName);
   if (!parsed.success) throw new TeamInviteHttpError("invalid_request", 400);
   if (!user.createTeam) throw new TeamInviteHttpError("service_unavailable", 503);
-  return user.createTeam({ displayName: parsed.data });
+  const team = await user.createTeam({ displayName: parsed.data });
+  await grantTeamAdmin(user, team);
+  return team;
 }
 
 export async function updateTeamName(user: StackTeamUserLike, displayName: unknown): Promise<TeamSummaryDto> {
   const parsed = teamNameSchema.safeParse(displayName);
   if (!parsed.success) throw new TeamInviteHttpError("invalid_request", 400);
   const team = await currentTeamForMember(user);
+  await requireTeamAdmin(user, team);
   if (!team.update) throw new TeamInviteHttpError("service_unavailable", 503);
   await team.update({ displayName: parsed.data });
   return loadTeamSummary(user);
@@ -150,12 +178,20 @@ export async function loadTeamSummary(user: StackTeamUserLike): Promise<TeamSumm
     team.listInvitations?.() ?? Promise.resolve([]),
     latestActiveTeamSeatCount(team.id),
   ]);
+  const roles = await roleMapForMembers(team, members);
+  const currentUserRole = roleForMember(user.id, roles);
   return {
     teamId: team.id,
     teamName: teamDisplayName(team),
-    members: members.map(memberDto),
-    invitations: invitations.map((invitation) => invitationDto(invitation, null)),
+    members: members.map((member) => memberDto(member, roleForMember(member.id, roles))),
+    invitations: await Promise.all(invitations.map(async (invitation) => invitationDto(
+      invitation,
+      null,
+      await storedInviteRole(invitation.id),
+    ))),
     seats,
+    currentUserRole,
+    canManageTeam: currentUserRole === "admin",
   };
 }
 
@@ -164,13 +200,22 @@ export async function sendTeamInvite(params: {
   request: Request;
   email: unknown;
   locale: string;
+  role?: unknown;
 }): Promise<{ invitation: TeamInvitationDto; acceptUrl: string }> {
   await enforceTeamInviteRateLimit(params.request);
   const email = normalizeInviteEmail(params.email);
   if (!email) throw new TeamInviteHttpError("invalid_email", 400);
   const team = await currentTeamForMember(params.user);
+  await requireTeamAdmin(params.user, team);
+  const role = teamRoleSchema.parse(params.role);
   const callbackUrl = acceptBaseUrl(params.request, params.locale);
   const invitation = await createStackInvitation(team, email, callbackUrl);
+  await recordInviteRole({
+    invitationId: invitation.id,
+    stackTeamId: team.id,
+    role,
+    createdByUserId: params.user.id,
+  });
   const acceptUrl = acceptUrlForInvitation(params.request, params.locale, invitation);
   await sendBrandedInviteEmail({
     to: email,
@@ -179,7 +224,7 @@ export async function sendTeamInvite(params: {
     acceptUrl,
     invitationId: invitation.id,
   });
-  return { invitation: invitationDto(invitation, acceptUrl), acceptUrl };
+  return { invitation: invitationDto(invitation, acceptUrl, role), acceptUrl };
 }
 
 export async function resendTeamInvite(params: {
@@ -191,20 +236,36 @@ export async function resendTeamInvite(params: {
   await enforceTeamInviteRateLimit(params.request);
   const invitationId = stringId(params.invitationId);
   const team = await currentTeamForMember(params.user);
+  await requireTeamAdmin(params.user, team);
   const invitation = await findInvitation(team, invitationId);
   const email = invitationEmail(invitation);
   let resentInvitation = invitation;
+  let stackResent = false;
   if (invitation.resend) {
     await invitation.resend();
+    stackResent = true;
   } else if (invitation.send) {
     await invitation.send();
+    stackResent = true;
   } else if (email && invitation.revoke) {
+    const role = await storedInviteRole(invitation.id);
     await invitation.revoke();
+    await markInviteRevoked(invitation.id);
     resentInvitation = await createStackInvitation(
       team,
       email,
       acceptBaseUrl(params.request, params.locale),
     );
+    await recordInviteRole({
+      invitationId: resentInvitation.id,
+      stackTeamId: team.id,
+      role,
+      createdByUserId: params.user.id,
+    });
+    stackResent = true;
+  }
+  if (!stackResent) {
+    throw new TeamInviteHttpError("email_unavailable", 502);
   }
   const acceptUrl = acceptUrlForInvitation(params.request, params.locale, resentInvitation);
   if (email) {
@@ -216,29 +277,75 @@ export async function resendTeamInvite(params: {
       invitationId: resentInvitation.id,
     });
   }
-  return { invitation: invitationDto(resentInvitation, acceptUrl), acceptUrl };
+  const role = await storedInviteRole(resentInvitation.id);
+  return { invitation: invitationDto(resentInvitation, acceptUrl, role), acceptUrl };
 }
 
 export async function revokeTeamInvite(user: StackTeamUserLike, invitationId: unknown): Promise<TeamSummaryDto> {
   const team = await currentTeamForMember(user);
+  await requireTeamAdmin(user, team);
   const invitation = await findInvitation(team, stringId(invitationId));
   if (!invitation.revoke) throw new TeamInviteHttpError("service_unavailable", 503);
   await invitation.revoke();
+  await markInviteRevoked(invitation.id);
   return loadTeamSummary(user);
 }
 
 export async function removeTeamMember(user: StackTeamUserLike, memberId: unknown): Promise<TeamSummaryDto> {
   const targetId = stringId(memberId);
-  if (targetId === user.id) throw new TeamInviteHttpError("cannot_remove_self", 400);
-  const team = await currentTeamForMember(user);
+  const team = targetId === user.id
+    ? await currentStackTeamForMember(user)
+    : await currentTeamForMember(user);
   const members = await requireTeamUsers(team);
   if (members.length <= 1) throw new TeamInviteHttpError("cannot_remove_last_member", 400);
   if (!members.some((member) => member.id === targetId)) {
     throw new TeamInviteHttpError("member_not_found", 404);
   }
+  if (targetId !== user.id) {
+    await requireTeamAdmin(user, team);
+  }
+  await guardTargetIsNotLastAdmin(team, members, targetId, "cannot_remove_last_admin");
   if (!team.removeUser) throw new TeamInviteHttpError("service_unavailable", 503);
   await team.removeUser(targetId);
+  if (targetId === user.id) return loadTeamSummaryFromTeam(team, user.id);
   return loadTeamSummary(user);
+}
+
+export async function updateTeamMemberRole(
+  user: StackTeamUserLike,
+  memberId: unknown,
+  role: unknown,
+): Promise<TeamSummaryDto> {
+  const targetId = stringId(memberId);
+  const parsedRole = teamRoleSchema.parse(role);
+  const team = await currentTeamForMember(user);
+  await requireTeamAdmin(user, team);
+  const members = await requireTeamUsers(team);
+  const target = members.find((member) => member.id === targetId);
+  if (!target) throw new TeamInviteHttpError("member_not_found", 404);
+  if (parsedRole === "admin") {
+    await grantTeamAdmin(target, team);
+  } else {
+    await guardTargetIsNotLastAdmin(team, members, targetId, "cannot_demote_last_admin");
+    if (!target.revokePermission) throw new TeamInviteHttpError("service_unavailable", 503);
+    await target.revokePermission(team, TEAM_ADMIN_PERMISSION_ID);
+  }
+  return loadTeamSummary(user);
+}
+
+export async function applyAcceptedInvitationRole(params: {
+  user: StackTeamUserLike;
+  invitationId: string;
+  teamId?: string | null;
+}): Promise<void> {
+  const role = await storedInviteRole(params.invitationId);
+  if (role !== "admin") {
+    await markInviteAccepted(params.invitationId);
+    return;
+  }
+  const team = await acceptedTeam(params.user, params.teamId);
+  await grantTeamAdmin(params.user, team);
+  await markInviteAccepted(params.invitationId);
 }
 
 export function teamInviteJson(data: unknown, status = 200): Response {
@@ -298,6 +405,49 @@ async function stackTeamById(user: StackTeamUserLike, teamId: string): Promise<S
   return teams.map(stackTeamFromUnknown).find((team): team is StackTeam => !!team && team.id === teamId) ?? null;
 }
 
+async function currentStackTeamForMember(user: StackTeamUserLike): Promise<StackTeam> {
+  const candidates = [
+    stackTeamFromUnknown(user.selectedTeam),
+    ...(typeof user.listTeams === "function" ? (await user.listTeams()).map(stackTeamFromUnknown) : []),
+  ].filter((team): team is StackTeam => !!team);
+  for (const team of candidates) {
+    try {
+      await requireTeamMember(team, user.id);
+      return team;
+    } catch (error) {
+      if (!isTeamInviteErrorCode(error, "team_not_found")) throw error;
+    }
+  }
+  throw new TeamInviteHttpError("team_not_found", 404);
+}
+
+async function loadTeamSummaryFromTeam(team: StackTeam, currentUserId: string): Promise<TeamSummaryDto> {
+  const [members, invitations, seats] = await Promise.all([
+    team.listUsers?.() ?? Promise.resolve([]),
+    team.listInvitations?.() ?? Promise.resolve([]),
+    latestActiveTeamSeatCount(team.id),
+  ]);
+  const roles = await roleMapForMembers(team, members);
+  const currentUserRole = roleForMember(currentUserId, roles);
+  return {
+    teamId: team.id,
+    teamName: teamDisplayName(team),
+    members: members.map((member) => memberDto(member, roleForMember(member.id, roles))),
+    invitations: await Promise.all(invitations.map(async (invitation) => invitationDto(
+      invitation,
+      null,
+      await storedInviteRole(invitation.id),
+    ))),
+    seats,
+    currentUserRole,
+    canManageTeam: currentUserRole === "admin",
+  };
+}
+
+function isTeamInviteErrorCode(error: unknown, code: string): boolean {
+  return !!error && typeof error === "object" && (error as { code?: unknown }).code === code;
+}
+
 function stackTeamFromUnknown(value: unknown): StackTeam | null {
   if (!value || typeof value !== "object") return null;
   const id = (value as { id?: unknown }).id;
@@ -340,21 +490,23 @@ function invitationEmail(invitation: StackTeamInvitation): string | null {
   return typeof email === "string" && email.trim() ? email.trim().toLowerCase() : null;
 }
 
-function invitationDto(invitation: StackTeamInvitation, acceptUrl: string | null): TeamInvitationDto {
+function invitationDto(invitation: StackTeamInvitation, acceptUrl: string | null, role: TeamRole): TeamInvitationDto {
   return {
     id: invitation.id,
     email: invitationEmail(invitation) ?? "",
     createdAt: dateString(invitation.expiresAt),
     acceptUrl,
+    role,
   };
 }
 
-function memberDto(member: StackTeamUser): TeamMemberDto {
+function memberDto(member: StackTeamUser, role: TeamRole): TeamMemberDto {
   return {
     id: member.id,
     displayName: member.displayName ?? null,
     email: member.primaryEmail ?? null,
     profileImageUrl: member.profileImageUrl ?? null,
+    role,
   };
 }
 
@@ -377,7 +529,7 @@ function safeLocale(locale: string): string {
 }
 
 function acceptBaseUrl(request: Request, locale: string): string {
-  const url = new URL(`/${safeLocale(locale)}/dashboard/team/accept`, request.url);
+  const url = new URL(`/${safeLocale(locale)}/dashboard/team/accept`, trustedInviteOrigin(request));
   return url.toString();
 }
 
@@ -385,6 +537,150 @@ function acceptUrlForInvitation(request: Request, locale: string, invitation: St
   const url = new URL(acceptBaseUrl(request, locale));
   url.searchParams.set("invitation", invitation.id);
   return url.toString();
+}
+
+function trustedInviteOrigin(request: Request): string {
+  const configured = process.env.CMUX_TEAM_INVITE_ORIGIN?.trim() || process.env.CMUX_APP_ORIGIN?.trim();
+  if (configured) return originOrDefault(configured);
+  if (process.env.VERCEL_ENV === "production" || process.env.NODE_ENV === "production") {
+    return DEFAULT_TEAM_INVITE_ORIGIN;
+  }
+  return originOrDefault(request.url);
+}
+
+function originOrDefault(value: string): string {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return DEFAULT_TEAM_INVITE_ORIGIN;
+  }
+}
+
+async function requireTeamAdmin(user: StackTeamUserLike, team: StackTeam): Promise<void> {
+  if (await canManageTeam(user, team)) return;
+  throw new TeamInviteHttpError("not_team_admin", 403);
+}
+
+async function canManageTeam(user: StackTeamUserLike, team: StackTeam): Promise<boolean> {
+  if (await hasTeamAdminPermission(user, team)) return true;
+  const members = await requireTeamUsers(team);
+  if (!members.some((member) => member.id === user.id)) return false;
+  const roles = await roleMapForMembers(team, members);
+  const hasAnyAdmin = Array.from(roles.values()).includes("admin");
+  if (!hasAnyAdmin) {
+    console.warn("team has no admins; applying legacy member-as-admin fallback", { teamId: team.id });
+    return true;
+  }
+  return false;
+}
+
+async function roleMapForMembers(
+  team: StackTeam,
+  members: readonly StackTeamUser[],
+): Promise<Map<string, TeamRole>> {
+  const roles = new Map(members.map((member) => [member.id, "member" as TeamRole]));
+  const app = getStackServerApp() as {
+    listTeamMemberPermissions?: (
+      teamId: string,
+      options?: { recursive?: boolean },
+    ) => Promise<readonly { userId: string; permissionId: string }[]>;
+  };
+  if (app.listTeamMemberPermissions) {
+    const grants = await app.listTeamMemberPermissions(team.id, { recursive: true });
+    for (const grant of grants) {
+      if (grant.permissionId === TEAM_ADMIN_PERMISSION_ID && roles.has(grant.userId)) {
+        roles.set(grant.userId, "admin");
+      }
+    }
+    return roles;
+  }
+  await Promise.all(members.map(async (member) => {
+    if (await hasTeamAdminPermission(member, team)) roles.set(member.id, "admin");
+  }));
+  return roles;
+}
+
+function roleForMember(userId: string, roles: ReadonlyMap<string, TeamRole>): TeamRole {
+  return roles.get(userId) ?? "member";
+}
+
+async function hasTeamAdminPermission(user: StackTeamUserLike, team: StackTeam): Promise<boolean> {
+  if (user.hasPermission) return user.hasPermission(team, TEAM_ADMIN_PERMISSION_ID);
+  if (user.listPermissions) {
+    return (await user.listPermissions(team, { recursive: true }))
+      .some((permission) => permission.id === TEAM_ADMIN_PERMISSION_ID);
+  }
+  return false;
+}
+
+async function grantTeamAdmin(user: StackTeamUserLike, team: StackTeam): Promise<void> {
+  if (!user.grantPermission) throw new TeamInviteHttpError("service_unavailable", 503);
+  await user.grantPermission(team, TEAM_ADMIN_PERMISSION_ID);
+}
+
+async function guardTargetIsNotLastAdmin(
+  team: StackTeam,
+  members: readonly StackTeamUser[],
+  targetId: string,
+  code: string,
+): Promise<void> {
+  const roles = await roleMapForMembers(team, members);
+  if (roleForMember(targetId, roles) !== "admin") return;
+  const adminCount = Array.from(roles.values()).filter((role) => role === "admin").length;
+  if (adminCount <= 1) throw new TeamInviteHttpError(code, 400);
+}
+
+async function acceptedTeam(user: StackTeamUserLike, teamId: string | null | undefined): Promise<StackTeam> {
+  const teams = typeof user.listTeams === "function" ? await user.listTeams() : [];
+  const team = teams.map(stackTeamFromUnknown).find((candidate): candidate is StackTeam =>
+    !!candidate && (!teamId || candidate.id === teamId)
+  );
+  if (!team) throw new TeamInviteHttpError("team_not_found", 404);
+  return team;
+}
+
+async function recordInviteRole(params: {
+  invitationId: string;
+  stackTeamId: string;
+  role: TeamRole;
+  createdByUserId: string;
+}): Promise<void> {
+  await cloudDb()
+    .insert(teamInviteRoles)
+    .values(params)
+    .onConflictDoUpdate({
+      target: teamInviteRoles.invitationId,
+      set: {
+        stackTeamId: params.stackTeamId,
+        role: params.role,
+        createdByUserId: params.createdByUserId,
+        revokedAt: null,
+        acceptedAt: null,
+      },
+    });
+}
+
+async function storedInviteRole(invitationId: string): Promise<TeamRole> {
+  const [row] = await cloudDb()
+    .select({ role: teamInviteRoles.role })
+    .from(teamInviteRoles)
+    .where(eq(teamInviteRoles.invitationId, invitationId))
+    .limit(1);
+  return row?.role === "admin" ? "admin" : "member";
+}
+
+async function markInviteAccepted(invitationId: string): Promise<void> {
+  await cloudDb()
+    .update(teamInviteRoles)
+    .set({ acceptedAt: new Date() })
+    .where(eq(teamInviteRoles.invitationId, invitationId));
+}
+
+async function markInviteRevoked(invitationId: string): Promise<void> {
+  await cloudDb()
+    .update(teamInviteRoles)
+    .set({ revokedAt: new Date() })
+    .where(eq(teamInviteRoles.invitationId, invitationId));
 }
 
 async function latestActiveTeamSeatCount(stackTeamId: string): Promise<number> {

--- a/web/tests/team-accept-page.test.tsx
+++ b/web/tests/team-accept-page.test.tsx
@@ -19,7 +19,7 @@ let currentUser: {
   grantPermission?: ReturnType<typeof mock>;
 } | null = null;
 let redirectTarget: string | null = null;
-let inviteRoleRows = new Map<string, "admin" | "member">();
+let inviteRoleRows = new Map<string, { role: "admin" | "member"; stackTeamId: string }>();
 const getUser = mock(async () => currentUser);
 const redirect = mock((target: unknown) => {
   redirectTarget = String(target);
@@ -51,7 +51,7 @@ mock.module("../db/client", () => ({
         where: () => ({
           limit: mock(async () => {
             const row = Array.from(inviteRoleRows.values())[0];
-            return row ? [{ role: row }] : [];
+            return row ? [{ role: row.role, stackTeamId: row.stackTeamId }] : [];
           }),
         }),
       }),
@@ -110,7 +110,7 @@ describe("team invite accept page", () => {
     const accept = mock(async () => undefined);
     const grantPermission = mock(async () => undefined);
     const team = { id: "team-1", displayName: "Team One" };
-    inviteRoleRows.set("inv_admin", "admin");
+    inviteRoleRows.set("inv_admin", { role: "admin", stackTeamId: "team-1" });
     currentUser = {
       listTeamInvitations: mock(async () => [{ id: "inv_admin", teamId: "team-1", accept }]),
       listTeams: mock(async () => [team]),
@@ -128,7 +128,7 @@ describe("team invite accept page", () => {
     const acceptTeamInvitation = mock(async () => undefined);
     const grantPermission = mock(async () => undefined);
     const team = { id: "team-1", displayName: "Team One" };
-    inviteRoleRows.set("inv_admin", "admin");
+    inviteRoleRows.set("inv_admin", { role: "admin", stackTeamId: "team-1" });
     currentUser = {
       acceptTeamInvitation,
       listTeamInvitations: mock(async () => [{ id: "inv_admin", teamId: "team-1" }]),

--- a/web/tests/team-accept-page.test.tsx
+++ b/web/tests/team-accept-page.test.tsx
@@ -124,6 +124,25 @@ describe("team invite accept page", () => {
     expect(redirectTarget).toBe("/en/dashboard/team?joined=1");
   });
 
+  test("code accept with one pending admin invite grants admin", async () => {
+    const acceptTeamInvitation = mock(async () => undefined);
+    const grantPermission = mock(async () => undefined);
+    const team = { id: "team-1", displayName: "Team One" };
+    inviteRoleRows.set("inv_admin", "admin");
+    currentUser = {
+      acceptTeamInvitation,
+      listTeamInvitations: mock(async () => [{ id: "inv_admin", teamId: "team-1" }]),
+      listTeams: mock(async () => [team]),
+      grantPermission,
+    };
+
+    await expect(renderAccept("opaque-code")).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(acceptTeamInvitation).toHaveBeenCalledWith("opaque-code");
+    expect(grantPermission).toHaveBeenCalledWith(team, "team_admin");
+    expect(redirectTarget).toBe("/en/dashboard/team?joined=1");
+  });
+
   test("email mismatch renders a friendly switch-account error", async () => {
     currentUser = {
       acceptTeamInvitation: mock(async () => {

--- a/web/tests/team-accept-page.test.tsx
+++ b/web/tests/team-accept-page.test.tsx
@@ -10,12 +10,16 @@ const nextNavigationModule = await import("next/navigation");
 const stackModule = await import("../app/lib/stack");
 const nextIntlServerModule = await import("next-intl/server");
 const i18nNavigationModule = await import("../i18n/navigation");
+const dbClientModule = await import("../db/client");
 
 let currentUser: {
   acceptTeamInvitation?: ReturnType<typeof mock>;
   listTeamInvitations?: ReturnType<typeof mock>;
+  listTeams?: ReturnType<typeof mock>;
+  grantPermission?: ReturnType<typeof mock>;
 } | null = null;
 let redirectTarget: string | null = null;
+let inviteRoleRows = new Map<string, "admin" | "member">();
 const getUser = mock(async () => currentUser);
 const redirect = mock((target: unknown) => {
   redirectTarget = String(target);
@@ -39,12 +43,33 @@ mock.module("../i18n/navigation", () => ({
     <a href={href} {...props}>{children}</a>
   ),
 }));
+mock.module("../db/client", () => ({
+  ...dbClientModule,
+  cloudDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: mock(async () => {
+            const row = Array.from(inviteRoleRows.values())[0];
+            return row ? [{ role: row }] : [];
+          }),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: mock(async () => undefined),
+      }),
+    }),
+  }),
+}));
 
 const { default: TeamInviteAcceptPage } = await import("../app/[locale]/dashboard/team/accept/page");
 
 describe("team invite accept page", () => {
   beforeEach(() => {
     redirectTarget = null;
+    inviteRoleRows = new Map();
     currentUser = null;
     getUser.mockClear();
     redirect.mockClear();
@@ -78,6 +103,24 @@ describe("team invite accept page", () => {
     await expect(renderAcceptInvitation("inv_1")).rejects.toThrow("NEXT_REDIRECT");
 
     expect(accept).toHaveBeenCalled();
+    expect(redirectTarget).toBe("/en/dashboard/team?joined=1");
+  });
+
+  test("accepting an admin invite grants the Stack team admin permission", async () => {
+    const accept = mock(async () => undefined);
+    const grantPermission = mock(async () => undefined);
+    const team = { id: "team-1", displayName: "Team One" };
+    inviteRoleRows.set("inv_admin", "admin");
+    currentUser = {
+      listTeamInvitations: mock(async () => [{ id: "inv_admin", teamId: "team-1", accept }]),
+      listTeams: mock(async () => [team]),
+      grantPermission,
+    };
+
+    await expect(renderAcceptInvitation("inv_admin")).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(accept).toHaveBeenCalled();
+    expect(grantPermission).toHaveBeenCalledWith(team, "team_admin");
     expect(redirectTarget).toBe("/en/dashboard/team?joined=1");
   });
 

--- a/web/tests/team-accept-page.test.tsx
+++ b/web/tests/team-accept-page.test.tsx
@@ -3,6 +3,14 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import enMessages from "../messages/en.json";
 
+// Spread the real modules into every mock: bun's mock.module replaces the
+// module process-wide for the whole run, so dropping exports (e.g. useRouter
+// from i18n/navigation) breaks later-sorted test files.
+const nextNavigationModule = await import("next/navigation");
+const stackModule = await import("../app/lib/stack");
+const nextIntlServerModule = await import("next-intl/server");
+const i18nNavigationModule = await import("../i18n/navigation");
+
 let currentUser: {
   acceptTeamInvitation?: ReturnType<typeof mock>;
   listTeamInvitations?: ReturnType<typeof mock>;
@@ -14,16 +22,19 @@ const redirect = mock((target: unknown) => {
   throw new Error(`NEXT_REDIRECT:${target}`);
 });
 
-mock.module("next/navigation", () => ({ redirect }));
+mock.module("next/navigation", () => ({ ...nextNavigationModule, redirect }));
 mock.module("../app/lib/stack", () => ({
+  ...stackModule,
   getStackServerApp: () => ({ getUser }),
   isStackConfigured: () => true,
 }));
 mock.module("next-intl/server", () => ({
+  ...nextIntlServerModule,
   getTranslations: async (input?: string | { namespace?: string }) =>
     translator(typeof input === "string" ? input : input?.namespace),
 }));
 mock.module("../i18n/navigation", () => ({
+  ...i18nNavigationModule,
   Link: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
     <a href={href} {...props}>{children}</a>
   ),

--- a/web/tests/team-accept-page.test.tsx
+++ b/web/tests/team-accept-page.test.tsx
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import enMessages from "../messages/en.json";
+
+let currentUser: {
+  acceptTeamInvitation?: ReturnType<typeof mock>;
+  listTeamInvitations?: ReturnType<typeof mock>;
+} | null = null;
+let redirectTarget: string | null = null;
+const getUser = mock(async () => currentUser);
+const redirect = mock((target: unknown) => {
+  redirectTarget = String(target);
+  throw new Error(`NEXT_REDIRECT:${target}`);
+});
+
+mock.module("next/navigation", () => ({ redirect }));
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => true,
+}));
+mock.module("next-intl/server", () => ({
+  getTranslations: async (input?: string | { namespace?: string }) =>
+    translator(typeof input === "string" ? input : input?.namespace),
+}));
+mock.module("../i18n/navigation", () => ({
+  Link: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+const { default: TeamInviteAcceptPage } = await import("../app/[locale]/dashboard/team/accept/page");
+
+describe("team invite accept page", () => {
+  beforeEach(() => {
+    redirectTarget = null;
+    currentUser = null;
+    getUser.mockClear();
+    redirect.mockClear();
+  });
+
+  test("signed-out users bounce through vault sign-in with the accept return path", async () => {
+    await expect(renderAccept("abc")).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(redirectTarget).toContain("/handler/sign-in");
+    expect(decodeURIComponent(decodeURIComponent(redirectTarget ?? ""))).toContain(
+      "/en/dashboard/team/accept?code=abc",
+    );
+  });
+
+  test("accepts the Stack invitation and redirects to the team page", async () => {
+    const acceptTeamInvitation = mock(async () => undefined);
+    currentUser = { acceptTeamInvitation };
+
+    await expect(renderAccept("abc")).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(acceptTeamInvitation).toHaveBeenCalledWith("abc");
+    expect(redirectTarget).toBe("/en/dashboard/team?joined=1");
+  });
+
+  test("accepts branded invitation-id links through received invitations", async () => {
+    const accept = mock(async () => undefined);
+    currentUser = {
+      listTeamInvitations: mock(async () => [{ id: "inv_1", accept }]),
+    };
+
+    await expect(renderAcceptInvitation("inv_1")).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(accept).toHaveBeenCalled();
+    expect(redirectTarget).toBe("/en/dashboard/team?joined=1");
+  });
+
+  test("email mismatch renders a friendly switch-account error", async () => {
+    currentUser = {
+      acceptTeamInvitation: mock(async () => {
+        throw new Error("TeamInvitationEmailMismatch");
+      }),
+    };
+
+    const html = await renderAccept("abc");
+
+    expect(html).toContain("Use the invited email address");
+    expect(html).toContain("/handler/sign-out-and-sign-in");
+  });
+});
+
+async function renderAccept(code: string): Promise<string> {
+  const element = await TeamInviteAcceptPage({
+    params: Promise.resolve({ locale: "en" }),
+    searchParams: Promise.resolve({ code }),
+  });
+  return renderToStaticMarkup(element);
+}
+
+async function renderAcceptInvitation(invitation: string): Promise<string> {
+  const element = await TeamInviteAcceptPage({
+    params: Promise.resolve({ locale: "en" }),
+    searchParams: Promise.resolve({ invitation }),
+  });
+  return renderToStaticMarkup(element);
+}
+
+function translator(namespace?: string) {
+  return (key: string, values?: Record<string, string | number>) => {
+    const path = [...(namespace?.split(".") ?? []), ...key.split(".")];
+    let value: unknown = enMessages;
+    for (const part of path) value = (value as Record<string, unknown>)?.[part];
+    let text = typeof value === "string" ? value : key;
+    for (const [name, replacement] of Object.entries(values ?? {})) {
+      text = text.replaceAll(`{${name}}`, String(replacement));
+    }
+    return text;
+  };
+}

--- a/web/tests/team-invite-email.test.ts
+++ b/web/tests/team-invite-email.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildTeamInviteEmail,
+  teamInviteThreadRef,
+} from "../app/api/team/invite/team-invite-email";
+
+describe("buildTeamInviteEmail", () => {
+  test("builds a branded invite payload with the accept URL", () => {
+    const email = buildTeamInviteEmail({
+      from: "cmux <austin@manaflow.ai>",
+      to: "ada@example.com",
+      teamName: "Analytical Engines",
+      inviterName: "Grace Hopper",
+      acceptUrl: "https://cmux.test/en/dashboard/team/accept?code=abc",
+      invitationId: "inv_123",
+    });
+
+    expect(email.from).toBe("cmux <austin@manaflow.ai>");
+    expect(email.to).toEqual(["ada@example.com"]);
+    expect(email.subject).toBe("Join Analytical Engines on cmux");
+    expect(email.text).toContain("Grace invited you to join Analytical Engines on cmux.");
+    expect(email.text).toContain("https://cmux.test/en/dashboard/team/accept?code=abc");
+    expect(email.html).toContain("Accept invite");
+    expect(email.headers["X-Entity-Ref-ID"]).toBe(teamInviteThreadRef("inv_123"));
+  });
+});

--- a/web/tests/team-invite-routes.test.ts
+++ b/web/tests/team-invite-routes.test.ts
@@ -7,6 +7,7 @@ const errorsModule = await import("../services/errors");
 const dbClientModule = await import("../db/client");
 const billingProModule = await import("../services/billing/pro");
 const stackModule = await import("../app/lib/stack");
+const envModule = await import("../app/env");
 
 let currentUser: ReturnType<typeof stackUser> | null = null;
 let members: Array<{ id: string; primaryEmail: string }> = [];
@@ -51,8 +52,13 @@ mock.module("../app/lib/stack", () => ({
 // built query, so real operators/tables are harmless here and mocking them
 // process-wide would corrupt every later db test.
 
+// Spread the real env so no key is dropped process-wide (a partial env mock
+// leaked into notifications-push-route on CI, shrinking its body-size limit and
+// turning a 429 into a 413). Only override the three keys these tests control.
 mock.module("../app/env", () => ({
+  ...envModule,
   env: {
+    ...envModule.env,
     RESEND_API_KEY: "resend-test",
     CMUX_FEEDBACK_FROM_EMAIL: "austin@manaflow.ai",
     CMUX_FEEDBACK_RATE_LIMIT_ID: "team-invites-test",

--- a/web/tests/team-invite-routes.test.ts
+++ b/web/tests/team-invite-routes.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+// Import real modules so the process-wide mock.module overrides below only
+// replace the specific exports the test controls, never dropping the rest (bun
+// mock.module leaks into every later-sorted test file for the whole run).
+const errorsModule = await import("../services/errors");
+const dbClientModule = await import("../db/client");
+const billingProModule = await import("../services/billing/pro");
+const stackModule = await import("../app/lib/stack");
+
 let currentUser: ReturnType<typeof stackUser> | null = null;
 let members: Array<{ id: string; primaryEmail: string }> = [];
 let invitations: Array<{
@@ -25,17 +33,15 @@ const getUser = mock(async () => currentUser);
 const emailSend = mock(async () => ({ error: null }));
 
 mock.module("../app/lib/stack", () => ({
+  ...stackModule,
   getStackServerApp: () => ({ getUser }),
   isStackConfigured: () => true,
   stackServerApp: { getUser },
 }));
 
-mock.module("drizzle-orm", () => ({
-  and: (...parts: unknown[]) => parts,
-  desc: (value: unknown) => value,
-  eq: (left: unknown, right: unknown) => [left, right],
-  inArray: (left: unknown, right: unknown) => [left, right],
-}));
+// drizzle-orm and db/schema are left real: the mocked cloudDb below ignores the
+// built query, so real operators/tables are harmless here and mocking them
+// process-wide would corrupt every later db test.
 
 mock.module("../app/env", () => ({
   env: {
@@ -46,6 +52,7 @@ mock.module("../app/env", () => ({
 }));
 
 mock.module("../db/client", () => ({
+  ...dbClientModule,
   cloudDb: () => ({
     select: () => ({
       from: () => ({
@@ -59,24 +66,17 @@ mock.module("../db/client", () => ({
   }),
 }));
 
-mock.module("../db/schema", () => ({
-  stripeSubscriptions: {
-    seats: "seats",
-    stackTeamId: "stackTeamId",
-    scope: "scope",
-    plan: "plan",
-    status: "status",
-    currentPeriodEnd: "currentPeriodEnd",
-    updatedAt: "updatedAt",
-  },
-}));
-
 mock.module("../services/billing/pro", () => ({
+  ...billingProModule,
   ACTIVE_STRIPE_PRO_STATUSES: ["active", "trialing"],
   TEAM_PLAN_ID: "team",
 }));
 
+// bun's mock.module replaces the module process-wide for the whole run, so it
+// must carry EVERY export other test files import (e.g. testflight-service
+// relies on captureAscError). Spreading the real module avoids dropping exports.
 mock.module("../services/errors", () => ({
+  ...errorsModule,
   captureBillingError: mock(() => undefined),
 }));
 

--- a/web/tests/team-invite-routes.test.ts
+++ b/web/tests/team-invite-routes.test.ts
@@ -10,12 +10,15 @@ const stackModule = await import("../app/lib/stack");
 
 let currentUser: ReturnType<typeof stackUser> | null = null;
 let members: Array<{ id: string; primaryEmail: string }> = [];
+let adminIds = new Set<string>();
+let inviteRoleRows = new Map<string, { role: "admin" | "member"; stackTeamId: string }>();
 let invitations: Array<{
   id: string;
   recipientEmail: string;
   expiresAt: Date;
   revoke: ReturnType<typeof mock>;
-  resend: ReturnType<typeof mock>;
+  resend?: ReturnType<typeof mock>;
+  send?: ReturnType<typeof mock>;
 }> = [];
 const sendTeamInvitation = mock(async (options: unknown) => {
   const { email } = options as { email: string; callbackUrl: string };
@@ -34,7 +37,12 @@ const emailSend = mock(async () => ({ error: null }));
 
 mock.module("../app/lib/stack", () => ({
   ...stackModule,
-  getStackServerApp: () => ({ getUser }),
+  getStackServerApp: () => ({
+    getUser,
+    listTeamMemberPermissions: mock(async () =>
+      Array.from(adminIds).map((userId) => ({ userId, permissionId: "team_admin" }))
+    ),
+  }),
   isStackConfigured: () => true,
   stackServerApp: { getUser },
 }));
@@ -54,13 +62,32 @@ mock.module("../app/env", () => ({
 mock.module("../db/client", () => ({
   ...dbClientModule,
   cloudDb: () => ({
-    select: () => ({
+    select: (selection: Record<string, unknown>) => ({
       from: () => ({
         where: () => ({
           orderBy: () => ({
             limit: mock(async () => [{ seats: 3 }]),
           }),
+          limit: mock(async () => {
+            if ("role" in selection) {
+              const row = Array.from(inviteRoleRows.values())[0];
+              return row ? [{ role: row.role }] : [];
+            }
+            return [{ seats: 3 }];
+          }),
         }),
+      }),
+    }),
+    insert: () => ({
+      values: (row: { invitationId: string; stackTeamId: string; role: "admin" | "member" }) => ({
+        onConflictDoUpdate: mock(async () => {
+          inviteRoleRows.set(row.invitationId, { role: row.role, stackTeamId: row.stackTeamId });
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: mock(async () => undefined),
       }),
     }),
   }),
@@ -91,11 +118,17 @@ mock.module("resend", () => ({
 }));
 
 const inviteRoute = await import("../app/api/team/invite/route");
+const resendRoute = await import("../app/api/team/invite/resend/route");
 const revokeRoute = await import("../app/api/team/invite/revoke/route");
+const removeRoute = await import("../app/api/team/members/remove/route");
+const roleRoute = await import("../app/api/team/members/role/route");
+const teamRoute = await import("../app/api/team/route");
 
 describe("team invite routes", () => {
   beforeEach(() => {
     members = [{ id: "user-1", primaryEmail: "member@example.com" }];
+    adminIds = new Set(["user-1"]);
+    inviteRoleRows = new Map();
     invitations = [];
     currentUser = stackUser();
     getUser.mockClear();
@@ -104,15 +137,19 @@ describe("team invite routes", () => {
     process.env.VERCEL = "0";
   });
 
-  test("member can create a Stack invite and receives an accept URL", async () => {
+  test("admin can create a Stack invite and receives an accept URL", async () => {
     const response = await inviteRoute.POST(request("/api/team/invite", {
       email: " Ada@Example.com ",
       locale: "en",
     }));
-    const body = await response.json() as { acceptUrl: string; invitation: { email: string; id: string } };
+    const body = await response.json() as {
+      acceptUrl: string;
+      invitation: { email: string; id: string; role: string };
+    };
 
     expect(response.status).toBe(200);
     expect(body.invitation.email).toBe("ada@example.com");
+    expect(body.invitation.role).toBe("member");
     expect(body.acceptUrl).toContain("/en/dashboard/team/accept?invitation=inv_ada%40example.com");
     expect(sendTeamInvitation).toHaveBeenCalledWith({
       email: "ada@example.com",
@@ -121,20 +158,39 @@ describe("team invite routes", () => {
     expect(emailSend).toHaveBeenCalled();
   });
 
-  test("neutralizes an off-origin locale so invite URLs stay on-origin", async () => {
+  test("invite as admin stores the server-assigned role", async () => {
     const response = await inviteRoute.POST(request("/api/team/invite", {
+      email: "admin@example.com",
+      locale: "en",
+      role: "admin",
+    }));
+    const body = await response.json() as { invitation: { id: string; role: string } };
+
+    expect(response.status).toBe(200);
+    expect(body.invitation.role).toBe("admin");
+    expect(inviteRoleRows.get(body.invitation.id)?.role).toBe("admin");
+  });
+
+  test("neutralizes an off-origin locale and spoofed Host so invite URLs stay on trusted origin", async () => {
+    Object.assign(process.env, { NODE_ENV: "production" });
+    const response = await inviteRoute.POST(new Request("https://evil.example/api/team/invite", {
+      method: "POST",
+      headers: { "content-type": "application/json", host: "evil.example" },
+      body: JSON.stringify({
       email: "ada@example.com",
       locale: "//evil.com",
+      }),
     }));
     const body = await response.json() as { acceptUrl: string };
 
     expect(response.status).toBe(200);
-    expect(new URL(body.acceptUrl).origin).toBe("https://cmux.test");
+    expect(new URL(body.acceptUrl).origin).toBe("https://cmux.com");
     expect(body.acceptUrl).toContain("/en/dashboard/team/accept");
     expect(sendTeamInvitation).toHaveBeenCalledWith({
       email: "ada@example.com",
-      callbackUrl: "https://cmux.test/en/dashboard/team/accept",
+      callbackUrl: "https://cmux.com/en/dashboard/team/accept",
     });
+    Object.assign(process.env, { NODE_ENV: "test" });
   });
 
   test("rejects non-members before creating an invitation", async () => {
@@ -181,15 +237,125 @@ describe("team invite routes", () => {
     expect(revoke).toHaveBeenCalled();
     expect(body.invitations).toHaveLength(1);
   });
+
+  test("members are forbidden from mutating team management", async () => {
+    members = [
+      { id: "user-1", primaryEmail: "member@example.com" },
+      { id: "admin-1", primaryEmail: "admin@example.com" },
+      { id: "target-1", primaryEmail: "target@example.com" },
+    ];
+    adminIds = new Set(["admin-1"]);
+    invitations = [{
+      id: "inv_1",
+      recipientEmail: "ada@example.com",
+      expiresAt: new Date("2027-01-01T00:00:00Z"),
+      revoke: mock(async () => undefined),
+      resend: mock(async () => undefined),
+    }];
+
+    const cases = [
+      inviteRoute.POST(request("/api/team/invite", { email: "ada@example.com", locale: "en" })),
+      revokeRoute.POST(request("/api/team/invite/revoke", { invitationId: "inv_1" })),
+      resendRoute.POST(request("/api/team/invite/resend", { invitationId: "inv_1", locale: "en" })),
+      removeRoute.POST(request("/api/team/members/remove", { memberId: "target-1" })),
+      roleRoute.POST(request("/api/team/members/role", { memberId: "target-1", role: "admin" })),
+      teamRoute.POST(request("/api/team", { action: "rename", displayName: "New Name" })),
+    ];
+
+    for (const response of await Promise.all(cases)) {
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({ error: "not_team_admin" });
+    }
+  });
+
+  test("member can leave the team", async () => {
+    members = [
+      { id: "user-1", primaryEmail: "member@example.com" },
+      { id: "admin-1", primaryEmail: "admin@example.com" },
+    ];
+    adminIds = new Set(["admin-1"]);
+    currentUser = stackUser();
+
+    const response = await removeRoute.POST(request("/api/team/members/remove", { memberId: "user-1" }));
+
+    expect(response.status).toBe(200);
+    expect(currentUser?.selectedTeam.removeUser).toHaveBeenCalledWith("user-1");
+  });
+
+  test("last admin cannot be removed or demoted", async () => {
+    members = [
+      { id: "user-1", primaryEmail: "member@example.com" },
+      { id: "target-1", primaryEmail: "target@example.com" },
+    ];
+    adminIds = new Set(["user-1"]);
+
+    const removeResponse = await removeRoute.POST(request("/api/team/members/remove", { memberId: "user-1" }));
+    const demoteResponse = await roleRoute.POST(request("/api/team/members/role", {
+      memberId: "user-1",
+      role: "member",
+    }));
+
+    expect(removeResponse.status).toBe(400);
+    expect(await removeResponse.json()).toEqual({ error: "cannot_remove_last_admin" });
+    expect(demoteResponse.status).toBe(400);
+    expect(await demoteResponse.json()).toEqual({ error: "cannot_demote_last_admin" });
+  });
+
+  test("admin can promote and demote members", async () => {
+    members = [
+      { id: "user-1", primaryEmail: "member@example.com" },
+      { id: "target-1", primaryEmail: "target@example.com" },
+    ];
+    adminIds = new Set(["user-1"]);
+
+    const promoteResponse = await roleRoute.POST(request("/api/team/members/role", {
+      memberId: "target-1",
+      role: "admin",
+    }));
+    const demoteResponse = await roleRoute.POST(request("/api/team/members/role", {
+      memberId: "target-1",
+      role: "member",
+    }));
+
+    expect(promoteResponse.status).toBe(200);
+    expect(demoteResponse.status).toBe(200);
+    expect(adminIds.has("target-1")).toBe(false);
+  });
+
+  test("resend returns an error when no resend path can send email", async () => {
+    Object.assign(process.env, { NODE_ENV: "test" });
+    invitations = [{
+      id: "inv_1",
+      recipientEmail: "ada@example.com",
+      expiresAt: new Date("2027-01-01T00:00:00Z"),
+      revoke: undefined as unknown as ReturnType<typeof mock>,
+      resend: undefined,
+      send: undefined,
+    }];
+
+    const response = await resendRoute.POST(request("/api/team/invite/resend", {
+      invitationId: "inv_1",
+      locale: "en",
+    }));
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "email_unavailable" });
+    expect(emailSend).not.toHaveBeenCalled();
+  });
 });
 
 function stackUser() {
   const team = {
     id: "team-1",
     displayName: "Team One",
-    listUsers: mock(async () => members),
+    listUsers: mock(async () => members.map((member) => stackMember(member.id, member.primaryEmail))),
     listInvitations: mock(async () => invitations),
     sendTeamInvitation,
+    removeUser: mock(async (...args: unknown[]) => {
+      const userId = String(args[0]);
+      members = members.filter((member) => member.id !== userId);
+    }),
+    update: mock(async () => undefined),
   };
   return {
     id: "user-1",
@@ -197,6 +363,35 @@ function stackUser() {
     primaryEmail: "member@example.com",
     selectedTeam: team,
     listTeams: mock(async () => [team]),
+    hasPermission: mock(async (...args: unknown[]) => {
+      const permissionId = String(args[1]);
+      return permissionId === "team_admin" && adminIds.has("user-1");
+    }),
+    grantPermission: mock(async (...args: unknown[]) => {
+      const permissionId = String(args[1]);
+      if (permissionId === "team_admin") adminIds.add("user-1");
+    }),
+  };
+}
+
+function stackMember(id: string, primaryEmail: string) {
+  return {
+    id,
+    primaryEmail,
+    displayName: primaryEmail,
+    profileImageUrl: null,
+    hasPermission: mock(async (...args: unknown[]) => {
+      const permissionId = String(args[1]);
+      return permissionId === "team_admin" && adminIds.has(id);
+    }),
+    grantPermission: mock(async (...args: unknown[]) => {
+      const permissionId = String(args[1]);
+      if (permissionId === "team_admin") adminIds.add(id);
+    }),
+    revokePermission: mock(async (...args: unknown[]) => {
+      const permissionId = String(args[1]);
+      if (permissionId === "team_admin") adminIds.delete(id);
+    }),
   };
 }
 

--- a/web/tests/team-invite-routes.test.ts
+++ b/web/tests/team-invite-routes.test.ts
@@ -107,9 +107,11 @@ mock.module("../services/errors", () => ({
   captureBillingError: mock(() => undefined),
 }));
 
-mock.module("@vercel/firewall", () => ({
-  checkRateLimit: mock(async () => ({ error: null, rateLimited: false })),
-}));
+// Do NOT mock @vercel/firewall here: these tests run with VERCEL="0", so
+// enforceTeamInviteRateLimit early-returns and never calls checkRateLimit. bun
+// applies mock.module process-wide (last registration wins), so a mock here
+// would override notifications-push-route.test.ts's own checkRateLimit mock and
+// break its rate-limit assertion on CI.
 
 mock.module("resend", () => ({
   Resend: class {

--- a/web/tests/team-invite-routes.test.ts
+++ b/web/tests/team-invite-routes.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let currentUser: ReturnType<typeof stackUser> | null = null;
+let members: Array<{ id: string; primaryEmail: string }> = [];
+let invitations: Array<{
+  id: string;
+  recipientEmail: string;
+  expiresAt: Date;
+  revoke: ReturnType<typeof mock>;
+  resend: ReturnType<typeof mock>;
+}> = [];
+const sendTeamInvitation = mock(async (options: unknown) => {
+  const { email } = options as { email: string; callbackUrl: string };
+  const invitation = {
+    id: `inv_${email}`,
+    recipientEmail: email,
+    expiresAt: new Date("2027-01-01T00:00:00Z"),
+    revoke: mock(async () => undefined),
+    resend: mock(async () => undefined),
+  };
+  invitations.unshift(invitation);
+  return invitation;
+});
+const getUser = mock(async () => currentUser);
+const emailSend = mock(async () => ({ error: null }));
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => true,
+  stackServerApp: { getUser },
+}));
+
+mock.module("drizzle-orm", () => ({
+  and: (...parts: unknown[]) => parts,
+  desc: (value: unknown) => value,
+  eq: (left: unknown, right: unknown) => [left, right],
+  inArray: (left: unknown, right: unknown) => [left, right],
+}));
+
+mock.module("../app/env", () => ({
+  env: {
+    RESEND_API_KEY: "resend-test",
+    CMUX_FEEDBACK_FROM_EMAIL: "austin@manaflow.ai",
+    CMUX_FEEDBACK_RATE_LIMIT_ID: "team-invites-test",
+  },
+}));
+
+mock.module("../db/client", () => ({
+  cloudDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: mock(async () => [{ seats: 3 }]),
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+mock.module("../db/schema", () => ({
+  stripeSubscriptions: {
+    seats: "seats",
+    stackTeamId: "stackTeamId",
+    scope: "scope",
+    plan: "plan",
+    status: "status",
+    currentPeriodEnd: "currentPeriodEnd",
+    updatedAt: "updatedAt",
+  },
+}));
+
+mock.module("../services/billing/pro", () => ({
+  ACTIVE_STRIPE_PRO_STATUSES: ["active", "trialing"],
+  TEAM_PLAN_ID: "team",
+}));
+
+mock.module("../services/errors", () => ({
+  captureBillingError: mock(() => undefined),
+}));
+
+mock.module("@vercel/firewall", () => ({
+  checkRateLimit: mock(async () => ({ error: null, rateLimited: false })),
+}));
+
+mock.module("resend", () => ({
+  Resend: class {
+    emails = { send: emailSend };
+  },
+}));
+
+const inviteRoute = await import("../app/api/team/invite/route");
+const revokeRoute = await import("../app/api/team/invite/revoke/route");
+
+describe("team invite routes", () => {
+  beforeEach(() => {
+    members = [{ id: "user-1", primaryEmail: "member@example.com" }];
+    invitations = [];
+    currentUser = stackUser();
+    getUser.mockClear();
+    sendTeamInvitation.mockClear();
+    emailSend.mockClear();
+    process.env.VERCEL = "0";
+  });
+
+  test("member can create a Stack invite and receives an accept URL", async () => {
+    const response = await inviteRoute.POST(request("/api/team/invite", {
+      email: " Ada@Example.com ",
+      locale: "en",
+    }));
+    const body = await response.json() as { acceptUrl: string; invitation: { email: string; id: string } };
+
+    expect(response.status).toBe(200);
+    expect(body.invitation.email).toBe("ada@example.com");
+    expect(body.acceptUrl).toContain("/en/dashboard/team/accept?invitation=inv_ada%40example.com");
+    expect(sendTeamInvitation).toHaveBeenCalledWith({
+      email: "ada@example.com",
+      callbackUrl: "https://cmux.test/en/dashboard/team/accept",
+    });
+    expect(emailSend).toHaveBeenCalled();
+  });
+
+  test("rejects non-members before creating an invitation", async () => {
+    members = [{ id: "other", primaryEmail: "other@example.com" }];
+
+    const response = await inviteRoute.POST(request("/api/team/invite", {
+      email: "ada@example.com",
+      locale: "en",
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({ error: "team_not_found" });
+    expect(sendTeamInvitation).not.toHaveBeenCalled();
+  });
+
+  test("rejects invalid email", async () => {
+    const response = await inviteRoute.POST(request("/api/team/invite", {
+      email: "not-an-email",
+      locale: "en",
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_email" });
+    expect(sendTeamInvitation).not.toHaveBeenCalled();
+  });
+
+  test("revoke uses the invitation action and reconciles from team state", async () => {
+    const revoke = mock(async () => undefined);
+    invitations = [{
+      id: "inv_1",
+      recipientEmail: "ada@example.com",
+      expiresAt: new Date("2027-01-01T00:00:00Z"),
+      revoke,
+      resend: mock(async () => undefined),
+    }];
+
+    const response = await revokeRoute.POST(request("/api/team/invite/revoke", {
+      invitationId: "inv_1",
+    }));
+    const body = await response.json() as { invitations: unknown[] };
+
+    expect(response.status).toBe(200);
+    expect(revoke).toHaveBeenCalled();
+    expect(body.invitations).toHaveLength(1);
+  });
+});
+
+function stackUser() {
+  const team = {
+    id: "team-1",
+    displayName: "Team One",
+    listUsers: mock(async () => members),
+    listInvitations: mock(async () => invitations),
+    sendTeamInvitation,
+  };
+  return {
+    id: "user-1",
+    displayName: "Grace Hopper",
+    primaryEmail: "member@example.com",
+    selectedTeam: team,
+    listTeams: mock(async () => [team]),
+  };
+}
+
+function request(path: string, body: unknown): Request {
+  return new Request(`https://cmux.test${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}

--- a/web/tests/team-invite-routes.test.ts
+++ b/web/tests/team-invite-routes.test.ts
@@ -121,6 +121,22 @@ describe("team invite routes", () => {
     expect(emailSend).toHaveBeenCalled();
   });
 
+  test("neutralizes an off-origin locale so invite URLs stay on-origin", async () => {
+    const response = await inviteRoute.POST(request("/api/team/invite", {
+      email: "ada@example.com",
+      locale: "//evil.com",
+    }));
+    const body = await response.json() as { acceptUrl: string };
+
+    expect(response.status).toBe(200);
+    expect(new URL(body.acceptUrl).origin).toBe("https://cmux.test");
+    expect(body.acceptUrl).toContain("/en/dashboard/team/accept");
+    expect(sendTeamInvitation).toHaveBeenCalledWith({
+      email: "ada@example.com",
+      callbackUrl: "https://cmux.test/en/dashboard/team/accept",
+    });
+  });
+
   test("rejects non-members before creating an invitation", async () => {
     members = [{ id: "other", primaryEmail: "other@example.com" }];
 

--- a/web/tests/team-optimistic-revoke.test.ts
+++ b/web/tests/team-optimistic-revoke.test.ts
@@ -9,10 +9,12 @@ describe("applyOptimisticRevoke", () => {
       teamId: "team-1",
       teamName: "Team One",
       seats: 2,
+      currentUserRole: "admin",
+      canManageTeam: true,
       members: [],
       invitations: [
-        { id: "inv-1", email: "a@example.com", createdAt: null, acceptUrl: null },
-        { id: "inv-2", email: "b@example.com", createdAt: null, acceptUrl: null },
+        { id: "inv-1", email: "a@example.com", createdAt: null, acceptUrl: null, role: "member" },
+        { id: "inv-2", email: "b@example.com", createdAt: null, acceptUrl: null, role: "member" },
       ],
     };
 

--- a/web/tests/team-optimistic-revoke.test.ts
+++ b/web/tests/team-optimistic-revoke.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { applyOptimisticRevoke } from "../app/[locale]/dashboard/team/optimistic";
+import type { TeamSummaryDto } from "../services/team/invites";
+
+describe("applyOptimisticRevoke", () => {
+  test("returns next state plus rollback snapshot for one mutation path", () => {
+    const previous: TeamSummaryDto = {
+      teamId: "team-1",
+      teamName: "Team One",
+      seats: 2,
+      members: [],
+      invitations: [
+        { id: "inv-1", email: "a@example.com", createdAt: null, acceptUrl: null },
+        { id: "inv-2", email: "b@example.com", createdAt: null, acceptUrl: null },
+      ],
+    };
+
+    const mutation = applyOptimisticRevoke(previous, "inv-1", "req-1");
+
+    expect(mutation.requestId).toBe("req-1");
+    expect(mutation.previous).toBe(previous);
+    expect(mutation.next.invitations.map((invite) => invite.id)).toEqual(["inv-2"]);
+  });
+});


### PR DESCRIPTION
## What

A new `/dashboard/team` page to manage a team and invite people, built on Stack Auth's **native** team-invitation API (no custom token store).

## UX

- **Invite by email or link.** Multi-address email input (chips) + a prominent **"Copy invite link"** for Slack/DM sharing. Sending both creates the Stack invitation and emails a branded Resend invite.
- **Pending invites** list with optimistic resend/revoke (one mutation path, snapshot + rollback per the repo's optimistic-update policy).
- **Member list** with remove (self-remove guarded); avatar/name/email, "You" badge.
- **Seat awareness.** "N members · M seats" from the team's active Stripe subscription; over-seat is a **soft** nudge to `/api/billing/portal?scope=team` — never a hard block or auto-charge.
- **One-click accept.** Invitee link → sign in/up if needed (bounces via `vaultSignInHref` + `after_auth_return_to`) → `acceptTeamInvitation(code)` → "You've joined" → dashboard. Friendly errors on bad/mismatched codes.

## Security

- `POST /api/team/invite` resolves the caller's own team and **403s if they aren't a member**; rate-limited; emails validated; invite codes never logged.
- Accept relies on Stack's code verification (email match), not a trusted email param.

## Scope (v1)

Teams stay **flat** (no role system, matching the existing model). Seats are **soft** (awareness + nudge); seat↔membership auto-reconciliation is a deliberate follow-up rather than surprise-charging on accept.

## Verified

- `bun run typecheck` clean; full sorted web suite **573 tests, 0 fail** (25 new: email-template builder, invite route member/non-member/invalid-email, accept signed-out-bounce + success + mismatch, optimistic revoke).
- Localized across **all 20 message catalogs** (`dashboard.nav.team` + a 13-key `dashboard.team` block, key sets in sync; en + ja real translations).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786149343&installation_id=133855650&pr_number=7677&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7677&signature=344a84a8f739a98ed1f3f2136739114462fbb9fd13f9b52ec2314c4a8f83a8f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authorization (team_admin grants, role promotion, invite accept), membership mutations, and invite URL construction—areas where mistakes could escalate privileges or phish via off-origin links; mitigations are present but the surface area is large.
> 
> **Overview**
> Adds a **Team** section under the dashboard account nav with `/dashboard/team` for creating/renaming a team, inviting by email or copyable link, managing pending invites (optimistic revoke), and listing members with leave/remove and admin/member roles.
> 
> Backend work centers on `services/team/invites` plus `POST` routes under `/api/team/*`: Stack Auth native invitations, branded Resend emails, member checks, admin-gated mutations, rate limits, and a `team_invite_roles` table so invite role (admin vs member) is applied on accept—including ambiguous code-based accepts when only one pending invite exists.
> 
> Accept flow lives at `/dashboard/team/accept` (`code` or `invitation` query), with sign-in bounce and email-mismatch errors. Invite URLs are built from a trusted origin with validated locale. Team checkout auto-grants `team_admin` when it creates a team. Seat count is shown with a soft billing-portal nudge when over limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e4b64225fd81067b9a625f52aceb6280be91ec0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new /dashboard/team page to create a team, invite by email or shareable link, and manage members using `Stack Auth` native invitations with admin/member roles. Hardens invite URLs and correctly applies invited roles on accept with right-team checks; APIs are member-checked and `@vercel/firewall` rate-limited.

- **New Features**
  - Team management UI: create/rename; pending invites with optimistic resend/revoke; remove members (self-remove guarded); nav adds "team".
  - Roles: team creator is admin; invite as member/admin; promote/demote; never allow zero admins. Invited role is stored server-side and applied on accept for both link and code paths (ambiguous multi-invite falls back to member).
  - Invite flow: multi-email input and copyable invite link; branded emails via `Resend`; server routes for send/resend/revoke/member-remove/role update.
  - Accept flow at /dashboard/team/accept with auth bounce and friendly errors.
  - Seat awareness: shows members/seats with a soft nudge to the billing portal.

- **Bug Fixes**
  - Apply admin on accept using the authoritative stored team ID, and only if the user belongs to that exact team; opaque code with multiple pending invites downgrades to member, while the branded invitation-id link applies roles correctly.
  - Security: build invite/accept URLs from a trusted canonical origin and allowlist the locale to block off‑origin URLs.
  - Admin‑gate all mutating endpoints; fail closed on missing admin-role data; `resend` returns an error when it cannot resend.
  - Tests: fixed `bun` mock.module leaks and an env partial‑mock leak that caused unexpected 413s in CI.

<sup>Written for commit 1e4b64225fd81067b9a625f52aceb6280be91ec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dashboard Team section with team creation/renaming, inviting, pending-invite management, member removal, and role updates.
  * Added invite acceptance supporting both invite codes and invitation links, including localized redirects after joining.
  * Added team invite/member APIs (send, resend, revoke, remove, role update) with optimistic invitation revocation and copyable invite links.
* **Localization**
  * Added team navigation and complete team-management UI text across multiple languages.
* **Bug Fixes**
  * Improved handling for invalid invites and invited-email mismatches (with account-switch guidance).
* **Tests**
  * Added automated tests for invite acceptance, email generation, API routes, and optimistic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->