### PR TITLE
Fix session-autosave main-thread hang: replace JSON round-trip scan with O(1) tabID→panelID lookup

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -370,25 +370,7 @@ extension Workspace {
     }
     private func sessionPanelID(forExternalTabIDString tabIDString: String) -> UUID? {
         guard let tabUUID = UUID(uuidString: tabIDString) else { return nil }
-        for (surfaceId, panelId) in surfaceIdToPanelId {
-            guard let surfaceUUID = sessionSurfaceUUID(for: surfaceId) else { continue }
-            if surfaceUUID == tabUUID {
-                return panelId
-            }
-        }
-        return nil
-    }
-
-    private func sessionSurfaceUUID(for surfaceId: TabID) -> UUID? {
-        struct EncodedSurfaceID: Decodable {
-            let id: UUID
-        }
-
-        guard let data = try? JSONEncoder().encode(surfaceId),
-              let decoded = try? JSONDecoder().decode(EncodedSurfaceID.self, from: data) else {
-            return nil
-        }
-        return decoded.id
+        return surfaceIdToPanelId[TabID(uuid: tabUUID)]
     }
 
     private func sessionPanelSnapshot(

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -19,7 +19,20 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
 
     override func tearDown() {
         ClosedItemHistoryStore.shared.removeAll()
+        retainedManagers.removeAll()
         super.tearDown()
+    }
+
+    private var retainedManagers: [TabManager] = []
+
+    private func makeManagerAndWorkspace() throws -> (TabManager, Workspace) {
+        let manager = TabManager()
+        retainedManagers.append(manager)
+        return (manager, try XCTUnwrap(manager.selectedWorkspace))
+    }
+
+    private func makeWorkspace() throws -> Workspace {
+        try makeManagerAndWorkspace().1
     }
 
     private func reserveRemoteRestoreSocket() -> String {
@@ -63,8 +76,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testSessionSnapshotLayoutPreservesPanelIdsFromBonsplitTabs() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let firstPanelId = try XCTUnwrap(workspace.focusedPanelId)
         let secondPanelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
@@ -79,8 +91,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testFocusHistoryNavigatesWithinWorkspacePanels() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let firstPanelId = try XCTUnwrap(workspace.focusedPanelId)
         let secondPanelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
@@ -141,8 +152,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testFocusHistoryBackSkipsStaleEntriesThatResolveToCurrentPanel() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let closedPanelId = try XCTUnwrap(workspace.focusedPanelId)
         let fallbackPanelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
@@ -173,8 +183,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testFocusHistoryRevisionInvalidatesWhenClosedPanelChangesAvailability() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let closedPanelId = try XCTUnwrap(workspace.focusedPanelId)
         let fallbackPanelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
@@ -204,8 +213,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testFocusHistoryRevisionInvalidatesWhenClosedPaneChangesAvailability() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let leftPanelId = try XCTUnwrap(workspace.focusedPanelId)
         let leftPaneId = try XCTUnwrap(workspace.paneId(forPanelId: leftPanelId))
         let rightPanel = try XCTUnwrap(workspace.newTerminalSplit(from: leftPanelId, orientation: .horizontal))
@@ -286,8 +294,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testGhosttyFocusSurfaceIdRecordsMappedPanelInFocusHistory() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let secondPanelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
         let secondSurfaceId = try XCTUnwrap(workspace.surfaceIdFromPanelId(secondPanelId))
@@ -523,8 +530,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testReopenClosedItemRestoresClosedPanelSnapshot() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let panelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
 
@@ -540,8 +546,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testReopenClosedPanelRestoresUnreadIndicator() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let panelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
         workspace.setPanelCustomTitle(panelId: panelId, title: "Unread Tab")
@@ -561,8 +566,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testReopenClosedPanelRestoresManualUnreadState() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let panelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
         workspace.setPanelCustomTitle(panelId: panelId, title: "Manual Unread Tab")
@@ -673,8 +677,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testReopenClosedBrowserSplitFromClosedItemHistoryRestoresCollapsedPane() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let sourcePanelId = try XCTUnwrap(workspace.focusedPanelId)
         let splitBrowserId = try XCTUnwrap(manager.newBrowserSplit(
             tabId: workspace.id,
@@ -702,8 +705,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testReopenClosedTerminalSplitFromClosedItemHistoryRestoresCollapsedPane() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let sourcePanelId = try XCTUnwrap(workspace.focusedPanelId)
         let splitTerminal = try XCTUnwrap(workspace.newTerminalSplit(
             from: sourcePanelId,
@@ -732,8 +734,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testClosingPaneRecordsTabsInRecentlyClosedHistory() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let sourcePanelId = try XCTUnwrap(workspace.focusedPanelId)
         let splitTerminal = try XCTUnwrap(workspace.newTerminalSplit(
             from: sourcePanelId,
@@ -876,8 +877,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             AppDelegate.shared = originalAppDelegate
         }
 
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         workspace.setCustomTitle("Recovered Window Workspace")
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let closedPanelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
@@ -906,8 +906,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testClosedWindowRestoreRemapsClosedWorkspaceWindowIds() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         workspace.setCustomTitle("Closed Workspace")
         let workspaceSnapshot = workspace.sessionSnapshot(includeScrollback: false)
         let oldWindowId = UUID()
@@ -1013,8 +1012,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         ClosedItemHistoryStore.shared.removeAll()
         defer { ClosedItemHistoryStore.shared.removeAll() }
 
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         var panelSnapshot = try XCTUnwrap(workspace.sessionSnapshot(includeScrollback: false).panels.first)
         panelSnapshot.customTitle = "Stale Replaced Tab"
         ClosedItemHistoryStore.shared.push(.panel(ClosedPanelHistoryEntry(
@@ -1042,8 +1040,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testRecentlyClosedMenuSnapshotListsPanelWorkspaceAndWindowRowsNewestFirst() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         workspace.setCustomTitle("Workspace Row")
 
         var panelSnapshot = try XCTUnwrap(workspace.sessionSnapshot(includeScrollback: false).panels.first)
@@ -1091,8 +1088,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let historyURL = tempDir.appendingPathComponent("history.json", isDirectory: false)
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         let store = ClosedItemHistoryStore(
             capacity: nil,
             fileURL: historyURL,
@@ -1141,8 +1137,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let historyURL = tempDir.appendingPathComponent("history.json", isDirectory: false)
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         let seedStore = ClosedItemHistoryStore(
             capacity: nil,
             fileURL: historyURL,
@@ -1194,8 +1189,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let historyURL = tempDir.appendingPathComponent("history.json", isDirectory: false)
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         let store = ClosedItemHistoryStore(
             capacity: nil,
             fileURL: historyURL,
@@ -1231,8 +1225,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let historyURL = tempDir.appendingPathComponent("history.json", isDirectory: false)
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         var panelSnapshot = try XCTUnwrap(workspace.sessionSnapshot(includeScrollback: false).panels.first)
         panelSnapshot.customTitle = "Persisted Closed Tab"
         let oldWorkspaceId = workspace.id
@@ -1322,8 +1315,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testRecentlyClosedWorkspaceTitleIgnoresDotDirectoryFallback() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         var workspaceSnapshot = workspace.sessionSnapshot(includeScrollback: false)
         workspaceSnapshot.customTitle = nil
         workspaceSnapshot.processTitle = ""
@@ -1343,8 +1335,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testRecentlyClosedMenuSnapshotLimitsPreviewButKeepsFullCount() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         let panelSnapshot = try XCTUnwrap(workspace.sessionSnapshot(includeScrollback: false).panels.first)
 
         for index in 0..<12 {
@@ -1368,8 +1359,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testRecentlyClosedMenuSnapshotCarriesClosedTimestamp() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         var panelSnapshot = try XCTUnwrap(workspace.sessionSnapshot(includeScrollback: false).panels.first)
         panelSnapshot.customTitle = "Timed Panel"
         let closedAt = Date(timeIntervalSince1970: 1_700_000_000)
@@ -1440,8 +1430,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             AppDelegate.shared = originalAppDelegate
         }
 
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         var panelSnapshot = try XCTUnwrap(workspace.sessionSnapshot(includeScrollback: false).panels.first)
         panelSnapshot.customTitle = "Unreachable Tab"
         ClosedItemHistoryStore.shared.push(.panel(ClosedPanelHistoryEntry(
@@ -1490,8 +1479,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             AppDelegate.shared = originalAppDelegate
         }
 
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let restorablePanelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
         workspace.setPanelCustomTitle(panelId: restorablePanelId, title: "Restorable Tab")
@@ -1554,8 +1542,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testNoOpClosedPanelRemapDoesNotAdvanceRevision() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         let panelSnapshot = try XCTUnwrap(workspace.sessionSnapshot(includeScrollback: false).panels.first)
         let store = ClosedItemHistoryStore(capacity: 10)
         store.push(.panel(ClosedPanelHistoryEntry(
@@ -1579,8 +1566,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testFailedRestoreReinsertPreservesProtectedRecordWhenStoreIsAtCapacity() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         var protectedSnapshot = try XCTUnwrap(workspace.sessionSnapshot(includeScrollback: false).panels.first)
         protectedSnapshot.customTitle = "Failed Restore"
         var firstNewSnapshot = protectedSnapshot
@@ -1619,8 +1605,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testRestoreFirstRestorableCanSkipRecordsThatAlreadyFailedThisCommand() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         var oldSnapshot = try XCTUnwrap(workspace.sessionSnapshot(includeScrollback: false).panels.first)
         oldSnapshot.customTitle = "Old Failed"
         var newSnapshot = oldSnapshot
@@ -1683,8 +1668,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             AppDelegate.shared = originalAppDelegate
         }
 
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         var snapshot = workspace.sessionSnapshot(includeScrollback: false)
         var panelSnapshot = try XCTUnwrap(snapshot.panels.first)
         panelSnapshot.type = .markdown
@@ -1716,8 +1700,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     }
 
     func testClosedWindowRestoreValidationRejectsFailedRestorablePanelRestore() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         let snapshot = SessionWindowSnapshot(
             frame: nil,
             display: nil,
@@ -2056,8 +2039,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     func testRestoringLocalWorkspaceSnapshotClearsStaleRemoteState() throws {
         let localSnapshot = try XCTUnwrap(TabManager().selectedWorkspace)
             .sessionSnapshot(includeScrollback: false)
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let workspace = try makeWorkspace()
         let configuration = WorkspaceRemoteConfiguration(
             destination: "cmux-macmini",
             port: nil,
@@ -3310,8 +3292,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertTrue(terminalStartupCommand.contains("--id 71smiccrg35sw9pydt8k"), terminalStartupCommand)
         XCTAssertFalse(terminalStartupCommand.contains("ssh -p 22"), terminalStartupCommand)
 
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         workspace.setCustomTitle("sshd")
         workspace.configureRemoteConnection(configuration, autoConnect: false)
         let snapshot = manager.sessionSnapshot(includeScrollback: false)
@@ -3494,8 +3475,7 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
     /// title until a command ran. `applySessionPanelMetadata` wrote the restored title
     /// into `panelTitles` but never pushed it to the bonsplit tab header.
     func testRestoredTerminalPaneHeaderTitleSyncsToBonsplitTab() throws {
-        let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let (manager, workspace) = try makeManagerAndWorkspace()
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         let panelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
 

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -62,6 +62,22 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertEqual(restored.tabs[1].customTitle, "Second")
     }
 
+    func testSessionSnapshotLayoutPreservesPanelIdsFromBonsplitTabs() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        let firstPanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let secondPanelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+
+        guard case .pane(let paneSnapshot) = snapshot.layout else {
+            return XCTFail("Expected single-pane session layout")
+        }
+        XCTAssertEqual(Set(paneSnapshot.panelIds), Set([firstPanelId, secondPanelId]))
+        XCTAssertEqual(paneSnapshot.selectedPanelId, secondPanelId)
+    }
+
     func testFocusHistoryNavigatesWithinWorkspacePanels() throws {
         let manager = TabManager()
         let workspace = try XCTUnwrap(manager.selectedWorkspace)


### PR DESCRIPTION
Fixes the third-largest unresolved app-hang group in Sentry: [CMUXTERM-MACOS-KS](https://manaflow.sentry.io/issues/7291444348/) (App Hanging ≥ 8000 ms, 2709 events / 464 users, still occurring in v0.64.17 and the latest nightlies).

The autosave tick (`AppDelegate.finishSessionAutosaveTick` → `TabManager.sessionSnapshot` → `Workspace.sessionLayoutSnapshot`) resolved each external tab ID by JSON-encoding and decoding every `TabID` in `surfaceIdToPanelId` inside a linear scan, per tab, per pane, recursively over the layout tree, on the main actor. That is O(tabs × surfaces) `JSONEncoder`/`JSONDecoder` round trips per autosave; users with large sessions hang for seconds.

`TabID` already exposes `public var uuid` and `public init(uuid:)`, and it hashes over that same UUID, so `sessionPanelID(forExternalTabIDString:)` is now one dictionary lookup and `sessionSurfaceUUID(for:)` is deleted. Mapping results are byte-identical to the old path, so this is a pure perf fix; the new test in `TabManagerSessionSnapshotTests` pins the tabID→panelID mapping through `sessionSnapshot` (a red/green two-commit structure does not apply since the old code returned the same values, just slowly).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only path change with equivalent mapping semantics; risk is low unless `TabID(uuid:)` hashing diverges from the old JSON-derived UUID matching (tests lock layout behavior).
> 
> **Overview**
> Fixes **main-thread hangs during session autosave** by changing how external bonsplit tab IDs are turned into panel IDs when building the session layout snapshot.
> 
> **`sessionPanelID(forExternalTabIDString:)`** no longer walks `surfaceIdToPanelId` with a per-entry JSON encode/decode to extract a UUID. It parses the tab string once and does a single **`surfaceIdToPanelId[TabID(uuid:)]`** lookup. **`sessionSurfaceUUID(for:)`** is removed.
> 
> **Tests:** New coverage asserts multi-tab panes keep the right **`panelIds`** and **`selectedPanelId`** in **`sessionSnapshot`**. Many session snapshot tests now use **`makeManagerAndWorkspace` / `makeWorkspace`** with **`retainedManagers`** so **`TabManager`** instances stay alive for the test run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d1e0e1156ea2c2ac4ab5b1570148fe0b554226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786154698&installation_id=133855650&pr_number=7679&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7679&signature=6127a039a8dbd406e9a9150d7f8b178685b275ca67effaf861e274ecf60dbdb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a main-thread hang during session autosave by replacing a per-tab JSON scan with an O(1) tabID→panelID lookup. Large sessions no longer stall; behavior is unchanged.

- **Bug Fixes**
  - `Workspace.sessionPanelID(forExternalTabIDString:)` now uses a single dictionary lookup via `TabID(uuid:)`.
  - Removed `sessionSurfaceUUID(for:)` and the JSON encode/decode scan.
  - Added a test to pin panel ID preservation and selection in `sessionSnapshot`.

- **Refactors**
  - Deduped `TabManager`/`Workspace` test setup with `makeManagerAndWorkspace()` helpers and retained managers to preserve lifetimes, keeping the test file within the workflow guard.

<sup>Written for commit 65d1e0e1156ea2c2ac4ab5b1570148fe0b554226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restore by resolving external tabs to the correct panel more reliably.
  * Preserved panel IDs in workspace snapshots for split-pane layouts, including the selected panel.
* **Tests**
  * Added coverage to verify pane contents and selected panel ID remain consistent after saving and restoring a session snapshot, including nested split-pane behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->