### PR TITLE
Browser extensions via WKWebExtension — Bitwarden works (popup, autofill, ⌘⇧L, passkeys)

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -795,6 +795,24 @@ func cmuxOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
     return nil
 }
 
+/// Whether the responder chain passes through a browser web view, so
+/// web-extension shortcut commands (e.g. Bitwarden autofill) may claim the event.
+func cmuxRespondersContainBrowserWebView(_ responder: NSResponder?) -> Bool {
+    var current: NSResponder? = responder
+    while let next = current {
+        if next is CmuxWebView { return true }
+        if let view = next as? NSView {
+            var ancestor: NSView? = view.superview
+            while let candidate = ancestor {
+                if candidate is CmuxWebView { return true }
+                ancestor = candidate.superview
+            }
+        }
+        current = next.nextResponder
+    }
+    return false
+}
+
 func cmuxFieldEditorOwnerView(_ editor: NSTextView) -> NSView? {
     guard editor.isFieldEditor else { return nil }
     if let owner = cmuxTrackedFindFieldEditorOwner(editor) { return owner }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -16603,6 +16603,16 @@ private extension NSApplication {
             let responder = event.window?.firstResponder
                 ?? AppDelegate.shared?.shortcutRoutingKeyWindow?.firstResponder
                 ?? mainWindow?.firstResponder
+            // A stale default (e.g. ⌘⇧L after Open Browser is remapped) is free for
+            // web-extension commands like Bitwarden autofill while a browser web
+            // view has focus; otherwise the suppression below would eat it.
+            if #available(macOS 15.4, *), cmuxRespondersContainBrowserWebView(responder),
+               BrowserWebExtensionSupport.shared.performCommand(for: event) {
+#if DEBUG
+                cmuxDebugLog("app.sendEvent routed web-extension command before stale cmux menu shortcut")
+#endif
+                return
+            }
             if let ghosttyView = cmuxOwningGhosttyView(for: responder) {
                 ghosttyView.keyDown(with: event)
 #if DEBUG

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3593,6 +3593,9 @@ final class BrowserPanel: Panel, ObservableObject {
         // Ensure browser cookies/storage persist across navigations and launches.
         // This reduces repeated consent/bot-challenge flows on sites like Google.
         configuration.websiteDataStore = websiteDataStore
+        if #available(macOS 15.4, *) {
+            BrowserWebExtensionSupport.shared.attach(to: configuration)
+        }
         if configuration.urlSchemeHandler(forURLScheme: CmuxDiffViewerURLSchemeHandler.scheme) == nil {
             configuration.setURLSchemeHandler(
                 CmuxDiffViewerURLSchemeHandler.shared,
@@ -3976,6 +3979,9 @@ final class BrowserPanel: Panel, ObservableObject {
         hiddenWebViewDiscardManager.delegate = self
         applyProxyConfigurationIfAvailable()
         BrowserProfileStore.shared.noteUsed(resolvedProfileID)
+        if #available(macOS 15.4, *) {
+            BrowserWebExtensionSupport.shared.register(panel: self)
+        }
 
         // Set up navigation delegate
         let navDelegate = BrowserNavigationDelegate()
@@ -5326,6 +5332,9 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     func close() {
+        if #available(macOS 15.4, *) {
+            BrowserWebExtensionSupport.shared.unregister(panelID: id)
+        }
         cancelHiddenWebViewDiscard()
         isClosingWebViewLifecycle = true
         refreshWebViewLifecycleState()

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1349,6 +1349,15 @@ struct BrowserPanelView: View {
                     onClear: { panel.clearRecentDownloads() }
                 )
             }
+
+            if #available(macOS 15.4, *) {
+                BrowserWebExtensionToolbarButtons(
+                    support: BrowserWebExtensionSupport.shared,
+                    panel: panel,
+                    iconPointSize: chromeMetrics.navigationIconFontSize,
+                    hitSize: addressBarButtonHitSize
+                )
+            }
         }
     }
 

--- a/Sources/Panels/BrowserWebExtensionPopoutWindowController.swift
+++ b/Sources/Panels/BrowserWebExtensionPopoutWindowController.swift
@@ -1,0 +1,172 @@
+import AppKit
+import WebKit
+
+/// Hosts a `windows.create({type: "popup"})` window opened by a web extension —
+/// e.g. Bitwarden's passkey-confirmation, unlock, and 2FA popouts.
+///
+/// The controller is both the `WKWebExtensionWindow` and the owner of the native
+/// `NSWindow` + extension-page `WKWebView`; its single tab is a nested adapter.
+@available(macOS 15.4, *)
+@MainActor
+final class BrowserWebExtensionPopoutWindowController: NSObject, WKWebExtensionWindow, NSWindowDelegate {
+    private static let defaultSize = CGSize(width: 400, height: 600)
+
+    let window: NSWindow
+    let webView: WKWebView
+    private(set) lazy var tab = Tab(controller: self)
+    private weak var support: BrowserWebExtensionSupport?
+    private weak var extensionContext: WKWebExtensionContext?
+
+    init(
+        configuration: WKWebExtension.WindowConfiguration,
+        context: WKWebExtensionContext,
+        support: BrowserWebExtensionSupport
+    ) {
+        self.support = support
+        self.extensionContext = context
+
+        let webViewConfiguration = context.webViewConfiguration ?? WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
+        webView.isInspectable = true
+
+        var frame = configuration.frame
+        if frame.isNull || frame.isEmpty || frame.width < 50 || frame.height < 50 {
+            frame = CGRect(origin: .zero, size: Self.defaultSize)
+        }
+        window = NSWindow(
+            contentRect: frame,
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.level = .floating
+        window.contentView = webView
+        if configuration.frame.isNull || configuration.frame.isEmpty {
+            window.center()
+        }
+
+        super.init()
+        window.delegate = self
+        window.title = context.webExtension.displayName ?? "Extension"
+
+        if let url = configuration.tabURLs.first {
+            webView.load(URLRequest(url: url))
+        }
+        if configuration.shouldBeFocused {
+            NSApp.activate(ignoringOtherApps: false)
+            window.makeKeyAndOrderFront(nil)
+        } else {
+            window.orderFront(nil)
+        }
+    }
+
+    var isKeyWindow: Bool {
+        window.isKeyWindow
+    }
+
+    func closeFromExtensionOrUser() {
+        guard window.delegate === self else { return }
+        window.delegate = nil
+        support?.popoutDidClose(self)
+        window.close()
+    }
+
+    // MARK: - NSWindowDelegate
+
+    func windowWillClose(_ notification: Notification) {
+        window.delegate = nil
+        support?.popoutDidClose(self)
+    }
+
+    // MARK: - WKWebExtensionWindow
+
+    func tabs(for context: WKWebExtensionContext) -> [any WKWebExtensionTab] {
+        [tab]
+    }
+
+    func activeTab(for context: WKWebExtensionContext) -> (any WKWebExtensionTab)? {
+        tab
+    }
+
+    func windowType(for context: WKWebExtensionContext) -> WKWebExtension.WindowType {
+        .popup
+    }
+
+    func windowState(for context: WKWebExtensionContext) -> WKWebExtension.WindowState {
+        .normal
+    }
+
+    func isPrivate(for context: WKWebExtensionContext) -> Bool {
+        false
+    }
+
+    func frame(for context: WKWebExtensionContext) -> CGRect {
+        window.frame
+    }
+
+    func screenFrame(for context: WKWebExtensionContext) -> CGRect {
+        window.screen?.frame ?? NSScreen.main?.frame ?? .null
+    }
+
+    func focus(for context: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+        window.makeKeyAndOrderFront(nil)
+        completionHandler(nil)
+    }
+
+    func close(for context: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+        closeFromExtensionOrUser()
+        completionHandler(nil)
+    }
+
+    // MARK: - Tab
+
+    /// The popout window's single extension-page tab.
+    @MainActor
+    final class Tab: NSObject, WKWebExtensionTab {
+        private weak var controller: BrowserWebExtensionPopoutWindowController?
+
+        init(controller: BrowserWebExtensionPopoutWindowController) {
+            self.controller = controller
+        }
+
+        func window(for context: WKWebExtensionContext) -> (any WKWebExtensionWindow)? {
+            controller
+        }
+
+        func indexInWindow(for context: WKWebExtensionContext) -> Int {
+            0
+        }
+
+        func webView(for context: WKWebExtensionContext) -> WKWebView? {
+            controller?.webView
+        }
+
+        func url(for context: WKWebExtensionContext) -> URL? {
+            controller?.webView.url
+        }
+
+        func title(for context: WKWebExtensionContext) -> String? {
+            controller?.webView.title
+        }
+
+        func isSelected(for context: WKWebExtensionContext) -> Bool {
+            true
+        }
+
+        func isLoadingComplete(for context: WKWebExtensionContext) -> Bool {
+            guard let webView = controller?.webView else { return true }
+            return !webView.isLoading
+        }
+
+        func loadURL(_ url: URL, for context: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+            controller?.webView.load(URLRequest(url: url))
+            completionHandler(nil)
+        }
+
+        func close(for context: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+            controller?.closeFromExtensionOrUser()
+            completionHandler(nil)
+        }
+    }
+}

--- a/Sources/Panels/BrowserWebExtensionPopoutWindowController.swift
+++ b/Sources/Panels/BrowserWebExtensionPopoutWindowController.swift
@@ -30,7 +30,8 @@ final class BrowserWebExtensionPopoutWindowController: NSObject, WKWebExtensionW
         webView.isInspectable = true
 
         var frame = configuration.frame
-        if frame.isNull || frame.isEmpty || frame.width < 50 || frame.height < 50 {
+        let usesFallbackFrame = frame.isNull || frame.isEmpty || frame.width < 50 || frame.height < 50
+        if usesFallbackFrame {
             frame = CGRect(origin: .zero, size: Self.defaultSize)
         }
         window = NSWindow(
@@ -39,16 +40,22 @@ final class BrowserWebExtensionPopoutWindowController: NSObject, WKWebExtensionW
             backing: .buffered,
             defer: false
         )
+        // Standalone closable window: the stable identifier opts it into the
+        // shared close-shortcut routing (cmuxWindowShouldOwnCloseShortcut).
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.webExtensionPopout")
         window.isReleasedWhenClosed = false
         window.level = .floating
         window.contentView = webView
-        if configuration.frame.isNull || configuration.frame.isEmpty {
+        if usesFallbackFrame {
             window.center()
         }
 
         super.init()
         window.delegate = self
-        window.title = context.webExtension.displayName ?? "Extension"
+        window.title = context.webExtension.displayName ?? String(
+            localized: "browser.webExtension.action.help",
+            defaultValue: "Extension"
+        )
 
         if let url = configuration.tabURLs.first {
             webView.load(URLRequest(url: url))

--- a/Sources/Panels/BrowserWebExtensionSupport.swift
+++ b/Sources/Panels/BrowserWebExtensionSupport.swift
@@ -120,18 +120,6 @@ final class BrowserWebExtensionSupport: NSObject, ObservableObject {
         contexts.append(context)
 #if DEBUG
         logDiagnostics(for: context, label: "postLoad")
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(5))
-            self?.logDiagnostics(for: context, label: "postLoad+5s")
-        }
-        if ProcessInfo.processInfo.environment["CMUX_WEBEXT_AUTOPROBE"] == "1" {
-            Task { @MainActor [weak self] in
-                try? await Task.sleep(for: .seconds(8))
-                guard let self else { return }
-                cmuxDebugLog("browser.webext.autoprobe performAction")
-                context.performAction(for: self.activeTabAdapter)
-            }
-        }
 #endif
     }
 
@@ -188,8 +176,15 @@ final class BrowserWebExtensionSupport: NSObject, ObservableObject {
     func unregister(panelID: UUID) {
         guard let adapter = tabAdapters.removeValue(forKey: panelID) else { return }
         orderedPanelIDs.removeAll { $0 == panelID }
-        if activePanelID == panelID { activePanelID = orderedPanelIDs.last }
         controller.didCloseTab(adapter, windowIsClosing: false)
+        if activePanelID == panelID {
+            activePanelID = orderedPanelIDs.last
+            // Tell extensions which tab is active now, or they keep acting on
+            // the closed one until the next focus change.
+            if let successor = activePanelID.flatMap({ tabAdapters[$0] }) {
+                controller.didActivateTab(successor, previousActiveTab: adapter)
+            }
+        }
     }
 
     func noteActivated(panelID: UUID) {
@@ -238,14 +233,6 @@ final class BrowserWebExtensionSupport: NSObject, ObservableObject {
 #endif
             return true
         }
-#if DEBUG
-        if !contexts.isEmpty {
-            cmuxDebugLog(
-                "browser.webext.command unmatched key=\(event.charactersIgnoringModifiers ?? "?") " +
-                "mods=\(event.modifierFlags.intersection(.deviceIndependentFlagsMask).rawValue)"
-            )
-        }
-#endif
         return false
     }
 
@@ -349,71 +336,8 @@ extension BrowserWebExtensionSupport: WKWebExtensionControllerDelegate {
         }
         popover.behavior = .transient
         popover.show(relativeTo: anchor.bounds, of: anchor, preferredEdge: .maxY)
-#if DEBUG
-        if ProcessInfo.processInfo.environment["CMUX_WEBEXT_AUTOPROBE"] == "1",
-           let popupWebView = action.popupWebView {
-            probePopup(popupWebView)
-        }
-#endif
         completionHandler(nil)
     }
-
-#if DEBUG
-    /// Evaluates a WebExtension-API probe inside the action popup so tab/window
-    /// adapter behavior is observable from the extension's point of view.
-    /// Installs an error-capture hook and reloads the popup first so boot-time
-    /// console errors and unhandled rejections are observable.
-    private func probePopup(_ popupWebView: WKWebView) {
-        Task { @MainActor in
-            let hookSource = """
-            window.__errs = [];
-            window.addEventListener("error", (e) => window.__errs.push("E:" + e.message + "@" + (e.filename || "") + ":" + (e.lineno || 0)));
-            window.addEventListener("unhandledrejection", (e) => window.__errs.push("R:" + ((e.reason && (e.reason.stack || e.reason.message)) || e.reason)));
-            const ce = console.error.bind(console);
-            console.error = (...a) => { window.__errs.push("C:" + a.map(String).join(" ").slice(0, 300)); ce(...a); };
-            """
-            popupWebView.configuration.userContentController.addUserScript(
-                WKUserScript(source: hookSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
-            )
-            popupWebView.reload()
-            try? await Task.sleep(for: .seconds(5))
-            let script = """
-            try {
-              const api = globalThis.browser || globalThis.chrome;
-              const tabs = await api.tabs.query({ active: true, currentWindow: true });
-              const wins = await api.windows.getAll();
-              const win = await api.windows.getCurrent().catch((e) => 'ERR:' + e.message);
-              let popoutTest = "skipped";
-              try {
-                const w = await api.windows.create({ url: "popup/index.html", type: "popup", width: 380, height: 500, focused: false });
-                popoutTest = w ? "created:" + w.id + ":tabs=" + (w.tabs ? w.tabs.length : "?") : "null";
-                if (w) { await new Promise(r => setTimeout(r, 1500)); await api.windows.remove(w.id); popoutTest += ":removed"; }
-              } catch (e) { popoutTest = "ERR:" + (e && e.message); }
-              return JSON.stringify({
-                ready: document.readyState,
-                bodyChildren: document.body ? document.body.children.length : -1,
-                tabCount: tabs.length,
-                tab0: tabs[0] ? `${tabs[0].id}:${tabs[0].url || "nourl"}:${tabs[0].title || "notitle"}` : "none",
-                winCount: wins.length,
-                currentWin: typeof win === "string" ? win : (win ? win.id : "none"),
-                text: (document.body ? document.body.innerText : "").replace(/\\s+/g, " ").slice(0, 160),
-                html: (document.body ? document.body.innerHTML : "").replace(/\\s+/g, " ").slice(0, 240),
-                errs: (window.__errs || []).slice(0, 8),
-                popoutTest
-              });
-            } catch (e) { return "ERR:" + (e && e.message); }
-            """
-            popupWebView.callAsyncJavaScript(script, arguments: [:], in: nil, in: .page) { result in
-                switch result {
-                case .success(let value):
-                    cmuxDebugLog("browser.webext.popupProbe \(value ?? "nil")")
-                case .failure(let error):
-                    cmuxDebugLog("browser.webext.popupProbe error=\(error.localizedDescription)")
-                }
-            }
-        }
-    }
-#endif
 
     func webExtensionController(
         _ controller: WKWebExtensionController,

--- a/Sources/Panels/BrowserWebExtensionSupport.swift
+++ b/Sources/Panels/BrowserWebExtensionSupport.swift
@@ -1,0 +1,484 @@
+import AppKit
+import SwiftUI
+import WebKit
+
+/// Hosts Chrome/Safari-style web extensions in the built-in browser via WebKit's
+/// native `WKWebExtensionController` API (macOS 15.4+).
+///
+/// One shared controller (persistent storage keyed by a fixed identifier) is attached
+/// to every browser `WKWebViewConfiguration`. Extensions are discovered from:
+/// - directories listed in the `CMUX_BROWSER_EXTENSIONS` environment variable
+///   (colon-separated paths to unpacked extensions or `.appex` bundles), and
+/// - the Bitwarden desktop app's bundled Safari web extension, when installed.
+@available(macOS 15.4, *)
+@MainActor
+final class BrowserWebExtensionSupport: NSObject, ObservableObject {
+    static let shared = BrowserWebExtensionSupport()
+
+    /// Fixed identifier so extension storage (e.g. the Bitwarden vault cache)
+    /// persists across app launches.
+    private static let controllerIdentifier = UUID(uuidString: "8C0FDE2B-6EFD-4E8C-9E70-8E7D0A4C51B7")!
+
+    /// Bundled Safari web extension inside the Bitwarden desktop app.
+    private static let bitwardenAppexURL = URL(
+        fileURLWithPath: "/Applications/Bitwarden.app/Contents/PlugIns/safari.appex"
+    )
+
+    let controller: WKWebExtensionController
+
+    @Published private(set) var contexts: [WKWebExtensionContext] = []
+    @Published private(set) var loadErrors: [String] = []
+
+    private var didStartLoading = false
+    private var tabAdapters: [UUID: BrowserWebExtensionTabAdapter] = [:]
+    private var orderedPanelIDs: [UUID] = []
+    private(set) var activePanelID: UUID?
+    private(set) lazy var windowAdapter = BrowserWebExtensionWindowAdapter(support: self)
+    private var popouts: [BrowserWebExtensionPopoutWindowController] = []
+
+    /// Anchor for the next action popup presentation, set by the toolbar button
+    /// immediately before calling `performAction(context:panel:anchorView:)`.
+    private weak var pendingPopupAnchorView: NSView?
+
+    private var nativeMessageDropCount = 0
+
+    private override init() {
+        let configuration = WKWebExtensionController.Configuration(identifier: Self.controllerIdentifier)
+        // Extension-owned web views (background page, action popup) get WebKit's
+        // default user agent, which lacks the " Safari/" token. Extensions like
+        // Bitwarden classify the browser from the UA and crash on an unknown one,
+        // so present the same Safari application identity the browser panels use.
+        let webViewConfiguration = configuration.webViewConfiguration ?? WKWebViewConfiguration()
+        webViewConfiguration.applicationNameForUserAgent = "Version/26.2 Safari/605.1.15"
+        configuration.webViewConfiguration = webViewConfiguration
+        controller = WKWebExtensionController(configuration: configuration)
+        super.init()
+        controller.delegate = self
+    }
+
+    // MARK: - Configuration attachment
+
+    /// Attaches the shared extension controller to a browser web view configuration
+    /// and kicks off extension discovery on first use.
+    func attach(to configuration: WKWebViewConfiguration) {
+        configuration.webExtensionController = controller
+        loadInstalledExtensionsIfNeeded()
+    }
+
+    private func loadInstalledExtensionsIfNeeded() {
+        guard !didStartLoading else { return }
+        didStartLoading = true
+        Task { await loadInstalledExtensions() }
+    }
+
+    private func loadInstalledExtensions() async {
+        for url in Self.candidateExtensionURLs() {
+            do {
+                let webExtension: WKWebExtension
+                if url.pathExtension == "appex" {
+                    if let bundle = Bundle(url: url) {
+                        webExtension = try await WKWebExtension(appExtensionBundle: bundle)
+                    } else {
+                        // Fall back to reading the appex's web-extension resources directly.
+                        let resources = url.appendingPathComponent("Contents/Resources", isDirectory: true)
+                        webExtension = try await WKWebExtension(resourceBaseURL: resources)
+                    }
+                } else {
+                    webExtension = try await WKWebExtension(resourceBaseURL: url)
+                }
+                try load(webExtension)
+#if DEBUG
+                cmuxDebugLog(
+                    "browser.webext.loaded name=\(webExtension.displayName ?? "?") " +
+                    "version=\(webExtension.displayVersion ?? "?") url=\(url.path)"
+                )
+#endif
+            } catch {
+                loadErrors.append("\(url.lastPathComponent): \(error.localizedDescription)")
+#if DEBUG
+                cmuxDebugLog("browser.webext.loadFailed url=\(url.path) error=\(error.localizedDescription)")
+#endif
+            }
+        }
+    }
+
+    private func load(_ webExtension: WKWebExtension) throws {
+        let context = WKWebExtensionContext(for: webExtension)
+        // Grant everything the manifest requests up front; interactive permission
+        // prompting can come later. Repeat grants are also answered by the
+        // prompt delegate methods below.
+        for permission in webExtension.requestedPermissions {
+            context.setPermissionStatus(.grantedExplicitly, for: permission)
+        }
+        for pattern in webExtension.allRequestedMatchPatterns {
+            context.setPermissionStatus(.grantedExplicitly, for: pattern)
+        }
+#if DEBUG
+        context.isInspectable = true
+#endif
+        try controller.load(context)
+        contexts.append(context)
+#if DEBUG
+        logDiagnostics(for: context, label: "postLoad")
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(5))
+            self?.logDiagnostics(for: context, label: "postLoad+5s")
+        }
+        if ProcessInfo.processInfo.environment["CMUX_WEBEXT_AUTOPROBE"] == "1" {
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .seconds(8))
+                guard let self else { return }
+                cmuxDebugLog("browser.webext.autoprobe performAction")
+                context.performAction(for: self.activeTabAdapter)
+            }
+        }
+#endif
+    }
+
+#if DEBUG
+    private func logDiagnostics(for context: WKWebExtensionContext, label: String) {
+        let ext = context.webExtension
+        cmuxDebugLog(
+            "browser.webext.diag(\(label)) name=\(ext.displayName ?? "?") " +
+            "loaded=\(context.isLoaded ? 1 : 0) " +
+            "injected=\(ext.hasInjectedContent ? 1 : 0) " +
+            "background=\(ext.hasBackgroundContent ? 1 : 0) " +
+            "allURLs=\(context.hasAccessToAllURLs ? 1 : 0) " +
+            "perms=\(context.currentPermissions.count) " +
+            "patterns=\(context.currentPermissionMatchPatterns.count) " +
+            "openTabs=\(context.openTabs.count) " +
+            "ctxErrors=\(context.errors.map(\.localizedDescription).joined(separator: " | ")) " +
+            "extErrors=\(ext.errors.map(\.localizedDescription).joined(separator: " | "))"
+        )
+        for command in context.commands {
+            cmuxDebugLog(
+                "browser.webext.command registered id=\(command.id) " +
+                "key=\(command.activationKey ?? "nil") mods=\(command.modifierFlags.rawValue) " +
+                "title=\(command.title)"
+            )
+        }
+    }
+#endif
+
+    /// Extension bundles/directories to try loading, in order.
+    private static func candidateExtensionURLs() -> [URL] {
+        var urls: [URL] = []
+        if let env = ProcessInfo.processInfo.environment["CMUX_BROWSER_EXTENSIONS"] {
+            for path in env.split(separator: ":") where !path.isEmpty {
+                urls.append(URL(fileURLWithPath: String(path)))
+            }
+        }
+        if FileManager.default.fileExists(atPath: bitwardenAppexURL.path) {
+            urls.append(bitwardenAppexURL)
+        }
+        return urls
+    }
+
+    // MARK: - Tab lifecycle (called from BrowserPanel)
+
+    func register(panel: BrowserPanel) {
+        guard tabAdapters[panel.id] == nil else { return }
+        let adapter = BrowserWebExtensionTabAdapter(panel: panel, support: self)
+        tabAdapters[panel.id] = adapter
+        orderedPanelIDs.append(panel.id)
+        if activePanelID == nil { activePanelID = panel.id }
+        controller.didOpenTab(adapter)
+    }
+
+    func unregister(panelID: UUID) {
+        guard let adapter = tabAdapters.removeValue(forKey: panelID) else { return }
+        orderedPanelIDs.removeAll { $0 == panelID }
+        if activePanelID == panelID { activePanelID = orderedPanelIDs.last }
+        controller.didCloseTab(adapter, windowIsClosing: false)
+    }
+
+    func noteActivated(panelID: UUID) {
+        guard tabAdapters[panelID] != nil, activePanelID != panelID else { return }
+        let previous = activePanelID.flatMap { tabAdapters[$0] }
+        activePanelID = panelID
+        if let adapter = tabAdapters[panelID] {
+            controller.didActivateTab(adapter, previousActiveTab: previous)
+        }
+    }
+
+    func tabAdapter(for panelID: UUID) -> BrowserWebExtensionTabAdapter? {
+        tabAdapters[panelID]
+    }
+
+    var orderedTabAdapters: [BrowserWebExtensionTabAdapter] {
+        orderedPanelIDs.compactMap { tabAdapters[$0] }
+    }
+
+    var activeTabAdapter: BrowserWebExtensionTabAdapter? {
+        activePanelID.flatMap { tabAdapters[$0] }
+    }
+
+    func indexInWindow(of panelID: UUID) -> Int {
+        orderedPanelIDs.firstIndex(of: panelID) ?? 0
+    }
+
+    // MARK: - Action popup
+
+    /// Performs the extension's toolbar action for `panel`, anchoring any popup
+    /// the extension presents to `anchorView`.
+    func performAction(context: WKWebExtensionContext, panel: BrowserPanel, anchorView: NSView?) {
+        noteActivated(panelID: panel.id)
+        pendingPopupAnchorView = anchorView
+        context.performAction(for: tabAdapter(for: panel.id))
+    }
+
+    // MARK: - Keyboard commands
+
+    /// Offers a key equivalent to loaded extensions' declared commands
+    /// (e.g. Bitwarden's ⌘⇧L autofill). Returns true when one handled it.
+    func performCommand(for event: NSEvent) -> Bool {
+        for context in contexts where context.performCommand(for: event) {
+#if DEBUG
+            cmuxDebugLog("browser.webext.command handled name=\(context.webExtension.displayName ?? "?")")
+#endif
+            return true
+        }
+#if DEBUG
+        if !contexts.isEmpty {
+            cmuxDebugLog(
+                "browser.webext.command unmatched key=\(event.charactersIgnoringModifiers ?? "?") " +
+                "mods=\(event.modifierFlags.intersection(.deviceIndependentFlagsMask).rawValue)"
+            )
+        }
+#endif
+        return false
+    }
+
+    // MARK: - Popout windows
+
+    func popoutDidClose(_ popout: BrowserWebExtensionPopoutWindowController) {
+        guard popouts.contains(where: { $0 === popout }) else { return }
+        popouts.removeAll { $0 === popout }
+        controller.didCloseTab(popout.tab, windowIsClosing: true)
+        controller.didCloseWindow(popout)
+    }
+}
+
+// MARK: - WKWebExtensionControllerDelegate
+
+@available(macOS 15.4, *)
+extension BrowserWebExtensionSupport: WKWebExtensionControllerDelegate {
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        openWindowsFor extensionContext: WKWebExtensionContext
+    ) -> [any WKWebExtensionWindow] {
+        [windowAdapter] + popouts
+    }
+
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        focusedWindowFor extensionContext: WKWebExtensionContext
+    ) -> (any WKWebExtensionWindow)? {
+        popouts.first(where: \.isKeyWindow) ?? windowAdapter
+    }
+
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        openNewWindowUsing configuration: WKWebExtension.WindowConfiguration,
+        for extensionContext: WKWebExtensionContext,
+        completionHandler: @escaping ((any WKWebExtensionWindow)?, Error?) -> Void
+    ) {
+#if DEBUG
+        cmuxDebugLog(
+            "browser.webext.openWindow type=\(configuration.windowType.rawValue) " +
+            "urls=\(configuration.tabURLs.count) focused=\(configuration.shouldBeFocused ? 1 : 0)"
+        )
+#endif
+        let popout = BrowserWebExtensionPopoutWindowController(
+            configuration: configuration,
+            context: extensionContext,
+            support: self
+        )
+        popouts.append(popout)
+        controller.didOpenWindow(popout)
+        controller.didOpenTab(popout.tab)
+        completionHandler(popout, nil)
+    }
+
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        openNewTabUsing configuration: WKWebExtension.TabConfiguration,
+        for extensionContext: WKWebExtensionContext,
+        completionHandler: @escaping ((any WKWebExtensionTab)?, Error?) -> Void
+    ) {
+#if DEBUG
+        cmuxDebugLog("browser.webext.openTab url=\(configuration.url?.absoluteString.prefix(80) ?? "nil")")
+#endif
+        // External pages go to the user's default browser context inside cmux
+        // panels eventually; for now open http(s) URLs via the system and host
+        // extension pages in a popout window.
+        if let url = configuration.url, url.scheme == "https" || url.scheme == "http" {
+            NSWorkspace.shared.open(url)
+            completionHandler(nil, nil)
+            return
+        }
+        completionHandler(nil, NSError(
+            domain: "cmux.webExtension", code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "Opening extension tabs is not supported yet"]
+        ))
+    }
+
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        presentActionPopup action: WKWebExtension.Action,
+        for context: WKWebExtensionContext,
+        completionHandler: @escaping (Error?) -> Void
+    ) {
+        guard let popover = action.popupPopover else {
+            completionHandler(nil)
+            return
+        }
+        let candidates: [NSView?] = [
+            pendingPopupAnchorView,
+            activeTabAdapter?.panel?.webView,
+            orderedTabAdapters.first(where: { $0.panel?.webView.window != nil })?.panel?.webView,
+            NSApp.keyWindow?.contentView ?? NSApp.mainWindow?.contentView,
+        ]
+        pendingPopupAnchorView = nil
+        guard let anchor = candidates.compactMap({ $0 }).first(where: { $0.window != nil }) else {
+#if DEBUG
+            cmuxDebugLog("browser.webext.actionPopup no window-attached anchor; dropping popup")
+#endif
+            completionHandler(nil)
+            return
+        }
+        popover.behavior = .transient
+        popover.show(relativeTo: anchor.bounds, of: anchor, preferredEdge: .maxY)
+#if DEBUG
+        if ProcessInfo.processInfo.environment["CMUX_WEBEXT_AUTOPROBE"] == "1",
+           let popupWebView = action.popupWebView {
+            probePopup(popupWebView)
+        }
+#endif
+        completionHandler(nil)
+    }
+
+#if DEBUG
+    /// Evaluates a WebExtension-API probe inside the action popup so tab/window
+    /// adapter behavior is observable from the extension's point of view.
+    /// Installs an error-capture hook and reloads the popup first so boot-time
+    /// console errors and unhandled rejections are observable.
+    private func probePopup(_ popupWebView: WKWebView) {
+        Task { @MainActor in
+            let hookSource = """
+            window.__errs = [];
+            window.addEventListener("error", (e) => window.__errs.push("E:" + e.message + "@" + (e.filename || "") + ":" + (e.lineno || 0)));
+            window.addEventListener("unhandledrejection", (e) => window.__errs.push("R:" + ((e.reason && (e.reason.stack || e.reason.message)) || e.reason)));
+            const ce = console.error.bind(console);
+            console.error = (...a) => { window.__errs.push("C:" + a.map(String).join(" ").slice(0, 300)); ce(...a); };
+            """
+            popupWebView.configuration.userContentController.addUserScript(
+                WKUserScript(source: hookSource, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            )
+            popupWebView.reload()
+            try? await Task.sleep(for: .seconds(5))
+            let script = """
+            try {
+              const api = globalThis.browser || globalThis.chrome;
+              const tabs = await api.tabs.query({ active: true, currentWindow: true });
+              const wins = await api.windows.getAll();
+              const win = await api.windows.getCurrent().catch((e) => 'ERR:' + e.message);
+              let popoutTest = "skipped";
+              try {
+                const w = await api.windows.create({ url: "popup/index.html", type: "popup", width: 380, height: 500, focused: false });
+                popoutTest = w ? "created:" + w.id + ":tabs=" + (w.tabs ? w.tabs.length : "?") : "null";
+                if (w) { await new Promise(r => setTimeout(r, 1500)); await api.windows.remove(w.id); popoutTest += ":removed"; }
+              } catch (e) { popoutTest = "ERR:" + (e && e.message); }
+              return JSON.stringify({
+                ready: document.readyState,
+                bodyChildren: document.body ? document.body.children.length : -1,
+                tabCount: tabs.length,
+                tab0: tabs[0] ? `${tabs[0].id}:${tabs[0].url || "nourl"}:${tabs[0].title || "notitle"}` : "none",
+                winCount: wins.length,
+                currentWin: typeof win === "string" ? win : (win ? win.id : "none"),
+                text: (document.body ? document.body.innerText : "").replace(/\\s+/g, " ").slice(0, 160),
+                html: (document.body ? document.body.innerHTML : "").replace(/\\s+/g, " ").slice(0, 240),
+                errs: (window.__errs || []).slice(0, 8),
+                popoutTest
+              });
+            } catch (e) { return "ERR:" + (e && e.message); }
+            """
+            popupWebView.callAsyncJavaScript(script, arguments: [:], in: nil, in: .page) { result in
+                switch result {
+                case .success(let value):
+                    cmuxDebugLog("browser.webext.popupProbe \(value ?? "nil")")
+                case .failure(let error):
+                    cmuxDebugLog("browser.webext.popupProbe error=\(error.localizedDescription)")
+                }
+            }
+        }
+    }
+#endif
+
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        sendMessage message: Any,
+        toApplicationWithIdentifier applicationIdentifier: String?,
+        for extensionContext: WKWebExtensionContext,
+        replyHandler: @escaping (Any?, Error?) -> Void
+    ) {
+        // Native messaging (e.g. Bitwarden's desktop-app biometrics IPC) is not
+        // bridged. Never resolve the reply: an error reply sends Bitwarden into
+        // an unthrottled reconnect loop (observed ~175k messages/sec), while an
+        // unresolved promise parks the caller harmlessly.
+        nativeMessageDropCount += 1
+        if nativeMessageDropCount <= 5 {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.webext.nativeMessage dropped app=\(applicationIdentifier ?? "nil") " +
+                "count=\(nativeMessageDropCount)"
+            )
+#endif
+        }
+        _ = replyHandler
+    }
+
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        connectUsing port: WKWebExtension.MessagePort,
+        for extensionContext: WKWebExtensionContext,
+        completionHandler: @escaping (Error?) -> Void
+    ) {
+        // See sendMessage above: leave the native port unresolved rather than
+        // erroring, so extensions do not retry-loop.
+#if DEBUG
+        cmuxDebugLog("browser.webext.nativeConnect dropped app=\(port.applicationIdentifier ?? "nil")")
+#endif
+        _ = completionHandler
+    }
+
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        promptForPermissions permissions: Set<WKWebExtension.Permission>,
+        in tab: (any WKWebExtensionTab)?,
+        for extensionContext: WKWebExtensionContext,
+        completionHandler: @escaping (Set<WKWebExtension.Permission>, Date?) -> Void
+    ) {
+        completionHandler(permissions, nil)
+    }
+
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        promptForPermissionToAccess urls: Set<URL>,
+        in tab: (any WKWebExtensionTab)?,
+        for extensionContext: WKWebExtensionContext,
+        completionHandler: @escaping (Set<URL>, Date?) -> Void
+    ) {
+        completionHandler(urls, nil)
+    }
+
+    func webExtensionController(
+        _ controller: WKWebExtensionController,
+        promptForPermissionMatchPatterns matchPatterns: Set<WKWebExtension.MatchPattern>,
+        in tab: (any WKWebExtensionTab)?,
+        for extensionContext: WKWebExtensionContext,
+        completionHandler: @escaping (Set<WKWebExtension.MatchPattern>, Date?) -> Void
+    ) {
+        completionHandler(matchPatterns, nil)
+    }
+}

