### PR TITLE
fix(terminal): map Korean (ko) to Apple SD Gothic Neo CJK fallback

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/ConfigDiscovery/GhosttyConfigDiscovery.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/ConfigDiscovery/GhosttyConfigDiscovery.swift
@@ -56,6 +56,11 @@ public struct GhosttyConfigDiscovery {
         "U+30A0-U+30FF",  // Katakana
     ]
 
+    /// Unicode ranges specific to Korean (Hangul jamo and syllables).
+    /// Empty until the following commit populates it — declared here only so the
+    /// red half of this regression pair compiles and fails on behavior.
+    public static let koreanRanges: [String] = []
+
     /// Representative scalars used to detect whether the configured primary font
     /// already covers the ranges cmux would otherwise auto-map.
     public static let cjkCoverageSampleCharactersByRange: [String: [UniChar]] = [

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/ConfigDiscovery/GhosttyConfigDiscovery.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/ConfigDiscovery/GhosttyConfigDiscovery.swift
@@ -57,9 +57,11 @@ public struct GhosttyConfigDiscovery {
     ]
 
     /// Unicode ranges specific to Korean (Hangul jamo and syllables).
-    /// Empty until the following commit populates it — declared here only so the
-    /// red half of this regression pair compiles and fails on behavior.
-    public static let koreanRanges: [String] = []
+    public static let koreanRanges = [
+        "U+1100-U+11FF",  // Hangul Jamo
+        "U+3130-U+318F",  // Hangul Compatibility Jamo
+        "U+AC00-U+D7AF",  // Hangul Syllables
+    ]
 
     /// Representative scalars used to detect whether the configured primary font
     /// already covers the ranges cmux would otherwise auto-map.
@@ -90,16 +92,23 @@ public struct GhosttyConfigDiscovery {
 
         for lang in preferredLanguages {
             let lower = lang.lowercased()
+            // Compare the BCP-47 primary subtag, not a raw prefix: "kok"
+            // (Konkani) is a selectable macOS language, and a `hasPrefix("ko")`
+            // test would inject a Hangul font for its Devanagari script.
+            let primary = lower.prefix { $0 != "-" && $0 != "_" }
             let font: String
             var langRanges: [String] = []
 
-            if lower.hasPrefix("ja") {
+            if primary == "ja" {
                 font = "Hiragino Sans"
                 langRanges = Self.japaneseRanges
             } else if lower.hasPrefix("zh-hant") || lower.hasPrefix("zh-tw") || lower.hasPrefix("zh-hk") {
                 font = "PingFang TC"
-            } else if lower.hasPrefix("zh") {
+            } else if primary == "zh" {
                 font = "PingFang SC"
+            } else if primary == "ko" {
+                font = "Apple SD Gothic Neo"
+                langRanges = Self.koreanRanges
             } else {
                 continue
             }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigDiscoveryTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigDiscoveryTests.swift
@@ -35,8 +35,27 @@ private struct NoFontProbe: GhosttyFontProbing {
         #expect(ranges.isSuperset(of: GhosttyConfigDiscovery.japaneseRanges))
     }
 
-    @Test func koreanOnlyYieldsNoMappings() {
-        #expect(discovery.cjkFontMappings(preferredLanguages: ["ko-KR"]) == nil)
+    @Test func koreanMapsHangulAndSharedRanges() throws {
+        let mappings = try #require(discovery.cjkFontMappings(preferredLanguages: ["ko-KR", "en-US"]))
+        #expect(Set(mappings.map(\.1)) == ["Apple SD Gothic Neo"])
+        let ranges = Set(mappings.map(\.0))
+        #expect(ranges.isSuperset(of: GhosttyConfigDiscovery.sharedCJKRanges))
+        #expect(ranges.isSuperset(of: GhosttyConfigDiscovery.koreanRanges))
+    }
+
+    @Test func koreanFirstOwnsSharedRangesAlongsideJapanese() throws {
+        let mappings = try #require(discovery.cjkFontMappings(preferredLanguages: ["ko-KR", "ja-JP"]))
+        let shared = mappings.filter { GhosttyConfigDiscovery.sharedCJKRanges.contains($0.0) }
+        #expect(shared.allSatisfy { $0.1 == "Apple SD Gothic Neo" })
+        let kana = mappings.filter { GhosttyConfigDiscovery.japaneseRanges.contains($0.0) }
+        #expect(kana.allSatisfy { $0.1 == "Hiragino Sans" })
+    }
+
+    /// "kok" (Konkani) is a selectable macOS language that shares a prefix with
+    /// "ko", and its Devanagari script has nothing to do with the CJK ranges.
+    @Test func konkaniIsNotMistakenForKorean() {
+        #expect(discovery.cjkFontMappings(preferredLanguages: ["kok-IN"]) == nil)
+        #expect(discovery.cjkFontMappings(preferredLanguages: ["kok-Deva-IN"]) == nil)
     }
 
     @Test func traditionalChineseUsesPingFangTC() throws {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3858,10 +3858,17 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertFalse(ranges.contains("U+AC00-U+D7AF"), "Should NOT include Hangul")
     }
 
-    func testCJKFontMappingsReturnsNilForKoreanOnly() {
-        // Korean is not auto-mapped — Ghostty's native CTFontCreateForString
-        // fallback selects a better-matching font for Hangul.
-        XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR"]))
+    func testCJKFontMappingsReturnsAppleSDGothicNeoWithHangulForKorean() throws {
+        let mappings = try XCTUnwrap(GhosttyApp.cjkFontMappings(preferredLanguages: ["ko-KR", "en-US"]))
+        let fonts = Set(mappings.map(\.1))
+        let ranges = mappings.map(\.0)
+
+        XCTAssertEqual(fonts, Set(["Apple SD Gothic Neo"]))
+        XCTAssertTrue(ranges.contains("U+1100-U+11FF"), "Should include Hangul Jamo")
+        XCTAssertTrue(ranges.contains("U+3130-U+318F"), "Should include Hangul Compatibility Jamo")
+        XCTAssertTrue(ranges.contains("U+AC00-U+D7AF"), "Should include Hangul Syllables")
+        XCTAssertTrue(ranges.contains("U+4E00-U+9FFF"), "Should include CJK Ideographs")
+        XCTAssertFalse(ranges.contains("U+3040-U+309F"), "Should NOT include Hiragana")
     }
 
     func testCJKFontMappingsReturnsPingFangForChinese() {
@@ -3878,19 +3885,26 @@ final class GhosttyMouseFocusTests: XCTestCase {
     func testCJKFontMappingsReturnsNilForNonCJKLanguages() {
         XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: ["en-US", "fr-FR"]))
         XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: []))
+        // "kok" (Konkani) is a selectable macOS language sharing a prefix with "ko".
+        XCTAssertNil(GhosttyApp.cjkFontMappings(preferredLanguages: ["kok-IN"]))
     }
 
-    func testCJKFontMappingsMultiLanguageSkipsKorean() {
-        // When both ja and ko are preferred, only Japanese mappings are generated.
-        // Korean is left to Ghostty's native CTFontCreateForString fallback.
+    func testCJKFontMappingsMultiLanguageGivesSharedRangesToFirstLanguage() {
+        // Japanese is preferred first, so it owns the shared CJK ranges. Korean
+        // still claims its own Hangul ranges, which Hiragino Sans cannot render.
         let mappings = GhosttyApp.cjkFontMappings(preferredLanguages: ["ja-JP", "ko-KR"])!
 
         let hiraginoRanges = mappings.filter { $0.1 == "Hiragino Sans" }.map(\.0)
+        let gothicRanges = mappings.filter { $0.1 == "Apple SD Gothic Neo" }.map(\.0)
 
         XCTAssertTrue(hiraginoRanges.contains("U+3040-U+309F"), "Hiragana → Hiragino")
         XCTAssertTrue(hiraginoRanges.contains("U+4E00-U+9FFF"), "Shared CJK → first lang font")
-        XCTAssertFalse(mappings.contains { $0.1 == "Apple SD Gothic Neo" }, "No Korean font mapping")
         XCTAssertFalse(hiraginoRanges.contains("U+AC00-U+D7AF"), "Hangul NOT in Hiragino")
+        XCTAssertEqual(
+            Set(gothicRanges),
+            Set(["U+1100-U+11FF", "U+3130-U+318F", "U+AC00-U+D7AF"]),
+            "Hangul ranges → Apple SD Gothic Neo"
+        )
     }
 
     func testResolvedInjectedCJKFontNamePinsRegularWeightForHiraginoSans() throws {
@@ -3970,6 +3984,35 @@ final class GhosttyMouseFocusTests: XCTestCase {
 
             XCTAssertEqual(Set(mappings.map(\.0)), Set(["U+3040-U+309F", "U+30A0-U+30FF"]))
             XCTAssertEqual(Set(mappings.map(\.1)), Set(["Hiragino Sans"]))
+        }
+    }
+
+    func testAutoInjectedCJKFontMappingsKeepsHangulRangesForKorean() throws {
+        let coveredRanges: Set<String> = [
+            "U+3000-U+303F",
+            "U+4E00-U+9FFF",
+            "U+F900-U+FAFF",
+            "U+FF00-U+FFEF",
+            "U+3400-U+4DBF",
+        ]
+
+        try withTempConfig("font-family = Example CJK Mono\n") { path in
+            guard let mappings = GhosttyApp.autoInjectedCJKFontMappings(
+                preferredLanguages: ["ko-KR"],
+                configPaths: [path],
+                rangeCoverageProbe: { _, range in
+                    coveredRanges.contains(range)
+                }
+            ) else {
+                XCTFail("Korean locale should keep its Hangul ranges after coverage filtering")
+                return
+            }
+
+            XCTAssertEqual(
+                Set(mappings.map(\.0)),
+                Set(["U+1100-U+11FF", "U+3130-U+318F", "U+AC00-U+D7AF"])
+            )
+            XCTAssertEqual(Set(mappings.map(\.1)), Set(["Apple SD Gothic Neo"]))
         }
     }
 


### PR DESCRIPTION
## Summary

- **What changed?** Korean (`ko`) preferred languages now receive a managed CJK font fallback: `Apple SD Gothic Neo` for the shared CJK ranges plus the three Hangul ranges (Jamo, Compatibility Jamo, Syllables).
- **Why?** `GhosttyConfigDiscovery.cjkFontMappings` already branched on `ja` → Hiragino Sans, `zh-Hant`/`zh-TW`/`zh-HK` → PingFang TC, and `zh` → PingFang SC — but had no `ko` branch at all. A Korean-only locale fell through to `continue`, so the function returned `nil` and Hangul rendering depended entirely on whatever the primary font happened to cover. Korean was the only CJK locale without a managed fallback.

Language matching now compares the BCP-47 primary subtag instead of a raw prefix. `kok` (Konkani) ships as an available macOS locale identifier and shares a prefix with `ko`, so `hasPrefix("ko")` would have injected a Hangul font for a Devanagari-script locale. `ja` and `zh` use the same comparison for consistency; no shipping identifier collides with either, so their behavior is unchanged. The `zh-Hant`/`zh-TW`/`zh-HK` checks stay full-tag prefixes because they discriminate on script and region subtags.

Language-ownership semantics are unchanged: the first CJK language in `preferredLanguages` still owns the shared ranges, and each language only maps its own script ranges (so Hangul is never assigned to Hiragino Sans). `autoInjectedCJKFontMappings` still defers to an explicit user `font-codepoint-map` or `font-family` fallback chain, and still drops ranges the configured primary font already covers.

## Testing

- App-host suite: `xcodebuild test -scheme cmux-unit -only-testing:cmuxTests/GhosttyConfigTests` — **59 tests, 0 failures**.
- Package suite: `swift test --filter GhosttyConfigDiscovery` in `Packages/macOS/CmuxTerminalCore` — **19 tests in 5 suites, all pass**.
- Two-commit red/green, verified by building and running both commits:
  - At the test-only commit the package **builds** (`Build complete!`) and the new tests fail on *behavior* — `cjkFontMappings(["ko-KR", "en-US"])` returns `nil`, and with `["ko-KR", "ja-JP"]` the shared ranges resolve to `Hiragino Sans` instead of `Apple SD Gothic Neo`.
  - At the fix commit both suites go green.
  - `koreanRanges` is declared as an empty array in the test commit for exactly this reason: a test that fails to *compile* proves nothing about the bug.
- The old "Korean is deliberately unmapped" contract was asserted in **two** mirrors, not one. The app-host suite still held `testCJKFontMappingsReturnsNilForKoreanOnly` and `testCJKFontMappingsMultiLanguageSkipsKorean`. Both are flipped in the test commit, so the fix commit stays green and each commit remains a usable `git bisect` target.
- Added `testAutoInjectedCJKFontMappingsKeepsHangulRangesForKorean`, covering the `autoInjectedCJKFontMappings` coverage-filter path for `ko` — the gap Greptile flagged, and the one path the package suite cannot reach.
- Added `konkaniIsNotMistakenForKorean` (package) and a `kok-IN` case in `testCJKFontMappingsReturnsNilForNonCJKLanguages` (app-host), pinning the primary-subtag comparison. Verified against `Locale.availableIdentifiers`: `kok`, `kok_Deva`, `kok_Deva_IN` exist; no identifier collides with `ja` or `zh`.
- Repo guards pass: `scripts/lint-pbxproj-test-wiring.sh`, `scripts/check-package-resolved-policy.py`, `scripts/check-workspace-package-groups.py --check`.

**On CJK Extension A.** `Apple SD Gothic Neo` has no glyph for `U+3400`, which the shared ranges include. This is not a regression. Ghostty's `CodepointResolver.getIndexCodepointOverride` verifies `hasCodepoint` on the mapped face and returns `null` when the face misses it, falling through to normal fallback discovery. `Hiragino Sans` — the existing `ja` mapping — has the same gap at `U+3400` and `U+F900`.

## Demo Video

Not included — this change injects font-fallback configuration and adds no UI. I can attach a before/after screenshot of Hangul rendering in a Korean locale if that is preferred.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed — no user-facing docs or strings change. Localization audit: the only new strings are font-family names consumed as Ghostty config values; no UI copy, no `Resources/Localizable.xcstrings` keys, and no web message catalogs are touched.
- [ ] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved — Greptile's P2 (missing `autoInjectedCJKFontMappings` test for `ko`) is addressed; CodeRabbit and Cursor Bugbot reported no actionable comments.
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786152807&installation_id=133855650&pr_number=7678&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7678&signature=44f30addd856296fc627814d854f9fdd94dac00f9a6e571daa1f6bdf640d6dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect Ghostty font fallback injection for locale detection; behavior is covered by expanded unit tests and does not touch auth, data, or network paths.
> 
> **Overview**
> Korean locales now get the same managed CJK `font-codepoint-map` fallback as Japanese and Chinese: **Apple SD Gothic Neo** for shared Han/symbol ranges plus Hangul jamo and syllable ranges. Korean-only preferences no longer return `nil` from `cjkFontMappings`, so Hangul no longer depends only on the primary terminal font.
> 
> Language matching now uses the **BCP-47 primary subtag** (`ja`, `zh`, `ko`) instead of string prefixes, so **Konkani (`kok`)** is not treated as Korean. Multi-language ordering is unchanged—the first CJK language still owns shared ranges; Korean still only maps Hangul, Japanese still only maps kana.
> 
> Tests in the package and app-host suites were flipped from “Korean deliberately unmapped” to the new behavior, including mixed `ko`/`ja` ordering and `autoInjectedCJKFontMappings` coverage filtering for Hangul.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fcaccbf2bf58052212aa0fca5b7ab4ba5af809e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a managed CJK font fallback for Korean locales. `ko` now maps to `Apple SD Gothic Neo` for Hangul and shared CJK ranges, and language matching uses the primary BCP-47 subtag to avoid `kok` → `ko` collisions.

- **Bug Fixes**
  - Add `ko` branch in `GhosttyConfigDiscovery.cjkFontMappings`; define `koreanRanges` (Hangul Jamo, Compatibility Jamo, Syllables) mapped to `Apple SD Gothic Neo`. Preserve existing ownership and override rules (first CJK language owns shared ranges; Japanese stays on Hiragino; respect user `font-codepoint-map`/`font-family`; skip ranges covered by the primary font).
  - Match on the primary BCP-47 subtag for `ja`/`zh`/`ko`; keep full-tag checks for `zh-Hant`/`zh-TW`/`zh-HK`. Guard so `kok` (Konkani) is not treated as Korean.
  - Tests updated: `["ko-KR", "en-US"]`, `["ko-KR", "ja-JP"]`, `["ja-JP", "ko-KR"]`; add `kok` locale checks; keep `autoInjectedCJKFontMappings` coverage-filter test to ensure Hangul ranges remain for Korean.

<sup>Written for commit 1fcaccbf2bf58052212aa0fca5b7ab4ba5af809e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced automatic CJK font selection for Korean language settings, including dedicated Hangul range handling.
  * Korean now maps to **Apple SD Gothic Neo**, while shared CJK ideographs continue to map appropriately.
  * Combined Korean/Japanese preferences are split by script (Hangul vs. Hiragana/shared CJK) for more consistent rendering.
* **Bug Fixes**
  * Fixed cases where Korean CJK mappings could be missing.
* **Tests**
  * Updated and added font-mapping coverage, including regression checks for auto-injected mapping range filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
