### PR TITLE
Sidebar: memoize row snapshot fallback, defer context-menu construction to menu open

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -3,7 +3,7 @@
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 35600	CLI/cmux.swift
 17862	Sources/AppDelegate.swift
-16424	Sources/ContentView.swift
+16161	Sources/ContentView.swift
 15098	Sources/TerminalController.swift
 13164	Sources/Workspace.swift
 12501	Sources/GhosttyTerminalView.swift

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14165,6 +14165,9 @@ struct TabItemView: View, Equatable {
                 }
         }
         let _ = SidebarProfilingSignposts.end(signpost)
+#if DEBUG
+        let _ = { sidebarLazyContractProbe.workspaceRowBodyEnd?() }()
+#endif
         rowView
     }
     private func beginInlineRename() {
@@ -14206,17 +14209,6 @@ struct TabItemView: View, Equatable {
             workspaceSnapshotStorage = pendingSnapshot
         }
         contextMenuState.pendingWorkspaceSnapshot = nil
-    }
-
-    private func contextMenuLabel(multi: String, single: String, isMulti: Bool) -> String {
-        isMulti ? multi : single
-    }
-
-    private func remoteContextMenuWorkspaces() -> [Workspace] {
-        guard !remoteContextMenuWorkspaceIds.isEmpty else { return [] }
-        return remoteContextMenuWorkspaceIds.compactMap { workspaceId in
-            tabManager.tabs.first(where: { $0.id == workspaceId })
-        }
     }
 
     @ViewBuilder