--- a/Sources/Panels/BrowserWebExtensionTabAdapter.swift
+++ b/Sources/Panels/BrowserWebExtensionTabAdapter.swift
@@ -1,0 +1,78 @@
+import AppKit
+import WebKit
+
+/// Presents one `BrowserPanel` to web extensions as a browser tab.
+///
+/// All `WKWebExtensionTab` requirements are optional; this implements the subset
+/// extensions like Bitwarden need to identify, read, and navigate the active tab.
+@available(macOS 15.4, *)
+@MainActor
+final class BrowserWebExtensionTabAdapter: NSObject, WKWebExtensionTab {
+    private(set) weak var panel: BrowserPanel?
+    private weak var support: BrowserWebExtensionSupport?
+    private let panelID: UUID
+
+    init(panel: BrowserPanel, support: BrowserWebExtensionSupport) {
+        self.panel = panel
+        self.support = support
+        self.panelID = panel.id
+    }
+
+    func window(for context: WKWebExtensionContext) -> (any WKWebExtensionWindow)? {
+        support?.windowAdapter
+    }
+
+    func indexInWindow(for context: WKWebExtensionContext) -> Int {
+        support?.indexInWindow(of: panelID) ?? 0
+    }
+
+    func webView(for context: WKWebExtensionContext) -> WKWebView? {
+        panel?.webView
+    }
+
+    func url(for context: WKWebExtensionContext) -> URL? {
+        panel?.webView.url
+    }
+
+    func title(for context: WKWebExtensionContext) -> String? {
+        panel?.webView.title
+    }
+
+    func isLoadingComplete(for context: WKWebExtensionContext) -> Bool {
+        guard let webView = panel?.webView else { return true }
+        return !webView.isLoading
+    }
+
+    func isSelected(for context: WKWebExtensionContext) -> Bool {
+        support?.activePanelID == panelID
+    }
+
+    func activate(for context: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+        support?.noteActivated(panelID: panelID)
+        completionHandler(nil)
+    }
+
+    func loadURL(_ url: URL, for context: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+        panel?.webView.load(URLRequest(url: url))
+        completionHandler(nil)
+    }
+
+    func reload(fromOrigin: Bool, for context: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+        if fromOrigin {
+            panel?.webView.reloadFromOrigin()
+        } else {
+            panel?.webView.reload()
+        }
+        completionHandler(nil)
+    }
+
+    func goBack(for context: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+        panel?.webView.goBack()
+        completionHandler(nil)
+    }
+
+    func goForward(for context: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+        panel?.webView.goForward()
+        completionHandler(nil)
+    }
+}

