### PR TITLE
[CI red proof — do not merge] iOS free-drain regression test without the fix

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Package.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Package.swift
@@ -39,5 +39,12 @@ let package = Package(
                 .swiftLanguageMode(.v6),
             ]
         ),
+        .testTarget(
+            name: "CmuxMobileTerminalTests",
+            dependencies: ["CmuxMobileTerminal"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
     ]
 )

--- a/Packages/iOS/CmuxMobileTerminal/Package.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Package.swift
@@ -44,6 +44,11 @@ let package = Package(
             dependencies: ["CmuxMobileTerminal"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
+            ],
+            // GhosttyKit's static lib carries C++ objects (glslang); the
+            // standalone xctest bundle must link the C++ runtime itself.
+            linkerSettings: [
+                .linkedLibrary("c++"),
             ]
         ),
     ]

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RecoveryStress.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RecoveryStress.swift
@@ -1,0 +1,36 @@
+#if canImport(UIKit)
+#if DEBUG
+import UIKit
+
+/// DEBUG hooks for the recovery stress harness and the free-drain regression
+/// test. Kept out of GhosttySurfaceView.swift so the debug surface does not
+/// grow the main file; everything here drives the production recovery path.
+extension GhosttySurfaceView {
+    struct RecoveryStressSnapshot: Equatable, Sendable {
+        let generation: UInt64
+        let pendingSurfaceFreeCount: Int
+        let hasSurface: Bool
+        let recoveryPaused: Bool
+    }
+
+    func recoveryStressSnapshot() -> RecoveryStressSnapshot {
+        RecoveryStressSnapshot(
+            generation: surfaceGeneration,
+            pendingSurfaceFreeCount: pendingSurfaceFreeCount,
+            hasSurface: surface != nil,
+            recoveryPaused: renderPipelineRecoveryPaused
+        )
+    }
+
+    @discardableResult
+    func forceRecoveryForStress() -> RecoveryStressSnapshot {
+        _ = recoverRenderPipeline(
+            reason: "recovery_stress",
+            stalledMs: 0,
+            replay: .delegateWhenNoCaller
+        )
+        return recoveryStressSnapshot()
+    }
+}
+#endif
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+TestingHooks.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+TestingHooks.swift
@@ -1,0 +1,19 @@
+#if canImport(UIKit)
+import GhosttyKit
+import UIKit
+
+/// Test-only observation hooks (reached via `@testable import`); kept out of
+/// GhosttySurfaceView.swift so test plumbing does not grow the main file.
+extension GhosttySurfaceView {
+    func renderedHTMLForTesting(pointTag: ghostty_point_tag_e = GHOSTTY_POINT_VIEWPORT) -> String? {
+        _ = pointTag
+        // ghostty_surface_read_text_html not available in this build
+        return nil
+    }
+
+    func processExitedForTesting() -> Bool {
+        guard let surface else { return false }
+        return ghostty_surface_process_exited(surface)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -136,11 +136,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// the same FIFO-before-dispose ordering discipline.
     var outputQueue = GhosttySurfaceWorkQueue(generation: 0)
     private var outputQueueGeneration: UInt64 = 0
-    private var pendingSurfaceFreeCount = 0
+    private(set) var pendingSurfaceFreeCount = 0
     #if DEBUG
     var recoveryStressFreeDrainObserver: (@MainActor @Sendable (RecoveryStressSnapshot) -> Void)?
     #endif
-    private var renderPipelineRecoveryPaused = false
+    private(set) var renderPipelineRecoveryPaused = false
     private var lastRecoveryPausedDropLogTime: CFTimeInterval = 0
     private static let renderPipelineStallDeadline: CFTimeInterval = 2.0
     private static let outputApplyTimeout: CFTimeInterval = 2.0
@@ -307,7 +307,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }()
 
     private(set) var surface: ghostty_surface_t?
-    private var surfaceGeneration: UInt64 = 0
+    private(set) var surfaceGeneration: UInt64 = 0
     private var lastReportedSize: TerminalGridSize?
     /// Latest natural grid awaiting a debounced report to the Mac. The display
     /// link sends it only after the grid has held steady for
@@ -366,13 +366,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var keyboardHeightAnimationID = 0
 
     #if DEBUG
-    struct RecoveryStressSnapshot: Equatable, Sendable {
-        let generation: UInt64
-        let pendingSurfaceFreeCount: Int
-        let hasSurface: Bool
-        let recoveryPaused: Bool
-    }
-
     struct DebugGeometrySnapshot {
         let boundsSize: CGSize
         let renderRect: CGRect
@@ -423,29 +416,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             liveFontSize: liveFontSize,
             baseFontSize: userBaseFontSize
         )
-    }
-
-    func recoveryStressSnapshot() -> RecoveryStressSnapshot {
-        RecoveryStressSnapshot(
-            generation: surfaceGeneration,
-            pendingSurfaceFreeCount: pendingSurfaceFreeCount,
-            hasSurface: surface != nil,
-            recoveryPaused: renderPipelineRecoveryPaused
-        )
-    }
-
-    @discardableResult
-    func forceRecoveryForStress() -> RecoveryStressSnapshot {
-        _ = recoverRenderPipeline(
-            reason: "recovery_stress",
-            stalledMs: 0,
-            replay: .delegateWhenNoCaller
-        )
-        return recoveryStressSnapshot()
-    }
-
-    func setFocusForRecoveryStress(_ focused: Bool) {
-        setFocus(focused)
     }
 
     func setKeyboardHeightForTesting(_ height: CGFloat) {
@@ -2386,21 +2356,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
-    func renderedHTMLForTesting(pointTag: ghostty_point_tag_e = GHOSTTY_POINT_VIEWPORT) -> String? {
-        _ = pointTag
-        // ghostty_surface_read_text_html not available in this build
-        return nil
-    }
-
-    func processExitedForTesting() -> Bool {
-        guard let surface else { return false }
-        return ghostty_surface_process_exited(surface)
-    }
-
     func disposeSurface() {
         stopDisplayLink()
         guard let surface else { return }
-        let generation = surfaceGeneration
         GhosttySurfaceView.unregister(surface: surface)
         self.surface = nil
         let currentBridge = bridge
@@ -2416,7 +2374,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // work from being enqueued once `surface` is nil, so only the bounded
         // backlog drains before the free. (Retain the bridge across the hop; it
         // owns the userdata libghostty still references until the free.)
-        enqueueSurfaceFree(surface, bridge: currentBridge, generation: generation, on: currentQueue)
+        enqueueSurfaceFree(surface, bridge: currentBridge, generation: surfaceGeneration, on: currentQueue)
     }
 
     private func enqueueSurfaceFree(
@@ -2427,15 +2385,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         completion: (@MainActor @Sendable () -> Void)? = nil
     ) {
         let retainedBridge = Unmanaged.passRetained(bridge)
-        surfaceFreeDrainWatchdog.start(
-            generation: generation,
-            pendingFrees: { [weak self] in self?.pendingSurfaceFreeCount ?? 0 },
-            onStuck: { generation, pendingFrees in
-                let message = "surface.free.STUCK generation=\(generation) pendingFrees=\(pendingFrees)"
-                MobileDebugLog.anchormux(message)
-                log.fault("surface.free.STUCK generation=\(generation, privacy: .public) pendingFrees=\(pendingFrees, privacy: .public)")
-            }
-        )
+        surfaceFreeDrainWatchdog.start(generation: generation) { [weak self] in self?.pendingSurfaceFreeCount ?? 0 }
         // weak: a wedged free must not keep the whole view alive with it.
         queue.async { [weak self] in
             ghostty_surface_free(surface)
@@ -2491,7 +2441,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     @discardableResult
-    private func recoverRenderPipeline(
+    func recoverRenderPipeline(
         reason: String,
         stalledMs: Int,
         replay: RenderPipelineRecoveryReplay
@@ -2517,10 +2467,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let oldQueue = outputQueue
         oldBridge.detach()
         if let oldSurface {
-            let oldGeneration = surfaceGeneration
             GhosttySurfaceView.unregister(surface: oldSurface)
             pendingSurfaceFreeCount += 1
-            enqueueSurfaceFree(oldSurface, bridge: oldBridge, generation: oldGeneration, on: oldQueue) { [weak self] in
+            enqueueSurfaceFree(oldSurface, bridge: oldBridge, generation: surfaceGeneration, on: oldQueue) { [weak self] in
                 guard let self else { return }
                 self.pendingSurfaceFreeCount = max(0, self.pendingSurfaceFreeCount - 1)
                 MobileDebugLog.anchormux(
@@ -2990,7 +2939,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
-    private func setFocus(_ focused: Bool) {
+    func setFocus(_ focused: Bool) {
         guard let surface else { return }
         ghostty_surface_set_focus(surface, focused)
     }
@@ -3920,7 +3869,7 @@ extension GhosttySurfaceView: UIScrollViewDelegate {
     }
 }
 
-nonisolated private enum RenderPipelineRecoveryReplay {
+nonisolated enum RenderPipelineRecoveryReplay {
     case callerWillRequestReplay
     case delegateWhenNoCaller
 }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -94,6 +94,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var renderInFlight: Bool = false
     private var renderInFlightSince: CFTimeInterval?
     private var needsAnotherRender: Bool = false
+    private let surfaceFreeDrainWatchdog = SurfaceFreeDrainWatchdog()
     /// True while the app is inactive/backgrounded. On iOS `render_now`
     /// produces a frame synchronously on `outputQueue` and acquires a
     /// swap-chain frame slot from libghostty; if the app is backgrounded while
@@ -136,6 +137,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     var outputQueue = GhosttySurfaceWorkQueue(generation: 0)
     private var outputQueueGeneration: UInt64 = 0
     private var pendingSurfaceFreeCount = 0
+    #if DEBUG
+    var recoveryStressFreeDrainObserver: (@MainActor @Sendable (RecoveryStressSnapshot) -> Void)?
+    #endif
     private var renderPipelineRecoveryPaused = false
     private var lastRecoveryPausedDropLogTime: CFTimeInterval = 0
     private static let renderPipelineStallDeadline: CFTimeInterval = 2.0
@@ -362,6 +366,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var keyboardHeightAnimationID = 0
 
     #if DEBUG
+    struct RecoveryStressSnapshot: Equatable, Sendable {
+        let generation: UInt64
+        let pendingSurfaceFreeCount: Int
+        let hasSurface: Bool
+        let recoveryPaused: Bool
+    }
+
     struct DebugGeometrySnapshot {
         let boundsSize: CGSize
         let renderRect: CGRect
@@ -412,6 +423,29 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             liveFontSize: liveFontSize,
             baseFontSize: userBaseFontSize
         )
+    }
+
+    func recoveryStressSnapshot() -> RecoveryStressSnapshot {
+        RecoveryStressSnapshot(
+            generation: surfaceGeneration,
+            pendingSurfaceFreeCount: pendingSurfaceFreeCount,
+            hasSurface: surface != nil,
+            recoveryPaused: renderPipelineRecoveryPaused
+        )
+    }
+
+    @discardableResult
+    func forceRecoveryForStress() -> RecoveryStressSnapshot {
+        _ = recoverRenderPipeline(
+            reason: "recovery_stress",
+            stalledMs: 0,
+            replay: .delegateWhenNoCaller
+        )
+        return recoveryStressSnapshot()
+    }
+
+    func setFocusForRecoveryStress(_ focused: Bool) {
+        setFocus(focused)
     }
 
     func setKeyboardHeightForTesting(_ height: CGFloat) {
@@ -2366,6 +2400,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     func disposeSurface() {
         stopDisplayLink()
         guard let surface else { return }
+        let generation = surfaceGeneration
         GhosttySurfaceView.unregister(surface: surface)
         self.surface = nil
         let currentBridge = bridge
@@ -2381,21 +2416,33 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // work from being enqueued once `surface` is nil, so only the bounded
         // backlog drains before the free. (Retain the bridge across the hop; it
         // owns the userdata libghostty still references until the free.)
-        enqueueSurfaceFree(surface, bridge: currentBridge, on: currentQueue)
+        enqueueSurfaceFree(surface, bridge: currentBridge, generation: generation, on: currentQueue)
     }
 
     private func enqueueSurfaceFree(
         _ surface: ghostty_surface_t,
         bridge: GhosttySurfaceBridge,
+        generation: UInt64,
         on queue: GhosttySurfaceWorkQueue,
         completion: (@MainActor @Sendable () -> Void)? = nil
     ) {
         let retainedBridge = Unmanaged.passRetained(bridge)
-        queue.async {
+        surfaceFreeDrainWatchdog.start(
+            generation: generation,
+            pendingFrees: { [weak self] in self?.pendingSurfaceFreeCount ?? 0 },
+            onStuck: { generation, pendingFrees in
+                let message = "surface.free.STUCK generation=\(generation) pendingFrees=\(pendingFrees)"
+                MobileDebugLog.anchormux(message)
+                log.fault("surface.free.STUCK generation=\(generation, privacy: .public) pendingFrees=\(pendingFrees, privacy: .public)")
+            }
+        )
+        // weak: a wedged free must not keep the whole view alive with it.
+        queue.async { [weak self] in
             ghostty_surface_free(surface)
             retainedBridge.release()
-            if let completion {
-                Task { @MainActor in completion() }
+            Task { @MainActor in
+                self?.surfaceFreeDrainWatchdog.cancel(generation: generation)
+                completion?()
             }
         }
     }
@@ -2470,15 +2517,19 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let oldQueue = outputQueue
         oldBridge.detach()
         if let oldSurface {
+            let oldGeneration = surfaceGeneration
             GhosttySurfaceView.unregister(surface: oldSurface)
             pendingSurfaceFreeCount += 1
-            enqueueSurfaceFree(oldSurface, bridge: oldBridge, on: oldQueue) { [weak self] in
+            enqueueSurfaceFree(oldSurface, bridge: oldBridge, generation: oldGeneration, on: oldQueue) { [weak self] in
                 guard let self else { return }
                 self.pendingSurfaceFreeCount = max(0, self.pendingSurfaceFreeCount - 1)
                 MobileDebugLog.anchormux(
                     "render.recover.free_drained pendingFrees=\(self.pendingSurfaceFreeCount)"
                 )
                 self.resumePausedRenderPipelineRecoveryIfPossible()
+                #if DEBUG
+                self.recoveryStressFreeDrainObserver?(self.recoveryStressSnapshot())
+                #endif
             }
         }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressConfiguration.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressConfiguration.swift
@@ -1,0 +1,31 @@
+#if DEBUG
+import Foundation
+
+/// Launch-time configuration for the iOS render-recovery stress harness.
+public struct MobileRecoveryStressConfiguration: Equatable, Sendable {
+    /// The cycle count used when the launch argument omits or cannot parse a value.
+    public static let defaultCycles = 200
+
+    /// Number of forced render-pipeline recovery cycles to run.
+    public let cycles: Int
+
+    /// Creates a configuration with a positive cycle count.
+    public init(cycles: Int = Self.defaultCycles) {
+        self.cycles = max(1, cycles)
+    }
+
+    /// Parses `--cmux-recovery-stress <N>` from process launch arguments.
+    public static func parse(arguments: [String]) -> Self? {
+        guard let flagIndex = arguments.firstIndex(of: "--cmux-recovery-stress") else {
+            return nil
+        }
+        let valueIndex = arguments.index(after: flagIndex)
+        guard valueIndex < arguments.endIndex,
+              let parsed = Int(arguments[valueIndex]),
+              parsed > 0 else {
+            return Self()
+        }
+        return Self(cycles: parsed)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressCoordinator.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressCoordinator.swift
@@ -1,0 +1,219 @@
+#if canImport(UIKit) && DEBUG
+import CMUXMobileCore
+import CmuxMobileTerminalKit
+import Foundation
+import UIKit
+
+@MainActor
+final class MobileRecoveryStressCoordinator: NSObject, GhosttySurfaceViewDelegate {
+    weak var surfaceView: GhosttySurfaceView?
+    private let configuration: MobileRecoveryStressConfiguration
+    private let clock: ContinuousClock
+    private let monitor: MobileRecoveryStressMonitor
+    private let reporter: MobileRecoveryStressReporter
+    private var scenarioTask: Task<Void, Never>?
+    private var heartbeatTask: Task<Void, Never>?
+    private var watchdogTask: Task<Void, Never>?
+
+    init(
+        configuration: MobileRecoveryStressConfiguration,
+        clock: ContinuousClock = ContinuousClock(),
+        reporter: MobileRecoveryStressReporter = MobileRecoveryStressReporter()
+    ) {
+        self.configuration = configuration
+        self.clock = clock
+        self.reporter = reporter
+        self.monitor = MobileRecoveryStressMonitor(start: clock.now, reporter: reporter)
+        super.init()
+    }
+
+    deinit {
+        scenarioTask?.cancel()
+        heartbeatTask?.cancel()
+        watchdogTask?.cancel()
+    }
+
+    func start() {
+        guard scenarioTask == nil else { return }
+        surfaceView?.recoveryStressFreeDrainObserver = { [weak self] snapshot in
+            guard let self else { return }
+            let monitor = self.monitor
+            let clock = self.clock
+            Task {
+                await monitor.recordFreeDrain(
+                    pendingFrees: snapshot.pendingSurfaceFreeCount,
+                    now: clock.now
+                )
+            }
+        }
+        heartbeatTask = Task { @MainActor [weak self] in
+            await self?.runHeartbeat()
+        }
+        watchdogTask = Task.detached(priority: .background) { [monitor, clock] in
+            await MobileRecoveryStressCoordinator.runWatchdog(monitor: monitor, clock: clock)
+        }
+        scenarioTask = Task { @MainActor [weak self] in
+            await self?.runScenario()
+        }
+    }
+
+    func stop() {
+        surfaceView?.recoveryStressFreeDrainObserver = nil
+        scenarioTask?.cancel()
+        heartbeatTask?.cancel()
+        watchdogTask?.cancel()
+        scenarioTask = nil
+        heartbeatTask = nil
+        watchdogTask = nil
+    }
+
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {}
+
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize, reportID: UInt64) {
+        guard size.columns > 0, size.rows > 0 else { return }
+        surfaceView.applyViewSize(cols: max(1, size.columns - 1), rows: max(1, size.rows - 1))
+    }
+
+    private func runHeartbeat() async {
+        while !Task.isCancelled {
+            await monitor.recordHeartbeat(now: clock.now)
+            do {
+                // Bounded DEBUG liveness cadence; cancellation is tied to harness teardown.
+                try await clock.sleep(for: .milliseconds(100))
+            } catch {
+                return
+            }
+        }
+    }
+
+    nonisolated private static func runWatchdog(
+        monitor: MobileRecoveryStressMonitor,
+        clock: ContinuousClock
+    ) async {
+        while !Task.isCancelled {
+            do {
+                // Bounded DEBUG watchdog cadence; cancellation is tied to harness teardown.
+                try await clock.sleep(for: .milliseconds(200))
+            } catch {
+                return
+            }
+            if await monitor.emitStallIfNeeded(now: clock.now) {
+                return
+            }
+        }
+    }
+
+    private func runScenario() async {
+        reporter.emit("recovery.stress.START cycles=\(configuration.cycles)")
+        guard let view = surfaceView else { return }
+        guard await waitForMountedSurface(view) else {
+            reporter.emit("recovery.stress.DEADLOCK kind=mount elapsedMs=5000 pendingFrees=0")
+            return
+        }
+
+        for cycle in 1...configuration.cycles {
+            if Task.isCancelled {
+                return
+            }
+            if await monitor.stalled() {
+                return
+            }
+
+            let before = view.recoveryStressSnapshot()
+            await monitor.beginCycle(
+                cycle,
+                generation: before.generation,
+                pendingFreesBefore: before.pendingSurfaceFreeCount,
+                now: clock.now
+            )
+
+            view.processOutput(Self.syntheticOutput(cycle: cycle))
+            driveViewportChurn(on: view, cycle: cycle)
+
+            let after = view.forceRecoveryForStress()
+            await monitor.recordRecoveryResult(pendingFreesAfter: after.pendingSurfaceFreeCount)
+            driveViewportChurn(on: view, cycle: cycle + configuration.cycles)
+            reporter.emit(
+                "recovery.stress.cycle cycle=\(cycle) generation=\(before.generation) pendingBefore=\(before.pendingSurfaceFreeCount) pendingAfter=\(after.pendingSurfaceFreeCount)"
+            )
+
+            guard await waitForActiveCycleToDrain(cycle: cycle) else {
+                return
+            }
+        }
+
+        reporter.emit("recovery.stress.PASS cycles=\(configuration.cycles)")
+    }
+
+    private func waitForMountedSurface(_ view: GhosttySurfaceView) async -> Bool {
+        let deadline = clock.now + .seconds(5)
+        while clock.now < deadline {
+            if Task.isCancelled { return false }
+            if view.window != nil && view.bounds.width > 100 && view.bounds.height > 100 && view.surface != nil {
+                return true
+            }
+            do {
+                // Bounded mount deadline; cancellation is tied to harness teardown.
+                try await clock.sleep(for: .milliseconds(20))
+            } catch {
+                return false
+            }
+        }
+        return view.window != nil && view.bounds.width > 100 && view.bounds.height > 100 && view.surface != nil
+    }
+
+    private func waitForActiveCycleToDrain(cycle: Int) async -> Bool {
+        while !Task.isCancelled {
+            if await monitor.activeCycleDrained() {
+                if let record = await monitor.activeCycleRecord() {
+                    reporter.emit(
+                        "recovery.stress.drain cycle=\(cycle) generation=\(record.generation) drained=\(record.freeDrained) pendingAfter=\(record.pendingFreesAfter ?? -1)"
+                    )
+                }
+                return true
+            }
+            if await monitor.emitStallIfNeeded(now: clock.now) {
+                return false
+            }
+            do {
+                // Bounded free-drain deadline; cancellation is tied to harness teardown.
+                try await clock.sleep(for: .milliseconds(20))
+            } catch {
+                return false
+            }
+        }
+        return false
+    }
+
+    private func driveViewportChurn(on view: GhosttySurfaceView, cycle: Int) {
+        let width = CGFloat(360 + (cycle % 6) * 9)
+        let height = CGFloat(620 + (cycle % 5) * 13)
+        view.bounds = CGRect(origin: .zero, size: CGSize(width: width, height: height))
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+
+        let grid = view.currentGridSize
+        let cols = max(20, grid.columns - ((cycle % 4) + 1))
+        let rows = max(8, grid.rows - ((cycle % 3) + 1))
+        view.applyViewSize(cols: cols, rows: rows)
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+    }
+
+    private static func syntheticOutput(cycle: Int) -> Data {
+        var text = "\u{1b}[?2004h\u{1b}]133;A\u{07}\u{1b}]0;recovery stress \(cycle)\u{07}"
+        for line in 0..<96 {
+            text += "\u{1b}[38;5;\((line + cycle) % 216)m"
+            text += "recovery-stress cycle=\(cycle) line=\(line) "
+            text += "abcdefghijklmnopqrstuvwxyz 0123456789 wrapping payload "
+            text += "\u{1b}[0m\r\n"
+            if line % 8 == 0 {
+                text += "\u{1b}]7;file://stress/recovery/\(cycle)/\(line)\u{07}"
+                text += "\u{1b}[2K\r"
+            }
+        }
+        text += "\u{1b}]133;B\u{07}\u{1b}[?2004l\r\n"
+        return Data(text.utf8)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressCycleRecord.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressCycleRecord.swift
@@ -1,0 +1,14 @@
+#if DEBUG
+import Foundation
+
+/// Per-cycle accounting captured by the recovery stress monitor.
+struct MobileRecoveryStressCycleRecord: Equatable, Sendable {
+    let cycle: Int
+    let generation: UInt64
+    let pendingFreesBefore: Int
+    let startedMilliseconds: Int64
+    var pendingFreesAfter: Int?
+    var freeDrained: Bool
+    var drainedMilliseconds: Int64?
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressMonitor.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressMonitor.swift
@@ -1,0 +1,79 @@
+#if DEBUG
+import Foundation
+
+/// Background-readable monitor for main-thread heartbeat and free-drain progress.
+actor MobileRecoveryStressMonitor {
+    private let start: ContinuousClock.Instant
+    private let reporter: MobileRecoveryStressReporter
+    private var state: MobileRecoveryStressMonitorState
+    private var stallEmitted = false
+
+    init(
+        start: ContinuousClock.Instant,
+        reporter: MobileRecoveryStressReporter = MobileRecoveryStressReporter(),
+        state: MobileRecoveryStressMonitorState = MobileRecoveryStressMonitorState()
+    ) {
+        self.start = start
+        self.reporter = reporter
+        self.state = state
+    }
+
+    func recordHeartbeat(now: ContinuousClock.Instant) {
+        state.recordHeartbeat(atMilliseconds: milliseconds(at: now))
+    }
+
+    func beginCycle(
+        _ cycle: Int,
+        generation: UInt64,
+        pendingFreesBefore: Int,
+        now: ContinuousClock.Instant
+    ) {
+        state.beginCycle(
+            cycle,
+            generation: generation,
+            pendingFreesBefore: pendingFreesBefore,
+            atMilliseconds: milliseconds(at: now)
+        )
+    }
+
+    func recordRecoveryResult(pendingFreesAfter: Int) {
+        state.recordRecoveryResult(pendingFreesAfter: pendingFreesAfter)
+    }
+
+    func recordFreeDrain(pendingFrees: Int, now: ContinuousClock.Instant) {
+        state.recordFreeDrain(pendingFrees: pendingFrees, atMilliseconds: milliseconds(at: now))
+    }
+
+    func activeCycleDrained() -> Bool {
+        state.activeCycleDrained
+    }
+
+    func activeCycleRecord() -> MobileRecoveryStressCycleRecord? {
+        state.activeCycle
+    }
+
+    func stalled() -> Bool {
+        state.stalled != nil
+    }
+
+    @discardableResult
+    func emitStallIfNeeded(now: ContinuousClock.Instant) -> Bool {
+        guard let stall = state.evaluate(atMilliseconds: milliseconds(at: now)) else {
+            return false
+        }
+        if !stallEmitted {
+            stallEmitted = true
+            reporter.emit(stall.marker)
+        }
+        return true
+    }
+
+    private func milliseconds(at instant: ContinuousClock.Instant) -> Int64 {
+        let duration = start.duration(to: instant)
+        let components = duration.components
+        let seconds = components.seconds * 1_000
+        let attoseconds = components.attoseconds / 1_000_000_000_000_000
+        return seconds + Int64(attoseconds)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressMonitorState.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressMonitorState.swift
@@ -1,0 +1,102 @@
+#if DEBUG
+import Foundation
+
+/// Pure state machine for heartbeat and recovery-free drain deadlines.
+struct MobileRecoveryStressMonitorState: Equatable, Sendable {
+    let heartbeatTimeoutMilliseconds: Int64
+    let freeDrainDeadlineMilliseconds: Int64
+    private(set) var lastHeartbeatMilliseconds: Int64
+    private(set) var activeCycle: MobileRecoveryStressCycleRecord?
+    private(set) var stalled: MobileRecoveryStressStall?
+
+    init(
+        startMilliseconds: Int64 = 0,
+        heartbeatTimeoutMilliseconds: Int64 = 2_000,
+        freeDrainDeadlineMilliseconds: Int64 = 10_000
+    ) {
+        self.heartbeatTimeoutMilliseconds = heartbeatTimeoutMilliseconds
+        self.freeDrainDeadlineMilliseconds = freeDrainDeadlineMilliseconds
+        self.lastHeartbeatMilliseconds = startMilliseconds
+    }
+
+    mutating func recordHeartbeat(atMilliseconds now: Int64) {
+        lastHeartbeatMilliseconds = now
+    }
+
+    mutating func beginCycle(
+        _ cycle: Int,
+        generation: UInt64,
+        pendingFreesBefore: Int,
+        atMilliseconds now: Int64
+    ) {
+        activeCycle = MobileRecoveryStressCycleRecord(
+            cycle: cycle,
+            generation: generation,
+            pendingFreesBefore: pendingFreesBefore,
+            startedMilliseconds: now,
+            pendingFreesAfter: nil,
+            freeDrained: false,
+            drainedMilliseconds: nil
+        )
+    }
+
+    mutating func recordRecoveryResult(pendingFreesAfter: Int) {
+        activeCycle?.pendingFreesAfter = pendingFreesAfter
+        if pendingFreesAfter == 0 {
+            activeCycle?.freeDrained = true
+        }
+    }
+
+    mutating func recordFreeDrain(pendingFrees: Int, atMilliseconds now: Int64) {
+        guard activeCycle != nil else { return }
+        activeCycle?.pendingFreesAfter = pendingFrees
+        if pendingFrees == 0 {
+            activeCycle?.freeDrained = true
+            activeCycle?.drainedMilliseconds = now
+        }
+    }
+
+    var activeCycleDrained: Bool {
+        activeCycle?.freeDrained == true
+    }
+
+    mutating func evaluate(atMilliseconds now: Int64) -> MobileRecoveryStressStall? {
+        if let stalled {
+            return stalled
+        }
+
+        let heartbeatElapsed = max(0, now - lastHeartbeatMilliseconds)
+        if heartbeatElapsed >= heartbeatTimeoutMilliseconds {
+            let stall = MobileRecoveryStressStall(
+                kind: .heartbeat,
+                cycle: activeCycle?.cycle,
+                generation: activeCycle?.generation,
+                pendingFrees: activeCycle?.pendingFreesAfter ?? activeCycle?.pendingFreesBefore ?? 0,
+                elapsedMilliseconds: heartbeatElapsed
+            )
+            stalled = stall
+            return stall
+        }
+
+        guard let cycle = activeCycle,
+              cycle.freeDrained == false,
+              let pendingFreesAfter = cycle.pendingFreesAfter,
+              pendingFreesAfter > 0 else {
+            return nil
+        }
+        let freeElapsed = max(0, now - cycle.startedMilliseconds)
+        if freeElapsed >= freeDrainDeadlineMilliseconds {
+            let stall = MobileRecoveryStressStall(
+                kind: .freeDrain,
+                cycle: cycle.cycle,
+                generation: cycle.generation,
+                pendingFrees: pendingFreesAfter,
+                elapsedMilliseconds: freeElapsed
+            )
+            stalled = stall
+            return stall
+        }
+        return nil
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressReporter.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressReporter.swift
@@ -1,0 +1,14 @@
+#if DEBUG
+import CmuxMobileDiagnostics
+import Foundation
+
+/// Emits recovery stress markers to both the debug log and stdout.
+struct MobileRecoveryStressReporter: Sendable {
+    func emit(_ message: String) {
+        MobileDebugLog.anchormux(message)
+        if let data = "\(message)\n".data(using: .utf8) {
+            FileHandle.standardOutput.write(data)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressRepresentable.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressRepresentable.swift
@@ -1,0 +1,31 @@
+#if canImport(UIKit) && DEBUG
+import SwiftUI
+import UIKit
+
+struct MobileRecoveryStressRepresentable: UIViewRepresentable {
+    let configuration: MobileRecoveryStressConfiguration
+
+    func makeCoordinator() -> MobileRecoveryStressCoordinator {
+        MobileRecoveryStressCoordinator(configuration: configuration)
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        guard let runtime = try? GhosttyRuntime.shared() else {
+            let label = UILabel()
+            label.text = "RecoveryStress: runtime init failed"
+            label.textColor = .white
+            return label
+        }
+        let view = GhosttySurfaceView(runtime: runtime, delegate: context.coordinator, fontSize: 10)
+        context.coordinator.surfaceView = view
+        context.coordinator.start()
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+
+    static func dismantleUIView(_ uiView: UIView, coordinator: MobileRecoveryStressCoordinator) {
+        coordinator.stop()
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressStall.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressStall.swift
@@ -1,0 +1,33 @@
+#if DEBUG
+import Foundation
+
+/// Terminal condition detected by the recovery stress monitor.
+struct MobileRecoveryStressStall: Equatable, Sendable {
+    enum Kind: String, Equatable, Sendable {
+        case heartbeat
+        case freeDrain = "free_drain"
+    }
+
+    let kind: Kind
+    let cycle: Int?
+    let generation: UInt64?
+    let pendingFrees: Int
+    let elapsedMilliseconds: Int64
+
+    var marker: String {
+        var fields = [
+            "recovery.stress.DEADLOCK",
+            "kind=\(kind.rawValue)",
+            "elapsedMs=\(elapsedMilliseconds)",
+            "pendingFrees=\(pendingFrees)",
+        ]
+        if let cycle {
+            fields.append("cycle=\(cycle)")
+        }
+        if let generation {
+            fields.append("generation=\(generation)")
+        }
+        return fields.joined(separator: " ")
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileRecoveryStressView.swift
@@ -1,0 +1,20 @@
+#if canImport(UIKit) && DEBUG
+import SwiftUI
+
+/// DEBUG repro harness for repeated render-pipeline recovery teardown.
+public struct MobileRecoveryStressView: View {
+    private let configuration: MobileRecoveryStressConfiguration
+
+    /// Creates the recovery stress harness view.
+    public init(configuration: MobileRecoveryStressConfiguration = MobileRecoveryStressConfiguration()) {
+        self.configuration = configuration
+    }
+
+    /// The mounted recovery stress harness.
+    public var body: some View {
+        MobileRecoveryStressRepresentable(configuration: configuration)
+            .ignoresSafeArea()
+            .background(Color.black)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/SurfaceFreeDrainWatchdog.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/SurfaceFreeDrainWatchdog.swift
@@ -1,0 +1,41 @@
+#if canImport(UIKit)
+import Foundation
+
+@MainActor
+final class SurfaceFreeDrainWatchdog {
+    private let clock: ContinuousClock
+    private let deadline: Duration
+    private var tasks: [UInt64: Task<Void, Never>] = [:]
+
+    init(clock: ContinuousClock = ContinuousClock(), deadline: Duration = .seconds(10)) {
+        self.clock = clock
+        self.deadline = deadline
+    }
+
+    func start(
+        generation: UInt64,
+        pendingFrees: @MainActor @escaping @Sendable () -> Int,
+        onStuck: @MainActor @escaping @Sendable (_ generation: UInt64, _ pendingFrees: Int) -> Void
+    ) {
+        cancel(generation: generation)
+        let clock = clock
+        let deadline = deadline
+        tasks[generation] = Task { @MainActor in
+            do {
+                // Genuine free-drain deadline; cancellation is tied to the free completion.
+                try await clock.sleep(for: deadline)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            tasks[generation] = nil
+            onStuck(generation, pendingFrees())
+        }
+    }
+
+    func cancel(generation: UInt64) {
+        tasks.removeValue(forKey: generation)?.cancel()
+    }
+
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/SurfaceFreeDrainWatchdog.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/SurfaceFreeDrainWatchdog.swift
@@ -1,5 +1,9 @@
 #if canImport(UIKit)
+import CmuxMobileDiagnostics
 import Foundation
+import OSLog
+
+private let log = Logger(subsystem: "ai.manaflow.cmux.ios", category: "ghostty.surface.free")
 
 @MainActor
 final class SurfaceFreeDrainWatchdog {
@@ -15,7 +19,10 @@ final class SurfaceFreeDrainWatchdog {
     func start(
         generation: UInt64,
         pendingFrees: @MainActor @escaping @Sendable () -> Int,
-        onStuck: @MainActor @escaping @Sendable (_ generation: UInt64, _ pendingFrees: Int) -> Void
+        onStuck: @MainActor @escaping @Sendable (_ generation: UInt64, _ pendingFrees: Int) -> Void = { generation, pendingFrees in
+            MobileDebugLog.anchormux("surface.free.STUCK generation=\(generation) pendingFrees=\(pendingFrees)")
+            log.fault("surface.free.STUCK generation=\(generation, privacy: .public) pendingFrees=\(pendingFrees, privacy: .public)")
+        }
     ) {
         cancel(generation: generation)
         let clock = clock

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/MobileRecoveryStressConfigurationTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/MobileRecoveryStressConfigurationTests.swift
@@ -1,0 +1,28 @@
+#if DEBUG
+import Testing
+@testable import CmuxMobileTerminal
+
+@Suite("MobileRecoveryStressConfiguration")
+struct MobileRecoveryStressConfigurationTests {
+    @Test("missing launch argument disables harness")
+    func missingArgument() {
+        #expect(MobileRecoveryStressConfiguration.parse(arguments: ["app"]) == nil)
+    }
+
+    @Test("positive launch argument sets cycle count")
+    func positiveCycleCount() throws {
+        let config = try #require(MobileRecoveryStressConfiguration.parse(arguments: ["app", "--cmux-recovery-stress", "17"]))
+        #expect(config.cycles == 17)
+    }
+
+    @Test("missing or invalid cycle count falls back to default")
+    func invalidCycleCountUsesDefault() throws {
+        let missing = try #require(MobileRecoveryStressConfiguration.parse(arguments: ["app", "--cmux-recovery-stress"]))
+        let invalid = try #require(MobileRecoveryStressConfiguration.parse(arguments: ["app", "--cmux-recovery-stress", "nope"]))
+        let negative = try #require(MobileRecoveryStressConfiguration.parse(arguments: ["app", "--cmux-recovery-stress", "-3"]))
+        #expect(missing.cycles == MobileRecoveryStressConfiguration.defaultCycles)
+        #expect(invalid.cycles == MobileRecoveryStressConfiguration.defaultCycles)
+        #expect(negative.cycles == MobileRecoveryStressConfiguration.defaultCycles)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/MobileRecoveryStressFreeDrainTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/MobileRecoveryStressFreeDrainTests.swift
@@ -67,7 +67,7 @@ struct MobileRecoveryStressFreeDrainTests {
 
     private func pumpRecoveryTraffic(on view: GhosttySurfaceView) async throws {
         for cycle in 0..<6 {
-            view.setFocusForRecoveryStress(cycle.isMultiple(of: 2))
+            view.setFocus(cycle.isMultiple(of: 2))
             _ = await view.processOutputAndWait(Self.syntheticOutput(cycle: cycle))
             view.bounds = CGRect(
                 origin: .zero,

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/MobileRecoveryStressFreeDrainTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/MobileRecoveryStressFreeDrainTests.swift
@@ -1,0 +1,155 @@
+#if canImport(UIKit) && DEBUG
+import CMUXMobileCore
+import Foundation
+import Testing
+import UIKit
+
+@testable import CmuxMobileTerminal
+
+@MainActor
+@Suite("Mobile recovery stress free drain", .serialized)
+struct MobileRecoveryStressFreeDrainTests {
+    private final class Delegate: NSObject, GhosttySurfaceViewDelegate {
+        func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {}
+
+        func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize, reportID: UInt64) {
+            guard size.columns > 0, size.rows > 0 else { return }
+            surfaceView.applyViewSize(cols: max(1, size.columns - 1), rows: max(1, size.rows - 1))
+        }
+    }
+
+    @MainActor
+    private struct Harness {
+        let window: UIWindow
+        let view: GhosttySurfaceView
+        let delegate: Delegate
+
+        func tearDown() {
+            view.recoveryStressFreeDrainObserver = nil
+            view.prepareForDismantle()
+            view.removeFromSuperview()
+            window.isHidden = true
+        }
+    }
+
+    @Test("forced recovery drains the old surface free")
+    func forcedRecoveryDrainsOldSurfaceFree() async throws {
+        let harness = try makeHarness()
+        defer { harness.tearDown() }
+
+        try await waitForMountedSurface(harness.view)
+        try await pumpRecoveryTraffic(on: harness.view)
+
+        let drained = await waitForFreeDrain(afterForcingRecoveryOn: harness.view)
+        #expect(drained, "the old surface free should drain after forced render-pipeline recovery")
+    }
+
+    private func makeHarness() throws -> Harness {
+        let runtime = try GhosttyRuntime.shared()
+        let delegate = Delegate()
+        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
+        view.autoFocusOnWindowAttach = false
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
+        view.frame = window.bounds
+        window.addSubview(view)
+        window.isHidden = false
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        return Harness(window: window, view: view, delegate: delegate)
+    }
+
+    private func waitForMountedSurface(_ view: GhosttySurfaceView) async throws {
+        let mounted = await waitUntil(timeout: .seconds(5)) {
+            view.window != nil && view.bounds.width > 100 && view.bounds.height > 100 && view.surface != nil
+        }
+        #expect(mounted, "test surface should mount before recovery stress starts")
+    }
+
+    private func pumpRecoveryTraffic(on view: GhosttySurfaceView) async throws {
+        for cycle in 0..<6 {
+            view.setFocusForRecoveryStress(cycle.isMultiple(of: 2))
+            _ = await view.processOutputAndWait(Self.syntheticOutput(cycle: cycle))
+            view.bounds = CGRect(
+                origin: .zero,
+                size: CGSize(width: 390 + CGFloat(cycle * 2), height: 820 - CGFloat(cycle * 3))
+            )
+            view.setNeedsLayout()
+            view.layoutIfNeeded()
+        }
+    }
+
+    private func waitForFreeDrain(afterForcingRecoveryOn view: GhosttySurfaceView) async -> Bool {
+        let stream = AsyncStream<GhosttySurfaceView.RecoveryStressSnapshot> { continuation in
+            Task { @MainActor in
+                view.recoveryStressFreeDrainObserver = { snapshot in
+                    continuation.yield(snapshot)
+                }
+            }
+        }
+
+        let after = view.forceRecoveryForStress()
+        if after.pendingSurfaceFreeCount == 0 {
+            return true
+        }
+
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await snapshot in stream {
+                    if snapshot.pendingSurfaceFreeCount == 0 {
+                        return true
+                    }
+                }
+                return false
+            }
+            group.addTask {
+                let clock = ContinuousClock()
+                do {
+                    // Genuine test deadline for the teardown drain signal.
+                    try await clock.sleep(for: .seconds(15))
+                } catch {
+                    return false
+                }
+                return false
+            }
+
+            let result = await group.next() ?? false
+            group.cancelAll()
+            view.recoveryStressFreeDrainObserver = nil
+            return result
+        }
+    }
+
+    private func waitUntil(
+        timeout: Duration,
+        _ predicate: @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if predicate() { return true }
+            do {
+                // Bounded simulator test wait; cancellation comes from the test task.
+                try await clock.sleep(for: .milliseconds(25))
+            } catch {
+                return false
+            }
+        }
+        return predicate()
+    }
+
+    private static func syntheticOutput(cycle: Int) -> Data {
+        var text = "\u{1b}[?2004h\u{1b}]133;A\u{07}\u{1b}]0;free drain regression \(cycle)\u{07}"
+        for line in 0..<80 {
+            text += "\u{1b}[38;5;\((line + cycle) % 216)m"
+            text += "free-drain-regression cycle=\(cycle) line=\(line) "
+            text += "abcdefghijklmnopqrstuvwxyz 0123456789 wrapping payload "
+            text += "\u{1b}[0m\r\n"
+            if line % 8 == 0 {
+                text += "\u{1b}]7;file://stress/free-drain/\(cycle)/\(line)\u{07}"
+            }
+        }
+        text += "\u{1b}]133;B\u{07}\u{1b}[?2004l\r\n"
+        return Data(text.utf8)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/MobileRecoveryStressMonitorStateTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/MobileRecoveryStressMonitorStateTests.swift
@@ -1,0 +1,70 @@
+#if DEBUG
+import Testing
+@testable import CmuxMobileTerminal
+
+@Suite("MobileRecoveryStressMonitorState")
+struct MobileRecoveryStressMonitorStateTests {
+    @Test("records cycle and drain completion")
+    func recordsDrainCompletion() {
+        var state = MobileRecoveryStressMonitorState(
+            startMilliseconds: 0,
+            heartbeatTimeoutMilliseconds: 2_000,
+            freeDrainDeadlineMilliseconds: 10_000
+        )
+        state.beginCycle(3, generation: 12, pendingFreesBefore: 0, atMilliseconds: 100)
+        state.recordRecoveryResult(pendingFreesAfter: 1)
+        #expect(state.activeCycleDrained == false)
+        state.recordFreeDrain(pendingFrees: 0, atMilliseconds: 250)
+        #expect(state.activeCycleDrained)
+        #expect(state.activeCycle?.cycle == 3)
+        #expect(state.activeCycle?.generation == 12)
+        #expect(state.activeCycle?.drainedMilliseconds == 250)
+    }
+
+    @Test("detects free drain deadline")
+    func detectsFreeDrainDeadline() {
+        var state = MobileRecoveryStressMonitorState(
+            startMilliseconds: 0,
+            heartbeatTimeoutMilliseconds: 2_000,
+            freeDrainDeadlineMilliseconds: 10_000
+        )
+        state.recordHeartbeat(atMilliseconds: 9_000)
+        state.beginCycle(4, generation: 20, pendingFreesBefore: 0, atMilliseconds: 0)
+        state.recordRecoveryResult(pendingFreesAfter: 1)
+        let stall = state.evaluate(atMilliseconds: 10_000)
+        #expect(stall?.kind == .freeDrain)
+        #expect(stall?.cycle == 4)
+        #expect(stall?.generation == 20)
+        #expect(stall?.pendingFrees == 1)
+    }
+
+    @Test("detects stale heartbeat")
+    func detectsHeartbeatDeadline() {
+        var state = MobileRecoveryStressMonitorState(
+            startMilliseconds: 0,
+            heartbeatTimeoutMilliseconds: 2_000,
+            freeDrainDeadlineMilliseconds: 10_000
+        )
+        state.recordHeartbeat(atMilliseconds: 100)
+        let stall = state.evaluate(atMilliseconds: 2_100)
+        #expect(stall?.kind == .heartbeat)
+        #expect(stall?.elapsedMilliseconds == 2_000)
+    }
+
+    @Test("heartbeat deadline wins before free drain deadline")
+    func heartbeatWinsBeforeFreeDrain() {
+        var state = MobileRecoveryStressMonitorState(
+            startMilliseconds: 0,
+            heartbeatTimeoutMilliseconds: 2_000,
+            freeDrainDeadlineMilliseconds: 10_000
+        )
+        state.recordHeartbeat(atMilliseconds: 0)
+        state.beginCycle(5, generation: 30, pendingFreesBefore: 0, atMilliseconds: 0)
+        state.recordRecoveryResult(pendingFreesAfter: 1)
+        let stall = state.evaluate(atMilliseconds: 2_000)
+        #expect(stall?.kind == .heartbeat)
+        #expect(stall?.cycle == 5)
+        #expect(stall?.generation == 30)
+    }
+}
+#endif

--- a/ios/cmux.xcworkspace/contents.xcworkspacedata
+++ b/ios/cmux.xcworkspace/contents.xcworkspacedata
@@ -5,6 +5,9 @@
       location = "group:cmuxPackage">
    </FileRef>
    <FileRef
+      location = "group:../Packages/iOS/CmuxMobileTerminal">
+   </FileRef>
+   <FileRef
       location = "group:cmux-ios.xcodeproj">
    </FileRef>
 </Workspace>

--- a/ios/cmux/cmux.xctestplan
+++ b/ios/cmux/cmux.xctestplan
@@ -25,6 +25,13 @@
     },
     {
       "target" : {
+        "containerPath" : "container:..\/Packages\/iOS\/CmuxMobileTerminal",
+        "identifier" : "CmuxMobileTerminalTests",
+        "name" : "CmuxMobileTerminalTests"
+      }
+    },
+    {
+      "target" : {
         "containerPath" : "container:cmux-ios.xcodeproj",
         "identifier" : "8B41F65B2DEDD0D6001A66F9",
         "name" : "cmuxUITests"

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -243,6 +243,8 @@ public struct CMUXMobileRootScene: View {
         #if DEBUG
         if UITestConfig.workspaceListLayoutPreviewEnabled {
             WorkspaceListLayoutPreviewView()
+        } else if let recoveryStress = MobileRecoveryStressConfiguration.parse(arguments: ProcessInfo.processInfo.arguments) {
+            MobileRecoveryStressView(configuration: recoveryStress)
         } else if ProcessInfo.processInfo.environment["CMUX_ZOOM_STRESS"] == "1" {
             MobileZoomStressView()
         } else if ProcessInfo.processInfo.environment["CMUX_BOTTOM_SCROLL_STRESS"] == "1" {


### PR DESCRIPTION
CI-proof companion to https://github.com/manaflow-ai/cmux/pull/7666: this branch carries the new free-drain regression test WITHOUT the libxev/ghostty fix (old submodule pointer), so the ios-simulator jobs here should go RED on MobileRecoveryStressFreeDrainTests — proving the test catches the surface-teardown deadlock. Will be closed once the red run lands; the fix PR's green run on the same test completes the pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786156081&installation_id=133855650&pr_number=7682&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7682&signature=236ce275b4082f687a58b9cdac7feaf600d78cba820b6c1a2e8788d935bd5c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an iOS render-recovery stress harness and a free-drain watchdog, plus a regression test that reproduces the surface-teardown deadlock. This branch intentionally omits the `libxev`/`ghostty` fix so iOS simulator CI should fail on `MobileRecoveryStressFreeDrainTests`, proving the test.

- **New Features**
  - `--cmux-recovery-stress <N>` harness (`MobileRecoveryStressView`) that mounts a local surface, churns viewport/output, forces production `recoverRenderPipeline`, and emits PASS/DEADLOCK markers.
  - `SurfaceFreeDrainWatchdog` logs `surface.free.STUCK` if a `ghostty_surface_free` hasn’t drained within 10s.
  - Moved debug/test hooks to `GhosttySurfaceView+RecoveryStress.swift` and `GhosttySurfaceView+TestingHooks.swift`; minimal visibility tweaks.

- **Tests**
  - iOS test target `CmuxMobileTerminalTests` with unit tests for config and monitor state; added to the workspace and `cmux.xctestplan` so iOS simulator CI runs the suite (expected red). Links `c++` to satisfy `GhosttyKit` static lib symbols.
  - `MobileRecoveryStressFreeDrainTests` forces recovery and asserts the old surface’s free drains within 15s (expected to fail here).
  - `CMUXMobileRootScene` wires the harness to the launch arg for local repro.

<sup>Written for commit 763956a4a1823ef8493cb56956555ef3d71b8209. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