@@ -14754,6 +14746,9 @@ struct TabItemView: View, Equatable {
     }
 
     private func makeWorkspaceSnapshot() -> SidebarWorkspaceSnapshotBuilder.Snapshot {
+#if DEBUG
+        sidebarLazyContractProbe.workspaceSnapshotBuild?()
+#endif
         let signpost = SidebarProfilingSignposts.begin("sidebar-workspace-snapshot", "workspace=\(sidebarShortTabId(tab.id)) details=\(settings.visibleAuxiliaryDetails)"); defer { SidebarProfilingSignposts.end(signpost) }
         let detailVisibility = visibleAuxiliaryDetails
         let orderedPanelIds: [UUID]? = (detailVisibility.showsBranchDirectory || detailVisibility.showsPullRequests)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13283,11 +13283,20 @@ struct TabItemView: View, Equatable {
     let onContextMenuAppear: () -> Void
     let onContextMenuDisappear: () -> Void
     @State private var workspaceSnapshotStorage: SidebarWorkspaceSnapshotBuilder.Snapshot?
+    // Fallback memo for the `workspaceSnapshot` getter: a plain box, not
+    // observed state, so body evaluations can fill it without invalidating the
+    // row. Before onAppear seeds workspaceSnapshotStorage, every access used to
+    // rebuild the snapshot (a full bonsplit tree walk) — several times per
+    // mounted row per scroll.
+    final class WorkspaceSnapshotScratch {
+        var value: SidebarWorkspaceSnapshotBuilder.Snapshot?
+    }
+    @State private var workspaceSnapshotScratch = WorkspaceSnapshotScratch()
     // Row-local selection projection: selectedTabId changes update only rows whose boolean flips.
     @State private var observedIsActive: Bool?
     @State private var contextMenuState = SidebarTabItemContextMenuState()
     @State private var rowInteractionState = SidebarWorkspaceRowInteractionState()
-    @State private var workspaceFinderDirectoryOpenRequest: WorkspaceFinderDirectoryOpenRequest?
+    @State var workspaceFinderDirectoryOpenRequest: WorkspaceFinderDirectoryOpenRequest?
     @State private var isEditing = false
     @State private var renameDraft = ""
     @State private var renameBaselineHadUserCustomTitle = false
@@ -13335,12 +13344,19 @@ struct TabItemView: View, Equatable {
         settings.showsSSH
     }
 
-    private var workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot {
+    var workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot {
+        let presentationKey = workspaceSnapshotPresentationKey
         if let workspaceSnapshotStorage,
-           workspaceSnapshotStorage.presentationKey == workspaceSnapshotPresentationKey {
+           workspaceSnapshotStorage.presentationKey == presentationKey {
             return workspaceSnapshotStorage
         }
-        return makeWorkspaceSnapshot()
+        if let scratch = workspaceSnapshotScratch.value,
+           scratch.presentationKey == presentationKey {
+            return scratch
+        }
+        let snapshot = makeWorkspaceSnapshot()
+        workspaceSnapshotScratch.value = snapshot
+        return snapshot
     }
 
     private var activeTabIndicatorStyle: WorkspaceIndicatorStyle {
@@ -13597,11 +13613,11 @@ struct TabItemView: View, Equatable {
         }
     }
 
-    private func copyWorkspaceIdsToPasteboard(_ ids: [UUID], includeRefs: Bool = false) {
+    func copyWorkspaceIdsToPasteboard(_ ids: [UUID], includeRefs: Bool = false) {
         WorkspaceSurfaceIdentifierClipboardText.copyWorkspaceIds(ids, includeRefs: includeRefs)
     }
 
-    private func copyWorkspaceLinksToPasteboard(_ ids: [UUID]) {
+    func copyWorkspaceLinksToPasteboard(_ ids: [UUID]) {
         WorkspaceSurfaceIdentifierClipboardText.copyWorkspaceLinks(ids, resolvingStableIdsFrom: tabManager.tabs)
     }
 
@@ -14151,7 +14167,7 @@ struct TabItemView: View, Equatable {
             onMoveDown: { moveBy(1) }
         ))
         .contextMenu {
-            workspaceContextMenu
+            TabItemWorkspaceContextMenuContent(row: self)
                 .onAppear {
                     rowInteractionState.contextMenuDidAppear()
                     contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
@@ -14184,6 +14200,7 @@ struct TabItemView: View, Equatable {
 
     func refreshWorkspaceSnapshot(force: Bool = false) {
         let nextSnapshot = makeWorkspaceSnapshot()
+        workspaceSnapshotScratch.value = nextSnapshot
         let decision = SidebarWorkspaceSnapshotRefreshPolicy().decision(
             current: workspaceSnapshotStorage,
             next: nextSnapshot,
@@ -14209,281 +14226,6 @@ struct TabItemView: View, Equatable {
             workspaceSnapshotStorage = pendingSnapshot
         }
         contextMenuState.pendingWorkspaceSnapshot = nil
-    }
-
-    @ViewBuilder
-    private var workspaceContextMenu: some View {
-        let workspaceSnapshot = self.workspaceSnapshot
-        let targetIds = contextMenuWorkspaceIds
-        let isMulti = targetIds.count > 1
-        let shouldPin = contextMenuPinState?.pinned ?? !tab.isPinned
-        let reconnectLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.reconnectWorkspaces", defaultValue: "Reconnect Workspaces"),
-            single: String(localized: "contextMenu.reconnectWorkspace", defaultValue: "Reconnect Workspace"),
-            isMulti: isMulti)
-        let disconnectLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.disconnectWorkspaces", defaultValue: "Disconnect Workspaces"),
-            single: String(localized: "contextMenu.disconnectWorkspace", defaultValue: "Disconnect Workspace"),
-            isMulti: isMulti)
-        let pinLabel = shouldPin
-            ? contextMenuLabel(
-                multi: String(localized: "contextMenu.pinWorkspaces", defaultValue: "Pin Workspaces"),
-                single: String(localized: "contextMenu.pinWorkspace", defaultValue: "Pin Workspace"),
-                isMulti: isMulti)
-            : contextMenuLabel(
-                multi: String(localized: "contextMenu.unpinWorkspaces", defaultValue: "Unpin Workspaces"),
-                single: String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace"),
-                isMulti: isMulti)
-        let closeLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.closeWorkspaces", defaultValue: "Close Workspaces"),
-            single: String(localized: "contextMenu.closeWorkspace", defaultValue: "Close Workspace"),
-            isMulti: isMulti)
-        let markReadLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.markWorkspacesRead", defaultValue: "Mark Workspaces as Read"),
-            single: String(localized: "contextMenu.markWorkspaceRead", defaultValue: "Mark Workspace as Read"),
-            isMulti: isMulti)
-        let markUnreadLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.markWorkspacesUnread", defaultValue: "Mark Workspaces as Unread"),
-            single: String(localized: "contextMenu.markWorkspaceUnread", defaultValue: "Mark Workspace as Unread"),
-            isMulti: isMulti)
-        let clearLatestNotificationLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.clearLatestNotifications", defaultValue: "Clear Latest Notifications"),
-            single: String(localized: "contextMenu.clearLatestNotification", defaultValue: "Clear Latest Notification"),
-            isMulti: isMulti)
-        let copyWorkspaceIDLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.copyWorkspaceIDs", defaultValue: "Copy Workspace IDs"),
-            single: String(localized: "contextMenu.copyWorkspaceID", defaultValue: "Copy Workspace ID"),
-            isMulti: isMulti)
-        let copyWorkspaceLinkLabel = contextMenuLabel(
-            multi: String(localized: "contextMenu.copyWorkspaceLinks", defaultValue: "Copy Workspace Links"),
-            single: String(localized: "contextMenu.copyWorkspaceLink", defaultValue: "Copy Workspace Link"),
-            isMulti: isMulti)
-        let renameWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .renameWorkspace)
-        let editWorkspaceDescriptionShortcut = KeyboardShortcutSettings.shortcut(for: .editWorkspaceDescription)
-        let closeWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .closeWorkspace)
-        let referenceWindowId = AppDelegate.shared?.windowId(for: tabManager)
-        let windowMoveTargets = AppDelegate.shared?.windowMoveTargets(referenceWindowId: referenceWindowId) ?? []
-        let moveMenuTitle = targetIds.count > 1
-            ? String(localized: "contextMenu.moveWorkspacesToWindow", defaultValue: "Move Workspaces to Window")
-            : String(localized: "contextMenu.moveWorkspaceToWindow", defaultValue: "Move Workspace to Window")
-
-        Button(pinLabel) {
-            guard let contextMenuPinState else {
-                NSSound.beep()
-                return
-            }
-            let result = WorkspaceActionDispatcher.performPinAction(contextMenuPinState, in: tabManager)
-            if result.changedWorkspaceIds.isEmpty {
-                refreshWorkspaceSnapshot(force: true)
-            }
-            syncSelectionAfterMutation()
-        }
-        .disabled(contextMenuPinState == nil)
-
-        workspaceGroupContextMenuSection(targetIds: targetIds, isMulti: isMulti)
-
-        Divider()
-
-        if let key = renameWorkspaceShortcut.keyEquivalent {
-            Button(String(localized: "contextMenu.renameWorkspace", defaultValue: "Rename Workspace…")) {
-                promptRename()
-            }
-            .keyboardShortcut(key, modifiers: renameWorkspaceShortcut.eventModifiers)
-        } else {
-            Button(String(localized: "contextMenu.renameWorkspace", defaultValue: "Rename Workspace…")) {
-                promptRename()
-            }
-        }
-
-        if tab.hasCustomTitle {
-            Button(String(localized: "contextMenu.removeCustomWorkspaceName", defaultValue: "Remove Custom Workspace Name")) {
-                tabManager.clearCustomTitle(tabId: tab.id)
-            }
-        }
-
-        if !isMulti {
-            if let key = editWorkspaceDescriptionShortcut.keyEquivalent {
-                Button(String(localized: "contextMenu.editWorkspaceDescription", defaultValue: "Edit Workspace Description…")) {
-                    beginWorkspaceDescriptionEditFromContextMenu()
-                }
-                .keyboardShortcut(key, modifiers: editWorkspaceDescriptionShortcut.eventModifiers)
-            } else {
-                Button(String(localized: "contextMenu.editWorkspaceDescription", defaultValue: "Edit Workspace Description…")) {
-                    beginWorkspaceDescriptionEditFromContextMenu()
-                }
-            }
-
-            if tab.hasCustomDescription {
-                Button(String(localized: "contextMenu.clearWorkspaceDescription", defaultValue: "Clear Workspace Description")) {
-                    tabManager.clearCustomDescription(tabId: tab.id)
-                }
-            }
-        }
-
-        if !remoteContextMenuWorkspaceIds.isEmpty {
-            Divider()
-
-            Button(reconnectLabel) {
-                for workspace in remoteContextMenuWorkspaces() {
-                    workspace.reconnectRemoteConnection()
-                }
-            }
-            .disabled(allRemoteContextMenuTargetsConnecting)
-
-            Button(disconnectLabel) {
-                for workspace in remoteContextMenuWorkspaces() {
-                    workspace.disconnectRemoteConnection(clearConfiguration: false)
-                }
-            }
-            .disabled(allRemoteContextMenuTargetsDisconnected)
-        }
-
-        Menu(String(localized: "contextMenu.workspaceColor", defaultValue: "Workspace Color")) {
-            let tabColorPalette = WorkspaceTabColorSettings.palette()
-
-            if tab.customColor != nil {
-                Button {
-                    applyTabColor(nil, targetIds: targetIds)
-                } label: {
-                    Label(String(localized: "contextMenu.clearColor", defaultValue: "Clear Color"), systemImage: "xmark.circle")
-                }
-            }
-
-            Button {
-                promptCustomColor(targetIds: targetIds)
-            } label: {
-                Label(String(localized: "contextMenu.chooseCustomColor", defaultValue: "Choose Custom Color…"), systemImage: "paintpalette")
-            }
-
-            if !tabColorPalette.isEmpty {
-                Divider()
-            }
-
-            ForEach(tabColorPalette, id: \.id) { entry in
-                Button {
-                    applyTabColor(entry.hex, targetIds: targetIds)
-                } label: {
-                    Label {
-                        Text(entry.name)
-                    } icon: {
-                        Image(nsImage: coloredCircleImage(color: tabColorSwatchColor(for: entry.hex)))
-                    }
-                }
-            }
-        }
-
-        if let copyableSidebarSSHError = workspaceSnapshot.copyableSidebarSSHError {
-            Divider()
-
-            Button(String(localized: "contextMenu.copySshError", defaultValue: "Copy SSH Error")) {
-                WorkspaceSurfaceIdentifierClipboardText.copy(copyableSidebarSSHError)
-            }
-        }
-
-        Divider()
-
-        Button(String(localized: "contextMenu.moveUp", defaultValue: "Move Up")) {
-            moveBy(-1)
-        }
-        .disabled(index == 0)
-
-        Button(String(localized: "contextMenu.moveDown", defaultValue: "Move Down")) {
-            moveBy(1)
-        }
-        .disabled(index >= tabManager.tabs.count - 1)
-
-        Button(String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top")) {
-            tabManager.moveTabsToTop(Set(targetIds))
-            syncSelectionAfterMutation()
-        }
-        .disabled(targetIds.isEmpty)
-
-        Menu(moveMenuTitle) {
-            Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {
-                moveWorkspacesToNewWindow(targetIds)
-            }
-            .disabled(targetIds.isEmpty)
-
-            if !windowMoveTargets.isEmpty {
-                Divider()
-            }
-
-            ForEach(windowMoveTargets) { target in
-                Button(target.label) {
-                    moveWorkspaces(targetIds, toWindow: target.windowId)
-                }
-                .disabled(target.isCurrentWindow || targetIds.isEmpty)
-            }
-        }
-        .disabled(targetIds.isEmpty)
-
-        Divider()
-
-        if let key = closeWorkspaceShortcut.keyEquivalent {
-            Button(closeLabel) {
-                closeTabs(targetIds, allowPinned: true)
-            }
-            .keyboardShortcut(key, modifiers: closeWorkspaceShortcut.eventModifiers)
-            .disabled(targetIds.isEmpty)
-        } else {
-            Button(closeLabel) {
-                closeTabs(targetIds, allowPinned: true)
-            }
-            .disabled(targetIds.isEmpty)
-        }
-
-        Button(String(localized: "contextMenu.closeOtherWorkspaces", defaultValue: "Close Other Workspaces")) {
-            closeOtherTabs(targetIds)
-        }
-        .disabled(tabManager.tabs.count <= 1 || targetIds.count == tabManager.tabs.count)
-
-        Button(String(localized: "contextMenu.closeWorkspacesBelow", defaultValue: "Close Workspaces Below")) {
-            closeTabsBelow(tabId: tab.id)
-        }
-        .disabled(index >= tabManager.tabs.count - 1)
-
-        Button(String(localized: "contextMenu.closeWorkspacesAbove", defaultValue: "Close Workspaces Above")) {
-            closeTabsAbove(tabId: tab.id)
-        }
-        .disabled(index == 0)
-
-        Divider()
-
-        Button(markReadLabel) {
-            markTabsRead(targetIds)
-        }
-        .disabled(!notificationStore.canMarkWorkspaceRead(forTabIds: targetIds))
-
-        Button(markUnreadLabel) {
-            markTabsUnread(targetIds)
-        }
-        .disabled(!notificationStore.canMarkWorkspaceUnread(forTabIds: targetIds))
-
-        Button(clearLatestNotificationLabel) {
-            clearLatestNotifications(targetIds)
-        }
-        .disabled(!hasLatestNotifications(in: targetIds))
-
-        workspaceNotificationsContextMenu(targetIds)
-        Divider()
-        Button(copyWorkspaceIDLabel) {
-            copyWorkspaceIdsToPasteboard(targetIds)
-        }
-        .disabled(targetIds.isEmpty)
-
-        Button(copyWorkspaceLinkLabel) {
-            copyWorkspaceLinksToPasteboard(targetIds)
-        }
-        .disabled(targetIds.isEmpty)
-
-        if !isMulti {
-            Button(String(localized: "contextMenu.showWorkspaceInFinder", defaultValue: "Show in Finder")) {
-                let url = workspaceSnapshot.finderDirectoryPath
-                    .map { URL(fileURLWithPath: $0, isDirectory: true) }
-                workspaceFinderDirectoryOpenRequest = WorkspaceFinderDirectoryOpenRequest(directoryURL: url)
-            }
-            .disabled(workspaceSnapshot.finderDirectoryPath == nil)
-        }
     }
 
     private var backgroundColor: Color {
@@ -14514,7 +14256,7 @@ struct TabItemView: View, Equatable {
         return Color(nsColor: railColor).opacity(0.95)
     }
 
-    private func tabColorSwatchColor(for hex: String) -> NSColor {
+    func tabColorSwatchColor(for hex: String) -> NSColor {
         WorkspaceTabColorSettings.displayNSColor(
             hex: hex,
             colorScheme: colorScheme,
@@ -14526,7 +14268,7 @@ struct TabItemView: View, Equatable {
         String(localized: "accessibility.workspacePosition", defaultValue: "\(workspaceSnapshot.title), workspace \(index + 1) of \(accessibilityWorkspaceCount)")
     }
 
-    private func moveBy(_ delta: Int) {
+    func moveBy(_ delta: Int) {
         let targetIndex = index + delta
         guard targetIndex >= 0, targetIndex < tabManager.tabs.count else { return }
         guard tabManager.reorderWorkspace(tabId: tab.id, toIndex: targetIndex) else { return }
@@ -14614,52 +14356,52 @@ struct TabItemView: View, Equatable {
         setSelectionToTabs()
     }
 
-    private func closeTabs(_ targetIds: [UUID], allowPinned: Bool) {
+    func closeTabs(_ targetIds: [UUID], allowPinned: Bool) {
         tabManager.closeWorkspacesWithConfirmation(targetIds, allowPinned: allowPinned)
         syncSelectionAfterMutation()
     }
 
-    private func closeOtherTabs(_ targetIds: [UUID]) {
+    func closeOtherTabs(_ targetIds: [UUID]) {
         let keepIds = Set(targetIds)
         let idsToClose = tabManager.tabs.compactMap { keepIds.contains($0.id) ? nil : $0.id }
         closeTabs(idsToClose, allowPinned: true)
     }
 
-    private func closeTabsBelow(tabId: UUID) {
+    func closeTabsBelow(tabId: UUID) {
         guard let anchorIndex = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
         let idsToClose = tabManager.tabs.suffix(from: anchorIndex + 1).map { $0.id }
         closeTabs(idsToClose, allowPinned: true)
     }
 
-    private func closeTabsAbove(tabId: UUID) {
+    func closeTabsAbove(tabId: UUID) {
         guard let anchorIndex = tabManager.tabs.firstIndex(where: { $0.id == tabId }) else { return }
         let idsToClose = tabManager.tabs.prefix(upTo: anchorIndex).map { $0.id }
         closeTabs(idsToClose, allowPinned: true)
     }
 
-    private func markTabsRead(_ targetIds: [UUID]) {
+    func markTabsRead(_ targetIds: [UUID]) {
         for id in targetIds {
             notificationStore.markRead(forTabId: id)
         }
     }
 
-    private func markTabsUnread(_ targetIds: [UUID]) {
+    func markTabsUnread(_ targetIds: [UUID]) {
         for id in targetIds {
             notificationStore.markUnread(forTabId: id)
         }
     }
 
-    private func clearLatestNotifications(_ targetIds: [UUID]) {
+    func clearLatestNotifications(_ targetIds: [UUID]) {
         for id in targetIds {
             notificationStore.clearLatestNotification(forTabId: id)
         }
     }
 
-    private func hasLatestNotifications(in targetIds: [UUID]) -> Bool {
+    func hasLatestNotifications(in targetIds: [UUID]) -> Bool {
         targetIds.contains { notificationStore.latestNotification(forTabId: $0) != nil }
     }
 
-    private func syncSelectionAfterMutation() {
+    func syncSelectionAfterMutation() {
         let existingIds = Set(tabManager.tabs.map { $0.id })
         selectedTabIds = selectedTabIds.filter { existingIds.contains($0) }
         if selectedTabIds.isEmpty, let selectedId = tabManager.selectedTabId {
@@ -14831,7 +14573,7 @@ struct TabItemView: View, Equatable {
         return description
     }
 
-    private func moveWorkspaces(_ workspaceIds: [UUID], toWindow windowId: UUID) {
+    func moveWorkspaces(_ workspaceIds: [UUID], toWindow windowId: UUID) {
         guard let app = AppDelegate.shared else { return }
         let orderedWorkspaceIds = tabManager.tabs.compactMap { workspaceIds.contains($0.id) ? $0.id : nil }
         guard !orderedWorkspaceIds.isEmpty else { return }
@@ -14845,7 +14587,7 @@ struct TabItemView: View, Equatable {
         syncSelectionAfterMutation()
     }
 
-    private func moveWorkspacesToNewWindow(_ workspaceIds: [UUID]) {
+    func moveWorkspacesToNewWindow(_ workspaceIds: [UUID]) {
         guard let app = AppDelegate.shared else { return }
         let orderedWorkspaceIds = tabManager.tabs.compactMap { workspaceIds.contains($0.id) ? $0.id : nil }
         guard let firstWorkspaceId = orderedWorkspaceIds.first else { return }
@@ -15189,11 +14931,11 @@ struct TabItemView: View, Equatable {
         }
     }
 
-    private func applyTabColor(_ hex: String?, targetIds: [UUID]) {
+    func applyTabColor(_ hex: String?, targetIds: [UUID]) {
         tabManager.applyWorkspaceColor(hex, toWorkspaceIds: targetIds)
     }
 
-    private func promptCustomColor(targetIds: [UUID]) {
+    func promptCustomColor(targetIds: [UUID]) {
         let alert = NSAlert()
         alert.messageText = String(localized: "alert.customColor.title", defaultValue: "Custom Workspace Color")
         alert.informativeText = String(localized: "alert.customColor.message", defaultValue: "Enter a hex color in the format #RRGGBB.")
@@ -15236,7 +14978,7 @@ struct TabItemView: View, Equatable {
         _ = alert.runModal()
     }
 
-    private func promptRename() {
+    func promptRename() {
         let alert = NSAlert()
         alert.messageText = String(localized: "alert.renameWorkspace.title", defaultValue: "Rename Workspace")
         alert.informativeText = String(localized: "alert.renameWorkspace.message", defaultValue: "Enter a custom name for this workspace.")
@@ -15257,7 +14999,7 @@ struct TabItemView: View, Equatable {
         tabManager.setCustomTitle(tabId: tab.id, title: input.stringValue)
     }
 
-    private func beginWorkspaceDescriptionEditFromContextMenu() {
+    func beginWorkspaceDescriptionEditFromContextMenu() {
         selectedTabIds = [tab.id]
         lastSidebarSelectionIndex = index
         tabManager.selectTab(tab)

--- a/Sources/Debug/SidebarLazyContractProbe.swift
+++ b/Sources/Debug/SidebarLazyContractProbe.swift
@@ -13,6 +13,8 @@ import SwiftUI
 /// Same pattern as `MinimalModeInvalidationProbe`; compiled out of Release.
 struct SidebarLazyContractProbe {
     var workspaceRowBody: (() -> Void)?
+    var workspaceRowBodyEnd: (() -> Void)?
     var groupHeaderRowBody: (() -> Void)?
+    var workspaceSnapshotBuild: (() -> Void)?
 }
 #endif

--- a/Sources/TabItemView+WorkspaceContextMenu.swift
+++ b/Sources/TabItemView+WorkspaceContextMenu.swift
@@ -1,15 +1,304 @@
 import AppKit
 import SwiftUI
 
+/// Menu-open-deferred wrapper for a sidebar row's workspace context menu.
+/// `contextMenu(menuItems:)` evaluates its content closure during every row
+/// body evaluation, so building the menu inline made each visible row resolve
+/// ~12 localized labels, keyboard-shortcut lookups, and the window-move target
+/// list on every render pass. Constructing this wrapper is a struct copy;
+/// `workspaceContextMenu` runs only when SwiftUI realizes the menu content.
+struct TabItemWorkspaceContextMenuContent: View {
+    let row: TabItemView
+
+    var body: some View {
+        row.workspaceContextMenu
+    }
+}
+
 extension TabItemView {
-    func contextMenuLabel(multi: String, single: String, isMulti: Bool) -> String {
+    private func contextMenuLabel(multi: String, single: String, isMulti: Bool) -> String {
         isMulti ? multi : single
     }
 
-    func remoteContextMenuWorkspaces() -> [Workspace] {
+    private func remoteContextMenuWorkspaces() -> [Workspace] {
         guard !remoteContextMenuWorkspaceIds.isEmpty else { return [] }
         return remoteContextMenuWorkspaceIds.compactMap { workspaceId in
             tabManager.tabs.first(where: { $0.id == workspaceId })
+        }
+    }
+
+    @ViewBuilder
+    var workspaceContextMenu: some View {
+        let workspaceSnapshot = self.workspaceSnapshot
+        let targetIds = contextMenuWorkspaceIds
+        let isMulti = targetIds.count > 1
+        let shouldPin = contextMenuPinState?.pinned ?? !tab.isPinned
+        let reconnectLabel = contextMenuLabel(
+            multi: String(localized: "contextMenu.reconnectWorkspaces", defaultValue: "Reconnect Workspaces"),
+            single: String(localized: "contextMenu.reconnectWorkspace", defaultValue: "Reconnect Workspace"),
+            isMulti: isMulti)
+        let disconnectLabel = contextMenuLabel(
+            multi: String(localized: "contextMenu.disconnectWorkspaces", defaultValue: "Disconnect Workspaces"),
+            single: String(localized: "contextMenu.disconnectWorkspace", defaultValue: "Disconnect Workspace"),
+            isMulti: isMulti)
+        let pinLabel = shouldPin
+            ? contextMenuLabel(
+                multi: String(localized: "contextMenu.pinWorkspaces", defaultValue: "Pin Workspaces"),
+                single: String(localized: "contextMenu.pinWorkspace", defaultValue: "Pin Workspace"),
+                isMulti: isMulti)
+            : contextMenuLabel(
+                multi: String(localized: "contextMenu.unpinWorkspaces", defaultValue: "Unpin Workspaces"),
+                single: String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace"),
+                isMulti: isMulti)
+        let closeLabel = contextMenuLabel(
+            multi: String(localized: "contextMenu.closeWorkspaces", defaultValue: "Close Workspaces"),
+            single: String(localized: "contextMenu.closeWorkspace", defaultValue: "Close Workspace"),
+            isMulti: isMulti)
+        let markReadLabel = contextMenuLabel(
+            multi: String(localized: "contextMenu.markWorkspacesRead", defaultValue: "Mark Workspaces as Read"),
+            single: String(localized: "contextMenu.markWorkspaceRead", defaultValue: "Mark Workspace as Read"),
+            isMulti: isMulti)
+        let markUnreadLabel = contextMenuLabel(
+            multi: String(localized: "contextMenu.markWorkspacesUnread", defaultValue: "Mark Workspaces as Unread"),
+            single: String(localized: "contextMenu.markWorkspaceUnread", defaultValue: "Mark Workspace as Unread"),
+            isMulti: isMulti)
+        let clearLatestNotificationLabel = contextMenuLabel(
+            multi: String(localized: "contextMenu.clearLatestNotifications", defaultValue: "Clear Latest Notifications"),
+            single: String(localized: "contextMenu.clearLatestNotification", defaultValue: "Clear Latest Notification"),
+            isMulti: isMulti)
+        let copyWorkspaceIDLabel = contextMenuLabel(
+            multi: String(localized: "contextMenu.copyWorkspaceIDs", defaultValue: "Copy Workspace IDs"),
+            single: String(localized: "contextMenu.copyWorkspaceID", defaultValue: "Copy Workspace ID"),
+            isMulti: isMulti)
+        let copyWorkspaceLinkLabel = contextMenuLabel(
+            multi: String(localized: "contextMenu.copyWorkspaceLinks", defaultValue: "Copy Workspace Links"),
+            single: String(localized: "contextMenu.copyWorkspaceLink", defaultValue: "Copy Workspace Link"),
+            isMulti: isMulti)
+        let renameWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .renameWorkspace)
+        let editWorkspaceDescriptionShortcut = KeyboardShortcutSettings.shortcut(for: .editWorkspaceDescription)
+        let closeWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .closeWorkspace)
+        let referenceWindowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowMoveTargets = AppDelegate.shared?.windowMoveTargets(referenceWindowId: referenceWindowId) ?? []
+        let moveMenuTitle = targetIds.count > 1
+            ? String(localized: "contextMenu.moveWorkspacesToWindow", defaultValue: "Move Workspaces to Window")
+            : String(localized: "contextMenu.moveWorkspaceToWindow", defaultValue: "Move Workspace to Window")
+
+        Button(pinLabel) {
+            guard let contextMenuPinState else {
+                NSSound.beep()
+                return
+            }
+            let result = WorkspaceActionDispatcher.performPinAction(contextMenuPinState, in: tabManager)
+            if result.changedWorkspaceIds.isEmpty {
+                refreshWorkspaceSnapshot(force: true)
+            }
+            syncSelectionAfterMutation()
+        }
+        .disabled(contextMenuPinState == nil)
+
+        workspaceGroupContextMenuSection(targetIds: targetIds, isMulti: isMulti)
+
+        Divider()
+
+        if let key = renameWorkspaceShortcut.keyEquivalent {
+            Button(String(localized: "contextMenu.renameWorkspace", defaultValue: "Rename Workspace…")) {
+                promptRename()
+            }
+            .keyboardShortcut(key, modifiers: renameWorkspaceShortcut.eventModifiers)
+        } else {
+            Button(String(localized: "contextMenu.renameWorkspace", defaultValue: "Rename Workspace…")) {
+                promptRename()
+            }
+        }
+
+        if tab.hasCustomTitle {
+            Button(String(localized: "contextMenu.removeCustomWorkspaceName", defaultValue: "Remove Custom Workspace Name")) {
+                tabManager.clearCustomTitle(tabId: tab.id)
+            }
+        }
+
+        if !isMulti {
+            if let key = editWorkspaceDescriptionShortcut.keyEquivalent {
+                Button(String(localized: "contextMenu.editWorkspaceDescription", defaultValue: "Edit Workspace Description…")) {
+                    beginWorkspaceDescriptionEditFromContextMenu()
+                }
+                .keyboardShortcut(key, modifiers: editWorkspaceDescriptionShortcut.eventModifiers)
+            } else {
+                Button(String(localized: "contextMenu.editWorkspaceDescription", defaultValue: "Edit Workspace Description…")) {
+                    beginWorkspaceDescriptionEditFromContextMenu()
+                }
+            }
+
+            if tab.hasCustomDescription {
+                Button(String(localized: "contextMenu.clearWorkspaceDescription", defaultValue: "Clear Workspace Description")) {
+                    tabManager.clearCustomDescription(tabId: tab.id)
+                }
+            }
+        }
+
+        if !remoteContextMenuWorkspaceIds.isEmpty {
+            Divider()
+
+            Button(reconnectLabel) {
+                for workspace in remoteContextMenuWorkspaces() {
+                    workspace.reconnectRemoteConnection()
+                }
+            }
+            .disabled(allRemoteContextMenuTargetsConnecting)
+
+            Button(disconnectLabel) {
+                for workspace in remoteContextMenuWorkspaces() {
+                    workspace.disconnectRemoteConnection(clearConfiguration: false)
+                }
+            }
+            .disabled(allRemoteContextMenuTargetsDisconnected)
+        }
+
+        Menu(String(localized: "contextMenu.workspaceColor", defaultValue: "Workspace Color")) {
+            let tabColorPalette = WorkspaceTabColorSettings.palette()
+
+            if tab.customColor != nil {
+                Button {
+                    applyTabColor(nil, targetIds: targetIds)
+                } label: {
+                    Label(String(localized: "contextMenu.clearColor", defaultValue: "Clear Color"), systemImage: "xmark.circle")
+                }
+            }
+
+            Button {
+                promptCustomColor(targetIds: targetIds)
+            } label: {
+                Label(String(localized: "contextMenu.chooseCustomColor", defaultValue: "Choose Custom Color…"), systemImage: "paintpalette")
+            }
+
+            if !tabColorPalette.isEmpty {
+                Divider()
+            }
+
+            ForEach(tabColorPalette, id: \.id) { entry in
+                Button {
+                    applyTabColor(entry.hex, targetIds: targetIds)
+                } label: {
+                    Label {
+                        Text(entry.name)
+                    } icon: {
+                        Image(nsImage: coloredCircleImage(color: tabColorSwatchColor(for: entry.hex)))
+                    }
+                }
+            }
+        }
+
+        if let copyableSidebarSSHError = workspaceSnapshot.copyableSidebarSSHError {
+            Divider()
+
+            Button(String(localized: "contextMenu.copySshError", defaultValue: "Copy SSH Error")) {
+                WorkspaceSurfaceIdentifierClipboardText.copy(copyableSidebarSSHError)
+            }
+        }
+
+        Divider()
+
+        Button(String(localized: "contextMenu.moveUp", defaultValue: "Move Up")) {
+            moveBy(-1)
+        }
+        .disabled(index == 0)
+
+        Button(String(localized: "contextMenu.moveDown", defaultValue: "Move Down")) {
+            moveBy(1)
+        }
+        .disabled(index >= tabManager.tabs.count - 1)
+
+        Button(String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top")) {
+            tabManager.moveTabsToTop(Set(targetIds))
+            syncSelectionAfterMutation()
+        }
+        .disabled(targetIds.isEmpty)
+
+        Menu(moveMenuTitle) {
+            Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {
+                moveWorkspacesToNewWindow(targetIds)
+            }
+            .disabled(targetIds.isEmpty)
+
+            if !windowMoveTargets.isEmpty {
+                Divider()
+            }
+
+            ForEach(windowMoveTargets) { target in
+                Button(target.label) {
+                    moveWorkspaces(targetIds, toWindow: target.windowId)
+                }
+                .disabled(target.isCurrentWindow || targetIds.isEmpty)
+            }
+        }
+        .disabled(targetIds.isEmpty)
+
+        Divider()
+
+        if let key = closeWorkspaceShortcut.keyEquivalent {
+            Button(closeLabel) {
+                closeTabs(targetIds, allowPinned: true)
+            }
+            .keyboardShortcut(key, modifiers: closeWorkspaceShortcut.eventModifiers)
+            .disabled(targetIds.isEmpty)
+        } else {
+            Button(closeLabel) {
+                closeTabs(targetIds, allowPinned: true)
+            }
+            .disabled(targetIds.isEmpty)
+        }
+
+        Button(String(localized: "contextMenu.closeOtherWorkspaces", defaultValue: "Close Other Workspaces")) {
+            closeOtherTabs(targetIds)
+        }
+        .disabled(tabManager.tabs.count <= 1 || targetIds.count == tabManager.tabs.count)
+
+        Button(String(localized: "contextMenu.closeWorkspacesBelow", defaultValue: "Close Workspaces Below")) {
+            closeTabsBelow(tabId: tab.id)
+        }
+        .disabled(index >= tabManager.tabs.count - 1)
+
+        Button(String(localized: "contextMenu.closeWorkspacesAbove", defaultValue: "Close Workspaces Above")) {
+            closeTabsAbove(tabId: tab.id)
+        }
+        .disabled(index == 0)
+
+        Divider()
+
+        Button(markReadLabel) {
+            markTabsRead(targetIds)
+        }
+        .disabled(!notificationStore.canMarkWorkspaceRead(forTabIds: targetIds))
+
+        Button(markUnreadLabel) {
+            markTabsUnread(targetIds)
+        }
+        .disabled(!notificationStore.canMarkWorkspaceUnread(forTabIds: targetIds))
+
+        Button(clearLatestNotificationLabel) {
+            clearLatestNotifications(targetIds)
+        }
+        .disabled(!hasLatestNotifications(in: targetIds))
+
+        workspaceNotificationsContextMenu(targetIds)
+        Divider()
+        Button(copyWorkspaceIDLabel) {
+            copyWorkspaceIdsToPasteboard(targetIds)
+        }
+        .disabled(targetIds.isEmpty)
+
+        Button(copyWorkspaceLinkLabel) {
+            copyWorkspaceLinksToPasteboard(targetIds)
+        }
+        .disabled(targetIds.isEmpty)
+
+        if !isMulti {
+            Button(String(localized: "contextMenu.showWorkspaceInFinder", defaultValue: "Show in Finder")) {
+                let url = workspaceSnapshot.finderDirectoryPath
+                    .map { URL(fileURLWithPath: $0, isDirectory: true) }
+                workspaceFinderDirectoryOpenRequest = WorkspaceFinderDirectoryOpenRequest(directoryURL: url)
+            }
+            .disabled(workspaceSnapshot.finderDirectoryPath == nil)
         }
     }
 }

--- a/Sources/TabItemView+WorkspaceContextMenu.swift
+++ b/Sources/TabItemView+WorkspaceContextMenu.swift
@@ -1,0 +1,15 @@
+import AppKit
+import SwiftUI
+
+extension TabItemView {
+    func contextMenuLabel(multi: String, single: String, isMulti: Bool) -> String {
+        isMulti ? multi : single
+    }
+
+    func remoteContextMenuWorkspaces() -> [Workspace] {
+        guard !remoteContextMenuWorkspaceIds.isEmpty else { return [] }
+        return remoteContextMenuWorkspaceIds.compactMap { workspaceId in
+            tabManager.tabs.first(where: { $0.id == workspaceId })
+        }
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1273,6 +1273,7 @@
 		A5001303 /* SurfaceSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001301 /* SurfaceSearchOverlay.swift */; };
 		C7B0FACE000000000000000C /* SystemCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0FACE000000000000000D /* SystemCommandRunner.swift */; };
 		FBE660ABA1854983B84368C6 /* SystemWideHotkeyShortcutPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65154DD251384EE0A2C8923A /* SystemWideHotkeyShortcutPolicyTests.swift */; };
+		C9A5720DC9A5720DC9A5720D /* TabItemView+WorkspaceContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5720EC9A5720EC9A5720E /* TabItemView+WorkspaceContextMenu.swift */; };
 		C9A5720BC9A5720BC9A5720B /* TabItemView+WorkspaceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5720CC9A5720CC9A5720C /* TabItemView+WorkspaceGroups.swift */; };
 		A5F100000000000000000005 /* TabItemView+WorkspaceNotificationsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F100000000000000000006 /* TabItemView+WorkspaceNotificationsMenu.swift */; };
 		DCDC1000000000000000B015 /* TabManager+BrowserFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B016 /* TabManager+BrowserFocus.swift */; };
@@ -2827,6 +2828,7 @@
 		A5001301 /* SurfaceSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/SurfaceSearchOverlay.swift; sourceTree = "<group>"; };
 		C7B0FACE000000000000000D /* SystemCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemCommandRunner.swift; sourceTree = "<group>"; };
 		65154DD251384EE0A2C8923A /* SystemWideHotkeyShortcutPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemWideHotkeyShortcutPolicyTests.swift; sourceTree = "<group>"; };
+		C9A5720EC9A5720EC9A5720E /* TabItemView+WorkspaceContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabItemView+WorkspaceContextMenu.swift"; sourceTree = "<group>"; };
 		C9A5720CC9A5720CC9A5720C /* TabItemView+WorkspaceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabItemView+WorkspaceGroups.swift"; sourceTree = "<group>"; };
 		A5F100000000000000000006 /* TabItemView+WorkspaceNotificationsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabItemView+WorkspaceNotificationsMenu.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B016 /* TabManager+BrowserFocus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabManager+BrowserFocus.swift"; sourceTree = "<group>"; };
@@ -3550,6 +3552,7 @@
 				C0DE5F210000000000000002 /* SidebarMetadataMarkdownRenderer.swift */,
 				C9A57602C9A57602C9A57602 /* SidebarWorkspaceTopDropIndicator.swift */,
 				C9A5720CC9A5720CC9A5720C /* TabItemView+WorkspaceGroups.swift */,
+				C9A5720EC9A5720EC9A5720E /* TabItemView+WorkspaceContextMenu.swift */,
 				C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */,
 				C9A57204C9A57204C9A57204 /* WorkspaceGroupMenuSnapshot.swift */,
 				C9A57205C9A57205C9A57205 /* WorkspaceGroupMoveToMenuState.swift */,
@@ -5967,6 +5970,7 @@
 				F6572000A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift in Sources */,
 				A5001303 /* SurfaceSearchOverlay.swift in Sources */,
 				C7B0FACE000000000000000C /* SystemCommandRunner.swift in Sources */,
+				C9A5720DC9A5720DC9A5720D /* TabItemView+WorkspaceContextMenu.swift in Sources */,
 				C9A5720BC9A5720BC9A5720B /* TabItemView+WorkspaceGroups.swift in Sources */,
 				A5F100000000000000000005 /* TabItemView+WorkspaceNotificationsMenu.swift in Sources */,
 				DCDC1000000000000000B015 /* TabManager+BrowserFocus.swift in Sources */,

--- a/cmuxTests/SidebarLazyLayoutScaleTests.swift
+++ b/cmuxTests/SidebarLazyLayoutScaleTests.swift
@@ -39,9 +39,21 @@ final class SidebarLazyLayoutScaleTests {
     private final class RowBodyCounter {
         var workspaceRowBodies = 0
         var groupHeaderBodies = 0
+        var workspaceSnapshotBuilds = 0
+        // Snapshot builds bracketed by workspaceRowBody/workspaceRowBodyEnd,
+        // i.e. synchronous work inside a single TabItemView.body evaluation.
+        // Builds outside the bracket (onAppear refresh, observation publishers)
+        // are legitimate and not counted here.
+        var insideWorkspaceRowBody = false
+        var snapshotBuildsInCurrentRowBody = 0
+        var maxSnapshotBuildsInOneRowBody = 0
         func reset() {
             workspaceRowBodies = 0
             groupHeaderBodies = 0
+            workspaceSnapshotBuilds = 0
+            insideWorkspaceRowBody = false
+            snapshotBuildsInCurrentRowBody = 0
+            maxSnapshotBuildsInOneRowBody = 0
         }
     }
 
@@ -143,8 +155,24 @@ final class SidebarLazyLayoutScaleTests {
         .environment(
             \.sidebarLazyContractProbe,
             SidebarLazyContractProbe(
-                workspaceRowBody: { counter.workspaceRowBodies += 1 },
-                groupHeaderRowBody: { counter.groupHeaderBodies += 1 }
+                workspaceRowBody: {
+                    counter.workspaceRowBodies += 1
+                    counter.insideWorkspaceRowBody = true
+                    counter.snapshotBuildsInCurrentRowBody = 0
+                },
+                workspaceRowBodyEnd: {
+                    counter.insideWorkspaceRowBody = false
+                },
+                groupHeaderRowBody: { counter.groupHeaderBodies += 1 },
+                workspaceSnapshotBuild: {
+                    counter.workspaceSnapshotBuilds += 1
+                    guard counter.insideWorkspaceRowBody else { return }
+                    counter.snapshotBuildsInCurrentRowBody += 1
+                    counter.maxSnapshotBuildsInOneRowBody = max(
+                        counter.maxSnapshotBuildsInOneRowBody,
+                        counter.snapshotBuildsInCurrentRowBody
+                    )
+                }
             )
         )
         .defaultAppStorage(defaults)
@@ -231,6 +259,38 @@ final class SidebarLazyLayoutScaleTests {
             \(headerRealized) group-header bodies evaluated for 5 groups in one viewport. \
             The group-header row wrapper (sidebarWorkspaceGroupHeader) is defeating \
             virtualization or re-evaluating without bound — the #4385 regression site.
+            """
+        )
+    }
+
+    /// One TabItemView.body evaluation must build the workspace snapshot at
+    /// most once. The snapshot is a full per-workspace projection (bonsplit
+    /// tree walk, git branch summaries, PR rows); until `onAppear` seeds
+    /// `workspaceSnapshotStorage`, every `workspaceSnapshot` access in the
+    /// first body evaluation used to rebuild it from scratch, so each row a
+    /// scroll mounts paid the walk several times over. Builds outside body
+    /// evaluations (onAppear refresh, observation publishers) are legitimate
+    /// and excluded by the probe bracket.
+    @Test
+    @MainActor
+    func testRowBodyEvaluationBuildsWorkspaceSnapshotAtMostOnce() async throws {
+        let harness = try await Self.mountSidebar(workspaceCount: Self.workspaceCount)
+        defer { harness.tearDown() }
+
+        await Self.drainMainRunLoop(for: harness.window)
+
+        #expect(
+            harness.counter.workspaceSnapshotBuilds > 0,
+            "Sidebar mounted but no workspace snapshot was built; the probe wiring is broken."
+        )
+        let worstBody = harness.counter.maxSnapshotBuildsInOneRowBody
+        #expect(
+            worstBody <= 1,
+            """
+            A single TabItemView.body evaluation built the workspace snapshot \(worstBody) \
+            times. The snapshot fallback in the `workspaceSnapshot` getter must memoize \
+            within a body evaluation; N accesses before onAppear seeds storage must not \
+            mean N bonsplit tree walks per mounted row.
             """
         )
     }


### PR DESCRIPTION
Fixes the residual sidebar scroll lag on NIGHTLY (profile: main thread ~66% busy during sidebar scrolling at 100+ workspaces, capture /tmp/cmux-hang-20260708-195738 on 0.64.17-nightly).

Two per-frame costs in TabItemView:

1. **Snapshot rebuilt per access on row mount.** Until `onAppear` seeds `workspaceSnapshotStorage`, every `workspaceSnapshot` access in the first body evaluation rebuilt the full snapshot (bonsplit tree walk, git branch summaries, PR rows) — 3-4 walks per row every time a scroll mounts one. The getter now memoizes into a plain non-observed scratch box; `refreshWorkspaceSnapshot` overwrites the box on every observation-driven rebuild, so data freshness is unchanged (any signal that previously rebuilt the snapshot still does).

2. **Context menu built on every body evaluation.** `contextMenu(menuItems:)` evaluates its content closure during body, and `workspaceContextMenu` resolves ~12 localized labels, keyboard-shortcut lookups, and the window-move target list — 267/7001 main-thread samples in a 12s scroll capture on a seeded 120-workspace instance. The menu moved to `TabItemView+WorkspaceContextMenu.swift` behind `TabItemWorkspaceContextMenuContent`; constructing that wrapper is a struct copy, and the menu body runs only when the menu content is realized (menu open).

Two-commit structure: commit 1 adds the failing scale-test (`SidebarLazyLayoutScaleTests.testRowBodyEvaluationBuildsWorkspaceSnapshotAtMostOnce`, via new `SidebarLazyContractProbe` hooks bracketing body evaluation), commit 2 adds the fix. `ContentView.swift` shrinks by 263 lines; its length budget is lowered to match. `check-sidebar-lazy-layout.py`, pbxproj normalization, and test wiring lint all pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786160069&installation_id=133855650&pr_number=7689&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7689&signature=b2cc8ada98e8bd47da08fa7cc4a264b682fd8efb2276e4bf2e19af5d58586009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-focused refactor with behavior preserved; risk is mainly regression in context-menu actions or stale row display before snapshot refresh paths run.
> 
> **Overview**
> Improves sidebar scroll performance for large workspace lists by cutting redundant work during each `TabItemView` body pass.
> 
> **Workspace snapshot:** Before `onAppear` seeds `workspaceSnapshotStorage`, repeated reads of `workspaceSnapshot` no longer each trigger a full snapshot build (bonsplit walk, git/PR projection). A non-observed scratch box memoizes the fallback within a body evaluation; `refreshWorkspaceSnapshot` still updates scratch and storage so observation-driven freshness is unchanged.
> 
> **Context menu:** The workspace context menu moves to `TabItemView+WorkspaceContextMenu.swift` and is wired through `TabItemWorkspaceContextMenuContent`, so localized labels, shortcut lookups, and window-move targets are not rebuilt on every row render—only when menu content is realized. Several row helpers are widened to `internal` for the extension; menu behavior is intended to be unchanged.
> 
> **Tests / CI:** `SidebarLazyContractProbe` gains body-end and snapshot-build hooks; `SidebarLazyLayoutScaleTests` adds `testRowBodyEvaluationBuildsWorkspaceSnapshotAtMostOnce`. `ContentView.swift` line budget is lowered after the extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f60a4a59bf215604c9f99224d2793f24a1ce3ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce sidebar scroll lag by memoizing the initial workspace snapshot and building the context menu only when it opens. This removes per-frame work in the sidebar and smooths scrolling on NIGHTLY with 100+ workspaces.

- **Performance**
  - Memoized the snapshot fallback in the `workspaceSnapshot` getter using a non-observed scratch cache; refreshes overwrite it to keep data fresh.
  - Deferred context-menu construction to menu open via `TabItemWorkspaceContextMenuContent`; moved the full menu into `TabItemView+WorkspaceContextMenu.swift` so labels/shortcuts resolve only on demand.
  - Shrunk `ContentView.swift`; lowered its length budget accordingly.

- **Tests**
  - Added a scale test that asserts a row body builds the workspace snapshot at most once.
  - Extended `SidebarLazyContractProbe` with body-end and snapshot-build hooks to bracket and count synchronous work inside a single row body.

<sup>Written for commit f60a4a59bf215604c9f99224d2793f24a1ce3ccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar workspace snapshot loading with a more reliable fallback cache, reducing unnecessary rebuilds during row rendering and scrolling.
  * Refined the workspace context menu, including correct multi-selection labeling and more consistent action availability.
* **New Features**
  * Added/expanded workspace context menu actions (including remote workspace connect/disconnect, pin/unpin handling, rename/description edits, color selection, notifications, and copy link/ID options).
* **Tests**
  * Added coverage to ensure workspace snapshots are built no more than once per row evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->