--- a/Sources/Panels/BrowserWebExtensionToolbarButtons.swift
+++ b/Sources/Panels/BrowserWebExtensionToolbarButtons.swift
@@ -1,0 +1,98 @@
+import AppKit
+import SwiftUI
+import WebKit
+
+/// Toolbar buttons for loaded web extensions: one button per extension action,
+/// anchored so the extension's popup (e.g. the Bitwarden vault) opens beneath it.
+@available(macOS 15.4, *)
+struct BrowserWebExtensionToolbarButtons: View {
+    @ObservedObject var support: BrowserWebExtensionSupport
+    let panel: BrowserPanel
+    let iconPointSize: CGFloat
+    let hitSize: CGFloat
+
+    var body: some View {
+        ForEach(Array(support.contexts.enumerated()), id: \.offset) { _, context in
+            BrowserWebExtensionActionButton(
+                support: support,
+                context: context,
+                panel: panel,
+                iconPointSize: iconPointSize,
+                hitSize: hitSize
+            )
+        }
+    }
+}
+
+@available(macOS 15.4, *)
+private struct BrowserWebExtensionActionButton: View {
+    let support: BrowserWebExtensionSupport
+    let context: WKWebExtensionContext
+    let panel: BrowserPanel
+    let iconPointSize: CGFloat
+    let hitSize: CGFloat
+
+    @State private var anchorViewHolder = BrowserWebExtensionAnchorViewHolder()
+
+    var body: some View {
+        Button(action: {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.webext.action panel=\(panel.id.uuidString.prefix(5)) " +
+                "name=\(context.webExtension.displayName ?? "?")"
+            )
+#endif
+            support.performAction(context: context, panel: panel, anchorView: anchorViewHolder.view)
+        }) {
+            actionIcon
+                .frame(width: hitSize, height: hitSize, alignment: .center)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(OmnibarAddressButtonStyle())
+        .background(BrowserWebExtensionAnchorViewReader(holder: anchorViewHolder))
+        .safeHelp(context.webExtension.displayName ?? String(
+            localized: "browser.webExtension.action.help",
+            defaultValue: "Extension"
+        ))
+        .accessibilityIdentifier("BrowserWebExtensionActionButton")
+    }
+
+    @ViewBuilder
+    private var actionIcon: some View {
+        if let icon = context.webExtension.icon(for: CGSize(width: 32, height: 32)) {
+            Image(nsImage: icon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: iconPointSize + 3, height: iconPointSize + 3)
+        } else {
+            CmuxSystemSymbolImage(
+                systemName: "puzzlepiece.extension",
+                pointSize: iconPointSize,
+                weight: .medium
+            )
+        }
+    }
+}
+
+/// Captures the hosting `NSView` behind a SwiftUI button so an `NSPopover`
+/// (the extension action popup) can anchor to it.
+@available(macOS 15.4, *)
+@MainActor
+private final class BrowserWebExtensionAnchorViewHolder {
+    weak var view: NSView?
+}
+
+@available(macOS 15.4, *)
+private struct BrowserWebExtensionAnchorViewReader: NSViewRepresentable {
+    let holder: BrowserWebExtensionAnchorViewHolder
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        holder.view = view
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        holder.view = nsView
+    }
+}

