### PR TITLE
mux: tmux/zellij-familiar keybindings out of the box, all configurable

### DIFF
--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -1281,12 +1281,6 @@ impl App {
             self.forward_key(&key);
             return Ok(RenderAction::Draw);
         }
-        // 1-9 select a tab by number (fixed: they mirror the tab labels).
-        if let KeyCode::Char(c @ '1'..='9') = key.code {
-            let pane = self.active_pane();
-            self.session.select_tab(pane, Some(c as usize - '1' as usize), None);
-            return Ok(RenderAction::Draw);
-        }
         let Some(action) = self.config.keys.action_for(&key) else {
             return Ok(RenderAction::Draw); // unknown prefix command: swallow, redraw indicator
         };
@@ -1313,6 +1307,11 @@ impl App {
             Action::NewPaneSmart => self.new_pane_smart()?,
             Action::NextTab => self.session.select_tab(pane, None, Some(1)),
             Action::PrevTab => self.session.select_tab(pane, None, Some(-1)),
+            Action::SelectTab(_) => {
+                if let Some(index) = action.tab_index() {
+                    self.session.select_tab(pane, Some(index), None);
+                }
+            }
             Action::SplitRight => {
                 if let Some(pane) = pane {
                     self.split_pane(pane, SplitDir::Right)?;
@@ -1346,6 +1345,11 @@ impl App {
             }
             Action::PrevScreen => self.session.select_screen(None, Some(-1)),
             Action::NextScreen => self.session.select_screen(None, Some(1)),
+            Action::SelectScreen(_) => {
+                if let Some(index) = action.screen_index() {
+                    self.session.select_screen(Some(index), None);
+                }
+            }
             Action::NewScreen => self.new_screen()?,
             Action::NextWorkspace => self.session.select_workspace(None, Some(1)),
             Action::NewWorkspace => self.new_workspace()?,
@@ -1354,6 +1358,10 @@ impl App {
             Action::FocusRight => self.move_focus(1, 0),
             Action::FocusUp => self.move_focus(0, -1),
             Action::FocusDown => self.move_focus(0, 1),
+            Action::FocusNextPane => self.focus_next_pane(),
+            Action::SwapPanePrev => self.swap_pane_by_order(-1),
+            Action::SwapPaneNext => self.swap_pane_by_order(1),
+            Action::ZoomPane => self.session.zoom_pane(pane),
             Action::ResizeGrow => self.resize_focused_split(0.05),
             Action::ResizeShrink => self.resize_focused_split(-0.05),
             Action::ScrollUp => self.scroll_active(-10),
@@ -1621,6 +1629,38 @@ impl App {
         };
         if let Some(next) = layout.neighbor(active, dx, dy) {
             self.session.focus_pane(next);
+        }
+    }
+
+    fn active_screen_pane_order(&self) -> Vec<PaneId> {
+        self.tree
+            .active_screen()
+            .map(|screen| screen.panes.iter().map(|pane| pane.id).collect())
+            .unwrap_or_default()
+    }
+
+    fn adjacent_pane_by_order(&self, delta: isize) -> Option<PaneId> {
+        let active = self.active_pane()?;
+        let panes = self.active_screen_pane_order();
+        let position = panes.iter().position(|pane| *pane == active)?;
+        let len = panes.len();
+        if len < 2 {
+            return None;
+        }
+        let next = (position as isize + delta).rem_euclid(len as isize) as usize;
+        panes.get(next).copied()
+    }
+
+    fn focus_next_pane(&self) {
+        if let Some(next) = self.adjacent_pane_by_order(1) {
+            self.session.focus_pane(next);
+        }
+    }
+
+    fn swap_pane_by_order(&self, delta: isize) {
+        let Some(active) = self.active_pane() else { return };
+        if let Some(target) = self.adjacent_pane_by_order(delta) {
+            self.session.swap_pane(active, target);
         }
     }
 

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -47,7 +47,7 @@
 //!     "new-tab": ["t", "alt+t"],
 //!     "next-tab": "tab",
 //!     "prev-tab": "backtab",
-//!     "select_screen_1": "1",
+//!     "select-screen-1": "1",
 //!     "browser-edit-url": "u"
 //!   }
 //! }
@@ -67,7 +67,7 @@
 //! `select-tab-9`, `split-right`, `split-down`, `close-tab`,
 //! `close-pane`, `rename-tab` (alias: `rename-pane`), `rename-screen`,
 //! `rename-workspace`, `close-screen`, `prev-screen`, `next-screen`,
-//! `select_screen_0` through `select_screen_9`, `new-screen`,
+//! `select-screen-0` through `select-screen-9`, `new-screen`,
 //! `next-workspace`, `new-workspace`, `toggle-sidebar`, `focus-left`,
 //! `focus-right`, `focus-up`, `focus-down`, `focus-next-pane`,
 //! `swap-pane-prev`, `swap-pane-next`, `zoom-pane`, `resize-grow`,
@@ -78,8 +78,8 @@
 //! capability. `x` closes the active pane and `X` closes the active tab;
 //! set `"close-pane": "X"` and `"close-tab": "x"` to restore the old
 //! cmux defaults. Screens are visibly numbered from 1, so
-//! `select_screen_1` selects the first visible screen, ..., and
-//! `select_screen_0` selects the tenth visible screen. Zellij's modal
+//! `select-screen-1` selects the first visible screen, ..., and
+//! `select-screen-0` selects the tenth visible screen. Zellij's modal
 //! `ctrl+p`, `ctrl+t`, `ctrl+s`, `ctrl+n`, and `ctrl+o` modes are a
 //! deliberate non-goal because they conflict with shell/editor control
 //! keys.
@@ -382,7 +382,7 @@ impl Action {
             Action::CloseScreen => "close-screen".to_string(),
             Action::PrevScreen => "prev-screen".to_string(),
             Action::NextScreen => "next-screen".to_string(),
-            Action::SelectScreen(number) => format!("select_screen_{number}"),
+            Action::SelectScreen(number) => format!("select-screen-{number}"),
             Action::NewScreen => "new-screen".to_string(),
             Action::NextWorkspace => "next-workspace".to_string(),
             Action::NewWorkspace => "new-workspace".to_string(),
@@ -562,8 +562,16 @@ impl Keys {
                 self.prefix = chord;
                 continue;
             }
+            // The numbered families accept both spellings: select-screen-N /
+            // select_screen_N and select-tab-N / select_tab_N.
+            let normalized =
+                if name.starts_with("select_screen_") || name.starts_with("select_tab_") {
+                    name.replace('_', "-")
+                } else {
+                    name.clone()
+                };
             match all_actions().iter().find(|a| {
-                a.config_key() == name.as_str()
+                a.config_key() == normalized.as_str()
                     || (**a == Action::RenameTab && name == "rename-pane")
                     || (**a == Action::NewBrowserTab && name == "new_browser_tab")
             }) {
@@ -1077,7 +1085,7 @@ mod tests {
     fn select_screen_action_names_round_trip_and_parse() {
         for number in 0..=9 {
             let action = Action::SelectScreen(number);
-            let name = format!("select_screen_{number}");
+            let name = format!("select-screen-{number}");
             assert_eq!(action.config_key(), name);
             assert!(all_actions().contains(&action));
 
@@ -1089,6 +1097,17 @@ mod tests {
                 keys.action_for(&KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE)),
                 Some(action),
                 "{name} did not parse"
+            );
+
+            // The snake_case spelling is accepted as an alias.
+            let mut keys = Keys::default();
+            let mut raw = HashMap::new();
+            raw.insert(format!("select_screen_{number}"), Value::String("g".to_string()));
+            keys.apply(&raw);
+            assert_eq!(
+                keys.action_for(&KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+                Some(action),
+                "select_screen_{number} alias did not parse"
             );
         }
 

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -47,6 +47,7 @@
 //!     "new-tab": ["t", "alt+t"],
 //!     "next-tab": "tab",
 //!     "prev-tab": "backtab",
+//!     "select_screen_1": "1",
 //!     "browser-edit-url": "u"
 //!   }
 //! }
@@ -57,6 +58,31 @@
 //! colors: explicit config value, then the user's Ghostty config
 //! (`selection-background`/`selection-foreground`), then the built-in
 //! default.
+//!
+//! Key bindings are configured under `"keys"`. Each action accepts a
+//! chord string, an array of chord strings, or `"none"`. Overrides replace
+//! all default chords for that action. Action names are:
+//! `new-tab`, `new-browser-tab` (alias: `new_browser_tab`),
+//! `new-pane-smart`, `next-tab`, `prev-tab`, `select-tab-1` through
+//! `select-tab-9`, `split-right`, `split-down`, `close-tab`,
+//! `close-pane`, `rename-tab` (alias: `rename-pane`), `rename-screen`,
+//! `rename-workspace`, `close-screen`, `prev-screen`, `next-screen`,
+//! `select_screen_0` through `select_screen_9`, `new-screen`,
+//! `next-workspace`, `new-workspace`, `toggle-sidebar`, `focus-left`,
+//! `focus-right`, `focus-up`, `focus-down`, `focus-next-pane`,
+//! `swap-pane-prev`, `swap-pane-next`, `zoom-pane`, `resize-grow`,
+//! `resize-shrink`, `scroll-up`, `scroll-down`, `browser-back`,
+//! `browser-forward`, `browser-reload`, `browser-edit-url`, and `detach`.
+//!
+//! The defaults intentionally match tmux where cmux has the same
+//! capability. `x` closes the active pane and `X` closes the active tab;
+//! set `"close-pane": "X"` and `"close-tab": "x"` to restore the old
+//! cmux defaults. Screens are visibly numbered from 1, so
+//! `select_screen_1` selects the first visible screen, ..., and
+//! `select_screen_0` selects the tenth visible screen. Zellij's modal
+//! `ctrl+p`, `ctrl+t`, `ctrl+s`, `ctrl+n`, and `ctrl+o` modes are a
+//! deliberate non-goal because they conflict with shell/editor control
+//! keys.
 
 use std::collections::HashMap;
 
@@ -302,6 +328,7 @@ pub enum Action {
     NewPaneSmart,
     NextTab,
     PrevTab,
+    SelectTab(u8),
     SplitRight,
     SplitDown,
     CloseTab,
@@ -312,6 +339,7 @@ pub enum Action {
     CloseScreen,
     PrevScreen,
     NextScreen,
+    SelectScreen(u8),
     NewScreen,
     NextWorkspace,
     NewWorkspace,
@@ -320,6 +348,10 @@ pub enum Action {
     FocusRight,
     FocusUp,
     FocusDown,
+    FocusNextPane,
+    SwapPanePrev,
+    SwapPaneNext,
+    ZoomPane,
     ResizeGrow,
     ResizeShrink,
     ScrollUp,
@@ -332,40 +364,61 @@ pub enum Action {
 }
 
 impl Action {
-    fn config_key(&self) -> &'static str {
+    fn config_key(&self) -> String {
         match self {
-            Action::NewTab => "new-tab",
-            Action::NewBrowserTab => "new-browser-tab",
-            Action::NewPaneSmart => "new-pane-smart",
-            Action::NextTab => "next-tab",
-            Action::PrevTab => "prev-tab",
-            Action::SplitRight => "split-right",
-            Action::SplitDown => "split-down",
-            Action::CloseTab => "close-tab",
-            Action::ClosePane => "close-pane",
-            Action::RenameTab => "rename-tab",
-            Action::RenameScreen => "rename-screen",
-            Action::RenameWorkspace => "rename-workspace",
-            Action::CloseScreen => "close-screen",
-            Action::PrevScreen => "prev-screen",
-            Action::NextScreen => "next-screen",
-            Action::NewScreen => "new-screen",
-            Action::NextWorkspace => "next-workspace",
-            Action::NewWorkspace => "new-workspace",
-            Action::ToggleSidebar => "toggle-sidebar",
-            Action::FocusLeft => "focus-left",
-            Action::FocusRight => "focus-right",
-            Action::FocusUp => "focus-up",
-            Action::FocusDown => "focus-down",
-            Action::ResizeGrow => "resize-grow",
-            Action::ResizeShrink => "resize-shrink",
-            Action::ScrollUp => "scroll-up",
-            Action::ScrollDown => "scroll-down",
-            Action::BrowserBack => "browser-back",
-            Action::BrowserForward => "browser-forward",
-            Action::BrowserReload => "browser-reload",
-            Action::BrowserEditUrl => "browser-edit-url",
-            Action::Detach => "detach",
+            Action::NewTab => "new-tab".to_string(),
+            Action::NewBrowserTab => "new-browser-tab".to_string(),
+            Action::NewPaneSmart => "new-pane-smart".to_string(),
+            Action::NextTab => "next-tab".to_string(),
+            Action::PrevTab => "prev-tab".to_string(),
+            Action::SelectTab(number) => format!("select-tab-{number}"),
+            Action::SplitRight => "split-right".to_string(),
+            Action::SplitDown => "split-down".to_string(),
+            Action::CloseTab => "close-tab".to_string(),
+            Action::ClosePane => "close-pane".to_string(),
+            Action::RenameTab => "rename-tab".to_string(),
+            Action::RenameScreen => "rename-screen".to_string(),
+            Action::RenameWorkspace => "rename-workspace".to_string(),
+            Action::CloseScreen => "close-screen".to_string(),
+            Action::PrevScreen => "prev-screen".to_string(),
+            Action::NextScreen => "next-screen".to_string(),
+            Action::SelectScreen(number) => format!("select_screen_{number}"),
+            Action::NewScreen => "new-screen".to_string(),
+            Action::NextWorkspace => "next-workspace".to_string(),
+            Action::NewWorkspace => "new-workspace".to_string(),
+            Action::ToggleSidebar => "toggle-sidebar".to_string(),
+            Action::FocusLeft => "focus-left".to_string(),
+            Action::FocusRight => "focus-right".to_string(),
+            Action::FocusUp => "focus-up".to_string(),
+            Action::FocusDown => "focus-down".to_string(),
+            Action::FocusNextPane => "focus-next-pane".to_string(),
+            Action::SwapPanePrev => "swap-pane-prev".to_string(),
+            Action::SwapPaneNext => "swap-pane-next".to_string(),
+            Action::ZoomPane => "zoom-pane".to_string(),
+            Action::ResizeGrow => "resize-grow".to_string(),
+            Action::ResizeShrink => "resize-shrink".to_string(),
+            Action::ScrollUp => "scroll-up".to_string(),
+            Action::ScrollDown => "scroll-down".to_string(),
+            Action::BrowserBack => "browser-back".to_string(),
+            Action::BrowserForward => "browser-forward".to_string(),
+            Action::BrowserReload => "browser-reload".to_string(),
+            Action::BrowserEditUrl => "browser-edit-url".to_string(),
+            Action::Detach => "detach".to_string(),
+        }
+    }
+
+    pub fn screen_index(&self) -> Option<usize> {
+        match self {
+            Action::SelectScreen(0) => Some(9),
+            Action::SelectScreen(number @ 1..=9) => Some((*number as usize) - 1),
+            _ => None,
+        }
+    }
+
+    pub fn tab_index(&self) -> Option<usize> {
+        match self {
+            Action::SelectTab(number @ 1..=9) => Some((*number as usize) - 1),
+            _ => None,
         }
     }
 }
@@ -414,8 +467,8 @@ impl Default for Keys {
                 bind(KeyCode::BackTab, Action::PrevTab),
                 bind(KeyCode::Char('%'), Action::SplitRight),
                 bind(KeyCode::Char('"'), Action::SplitDown),
-                bind(KeyCode::Char('x'), Action::CloseTab),
-                bind(KeyCode::Char('X'), Action::ClosePane),
+                bind(KeyCode::Char('x'), Action::ClosePane),
+                bind(KeyCode::Char('X'), Action::CloseTab),
                 bind(KeyCode::Char(','), Action::RenameScreen),
                 bind(KeyCode::Char('$'), Action::RenameWorkspace),
                 bind(KeyCode::Char('&'), Action::CloseScreen),
@@ -423,10 +476,21 @@ impl Default for Keys {
                 alt(KeyCode::Char('['), Action::PrevScreen),
                 bind(KeyCode::Char('n'), Action::NextScreen),
                 alt(KeyCode::Char(']'), Action::NextScreen),
+                bind(KeyCode::Char('1'), Action::SelectScreen(1)),
+                bind(KeyCode::Char('2'), Action::SelectScreen(2)),
+                bind(KeyCode::Char('3'), Action::SelectScreen(3)),
+                bind(KeyCode::Char('4'), Action::SelectScreen(4)),
+                bind(KeyCode::Char('5'), Action::SelectScreen(5)),
+                bind(KeyCode::Char('6'), Action::SelectScreen(6)),
+                bind(KeyCode::Char('7'), Action::SelectScreen(7)),
+                bind(KeyCode::Char('8'), Action::SelectScreen(8)),
+                bind(KeyCode::Char('9'), Action::SelectScreen(9)),
+                bind(KeyCode::Char('0'), Action::SelectScreen(0)),
                 bind(KeyCode::Char('c'), Action::NewScreen),
                 bind(KeyCode::Char('w'), Action::NextWorkspace),
                 bind(KeyCode::Char('W'), Action::NewWorkspace),
                 bind(KeyCode::Char('s'), Action::ToggleSidebar),
+                bind(KeyCode::Char('o'), Action::FocusNextPane),
                 bind(KeyCode::Char('h'), Action::FocusLeft),
                 bind(KeyCode::Left, Action::FocusLeft),
                 alt(KeyCode::Char('h'), Action::FocusLeft),
@@ -445,6 +509,10 @@ impl Default for Keys {
                 alt(KeyCode::Down, Action::FocusDown),
                 alt(KeyCode::Char('='), Action::ResizeGrow),
                 alt(KeyCode::Char('-'), Action::ResizeShrink),
+                bind(KeyCode::Char('z'), Action::ZoomPane),
+                bind(KeyCode::Char('{'), Action::SwapPanePrev),
+                bind(KeyCode::Char('}'), Action::SwapPaneNext),
+                bind(KeyCode::Char('['), Action::ScrollUp),
                 bind(KeyCode::PageUp, Action::ScrollUp),
                 bind(KeyCode::PageDown, Action::ScrollDown),
                 bind(KeyCode::Char('<'), Action::BrowserBack),
@@ -495,7 +563,7 @@ impl Keys {
                 continue;
             }
             match all_actions().iter().find(|a| {
-                a.config_key() == name
+                a.config_key() == name.as_str()
                     || (**a == Action::RenameTab && name == "rename-pane")
                     || (**a == Action::NewBrowserTab && name == "new_browser_tab")
             }) {
@@ -536,6 +604,15 @@ fn all_actions() -> &'static [Action] {
         Action::NewPaneSmart,
         Action::NextTab,
         Action::PrevTab,
+        Action::SelectTab(1),
+        Action::SelectTab(2),
+        Action::SelectTab(3),
+        Action::SelectTab(4),
+        Action::SelectTab(5),
+        Action::SelectTab(6),
+        Action::SelectTab(7),
+        Action::SelectTab(8),
+        Action::SelectTab(9),
         Action::SplitRight,
         Action::SplitDown,
         Action::CloseTab,
@@ -546,6 +623,16 @@ fn all_actions() -> &'static [Action] {
         Action::CloseScreen,
         Action::PrevScreen,
         Action::NextScreen,
+        Action::SelectScreen(0),
+        Action::SelectScreen(1),
+        Action::SelectScreen(2),
+        Action::SelectScreen(3),
+        Action::SelectScreen(4),
+        Action::SelectScreen(5),
+        Action::SelectScreen(6),
+        Action::SelectScreen(7),
+        Action::SelectScreen(8),
+        Action::SelectScreen(9),
         Action::NewScreen,
         Action::NextWorkspace,
         Action::NewWorkspace,
@@ -554,6 +641,10 @@ fn all_actions() -> &'static [Action] {
         Action::FocusRight,
         Action::FocusUp,
         Action::FocusDown,
+        Action::FocusNextPane,
+        Action::SwapPanePrev,
+        Action::SwapPaneNext,
+        Action::ZoomPane,
         Action::ResizeGrow,
         Action::ResizeShrink,
         Action::ScrollUp,
@@ -934,12 +1025,76 @@ mod tests {
                 "duplicate default chord: {left:?}"
             );
         }
+        assert!(
+            !keys.bindings.iter().any(|(chord, _)| chord == &keys.prefix),
+            "default binding shadows prefix passthrough: {:?}",
+            keys.prefix
+        );
         for c in ['b', 'f', 'd', '.'] {
             assert_eq!(
                 keys.modeless_action_for(&KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT)),
                 None
             );
         }
+    }
+
+    #[test]
+    fn tmux_close_pane_flip_is_default() {
+        let keys = Keys::default();
+        assert_eq!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)),
+            Some(Action::ClosePane)
+        );
+        assert_eq!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('X'), KeyModifiers::SHIFT)),
+            Some(Action::CloseTab)
+        );
+    }
+
+    #[test]
+    fn new_action_names_parse_from_config_overrides() {
+        let cases = [
+            ("zoom-pane", Action::ZoomPane),
+            ("focus-next-pane", Action::FocusNextPane),
+            ("swap-pane-prev", Action::SwapPanePrev),
+            ("swap-pane-next", Action::SwapPaneNext),
+            ("scroll-up", Action::ScrollUp),
+        ];
+        for (name, action) in cases {
+            let mut keys = Keys::default();
+            let mut raw = HashMap::new();
+            raw.insert(name.to_string(), Value::String("f".to_string()));
+            keys.apply(&raw);
+            assert_eq!(
+                keys.action_for(&KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE)),
+                Some(action),
+                "{name} did not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn select_screen_action_names_round_trip_and_parse() {
+        for number in 0..=9 {
+            let action = Action::SelectScreen(number);
+            let name = format!("select_screen_{number}");
+            assert_eq!(action.config_key(), name);
+            assert!(all_actions().contains(&action));
+
+            let mut keys = Keys::default();
+            let mut raw = HashMap::new();
+            raw.insert(name.clone(), Value::String("f".to_string()));
+            keys.apply(&raw);
+            assert_eq!(
+                keys.action_for(&KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE)),
+                Some(action),
+                "{name} did not parse"
+            );
+        }
+
+        assert_eq!(Action::SelectScreen(1).screen_index(), Some(0));
+        assert_eq!(Action::SelectScreen(9).screen_index(), Some(8));
+        assert_eq!(Action::SelectScreen(0).screen_index(), Some(9));
     }
 
     #[test]

--- a/mux/crates/mux-tui/src/session/mod.rs
+++ b/mux/crates/mux-tui/src/session/mod.rs
@@ -17,7 +17,7 @@ use std::sync::mpsc::Receiver;
 use ghostty_vt::{RenderState, Terminal};
 use mux_core::{
     BrowserFrame, BrowserStatus, DefaultColors, Mux, MuxEvent, PaneId, ScreenId, SplitDir, Surface,
-    SurfaceId, SurfaceKind, WorkspaceId,
+    SurfaceId, SurfaceKind, WorkspaceId, ZoomMode,
 };
 use serde_json::json;
 
@@ -227,6 +227,17 @@ impl Session {
         }
     }
 
+    pub fn zoom_pane(&self, pane: Option<PaneId>) {
+        match self {
+            Session::Local(mux) => {
+                let _ = mux.zoom_pane(pane, ZoomMode::Toggle);
+            }
+            Session::Remote(remote) => {
+                let _ = remote.request(json!({"cmd": "zoom-pane", "pane": pane, "mode": "toggle"}));
+            }
+        }
+    }
+
     pub fn split(
         &self,
         pane: PaneId,
@@ -277,6 +288,17 @@ impl Session {
             Session::Local(mux) => mux.close_pane(pane),
             Session::Remote(remote) => {
                 let _ = remote.request(json!({"cmd": "close-pane", "pane": pane}));
+            }
+        }
+    }
+
+    pub fn swap_pane(&self, pane: PaneId, target: PaneId) {
+        match self {
+            Session::Local(mux) => {
+                mux.swap_panes(pane, target);
+            }
+            Session::Remote(remote) => {
+                let _ = remote.request(json!({"cmd": "swap-pane", "pane": pane, "target": target}));
             }
         }
     }

--- a/mux/docs/configuration.md
+++ b/mux/docs/configuration.md
@@ -75,10 +75,11 @@ The default launched profile is `~/Library/Application Support/cmux-mux/chrome-p
 | `keys.new-pane-smart` | chord string or array or `"none"` | `"alt+n"` | New pane using smart split direction |
 | `keys.next-tab` | chord string or array or `"none"` | `"tab"` | Next tab |
 | `keys.prev-tab` | chord string or array or `"none"` | `"backtab"` | Previous tab |
+| `keys.select-tab-1` through `keys.select-tab-9` | chord string or array or `"none"` | unbound | Select tab by visible tab number; use these to restore the old `Ctrl-b 1` through `Ctrl-b 9` tab selectors |
 | `keys.split-right` | chord string or array or `"none"` | `"%"` | Split right |
 | `keys.split-down` | chord string or array or `"none"` | `"\""` | Split down |
-| `keys.close-tab` | chord string or array or `"none"` | `"x"` | Close active tab |
-| `keys.close-pane` | chord string or array or `"none"` | `"X"` | Close active pane |
+| `keys.close-pane` | chord string or array or `"none"` | `"x"` | Close active pane |
+| `keys.close-tab` | chord string or array or `"none"` | `"X"` | Close active tab |
 | `keys.rename-tab` | chord string or array or `"none"` | unbound | Rename active tab |
 | `keys.rename-pane` | chord string or array or `"none"` | alias | Alias for `rename-tab` |
 | `keys.rename-screen` | chord string or array or `"none"` | `","` | Rename active screen |
@@ -86,21 +87,35 @@ The default launched profile is `~/Library/Application Support/cmux-mux/chrome-p
 | `keys.close-screen` | chord string or array or `"none"` | `"&"` | Close active screen |
 | `keys.prev-screen` | chord string or array or `"none"` | `["p","alt+["]` | Previous screen |
 | `keys.next-screen` | chord string or array or `"none"` | `["n","alt+]"]` | Next screen |
+| `keys.select_screen_1` through `keys.select_screen_9` | chord string or array or `"none"` | `"1"` through `"9"` | Select visible screen 1 through 9 |
+| `keys.select_screen_0` | chord string or array or `"none"` | `"0"` | Select visible screen 10 |
 | `keys.new-screen` | chord string or array or `"none"` | `"c"` | New screen |
 | `keys.next-workspace` | chord string or array or `"none"` | `"w"` | Next workspace |
 | `keys.new-workspace` | chord string or array or `"none"` | `"W"` | New workspace |
 | `keys.toggle-sidebar` | chord string or array or `"none"` | `"s"` | Toggle sidebar |
+| `keys.focus-next-pane` | chord string or array or `"none"` | `"o"` | Cycle to the next pane in the current screen |
 | `keys.focus-left` | chord string or array or `"none"` | `["h","left","alt+h","alt+left"]` | Focus left |
 | `keys.focus-right` | chord string or array or `"none"` | `["l","right","alt+l","alt+right"]` | Focus right |
 | `keys.focus-up` | chord string or array or `"none"` | `["k","up","alt+k","alt+up"]` | Focus up |
 | `keys.focus-down` | chord string or array or `"none"` | `["j","down","alt+j","alt+down"]` | Focus down |
+| `keys.swap-pane-prev` | chord string or array or `"none"` | `"{"` | Swap active pane with the previous pane in split-tree order |
+| `keys.swap-pane-next` | chord string or array or `"none"` | `"}"` | Swap active pane with the next pane in split-tree order |
+| `keys.zoom-pane` | chord string or array or `"none"` | `"z"` | Toggle zoom for the active pane |
 | `keys.resize-grow` | chord string or array or `"none"` | `"alt+="` | Grow the focused split |
 | `keys.resize-shrink` | chord string or array or `"none"` | `"alt+-"` | Shrink the focused split |
-| `keys.scroll-up` | chord string or array or `"none"` | `"pageup"` | Scroll active PTY up 10 rows |
+| `keys.scroll-up` | chord string or array or `"none"` | `["[","pageup"]` | Scroll active PTY up 10 rows |
 | `keys.scroll-down` | chord string or array or `"none"` | `"pagedown"` | Scroll active PTY down 10 rows |
+| `keys.browser-back` | chord string or array or `"none"` | `"<"` | Browser back |
+| `keys.browser-forward` | chord string or array or `"none"` | `">"` | Browser forward |
+| `keys.browser-reload` | chord string or array or `"none"` | `"r"` | Browser reload |
+| `keys.browser-edit-url` | chord string or array or `"none"` | `"u"` | Browser URL prompt |
 | `keys.detach` | chord string or array or `"none"` | `"d"` | Quit local TUI or detach attached TUI |
 
-Each action override replaces all default chords for that action. Values may be a string, an array of strings, or `"none"`. Non-string array entries are ignored. Set `keys.alt_shortcuts` to `false` to remove default Alt chords before applying user overrides; explicitly configured Alt chords still work. Prefix `1` through `9` stay fixed to tab selection.
+Each action override replaces all default chords for that action. Values may be a string, an array of strings, or `"none"`. Non-string array entries are ignored. Set `keys.alt_shortcuts` to `false` to remove default Alt chords before applying user overrides; explicitly configured Alt chords still work.
+
+`Ctrl-b x` now follows tmux and closes the active pane. `Ctrl-b X` closes the active tab. Existing users can restore the old cmux behavior with `"close-tab": "x"` and `"close-pane": "X"`.
+
+Screens are visibly numbered from 1, so `select_screen_1` selects the first visible screen and `select_screen_0` selects the tenth visible screen. `Ctrl-b ]` and `Ctrl-b q` are intentionally unbound: cmux has no paste-buffer command and no pane-number quick-jump overlay yet. Zellij's modal `ctrl+p`, `ctrl+t`, `ctrl+s`, `ctrl+n`, and `ctrl+o` modes are not defaults because they conflict with common shell and editor control keys.
 
 Chord strings can be single characters or a key name with optional `ctrl`, `control`, `alt`, `option`, or `shift` modifiers. Examples: `"c"`, `"%"`, `"ctrl+b"`, `"alt+enter"`, `"tab"`, `"backtab"`, `"shift+tab"`, `"pageup"`, `"pagedown"`, `"esc"`, `"space"`, `"left"`, `"right"`, `"up"`, `"down"`, `"home"`, and `"end"`.
 
@@ -151,13 +166,19 @@ Chord strings can be single characters or a key name with optional `ctrl`, `cont
     "new-pane-smart": "alt+n",
     "next-tab": "tab",
     "prev-tab": "backtab",
+    "select_screen_1": "1",
+    "select_screen_2": "2",
     "next-screen": ["n", "alt+]"],
     "prev-screen": ["p", "alt+["],
     "rename-tab": "r",
     "rename-screen": ",",
     "focus-left": ["h", "left", "alt+h", "alt+left"],
     "focus-right": ["l", "right", "alt+l", "alt+right"],
-    "close-pane": "none",
+    "close-pane": "x",
+    "close-tab": "X",
+    "zoom-pane": "z",
+    "swap-pane-prev": "{",
+    "swap-pane-next": "}",
     "detach": "d"
   }
 }

--- a/mux/docs/configuration.md
+++ b/mux/docs/configuration.md
@@ -87,8 +87,8 @@ The default launched profile is `~/Library/Application Support/cmux-mux/chrome-p
 | `keys.close-screen` | chord string or array or `"none"` | `"&"` | Close active screen |
 | `keys.prev-screen` | chord string or array or `"none"` | `["p","alt+["]` | Previous screen |
 | `keys.next-screen` | chord string or array or `"none"` | `["n","alt+]"]` | Next screen |
-| `keys.select_screen_1` through `keys.select_screen_9` | chord string or array or `"none"` | `"1"` through `"9"` | Select visible screen 1 through 9 |
-| `keys.select_screen_0` | chord string or array or `"none"` | `"0"` | Select visible screen 10 |
+| `keys.select-screen-1` through `keys.select-screen-9` | chord string or array or `"none"` | `"1"` through `"9"` | Select visible screen 1 through 9 |
+| `keys.select-screen-0` | chord string or array or `"none"` | `"0"` | Select visible screen 10 |
 | `keys.new-screen` | chord string or array or `"none"` | `"c"` | New screen |
 | `keys.next-workspace` | chord string or array or `"none"` | `"w"` | Next workspace |
 | `keys.new-workspace` | chord string or array or `"none"` | `"W"` | New workspace |
@@ -115,7 +115,7 @@ Each action override replaces all default chords for that action. Values may be 
 
 `Ctrl-b x` now follows tmux and closes the active pane. `Ctrl-b X` closes the active tab. Existing users can restore the old cmux behavior with `"close-tab": "x"` and `"close-pane": "X"`.
 
-Screens are visibly numbered from 1, so `select_screen_1` selects the first visible screen and `select_screen_0` selects the tenth visible screen. `Ctrl-b ]` and `Ctrl-b q` are intentionally unbound: cmux has no paste-buffer command and no pane-number quick-jump overlay yet. Zellij's modal `ctrl+p`, `ctrl+t`, `ctrl+s`, `ctrl+n`, and `ctrl+o` modes are not defaults because they conflict with common shell and editor control keys.
+Screens are visibly numbered from 1, so `select-screen-1` selects the first visible screen and `select-screen-0` selects the tenth visible screen. The snake_case spellings `select_screen_N` and `select_tab_N` are accepted as aliases. `Ctrl-b ]` and `Ctrl-b q` are intentionally unbound: cmux has no paste-buffer command and no pane-number quick-jump overlay yet. Zellij's modal `ctrl+p`, `ctrl+t`, `ctrl+s`, `ctrl+n`, and `ctrl+o` modes are not defaults because they conflict with common shell and editor control keys.
 
 Chord strings can be single characters or a key name with optional `ctrl`, `control`, `alt`, `option`, or `shift` modifiers. Examples: `"c"`, `"%"`, `"ctrl+b"`, `"alt+enter"`, `"tab"`, `"backtab"`, `"shift+tab"`, `"pageup"`, `"pagedown"`, `"esc"`, `"space"`, `"left"`, `"right"`, `"up"`, `"down"`, `"home"`, and `"end"`.
 
@@ -166,8 +166,8 @@ Chord strings can be single characters or a key name with optional `ctrl`, `cont
     "new-pane-smart": "alt+n",
     "next-tab": "tab",
     "prev-tab": "backtab",
-    "select_screen_1": "1",
-    "select_screen_2": "2",
+    "select-screen-1": "1",
+    "select-screen-2": "2",
     "next-screen": ["n", "alt+]"],
     "prev-screen": ["p", "alt+["],
     "rename-tab": "r",

--- a/mux/docs/keyboard.md
+++ b/mux/docs/keyboard.md
@@ -18,11 +18,12 @@ These defaults come from `Keys::default`.
 | `Alt-n` | Smart split into a new pane |
 | `Ctrl-b Tab` | Next tab in the active pane |
 | `Ctrl-b BackTab` | Previous tab in the active pane |
-| `Ctrl-b 1` through `Ctrl-b 9` | Select tab 1 through 9 in the active pane |
+| `Ctrl-b 1` through `Ctrl-b 9` | Select visible screen 1 through 9 |
+| `Ctrl-b 0` | Select visible screen 10 |
 | `Ctrl-b %` | Split the active pane right |
 | `Ctrl-b "` | Split the active pane down |
-| `Ctrl-b x` | Close the active tab |
-| `Ctrl-b X` | Close the active pane |
+| `Ctrl-b x` | Close the active pane |
+| `Ctrl-b X` | Close the active tab |
 | `Ctrl-b ,` | Rename the active screen |
 | `Ctrl-b $` | Rename the active workspace |
 | `Ctrl-b &` | Close the active screen |
@@ -31,6 +32,10 @@ These defaults come from `Keys::default`.
 | `Ctrl-b n` | Next screen in the active workspace |
 | `Alt-]` | Next screen in the active workspace |
 | `Ctrl-b c` | New screen in the active workspace |
+| `Ctrl-b z` | Toggle zoom for the active pane |
+| `Ctrl-b o` | Focus the next pane in the current screen |
+| `Ctrl-b {` | Swap the active pane with the previous pane |
+| `Ctrl-b }` | Swap the active pane with the next pane |
 | `Ctrl-b w` | Next workspace |
 | `Ctrl-b W` | New workspace |
 | `Ctrl-b s` | Toggle the workspace sidebar |
@@ -44,11 +49,16 @@ These defaults come from `Keys::default`.
 | `Alt-j` or `Alt-Down` | Focus down |
 | `Alt-=` | Grow the focused split |
 | `Alt--` | Shrink the focused split |
+| `Ctrl-b [` | Scroll the active PTY viewport up 10 rows |
 | `Ctrl-b PageUp` | Scroll the active PTY viewport up 10 rows |
 | `Ctrl-b PageDown` | Scroll the active PTY viewport down 10 rows |
 | `Ctrl-b d` | Quit a local TUI or detach an attached TUI |
 
-The screen bindings intentionally use tmux verbs: `c` creates a screen, `n` and `p` switch screens, `&` closes a screen, and `,` renames a screen. Tabs use `t`, `Tab`, `BackTab`, fixed number selectors, and tab-bar mouse actions.
+The screen bindings intentionally use tmux verbs: `c` creates a screen, `n` and `p` switch screens, `&` closes a screen, `,` renames a screen, `z` zooms a pane, `o` cycles panes, `{` and `}` swap panes, and number keys select visible screens. Screens are visibly numbered from 1, so `Ctrl-b 1` selects the first visible screen and `Ctrl-b 0` selects the tenth visible screen.
+
+`Ctrl-b x` now follows tmux and closes the active pane. `Ctrl-b X` closes the active tab. Restore the old cmux behavior with `"close-tab": "x"` and `"close-pane": "X"` in `mux.json`.
+
+`Ctrl-b ]` is unbound because cmux has no paste-buffer concept. `Ctrl-b q` is unbound because there is no pane-number quick-jump overlay yet.
 
 ## Modeless Alt Layer
 
@@ -56,9 +66,11 @@ Any configured Alt chord is active without the prefix. Default modeless commands
 
 Set `keys.alt_shortcuts` to `false` to remove the default Alt bindings. This kill switch only removes defaults; Alt chords explicitly configured in `mux.json` still work.
 
-## Fixed Number Selection
+Zellij's modal `ctrl+p`, `ctrl+t`, `ctrl+s`, `ctrl+n`, and `ctrl+o` modes are a deliberate non-goal because they conflict with common shell and editor control keys such as history, transpose, flow control, and editor navigation.
 
-`1` through `9` select tabs by visible tab number after the prefix. These number bindings are fixed and are not configured through `mux.json`.
+## Number Selection
+
+`0` through `9` are regular configurable screen-selection bindings. The old `Ctrl-b 1` through `Ctrl-b 9` tab selectors can be restored with `select-tab-1` through `select-tab-9`.
 
 ## Remapping
 
@@ -73,12 +85,16 @@ Each action accepts a string, an array of strings, or `"none"`. Setting an actio
     "alt_shortcuts": false,
     "new-tab": ["t", "alt+t"],
     "new-pane-smart": "alt+n",
+    "select_screen_1": "1",
+    "select_screen_2": "2",
     "next-screen": ["n", "alt+]"],
     "prev-screen": ["p", "alt+["],
     "focus-left": ["h", "left", "alt+h", "alt+left"],
     "rename-tab": "r",
     "rename-screen": ",",
-    "close-pane": "none"
+    "close-pane": "x",
+    "close-tab": "X",
+    "select-tab-1": "none"
   }
 }
 ```
@@ -91,6 +107,15 @@ new_browser_tab
 new-pane-smart
 next-tab
 prev-tab
+select-tab-1
+select-tab-2
+select-tab-3
+select-tab-4
+select-tab-5
+select-tab-6
+select-tab-7
+select-tab-8
+select-tab-9
 split-right
 split-down
 close-tab
@@ -101,6 +126,16 @@ rename-workspace
 close-screen
 prev-screen
 next-screen
+select_screen_0
+select_screen_1
+select_screen_2
+select_screen_3
+select_screen_4
+select_screen_5
+select_screen_6
+select_screen_7
+select_screen_8
+select_screen_9
 new-screen
 next-workspace
 new-workspace
@@ -109,10 +144,18 @@ focus-left
 focus-right
 focus-up
 focus-down
+focus-next-pane
+swap-pane-prev
+swap-pane-next
+zoom-pane
 resize-grow
 resize-shrink
 scroll-up
 scroll-down
+browser-back
+browser-forward
+browser-reload
+browser-edit-url
 detach
 ```
 

--- a/mux/docs/keyboard.md
+++ b/mux/docs/keyboard.md
@@ -85,8 +85,8 @@ Each action accepts a string, an array of strings, or `"none"`. Setting an actio
     "alt_shortcuts": false,
     "new-tab": ["t", "alt+t"],
     "new-pane-smart": "alt+n",
-    "select_screen_1": "1",
-    "select_screen_2": "2",
+    "select-screen-1": "1",
+    "select-screen-2": "2",
     "next-screen": ["n", "alt+]"],
     "prev-screen": ["p", "alt+["],
     "focus-left": ["h", "left", "alt+h", "alt+left"],
@@ -126,16 +126,16 @@ rename-workspace
 close-screen
 prev-screen
 next-screen
-select_screen_0
-select_screen_1
-select_screen_2
-select_screen_3
-select_screen_4
-select_screen_5
-select_screen_6
-select_screen_7
-select_screen_8
-select_screen_9
+select-screen-0
+select-screen-1
+select-screen-2
+select-screen-3
+select-screen-4
+select-screen-5
+select-screen-6
+select-screen-7
+select-screen-8
+select-screen-9
 new-screen
 next-workspace
 new-workspace

--- a/mux/scripts/smoke-tui.py
+++ b/mux/scripts/smoke-tui.py
@@ -359,7 +359,9 @@ text = output.decode("utf-8", "replace")
 assert "example.com" in text, text[-800:]
 os.write(fd, b"\x1b")
 drain(0.5)
-os.write(fd, b"\x02x")
+# Close the browser TAB. prefix-X since the tmux-alignment flip: x kills the
+# pane (which here is the only pane and would end the session), X the tab.
+os.write(fd, b"\x02X")
 drain(0.8)
 screen0 = active_screen(tree()[0])
 assert len(screen0["panes"][0]["tabs"]) == before_tabs, screen0


### PR DESCRIPTION
Adds the missing tmux muscle-memory bindings to the mux TUI where core support exists: prefix z (zoom), prefix 0-9 (select screen; the old select-tab-N defaults move to opt-in overrides), prefix o (cycle panes), prefix { } (swap panes), prefix [ (scrollback). Deliberate default change: x/X flipped to tmux semantics (x kills the pane, X the tab) — restorable via config. Zellij's alt-layer was already covered; its modal ctrl modes are deliberately not adopted (conflict with shell/editor keys). Every binding, old and new, is rebindable/unbindable through mux.json; the default table has a no-duplicate-chords unit test. Wire protocol untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786157953&installation_id=133855650&pr_number=7684&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7684&signature=66ceaaa8edf2b926f36c356c3ad0f982e65d929bc6e01a84c3c709d41960a4fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default keymap changes will surprise existing users (close keys and number keys); behavior touches session layout (zoom/swap) but uses existing mux-core APIs and remote commands already in the protocol.
> 
> **Overview**
> Aligns the mux TUI **default** prefix keymap with tmux where the mux already supports the behavior, and makes numbered tab/screen jumps and pane actions **fully configurable** via `mux.json` instead of hardcoded prefix handling.
> 
> **Breaking default changes:** `Ctrl-b x` / `Ctrl-b X` now close the **pane** / **tab** (tmux order); restore old cmux behavior with `"close-pane": "X"` and `"close-tab": "x"`. Prefix `1`–`9` no longer select tabs—they select **visible screens** (`0` = 10th); old tab-by-number behavior is opt-in via `select-tab-1` … `select-tab-9`.
> 
> **New prefix defaults:** `z` zoom toggle, `o` cycle panes, `{` / `}` swap with prev/next pane in screen order, `[` scrollback up (alongside PageUp). New `Action` variants (`SelectTab`, `SelectScreen`, pane focus/swap/zoom) route through `run_action`; pane cycling uses screen pane order helpers in `app.rs`. `Session` gains `zoom_pane` and `swap_pane` (local mux + remote JSON commands). Config parsing accepts `select_screen_N` / `select_tab_N` snake_case aliases; tests guard duplicate chords and the close-key flip. Docs and the browser smoke script (`prefix-X` to close tab) are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5bc2a6d312ca94f5ef322b4056e19d43832e7ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tmux- and zellij-familiar keybindings to the mux TUI with sane defaults and full remapping via `mux.json`. Improves navigation with screen number selection, pane zoom/cycle/swap, and keeps the wire protocol unchanged.

- **New Features**
  - Default bindings: prefix z (zoom pane), o (cycle panes), { / } (swap panes), [ (scrollback), 0–9 (select visible screen; 0 = 10).
  - All bindings configurable/unbindable; added actions like `select-screen-0..9` and `select-tab-1..9`. Config accepts snake_case aliases `select_screen_N` / `select_tab_N`.
  - Pane management helpers: focus next pane, swap panes by order, toggle zoom.
  - Docs updated for actions and chord syntax; unit tests cover no duplicate chords, tmux close flip, numbered selector parsing, and prefix not shadowed.

- **Migration**
  - Default flip: `Ctrl-b x` now closes the pane; `Ctrl-b X` closes the tab. Restore with `"close-tab": "x"` and `"close-pane": "X"`.
  - Old fixed tab number selection removed from defaults. Restore with `select-tab-1` through `select-tab-9` in `mux.json`.
  - Number keys now select screens by visible index (1–9, 0 = 10).

<sup>Written for commit f5bc2a6d312ca94f5ef322b4056e19d43832e7ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parameterized key actions for selecting numbered tabs (`select-tab-1`–`select-tab-9`) and screens (`select-screen-0`–`select-screen-9`).
  * Added pane controls: zoom, focus next pane, and swap with adjacent pane (prev/next).
* **Bug Fixes**
  * Updated default close shortcuts to tmux-style semantics (`x` closes the active pane; `X` closes the active tab).
  * Improved prefix-key handling for unknown prefix chords and custom bindings.
* **Documentation**
  * Updated keyboard/configuration docs and examples to reflect new defaults and remapping options (including selector/action naming aliases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->