### PR TITLE
ios-testflight: skip scheduled beta uploads when no iOS-affecting paths changed

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -32,11 +32,14 @@ on:
         type: boolean
   schedule:
     # Every ~2h (at :17 to stay off the top-of-hour rush). The decide job skips a
-    # run only when the current main HEAD was already uploaded by a prior
-    # successful run (SHA compare, not a wall-clock window), so an iOS-affecting
-    # change reaches the TestFlight beta lane within ~2h of landing on main, and
-    # a failed or missed run retries the not-yet-uploaded commit instead of
-    # permanently stranding it. These uploads are external-eligible too, and reuse
+    # run when the current main HEAD was already uploaded by a prior successful
+    # run (SHA compare, not a wall-clock window), and also when main advanced but
+    # the diff since the last uploaded beta touches no iOS-affecting path (every
+    # upload notifies every TestFlight tester, so web-only / macOS-only merges
+    # must not ship a new beta). An iOS-affecting change still reaches the
+    # TestFlight beta lane within ~2h of landing on main, and a failed or missed
+    # run retries the not-yet-uploaded commit instead of permanently stranding
+    # it. These uploads are external-eligible too, and reuse
     # the checked-in iOS MARKETING_VERSION so external testers receive new builds
     # under the already-approved version until that version is intentionally bumped.
     #
@@ -224,10 +227,64 @@ jobs:
             if (!forceBuild && context.eventName === 'schedule') {
               needsBuild = lastUploadedSha !== context.sha;
             }
+
+            // Path gate: even when main advanced, a scheduled beta only ships if
+            // the range since the last uploaded beta touches something that can
+            // change the iOS IPA. Every TestFlight upload notifies every tester,
+            // so web-only / macOS-only / docs-only merges must not produce a new
+            // build. The path set mirrors test-ios.yml's should_run gate plus the
+            // inputs the archive actually consumes: the ghostty submodule pointer
+            // (GhosttyKit is linked into the app), the GhosttyKit provisioning
+            // scripts, the zig toolchain pin, and this workflow itself (archive /
+            // export settings live here). This gate FAILS OPEN (builds anyway) on
+            // any doubt - a compare-API error, a diverged range, a >=300-file
+            // diff where the API truncates the file list - because a spurious
+            // upload costs one notification while a wrong skip silently strands
+            // an iOS change out of beta.
+            const iosPathPattern = /^(ios\/|Packages\/Shared\/|Packages\/iOS\/|Sources\/Mobile\/|vendor\/stack-auth-swift-sdk-prerelease\/|ghostty$|scripts\/ensure-ghosttykit\.sh$|scripts\/ghosttykit-checksums\.txt$|scripts\/install-zig-ci\.sh$|\.github\/workflows\/ios-testflight\.yml$)/;
+            let iosPathsChanged = 'not-evaluated';
+            if (!forceBuild && context.eventName === 'schedule' && needsBuild && lastUploadedSha) {
+              try {
+                const compare = await github.rest.repos.compareCommitsWithBasehead({
+                  owner,
+                  repo,
+                  basehead: `${lastUploadedSha}...${context.sha}`,
+                });
+                const files = compare.data.files || [];
+                if (compare.data.status !== 'ahead') {
+                  core.warning(`compare status is '${compare.data.status}', not 'ahead'; assuming iOS paths changed`);
+                  iosPathsChanged = 'assumed (non-linear history)';
+                } else if (files.length >= 300) {
+                  // The compare API caps the files list at 300 entries.
+                  core.warning('diff since last upload has >=300 files (API truncates); assuming iOS paths changed');
+                  iosPathsChanged = 'assumed (diff too large)';
+                } else {
+                  const changed = files.some(
+                    (f) =>
+                      iosPathPattern.test(f.filename) ||
+                      (f.previous_filename && iosPathPattern.test(f.previous_filename))
+                  );
+                  iosPathsChanged = String(changed);
+                  if (!changed) {
+                    needsBuild = false;
+                    core.notice(`skipping TestFlight upload: ${files.length} changed file(s) since ${lastUploadedSha} touch no iOS-affecting path`);
+                  }
+                }
+              } catch (e) {
+                core.warning(`could not diff ${lastUploadedSha}...${context.sha}; assuming iOS paths changed: ${e.message}`);
+                iosPathsChanged = 'assumed (compare failed)';
+              }
+            }
+
+            // Retry a not-yet-complete external-group assignment whenever this
+            // run is NOT building: both when HEAD was already uploaded and when
+            // the path gate skipped a non-iOS range (the previously uploaded
+            // build is still the current beta and its assignment must not be
+            // stranded until the next iOS change lands).
             const shouldAssignOnly =
               !forceBuild &&
               context.eventName === 'schedule' &&
-              lastUploadedSha === context.sha &&
+              !needsBuild &&
               lastAssignmentRetrySupported &&
               !lastAssignmentSucceeded;
 
