### PR TITLE
Fix zh-Hant showing as zh-Hans: own AppleLanguages writes and apply language selection at change time

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
@@ -54,11 +54,15 @@ public struct LanguageSettingsStore: Sendable {
         }
     }
 
-    /// Repairs or adopts cmux-owned explicit overrides at launch without
-    /// removing or replacing externally-managed `AppleLanguages` values.
+    /// Repairs or adopts cmux-owned explicit overrides at launch, and clears
+    /// stale cmux-owned overrides for ``AppLanguage/system`` without removing
+    /// externally-managed `AppleLanguages` values.
     public func reconcileLanguageOverrideAtLaunch() {
         let language = storedLanguage
-        guard language != .system else { return }
+        guard language != .system else {
+            applyLanguageOverride(.system)
+            return
+        }
 
         let expectedOverride = [language.rawValue]
         if let currentAppleLanguages {

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
@@ -9,8 +9,8 @@ import Foundation
 /// single-element list when the user chooses an explicit app language, and
 /// records that write in a companion key so returning to
 /// ``AppLanguage/system`` removes only an override cmux still owns. Launch
-/// reconciliation repairs missing cmux overrides for explicit selections but
-/// never deletes externally-managed `AppleLanguages` values.
+/// reconciliation repairs missing or stale cmux overrides for explicit
+/// selections but never deletes externally-managed `AppleLanguages` values.
 ///
 /// Isolation: a stateless `Sendable` struct, not an actor — its operations run
 /// synchronously at startup, from Settings, or from the settings importer, the
@@ -54,9 +54,9 @@ public struct LanguageSettingsStore: Sendable {
         }
     }
 
-    /// Repairs or adopts cmux-owned explicit overrides at launch, and clears
-    /// stale cmux-owned overrides for ``AppLanguage/system`` without removing
-    /// externally-managed `AppleLanguages` values.
+    /// Repairs, adopts, or refreshes cmux-owned explicit overrides at launch,
+    /// and clears stale cmux-owned overrides for ``AppLanguage/system`` without
+    /// removing externally-managed `AppleLanguages` values.
     public func reconcileLanguageOverrideAtLaunch() {
         let language = storedLanguage
         guard language != .system else {
@@ -66,9 +66,14 @@ public struct LanguageSettingsStore: Sendable {
 
         let expectedOverride = [language.rawValue]
         if let currentAppleLanguages {
-            guard currentAppleLanguages == expectedOverride else { return }
-            if defaults.string(forKey: appliedOverrideKey) == nil {
-                defaults.set(language.rawValue, forKey: appliedOverrideKey)
+            if currentAppleLanguages == expectedOverride {
+                if defaults.string(forKey: appliedOverrideKey) == nil {
+                    defaults.set(language.rawValue, forKey: appliedOverrideKey)
+                }
+            } else if let appliedOverride = defaults.string(forKey: appliedOverrideKey), currentAppleLanguages == [appliedOverride] {
+                applyLanguageOverride(language)
+            } else {
+                return
             }
         } else {
             applyLanguageOverride(language)

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
@@ -1,26 +1,36 @@
 import Foundation
 
 /// Repository for the app UI language, persisted in `UserDefaults` under the
-/// catalog's `app.language` key, plus the system `AppleLanguages` override
-/// that makes the choice take effect.
+/// catalog's `app.language` key, plus cmux-owned writes to the system
+/// `AppleLanguages` per-app override.
 ///
 /// `AppleLanguages` is the OS-defined per-app language override list that
-/// Foundation's localization machinery reads at process start; cmux writes a
-/// single-element list (or removes the override for
-/// ``AppLanguage/system``). The selection therefore applies on next launch,
-/// which is why the app reads ``storedLanguage`` once at startup.
+/// Foundation's localization machinery reads at process start. cmux writes a
+/// single-element list when the user chooses an explicit app language, and
+/// records that write in a companion key so returning to
+/// ``AppLanguage/system`` removes only an override cmux still owns. Launch
+/// reconciliation repairs missing cmux overrides for explicit selections but
+/// never deletes externally-managed `AppleLanguages` values.
 ///
-/// Isolation: a stateless `Sendable` struct, not an actor — both members run
-/// synchronously at startup or from the settings importer, the struct holds
-/// no mutable state, and `UserDefaults` is documented thread-safe.
+/// Isolation: a stateless `Sendable` struct, not an actor — its operations run
+/// synchronously at startup, from Settings, or from the settings importer, the
+/// struct holds no mutable state, and `UserDefaults` is documented thread-safe.
 public struct LanguageSettingsStore: Sendable {
     // UserDefaults is documented thread-safe and the reference is immutable.
     private nonisolated(unsafe) let defaults: UserDefaults
     private let keys = AppCatalogSection()
+    private let domainName: String?
+    private let appleLanguagesKey = "AppleLanguages"
+    private let appliedOverrideKey = "appLanguageAppliedOverride"
 
     /// Creates a store reading and writing the given defaults suite.
-    public init(defaults: UserDefaults) {
+    ///
+    /// Pass `domainName` for any non-`.standard` suite so ownership checks
+    /// read only that suite's persistent domain; without it, reads fall back
+    /// to the defaults search list, which inherits `NSGlobalDomain` values.
+    public init(defaults: UserDefaults, domainName: String? = nil) {
         self.defaults = defaults
+        self.domainName = domainName ?? (defaults === UserDefaults.standard ? Bundle.main.bundleIdentifier : nil)
     }
 
     /// The persisted language choice; unrecognized stored values read as
@@ -29,13 +39,42 @@ public struct LanguageSettingsStore: Sendable {
         keys.language.value(in: defaults)
     }
 
-    /// Writes (or, for ``AppLanguage/system``, removes) the `AppleLanguages`
-    /// override so `language` takes effect on the next launch.
+    /// Writes an explicit cmux-owned `AppleLanguages` override, or removes it
+    /// for ``AppLanguage/system`` only when the current value still matches
+    /// cmux's last recorded write.
     public func applyLanguageOverride(_ language: AppLanguage) {
         if language == .system {
-            defaults.removeObject(forKey: "AppleLanguages")
+            if let appliedOverride = defaults.string(forKey: appliedOverrideKey), currentAppleLanguages == [appliedOverride] {
+                defaults.removeObject(forKey: appleLanguagesKey)
+            }
+            defaults.removeObject(forKey: appliedOverrideKey)
         } else {
-            defaults.set([language.rawValue], forKey: "AppleLanguages")
+            defaults.set([language.rawValue], forKey: appleLanguagesKey)
+            defaults.set(language.rawValue, forKey: appliedOverrideKey)
         }
+    }
+
+    /// Repairs or adopts cmux-owned explicit overrides at launch without
+    /// removing or replacing externally-managed `AppleLanguages` values.
+    public func reconcileLanguageOverrideAtLaunch() {
+        let language = storedLanguage
+        guard language != .system else { return }
+
+        let expectedOverride = [language.rawValue]
+        if let currentAppleLanguages {
+            guard currentAppleLanguages == expectedOverride else { return }
+            if defaults.string(forKey: appliedOverrideKey) == nil {
+                defaults.set(language.rawValue, forKey: appliedOverrideKey)
+            }
+        } else {
+            applyLanguageOverride(language)
+        }
+    }
+
+    private var currentAppleLanguages: [String]? {
+        if let domainName {
+            return defaults.persistentDomain(forName: domainName)?[appleLanguagesKey] as? [String]
+        }
+        return defaults.array(forKey: appleLanguagesKey) as? [String]
     }
 }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
@@ -26,11 +26,11 @@ public struct LanguageSettingsStore: Sendable {
     /// Creates a store reading and writing the given defaults suite.
     ///
     /// Pass `domainName` for any non-`.standard` suite so ownership checks
-    /// read only that suite's persistent domain; without it, reads fall back
-    /// to the defaults search list, which inherits `NSGlobalDomain` values.
-    public init(defaults: UserDefaults, domainName: String? = nil) {
+    /// read only that suite's persistent domain; it defaults to the main
+    /// bundle identifier, which matches the `.standard` suite's app domain.
+    public init(defaults: UserDefaults, domainName: String? = Bundle.main.bundleIdentifier) {
         self.defaults = defaults
-        self.domainName = domainName ?? (defaults === UserDefaults.standard ? Bundle.main.bundleIdentifier : nil)
+        self.domainName = domainName
     }
 
     /// The persisted language choice; unrecognized stored values read as

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
@@ -89,6 +89,9 @@ public struct LanguageSettingsStore: Sendable {
         }
     }
 
+    // Optional (not `[]`) on purpose: `nil` distinguishes "no AppleLanguages
+    // key present" from "present but different value" for the repair branch
+    // in reconcileLanguageOverrideAtLaunch(). Do not collapse to [].
     private var currentAppleLanguages: [String]? {
         if let domainName {
             return defaults.persistentDomain(forName: domainName)?[appleLanguagesKey] as? [String]

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/LanguageSettingsStore.swift
@@ -42,6 +42,15 @@ public struct LanguageSettingsStore: Sendable {
     /// Writes an explicit cmux-owned `AppleLanguages` override, or removes it
     /// for ``AppLanguage/system`` only when the current value still matches
     /// cmux's last recorded write.
+    ///
+    /// A no-companion `AppleLanguages` value is never removed, even though a
+    /// pre-companion cmux build could have left one behind when its last
+    /// session switched to System: those bytes are indistinguishable from a
+    /// user's manual `defaults write` or the macOS per-app Language & Region
+    /// setting, and deleting them is the exact data loss of
+    /// https://github.com/manaflow-ai/cmux/issues/7686. The legacy leftover
+    /// self-heals when the user picks any explicit language (or toggles
+    /// through one back to System), which stamps the companion.
     public func applyLanguageOverride(_ language: AppLanguage) {
         if language == .system {
             if let appliedOverride = defaults.string(forKey: appliedOverrideKey), currentAppleLanguages == [appliedOverride] {

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/DomainSettingsStoreTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/DomainSettingsStoreTests.swift
@@ -372,7 +372,7 @@ struct LanguageSettingsStoreTests {
         // domain to observe only the override this store writes/removes.
         let suiteName = "cmux.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
-        let store = LanguageSettingsStore(defaults: defaults)
+        let store = LanguageSettingsStore(defaults: defaults, domainName: suiteName)
 
         store.applyLanguageOverride(.ja)
         #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] as? [String] == ["ja"])

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/LanguageSettingsStoreTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/LanguageSettingsStoreTests.swift
@@ -98,7 +98,20 @@ struct LanguageSettingsOverrideTests {
         #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] == nil)
     }
 
-    @Test func reconcileDoesNothingForSystemSelection() {
+    @Test func reconcileRemovesCmuxOwnedOverrideWhenStoredIsSystem() {
+        let (suiteName, defaults) = makeLanguageScratchDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)
+
+        defaults.set(["zh-Hant"], forKey: "AppleLanguages")
+        defaults.set("zh-Hant", forKey: "appLanguageAppliedOverride")
+        store.reconcileLanguageOverrideAtLaunch()
+
+        #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] == nil)
+        #expect(defaults.persistentDomain(forName: suiteName)?["appLanguageAppliedOverride"] == nil)
+    }
+
+    @Test func reconcilePreservesForeignOverrideForSystemSelection() {
         let (suiteName, defaults) = makeLanguageScratchDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/LanguageSettingsStoreTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/LanguageSettingsStoreTests.swift
@@ -70,6 +70,20 @@ struct LanguageSettingsOverrideTests {
         #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] as? [String] == ["zh-Hant"])
     }
 
+    @Test func reconcileRepairsStaleCmuxOwnedOverride() {
+        let (suiteName, defaults) = makeLanguageScratchDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)
+
+        defaults.set("zh-Hant", forKey: "appLanguage")
+        defaults.set(["en"], forKey: "AppleLanguages")
+        defaults.set("en", forKey: "appLanguageAppliedOverride")
+        store.reconcileLanguageOverrideAtLaunch()
+
+        #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] as? [String] == ["zh-Hant"])
+        #expect(defaults.persistentDomain(forName: suiteName)?["appLanguageAppliedOverride"] as? String == "zh-Hant")
+    }
+
     @Test func reconcileLeavesForeignOverrideUntouched() {
         let (suiteName, defaults) = makeLanguageScratchDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/LanguageSettingsStoreTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/LanguageSettingsStoreTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import CmuxSettings
+
+private func makeLanguageScratchDefaults() -> (String, UserDefaults) {
+    let suiteName = "cmux.tests.\(UUID().uuidString)"
+    return (suiteName, UserDefaults(suiteName: suiteName)!)
+}
+
+private func makeLanguageSettingsStore(defaults: UserDefaults, suiteName: String) -> LanguageSettingsStore {
+    LanguageSettingsStore(defaults: defaults)
+}
+
+@Suite("LanguageSettingsStore override ownership")
+struct LanguageSettingsOverrideTests {
+    @Test func systemSelectionPreservesForeignAppleLanguagesOverride() {
+        let (suiteName, defaults) = makeLanguageScratchDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)
+
+        defaults.set(["zh-Hant"], forKey: "AppleLanguages")
+        store.applyLanguageOverride(.system)
+
+        #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] as? [String] == ["zh-Hant"])
+    }
+
+    @Test func systemSelectionPreservesManuallyReplacedOverride() {
+        let (suiteName, defaults) = makeLanguageScratchDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)
+
+        store.applyLanguageOverride(.zhHant)
+        defaults.set(["fr"], forKey: "AppleLanguages")
+        store.applyLanguageOverride(.system)
+
+        #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] as? [String] == ["fr"])
+    }
+
+}

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/LanguageSettingsStoreTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/LanguageSettingsStoreTests.swift
@@ -8,7 +8,7 @@ private func makeLanguageScratchDefaults() -> (String, UserDefaults) {
 }
 
 private func makeLanguageSettingsStore(defaults: UserDefaults, suiteName: String) -> LanguageSettingsStore {
-    LanguageSettingsStore(defaults: defaults)
+    LanguageSettingsStore(defaults: defaults, domainName: suiteName)
 }
 
 @Suite("LanguageSettingsStore override ownership")
@@ -36,4 +36,77 @@ struct LanguageSettingsOverrideTests {
         #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] as? [String] == ["fr"])
     }
 
+    @Test func systemSelectionRemovesCmuxOwnedOverride() {
+        let (suiteName, defaults) = makeLanguageScratchDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)
+
+        store.applyLanguageOverride(.zhHant)
+        store.applyLanguageOverride(.system)
+
+        #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] == nil)
+        #expect(defaults.persistentDomain(forName: suiteName)?["appLanguageAppliedOverride"] == nil)
+    }
+
+    @Test func explicitSelectionWritesOverrideAndCompanion() {
+        let (suiteName, defaults) = makeLanguageScratchDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)
+
+        store.applyLanguageOverride(.zhHant)
+
+        #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] as? [String] == ["zh-Hant"])
+        #expect(defaults.persistentDomain(forName: suiteName)?["appLanguageAppliedOverride"] as? String == "zh-Hant")
+    }
+
+    @Test func reconcileRepairsMissingOverrideForExplicitSelection() {
+        let (suiteName, defaults) = makeLanguageScratchDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)
+
+        defaults.set("zh-Hant", forKey: "appLanguage")
+        store.reconcileLanguageOverrideAtLaunch()
+
+        #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] as? [String] == ["zh-Hant"])
+    }
+
+    @Test func reconcileLeavesForeignOverrideUntouched() {
+        let (suiteName, defaults) = makeLanguageScratchDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)
+
+        defaults.set("zh-Hant", forKey: "appLanguage")
+        defaults.set(["ja"], forKey: "AppleLanguages")
+        store.reconcileLanguageOverrideAtLaunch()
+
+        #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] as? [String] == ["ja"])
+        #expect(defaults.persistentDomain(forName: suiteName)?["appLanguageAppliedOverride"] == nil)
+    }
+
+    @Test func reconcileAdoptsPreFixOwnedState() {
+        let (suiteName, defaults) = makeLanguageScratchDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)
+
+        defaults.set("zh-Hant", forKey: "appLanguage")
+        defaults.set(["zh-Hant"], forKey: "AppleLanguages")
+        store.reconcileLanguageOverrideAtLaunch()
+
+        #expect(defaults.persistentDomain(forName: suiteName)?["appLanguageAppliedOverride"] as? String == "zh-Hant")
+
+        store.applyLanguageOverride(.system)
+        #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] == nil)
+    }
+
+    @Test func reconcileDoesNothingForSystemSelection() {
+        let (suiteName, defaults) = makeLanguageScratchDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = makeLanguageSettingsStore(defaults: defaults, suiteName: suiteName)
+
+        defaults.set(["zh-Hant"], forKey: "AppleLanguages")
+        store.reconcileLanguageOverrideAtLaunch()
+
+        #expect(defaults.persistentDomain(forName: suiteName)?["AppleLanguages"] as? [String] == ["zh-Hant"])
+        #expect(defaults.persistentDomain(forName: suiteName)?["appLanguageAppliedOverride"] == nil)
+    }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsHostActions.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsHostActions.swift
@@ -1,3 +1,4 @@
+import CmuxSettings
 import Foundation
 
 /// Host-supplied callbacks the package's section views invoke for
@@ -163,11 +164,18 @@ public protocol SettingsHostActions: AnyObject {
     /// Runs host-owned live-refresh side effects after the package resets every
     /// catalog-backed setting.
     func resetAllSettingsSideEffects()
+
+    /// Applies the host-side OS `AppleLanguages` override for a changed app
+    /// language selection.
+    func applyLanguageOverride(_ language: AppLanguage)
 }
 
 public extension SettingsHostActions {
     /// Default no-op for hosts with no app-owned reset side effects.
     func resetAllSettingsSideEffects() {}
+
+    /// Default no-op for package previews and tests without app-language ownership.
+    func applyLanguageOverride(_ language: AppLanguage) {}
 
     func openMobilePairingWindow() {}
 

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -169,7 +169,7 @@ public struct AppSection: View {
                     : nil,
                 controlWidth: Self.columnWidth
             ) {
-                Picker("", selection: Binding(get: { language.current }, set: { newLanguage in language.set(newLanguage) { LanguageSettingsStore(defaults: .standard).applyLanguageOverride(newLanguage) } })) {
+                Picker("", selection: Binding(get: { language.current }, set: { newLanguage in language.set(newLanguage) { hostActions.applyLanguageOverride(newLanguage) } })) {
                     ForEach(Self.legacyLanguageCases, id: \.self) { lang in
                         Text(languageDisplayName(lang)).tag(lang)
                     }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -169,7 +169,7 @@ public struct AppSection: View {
                     : nil,
                 controlWidth: Self.columnWidth
             ) {
-                Picker("", selection: Binding(get: { language.current }, set: { language.set($0) })) {
+                Picker("", selection: Binding(get: { language.current }, set: { newLanguage in language.set(newLanguage) { LanguageSettingsStore(defaults: .standard).applyLanguageOverride(newLanguage) } })) {
                     ForEach(Self.legacyLanguageCases, id: \.self) { lang in
                         Text(languageDisplayName(lang)).tag(lang)
                     }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -64,6 +64,8 @@ public struct AppSection: View {
     @State private var paletteAllSurfaces: DefaultsValueModel<Bool>
 
     @State private var languageAtAppear: AppLanguage?
+    // Sticky: a picker change can rewrite the OS AppleLanguages override even when the selection returns to its starting value (clearing a preserved foreign override via an explicit pick, then System), so the restart hint must not rely on the value comparison alone.
+    @State private var languageOverrideTouched = false
     @State private var telemetryAtAppear: Bool?
 
     public init(
@@ -164,12 +166,10 @@ public struct AppSection: View {
             SettingsCardRow(
                 configurationReview: .json("app.language"),
                 String(localized: "settings.app.language", defaultValue: "Language"),
-                subtitle: languageAtAppear != nil && language.current != languageAtAppear
-                    ? String(localized: "settings.app.language.restartSubtitle", defaultValue: "Restart cmux to apply")
-                    : nil,
+                subtitle: languageOverrideTouched || (languageAtAppear != nil && language.current != languageAtAppear) ? String(localized: "settings.app.language.restartSubtitle", defaultValue: "Restart cmux to apply") : nil,
                 controlWidth: Self.columnWidth
             ) {
-                Picker("", selection: Binding(get: { language.current }, set: { newLanguage in language.set(newLanguage) { hostActions.applyLanguageOverride(newLanguage) } })) {
+                Picker("", selection: Binding(get: { language.current }, set: { newLanguage in if newLanguage != language.current { languageOverrideTouched = true }; language.set(newLanguage) { hostActions.applyLanguageOverride(newLanguage) } })) {
                     ForEach(Self.legacyLanguageCases, id: \.self) { lang in
                         Text(languageDisplayName(lang)).tag(lang)
                     }

--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CMUXMobileCore
 import CmuxWorkspaces
+import CmuxSettings
 import CmuxSettingsUI
 import CmuxFoundation
 import Foundation
@@ -86,7 +87,12 @@ final class HostSettingsActions: SettingsHostActions {
     }
 
     func resetAllSettingsSideEffects() {
+        LanguageSettingsStore(defaults: .standard).applyLanguageOverride(.system)
         PaneChromeSettings.notifyDidChange()
+    }
+
+    func applyLanguageOverride(_ language: AppLanguage) {
+        LanguageSettingsStore(defaults: .standard).applyLanguageOverride(language)
     }
 
     func openConfigInExternalEditor() {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -158,9 +158,8 @@ struct cmuxApp: App {
         _ = KeyboardShortcutSettings.settingsFileStore
         StartupBreadcrumbLog.append("app.init.keyboardShortcuts.loaded")
 
-        // Apply saved language preference before any UI loads
-        let languageSettingsStore = LanguageSettingsStore(defaults: .standard)
-        languageSettingsStore.applyLanguageOverride(languageSettingsStore.storedLanguage)
+        // Reconcile saved language preference before any UI loads
+        LanguageSettingsStore(defaults: .standard).reconcileLanguageOverrideAtLaunch()
         StartupBreadcrumbLog.append("app.init.language.applied")
         self.settingsRuntime = SettingsRuntime(
             catalog: settingsCatalog,


### PR DESCRIPTION
Closes #7686

## User report

> Although both my macOS system language and cmux are set to Traditional Chinese, the interface still displays Simplified Chinese. … Running the following command in Terminal: `defaults write com.cmuxterm.app AppleLanguages '("zh-Hant")'`. Unfortunately, the interface is still displayed in Simplified Chinese.

## Root cause

The localization catalog, the built bundle (`zh-Hant.lproj` is present with genuinely Traditional strings), and CFBundle language matching are all correct — verified empirically on macOS 15.7.4 and macOS 26 with main-bundle probes. The bug is in cmux's own `AppleLanguages` handling, in two parts:

1. **Launch-time wipe of externally-owned overrides.** `cmuxApp.init` unconditionally re-applied the stored language on every launch. With the (default) *System* selection, `applyLanguageOverride(.system)` executed `removeObject(forKey: "AppleLanguages")` — silently deleting any override the user set manually with `defaults write` **and** the value macOS System Settings → General → Language & Region → Applications → cmux stores in the same key. Reproduced on a tagged Debug build: seed `AppleLanguages=("zh-Hant")` in a fresh domain, launch once → the key is gone; the next launch regresses to the global system language list. This is exactly why the reporter's documented workaround did nothing.

2. **Override applied one launch too late.** Selecting a language in cmux Settings only wrote `appLanguage`; `AppleLanguages` was written at the *next* launch — after Foundation had already snapshotted the process language list at process start. Reproduced: with `appLanguage="zh-Hant"` stored and no override present, the first relaunch still rendered the old language; only the second relaunch rendered zh-Hant. A user who restarts once concludes the setting is broken.

## Fix (ownership model)

`AppleLanguages` in the app's defaults domain has three writers: the cmux picker, macOS System Settings (per-app language), and manual `defaults write`. cmux now only removes or replaces a value **it wrote itself**, and writes at **change time** rather than recomputing at launch:

- `LanguageSettingsStore` records each write in a companion default (`appLanguageAppliedOverride`). Switching to *System* removes `AppleLanguages` only when the current value still matches cmux's recorded write; foreign values are left untouched.
- The Settings language picker applies the override immediately on selection (via the existing `set(_:afterCommit:)` pattern), so a **single restart** now suffices. The cmux.json import side effect goes through the same store call and inherits the safe semantics (including the first-ever import of the default template's `"language": "system"`, which previously wiped per-app System Settings languages on first run).
- Launch now performs a non-destructive reconcile: repair a missing override for an explicit stored selection, adopt pre-fix cmux-owned state (so a later switch to System still cleans up), never touch foreign values, never remove anything.
- Ownership checks read the app's persistent domain directly (not the defaults search list) so inherited `NSGlobalDomain` values can't fake ownership.

## Two-commit regression structure

- Commit 1 adds two failing tests (CI red): a foreign `AppleLanguages` override must survive `applyLanguageOverride(.system)` — both the reporter's `defaults write` scenario and a manually-replaced override.
- Commit 2 adds the fix plus six more tests covering explicit writes, owned removal, and all launch-reconcile branches.

## Verification

- `swift test --package-path Packages/macOS/CmuxSettings`: 249/249 green with the fix; the two red tests demonstrably fail without it.
- Tagged Debug build (`reload.sh --tag issue-7686-zh-hant`) menu-bar probes:
  - Reporter scenario: fresh domain + `defaults write <bid> AppleLanguages '("zh-Hant")'` → override survives both launches, menus render Traditional Chinese (檔案, 編輯, 顯示方式, 視窗, 輔助說明) on launch 1 **and** launch 2 (previously: wiped after launch 1, wrong language from launch 2 on).
  - System default: no language keys created; app follows the OS language.
- `python3 scripts/swift_file_length_budget.py` (CI diff-aware invocation) passes; `Sources/cmuxApp.swift` shrank by one line and `AppSection.swift` stayed at 974 — no budget TSV changes; no new warnings.
- Localization audit: behavior-only change, no new user-facing strings, no catalog changes needed.

zh-Hans and all other explicit language selections behave as before (plus the companion stamp); existing `DomainSettingsStoreTests.applyLanguageOverrideWritesAppleLanguagesList` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786162901&installation_id=133855650&pr_number=7698&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7698&signature=de73e5302265a4f1117168635a698d4336ef28730622c0afe65d0905ed1fd825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup and UserDefaults behavior for a process-wide localization key; mistakes could still wipe user overrides or leave stale overrides, but logic is narrowly scoped with extensive tests.
> 
> **Overview**
> Fixes **#7686** by changing how cmux reads and writes the per-app `AppleLanguages` override so user- or OS-set values (e.g. zh-Hant) are not wiped on launch.
> 
> **`LanguageSettingsStore`** now stamps a companion key (`appLanguageAppliedOverride`) on each cmux write. Choosing **System** removes `AppleLanguages` only when it still matches that stamp; foreign overrides from `defaults write` or System Settings are left alone. Ownership checks use the app **persistent domain** via an optional `domainName` init parameter. **`reconcileLanguageOverrideAtLaunch()`** replaces the old unconditional launch apply: it repairs missing or stale cmux-owned overrides for explicit languages and adopts legacy state without deleting external values.
> 
> The Settings language picker calls **`hostActions.applyLanguageOverride`** on change (not only on next launch), so one restart is enough. **`AppSection`** tracks **`languageOverrideTouched`** so the restart hint still appears when the picker round-trips but the OS override changed. Startup uses reconcile; **Reset All** clears cmux-owned language state through the same store.
> 
> New **`LanguageSettingsStoreTests`** cover ownership, reconcile branches, and foreign-override preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e1ade5549fd3f108dbc8180c65df7a39e1309a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7686 by correcting `AppleLanguages` handling so zh-Hant renders Traditional Chinese. We now own only our writes, apply changes at selection time, reconcile at launch, preserve foreign/legacy values, and keep the restart hint visible after a language change.

- **Bug Fixes**
  - Track ownership with `appLanguageAppliedOverride`; only remove `AppleLanguages` if cmux wrote it.
  - Apply the override immediately from the Settings picker via `SettingsHostActions.applyLanguageOverride`; the restart hint stays visible once the picker touches the override; one restart is enough.
  - Reconcile at launch: repair missing or stale cmux-owned overrides, adopt pre-fix state, preserve legacy or foreign values; host Reset All also clears cmux-owned overrides.
  - Read `AppleLanguages` from the app’s persistent domain; default `domainName` to the main bundle ID so `NSGlobalDomain` can’t fake ownership; keep `currentAppleLanguages` optional to distinguish nil vs empty; tests cover ownership, reconcile, and System cleanup.

<sup>Written for commit 90e1ade5549fd3f108dbc8180c65df7a39e1309a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced app language override handling in Settings with explicit ownership tracking and safer per-app overrides.
  * Added launch-time reconciliation to restore/repair cmux-owned language overrides.
  * Language picker now applies the selection immediately via host-side override hooks.

* **Bug Fixes**
  * Switching to **System** now removes only cmux-owned override state, preserving externally managed `AppleLanguages`.
  * Reset behavior now consistently reapplies the **System** language override.

* **Tests**
  * Added/updated coverage for ownership, reconciliation, and preservation rules (including per-suite persistence).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->