--- a/Sources/Panels/BrowserWebExtensionWindowAdapter.swift
+++ b/Sources/Panels/BrowserWebExtensionWindowAdapter.swift
@@ -1,0 +1,54 @@
+import AppKit
+import WebKit
+
+/// Presents cmux's browser panels to web extensions as a single browser window.
+///
+/// cmux has no traditional tab strip — browser panels live in panes across
+/// workspaces — so all live panels are exposed as tabs of one focused window,
+/// which is the topology extensions like Bitwarden expect for
+/// `tabs.query({active: true, currentWindow: true})`.
+@available(macOS 15.4, *)
+@MainActor
+final class BrowserWebExtensionWindowAdapter: NSObject, WKWebExtensionWindow {
+    private weak var support: BrowserWebExtensionSupport?
+
+    init(support: BrowserWebExtensionSupport) {
+        self.support = support
+    }
+
+    func tabs(for context: WKWebExtensionContext) -> [any WKWebExtensionTab] {
+        support?.orderedTabAdapters ?? []
+    }
+
+    func activeTab(for context: WKWebExtensionContext) -> (any WKWebExtensionTab)? {
+        support?.activeTabAdapter
+    }
+
+    func windowType(for context: WKWebExtensionContext) -> WKWebExtension.WindowType {
+        .normal
+    }
+
+    func windowState(for context: WKWebExtensionContext) -> WKWebExtension.WindowState {
+        .normal
+    }
+
+    func isPrivate(for context: WKWebExtensionContext) -> Bool {
+        false
+    }
+
+    func frame(for context: WKWebExtensionContext) -> CGRect {
+        hostWindow?.frame ?? .null
+    }
+
+    func screenFrame(for context: WKWebExtensionContext) -> CGRect {
+        hostWindow?.screen?.frame ?? NSScreen.main?.frame ?? .null
+    }
+
+    func focus(for context: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+        completionHandler(nil)
+    }
+
+    private var hostWindow: NSWindow? {
+        support?.activeTabAdapter?.panel?.webView.window ?? NSApp.keyWindow
+    }
+}

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -699,6 +699,13 @@ final class CmuxWebView: WKWebView {
             return finish(super.performKeyEquivalent(with: event))
         }
 