@@ -245,6 +302,7 @@ jobs:
                 [{ data: 'head sha', header: true }, context.sha],
                 [{ data: 'last uploaded sha (schedule only)', header: true }, String(lastUploadedSha)],
                 [{ data: 'last uploaded run id', header: true }, String(lastUploadedRunId)],
+                [{ data: 'ios paths changed since last upload', header: true }, iosPathsChanged],
                 [{ data: 'last external assignment succeeded', header: true }, String(lastAssignmentSucceeded)],
                 [{ data: 'should build', header: true }, String(shouldBuild)],
                 [{ data: 'should assign only', header: true }, String(shouldAssignOnly)],


### PR DESCRIPTION
Every TestFlight upload notifies every tester, but the scheduled beta lane's `decide` job only SHA-compared HEAD to the last uploaded commit, so any merge to main (web-only, macOS-only, docs) shipped a new beta build within ~2h and pinged external testers for nothing.

`decide` now diffs `last-uploaded-SHA...HEAD` with the compare API and skips the upload when no file in the range matches the iOS path set. The set mirrors `test-ios.yml`'s `should_run` gate (`ios/`, `Packages/Shared/`, `Packages/iOS/`, `Sources/Mobile/`, `vendor/stack-auth-swift-sdk-prerelease/`) plus the inputs the archive actually consumes: the `ghostty` submodule pointer (GhosttyKit links into the app), `scripts/ensure-ghosttykit.sh`, `scripts/ghosttykit-checksums.txt`, `scripts/install-zig-ci.sh`, and the workflow file itself.

The gate fails open (builds anyway) on a compare-API error, a non-`ahead` range, or a truncated >=300-file diff: a spurious upload costs one notification, a wrong skip silently strands an iOS change out of beta. `workflow_dispatch` behavior is unchanged (always uploads). Assignment-only retries now also fire when the path gate skips a build, so a pending external-group assignment on the previous upload isn't stranded until the next iOS change lands.

Verified with a stub harness driving the extracted `decide` script through 16 scenarios (web-only skip, iOS build, ghostty pointer, rename tracking via `previous_filename`, lookalike-path non-match, fail-open on throw/diverged/truncated, already-uploaded skip, first-run build, dispatch always-build, assign-only retry on skipped build); all pass. The decision summary table now includes an `ios paths changed since last upload` row for auditing scheduled runs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786159962&installation_id=133855650&pr_number=7688&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7688&signature=895e4dcc60ed0acc66cf155de3e06bbbe69e4b3bcb04f5104482880c2e7933b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and path-based skip logic; a wrong skip could strand iOS fixes from beta, though the implementation deliberately fails open on API uncertainty.
> 
> **Overview**
> Scheduled **iOS TestFlight** runs used to upload whenever **main** moved ahead of the last uploaded SHA, so **web-only / macOS-only / docs** merges still pinged every beta tester. The **`decide`** job now compares **`last-uploaded-SHA...HEAD`** and **skips the build** when nothing in that range matches an **iOS-affecting path set** (aligned with **`test-ios.yml`**, plus **`ghostty`**, GhosttyKit/Zig scripts, and the workflow file).
> 
> The path gate **fails open** on compare errors, non-linear history, or **≥300** changed files (API truncation). **`workflow_dispatch`** is unchanged. **Assign-only** retries now run whenever **`needsBuild`** is false—including path-gated skips—so pending external-group assignment is not left hanging. The decision summary table adds **`ios paths changed since last upload`** for auditing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b81e05c6b9cc3eaa87f3b9a155bea4f176a9fb3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip scheduled iOS TestFlight uploads when no iOS-related files changed since the last uploaded build. This cuts noisy tester notifications while still shipping real iOS changes within ~2h.

- New Features
  - Diff `last-uploaded-SHA...HEAD` via the compare API and skip scheduled uploads when no iOS-affecting paths changed.
  - Path gate mirrors `test-ios.yml` `should_run` plus real archive inputs (Ghostty submodule, provisioning/scripts, and the workflow file).
  - Fail-open policy: build anyway on compare errors, non-`ahead` ranges, or truncated diffs.
  - `workflow_dispatch` behavior unchanged (always uploads).
  - Assignment-only retries also run when a build is skipped by the path gate.
  - Decision summary now shows `ios paths changed since last upload` for auditing.

<sup>Written for commit b81e05c6b9cc3eaa87f3b9a155bea4f176a9fb3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled iOS TestFlight runs now check whether recent changes affect iOS before building and uploading.
  * Added clearer run summaries showing whether iOS-related files changed since the last upload.

* **Bug Fixes**
  * Reduced unnecessary scheduled beta uploads by skipping builds when no iOS-relevant changes are detected.
  * Improved retry behavior so upload-only retries follow the new change-detection check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->