### PR TITLE
cmux-tui-artifacts: transitional double-publish under the legacy mux/ prefix

### DIFF
--- a/.github/workflows/cmux-tui-artifacts.yml
+++ b/.github/workflows/cmux-tui-artifacts.yml
@@ -110,3 +110,31 @@ jobs:
             publish_prefix "cmux-tui/latest" "no-cache, no-store, must-revalidate"
           fi
           echo "Published: https://files.cmux.com/cmux-tui/$GITHUB_SHA/manifest.json"
+
+          # Transitional double-publish under the pre-rename prefix and binary
+          # names: out-of-repo consumers (cmux-cloud bootstrap/install-mux.sh
+          # and snapshot builders) still curl files.cmux.com/mux/<ref>/cmux-mux-*.
+          # Remove once cmux-cloud switches to the cmux-tui prefix
+          # (https://github.com/manaflow-ai/cmux-cloud/pull/2).
+          legacy_assets="assets-legacy"
+          mkdir -p "$legacy_assets"
+          for file in assets/cmux-tui-*; do
+            cp "$file" "$legacy_assets/$(basename "$file" | sed 's/^cmux-tui-/cmux-mux-/')"
+          done
+          cp assets/manifest.json "$legacy_assets/manifest.json"
+          publish_legacy_prefix() {
+            local prefix="$1"
+            local cache="$2"
+            for file in "$legacy_assets"/*; do
+              python3 scripts/ci/upload-r2-object.py \
+                --file "$file" \
+                --endpoint-url "$R2_ENDPOINT" \
+                --bucket cmux-binaries \
+                --key "$prefix/$(basename "$file")" \
+                --cache-control "$cache"
+            done
+          }
+          publish_legacy_prefix "mux/$GITHUB_SHA" "public, max-age=31536000, immutable"
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            publish_legacy_prefix "mux/latest" "no-cache, no-store, must-revalidate"
+          fi


### PR DESCRIPTION
The rename (https://github.com/manaflow-ai/cmux/pull/7710) moved the R2 artifact prefix to files.cmux.com/cmux-tui/ with cmux-tui-<target> binary names, but cmux-cloud's bootstrap/install-mux.sh and snapshot builders still curl the old mux/<ref>/cmux-mux-<target> URLs, so they would silently stop receiving updates. Double-publish copies under the legacy prefix + names until https://github.com/manaflow-ai/cmux-cloud/pull/2 switches over (commented in the workflow). Workflow-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786177443&installation_id=133855650&pr_number=7716&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7716&signature=71dbb7f534cc0a899039b19f40a3bb7f83e91c16f3e75dea066ceb2e8838624a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI publish-step extension only; duplicates existing artifacts under legacy keys with no runtime or security impact.
> 
> **Overview**
> After the normal **`cmux-tui/`** R2 publish, the **cmux-tui artifacts** workflow now **transitionally mirrors** the same binaries under the pre-rename layout: **`mux/<commit>`** and **`mux/latest`** (on `main`), with filenames rewritten from **`cmux-tui-*`** to **`cmux-mux-*`**, plus a copied **`manifest.json`**.
> 
> This keeps **cmux-cloud** bootstrap/install and snapshot builders working on **`files.cmux.com/mux/...`** until they move to the new prefix (noted in workflow comments with a follow-up PR). **Workflow-only**; no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 694c5ec8781213420146f562f41f73f56807ef10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily double-publishes TUI artifacts to the legacy mux/ prefix with cmux-mux-* names so external consumers keep receiving updates until `cmux-cloud` migrates to cmux-tui paths. Workflow-only change.

- **Bug Fixes**
  - Copy `cmux-tui-*` to legacy `cmux-mux-*` and upload to `mux/<sha>` and `mux/latest` with appropriate cache headers.
  - Keeps URLs used by `cmux-cloud` bootstrap and snapshot builders working until they switch to `cmux-tui/`.

<sup>Written for commit 694c5ec8781213420146f562f41f73f56807ef10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded release publishing so built binaries are available through both the current download location and an older compatibility path.
  * Updated the latest-release files on the main branch to keep legacy downloads working for existing consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->