+        // Web-extension commands (e.g. Bitwarden's ⌘⇧L autofill) match only
+        // shortcuts the extension manifest declares; everything else falls through.
+        if #available(macOS 15.4, *),
+           BrowserWebExtensionSupport.shared.performCommand(for: event) {
+            return finish(true)
+        }
+
         if Self.isPasteAsPlainTextCommandEquivalent(event) {
             if event.timestamp > 0 {
                 lastPasteAsPlainTextPerformKeyEventTimestamp = event.timestamp

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9712,6 +9712,9 @@ final class Workspace: Identifiable, ObservableObject {
         focusIntent: PanelFocusIntent? = nil
     ) {
         markExplicitFocusIntent(on: panelId)
+        if #available(macOS 15.4, *), panels[panelId] is BrowserPanel {
+            BrowserWebExtensionSupport.shared.noteActivated(panelID: panelId)
+        }
 #if DEBUG
         let pane = bonsplitController.focusedPaneId?.id.uuidString.prefix(5) ?? "nil"
         let triggerLabel = trigger == .terminalFirstResponder ? "firstResponder" : "standard"

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1493,6 +1493,7 @@ private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.titlebarLayoutDebug",
     "cmux.devWindowDisplay",
     "cmux.mobilePairingWindow",
+    "cmux.webExtensionPopout",
 ]
 
 /// Returns whether the given window should handle the standard close shortcut

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -266,6 +266,11 @@
 		A50100000000000000000020 /* BrowserWebAuthnTransportSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5010000000000000000001F /* BrowserWebAuthnTransportSummary.swift */; };
 		A50100000000000000000022 /* BrowserWebAuthnUserDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50100000000000000000021 /* BrowserWebAuthnUserDescriptor.swift */; };
 		C0DE49870000000000000001 /* BrowserWebContentProcessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */; };
