### PR TITLE
mux: pluggable sidebar — host external TUI plugins in the sidebar

### DIFF
--- a/mux/crates/mux-core/src/lib.rs
+++ b/mux/crates/mux-core/src/lib.rs
@@ -27,7 +27,7 @@ pub use model::{Node, Pane, Screen, State, Workspace};
 pub use mux::{
     AgentRecord, AgentSource, AgentState, AppliedLayout, AppliedPane, Direction, LayoutLeafSpec,
     LayoutSpec, Mux, MuxEvent, NotificationEvent, NotificationLevel, RunPlacement,
-    SurfaceNotification, ZoomMode, ZoomState,
+    SidebarPluginOptions, SidebarPluginStatus, SurfaceNotification, ZoomMode, ZoomState,
 };
 pub use short_id::assign_short_ids;
 pub use surface::{

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::browser::{self, BrowserBootstrap, BrowserRuntime};
 use crate::layout::{Rect, layout_screen};
@@ -195,6 +195,28 @@ pub struct ZoomState {
     pub zoomed_pane: Option<PaneId>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidebarPluginOptions {
+    pub command: Vec<String>,
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SidebarPluginStatus {
+    pub surface: Option<SurfaceId>,
+    pub error: Option<String>,
+    pub retry_after: Option<Duration>,
+}
+
+#[derive(Debug, Default)]
+struct SidebarPluginRuntime {
+    options: Option<SidebarPluginOptions>,
+    surface: Option<SurfaceId>,
+    last_error: Option<String>,
+    failures: u32,
+    retry_at: Option<Instant>,
+}
+
 /// The multiplexer. Shared by frontends and the control socket server.
 pub struct Mux {
     state: Mutex<State>,
@@ -206,6 +228,7 @@ pub struct Mux {
     browser_runtime: Mutex<Option<Arc<BrowserRuntime>>>,
     cell_pixels: Mutex<(u16, u16)>,
     default_colors: Mutex<DefaultColors>,
+    sidebar_plugin: Mutex<SidebarPluginRuntime>,
     agent_records: Mutex<HashMap<SurfaceId, AgentRecord>>,
     surface_notifications: Mutex<HashMap<SurfaceId, SurfaceNotification>>,
     #[cfg(test)]
@@ -241,6 +264,7 @@ impl Mux {
             browser_runtime: Mutex::new(None),
             cell_pixels: Mutex::new((8, 16)),
             default_colors: Mutex::new(DefaultColors::default()),
+            sidebar_plugin: Mutex::new(SidebarPluginRuntime::default()),
             agent_records: Mutex::new(HashMap::new()),
             surface_notifications: Mutex::new(HashMap::new()),
             #[cfg(test)]
@@ -328,6 +352,33 @@ impl Mux {
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<Arc<Surface>> {
         self.spawn_surface_with_command(cwd, size, None)
+    }
+
+    fn spawn_sidebar_plugin_surface(
+        self: &Arc<Self>,
+        options: &SidebarPluginOptions,
+        size: (u16, u16),
+    ) -> anyhow::Result<Arc<Surface>> {
+        if options.command.is_empty() {
+            anyhow::bail!("sidebar plugin command is empty");
+        }
+        let id = self.next_id();
+        let mut opts = self.surface_options.lock().unwrap().clone();
+        opts.command = Some(options.command.clone());
+        opts.cwd = options.cwd.clone();
+        opts.cols = size.0.max(1);
+        opts.rows = size.1.max(1);
+        opts.extra_env.push(("CMUX_SIDEBAR".to_string(), "1".to_string()));
+        #[cfg(test)]
+        let surface = if self.test_surface_runtime {
+            Surface::spawn_for_test(id, opts, Arc::downgrade(self))?
+        } else {
+            Surface::spawn(id, opts, Arc::downgrade(self))?
+        };
+        #[cfg(not(test))]
+        let surface = Surface::spawn(id, opts, Arc::downgrade(self))?;
+        self.state.lock().unwrap().surfaces.insert(id, surface.clone());
+        Ok(surface)
     }
 
     fn spawn_browser_surface(
@@ -536,6 +587,93 @@ impl Mux {
         let mut options = self.surface_options.lock().unwrap();
         update(&mut options);
         options.browser_session_name = self.session.clone();
+    }
+
+    pub fn configure_sidebar_plugin(&self, options: Option<SidebarPluginOptions>) {
+        let old_surface = {
+            let mut runtime = self.sidebar_plugin.lock().unwrap();
+            if runtime.options == options {
+                return;
+            }
+            runtime.options = options;
+            runtime.last_error = None;
+            runtime.failures = 0;
+            runtime.retry_at = None;
+            runtime.surface.take()
+        };
+        if let Some(surface) =
+            old_surface.and_then(|id| self.state.lock().unwrap().surfaces.remove(&id))
+        {
+            surface.kill();
+            self.emit(MuxEvent::SurfaceExited(surface.id));
+        }
+    }
+
+    pub fn ensure_sidebar_plugin(
+        self: &Arc<Self>,
+        cols: u16,
+        rows: u16,
+        relaunch: bool,
+    ) -> SidebarPluginStatus {
+        let now = Instant::now();
+        let size = (cols.max(1), rows.max(1));
+        let spawn_options = {
+            let mut runtime = self.sidebar_plugin.lock().unwrap();
+            let Some(options) = runtime.options.clone() else {
+                return SidebarPluginStatus { surface: None, error: None, retry_after: None };
+            };
+            if let Some(surface_id) = runtime.surface {
+                if let Some(surface) = self.surface(surface_id).filter(|surface| !surface.is_dead())
+                {
+                    drop(runtime);
+                    let _ = self.resize_surface(surface_id, size.0, size.1);
+                    drop(surface);
+                    return SidebarPluginStatus {
+                        surface: Some(surface_id),
+                        error: None,
+                        retry_after: None,
+                    };
+                }
+                runtime.surface = None;
+            }
+            if let Some(error) = runtime.last_error.clone() {
+                let retry_after = runtime.retry_at.and_then(|retry_at| {
+                    (retry_at > now).then_some(retry_at.saturating_duration_since(now))
+                });
+                if !relaunch || retry_after.is_some() {
+                    return SidebarPluginStatus { surface: None, error: Some(error), retry_after };
+                }
+            }
+            options
+        };
+        match self.spawn_sidebar_plugin_surface(&spawn_options, size) {
+            Ok(surface) => {
+                let surface_id = surface.id;
+                {
+                    let mut runtime = self.sidebar_plugin.lock().unwrap();
+                    runtime.surface = Some(surface_id);
+                    runtime.last_error = None;
+                    runtime.failures = 0;
+                    runtime.retry_at = None;
+                }
+                self.reap_if_dead(&surface);
+                SidebarPluginStatus { surface: Some(surface_id), error: None, retry_after: None }
+            }
+            Err(err) => {
+                let mut runtime = self.sidebar_plugin.lock().unwrap();
+                runtime.surface = None;
+                runtime.failures = runtime.failures.saturating_add(1);
+                let delay = sidebar_retry_delay(runtime.failures);
+                let message = format!("sidebar plugin failed to start: {err}");
+                runtime.last_error = Some(message.clone());
+                runtime.retry_at = Some(now + delay);
+                SidebarPluginStatus {
+                    surface: None,
+                    error: Some(message),
+                    retry_after: Some(delay),
+                }
+            }
+        }
     }
 
     pub fn set_cell_pixel_size(&self, width_px: u16, height_px: u16) {
@@ -1207,8 +1345,27 @@ impl Mux {
     /// reaps the surface out of the tree itself, so frontends only need to
     /// drop their render state.
     pub fn surface_exited(&self, id: SurfaceId) {
+        if self.sidebar_surface_exited(id) {
+            self.emit(MuxEvent::SurfaceExited(id));
+            return;
+        }
         self.close_surface(id);
         self.emit(MuxEvent::SurfaceExited(id));
+    }
+
+    fn sidebar_surface_exited(&self, id: SurfaceId) -> bool {
+        let mut runtime = self.sidebar_plugin.lock().unwrap();
+        if runtime.surface != Some(id) {
+            return false;
+        }
+        runtime.surface = None;
+        runtime.failures = runtime.failures.saturating_add(1);
+        let delay = sidebar_retry_delay(runtime.failures);
+        runtime.last_error = Some("sidebar plugin exited".to_string());
+        runtime.retry_at = Some(Instant::now() + delay);
+        drop(runtime);
+        self.state.lock().unwrap().surfaces.remove(&id);
+        true
     }
 
     /// Make `pane` the active pane of its screen (and that screen and
@@ -1583,6 +1740,11 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)
         .unwrap_or(0)
+}
+
+fn sidebar_retry_delay(failures: u32) -> Duration {
+    let shift = failures.saturating_sub(1).min(5);
+    Duration::from_secs(1u64 << shift)
 }
 
 impl Drop for Mux {

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -34,11 +34,11 @@ use crate::model::{Screen, State};
 use crate::platform::{self, transport};
 use crate::{
     AgentRecord, AgentSource, AgentState, AttachFrame, DefaultColors, Direction, LayoutLeafSpec,
-    LayoutSpec, Mux, MuxEvent, Node, NotificationLevel, PaneId, Rgb, ScreenId, SplitDir, SurfaceId,
-    SurfaceKind, SurfaceNotification, WorkspaceId, ZoomMode, assign_short_ids,
+    LayoutSpec, Mux, MuxEvent, Node, NotificationLevel, PaneId, Rgb, ScreenId, SidebarPluginStatus,
+    SplitDir, SurfaceId, SurfaceKind, SurfaceNotification, WorkspaceId, ZoomMode, assign_short_ids,
 };
 
-pub const PROTOCOL_VERSION: u32 = 6;
+pub const PROTOCOL_VERSION: u32 = 7;
 
 /// Default socket path for a session.
 pub fn default_socket_path(session: &str) -> PathBuf {
@@ -84,6 +84,12 @@ enum Command {
     },
     ReadScreen {
         surface: SurfaceId,
+    },
+    SidebarPlugin {
+        cols: u16,
+        rows: u16,
+        #[serde(default)]
+        relaunch: bool,
     },
     WaitFor {
         surface: SurfaceId,
@@ -711,6 +717,15 @@ fn get_surface(mux: &Mux, id: SurfaceId) -> anyhow::Result<Arc<crate::Surface>> 
     mux.surface(id).ok_or_else(|| anyhow::anyhow!("unknown surface {id}"))
 }
 
+fn sidebar_plugin_status_json(status: SidebarPluginStatus) -> Value {
+    let retry_after_ms = status.retry_after.map(|duration| duration.as_millis() as u64);
+    json!({
+        "surface": status.surface,
+        "error": status.error,
+        "retry_after_ms": retry_after_ms,
+    })
+}
+
 fn require_pty(surface: &crate::Surface) -> anyhow::Result<()> {
     if surface.kind() == SurfaceKind::Pty {
         Ok(())
@@ -920,6 +935,9 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             require_pty(&surface)?;
             let text = surface.try_with_terminal(|t| t.viewport_text())??;
             Ok(json!({ "text": text }))
+        }
+        Command::SidebarPlugin { cols, rows, relaunch } => {
+            Ok(sidebar_plugin_status_json(mux.ensure_sidebar_plugin(cols, rows, relaunch)))
         }
         Command::WaitFor { surface, pattern, timeout_ms } => {
             let surface = get_surface(mux, surface)?;

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -38,7 +38,7 @@ use crate::{
     SplitDir, SurfaceId, SurfaceKind, SurfaceNotification, WorkspaceId, ZoomMode, assign_short_ids,
 };
 
-pub const PROTOCOL_VERSION: u32 = 7;
+pub const PROTOCOL_VERSION: u32 = 6;
 
 /// Default socket path for a session.
 pub fn default_socket_path(session: &str) -> PathBuf {

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -2237,6 +2237,10 @@ impl App {
             self.sidebar_focused = self.sidebar_plugin_surface.is_some();
             return Ok(RenderAction::Draw);
         }
+        // Any click outside the plugin rect returns keyboard focus to the
+        // panes; otherwise typing would keep going to the plugin PTY after
+        // the user clicked into a pane.
+        self.sidebar_focused = false;
 
         if let Some(hit) = self.hit_at(x, y) {
             match hit {

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -388,8 +388,12 @@ pub struct App {
     pub prefix_armed: bool,
     pub session_label: String,
     pub sidebar_visible: bool,
+    pub sidebar_focused: bool,
     /// Width of the sidebar in the current frame (0 when hidden).
     pub sidebar_width: u16,
+    pub sidebar_plugin_surface: Option<SurfaceId>,
+    pub sidebar_plugin_error: Option<String>,
+    pub sidebar_plugin_retry_after_ms: Option<u64>,
     sidebar_width_override: Option<u16>,
     /// Pane region of the current frame (screen minus sidebar/status).
     pub content_area: Rect,
@@ -639,7 +643,11 @@ pub fn run(session: Session, session_label: String) -> anyhow::Result<()> {
         prefix_armed: false,
         session_label,
         sidebar_visible: true,
+        sidebar_focused: false,
         sidebar_width: 0,
+        sidebar_plugin_surface: None,
+        sidebar_plugin_error: None,
+        sidebar_plugin_retry_after_ms: None,
         sidebar_width_override: None,
         content_area: Rect::default(),
         hits: Vec::new(),
@@ -868,6 +876,7 @@ impl App {
             height: height.saturating_sub(1), // status bar
         };
         self.content_area = area;
+        self.sync_sidebar_plugin(false);
         self.tree = self.session.tree();
         let layout = self
             .tree
@@ -915,6 +924,36 @@ impl App {
         }
     }
 
+    pub fn sidebar_plugin_rect(&self) -> Rect {
+        Rect {
+            x: 0,
+            y: 0,
+            width: self.sidebar_width.saturating_sub(1),
+            height: self.content_area.height.saturating_add(1),
+        }
+    }
+
+    fn sync_sidebar_plugin(&mut self, relaunch: bool) {
+        if self.config.sidebar.plugin.is_none() || self.sidebar_width < 3 || !self.sidebar_visible {
+            self.sidebar_plugin_surface = None;
+            self.sidebar_plugin_error = None;
+            self.sidebar_plugin_retry_after_ms = None;
+            self.sidebar_focused = false;
+            return;
+        }
+        let rect = self.sidebar_plugin_rect();
+        if rect.width == 0 || rect.height == 0 {
+            return;
+        }
+        let status = self.session.sidebar_plugin((rect.width, rect.height), relaunch);
+        self.sidebar_plugin_surface = status.surface_id;
+        self.sidebar_plugin_error = status.error;
+        self.sidebar_plugin_retry_after_ms = status.retry_after_ms;
+        if self.sidebar_focused && self.sidebar_plugin_surface.is_none() {
+            self.sidebar_focused = false;
+        }
+    }
+
     fn handle(&mut self, event: AppEvent) -> anyhow::Result<RenderAction> {
         match event {
             AppEvent::Mux(MuxEvent::Empty) => {
@@ -924,6 +963,11 @@ impl App {
             AppEvent::Mux(MuxEvent::SurfaceExited(id)) => {
                 self.render_states.remove(&id);
                 self.session.forget_surface(id);
+                if self.sidebar_plugin_surface == Some(id) {
+                    self.sidebar_plugin_surface = None;
+                    self.sidebar_plugin_error = Some("sidebar plugin exited".to_string());
+                    self.sidebar_focused = false;
+                }
                 if self.selection.is_some_and(|s| s.surface == id) {
                     self.selection = None;
                 }
@@ -948,6 +992,9 @@ impl App {
                 Ok(RenderAction::None)
             }
             AppEvent::Mux(MuxEvent::SurfaceOutput(id)) => {
+                if self.sidebar_plugin_surface == Some(id) {
+                    return Ok(RenderAction::Draw);
+                }
                 if self.frame_only_browser_update(id) {
                     Ok(RenderAction::Graphics)
                 } else {
@@ -974,6 +1021,9 @@ impl App {
                     clear_omnibar_selection(state);
                     state.input.insert_str(&text);
                     Ok(RenderAction::Draw)
+                } else if self.sidebar_focused {
+                    self.paste_sidebar(&text);
+                    Ok(RenderAction::None)
                 } else {
                     self.paste(&text);
                     Ok(RenderAction::None)
@@ -986,6 +1036,7 @@ impl App {
             AppEvent::Input(Event::Resize(_, _)) => {
                 self.refresh_cell_pixels(false);
                 self.render_states.clear();
+                self.sidebar_plugin_surface = None;
                 Ok(RenderAction::Draw)
             }
             AppEvent::Input(_) => Ok(RenderAction::None),
@@ -1014,6 +1065,16 @@ impl App {
     }
 
     fn reassert_visible_surface_sizes(&self) {
+        if self.config.sidebar.plugin.is_some()
+            && self.sidebar_visible
+            && self.sidebar_width >= 3
+            && let Some(surface) = self.sidebar_surface_handle()
+        {
+            let rect = self.sidebar_plugin_rect();
+            if rect.width > 0 && rect.height > 0 {
+                surface.reassert_size(rect.width, rect.height);
+            }
+        }
         for area in &self.pane_areas {
             if area.content.width == 0 || area.content.height == 0 {
                 continue;
@@ -1123,9 +1184,6 @@ impl App {
         if self.omnibar.is_some() {
             return self.handle_omnibar_key(key);
         }
-        if let Some(action) = self.config.keys.modeless_action_for(&key) {
-            return self.run_action(action);
-        }
         if self.prefix_armed {
             self.prefix_armed = false;
             return self.handle_prefixed(key);
@@ -1133,6 +1191,13 @@ impl App {
         if self.config.keys.prefix.matches(&key) {
             self.prefix_armed = true;
             return Ok(RenderAction::Draw);
+        }
+        if self.sidebar_focused {
+            self.forward_sidebar_key(&key);
+            return Ok(RenderAction::None);
+        }
+        if let Some(action) = self.config.keys.modeless_action_for(&key) {
+            return self.run_action(action);
         }
         // Typing replaces any selection highlight.
         self.selection = None;
@@ -1278,12 +1343,26 @@ impl App {
     fn handle_prefixed(&mut self, key: KeyEvent) -> anyhow::Result<RenderAction> {
         // Prefix twice forwards the prefix chord literally.
         if self.config.keys.prefix.matches(&key) {
-            self.forward_key(&key);
+            if self.sidebar_focused {
+                self.forward_sidebar_key(&key);
+            } else {
+                self.forward_key(&key);
+            }
             return Ok(RenderAction::Draw);
         }
         let Some(action) = self.config.keys.action_for(&key) else {
+            if self.sidebar_focused {
+                self.sidebar_focused = false;
+            }
             return Ok(RenderAction::Draw); // unknown prefix command: swallow, redraw indicator
         };
+        let was_sidebar_focused = self.sidebar_focused;
+        if self.sidebar_focused {
+            self.sidebar_focused = false;
+        }
+        if was_sidebar_focused && action == Action::FocusSidebar {
+            return Ok(RenderAction::Draw);
+        }
         if browser_only_action(action)
             && !self
                 .active_surface_handle()
@@ -1353,7 +1432,13 @@ impl App {
             Action::NewScreen => self.new_screen()?,
             Action::NextWorkspace => self.session.select_workspace(None, Some(1)),
             Action::NewWorkspace => self.new_workspace()?,
-            Action::ToggleSidebar => self.sidebar_visible = !self.sidebar_visible,
+            Action::ToggleSidebar => {
+                self.sidebar_visible = !self.sidebar_visible;
+                if !self.sidebar_visible {
+                    self.sidebar_focused = false;
+                }
+            }
+            Action::FocusSidebar => self.toggle_sidebar_focus(),
             Action::FocusLeft => self.move_focus(-1, 0),
             Action::FocusRight => self.move_focus(1, 0),
             Action::FocusUp => self.move_focus(0, -1),
@@ -1673,6 +1758,29 @@ impl App {
         }
     }
 
+    fn toggle_sidebar_focus(&mut self) {
+        if self.sidebar_focused {
+            self.sidebar_focused = false;
+            return;
+        }
+        if self.config.sidebar.plugin.is_none() {
+            return;
+        }
+        self.sidebar_visible = true;
+        self.sync_sidebar_plugin(true);
+        if self.sidebar_plugin_surface.is_some() {
+            self.sidebar_focused = true;
+            self.menu = None;
+            self.prompt = None;
+            self.omnibar = None;
+            self.selection = None;
+        }
+    }
+
+    fn sidebar_surface_handle(&self) -> Option<SurfaceHandle> {
+        self.sidebar_plugin_surface.and_then(|surface| self.session.surface(surface))
+    }
+
     fn forward_key(&mut self, key: &KeyEvent) {
         if self
             .active_surface_handle()
@@ -1683,6 +1791,22 @@ impl App {
         }
         let Some(input) = keys::key_input_from(key) else { return };
         let Some(surface) = self.active_surface_handle() else { return };
+        self.encode_buf.clear();
+        let _ = surface.scroll_to_bottom();
+        let Some(encoded) = surface.with_terminal(|term| {
+            self.encoder.sync_from_terminal(term);
+            self.encoder.encode(&input, &mut self.encode_buf)
+        }) else {
+            return;
+        };
+        if encoded.is_ok() && !self.encode_buf.is_empty() {
+            surface.write_bytes(&self.encode_buf);
+        }
+    }
+
+    fn forward_sidebar_key(&mut self, key: &KeyEvent) {
+        let Some(input) = keys::key_input_from(key) else { return };
+        let Some(surface) = self.sidebar_surface_handle() else { return };
         self.encode_buf.clear();
         let _ = surface.scroll_to_bottom();
         let Some(encoded) = surface.with_terminal(|term| {
@@ -1753,6 +1877,22 @@ impl App {
             });
             return;
         }
+        let Some(bracketed) = surface.with_terminal(|t| t.mode(2004, false)) else {
+            return;
+        };
+        if bracketed {
+            let mut bytes = Vec::with_capacity(text.len() + 12);
+            bytes.extend_from_slice(b"\x1b[200~");
+            bytes.extend_from_slice(text.as_bytes());
+            bytes.extend_from_slice(b"\x1b[201~");
+            surface.write_bytes(&bytes);
+        } else {
+            surface.write_bytes(text.as_bytes());
+        }
+    }
+
+    fn paste_sidebar(&mut self, text: &str) {
+        let Some(surface) = self.sidebar_surface_handle() else { return };
         let Some(bracketed) = surface.with_terminal(|t| t.mode(2004, false)) else {
             return;
         };
@@ -2087,6 +2227,15 @@ impl App {
             if !editing_rect.is_some_and(|rect| rect.contains(x, y)) {
                 self.omnibar = None;
             }
+        }
+
+        if self.config.sidebar.plugin.is_some()
+            && self.sidebar_plugin_rect().contains(x, y)
+            && self.sidebar_visible
+        {
+            self.sync_sidebar_plugin(true);
+            self.sidebar_focused = self.sidebar_plugin_surface.is_some();
+            return Ok(RenderAction::Draw);
         }
 
         if let Some(hit) = self.hit_at(x, y) {
@@ -2835,7 +2984,11 @@ mod tests {
             prefix_armed: false,
             session_label: "test".to_string(),
             sidebar_visible: true,
+            sidebar_focused: false,
             sidebar_width: 0,
+            sidebar_plugin_surface: None,
+            sidebar_plugin_error: None,
+            sidebar_plugin_retry_after_ms: None,
             sidebar_width_override: None,
             content_area: Rect::default(),
             hits: Vec::new(),

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -26,7 +26,11 @@
 //!   },
 //!   "sidebar": {
 //!     "width": 22,
-//!     "max_width": 0
+//!     "max_width": 0,
+//!     "plugin": {
+//!       "command": ["/path/to/plugin-binary"],
+//!       "cwd": "/optional"
+//!     }
 //!   },
 //!   "browser": {
 //!     "chrome_binary": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
@@ -68,8 +72,8 @@
 //! `close-pane`, `rename-tab` (alias: `rename-pane`), `rename-screen`,
 //! `rename-workspace`, `close-screen`, `prev-screen`, `next-screen`,
 //! `select-screen-0` through `select-screen-9`, `new-screen`,
-//! `next-workspace`, `new-workspace`, `toggle-sidebar`, `focus-left`,
-//! `focus-right`, `focus-up`, `focus-down`, `focus-next-pane`,
+//! `next-workspace`, `new-workspace`, `toggle-sidebar`, `focus-sidebar`,
+//! `focus-left`, `focus-right`, `focus-up`, `focus-down`, `focus-next-pane`,
 //! `swap-pane-prev`, `swap-pane-next`, `zoom-pane`, `resize-grow`,
 //! `resize-shrink`, `scroll-up`, `scroll-down`, `browser-back`,
 //! `browser-forward`, `browser-reload`, `browser-edit-url`, and `detach`.
@@ -87,6 +91,7 @@
 use std::collections::HashMap;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use mux_core::SidebarPluginOptions;
 use mux_core::SurfaceOptions;
 use mux_core::platform;
 use ratatui::style::Color;
@@ -159,6 +164,14 @@ struct RawTabs {
 struct RawSidebar {
     width: Option<u16>,
     max_width: Option<u16>,
+    plugin: Option<RawSidebarPlugin>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawSidebarPlugin {
+    command: Option<Vec<String>>,
+    cwd: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -281,15 +294,16 @@ impl Default for Tabs {
 }
 
 /// Sidebar behavior.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Sidebar {
     pub width: u16,
     pub max_width: u16,
+    pub plugin: Option<SidebarPluginOptions>,
 }
 
 impl Default for Sidebar {
     fn default() -> Self {
-        Sidebar { width: 22, max_width: 0 }
+        Sidebar { width: 22, max_width: 0, plugin: None }
     }
 }
 
@@ -344,6 +358,7 @@ pub enum Action {
     NextWorkspace,
     NewWorkspace,
     ToggleSidebar,
+    FocusSidebar,
     FocusLeft,
     FocusRight,
     FocusUp,
@@ -387,6 +402,7 @@ impl Action {
             Action::NextWorkspace => "next-workspace".to_string(),
             Action::NewWorkspace => "new-workspace".to_string(),
             Action::ToggleSidebar => "toggle-sidebar".to_string(),
+            Action::FocusSidebar => "focus-sidebar".to_string(),
             Action::FocusLeft => "focus-left".to_string(),
             Action::FocusRight => "focus-right".to_string(),
             Action::FocusUp => "focus-up".to_string(),
@@ -490,6 +506,7 @@ impl Default for Keys {
                 bind(KeyCode::Char('w'), Action::NextWorkspace),
                 bind(KeyCode::Char('W'), Action::NewWorkspace),
                 bind(KeyCode::Char('s'), Action::ToggleSidebar),
+                bind(KeyCode::Char('S'), Action::FocusSidebar),
                 bind(KeyCode::Char('o'), Action::FocusNextPane),
                 bind(KeyCode::Char('h'), Action::FocusLeft),
                 bind(KeyCode::Left, Action::FocusLeft),
@@ -645,6 +662,7 @@ fn all_actions() -> &'static [Action] {
         Action::NextWorkspace,
         Action::NewWorkspace,
         Action::ToggleSidebar,
+        Action::FocusSidebar,
         Action::FocusLeft,
         Action::FocusRight,
         Action::FocusUp,
@@ -791,6 +809,22 @@ pub fn load() -> Config {
     }
     if let Some(w) = raw.sidebar.max_width {
         config.sidebar.max_width = w;
+    }
+    if let Some(plugin) = raw.sidebar.plugin {
+        let command = plugin
+            .command
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|arg| !arg.is_empty())
+            .collect::<Vec<_>>();
+        if command.is_empty() {
+            eprintln!("cmux-mux: ignoring sidebar.plugin with empty command");
+        } else {
+            config.sidebar.plugin = Some(SidebarPluginOptions {
+                command,
+                cwd: plugin.cwd.filter(|cwd| !cwd.trim().is_empty()),
+            });
+        }
     }
     config.browser.chrome_binary = raw.browser.chrome_binary.filter(|s| !s.trim().is_empty());
     config.browser.cdp_url = raw.browser.cdp_url.filter(|s| !s.trim().is_empty());
@@ -976,7 +1010,14 @@ mod tests {
                     "tab_bg": 44
                 },
                 "tabs": {"min_width": 9, "solid_background": false},
-                "sidebar": {"width": 30, "max_width": 38},
+                "sidebar": {
+                    "width": 30,
+                    "max_width": 38,
+                    "plugin": {
+                        "command": ["/tmp/sidebar-plugin", "--mode", "test"],
+                        "cwd": "/tmp"
+                    }
+                },
                 "scrollbar": {"position": "border"},
                 "keys": {
                     "alt_shortcuts": false,
@@ -1002,6 +1043,9 @@ mod tests {
         assert!(!config.tabs.solid_background);
         assert_eq!(config.sidebar.width, 30);
         assert_eq!(config.sidebar.max_width, 38);
+        let plugin = config.sidebar.plugin.as_ref().expect("sidebar plugin config");
+        assert_eq!(plugin.command, vec!["/tmp/sidebar-plugin", "--mode", "test"]);
+        assert_eq!(plugin.cwd.as_deref(), Some("/tmp"));
         assert_eq!(config.scrollbar.position, ScrollbarPosition::Border);
         assert_eq!(
             config.keys.action_for(&KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)),
@@ -1011,6 +1055,10 @@ mod tests {
         assert_eq!(
             config.keys.action_for(&KeyEvent::new(KeyCode::Char('u'), KeyModifiers::NONE)),
             Some(Action::BrowserEditUrl)
+        );
+        assert_eq!(
+            config.keys.action_for(&KeyEvent::new(KeyCode::Char('S'), KeyModifiers::SHIFT)),
+            Some(Action::FocusSidebar)
         );
         assert_eq!(
             config.keys.modeless_action_for(&KeyEvent::new(KeyCode::Char('n'), KeyModifiers::ALT)),

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -183,6 +183,7 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     surface_options.extra_env.push(("CMUX_MUX_SOCKET".into(), socket_path.display().to_string()));
 
     let mux = Mux::new(args.session.clone(), surface_options);
+    mux.configure_sidebar_plugin(config.sidebar.plugin.clone());
     mux_core::server::serve(mux.clone(), Some(socket_path.clone()))?;
 
     let result = if args.headless {

--- a/mux/crates/mux-tui/src/session/mod.rs
+++ b/mux/crates/mux-tui/src/session/mod.rs
@@ -16,8 +16,8 @@ use std::sync::mpsc::Receiver;
 
 use ghostty_vt::{RenderState, Terminal};
 use mux_core::{
-    BrowserFrame, BrowserStatus, DefaultColors, Mux, MuxEvent, PaneId, ScreenId, SplitDir, Surface,
-    SurfaceId, SurfaceKind, WorkspaceId, ZoomMode,
+    BrowserFrame, BrowserStatus, DefaultColors, Mux, MuxEvent, PaneId, ScreenId,
+    SidebarPluginStatus, SplitDir, Surface, SurfaceId, SurfaceKind, WorkspaceId, ZoomMode,
 };
 use serde_json::json;
 
@@ -29,6 +29,12 @@ pub enum Session {
     Remote(Arc<RemoteSession>),
 }
 
+pub struct SidebarPluginSurface {
+    pub surface_id: Option<SurfaceId>,
+    pub error: Option<String>,
+    pub retry_after_ms: Option<u64>,
+}
+
 /// Attach optional cols/rows fields to a remote command.
 fn with_size(mut cmd: serde_json::Value, size: Option<(u16, u16)>) -> serde_json::Value {
     if let Some((cols, rows)) = size {
@@ -36,6 +42,15 @@ fn with_size(mut cmd: serde_json::Value, size: Option<(u16, u16)>) -> serde_json
         cmd["rows"] = json!(rows);
     }
     cmd
+}
+
+fn sidebar_status_to_surface(status: SidebarPluginStatus) -> SidebarPluginSurface {
+    let surface_id = status.surface;
+    SidebarPluginSurface {
+        surface_id,
+        error: status.error,
+        retry_after_ms: status.retry_after.map(|duration| duration.as_millis() as u64),
+    }
 }
 
 pub(crate) fn resize_action(
@@ -94,6 +109,48 @@ impl Session {
             mux.update_surface_options(|options| {
                 crate::config::apply_browser_to_surface_options(config, options);
             });
+            mux.configure_sidebar_plugin(config.sidebar.plugin.clone());
+        }
+    }
+
+    pub fn sidebar_plugin(&self, size: (u16, u16), relaunch: bool) -> SidebarPluginSurface {
+        match self {
+            Session::Local(mux) => {
+                let status = mux.ensure_sidebar_plugin(size.0, size.1, relaunch);
+                sidebar_status_to_surface(status)
+            }
+            Session::Remote(remote) => {
+                let Ok(data) = remote.request(json!({
+                    "cmd": "sidebar-plugin",
+                    "cols": size.0,
+                    "rows": size.1,
+                    "relaunch": relaunch,
+                })) else {
+                    return SidebarPluginSurface {
+                        surface_id: None,
+                        error: Some("sidebar plugin unavailable over attach".to_string()),
+                        retry_after_ms: None,
+                    };
+                };
+                let surface_id = data
+                    .get("surface")
+                    .and_then(serde_json::Value::as_u64)
+                    .map(|id| id as SurfaceId);
+                let surface = surface_id.and_then(|id| {
+                    remote
+                        .ensure_surface_with_kind(id, SurfaceKind::Pty, Some(size))
+                        .map(|surface| SurfaceHandle::Remote(surface, remote.clone()))
+                });
+                drop(surface);
+                SidebarPluginSurface {
+                    surface_id,
+                    error: data
+                        .get("error")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string),
+                    retry_after_ms: data.get("retry_after_ms").and_then(serde_json::Value::as_u64),
+                }
+            }
         }
     }
 

--- a/mux/crates/mux-tui/src/session/remote.rs
+++ b/mux/crates/mux-tui/src/session/remote.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 
 use super::tree::{TreeView, parse_tree};
 
-const SUPPORTED_PROTOCOL_VERSION: u64 = 7;
+const SUPPORTED_PROTOCOL_VERSION: u64 = 6;
 #[derive(Clone)]
 struct RemoteBrowserFrame {
     frame: BrowserFrame,
@@ -221,7 +221,7 @@ impl RemoteSession {
         let protocol = ident.get("protocol").and_then(|v| v.as_u64()).unwrap_or(0);
         if protocol != SUPPORTED_PROTOCOL_VERSION {
             anyhow::bail!(
-                "unsupported cmux-mux protocol {protocol}; this client requires protocol 7 because sidebar plugin hosting and attach-stream resize markers are authoritative; restart the cmux-mux server"
+                "unsupported cmux-mux protocol {protocol}; this client requires protocol 6; restart the cmux-mux server"
             );
         }
         session.request(json!({"cmd": "subscribe"}))?;

--- a/mux/crates/mux-tui/src/session/remote.rs
+++ b/mux/crates/mux-tui/src/session/remote.rs
@@ -20,7 +20,7 @@ use serde_json::{Value, json};
 
 use super::tree::{TreeView, parse_tree};
 
-const SUPPORTED_PROTOCOL_VERSION: u64 = 6;
+const SUPPORTED_PROTOCOL_VERSION: u64 = 7;
 #[derive(Clone)]
 struct RemoteBrowserFrame {
     frame: BrowserFrame,
@@ -221,7 +221,7 @@ impl RemoteSession {
         let protocol = ident.get("protocol").and_then(|v| v.as_u64()).unwrap_or(0);
         if protocol != SUPPORTED_PROTOCOL_VERSION {
             anyhow::bail!(
-                "unsupported cmux-mux protocol {protocol}; this client requires protocol 6 because attach-stream resize markers are authoritative; restart the cmux-mux server"
+                "unsupported cmux-mux protocol {protocol}; this client requires protocol 7 because sidebar plugin hosting and attach-stream resize markers are authoritative; restart the cmux-mux server"
             );
         }
         session.request(json!({"cmd": "subscribe"}))?;
@@ -475,12 +475,25 @@ impl RemoteSession {
         id: SurfaceId,
         size: Option<(u16, u16)>,
     ) -> Option<Arc<RemoteSurface>> {
+        let kind = {
+            let tree = self.tree.lock().unwrap();
+            tree.surface_kind(id)
+        };
+        self.ensure_surface_with_kind(id, kind, size)
+    }
+
+    pub fn ensure_surface_with_kind(
+        self: &Arc<Self>,
+        id: SurfaceId,
+        kind: SurfaceKind,
+        size: Option<(u16, u16)>,
+    ) -> Option<Arc<RemoteSurface>> {
         if let Some(surface) = self.surfaces.lock().unwrap().get(&id) {
             return Some(surface.clone());
         }
-        let (kind, source) = {
+        let source = {
             let tree = self.tree.lock().unwrap();
-            (tree.surface_kind(id), browser_source_from_tree(&tree, id))
+            browser_source_from_tree(&tree, id)
         };
         let (cols, rows) = size.unwrap_or((80, 24));
         let term = Terminal::new(cols, rows, 10_000, Callbacks::default()).ok()?;

--- a/mux/crates/mux-tui/src/ui/mod.rs
+++ b/mux/crates/mux-tui/src/ui/mod.rs
@@ -11,6 +11,7 @@ mod overlay;
 mod pane;
 mod scrollbar;
 mod sidebar;
+pub(crate) mod terminal_grid;
 
 use mux_core::Rect;
 use ratatui::Frame;

--- a/mux/crates/mux-tui/src/ui/pane.rs
+++ b/mux/crates/mux-tui/src/ui/pane.rs
@@ -6,6 +6,7 @@
 //! pane's border is highlighted — this is also where flashing
 //! notifications will hook in later.
 
+use ghostty_vt::RenderState;
 use mux_core::{BrowserStatus, Rect, SurfaceKind};
 use ratatui::Frame;
 use ratatui::style::{Color, Modifier, Style};

--- a/mux/crates/mux-tui/src/ui/pane.rs
+++ b/mux/crates/mux-tui/src/ui/pane.rs
@@ -6,7 +6,6 @@
 //! pane's border is highlighted — this is also where flashing
 //! notifications will hook in later.
 
-use ghostty_vt::{Cell as VtCell, ColorSpec, RenderState, Rgb};
 use mux_core::{BrowserStatus, Rect, SurfaceKind};
 use ratatui::Frame;
 use ratatui::style::{Color, Modifier, Style};
@@ -303,52 +302,10 @@ fn draw_content(
     }
     rs.set_clean();
 
-    let screen = frame.area();
-    let buf = frame.buffer_mut();
-    let max_cols = rect.width.min(screen.width.saturating_sub(rect.x)) as usize;
-    let max_rows = rect.height.min(screen.height.saturating_sub(rect.y)) as usize;
-    let colors = PaletteResolver::from_render_state(rs);
-
-    rs.walk_rows(|row, _dirty, cells| {
-        if row >= max_rows {
-            return;
-        }
-        let y = rect.y + row as u16;
-        for (col, cell) in cells.iter().enumerate() {
-            if col >= max_cols {
-                break;
-            }
-            let x = rect.x + col as u16;
-            let selected = selection
-                .is_some_and(|s| s.contains_viewport(col as u16, row as u16, selection_offset));
-            apply_cell(&mut buf[(x, y)], cell, &colors, selected.then_some(&theme));
-        }
-        // Pane narrower than the rect (during resize races): blank the rest.
-        for col in cells.len()..max_cols {
-            let x = rect.x + col as u16;
-            buf[(x, y)].set_symbol(" ").set_style(Style::default());
-        }
-    })
-    .ok()?;
-
-    // Rows beyond what the snapshot provided.
-    let (_, snap_rows) = rs.size();
-    for row in (snap_rows as usize)..max_rows {
-        let y = rect.y + row as u16;
-        for col in 0..max_cols {
-            let x = rect.x + col as u16;
-            buf[(x, y)].set_symbol(" ").set_style(Style::default());
-        }
-    }
-
-    if focused
-        && let Some(cursor) = rs.cursor()
-        && (cursor.x as usize) < max_cols
-        && (cursor.y as usize) < max_rows
-    {
-        return Some((rect.x + cursor.x, rect.y + cursor.y));
-    }
-    None
+    let cursor = super::terminal_grid::draw_render_state(frame, rect, rs, &theme, |col, row| {
+        selection.is_some_and(|s| s.contains_viewport(col, row, selection_offset))
+    });
+    focused.then_some(cursor).flatten()
 }
 
 fn draw_browser_content(
@@ -506,156 +463,4 @@ fn push_resize_hits(app: &mut App, area: &PaneArea) {
         ));
     }
     app.hits.extend(hits);
-}
-
-#[derive(Clone, Copy)]
-struct PaletteResolver {
-    colors: [Rgb; 256],
-    overridden: [bool; 256],
-}
-
-impl PaletteResolver {
-    fn from_render_state(rs: &RenderState) -> Self {
-        Self {
-            colors: std::array::from_fn(|idx| rs.palette_color(idx as u8)),
-            overridden: std::array::from_fn(|idx| rs.palette_overridden(idx as u8)),
-        }
-    }
-
-    fn resolve(&self, spec: ColorSpec) -> Color {
-        match spec {
-            ColorSpec::Default => Color::Reset,
-            ColorSpec::Rgb(rgb) => Color::Rgb(rgb.r, rgb.g, rgb.b),
-            ColorSpec::Palette(idx) => {
-                resolve_palette_color(idx, self.overridden[idx as usize], self.colors[idx as usize])
-            }
-        }
-    }
-}
-
-fn resolve_palette_color(idx: u8, overridden: bool, rgb: Rgb) -> Color {
-    if overridden {
-        return Color::Rgb(rgb.r, rgb.g, rgb.b);
-    }
-    if idx < 16 {
-        return BASIC_PALETTE_COLORS[idx as usize];
-    }
-    Color::Indexed(idx)
-}
-
-// ANSI palette slots 0-15 as host-terminal colors. Ratatui maps these to crossterm's
-// dark/bright variants; crossterm 0.28 serializes them as the indexed equivalent of
-// SGR 30-37 and 90-97 (foreground) or 40-47 and 100-107 (background).
-const BASIC_PALETTE_COLORS: [Color; 16] = [
-    Color::Black,        // 0: 30/40
-    Color::Red,          // 1: 31/41
-    Color::Green,        // 2: 32/42
-    Color::Yellow,       // 3: 33/43
-    Color::Blue,         // 4: 34/44
-    Color::Magenta,      // 5: 35/45
-    Color::Cyan,         // 6: 36/46
-    Color::Gray,         // 7: 37/47
-    Color::DarkGray,     // 8: 90/100
-    Color::LightRed,     // 9: 91/101
-    Color::LightGreen,   // 10: 92/102
-    Color::LightYellow,  // 11: 93/103
-    Color::LightBlue,    // 12: 94/104
-    Color::LightMagenta, // 13: 95/105
-    Color::LightCyan,    // 14: 96/106
-    Color::White,        // 15: 97/107
-];
-
-fn apply_cell(
-    target: &mut ratatui::buffer::Cell,
-    cell: &VtCell,
-    colors: &PaletteResolver,
-    selected: Option<&Theme>,
-) {
-    if cell.text.is_empty() {
-        target.set_symbol(" ");
-    } else {
-        target.set_symbol(&cell.text);
-    }
-
-    let mut style = Style::default();
-    style = style.fg(colors.resolve(cell.fg));
-    style = style.bg(colors.resolve(cell.bg));
-    let mut modifier = Modifier::empty();
-    if cell.bold {
-        modifier |= Modifier::BOLD;
-    }
-    if cell.faint {
-        modifier |= Modifier::DIM;
-    }
-    if cell.italic {
-        modifier |= Modifier::ITALIC;
-    }
-    if cell.underline {
-        modifier |= Modifier::UNDERLINED;
-    }
-    if cell.strikethrough {
-        modifier |= Modifier::CROSSED_OUT;
-    }
-    if cell.inverse {
-        modifier |= Modifier::REVERSED;
-    }
-    if cell.blink {
-        modifier |= Modifier::SLOW_BLINK;
-    }
-    if cell.invisible {
-        modifier |= Modifier::HIDDEN;
-    }
-    style = style.add_modifier(modifier);
-    // Selection paints the themed background over the cell (the color
-    // comes from mux.json, else the user's Ghostty selection-background,
-    // else a dark grey default).
-    if let Some(theme) = selected {
-        style = style.bg(theme.selection_bg);
-        if let Some(fg) = theme.selection_fg {
-            style = style.fg(fg);
-        }
-        style = style.remove_modifier(Modifier::REVERSED);
-    }
-    target.set_style(style);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn palette_color_mapping_preserves_host_palette_when_not_overridden() {
-        let rgb = Rgb { r: 1, g: 2, b: 3 };
-        let expected = [
-            Color::Black,
-            Color::Red,
-            Color::Green,
-            Color::Yellow,
-            Color::Blue,
-            Color::Magenta,
-            Color::Cyan,
-            Color::Gray,
-            Color::DarkGray,
-            Color::LightRed,
-            Color::LightGreen,
-            Color::LightYellow,
-            Color::LightBlue,
-            Color::LightMagenta,
-            Color::LightCyan,
-            Color::White,
-        ];
-
-        for (idx, color) in expected.into_iter().enumerate() {
-            assert_eq!(resolve_palette_color(idx as u8, false, rgb), color);
-        }
-        assert_eq!(resolve_palette_color(16, false, rgb), Color::Indexed(16));
-        assert_eq!(resolve_palette_color(196, false, rgb), Color::Indexed(196));
-    }
-
-    #[test]
-    fn palette_color_mapping_renders_overrides_as_rgb() {
-        let rgb = Rgb { r: 1, g: 2, b: 3 };
-        assert_eq!(resolve_palette_color(1, true, rgb), Color::Rgb(1, 2, 3));
-        assert_eq!(resolve_palette_color(196, true, rgb), Color::Rgb(1, 2, 3));
-    }
 }

--- a/mux/crates/mux-tui/src/ui/sidebar.rs
+++ b/mux/crates/mux-tui/src/ui/sidebar.rs
@@ -35,6 +35,71 @@ fn workspace_unread_color(
 }
 
 pub fn draw(app: &mut App, frame: &mut Frame) {
+    if app.config.sidebar.plugin.is_some() {
+        draw_plugin(app, frame);
+        return;
+    }
+    draw_builtin(app, frame);
+}
+
+fn draw_plugin(app: &mut App, frame: &mut Frame) {
+    let area = frame.area();
+    let width = app.sidebar_width;
+    let height = area.height;
+    if width < 3 || height == 0 {
+        return;
+    }
+    let content = app.sidebar_plugin_rect();
+    let border_x = width - 1;
+    let focused = app.sidebar_focused;
+    let border_style = Style::default().fg(if focused {
+        app.config.theme.border_active
+    } else {
+        app.config.theme.border_inactive
+    });
+    {
+        let buf = frame.buffer_mut();
+        for y in 0..height {
+            buf[(border_x, y)].set_symbol("│").set_style(border_style);
+        }
+    }
+    if let Some(surface_id) = app.sidebar_plugin_surface {
+        let Some(surface) = app.session.surface(surface_id) else { return };
+        surface.take_dirty();
+        let theme = app.config.theme;
+        let rs = app
+            .render_states
+            .entry(surface_id)
+            .or_insert_with(|| ghostty_vt::RenderState::new().expect("render state alloc"));
+        if surface.snapshot(rs).is_ok() {
+            rs.set_clean();
+            let _ =
+                super::terminal_grid::draw_render_state(frame, content, rs, &theme, |_, _| false);
+            {
+                let buf = frame.buffer_mut();
+                for y in 0..height {
+                    buf[(border_x, y)].set_symbol("│").set_style(border_style);
+                }
+            }
+            return;
+        }
+    }
+    let message = app.sidebar_plugin_error.as_deref().unwrap_or("sidebar plugin unavailable");
+    let base = Style::default();
+    let dim = base.fg(Color::Indexed(244));
+    let buf = frame.buffer_mut();
+    for y in 0..height {
+        for x in 0..content.width {
+            buf[(x, y)].set_symbol(" ").set_style(base);
+        }
+    }
+    let text = truncate(message, content.width.saturating_sub(2) as usize);
+    if content.width > 2 {
+        buf.set_stringn(1, height / 2, &text, content.width.saturating_sub(2) as usize, dim);
+    }
+}
+
+fn draw_builtin(app: &mut App, frame: &mut Frame) {
     let area = frame.area();
     let width = app.sidebar_width;
     let height = area.height;

--- a/mux/crates/mux-tui/src/ui/terminal_grid.rs
+++ b/mux/crates/mux-tui/src/ui/terminal_grid.rs
@@ -1,0 +1,202 @@
+use ghostty_vt::{Cell as VtCell, ColorSpec, RenderState, Rgb};
+use mux_core::Rect;
+use ratatui::Frame;
+use ratatui::style::{Color, Modifier, Style};
+
+use crate::config::Theme;
+
+pub fn draw_render_state(
+    frame: &mut Frame,
+    rect: Rect,
+    rs: &RenderState,
+    theme: &Theme,
+    selected: impl Fn(u16, u16) -> bool,
+) -> Option<(u16, u16)> {
+    if rect.width == 0 || rect.height == 0 {
+        return None;
+    }
+    let screen = frame.area();
+    let max_cols = rect.width.min(screen.width.saturating_sub(rect.x)) as usize;
+    let max_rows = rect.height.min(screen.height.saturating_sub(rect.y)) as usize;
+    let colors = PaletteResolver::from_render_state(rs);
+    let buf = frame.buffer_mut();
+
+    rs.walk_rows(|row, _dirty, cells| {
+        if row >= max_rows {
+            return;
+        }
+        let y = rect.y + row as u16;
+        for (col, cell) in cells.iter().enumerate() {
+            if col >= max_cols {
+                break;
+            }
+            let x = rect.x + col as u16;
+            let selected = selected(col as u16, row as u16);
+            apply_cell(&mut buf[(x, y)], cell, &colors, selected.then_some(theme));
+        }
+        for col in cells.len()..max_cols {
+            let x = rect.x + col as u16;
+            buf[(x, y)].set_symbol(" ").set_style(Style::default());
+        }
+    })
+    .ok()?;
+
+    let (_, snap_rows) = rs.size();
+    for row in (snap_rows as usize)..max_rows {
+        let y = rect.y + row as u16;
+        for col in 0..max_cols {
+            let x = rect.x + col as u16;
+            buf[(x, y)].set_symbol(" ").set_style(Style::default());
+        }
+    }
+
+    rs.cursor()
+        .filter(|cursor| (cursor.x as usize) < max_cols && (cursor.y as usize) < max_rows)
+        .map(|cursor| (rect.x + cursor.x, rect.y + cursor.y))
+}
+
+#[derive(Clone, Copy)]
+struct PaletteResolver {
+    colors: [Rgb; 256],
+    overridden: [bool; 256],
+}
+
+impl PaletteResolver {
+    fn from_render_state(rs: &RenderState) -> Self {
+        Self {
+            colors: std::array::from_fn(|idx| rs.palette_color(idx as u8)),
+            overridden: std::array::from_fn(|idx| rs.palette_overridden(idx as u8)),
+        }
+    }
+
+    fn resolve(&self, spec: ColorSpec) -> Color {
+        match spec {
+            ColorSpec::Default => Color::Reset,
+            ColorSpec::Rgb(rgb) => Color::Rgb(rgb.r, rgb.g, rgb.b),
+            ColorSpec::Palette(idx) => {
+                resolve_palette_color(idx, self.overridden[idx as usize], self.colors[idx as usize])
+            }
+        }
+    }
+}
+
+fn resolve_palette_color(idx: u8, overridden: bool, rgb: Rgb) -> Color {
+    if overridden {
+        return Color::Rgb(rgb.r, rgb.g, rgb.b);
+    }
+    if idx < 16 {
+        return BASIC_PALETTE_COLORS[idx as usize];
+    }
+    Color::Indexed(idx)
+}
+
+const BASIC_PALETTE_COLORS: [Color; 16] = [
+    Color::Black,
+    Color::Red,
+    Color::Green,
+    Color::Yellow,
+    Color::Blue,
+    Color::Magenta,
+    Color::Cyan,
+    Color::Gray,
+    Color::DarkGray,
+    Color::LightRed,
+    Color::LightGreen,
+    Color::LightYellow,
+    Color::LightBlue,
+    Color::LightMagenta,
+    Color::LightCyan,
+    Color::White,
+];
+
+fn apply_cell(
+    target: &mut ratatui::buffer::Cell,
+    cell: &VtCell,
+    colors: &PaletteResolver,
+    selected: Option<&Theme>,
+) {
+    if cell.text.is_empty() {
+        target.set_symbol(" ");
+    } else {
+        target.set_symbol(&cell.text);
+    }
+
+    let mut style = Style::default();
+    style = style.fg(colors.resolve(cell.fg));
+    style = style.bg(colors.resolve(cell.bg));
+    let mut modifier = Modifier::empty();
+    if cell.bold {
+        modifier |= Modifier::BOLD;
+    }
+    if cell.faint {
+        modifier |= Modifier::DIM;
+    }
+    if cell.italic {
+        modifier |= Modifier::ITALIC;
+    }
+    if cell.underline {
+        modifier |= Modifier::UNDERLINED;
+    }
+    if cell.strikethrough {
+        modifier |= Modifier::CROSSED_OUT;
+    }
+    if cell.inverse {
+        modifier |= Modifier::REVERSED;
+    }
+    if cell.blink {
+        modifier |= Modifier::SLOW_BLINK;
+    }
+    if cell.invisible {
+        modifier |= Modifier::HIDDEN;
+    }
+    style = style.add_modifier(modifier);
+    if let Some(theme) = selected {
+        style = style.bg(theme.selection_bg);
+        if let Some(fg) = theme.selection_fg {
+            style = style.fg(fg);
+        }
+        style = style.remove_modifier(Modifier::REVERSED);
+    }
+    target.set_style(style);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn palette_color_mapping_preserves_host_palette_when_not_overridden() {
+        let rgb = Rgb { r: 1, g: 2, b: 3 };
+        let expected = [
+            Color::Black,
+            Color::Red,
+            Color::Green,
+            Color::Yellow,
+            Color::Blue,
+            Color::Magenta,
+            Color::Cyan,
+            Color::Gray,
+            Color::DarkGray,
+            Color::LightRed,
+            Color::LightGreen,
+            Color::LightYellow,
+            Color::LightBlue,
+            Color::LightMagenta,
+            Color::LightCyan,
+            Color::White,
+        ];
+
+        for (idx, color) in expected.into_iter().enumerate() {
+            assert_eq!(resolve_palette_color(idx as u8, false, rgb), color);
+        }
+        assert_eq!(resolve_palette_color(16, false, rgb), Color::Indexed(16));
+        assert_eq!(resolve_palette_color(196, false, rgb), Color::Indexed(196));
+    }
+
+    #[test]
+    fn palette_color_mapping_renders_overrides_as_rgb() {
+        let rgb = Rgb { r: 1, b: 3, g: 2 };
+        assert_eq!(resolve_palette_color(1, true, rgb), Color::Rgb(1, 2, 3));
+        assert_eq!(resolve_palette_color(196, true, rgb), Color::Rgb(1, 2, 3));
+    }
+}

--- a/mux/crates/mux-tui/src/ui/terminal_grid.rs
+++ b/mux/crates/mux-tui/src/ui/terminal_grid.rs
@@ -8,7 +8,7 @@ use crate::config::Theme;
 pub fn draw_render_state(
     frame: &mut Frame,
     rect: Rect,
-    rs: &RenderState,
+    rs: &mut RenderState,
     theme: &Theme,
     selected: impl Fn(u16, u16) -> bool,
 ) -> Option<(u16, u16)> {

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -69,7 +69,7 @@ fn cli_verbs_cover_command_output_errors_and_streams() {
     assert_success(&ping_json);
     let ping: serde_json::Value = serde_json::from_slice(&ping_json.stdout).unwrap();
     assert_eq!(ping.get("ok").and_then(|v| v.as_bool()), Some(true));
-    assert_eq!(ping.get("protocol").and_then(|v| v.as_u64()), Some(6));
+    assert_eq!(ping.get("protocol").and_then(|v| v.as_u64()), Some(7));
 
     let title = cli(&server, &["set-window-title", "--title", "hello"]);
     assert_success(&title);

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -69,7 +69,7 @@ fn cli_verbs_cover_command_output_errors_and_streams() {
     assert_success(&ping_json);
     let ping: serde_json::Value = serde_json::from_slice(&ping_json.stdout).unwrap();
     assert_eq!(ping.get("ok").and_then(|v| v.as_bool()), Some(true));
-    assert_eq!(ping.get("protocol").and_then(|v| v.as_u64()), Some(7));
+    assert_eq!(ping.get("protocol").and_then(|v| v.as_u64()), Some(6));
 
     let title = cli(&server, &["set-window-title", "--title", "hello"]);
     assert_success(&title);

--- a/mux/docs/configuration.md
+++ b/mux/docs/configuration.md
@@ -40,6 +40,8 @@ Tabs are numbered by default. A recognized agent program can appear after the nu
 | --- | --- | --- | --- |
 | `sidebar.width` | integer | `22` | Sidebar width, clamped to 10 through 60 on load |
 | `sidebar.max_width` | integer | `0` | Maximum live drag width; `0` means no configured maximum |
+| `sidebar.plugin.command` | array of strings | unset | External sidebar plugin argv; when set, the sidebar hosts this program in a PTY instead of the built-in list |
+| `sidebar.plugin.cwd` | string | unset | Working directory for the sidebar plugin process |
 
 Live sidebar dragging also leaves at least 40 columns for pane content.
 
@@ -93,6 +95,7 @@ The default launched profile is `~/Library/Application Support/cmux-mux/chrome-p
 | `keys.next-workspace` | chord string or array or `"none"` | `"w"` | Next workspace |
 | `keys.new-workspace` | chord string or array or `"none"` | `"W"` | New workspace |
 | `keys.toggle-sidebar` | chord string or array or `"none"` | `"s"` | Toggle sidebar |
+| `keys.focus-sidebar` | chord string or array or `"none"` | `"S"` | Focus the sidebar plugin (keys forward to it; prefix returns) |
 | `keys.focus-next-pane` | chord string or array or `"none"` | `"o"` | Cycle to the next pane in the current screen |
 | `keys.focus-left` | chord string or array or `"none"` | `["h","left","alt+h","alt+left"]` | Focus left |
 | `keys.focus-right` | chord string or array or `"none"` | `["l","right","alt+l","alt+right"]` | Focus right |

--- a/mux/docs/keyboard.md
+++ b/mux/docs/keyboard.md
@@ -39,6 +39,7 @@ These defaults come from `Keys::default`.
 | `Ctrl-b w` | Next workspace |
 | `Ctrl-b W` | New workspace |
 | `Ctrl-b s` | Toggle the workspace sidebar |
+| `Ctrl-b S` | Focus the sidebar plugin (when `sidebar.plugin` is configured; keys forward to it, `Ctrl-b` returns focus) |
 | `Ctrl-b h` or `Ctrl-b Left` | Focus left |
 | `Alt-h` or `Alt-Left` | Focus left |
 | `Ctrl-b l` or `Ctrl-b Right` | Focus right |
@@ -140,6 +141,7 @@ new-screen
 next-workspace
 new-workspace
 toggle-sidebar
+focus-sidebar
 focus-left
 focus-right
 focus-up

--- a/mux/scripts/smoke-tui.py
+++ b/mux/scripts/smoke-tui.py
@@ -1,4 +1,4 @@
-import os, pty, select, socket, json, time, sys, signal, subprocess, re
+import os, pty, select, socket, json, time, sys, signal, subprocess, re, tempfile
 
 BIN = os.environ.get("CMUX_MUX_BIN", "target/debug/cmux-mux")
 SESSION = f"smoke-{os.getpid()}"
@@ -108,6 +108,26 @@ def send_prefix_t_until_tab_count(count):
 
 SOCK = discover_socket_path()
 
+tmpdir = tempfile.TemporaryDirectory(prefix="cmux-mux-smoke-")
+config_path = os.path.join(tmpdir.name, "mux.json")
+with open(config_path, "w", encoding="utf-8") as f:
+    json.dump(
+        {
+            "sidebar": {
+                "width": 22,
+                "plugin": {
+                    "command": [
+                        "/bin/sh",
+                        "-c",
+                        "printf 'SIDEBAR-MARKER\\n'; cat",
+                    ]
+                },
+            }
+        },
+        f,
+    )
+os.environ["CMUX_MUX_CONFIG"] = config_path
+
 pid, fd = pty.fork()
 if pid == 0:
     os.environ["TERM"] = "xterm-256color"
@@ -175,6 +195,16 @@ def wait_screen_contains(surface_id, needle, seconds=15):
         if needle in last:
             return last
     raise AssertionError(last[-500:])
+
+def wait_render_contains(needle, seconds=15):
+    deadline = time.time() + seconds
+    last = ""
+    while time.time() < deadline:
+        drain(0.2)
+        last = render_text_snapshot(output)
+        if needle in last:
+            return last
+    raise AssertionError(last[-1200:])
 
 def render_style_snapshot(data, rows=30, cols=100):
     grid = [[{"bg": None, "bold": False, "dim": False, "reverse": False} for _ in range(cols)] for _ in range(rows)]
@@ -318,7 +348,7 @@ assert probe_answers[10] > 0 and probe_answers[11] > 0, probe_answers
 
 ident = rpc({"id": 1, "cmd": "identify"})
 assert ident["ok"] and ident["data"]["app"] == "cmux-mux", ident
-assert ident["data"]["protocol"] == 6, ident
+assert ident["data"]["protocol"] == 7, ident
 print("identify ok:", ident["data"])
 
 ws0 = tree()[0]
@@ -343,6 +373,22 @@ text = output.decode("utf-8", "replace")
 assert " 1 " in text, text[-500:]
 assert " + " in text, text[-500:]
 print("always-on tab bar with numbered tab ok")
+
+wait_render_contains("SIDEBAR-MARKER")
+print("sidebar plugin marker rendered ok")
+os.write(fd, b"\x02S")
+drain(0.5)
+os.write(fd, b"plugin-echo-ok\r")
+wait_render_contains("plugin-echo-ok")
+print("sidebar plugin focus and key echo ok")
+os.write(fd, b"\x02S")
+drain(0.5)
+with open(config_path, "w", encoding="utf-8") as f:
+    json.dump({"sidebar": {"width": 22}}, f)
+assert rpc({"id": 31, "cmd": "reload-config"})["ok"]
+drain(1.0)
+assert "workspaces" in render_text_snapshot(output), output[-1200:]
+print("sidebar plugin config reload falls back to built-in sidebar ok")
 
 # Prefix-B creates a browser tab immediately and focuses its in-pane
 # omnibar. The dead CDP endpoint keeps this Chrome-free and fast.

--- a/mux/scripts/smoke-tui.py
+++ b/mux/scripts/smoke-tui.py
@@ -119,7 +119,7 @@ with open(config_path, "w", encoding="utf-8") as f:
                     "command": [
                         "/bin/sh",
                         "-c",
-                        "printf 'SIDEBAR-MARKER\\n'; cat",
+                        "printf 'SIDEBAR-MARKER\\n'; awk '{print \"PLUGIN:\" $0; fflush()}'",
                     ]
                 },
             }
@@ -348,7 +348,7 @@ assert probe_answers[10] > 0 and probe_answers[11] > 0, probe_answers
 
 ident = rpc({"id": 1, "cmd": "identify"})
 assert ident["ok"] and ident["data"]["app"] == "cmux-mux", ident
-assert ident["data"]["protocol"] == 7, ident
+assert ident["data"]["protocol"] == 6, ident
 print("identify ok:", ident["data"])
 
 ws0 = tree()[0]
@@ -379,10 +379,17 @@ print("sidebar plugin marker rendered ok")
 os.write(fd, b"\x02S")
 drain(0.5)
 os.write(fd, b"plugin-echo-ok\r")
-wait_render_contains("plugin-echo-ok")
+# The plugin awk-prefixes forwarded lines, so this string can only appear if
+# prefix-S focused the plugin and keys were forwarded to its PTY (a shell
+# echo of the raw text would not carry the PLUGIN: prefix).
+wait_render_contains("PLUGIN:plugin-echo-ok")
 print("sidebar plugin focus and key echo ok")
 os.write(fd, b"\x02S")
 drain(0.5)
+# Focus must be back on the pane: run a shell command and require its output.
+os.write(fd, b"echo back-to-pane-$((40 + 2))\r")
+wait_render_contains("back-to-pane-42")
+print("prefix-S returns focus to the pane ok")
 with open(config_path, "w", encoding="utf-8") as f:
     json.dump({"sidebar": {"width": 22}}, f)
 assert rpc({"id": 31, "cmd": "reload-config"})["ok"]

--- a/mux/spec/README.md
+++ b/mux/spec/README.md
@@ -1,6 +1,6 @@
 # cmux-mux Programmability Contract
 
-This directory is the source of truth for the cmux-mux control protocol, the generated `cmux-mux` command surface, plugin contracts, and future generated language bindings. The implemented protocol described here is protocol version 7, as defined by `mux-core/src/server.rs`.
+This directory is the source of truth for the cmux-mux control protocol, the generated `cmux-mux` command surface, plugin contracts, and future generated language bindings. The implemented protocol described here is protocol version 6, as defined by `mux-core/src/server.rs`.
 
 The spec is intentionally stricter than prose docs. Implemented commands and events describe the current server behavior exactly, including awkward result shapes and no-op cases. Proposed commands, events, transports, and config are marked `proposed` and are not part of the implemented protocol.
 
@@ -14,7 +14,7 @@ The spec version tracks the mux protocol version.
 | Additive command, event, field, CLI flag, binding helper, or transport option | Minor protocol version |
 | Removal, rename, incompatible type change, changed error semantics, or changed ordering guarantee | Major protocol version |
 
-Protocol v7 is the implemented baseline. Proposed additions in this directory target the next minor protocol unless a later spec says otherwise.
+Protocol v6 is the implemented baseline. Proposed additions in this directory target the next minor protocol unless a later spec says otherwise.
 
 Generated clients must inspect `identify.protocol` before using features newer than the connected server. Bindings may expose proposed APIs behind version checks, but they must not send proposed commands to an older server unless the caller explicitly opts into probing.
 
@@ -39,4 +39,4 @@ The generator must preserve the wire command names, parameter names, result shap
 
 ## Implemented Inventory
 
-Protocol v7 implements the socket commands listed in `commands.md` and the event names listed in `events.md`. Events include subscribe events, attach-stream events, and the implemented `empty` and `detached` lifecycle events.
+Protocol v6 implements the socket commands listed in `commands.md` and the event names listed in `events.md`. Events include subscribe events, attach-stream events, and the implemented `empty` and `detached` lifecycle events.

--- a/mux/spec/README.md
+++ b/mux/spec/README.md
@@ -1,8 +1,8 @@
 # cmux-mux Programmability Contract
 
-This directory is the source of truth for the cmux-mux control protocol, the generated `cmux-mux` command surface, and future generated language bindings. The implemented protocol described here is protocol version 5, as defined by `mux-core/src/server.rs`.
+This directory is the source of truth for the cmux-mux control protocol, the generated `cmux-mux` command surface, plugin contracts, and future generated language bindings. The implemented protocol described here is protocol version 7, as defined by `mux-core/src/server.rs`.
 
-The spec is intentionally stricter than prose docs. Implemented commands and events describe the current server behavior exactly, including awkward result shapes and no-op cases. Proposed commands, events, transports, and config are marked `proposed` and are not part of protocol v5.
+The spec is intentionally stricter than prose docs. Implemented commands and events describe the current server behavior exactly, including awkward result shapes and no-op cases. Proposed commands, events, transports, and config are marked `proposed` and are not part of the implemented protocol.
 
 ## Versioning
 
@@ -14,9 +14,9 @@ The spec version tracks the mux protocol version.
 | Additive command, event, field, CLI flag, binding helper, or transport option | Minor protocol version |
 | Removal, rename, incompatible type change, changed error semantics, or changed ordering guarantee | Major protocol version |
 
-Protocol v5 is the implemented baseline. Proposed additions in this directory target protocol v6 unless a later spec says otherwise.
+Protocol v7 is the implemented baseline. Proposed additions in this directory target the next minor protocol unless a later spec says otherwise.
 
-Generated clients must inspect `identify.protocol` before using features newer than the connected server. Bindings may expose proposed APIs behind version checks, but they must not send proposed commands to a v5 server unless the caller explicitly opts into probing.
+Generated clients must inspect `identify.protocol` before using features newer than the connected server. Bindings may expose proposed APIs behind version checks, but they must not send proposed commands to an older server unless the caller explicitly opts into probing.
 
 ## Generation Model
 
@@ -35,9 +35,8 @@ The generator must preserve the wire command names, parameter names, result shap
 | `transports.md` | Implemented Unix socket transport and proposed HTTP, SSE, and WebSocket transports |
 | `cli.md` | Generated `cmux-mux <verb>` conventions, exit codes, stdin rules, verb table, and examples |
 | `bindings.md` | Language binding style sheets and conformance suite contract |
+| `plugins.md` | Sidebar plugin PTY, manifest, lifecycle, focus, and config contract |
 
 ## Implemented Inventory
 
-Protocol v5 implements 30 socket commands and 10 event names in the consumer-side contract. The command inventory is listed in `commands.md`. Events include subscribe events, attach-stream events, and the implemented `empty` and `detached` lifecycle events.
-
-The current branch's `server.rs` predates the landed `move-tab`, `move-workspace`, and protocol v6 attach resize replay behavior. Those entries are marked with verification notes where field names or runtime behavior could not be checked against this branch.
+Protocol v7 implements the socket commands listed in `commands.md` and the event names listed in `events.md`. Events include subscribe events, attach-stream events, and the implemented `empty` and `detached` lifecycle events.

--- a/mux/spec/cli.md
+++ b/mux/spec/cli.md
@@ -176,3 +176,5 @@ cmux-mux subscribe |
 sid=$(cmux-mux ids --kind surface | awk 'NR == 1 {print $3}')
 cmux-mux send-key --surface "$sid" enter
 ```
+
+`sidebar-plugin` has no CLI verb: it is client-internal, issued by attach clients to obtain and size the sidebar plugin surface.

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -1,6 +1,6 @@
 # Command Contract
 
-This file specifies the JSON command contract for the cmux-mux protocol. Implemented commands match protocol v7 in `mux/crates/mux-core/src/server.rs`.
+This file specifies the JSON command contract for the cmux-mux protocol. Implemented commands match protocol v6 in `mux/crates/mux-core/src/server.rs`.
 
 ## Notation
 
@@ -131,7 +131,7 @@ Example:
 
 ```json
 {"id":1,"cmd":"identify"}
-{"id":1,"ok":true,"data":{"app":"cmux-mux","version":"0.1.0","protocol":7,"session":"main","pid":12345}}
+{"id":1,"ok":true,"data":{"app":"cmux-mux","version":"0.1.0","protocol":6,"session":"main","pid":12345}}
 ```
 
 ### ping
@@ -160,7 +160,7 @@ Example:
 
 ```json
 {"id":2,"cmd":"ping"}
-{"id":2,"ok":true,"data":{"ok":true,"version":"0.1.0","protocol":7}}
+{"id":2,"ok":true,"data":{"ok":true,"version":"0.1.0","protocol":6}}
 ```
 
 ### reload-config

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -1,6 +1,6 @@
 # Command Contract
 
-This file specifies the JSON command contract for the cmux-mux protocol. Implemented commands match protocol v6 in `mux/crates/mux-core/src/server.rs`.
+This file specifies the JSON command contract for the cmux-mux protocol. Implemented commands match protocol v7 in `mux/crates/mux-core/src/server.rs`.
 
 ## Notation
 
@@ -27,7 +27,7 @@ The canonical request and response envelope is defined in `transports.md`. Comma
 
 Malformed JSON, unknown command names, missing required fields, and wrong JSON types fail during request decoding with the transport-level `bad request: ...` envelope.
 
-The v5 server does not explicitly deny unknown JSON fields. Clients must not depend on unknown fields being rejected.
+The server does not explicitly deny unknown JSON fields. Clients must not depend on unknown fields being rejected.
 
 Common CLI exit codes for every mapping are `0` success, `1` command error, `2` CLI usage error, and `3` connection error.
 
@@ -89,7 +89,7 @@ object{
 }
 ```
 
-The `dead` pane variant is serialized by the v5 server only if the tree references a pane missing from state. That should not occur in normal operation, but clients must tolerate it.
+The `dead` pane variant is serialized only if the tree references a pane missing from state. That should not occur in normal operation, but clients must tolerate it.
 
 ## Implemented Commands
 
@@ -131,7 +131,7 @@ Example:
 
 ```json
 {"id":1,"cmd":"identify"}
-{"id":1,"ok":true,"data":{"app":"cmux-mux","version":"0.1.0","protocol":6,"session":"main","pid":12345}}
+{"id":1,"ok":true,"data":{"app":"cmux-mux","version":"0.1.0","protocol":7,"session":"main","pid":12345}}
 ```
 
 ### ping
@@ -160,7 +160,7 @@ Example:
 
 ```json
 {"id":2,"cmd":"ping"}
-{"id":2,"ok":true,"data":{"ok":true,"version":"0.1.0","protocol":6}}
+{"id":2,"ok":true,"data":{"ok":true,"version":"0.1.0","protocol":7}}
 ```
 
 ### reload-config
@@ -450,6 +450,41 @@ Example:
 ```json
 {"id":4,"cmd":"read-screen","surface":1}
 {"id":4,"ok":true,"data":{"text":"$ ls\nREADME.md\n"}}
+```
+
+### sidebar-plugin
+
+| Field | Value |
+| --- | --- |
+| name | `sidebar-plugin` |
+| status | implemented |
+| since | protocol 7 |
+
+Ensures the configured server-owned sidebar plugin PTY exists at the requested size and returns the surface id to render through `attach-surface`. This command does not install, build, or discover plugins; it only hosts the command already configured in server-side `mux.json`.
+
+Params:
+
+```text
+object{cmd:"sidebar-plugin",cols:uint16,rows:uint16,relaunch?:boolean}
+```
+
+Result:
+
+```text
+object{surface:Id|null,error:string|null,retry_after_ms:uint64|null}
+```
+
+Compatibility notes:
+
+- Attached clients use this command to obtain the server-owned plugin surface, then render it through `attach-surface` and send input through `send`.
+- If no sidebar plugin is configured, `surface`, `error`, and `retry_after_ms` are all `null`.
+- If the plugin exited or failed to start, `error` is populated. The server may also return `retry_after_ms` to indicate restart backoff. A client should pass `relaunch:true` only when the user focuses the sidebar or explicitly retries.
+
+Example:
+
+```json
+{"id":104,"cmd":"sidebar-plugin","cols":21,"rows":30,"relaunch":true}
+{"id":104,"ok":true,"data":{"surface":42,"error":null,"retry_after_ms":null}}
 ```
 
 ### vt-state
@@ -916,7 +951,7 @@ CLI mapping: verb `process-info`; flags `--surface <id>`; plain stdout prints `p
 | status | implemented |
 | since | protocol 5 |
 
-Updates the session default foreground and/or background colors used by PTY surfaces. Missing fields preserve their previous values. Existing PTY surfaces receive the merged defaults. The v5 server emits `surface-output` for every existing surface, including browser surfaces; browser color application is a no-op, but the event is still emitted. Future PTY surfaces start with the merged defaults.
+Updates the session default foreground and/or background colors used by PTY surfaces. Missing fields preserve their previous values. Existing PTY surfaces receive the merged defaults. The server emits `surface-output` for every existing surface, including browser surfaces; browser color application is a no-op, but the event is still emitted. Future PTY surfaces start with the merged defaults.
 
 Params:
 

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -457,8 +457,9 @@ Example:
 | Field | Value |
 | --- | --- |
 | name | `sidebar-plugin` |
+| CLI mapping | none (client-internal: issued by attach clients to obtain the sidebar plugin surface) |
 | status | implemented |
-| since | protocol 7 |
+| since | protocol 6 |
 
 Ensures the configured server-owned sidebar plugin PTY exists at the requested size and returns the surface id to render through `attach-surface`. This command does not install, build, or discover plugins; it only hosts the command already configured in server-side `mux.json`.
 

--- a/mux/spec/plugins.md
+++ b/mux/spec/plugins.md
@@ -1,0 +1,82 @@
+# Plugin Contract
+
+This document specifies the mux-side sidebar plugin contract.
+
+## Sidebar Plugins
+
+A sidebar plugin is an executable terminal program. The mux server starts it inside a PTY and the TUI renders that PTY in the sidebar using the same Ghostty VT surface pipeline used by pane PTYs.
+
+### Configuration
+
+`~/.config/cmux/mux.json`:
+
+```json
+{
+  "sidebar": {
+    "plugin": {
+      "command": ["/path/to/plugin-binary"],
+      "cwd": "/optional"
+    }
+  }
+}
+```
+
+When `sidebar.plugin` is absent, the built-in workspace sidebar is used. When present, the plugin replaces the built-in sidebar. In a local TUI session, `reload-config` applies this key through the existing config reload path. A headless server or attached-client setup may require restarting the server process so the server, not the attach client, picks up the plugin command.
+
+The sidebar content PTY is sized to the sidebar content cells. The host TUI keeps one separator/focus-border column at the right edge. Resizes use normal PTY resizing (`TIOCSWINSZ` on Unix), so plugins observe the standard terminal resize behavior and `SIGWINCH`; there is no plugin-specific resize protocol.
+
+### Environment
+
+The child process receives:
+
+| Variable | Value |
+| --- | --- |
+| `CMUX_MUX_SOCKET` | The server process control socket path for this mux session. |
+| `CMUX_SIDEBAR` | `1`. |
+| `TERM` | The same TERM configured for ordinary PTY surfaces. |
+
+The plugin runs in the server process context. Attached TUI clients request and render the server-owned plugin surface; they do not spawn their own plugin process.
+
+### Lifecycle
+
+The mux starts the plugin when the plugin sidebar first becomes visible. Hiding the sidebar stops rendering but does not kill the plugin. The plugin is killed when the mux server exits or when config changes remove or replace the plugin command.
+
+If the plugin exits or fails to start, the TUI renders a visible error message in the sidebar. The server records a bounded restart backoff and will not hot crash-loop. Focusing the sidebar requests a relaunch after the backoff has elapsed.
+
+### Focus And Input
+
+`focus-sidebar` is the keyboard action for focusing the sidebar plugin. The default binding is `prefix S`.
+
+While the sidebar is focused, key and paste input are forwarded as PTY bytes using the same key encoder and terminal-mode state as pane PTYs. The global prefix chord is the escape hatch back to cmux:
+
+- `prefix prefix` sends a literal prefix key to the plugin and keeps sidebar focus.
+- `prefix <command>` leaves sidebar focus and runs the normal cmux prefixed command.
+- `prefix S` leaves sidebar focus when already focused.
+
+Mouse input is not forwarded to sidebar plugins in this round because ordinary PTY pane mouse forwarding is not implemented in this TUI path. Clicking inside the plugin sidebar focuses it.
+
+### Manifest
+
+Plugin directories use `cmux-plugin.toml` at the directory root:
+
+```toml
+[plugin]
+name = "fzf"
+kind = "sidebar"
+version = "0.1.0"
+description = "Fuzzy-find workspaces, screens, and panes"
+
+[run]
+command = ["target/release/cmux-sidebar-fzf"]
+
+[build]
+command = ["cargo", "build", "--release"]
+```
+
+The host reads the already-installed command from `mux.json` in this round. Plugin manager install/build verbs are separate follow-up work. The install-directory convention for that follow-up is:
+
+```text
+~/.local/share/cmux/mux-plugins/<name>
+```
+
+Relative manifest commands are resolved by the plugin manager before it writes the runnable command into `mux.json`.


### PR DESCRIPTION
Implements the mux side of the sidebar-plugin contract (reference plugin: https://github.com/manaflow-ai/cmux-sidebar-fzf, already live-tested against the control socket).

A sidebar plugin is an ordinary TUI program: mux runs it in a PTY sized to the sidebar and renders it via the existing ghostty-vt pipeline (shared ui/terminal_grid.rs, factored from the pane renderer — no second VT path). Env contract: CMUX_MUX_SOCKET + CMUX_SIDEBAR=1; resize is plain SIGWINCH. prefix S focuses the sidebar; keys forward verbatim, the global prefix escapes back. Plugins survive sidebar hide/show, restart with bounded backoff on exit, and die with the server. Attach clients get the plugin surface via a new additive protocol command. Built-in sidebar is untouched when no plugin is configured.

spec/plugins.md documents the contract incl. the cmux-plugin.toml manifest for the follow-up plugin-manager round. smoke-tui.py now boots a trivial echo plugin, focuses it, types, asserts the echo renders, then reload-configs back to the built-in sidebar.

Local compile fully blocked (host ghostty zig issue) — CI is the compile gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786162010&installation_id=133855650&pr_number=7695&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7695&signature=3224d59f62fc29fef25c2f73203a5bbea8ade07afb6221bcc048943803fb8f5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spawns and manages an extra server-owned PTY with new input-focus routing and attach-client behavior; impact is mostly scoped to sessions that enable `sidebar.plugin`, but failures or focus bugs could affect the whole TUI frame.
> 
> **Overview**
> Adds an optional **sidebar plugin** path: when `sidebar.plugin` is set in `mux.json`, the mux server runs that command in a dedicated PTY (with `CMUX_SIDEBAR=1` and normal resize), instead of the built-in workspace list.
> 
> **Mux core** gains `configure_sidebar_plugin` / `ensure_sidebar_plugin` with exponential backoff on start/exit failures; plugin surfaces are kept outside the pane tree and reaped specially on exit. The control socket exposes an additive **`sidebar-plugin`** command (protocol remains **v6**) returning surface id, error, and `retry_after_ms`.
> 
> **TUI** syncs plugin size each frame, draws it through new shared **`ui/terminal_grid`** (VT painting factored out of pane rendering), and adds **`focus-sidebar`** (`prefix S`) plus click-to-focus with keys/paste forwarded to the plugin while focused; prefix still escapes back to panes. Attached clients call `sidebar-plugin` over RPC and attach the returned surface.
> 
> Config reload applies plugin changes; smoke tests cover plugin render, focus/echo, and fallback to the built-in sidebar. **`spec/plugins.md`** documents the contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43fcbf8aee8a496454020a161ca6f75923680677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pluggable sidebar that runs an external TUI in a server-owned PTY and renders it via a shared VT grid. Introduces an additive `sidebar-plugin` socket command (protocol stays v6); clicking outside the plugin now returns focus to panes.

- **New Features**
  - Server: runs a sidebar plugin PTY sized to the sidebar; sets `CMUX_MUX_SOCKET` and `CMUX_SIDEBAR=1`; survives hide/show; restarts with bounded backoff; exits on shutdown or config change.
  - TUI: focus sidebar with `prefix S` or click; keys and paste forward verbatim while focused; `prefix` escapes; click outside unfocuses; drawing uses shared `ui/terminal_grid`.
  - Config: `sidebar.plugin` in `mux.json` with `command` and optional `cwd`; `reload-config` applies; when unset, the built‑in sidebar is used.
  - Attach/protocol: new `sidebar-plugin` command returns `{surface,error,retry_after_ms}`; clients render via `attach-surface`; docs/spec/tests updated (no CLI verb); protocol remains v6.

- **Migration**
  - To enable: set `sidebar.plugin.command` in `~/.config/cmux/mux.json` (e.g. `["/path/to/plugin"]`), then `reload-config` or restart the server.
  - Attached clients must support protocol v6 and call `sidebar-plugin` to obtain the server-owned surface before attaching.
  - No changes if no plugin is configured; falls back to the built‑in sidebar.

<sup>Written for commit 43fcbf8aee8a496454020a161ca6f75923680677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional sidebar plugin, including configuration, startup, resizing, focus handling, and input forwarding.
  * Introduced a new sidebar-focused keyboard shortcut to switch focus to the sidebar plugin.
  * Added a control-socket command for clients to request sidebar plugin status.

* **Bug Fixes**
  * Improved sidebar plugin recovery with retry/backoff behavior after failures or exits.
  * Updated sidebar rendering to show plugin output or a helpful error/unavailable message when needed.

* **Documentation**
  * Updated configuration, keyboard, and protocol docs to describe the new sidebar plugin behavior and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->