+		B1CFE0050000000000000001 /* BrowserWebExtensionPopoutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CFE0050000000000000002 /* BrowserWebExtensionPopoutWindowController.swift */; };
+		B1CFE0010000000000000001 /* BrowserWebExtensionSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CFE0010000000000000002 /* BrowserWebExtensionSupport.swift */; };
+		B1CFE0020000000000000001 /* BrowserWebExtensionTabAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CFE0020000000000000002 /* BrowserWebExtensionTabAdapter.swift */; };
+		B1CFE0040000000000000001 /* BrowserWebExtensionToolbarButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CFE0040000000000000002 /* BrowserWebExtensionToolbarButtons.swift */; };
+		B1CFE0030000000000000001 /* BrowserWebExtensionWindowAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CFE0030000000000000002 /* BrowserWebExtensionWindowAdapter.swift */; };
 		C0DE58990000000000000003 /* BrowserWebKitKeyDownDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE58990000000000000001 /* BrowserWebKitKeyDownDispatch.swift */; };
 		A5001534 /* BrowserWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001533 /* BrowserWindowPortal.swift */; };
 		B1F0C00A0000000000000001 /* BrowserWindowPortalInspectorLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C00A0000000000000002 /* BrowserWindowPortalInspectorLayout.swift */; };
@@ -1864,6 +1869,11 @@
 		A5010000000000000000001F /* BrowserWebAuthnTransportSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnTransportSummary.swift; sourceTree = "<group>"; };
 		A50100000000000000000021 /* BrowserWebAuthnUserDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnUserDescriptor.swift; sourceTree = "<group>"; };
 		C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWebContentProcessTests.swift; sourceTree = "<group>"; };
+		B1CFE0050000000000000002 /* BrowserWebExtensionPopoutWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebExtensionPopoutWindowController.swift; sourceTree = "<group>"; };
+		B1CFE0010000000000000002 /* BrowserWebExtensionSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebExtensionSupport.swift; sourceTree = "<group>"; };
+		B1CFE0020000000000000002 /* BrowserWebExtensionTabAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebExtensionTabAdapter.swift; sourceTree = "<group>"; };
+		B1CFE0040000000000000002 /* BrowserWebExtensionToolbarButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebExtensionToolbarButtons.swift; sourceTree = "<group>"; };
+		B1CFE0030000000000000002 /* BrowserWebExtensionWindowAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebExtensionWindowAdapter.swift; sourceTree = "<group>"; };
 		C0DE58990000000000000001 /* BrowserWebKitKeyDownDispatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebKitKeyDownDispatch.swift; sourceTree = "<group>"; };
 		A5001533 /* BrowserWindowPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWindowPortal.swift; sourceTree = "<group>"; };
 		B1F0C00A0000000000000002 /* BrowserWindowPortalInspectorLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWindowPortalInspectorLayout.swift; sourceTree = "<group>"; };
@@ -3902,6 +3912,11 @@
 				C67540080000000000000002 /* BrowserNavigationDebugURL.swift */,
 				C67540110000000000000002 /* BrowserDownloadRecord.swift */,
 				C67540120000000000000002 /* BrowserDownloadsToolbarButton.swift */,
+				B1CFE0040000000000000002 /* BrowserWebExtensionToolbarButtons.swift */,
+				B1CFE0030000000000000002 /* BrowserWebExtensionWindowAdapter.swift */,
+				B1CFE0020000000000000002 /* BrowserWebExtensionTabAdapter.swift */,
+				B1CFE0010000000000000002 /* BrowserWebExtensionSupport.swift */,
+				B1CFE0050000000000000002 /* BrowserWebExtensionPopoutWindowController.swift */,
 				C67540100000000000000002 /* BrowserNavigationPopupPolicy.swift */,
 				A5001412 /* BrowserPanel.swift */,
 				B1F0C0090000000000000002 /* BrowserPanelDeveloperToolsLifecycle.swift */,
@@ -5326,6 +5341,11 @@
 				A5010000000000000000001E /* BrowserWebAuthnTransport.swift in Sources */,
 				A50100000000000000000020 /* BrowserWebAuthnTransportSummary.swift in Sources */,
 				A50100000000000000000022 /* BrowserWebAuthnUserDescriptor.swift in Sources */,
+				B1CFE0050000000000000001 /* BrowserWebExtensionPopoutWindowController.swift in Sources */,
+				B1CFE0010000000000000001 /* BrowserWebExtensionSupport.swift in Sources */,
+				B1CFE0020000000000000001 /* BrowserWebExtensionTabAdapter.swift in Sources */,
+				B1CFE0040000000000000001 /* BrowserWebExtensionToolbarButtons.swift in Sources */,
+				B1CFE0030000000000000001 /* BrowserWebExtensionWindowAdapter.swift in Sources */,
 				C0DE58990000000000000003 /* BrowserWebKitKeyDownDispatch.swift in Sources */,
 				A5001534 /* BrowserWindowPortal.swift in Sources */,
 				B1F0C00A0000000000000001 /* BrowserWindowPortalInspectorLayout.swift in Sources */,


### PR DESCRIPTION
## Summary

Adds web-extension support to cmux's built-in browser using WebKit's native `WKWebExtension` / `WKWebExtensionController` API (macOS 15.4+, fully availability-gated — deployment target stays 14.0). Motivated by discussion https://github.com/manaflow-ai/cmux/discussions/2001 (1Password/extensions in the cmux browser).

**Verified end-to-end with Bitwarden 2026.2.0** (loaded from the Bitwarden desktop app's bundled Safari web extension): vault login in the toolbar popup, content-script autofill, the ⌘⇧L autofill command, and **passkey sign-in** confirmed via Bitwarden's popout window on a real site.

Unpacked (Chrome/Firefox-style) extensions also load via `CMUX_BROWSER_EXTENSIONS=/path/one:/path/two`, mirroring agent-browser's `--extension` ergonomics.

## How it works

- `BrowserWebExtensionSupport` owns one persistent `WKWebExtensionController` (fixed identifier, so extension storage survives relaunches) attached in `BrowserPanel.configureWebViewConfiguration`, and implements the controller delegate: action popups (WebKit's own `NSPopover`), permission prompts (auto-grant for now), `windows.create` popouts, native messaging, and keyboard commands.
- `BrowserWebExtensionTabAdapter` / `BrowserWebExtensionWindowAdapter` present browser panels to extensions as tabs of one virtual window (cmux has panes, not a tab strip); `Workspace.focusPanel` fires tab-activation events. Verified from inside the extension: `tabs.query({active:true, currentWindow:true})` returns the focused panel with correct URL/title.
- `BrowserWebExtensionPopoutWindowController` implements `windows.create({type:"popup"})` as a floating native window hosting the extension page — this is what makes Bitwarden's passkey confirmation, unlock, and 2FA popouts work.
- Extension shortcuts are offered from `CmuxWebView.performKeyEquivalent` (⌘-combos only, outside the typing-latency-sensitive path), and from the stale-menu-shortcut suppression in `sendEvent` — ⌘⇧L is the *remapped-away default* of cmux's Open Browser action, and previously got swallowed app-wide.

## Sharp edges encoded in comments (found the hard way)

- Extension-owned web views (popup/background) get WebKit's default UA, which lacks the `" Safari/"` token — Bitwarden's UI crashes at boot classifying the browser. The controller configuration's `webViewConfiguration` sets `applicationNameForUserAgent` to the same Safari identity browser panels present.
- Never reply to `runtime.sendNativeMessage` with an error: Bitwarden reconnect-loops with zero backoff (observed ~7M messages / 453 MB of debug log in 40 s). Requests are parked unresolved instead; consequence is biometric unlock is unavailable (master-password unlock works).

## Known gaps / follow-ups

- Tabs already loading before the extension context finishes (session restore) don't get content scripts until reloaded once.
- Permissions are auto-granted without UI; `tabs.create` for extension pages is unimplemented (http/https URLs open externally).
- A follow-up branch adds extension management in Settings (discover installed Safari web extensions via `pluginkit`, load-unpacked picker, enable/disable).
- No automated tests yet: exercising WKWebExtension needs a runtime harness seam (per repo test policy, skipping a fake source-shape test); suggestions welcome on where an e2e hook would fit.

## Verification

Tagged Debug build (`reload.sh --tag bitwarden-ext`), dogfooded live: extension load diagnostics clean (`injected=1 background=1`, no context/extension errors), popup boots, passkey login succeeded on a production site, ⌘⇧L routed and handled (debug-log traced end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786161260&installation_id=133855650&pr_number=7692&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7692&signature=be72d2170fb9fabaafc6898030f2fb5512c8d8e27297f675c6508a81d3be046d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global event routing and grants extension permissions without UI; behavior is gated to macOS 15.4+ but autofill/passkey flows depend on WebKit extension APIs and third-party extension quirks.
> 
> **Overview**
> Adds **native web extension hosting** in the built-in browser via WebKit `WKWebExtensionController` (macOS 15.4+, availability-gated). A shared persistent controller attaches to every browser `WKWebViewConfiguration`; extensions load from `CMUX_BROWSER_EXTENSIONS` paths and Bitwarden’s bundled Safari `.appex` when present.
> 
> **Browser panels are exposed to extensions** as tabs in one virtual window (`BrowserWebExtensionTabAdapter` / `BrowserWebExtensionWindowAdapter`), with activation wired through panel register/unregister and `Workspace.focusPanel`. Toolbar buttons trigger extension actions with anchored popovers; `windows.create` popups use `BrowserWebExtensionPopoutWindowController` (registered as an auxiliary close-shortcut window).
> 
> **Keyboard routing** offers manifest-declared commands from `CmuxWebView` and, when a browser web view is focused, from stale menu-shortcut suppression in `sendEvent` via `cmuxRespondersContainBrowserWebView` + `performCommand` (e.g. ⌘⇧L after Open Browser is remapped). Extension web views get a Safari-style user agent; native messaging is intentionally not replied to avoid reconnect storms; permissions are auto-granted for now.
> 
> Adds localized `browser.webExtension.action.help` and Xcode project entries for the new panel sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48a0d56bdebc971fb5cec6cf812689b7fbf0408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native browser extension support to the built-in browser using WebKit’s `WKWebExtension` on macOS 15.4+, verified end-to-end with Bitwarden (popup, autofill, ⌘⇧L, passkeys). Also supports loading unpacked extensions via `CMUX_BROWSER_EXTENSIONS`, and fixes tab-activation after close, localized popout titles, and proper ⌘W handling for popouts.

- **New Features**
  - One persistent `WKWebExtensionController` across browser views; storage survives relaunches.
  - Discover extensions from Bitwarden’s bundled Safari extension and unpacked paths in `CMUX_BROWSER_EXTENSIONS`.
  - One toolbar button per extension; anchored action popups; `windows.create` popouts for extension pages (passkeys, unlock, 2FA).
  - Present panels as tabs of one virtual window; route activation and keyboard commands (e.g., ⌘⇧L) to extensions.
  - Known gaps: restored tabs may need a reload for content scripts; `tabs.create` for extension pages is not implemented; native messaging is not bridged; permissions are auto-granted and there’s no in-app management yet.

- **Bug Fixes**
  - Activate the successor tab when the active browser panel closes so extensions stop acting on the closed tab.
  - Register extension popouts as auxiliary windows so ⌘W and close-shortcut routing target the popout.
  - Center fallback-sized popouts instead of placing small frames at 0,0.
  - Localize the popout window’s fallback title.

<sup>Written for commit e48a0d56bdebc971fb5cec6cf812689b7fbf0408. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Web Extension support for macOS 15.4+, including toolbar action buttons, popup hosting, and window/tab adapters.
  * Enabled extension actions to surface in the browser UI and display popups anchored to the active panel.
  * Added support for loading extensions from bundled and external extension packages.
* **Bug Fixes**
  * Improved command/shortcut routing so Web Extension shortcuts work reliably when a web view is focused.
  * Fixed focus and lifecycle behavior for extension popups and popout windows.
* **Documentation**
  * Updated localized help text for Web Extension toolbar actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->